### PR TITLE
fix(bedrock): add type to tool_choice when disabling parallel tool use

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -100,6 +100,52 @@ UNSUPPORTED_BEDROCK_CONVERSE_BETA_PATTERNS = [
 ]
 
 
+def _bedrock_tool_choice_type(tool_choice: Any) -> str:
+    """Map an OpenAI tool_choice to the Anthropic ``tool_choice.type`` used in the
+    Bedrock parallel-tool-use config: ``required`` -> ``any``, a named-function
+    dict -> ``tool``, everything else (incl. ``auto`` / unset) -> ``auto``.
+
+    Derives the type from an explicit tool_choice so the parallel-tool-use config
+    does not override the caller's intent with ``auto``.
+    """
+    if tool_choice == "required":
+        return "any"
+    if isinstance(tool_choice, dict) and tool_choice.get("type") == "function":
+        return "tool"
+    return "auto"
+
+
+def _apply_parallel_tool_use_config(
+    parallel_tool_use_config: dict,
+    additional_request_params: dict,
+    inference_params: dict,
+) -> None:
+    """Merge the parallel-tool-use config into ``additionalModelRequestFields``.
+
+    The disable-parallel flag can only ride on the Anthropic-passthrough
+    ``tool_choice`` (Bedrock's native ``toolConfig.toolChoice`` has no such
+    field). When an explicit tool_choice was ALSO mapped into the native
+    channel, sending both makes Bedrock reject the request ("The additional
+    field tool_choice/type conflicts with the existing field
+    toolConfig.toolChoice.<type>"). The passthrough already carries the
+    equivalent type (any/auto/tool), so drop the native toolChoice to leave a
+    single, non-conflicting directive.
+    """
+    for key, value in parallel_tool_use_config.items():
+        if (
+            key in additional_request_params
+            and isinstance(additional_request_params[key], dict)
+            and isinstance(value, dict)
+        ):
+            additional_request_params[key].update(value)
+        else:
+            additional_request_params[key] = value
+
+    passthrough_tool_choice = parallel_tool_use_config.get("tool_choice")
+    if isinstance(passthrough_tool_choice, dict) and "type" in passthrough_tool_choice:
+        inference_params.pop("tool_choice", None)
+
+
 class AmazonConverseConfig(BaseConfig):
     """
     Reference - https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
@@ -893,9 +939,16 @@ class AmazonConverseConfig(BaseConfig):
                 if _tool_choice_value is not None:
                     optional_params["tool_choice"] = _tool_choice_value
             if param == "parallel_tool_calls":
-                disable_parallel = not value
+                # ``tool_choice`` forwarded to the Anthropic-on-Bedrock validator
+                # requires a ``type`` (matches the native Anthropic transform,
+                # which sets disable_parallel_tool_use on the existing choice and
+                # defaults to ``type="auto"`` only when none was given). Without a
+                # ``type`` Bedrock Converse returns 400 "missing field `type`".
                 optional_params["_parallel_tool_use_config"] = {
-                    "tool_choice": {"disable_parallel_tool_use": disable_parallel}
+                    "tool_choice": {
+                        "type": _bedrock_tool_choice_type(non_default_params.get("tool_choice")),
+                        "disable_parallel_tool_use": not value,
+                    }
                 }
             if param == "thinking":
                 optional_params["thinking"] = value
@@ -1253,15 +1306,7 @@ class AmazonConverseConfig(BaseConfig):
         # Handle parallel_tool_calls configuration
         parallel_tool_use_config = additional_request_params.pop("_parallel_tool_use_config", None)
         if parallel_tool_use_config is not None and bedrock_converse_supports_parallel_tool_use_config(model):
-            for key, value in parallel_tool_use_config.items():
-                if (
-                    key in additional_request_params
-                    and isinstance(additional_request_params[key], dict)
-                    and isinstance(value, dict)
-                ):
-                    additional_request_params[key].update(value)
-                else:
-                    additional_request_params[key] = value
+            _apply_parallel_tool_use_config(parallel_tool_use_config, additional_request_params, inference_params)
 
         additional_request_params.pop("parallel_tool_calls", None)
 

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -115,6 +115,30 @@ def _bedrock_tool_choice_type(tool_choice: Any) -> str:
     return "auto"
 
 
+def _bedrock_parallel_tool_choice(tool_choice: Any, disable_parallel: bool) -> dict:
+    """Build the Anthropic-on-Bedrock ``tool_choice`` payload for the
+    parallel-tool-use config.
+
+    Derives ``type`` from an explicit tool_choice (see
+    ``_bedrock_tool_choice_type``) and carries the ``disable_parallel_tool_use``
+    flag this config exists to set. For a named-function choice (``type ==
+    "tool"``) it also forwards the function ``name`` — mirroring the native
+    Anthropic transform (``_tool_choice["name"] = _tool_name``). Without the
+    name, ``_apply_parallel_tool_use_config`` drops the native ``toolChoice``
+    that carried it, so Bedrock would receive ``type="tool"`` with no tool named
+    and reject the request.
+    """
+    payload: dict = {
+        "type": _bedrock_tool_choice_type(tool_choice),
+        "disable_parallel_tool_use": disable_parallel,
+    }
+    if payload["type"] == "tool" and isinstance(tool_choice, dict):
+        name = tool_choice.get("function", {}).get("name")
+        if name:
+            payload["name"] = name
+    return payload
+
+
 def _apply_parallel_tool_use_config(
     parallel_tool_use_config: dict,
     additional_request_params: dict,
@@ -945,10 +969,7 @@ class AmazonConverseConfig(BaseConfig):
                 # defaults to ``type="auto"`` only when none was given). Without a
                 # ``type`` Bedrock Converse returns 400 "missing field `type`".
                 optional_params["_parallel_tool_use_config"] = {
-                    "tool_choice": {
-                        "type": _bedrock_tool_choice_type(non_default_params.get("tool_choice")),
-                        "disable_parallel_tool_use": not value,
-                    }
+                    "tool_choice": _bedrock_parallel_tool_choice(non_default_params.get("tool_choice"), not value)
                 }
             if param == "thinking":
                 optional_params["thinking"] = value

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -696,17 +696,24 @@ def test_parallel_tool_calls_tool_choice_includes_type(model: str):
 
 
 @pytest.mark.parametrize(
-    "tool_choice, expected_type",
+    "tool_choice, expected_type, expected_name",
     [
         # An explicit tool_choice must drive the parallel-config type rather than
         # being silently overridden with "auto" (mirrors the native Anthropic
         # transform, which sets disable_parallel_tool_use on the existing choice).
-        ("required", "any"),
-        ("auto", "auto"),
-        ({"type": "function", "function": {"name": "get_current_weather"}}, "tool"),
+        ("required", "any", None),
+        ("auto", "auto", None),
+        # A named-function choice must forward the function name alongside
+        # type="tool" — else _apply_parallel_tool_use_config drops the native
+        # toolChoice carrying it and Bedrock gets a nameless "tool" choice.
+        (
+            {"type": "function", "function": {"name": "get_current_weather"}},
+            "tool",
+            "get_current_weather",
+        ),
     ],
 )
-def test_parallel_tool_calls_preserves_explicit_tool_choice_type(tool_choice, expected_type):
+def test_parallel_tool_calls_preserves_explicit_tool_choice_type(tool_choice, expected_type, expected_name):
     old_env = os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP")
     old_cost = litellm.model_cost
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
@@ -726,6 +733,53 @@ def test_parallel_tool_calls_preserves_explicit_tool_choice_type(tool_choice, ex
         tc = optional_params["_parallel_tool_use_config"]["tool_choice"]
         assert tc["type"] == expected_type, f"expected {expected_type}, got {tc}"
         assert tc["disable_parallel_tool_use"] is True
+        assert tc.get("name") == expected_name, f"name mismatch: {tc}"
+    finally:
+        litellm.model_cost = old_cost
+        if old_env is None:
+            os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
+        else:
+            os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = old_env
+
+
+def test_parallel_tool_calls_named_function_survives_to_request():
+    """End-to-end: a named-function tool_choice with parallel_tool_calls=False
+    must reach Bedrock as a single, complete tool_choice — type="tool" WITH the
+    function name — in additionalModelRequestFields, and the native toolChoice
+    must be dropped so the two don't conflict."""
+    old_env = os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP")
+    old_cost = litellm.model_cost
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    try:
+        config = AmazonConverseConfig()
+        optional_params = config.map_openai_params(
+            model="anthropic.claude-sonnet-5",
+            non_default_params={
+                "tool_choice": {
+                    "type": "function",
+                    "function": {"name": "get_current_weather"},
+                },
+                "parallel_tool_calls": False,
+                "tools": _TOOL_PARAM,
+            },
+            optional_params={},
+            drop_params=False,
+        )
+        data = config._transform_request_helper(
+            model="anthropic.claude-sonnet-5",
+            system_content_blocks=[],
+            optional_params=optional_params,
+            messages=None,
+        )
+        tool_choice = data["additionalModelRequestFields"]["tool_choice"]
+        assert tool_choice == {
+            "type": "tool",
+            "name": "get_current_weather",
+            "disable_parallel_tool_use": True,
+        }
+        # Native toolChoice dropped to avoid the conflicting-field 400.
+        assert "toolChoice" not in data.get("toolConfig", {})
     finally:
         litellm.model_cost = old_cost
         if old_env is None:

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -632,9 +632,100 @@ def test_parallel_tool_calls_config_kept_for_sonnet_5():
             messages=None,
         )
 
