### PR TITLE
chore: bump litellm-enterprise 0.1.48 -> 0.1.49

### DIFF
--- a/enterprise/pyproject.toml
+++ b/enterprise/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm-enterprise"
-version = "0.1.48"
+version = "0.1.49"
 description = "Package for LiteLLM Enterprise features"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -26,7 +26,7 @@ required-version = ">=0.10.9"
 module-root = ""
 
 [tool.commitizen]
-version = "0.1.48"
+version = "0.1.49"
 version_files = [
     "pyproject.toml:^version",
     "../pyproject.toml:litellm-enterprise==",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ proxy = [
     "azure-storage-blob>=12.28.0,<13.0",
     "mcp>=1.26.0,<2.0",
     "litellm-proxy-extras==0.4.75",
-    "litellm-enterprise==0.1.48",
+    "litellm-enterprise==0.1.49",
     "RestrictedPython>=8.1,<9.0",
     "rich>=13.9.4,<14.0",
     "polars>=1.38.1,<2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-04T17:13:14.93495Z"
+exclude-newer = "2026-07-06T16:10:51.214184Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3639,7 +3639,7 @@ proxy-dev = [
 
 [[package]]
 name = "litellm-enterprise"
-version = "0.1.48"
+version = "0.1.49"
 source = { editable = "enterprise" }
 
 [[package]]


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Not applicable; this is a version-bump-only change with no runtime behavior to demonstrate

## Type

🚄 Infrastructure

## Changes

Bumps `litellm-enterprise` from `0.1.48` to `0.1.49` ahead of promoting `litellm_internal_staging` into `main` for the next nightly cut. The enterprise folder changed since the last release while its version still matched main, so its published version needs to move to keep reflecting its contents

The root `litellm` package is not bumped: the `1.93.0` line has only a dev tag (`v1.93.0-dev.1`) and no rc or stable, so it is still mid-cycle and this promotion is the second nightly rather than the first release of a new line. `litellm-proxy-extras` is unchanged since the last release, so it is left alone

`uv.lock` is refreshed in the same commit; the only substantive change is the `litellm-enterprise` editable version, alongside the rolling `exclude-newer` window moving forward by design. No third-party dependency versions changed
