### PR TITLE
fix: map chat file URLs to responses file_url

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -114,6 +114,15 @@ def _reasoning_item_to_response_input(
     return r_input
 
 
+def _convert_chat_file_id_to_responses_file_reference(file_data: Dict[str, Any]) -> Dict[str, Any]:
+    if "file_id" not in file_data:
+        return {}
+    file_id = file_data["file_id"]
+    if isinstance(file_id, str) and file_id.startswith(("http://", "https://")):
+        return {"file_url": file_id}
+    return {"file_id": file_id}
+
+
 class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
     """
     Handler for transforming /chat/completions api requests to litellm.responses requests
@@ -834,7 +843,8 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                             file_data = item.get("file", {})
                             converted = {"type": "input_file"}
                             if isinstance(file_data, dict):
-                                for key in ["file_id", "file_data", "filename"]:
+                                converted.update(_convert_chat_file_id_to_responses_file_reference(file_data))
+                                for key in ["file_data", "filename"]:
                                     if key in file_data:
                                         converted[key] = file_data[key]
                             result.append(converted)

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -2576,6 +2576,41 @@ def test_convert_chat_completion_file_type_with_file_id():
     assert "file_data" not in content[1]
 
 
+def test_convert_chat_completion_file_type_with_url_file_id_maps_to_file_url():
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    handler = LiteLLMResponsesTransformationHandler()
+    file_url = "https://arxiv.org/pdf/1706.03762"
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is this document about?"},
+                {
+                    "type": "file",
+                    "file": {
+                        "file_id": file_url,
+                        "format": "application/pdf",
+                    },
+                },
+            ],
+        }
+    ]
+
+    (
+        input_items,
+        instructions,
+    ) = handler.convert_chat_completion_messages_to_responses_api(messages)
+
+    content = input_items[0]["content"]
+    assert content[1]["type"] == "input_file"
+    assert content[1]["file_url"] == file_url
+    assert "file_id" not in content[1]
+
+
 # =============================================================================
 # Tests for reasoning_items round-trip (encrypted_content preservation)
 # =============================================================================


### PR DESCRIPTION
## Relevant issues

Fixes #25456

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

No live proxy proof captured in this Windows workspace because provider-backed e2e configuration is not available here

Local regression evidence before the fix:

```text
test_convert_chat_completion_file_type_with_url_file_id_maps_to_file_url failed with KeyError: 'file_url'
```

Local regression evidence after commit `c05e3a6a99`:

```text
python -m pytest tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py -q
46 passed in 1.88s

python -m ruff format --check litellm/completion_extras/litellm_responses_transformation/transformation.py
1 file already formatted

python -m ruff check litellm/completion_extras/litellm_responses_transformation/transformation.py
All checks passed

python scripts/ruff_strict_gate.py --base upstream/litellm_internal_staging
OK: every strict rule is within its codebase ceiling

git diff --check
passed with no output
```

`make pre-commit` could not run locally because `make` is not available in this Windows shell

GitHub Actions, Codecov, and CodSpeed Performance Analysis passed

Greptile Confidence Score: 5/5

## Type

Bug Fix
Test

## Changes

Maps Chat Completions `file.file_id` URL inputs to Responses API `input_file.file_url` while preserving non-URL file ids as `input_file.file_id`

Adds a regression test for the documented URL pattern from #25456

