### PR TITLE
fix(proxy): hydrate DB-backed MCP servers on startup when store_model_in_db is true

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7929,8 +7929,7 @@ class ProxyStartupEvent:
             )
             await proxy_config.get_credentials(prisma_client=prisma_client)
 
-        if store_model_in_db is not True:
-            await proxy_config.init_mcp_servers_from_db()
+        await proxy_config.init_mcp_servers_from_db()
 
         await cls._initialize_slack_alerting_jobs(
             scheduler=scheduler,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -9176,8 +9176,12 @@ class ProxyStartupEvent:
                 redis_cache=redis_usage_cache,
             )
 
+        # init_mcp_servers_from_db already gates on _should_load_db_object("mcp"), so calling
+        # it unconditionally keeps the allowlist behavior while letting store_model_in_db=True
+        # deployments hydrate the in-memory MCP registry on boot.
+        await proxy_config.init_mcp_servers_from_db()
+
         if store_model_in_db is not True:
-            await proxy_config.init_mcp_servers_from_db()
             # Without this branch's own refresh, a UI-created search tool never reaches the router:
             # the add_deployment job that carries it in store_model_in_db=True mode is not scheduled.
             await proxy_config.reload_search_tools_from_db()

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -789,6 +789,41 @@ async def test_initialize_scheduled_jobs_hydrates_mcp_when_store_model_in_db_fal
 
 
 @pytest.mark.asyncio
