### PR TITLE
fix(audio): derive transcription filename with os.path.basename

### DIFF
--- a/litellm/litellm_core_utils/audio_utils/utils.py
+++ b/litellm/litellm_core_utils/audio_utils/utils.py
@@ -69,7 +69,7 @@ def process_audio_file(audio_file: FileTypes) -> ProcessedAudioFile:
         file_path = str(audio_file)
         with open(file_path, "rb") as f:
             file_content = f.read()
-        filename = file_path.split("/")[-1]
+        filename = os.path.basename(file_path)
     elif isinstance(audio_file, tuple):
         # Tuple format: (filename, content, content_type) or (filename, content)
         if len(audio_file) >= 2:

--- a/tests/test_litellm/litellm_core_utils/test_audio_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_audio_utils.py
@@ -69,6 +69,35 @@ class TestProcessAudioFile:
         with pytest.raises(ValueError, match="does not accept bare str inputs"):
             process_audio_file("/etc/passwd")
 
+    def test_process_windows_pathlib_input_basename(self):
+        """A Windows path must yield only the basename, not the full drive path.
+
+        On Windows, str(Path('C:/dir/name.mp3')) is 'C:\\dir\\name.mp3', which
+        contains no '/'. Deriving the filename with str.split('/')[-1] would send
+        the entire path (drive letter and backslashes) to the provider as the
+        multipart file name. os.path is patched to ntpath here to reproduce
+        Windows semantics on any host.
+        """
+        import ntpath
+        from pathlib import PureWindowsPath
+
+        windows_path = PureWindowsPath("C:/Users/me/audio recording.mp3")
+        test_content = b"test audio content"
+
+        with (
+            patch("litellm.litellm_core_utils.audio_utils.utils.os.path", ntpath),
+            patch(
+                "litellm.litellm_core_utils.audio_utils.utils.open",
+                mock_open(read_data=test_content),
+                create=True,
+            ),
+        ):
+            result = process_audio_file(windows_path)
+
+        assert result.file_content == test_content
+        assert result.filename == "audio recording.mp3"
+        assert result.content_type == "audio/mpeg"
+
     def test_process_tuple_input_with_bytes(self):
         """Test processing tuple input with bytes content"""
         filename = "test.wav"


### PR DESCRIPTION

## Relevant issues

No existing issue. This is a small correctness fix found while reading the
file-input hardening added in #27762.

## Linear ticket

<!-- external contributor: none -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

`process_audio_file` builds the multipart file name that is sent to provider
transcription APIs. For a `PathLike` input on Windows the file name was the
whole path instead of the base name. The added regression test reproduces
Windows path semantics on any host by pointing the module's `os.path` at
`ntpath`:

Before the fix (old `file_path.split("/")[-1]`):

```
assert result.filename == "audio recording.mp3"
AssertionError: assert 'C:\\Users\\me\\audio recording.mp3' == 'audio recording.mp3'
```

After the fix (`os.path.basename(file_path)`):

```
tests/test_litellm/litellm_core_utils/test_audio_utils.py::TestProcessAudioFile::test_process_windows_pathlib_input_basename PASSED
```

## Type

🐛 Bug Fix

## Changes

`process_audio_file` (in `litellm/litellm_core_utils/audio_utils/utils.py`)
derived the multipart file name from a `PathLike` input with
`filename = file_path.split("/")[-1]`, where `file_path = str(audio_file)`.

That split assumes a POSIX separator. On Windows,
`str(Path("C:/dir/name.mp3"))` is `"C:\\dir\\name.mp3"`, which contains no
forward slash, so `split("/")[-1]` returns the entire path (drive letter and
backslashes) rather than the base name. The full path then reaches provider
transcription requests as the form-data file part name (for example the
`files={"file": (filename, content, content_type)}` payload built by the
mistral, soniox, azure, deepgram and other transcription transformers that call
`process_audio_file`).

The fix uses `os.path.basename(file_path)`, which extracts the base name
correctly on each OS because `str(PathLike)` and `os.path` use the same
separator for the host. This matches the sibling `PathLike` file-input sink in
`litellm/ocr/main.py`, which was hardened alongside this code in #27762.

A regression test (`test_process_windows_pathlib_input_basename`) was added to
the existing mapped test file. It patches the module's `os.path` to `ntpath`
and feeds a `PureWindowsPath`, so it reproduces Windows behavior on the POSIX CI
host: it fails on the old split (the full path leaks) and passes on the fix.

---

## Diff (2 files, +30 / -1)

```diff
diff --git a/litellm/litellm_core_utils/audio_utils/utils.py b/litellm/litellm_core_utils/audio_utils/utils.py
@@ -69,7 +69,7 @@ def process_audio_file(audio_file: FileTypes) -> ProcessedAudioFile:
         file_path = str(audio_file)
         with open(file_path, "rb") as f:
             file_content = f.read()
-        filename = file_path.split("/")[-1]
+        filename = os.path.basename(file_path)
     elif isinstance(audio_file, tuple):
```

Plus the new test `test_process_windows_pathlib_input_basename` in
`tests/test_litellm/litellm_core_utils/test_audio_utils.py`.
