### PR TITLE
fix(logging): parse JSON_LOGS env var so JSON_LOGS=False disables JSON logs

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -77,7 +77,11 @@ class SecretRedactionFilter(logging.Filter):
 _secret_filter = SecretRedactionFilter()
 
 
-json_logs = bool(os.getenv("JSON_LOGS", False))
+def _env_flag_enabled(value: Optional[str]) -> bool:
+    return (value or "").strip().lower() == "true"
+
+
+json_logs = _env_flag_enabled(os.getenv("JSON_LOGS"))
 # Create a handler for the logger (you may need to adapt this based on your needs)
 log_level = os.getenv("LITELLM_LOG", "DEBUG")
 numeric_level: str = getattr(logging, log_level.upper())

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -16,6 +16,7 @@ import litellm
 from litellm._logging import (
     ALL_LOGGERS,
     JsonFormatter,
+    _env_flag_enabled,
     _initialize_loggers_with_handler,
     _turn_on_json,
     verbose_logger,
@@ -64,6 +65,33 @@ def test_json_mode_emits_one_record_per_logger(capfd):
         assert "message" in obj, "`message` key missing"
         assert "level" in obj, "`level` key missing"
         assert "timestamp" in obj, "`timestamp` key missing"
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("True", True),
+        ("true", True),
+        ("TRUE", True),
+        (" true ", True),
+        ("1", False),
+        ("False", False),
+        ("false", False),
+        ("0", False),
+        ("no", False),
+        ("off", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_env_flag_enabled_only_true_enables(value, expected):
+    """
+    Regression: JSON_LOGS is a boolean env flag, so only "true" (case-insensitive)
+    may enable it. The previous bool(os.getenv("JSON_LOGS", False)) turned any
+    non-empty string, including "False"/"0"/"no", into True, so JSON logging could
+    never be disabled via the documented env var.
+    """
+    assert _env_flag_enabled(value) is expected
 
 
 def test_json_formatter_parses_embedded_json_message():


### PR DESCRIPTION

## Relevant issues

<!-- no existing issue; self-found correctness bug -->

## Linear ticket

<!-- external contribution; no Linear ticket -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

`json_logs` in `litellm/_logging.py` was derived with `bool(os.getenv("JSON_LOGS", False))`
`os.getenv` returns a string (or `None`), never the `False` default, so `bool()` is truthy
for every non-empty value; that means `JSON_LOGS=False` (and `"0"`, `"no"`, `"off"`) turned
JSON logging on, the opposite of intent, and once it was on there was no value other than an
empty string that could turn it back off

The end-user impact is visible in how the proxy formats its logs at startup. With the bug,
setting `JSON_LOGS=False` still emitted JSON log lines; after the fix, `JSON_LOGS=False`
emits the normal colorized human-readable lines and only `JSON_LOGS=True` emits JSON

Before the fix, on `litellm_internal_staging` (JSON logging can't be turned off):

```bash
git checkout litellm_internal_staging
# JSON_LOGS=False should give human-readable logs, but prints JSON
JSON_LOGS=False python litellm/proxy/proxy_cli.py \
  --config litellm/proxy/dev_config.yaml --port 4000 2>&1 | tee before.log &
sleep 20
curl -s http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-1234" \
  -d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "say hi"}]}' > /dev/null
# startup/access lines in before.log are JSON objects like {"message": ..., "level": ...}
grep -m1 '"level"' before.log
kill %1
```

After the fix, on this branch (`JSON_LOGS=False` correctly disables JSON logging):

```bash
git checkout litellm_fix_json_logs_env_parse
JSON_LOGS=False python litellm/proxy/proxy_cli.py \
  --config litellm/proxy/dev_config.yaml --port 4000 2>&1 | tee after_false.log &
sleep 20
curl -s http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-1234" \
  -d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "say hi"}]}' > /dev/null
# after_false.log now shows colorized "HH:MM:SS - name:LEVEL: file:line - message" lines, no JSON
kill %1

# and JSON_LOGS=True still emits JSON
JSON_LOGS=True python litellm/proxy/proxy_cli.py \
  --config litellm/proxy/dev_config.yaml --port 4000 2>&1 | tee after_true.log &
sleep 20
curl -s http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-1234" \
  -d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "say hi"}]}' > /dev/null
grep -m1 '"level"' after_true.log
kill %1
```

## Type

🐛 Bug Fix

## Changes

`litellm/_logging.py` now parses `JSON_LOGS` case-insensitively so only `"true"` (ignoring
surrounding whitespace and case) enables JSON logging, matching the fallback that already
exists in `litellm-proxy-extras/litellm_proxy_extras/_logging.py` (`os.getenv("JSON_LOGS", "false").lower() == "true"`)
The parse lives in a small pure helper, `_env_flag_enabled(value: Optional[str]) -> bool`,
so it is unit-testable without import-time side effects; inlining it here also avoids a
circular import, since importing `str_to_bool` from `litellm.secret_managers.main` would pull
in a module that imports `verbose_logger` back from `litellm._logging`

This flag also propagates to the global `litellm.json_logs`, which `litellm-proxy-extras`
reads first via `getattr(litellm, "json_logs", False)`, so the same parse bug was corrupting
proxy-extras log formatting too; fixing it here fixes both

The regression test in `tests/test_litellm/test_logging.py` asserts that `"True"/"true"/"TRUE"/" true "`
enable and `"1"/"False"/"false"/"0"/"no"/"off"/""/None` do not; it fails on the old
`bool(os.getenv(...))` code and passes after this change