+async def test_initialize_scheduled_jobs_hydrates_mcp_when_store_model_in_db_true(monkeypatch):
+    """
+    Regression (issue #32575): with store_model_in_db=True the startup gate skipped
+    init_mcp_servers_from_db entirely, so DB-backed MCP servers created via the Admin
+    UI vanished from GET /v1/mcp/server after a restart until the next write. MCP
+    hydration must run regardless of store_model_in_db.
+    """
+    monkeypatch.delenv("DISABLE_PRISMA_SCHEMA_UPDATE", raising=False)
+    monkeypatch.delenv("STORE_MODEL_IN_DB", raising=False)
+    from litellm.proxy.proxy_server import ProxyStartupEvent
+    from litellm.proxy.utils import ProxyLogging
+
+    mock_prisma_client = MagicMock()
+    mock_proxy_logging = MagicMock(spec=ProxyLogging)
+    mock_proxy_logging.slack_alerting_instance = MagicMock()
+    mock_proxy_config = AsyncMock()
+
+    with (
+        patch("litellm.proxy.proxy_server.proxy_config", mock_proxy_config),
+        patch("litellm.proxy.proxy_server.store_model_in_db", True),
+    ):
+        await ProxyStartupEvent.initialize_scheduled_background_jobs(
+            general_settings={},
+            prisma_client=mock_prisma_client,
+            proxy_budget_rescheduler_min_time=1,
+            proxy_budget_rescheduler_max_time=2,
+            proxy_batch_write_at=5,
+            proxy_logging_obj=mock_proxy_logging,
+        )
+
+    mock_proxy_config.add_deployment.assert_awaited()
+    mock_proxy_config.init_mcp_servers_from_db.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_init_mcp_servers_from_db_respects_supported_db_objects(monkeypatch):
     """
     init_mcp_servers_from_db hydrates MCP from the DB by default but skips it when

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -927,6 +927,43 @@ async def test_initialize_scheduled_jobs_hydrates_mcp_when_store_model_in_db_fal
 
 
 @pytest.mark.asyncio
+async def test_initialize_scheduled_jobs_hydrates_mcp_when_store_model_in_db_true(monkeypatch):  # test-quality-ok: the awaited call is the behaviour; the bug was that it never ran
+    """
+    Regression (issue #32575): with store_model_in_db=True the startup gate skipped
+    init_mcp_servers_from_db entirely, so DB-backed MCP servers created via the Admin
+    UI vanished from GET /v1/mcp/server after a restart until the next write. MCP
+    hydration must run regardless of store_model_in_db.
+    """
+    monkeypatch.delenv("DISABLE_PRISMA_SCHEMA_UPDATE", raising=False)
+    monkeypatch.delenv("STORE_MODEL_IN_DB", raising=False)
+    from litellm.proxy.proxy_server import ProxyStartupEvent
+    from litellm.proxy.utils import ProxyLogging
+
+    mock_prisma_client = MagicMock()
+    mock_proxy_logging = MagicMock(spec=ProxyLogging)
+    mock_proxy_logging.slack_alerting_instance = MagicMock()
+    # set on the instance, so a class spec does not expose it
+    mock_proxy_logging.db_spend_update_writer = MagicMock()
+    mock_proxy_config = AsyncMock()
+
+    with (
+        patch("litellm.proxy.proxy_server.proxy_config", mock_proxy_config),  # test-quality-ok: proxy_config is module state the startup path reads, no injection point
+        patch("litellm.proxy.proxy_server.store_model_in_db", True),  # test-quality-ok: store_model_in_db is the module flag whose gate this test exercises
+    ):
+        await ProxyStartupEvent.initialize_scheduled_background_jobs(
+            general_settings={},
+            prisma_client=mock_prisma_client,
+            proxy_budget_rescheduler_min_time=1,
+            proxy_budget_rescheduler_max_time=2,
+            proxy_batch_write_at=5,
+            proxy_logging_obj=mock_proxy_logging,
+        )
+
+    mock_proxy_config.add_deployment.assert_awaited()
+    mock_proxy_config.init_mcp_servers_from_db.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_init_mcp_servers_from_db_respects_supported_db_objects(monkeypatch):
     """
     init_mcp_servers_from_db hydrates MCP from the DB by default but skips it when


### PR DESCRIPTION
## TLDR

Problem this solves:

- MCP servers created in the Admin UI vanish after a proxy restart
- Startup skipped MCP hydration whenever models are stored in the DB
- They reappear only after some unrelated MCP write

How it solves it:

- Hydrate MCP servers on boot regardless of the model storage setting
- The existing allowlist gate still decides whether hydration does anything

## User Flow

Before: an admin who adds an MCP server in the UI loses it on the next restart

1. The admin runs the proxy with models stored in the database
2. They add an MCP server at https://litellm-domain/ui/ and confirm it is listed
3. They send GET https://litellm-domain/v1/mcp/server and the server is in the response
4. They restart the proxy
5. They send GET https://litellm-domain/v1/mcp/server again and the list comes back without it
6. The server only returns to the list after they add, edit or delete any MCP server

After: the same server is still there after the restart

1. The admin runs the proxy with models stored in the database
2. They add an MCP server at https://litellm-domain/ui/ and confirm it is listed
3. They send GET https://litellm-domain/v1/mcp/server and the server is in the response
4. They restart the proxy
5. They send GET https://litellm-domain/v1/mcp/server again and the server is still listed
6. No extra write is needed

## Relevant issues

Fixes #32575

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] The handful of test files covering my change pass locally. I could not run `tests/test_litellm/proxy/` on this machine: its `conftest.py` imports `prisma`, which is absent from my environment. CI ran them, see below
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

I do not have a database-backed proxy deployment or provider credentials, so I cannot supply the live restart run this section asks for. Please treat what follows as short of the bar. The reproduction in #32575 is the user-facing evidence; the check below is what I can point at.

### Before (`litellm_internal_staging`)

#### Startup hydration with models stored in the DB

1. The startup path called MCP hydration only on the branch taken when models are not stored in the database
2. Observed in #32575: DB-backed MCP servers are missing from `GET /v1/mcp/server` after a restart until any MCP write

### After (`c052429f`)

#### Startup hydration with models stored in the DB

1. `tests/test_litellm/proxy/test_proxy_server.py::test_initialize_scheduled_jobs_hydrates_mcp_when_store_model_in_db_true`
2. Observed: passing on CI, 79 of 79 checks green at this head. The companion case for the false setting still passes, so the existing path is unchanged

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Hydration now runs on every boot, not only one branch
- The allowlist gate still short-circuits it when MCP is not enabled

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

I am leaving this unticked deliberately. The added tests pass on CI and I reviewed what they assert, but I could not run this proxy test file locally, and I have no deployment to exercise the real customer flow described above. I would rather say that than tick a box I cannot stand behind.
