### PR TITLE
fix(videos): return 404 when video content is not ready

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -6879,6 +6879,8 @@ class BaseLLMHTTPHandler:
                     params=data,
                 )
 
+            response.raise_for_status()
+
             # Transform the response using the provider config
             return video_content_provider_config.transform_video_content_response(
                 raw_response=response,
@@ -6956,6 +6958,8 @@ class BaseLLMHTTPHandler:
                     headers=headers,
                     params=data,
                 )
+
+            response.raise_for_status()
 
             # Transform the response using the provider config
             return await video_content_provider_config.async_transform_video_content_response(

--- a/tests/test_litellm/test_video_generation.py
+++ b/tests/test_litellm/test_video_generation.py
@@ -1134,6 +1134,56 @@ def test_video_content_handler_uses_get_for_openai():
     assert called_url == "https://api.openai.com/v1/videos/video_abc/content"
 
 
+def test_video_content_handler_raises_on_not_ready_response():
+    """OpenAI returns 404 while video is processing; proxy must not return 200."""
+    import httpx
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+    from litellm.llms.base_llm.chat.transformation import BaseLLMException
+    from litellm.types.router import GenericLiteLLMParams
+
+    if hasattr(litellm, "in_memory_llm_clients_cache"):
+        litellm.in_memory_llm_clients_cache.flush_cache()
+
+    handler = BaseLLMHTTPHandler()
+    config = OpenAIVideoConfig()
+    error_body = (
+        '{"error":{"message":"Video is not ready yet, use GET /v1/videos/{video_id} to check status",'
+        '"type":"invalid_request_error","param":null,"code":null}}'
+    )
+    mock_response = httpx.Response(
+        status_code=404,
+        content=error_body.encode(),
+        request=httpx.Request(
+            "GET", "https://api.openai.com/v1/videos/video_abc/content"
+        ),
+    )
+
+    mock_client = MagicMock(spec=HTTPHandler)
+    mock_client.get.return_value = mock_response
+
+    with patch(
+        "litellm.llms.custom_httpx.llm_http_handler._get_httpx_client",
+        return_value=mock_client,
+    ):
+        with pytest.raises(BaseLLMException) as exc_info:
+            handler.video_content_handler(
+                video_id="video_abc",
+                video_content_provider_config=config,
+                custom_llm_provider="openai",
+                litellm_params=GenericLiteLLMParams(
+                    api_base="https://api.openai.com/v1"
+                ),
+                logging_obj=MagicMock(),
+                timeout=5.0,
+                api_key="sk-test",
+                client=mock_client,
+                _is_async=False,
+            )
+
+    assert exc_info.value.status_code == 404
+    assert "Video is not ready yet" in exc_info.value.message
+
+
 def test_video_content_respects_api_base_and_api_key_from_kwargs():
     """Test that video_content respects api_base and api_key from kwargs (simulating database entry)."""
     from litellm.videos.main import video_content

--- a/tests/test_litellm/test_video_generation.py
+++ b/tests/test_litellm/test_video_generation.py
@@ -1184,6 +1184,55 @@ def test_video_content_handler_raises_on_not_ready_response():
     assert "Video is not ready yet" in exc_info.value.message
 
 
+@pytest.mark.asyncio
+async def test_async_video_content_handler_raises_on_not_ready_response():
+    """Async path must also propagate upstream 404 while video is processing."""
+    import httpx
+    from litellm.llms.base_llm.chat.transformation import BaseLLMException
+    from litellm.types.router import GenericLiteLLMParams
+
+    if hasattr(litellm, "in_memory_llm_clients_cache"):
+        litellm.in_memory_llm_clients_cache.flush_cache()
+
+    handler = BaseLLMHTTPHandler()
+    config = OpenAIVideoConfig()
+    error_body = (
+        '{"error":{"message":"Video is not ready yet, use GET /v1/videos/{video_id} to check status",'
+        '"type":"invalid_request_error","param":null,"code":null}}'
+    )
+    mock_response = httpx.Response(
+        status_code=404,
+        content=error_body.encode(),
+        request=httpx.Request(
+            "GET", "https://api.openai.com/v1/videos/video_abc/content"
+        ),
+    )
+
+    mock_client = MagicMock(spec=AsyncHTTPHandler)
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    with patch(
+        "litellm.llms.custom_httpx.llm_http_handler.get_async_httpx_client",
+        return_value=mock_client,
+    ):
+        with pytest.raises(BaseLLMException) as exc_info:
+            await handler.async_video_content_handler(
+                video_id="video_abc",
+                video_content_provider_config=config,
+                custom_llm_provider="openai",
+                litellm_params=GenericLiteLLMParams(
+                    api_base="https://api.openai.com/v1"
+                ),
+                logging_obj=MagicMock(),
+                timeout=5.0,
+                api_key="sk-test",
+                client=mock_client,
+            )
+
+    assert exc_info.value.status_code == 404
+    assert "Video is not ready yet" in exc_info.value.message
+
+
 def test_video_content_respects_api_base_and_api_key_from_kwargs():
     """Test that video_content respects api_base and api_key from kwargs (simulating database entry)."""
     from litellm.videos.main import video_content


### PR DESCRIPTION
## Summary
- Add `raise_for_status()` to sync/async `video_content_handler` so upstream 404s are propagated instead of returned as 200 with error JSON as `video/mp4`
- Verified against live OpenAI API: `GET /v1/videos/{id}/content` returns 404 with `"Video is not ready yet..."` while status is `queued`/`in_progress`
- Added test asserting a 404 upstream response raises with status 404 and the OpenAI error message


**Before the video generation is completed**
<img width="1094" height="731" alt="image" src="https://github.com/user-attachments/assets/3ff0e989-9045-46bd-bd0b-bdb7268a01d5" />

**After the video generation is completed** 
<img width="1094" height="812" alt="image" src="https://github.com/user-attachments/assets/703000a2-b1e5-49e1-93fc-9359aea89f96" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fix that only affects error handling on the video content download path; success behavior is unchanged.
> 
> **Overview**
> Fixes a bug where **sync and async `video_content_handler`** treated upstream error responses (e.g. OpenAI **404** while a video is still `queued`/`in_progress`) as success and passed the error JSON through the content transform—so clients could see **HTTP 200** with `video/mp4` body containing JSON instead of the real status.
> 
> Both paths now call **`response.raise_for_status()`** after the GET/POST, matching other handlers in `llm_http_handler.py`, so failures flow through **`_handle_error`** and surface as **`BaseLLMException`** with the upstream status and message.
> 
> Tests cover sync and async handlers with a mocked **404** “Video is not ready yet” response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4440de8cfd6a90251966239dcf9b34681dbf499d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->