### PR TITLE
fix(responses): preserve non-message input items when prompt management hooks run

### DIFF
--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -529,7 +529,11 @@ async def aresponses(
                 prompt_label=kwargs.get("prompt_label", None),
                 prompt_version=kwargs.get("prompt_version", None),
             )
-            input = cast(Union[str, ResponseInputParam], merged_input)
+            input = _restore_non_message_input_items(
+                original_input=input,
+                client_input=client_input,
+                merged_input=merged_input,
+            )
             if model != original_model:
                 _, custom_llm_provider, _, _ = litellm.get_llm_provider(model=model)
             kwargs.pop("prompt_id", None)
@@ -601,6 +605,50 @@ async def aresponses(
         )
 
 
+def _restore_non_message_input_items(
+    original_input: Union[str, ResponseInputParam],
+    client_input: list[AllMessageValues],
+    merged_input: list[AllMessageValues],
+) -> Union[str, ResponseInputParam]:
+    """
+    Re-attach Responses API input items that were hidden from prompt management hooks.
+
+    Prompt management hooks operate on chat-completion style messages, so only dict
+    items with a "role" (``client_input``) are shown to them. Multi-turn Responses API
+    input can also carry role-less items ("reasoning", "function_call",
+    "function_call_output", "item_reference", ...) that must survive the merge:
+    providers reject message items whose paired reasoning items are missing, e.g.
+    Azure's "Item 'msg_...' of type 'message' was provided without its required
+    'reasoning' item: 'rs_...'".
+
+    Relevant issue: https://github.com/BerriAI/litellm/issues/32335
+    """
+    if isinstance(original_input, str):
+        return cast(ResponseInputParam, merged_input)
+
+    original_items = list(original_input)
+    non_message_items = [item for item in original_items if not (isinstance(item, dict) and "role" in item)]
+    if not non_message_items:
+        return cast(ResponseInputParam, merged_input)
+
+    if list(merged_input) == list(client_input):
+        return original_input
+
+    num_client_items = len(client_input)
+    hook_kept_client_as_suffix = num_client_items > 0 and list(merged_input[-num_client_items:]) == list(client_input)
+    if num_client_items == 0 or hook_kept_client_as_suffix:
+        prepended = list(merged_input[: len(merged_input) - num_client_items])
+        return cast(ResponseInputParam, prepended + original_items)
+
+    verbose_logger.warning(
+        "Prompt management hook rewrote the Responses API message list; %d non-message "
+        "input item(s) (e.g. reasoning or function_call items) could not be realigned "
+        "and were dropped from the request.",
+        len(non_message_items),
+    )
+    return cast(ResponseInputParam, merged_input)
+
+
 def _apply_prompt_management_to_responses_call(
     input: Union[str, ResponseInputParam],
     model: str,
@@ -644,7 +692,11 @@ def _apply_prompt_management_to_responses_call(
             prompt_label=kwargs.get("prompt_label", None),
             prompt_version=kwargs.get("prompt_version", None),
         )
-        input = cast(Union[str, ResponseInputParam], merged_input)
+        input = _restore_non_message_input_items(
+            original_input=input,
+            client_input=client_input,
+            merged_input=merged_input,
+        )
         local_vars["input"] = input
         local_vars["model"] = model
         if model != original_model:

--- a/tests/test_litellm/responses/test_responses_prompt_management.py
+++ b/tests/test_litellm/responses/test_responses_prompt_management.py
@@ -13,7 +13,6 @@ Covers:
   I) async path propagates optional params to downstream handler
 """
 
-import asyncio
 from typing import List
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -54,18 +53,15 @@ def _patch_responses_dispatch():
             return_value=("gpt-4o", "openai", None, None),
         ),
         patch(
-            "litellm.responses.mcp.litellm_proxy_mcp_handler."
-            "LiteLLM_Proxy_MCP_Handler._should_use_litellm_mcp_gateway",
+            "litellm.responses.mcp.litellm_proxy_mcp_handler.LiteLLM_Proxy_MCP_Handler._should_use_litellm_mcp_gateway",
             return_value=False,
         ),
         patch(
-            "litellm.responses.main.ProviderConfigManager"
-            ".get_provider_responses_api_config",
+            "litellm.responses.main.ProviderConfigManager.get_provider_responses_api_config",
             return_value=None,
         ),
         patch(
-            "litellm.responses.main.litellm_completion_transformation_handler"
-            ".response_api_handler",
+            "litellm.responses.main.litellm_completion_transformation_handler.response_api_handler",
             return_value=MagicMock(),
         ),
     ]
@@ -77,7 +73,6 @@ def _patch_responses_dispatch():
 
 
 class TestResponsesAPIPromptManagement:
-
     def test_str_input_coerced_and_merged(self):
         """[A] str input is wrapped into a message list before being passed to the hook."""
         template_messages: List[AllMessageValues] = [
@@ -108,9 +103,7 @@ class TestResponsesAPIPromptManagement:
         logging_obj.get_chat_completion_prompt.assert_called_once()
         call_kwargs = logging_obj.get_chat_completion_prompt.call_args.kwargs
         # str was coerced to a single user message before being passed to the hook
-        assert call_kwargs["messages"] == [
-            {"role": "user", "content": "Tell me about AI."}
-        ]
+        assert call_kwargs["messages"] == [{"role": "user", "content": "Tell me about AI."}]
         assert call_kwargs["prompt_id"] == "summariser-prompt"
 
     def test_list_input_merged_with_template(self):
@@ -393,3 +386,169 @@ class TestAsyncResponsesAPIPromptManagement:
         passed_messages = call_kwargs["messages"]
         assert all(isinstance(m, dict) and "role" in m for m in passed_messages)
         assert len(passed_messages) == 1
+
+
+class TestResponsesAPIPromptManagementPreservesNonMessageItems:
+    """Regression tests for https://github.com/BerriAI/litellm/issues/32335.
+
+    Multi-turn Responses API input carries role-less items ("reasoning",
+    "function_call", ...) alongside messages. The prompt management hook only
+    sees the message items; the merged result must not silently drop the
+    role-less ones, otherwise providers reject the request (Azure: "Item
+    'msg_...' was provided without its required 'reasoning' item: 'rs_...'").
+    """
+
+    @staticmethod
+    def _mixed_input():
+        return [
+            {"role": "user", "content": "Analyze this code snippet for bugs"},
+            {"type": "reasoning", "id": "rs_123", "summary": []},
+            {
+                "type": "message",
+                "id": "msg_123",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": "Analysis done", "annotations": []}],
+            },
+            {
+                "type": "function_call",
+                "id": "fc_1",
+                "call_id": "call_1",
+                "name": "lookup",
+                "arguments": "{}",
+            },
+            {"role": "user", "content": "Now check for security issues too"},
+        ]
+
+    @staticmethod
+    def _role_items(items):
+        return [item for item in items if isinstance(item, dict) and "role" in item]
+
+    def test_sync_noop_hook_preserves_non_message_items(self):
+        """When the hook returns the messages unchanged (e.g. no prompt logger
+        matched), the original input must reach the downstream handler intact,
+        including reasoning and function_call items."""
+        mixed_input = self._mixed_input()
+        client_messages = self._role_items(mixed_input)
+        logging_obj = _make_logging_obj(
+            merged_model="openai/gpt-4o",
+            merged_messages=list(client_messages),  # type: ignore[arg-type]
+        )
+
+        patches = _patch_responses_dispatch()
+        with patches[0], patches[1], patches[2], patches[3] as mock_handler:
+            import litellm
+
+            litellm.responses(
+                input=mixed_input,  # type: ignore[arg-type]
+                model="gpt-4o",
+                prompt_id="noop-hook",
+                litellm_logging_obj=logging_obj,
+            )
+
+        handler_input = mock_handler.call_args.kwargs["input"]
+        assert handler_input == mixed_input
+        assert {"type": "reasoning", "id": "rs_123", "summary": []} in handler_input
+
+    def test_sync_template_prepend_preserves_non_message_items(self):
+        """When the hook prepends template messages, the new messages are
+        prepended to the full original input rather than replacing it with the
+        filtered message subset."""
+        mixed_input = self._mixed_input()
+        client_messages = self._role_items(mixed_input)
+        template = [{"role": "system", "content": "You are a security reviewer."}]
+        logging_obj = _make_logging_obj(
+            merged_model="openai/gpt-4o",
+            merged_messages=template + list(client_messages),  # type: ignore[arg-type]
+        )
+
+        patches = _patch_responses_dispatch()
+        with patches[0], patches[1], patches[2], patches[3] as mock_handler:
+            import litellm
+
+            litellm.responses(
+                input=mixed_input,  # type: ignore[arg-type]
+                model="gpt-4o",
+                prompt_id="template-prepend",
+                litellm_logging_obj=logging_obj,
+            )
+
+        handler_input = mock_handler.call_args.kwargs["input"]
+        assert handler_input == template + mixed_input
+
+    @pytest.mark.asyncio
+    async def test_async_noop_hook_preserves_non_message_items(self):
+        """The async aresponses() path must also preserve role-less items."""
+        mixed_input = self._mixed_input()
+        client_messages = self._role_items(mixed_input)
+        logging_obj = _make_logging_obj(
+            merged_model="openai/gpt-4o",
+            merged_messages=list(client_messages),  # type: ignore[arg-type]
+        )
+
+        patches = _patch_responses_dispatch()
+        with patches[0], patches[1], patches[2], patches[3] as mock_handler:
+            import litellm
+
+            await litellm.aresponses(
+                input=mixed_input,  # type: ignore[arg-type]
+                model="gpt-4o",
+                prompt_id="async-noop-hook",
+                litellm_logging_obj=logging_obj,
+            )
+
+        handler_input = mock_handler.call_args.kwargs["input"]
+        assert handler_input == mixed_input
+
+    def test_sync_rewriting_hook_falls_back_to_merged_messages(self):
+        """When the hook rewrites messages in a way that can't be aligned with
+        the original input, the merged messages are used as-is (pre-existing
+        behavior, now logged)."""
+        mixed_input = self._mixed_input()
+        rewritten = [{"role": "user", "content": "Entirely rewritten prompt"}]
+        logging_obj = _make_logging_obj(
+            merged_model="openai/gpt-4o",
+            merged_messages=rewritten,  # type: ignore[arg-type]
+        )
+
+        patches = _patch_responses_dispatch()
+        with patches[0], patches[1], patches[2], patches[3] as mock_handler:
+            import litellm
+
+            litellm.responses(
+                input=mixed_input,  # type: ignore[arg-type]
+                model="gpt-4o",
+                prompt_id="rewriting-hook",
+                litellm_logging_obj=logging_obj,
+            )
+
+        handler_input = mock_handler.call_args.kwargs["input"]
+        assert handler_input == rewritten
+
+    def test_sync_input_with_no_message_items_preserved(self):
+        """Input consisting entirely of role-less items (no message the hook can
+        see) must survive: a template-only hook prepends its messages in front of
+        the role-less items rather than replacing them."""
+        role_less_input = [
+            {"type": "reasoning", "id": "rs_1", "summary": []},
+            {"type": "function_call_output", "call_id": "call_1", "output": "42"},
+        ]
+        template = [{"role": "system", "content": "You are helpful."}]
+        logging_obj = _make_logging_obj(
+            merged_model="openai/gpt-4o",
+            merged_messages=list(template),  # type: ignore[arg-type]
+        )
+
+        patches = _patch_responses_dispatch()
+        with patches[0], patches[1], patches[2], patches[3] as mock_handler:
+            import litellm
+
+            litellm.responses(
+                input=role_less_input,  # type: ignore[arg-type]
+                model="gpt-4o",
+                prompt_id="template-only",
+                litellm_logging_obj=logging_obj,
+            )
+
+        handler_input = mock_handler.call_args.kwargs["input"]
+        assert handler_input == template + role_less_input


### PR DESCRIPTION
## Relevant issues

Fixes #32335

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Reproduced at unit level; the three new regression tests fail on current `main` and pass with this change:

```
$ pytest tests/test_litellm/responses/test_responses_prompt_management.py -q   # before fix
FAILED ...::TestResponsesAPIPromptManagementPreservesNonMessageItems::test_async_noop_hook_preserves_non_message_items
FAILED ...::TestResponsesAPIPromptManagementPreservesNonMessageItems::test_sync_noop_hook_preserves_non_message_items
FAILED ...::TestResponsesAPIPromptManagementPreservesNonMessageItems::test_sync_template_prepend_preserves_non_message_items
3 failed, 11 passed

$ pytest tests/test_litellm/responses/test_responses_prompt_management.py -q   # with fix
14 passed
```

I don't have an Azure OpenAI reasoning-model deployment to show a live proxy round trip; the failing request shape from #32335 (multi-turn `input` echoing `response.output` reasoning items) is what the regression tests replay.

## Type

🐛 Bug Fix

## Changes

Multi-turn Responses API input can carry role-less items (`reasoning`, `function_call`, `function_call_output`, ...) alongside messages; this is what clients like the openai-agents SDK send back on turn two. When prompt management hooks run, both `aresponses()` and the sync `responses()` path filter the input down to dict items that have a `"role"` key before calling `get_chat_completion_prompt`, and then replace the entire `input` with the merged result. Every role-less item is silently dropped, so Azure rejects the request with `Item 'msg_...' of type 'message' was provided without its required 'reasoning' item: 'rs_...'` (the v1.83.7 regression reported in #32335).

This PR adds `_restore_non_message_input_items` in `litellm/responses/main.py` and calls it from both paths after the hook merge. When nothing was filtered out, behavior is unchanged. When the hook made no changes (the common case where the hook gate fires but no prompt logger matches), the original input is kept untouched. When the hook prepended messages (prompt template pattern), the prepended messages are attached in front of the full original input instead of the filtered subset. If the hook rewrote messages in a way that can't be aligned with the original list, the merged messages are used as before, now with a warning log so the dropped items are observable.

Tests live in the mapped file `tests/test_litellm/responses/test_responses_prompt_management.py`: sync and async no-op hook preservation, template-prepend preservation, and the rewrite fallback.