+        # ``tool_choice`` must carry ``type`` — the Anthropic-on-Bedrock
+        # validator returns 400 "missing field `type`" otherwise (verified live
+        # against Sonnet 5 / Opus 4.8 Converse). Mirrors the native Anthropic
+        # transform, which defaults to ``type="auto"``.
         assert data["additionalModelRequestFields"]["tool_choice"] == {
-            "disable_parallel_tool_use": True
+            "type": "auto",
+            "disable_parallel_tool_use": True,
         }
+    finally:
+        litellm.model_cost = old_cost
+        if old_env is None:
+            os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
+        else:
+            os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = old_env
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        # Current-gen Anthropic-on-Bedrock models (released after the original
+        # Claude-4.5-only report #22637) — all route through the validator that
+        # requires tool_choice.type. Verified live: typeless -> 400
+        # "missing field `type`"; with type="auto" -> 200.
+        "anthropic.claude-sonnet-5",
+        "us.anthropic.claude-sonnet-5",
+        "anthropic.claude-opus-4-8",
+        "us.anthropic.claude-opus-4-8",
+        "anthropic.claude-fable-5",
+        "us.anthropic.claude-fable-5",
+    ],
+)
+def test_parallel_tool_calls_tool_choice_includes_type(model: str):
+    """tool_choice must carry ``type`` for every current Bedrock Converse model
+    that supports the parallel-tool-use config, else Bedrock 400s."""
+    old_env = os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP")
+    old_cost = litellm.model_cost
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    try:
+        config = AmazonConverseConfig()
+        optional_params = config.map_openai_params(
+            model=model,
+            non_default_params={"parallel_tool_calls": False},
+            optional_params={},
+            drop_params=False,
+        )
+        data = config._transform_request_helper(
+            model=model,
+            system_content_blocks=[],
+            optional_params=optional_params,
+            messages=None,
+        )
+        tool_choice = data["additionalModelRequestFields"]["tool_choice"]
+        assert tool_choice["type"] == "auto", f"tool_choice.type missing for {model}: {tool_choice}"
+        assert tool_choice["disable_parallel_tool_use"] is True
+    finally:
+        litellm.model_cost = old_cost
+        if old_env is None:
+            os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
+        else:
+            os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = old_env
+
+
+@pytest.mark.parametrize(
+    "tool_choice, expected_type",
+    [
+        # An explicit tool_choice must drive the parallel-config type rather than
+        # being silently overridden with "auto" (mirrors the native Anthropic
+        # transform, which sets disable_parallel_tool_use on the existing choice).
+        ("required", "any"),
+        ("auto", "auto"),
+        ({"type": "function", "function": {"name": "get_current_weather"}}, "tool"),
+    ],
+)
+def test_parallel_tool_calls_preserves_explicit_tool_choice_type(tool_choice, expected_type):
+    old_env = os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP")
+    old_cost = litellm.model_cost
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    try:
+        config = AmazonConverseConfig()
+        optional_params = config.map_openai_params(
+            model="anthropic.claude-sonnet-5",
+            non_default_params={
+                "tool_choice": tool_choice,
+                "parallel_tool_calls": False,
+                "tools": _TOOL_PARAM,
+            },
+            optional_params={},
+            drop_params=False,
+        )
+        tc = optional_params["_parallel_tool_use_config"]["tool_choice"]
+        assert tc["type"] == expected_type, f"expected {expected_type}, got {tc}"
+        assert tc["disable_parallel_tool_use"] is True
     finally:
         litellm.model_cost = old_cost
         if old_env is None:


