### PR TITLE
fix(tests): poll proxy readiness instead of probing it once

### DIFF
--- a/tests/spend_tracking_tests/test_spend_accuracy_tests.py
+++ b/tests/spend_tracking_tests/test_spend_accuracy_tests.py
@@ -45,6 +45,11 @@ UPSTREAM_MODEL = "gpt-5-mini"
 POLL_INTERVAL_SECONDS = 2
 POLL_TIMEOUT_SECONDS = 60
 
+# The proxy binds the port before Prisma finishes connecting, and CI's wait step
+# only checks that the port answers. Poll readiness rather than probing it once.
+READINESS_POLL_INTERVAL_SECONDS = 2
+READINESS_TIMEOUT_SECONDS = 60
+
 TOLERANCE = 1e-10
 
 
@@ -135,15 +140,35 @@ async def get_proxy_readiness(session):
         return response.status, await response.json()
 
 
-async def assert_proxy_healthy(session):
-    """Fail fast if the proxy's DB or cache is not reachable — no point running the test."""
-    status, body = await get_proxy_readiness(session)
-    if status != 200 or body.get("db") != "connected":
-        pytest.fail(
-            f"Proxy /health/readiness/details unhealthy (status={status}). "
-            f"Cannot run spend accuracy test. Response: {body}"
-        )
-    print(f"Proxy readiness OK: {body}")
+async def assert_proxy_healthy(session, timeout_seconds: float = READINESS_TIMEOUT_SECONDS):
+    """
+    Wait for the proxy's DB link, then fail if it never comes up.
+
+    The proxy serves HTTP before Prisma finishes connecting, and CI only waits
+    for the port to answer. Probing readiness once therefore races startup and
+    fails the whole run under pytest -x before a single spend assertion runs.
+    Polling instead of failing on the first probe removes the race; a proxy that
+    is genuinely broken still fails, just `timeout_seconds` later.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    status, body = None, None
+    while True:
+        try:
+            status, body = await get_proxy_readiness(session)
+        except aiohttp.ClientError as exc:
+            status, body = None, {"error": repr(exc)}
+
+        if status == 200 and body.get("db") == "connected":
+            print(f"Proxy readiness OK: {body}")
+            return
+
+        if time.monotonic() >= deadline:
+            pytest.fail(
+                f"Proxy /health/readiness/details never reported db=connected within "
+                f"{timeout_seconds}s (last status={status}). "
+                f"Cannot run spend accuracy test. Response: {body}"
+            )
+        await asyncio.sleep(READINESS_POLL_INTERVAL_SECONDS)
 
 
 def compute_expected_spend(responses) -> float:
@@ -393,3 +418,87 @@ async def test_long_term_spend_accuracy_with_bursts():
         assert (
             abs(org_info["spend"] - total_expected) < TOLERANCE
         ), f"Organization spend {org_info['spend']} does not match expected {total_expected}"
+
+
+class _FakeReadinessResponse:
+    def __init__(self, status, body):
+        self.status = status
+        self._body = body
+
+    async def json(self):
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
+class _FakeReadinessSession:
+    """Replays a scripted readiness sequence. A ClientError entry is raised, not returned."""
+
+    def __init__(self, script):
+        self._script = list(script)
+        self.calls = 0
+
+    def get(self, url, headers=None):
+        self.calls += 1
+        step = self._script[min(self.calls - 1, len(self._script) - 1)]
+        if isinstance(step, Exception):
+            raise step
+        status, body = step
+        return _FakeReadinessResponse(status, body)
+
+
+@pytest.fixture
+def no_readiness_backoff(monkeypatch):
+    """Collapse the retry sleep so the polling tests do not pay real wall-clock."""
+    monkeypatch.setitem(globals(), "READINESS_POLL_INTERVAL_SECONDS", 0)
+
+
+@pytest.mark.asyncio
+async def test_assert_proxy_healthy_waits_for_db_to_connect(no_readiness_backoff):
+    """
+    The proxy answers on the port before Prisma connects. A single probe would
+    fail the run here; the gate must keep polling until db=connected.
+    """
+    session = _FakeReadinessSession(
+        [
+            (503, {"db": "not_connected"}),
+            (200, {"db": "not_connected"}),
+            (200, {"db": "connected"}),
+        ]
+    )
+
+    await assert_proxy_healthy(session, timeout_seconds=5)
+
+    assert session.calls == 3
+
+
+@pytest.mark.asyncio
+async def test_assert_proxy_healthy_retries_through_connection_errors(no_readiness_backoff):
+    """A refused connection during startup is a retryable condition, not a verdict."""
+    session = _FakeReadinessSession(
+        [
+            aiohttp.ClientConnectionError("connection refused"),
+            (200, {"db": "connected"}),
+        ]
+    )
+
+    await assert_proxy_healthy(session, timeout_seconds=5)
+
+    assert session.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_assert_proxy_healthy_fails_when_db_never_connects(no_readiness_backoff):
+    """A genuinely broken proxy still fails, bounded by the timeout rather than hanging."""
+    session = _FakeReadinessSession([(200, {"db": "not_connected"})])
+
+    started = time.monotonic()
+    with pytest.raises(pytest.fail.Exception, match="never reported db=connected"):
+        await assert_proxy_healthy(session, timeout_seconds=0.2)
+
+    assert time.monotonic() - started < 5
+    assert session.calls >= 1


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This changes a CI test harness, so there is no end-user request to curl; the consumer of this code is the `proxy_spend_accuracy_tests` job. The proof is therefore the observed CI behavior plus a before/after run of the gate itself

Real CI evidence for the race. On one pipeline the job went `pending` at 08:23:56Z and `failure` at 08:25:21Z, which is 85 seconds. A passing run of the same job takes about 230 seconds (`pending` 07:53:18Z, `success` 07:57:08Z). Setup alone (uv sync, postgres, redis, `docker load`, `wait_for_service`) consumes most of a passing run, so an 85 second failure never reaches the first spend assertion. It died in `assert_proxy_healthy`, which is the first thing each test does. The sibling job `build_and_test` requires the same `build_docker_database_image`, loads the same image and boots the same proxy; it started 7 seconds later and passed, so the image and the proxy itself were fine. The identical tree then passed the spend job on a later run with no code change touching it, which is what a race looks like

Before, at `f0b217f2c26c60c515c5cf1c3dc425e8f1ab01b0` (single-probe gate), the three new tests fail because the gate gives a verdict on the first probe:

```
$ python -m pytest -q tests/spend_tracking_tests/test_spend_accuracy_tests.py -k assert_proxy_healthy
FAILED tests/spend_tracking_tests/test_spend_accuracy_tests.py::test_assert_proxy_healthy_waits_for_db_to_connect
FAILED tests/spend_tracking_tests/test_spend_accuracy_tests.py::test_assert_proxy_healthy_retries_through_connection_errors
FAILED tests/spend_tracking_tests/test_spend_accuracy_tests.py::test_assert_proxy_healthy_fails_when_db_never_connects
3 failed, 2 deselected in 1.16s
```

After, at `dd15fc0e74` (this branch):

```
$ python -m pytest -q tests/spend_tracking_tests/test_spend_accuracy_tests.py -k assert_proxy_healthy
...                                                                      [100%]
3 passed, 2 deselected in 1.43s
```

The green `proxy_spend_accuracy_tests` job on this PR is the end-to-end proof: it boots the real dockerized proxy against real postgres and redis, drives real chat completions, and passes through the new gate

## Type

🚄 Infrastructure

✅ Test

## Changes

`assert_proxy_healthy` in `tests/spend_tracking_tests/test_spend_accuracy_tests.py` probed `GET /health/readiness/details` exactly once and called `pytest.fail` if the response was not 200 with `db=connected`. CircleCI's `wait_for_service` step only waits for port 4000 to answer, and the proxy binds that port before Prisma finishes connecting, so the gate raced proxy startup. Because the job runs `pytest -x`, losing that race killed the entire job on the first test rather than on anything the tests are meant to measure

The gate now polls readiness for a bounded 60 seconds at a 2 second interval before giving up, and treats an `aiohttp.ClientError` during startup as retryable rather than as a verdict. A proxy that is genuinely broken still fails the run; it just fails 60 seconds later, and the failure message now carries the last observed status and body so the CI output still points at the real cause

`wait_for_service` was left alone deliberately. It is a shared CircleCI command used for plain TCP waits on postgres and redis as well, so teaching it to understand an authenticated proxy readiness endpoint would be a larger and less obvious diff than fixing the gate that actually makes the assertion

Three tests cover the new behavior, all driven by a scripted fake session so they need no live proxy: readiness that reports `db=not_connected` before it connects is waited out, a connection error during startup is retried, and a proxy that never connects still fails inside the timeout instead of hanging. Each of the three fails against the previous single-probe gate