### PR DESCRIPTION
## Relevant issues

Fixes #22637. Supersedes the stalled #22638 (same one-line root fix by @baniol, but that PR has been `CONFLICTING` / merge-blocked since 2026-05-21) — this is rebased on current `main` and extends coverage to the models that released since (Sonnet 5, Opus 4.8, Fable 5).

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## What this fixes

When `parallel_tool_calls=False` is passed for a Bedrock Converse Anthropic model, `map_openai_params` builds `additionalModelRequestFields.tool_choice` with only `disable_parallel_tool_use` and **no `type`**. Anthropic's Bedrock validator rejects it:

```
tool_choice.type: Field required   (a.k.a. "missing field \`type\`")
```

Originally reported for Claude 4.5 (#22637), but since litellm added `bedrock_converse_supports_parallel_tool_use_config` the config now applies to **all current Anthropic-on-Bedrock models**, so any tool-calling request with `parallel_tool_calls=False` 400s at the first call (SDKs such as openai-agents set this by default).

## The change

Add `"type": "auto"` to the emitted `tool_choice`, matching the native Anthropic transform (`litellm/llms/anthropic/chat/transformation.py`), which already defaults to `type="auto"` when only the disable-parallel flag is set. One line + tests.

## Screenshots / Proof of Fix

Live Bedrock Converse (us-east-1, real $), at commit `133fb41`:

```
# us.anthropic.claude-sonnet-5
  BEFORE (litellm today: no type): 400 -> missing field `type` at line 1 column 326
  AFTER  (this PR: type=auto):     200 OK (stop=tool_use)
# us.anthropic.claude-opus-4-8
  BEFORE: 400 -> missing field `type`     AFTER: 200 OK
# us.anthropic.claude-fable-5
  BEFORE: 400 -> missing field `type`     AFTER: 200 OK
```

Unit tests: `pytest tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py -k parallel_tool_calls` → 11 passed (incl. a new parametrized regression over Sonnet 5 / Opus 4.8 / Fable 5).

## Type

🐛 Bug Fix

Co-authored with Claude Opus 4.8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bedrock Converse request handling so parallel tool-use settings are sent with the required `tool_choice.type`, preventing validation errors.
  * Avoided conflicts when both native and forwarded tool-choice settings are present.
  * Expanded coverage for parallel tool-call behavior across newer Claude models, including explicit and automatic tool-choice cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->