### PR TITLE
fix(proxy): build redis usage cache from REDIS_* env when cache backend is not Redis

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -212,6 +212,7 @@ from contextlib import asynccontextmanager
 from functools import lru_cache
 
 import litellm
+import litellm._redis
 from litellm import Router
 from litellm._logging import verbose_proxy_logger, verbose_router_logger
 from litellm.caching.caching import DualCache, RedisCache
@@ -3549,6 +3550,22 @@ def _apply_ssrf_general_settings(settings: Mapping[str, object]) -> None:
         )
 
 
+def _build_redis_usage_cache_from_environment() -> RedisCache | None:
+    """
+    Builds a standalone RedisCache from REDIS_* environment variables.
+
+    Lets the proxy's coordination Redis (cross-pod tpm/rpm rate limits, spend
+    tracking, pod lock manager) run when the response-cache backend is not a
+    plain Redis KV cache (e.g. a semantic cache, disk, or s3).
+
+    Returns None when no Redis host or url is set in the environment.
+    """
+    redis_env_kwargs = litellm._redis._redis_kwargs_from_environment()
+    if "host" not in redis_env_kwargs and "url" not in redis_env_kwargs:
+        return None
+    return RedisCache(**redis_env_kwargs)
+
+
 class ProxyConfig:
     """
     Abstraction class on top of config loading/updating logic. Gives us one place to control all config updating logic.
@@ -3763,9 +3780,21 @@ class ProxyConfig:
 
         litellm.cache = Cache(**cache_params)
 
-        if litellm.cache is not None and isinstance(litellm.cache.cache, (RedisCache, RedisClusterCache)):
+        cache_backend = litellm.cache.cache if litellm.cache is not None else None
+        if isinstance(cache_backend, (RedisCache, RedisClusterCache)):
             ## INIT PROXY REDIS USAGE CLIENT ##
-            redis_usage_cache = litellm.cache.cache
+            redis_usage_cache = cache_backend
+        elif redis_usage_cache is None:
+            redis_usage_cache = _build_redis_usage_cache_from_environment()
+            if redis_usage_cache is not None:
+                verbose_proxy_logger.info(
+                    "Cache backend %s is not a Redis KV cache; built a standalone "
+                    "Redis from REDIS_* environment variables for usage tracking, "
+                    "rate limiting, and cross-pod coordination.",
+                    type(cache_backend).__name__,
+                )
+
+        if redis_usage_cache is not None:
             spend_counter_cache.attach_redis_cache(
                 redis_usage_cache,
                 default_redis_ttl=litellm.default_redis_ttl,
@@ -7277,7 +7306,6 @@ class ProxyStartupEvent:
         Returns None when the buffer is disabled, or when no Redis host or url
         is set in the environment.
         """
-        from litellm._redis import _redis_kwargs_from_environment
         from litellm.secret_managers.main import str_to_bool
 
         _use_redis_transaction_buffer: bool | str | None = general_settings.get("use_redis_transaction_buffer", False)
@@ -7287,11 +7315,7 @@ class ProxyStartupEvent:
         if not _use_redis_transaction_buffer:
             return None
 
-        redis_env_kwargs = _redis_kwargs_from_environment()
-        if "host" not in redis_env_kwargs and "url" not in redis_env_kwargs:
-            return None
-
-        return RedisCache(**redis_env_kwargs)
+        return _build_redis_usage_cache_from_environment()
 
     @classmethod
     async def _initialize_semantic_tool_filter(

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -5,6 +5,7 @@ import os
 import socket
 import subprocess
 import sys
+import types
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest import mock
@@ -23,6 +24,9 @@ sys.path.insert(
 )  # Adds the parent directory to the system-path
 
 import litellm
+import litellm.proxy.proxy_server as proxy_server_module
+from litellm.caching.caching import RedisCache
+from litellm.caching.dual_cache import DualCache
 from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.proxy_server import app, initialize
@@ -9358,3 +9362,89 @@ def test_update_config_redacts_all_environment_variable_values(
         assert "db.internal" not in data["updated_values"]
     finally:
         restore()
+
+
+class _EnvBuiltRedisCache(RedisCache):
+    """RedisCache stand-in that records its constructor kwargs and never
+    opens a network connection, so tests can assert which connection params
+    the proxy used to build its coordination Redis."""
+
+    def __init__(self, **kwargs):
+        self.init_kwargs = kwargs
+
+
+def _run_init_cache_with_backend(cache_backend, redis_env_kwargs):
+    """Run ProxyConfig._init_cache with a stubbed response-cache backend and a
+    controlled REDIS_* environment, returning (redis_usage_cache,
+    spend_counter redis, config-cache redis) as observed after the call."""
+    mock_litellm_cache = MagicMock()
+    mock_litellm_cache.cache = cache_backend
+    fresh_spend_cache = DualCache()
+    fresh_config_cache = types.SimpleNamespace(redis_cache=None)
+
+    with (
+        patch.object(proxy_server_module, "redis_usage_cache", None),
+        patch.object(proxy_server_module, "spend_counter_cache", fresh_spend_cache),
+        patch.object(proxy_server_module, "user_api_key_cache", DualCache()),
+        patch.object(proxy_server_module, "llm_router", None),
+        patch.object(proxy_server_module, "litellm_config_cache", fresh_config_cache),
+        patch.object(proxy_server_module, "RedisCache", _EnvBuiltRedisCache),
+        patch(
+            "litellm._redis._redis_kwargs_from_environment",
+            return_value=redis_env_kwargs,
+        ),
+        patch("litellm.Cache", return_value=mock_litellm_cache),
+    ):
+        litellm.cache = None
+        proxy_server_module.ProxyConfig()._init_cache(
+            cache_params={"type": "qdrant-semantic"}
+        )
+        return (
+            proxy_server_module.redis_usage_cache,
+            fresh_spend_cache.redis_cache,
+            fresh_config_cache.redis_cache,
+        )
+
+
+def test_init_cache_non_redis_backend_builds_usage_redis_from_environment():
+    """A semantic (non-Redis-KV) response cache must not disable the proxy's
+    coordination Redis: when REDIS_* env vars provide a connection,
+    _init_cache builds a standalone usage cache so cross-pod rate limits,
+    spend tracking, and the pod lock manager stay Redis-backed."""
+    usage_cache, spend_redis, config_redis = _run_init_cache_with_backend(
+        cache_backend=object(),
+        redis_env_kwargs={"host": "coordination-redis", "port": "6379"},
+    )
+
+    assert isinstance(usage_cache, _EnvBuiltRedisCache)
+    assert usage_cache.init_kwargs["host"] == "coordination-redis"
+    assert spend_redis is usage_cache
+    assert config_redis is usage_cache
+
+
+def test_init_cache_non_redis_backend_without_redis_env_stays_in_memory():
+    """Without any REDIS_* connection info, a non-Redis response cache must
+    leave the coordination Redis unset instead of building a broken client."""
+    usage_cache, spend_redis, config_redis = _run_init_cache_with_backend(
+        cache_backend=object(),
+        redis_env_kwargs={},
+    )
+
+    assert usage_cache is None
+    assert spend_redis is None
+    assert config_redis is None
+
+
+def test_init_cache_redis_backend_reuses_cache_backend_over_environment():
+    """When the response cache itself is a plain Redis KV cache, it must be
+    reused as the coordination Redis; the REDIS_* environment fallback must
+    not construct a second client."""
+    redis_backend = _EnvBuiltRedisCache(host="cache-params-host")
+    usage_cache, spend_redis, _ = _run_init_cache_with_backend(
+        cache_backend=redis_backend,
+        redis_env_kwargs={"host": "env-host"},
+    )
+
+    assert usage_cache is redis_backend
+    assert usage_cache.init_kwargs["host"] == "cache-params-host"
+    assert spend_redis is redis_backend


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3861

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This fix is specifically about running **both Redis roles at once**: a `redis-semantic` Redis serving the LLM response cache, and a plain Redis serving cross-pod coordination (tpm/rpm rate limits, parallel request limits, spend tracking, the pod lock manager). Before this change those were the same connection, so choosing a semantic response cache silently left the coordination role unfilled and every limit fell back to per-pod memory. After it, the semantic response cache keeps serving cache hits while the coordination Redis independently enforces limits across pods, at the same time, in the same deployment

Setup: a real two pod deployment sharing one Postgres and one Redis 8, with a `redis-semantic` response cache configured and `REDIS_*` env vars set. Two proxy instances launched from the same tree on ports 4861 and 4862, real OpenAI calls to `gpt-5.4-mini` with `text-embedding-3-small` embeddings for the semantic cache

```yaml
litellm_settings:
  cache: true
  cache_params:
    type: redis-semantic
    similarity_threshold: 0.85
    redis_semantic_cache_embedding_model: openai/text-embedding-3-small
    redis_url: os.environ/REDIS_URL
```

Before (unfixed, commit 60729f733e): a key with `rpm_limit: 2` is enforced per pod, not cluster wide. Four requests alternating between the two pods all succeed

```
$ for i in 1 2 3 4; do curl -s -o /dev/null -w "req $i -> pod ${PORTS[$i]} : HTTP %{http_code}\n" \
    -X POST "http://127.0.0.1:${PORTS[$i]}/v1/chat/completions" \
    -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
    -d "{\"model\": \"gpt-5.4-mini\", \"messages\": [{\"role\": \"user\", \"content\": \"${PROMPTS[$i]}\"}]}"; done
req 1 -> pod 4861 : HTTP 200
req 2 -> pod 4862 : HTTP 200
req 3 -> pod 4861 : HTTP 200
req 4 -> pod 4862 : HTTP 200
```

The limiter itself is alive, just pod local: a fifth request to pod 4861 (its third) returns 429 with `Current limit: 2`. And Redis holds only semantic cache entries, no coordination keys at all

```
$ docker exec litfix-3861-redis redis-cli --scan | sort
litellm_semantic_cache_index:0b02fbbcde21c17eecc4ee2271e22ca7c975ec84b3019139ec0ae14bca1c9908
litellm_semantic_cache_index:11f4c4b783bd275714a3786493a9163cbe81ae6a6434fff64ec412965dd90eb5
... (semantic cache index entries only)
```

After (fixed, commit 635cbd1e7b): same config, same four requests with a fresh `rpm_limit: 2` key. The limit is now enforced across both pods

```
req 1 -> pod 4861 : HTTP 200
req 2 -> pod 4862 : HTTP 200
req 3 -> pod 4861 : HTTP 429
req 4 -> pod 4862 : HTTP 429

$ head -c 300 resp-after-3.json
{"error":{"message":"Rate limit exceeded for api_key: 8d219d83... Limit type: requests. Current limit: 2, Remaining: 0. ...","type":"throttling_error","code":"429"}}
```

Redis now carries the rate limit windows, spend counters, and parallel request slots next to the semantic cache index

```
$ docker exec litfix-3861-redis redis-cli --scan | sort
{api_key:8d219d83...}:max_parallel_requests
{api_key:8d219d83...}:requests
{api_key:8d219d83...}:tokens
{api_key:8d219d83...}:window
{model_per_key:8d219d83...:gpt-5.4-mini}:tokens
litellm_semantic_cache_index:09c6aacdf650c84bd13b6d05274b2e3b9f3d538556a81dd64ed40161a7abb4f8
litellm_semantic_cache_index:fabd2aed27847f28c061df8adf7240e97b1a18de6dd58384ee925a58027c0c2c
spend:key:8d219d83...
spend:tag:User-Agent: curl
```

Both roles are live simultaneously: the semantic response cache still serves a cross pod hit (identical prompt to pod 4862 then pod 4861 returns the same completion id) while the coordination keys above enforce the rate limit across the same two pods

```
pod 4862 id: chatcmpl-Dzlwx0Knv3iEMtjpV0nnYeygsj7Ge cache-hdr:
pod 4861 id: chatcmpl-Dzlwx0Knv3iEMtjpV0nnYeygsj7Ge cache-hdr: x-litellm-cache-key: 049d22c95fbcf3927b8be59b68c521691262efd3d01905e395a46d8742a6a394
```

### Independent e2e verification

The media below come from an independent end to end run reproducing the exact repro above: two proxy pods on `127.0.0.1:4861` and `127.0.0.1:4862`, one shared Postgres and one shared Redis 8, a `redis-semantic` response cache with `REDIS_*` set, and real `gpt-5.4-mini` chat plus `text-embedding-3-small` embeddings. Parent commit `60729f733e` gives 200/200/200/200; PR tip `635cbd1e7b` gives 200/200/429/429 with the coordination keys present and the semantic cache still shared cross pod

![Independent e2e run: full BEFORE to AFTER terminal flow](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/pr32635/demo.gif)

Independent e2e verification: full BEFORE all 200 to AFTER 200 200 429 429 flow ending with the cross pod semantic cache hit

![BEFORE unfixed: four alternating requests all 200, Redis holds only semantic cache index keys](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/pr32635/before-all-200.png)

Independent e2e verification: BEFORE on parent commit 60729f733e where the rpm_limit 2 key is enforced per pod so all four requests return 200 and Redis carries only `litellm_semantic_cache_index:*`

![BEFORE Redis scan then AFTER pods relaunching on the fixed commit](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/pr32635/before-scan-after-relaunch.png)

Independent e2e verification: the BEFORE Redis scan showing only semantic cache index keys, then both pods relaunching on PR tip 635cbd1e7b

![AFTER fixed: 200 200 429 429 with rate limit and spend keys in Redis and a cross pod cache hit](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/pr32635/after-200-429-and-scan.png)

Independent e2e verification: AFTER on PR tip 635cbd1e7b where requests three and four return 429 on both pods, Redis now holds the rate limit windows, spend counters, and parallel request slots next to the semantic cache index, and the same completion id is served cross pod


## Type

🐛 Bug Fix

## Changes

The proxy's coordination Redis (`redis_usage_cache`) was only ever populated from the response cache backend, gated on that backend being a plain `RedisCache`/`RedisClusterCache` in `ProxyConfig._init_cache`. Selecting any semantic response cache (`redis-semantic`, `valkey-semantic`, `qdrant-semantic`) or another non Redis backend (disk, s3) therefore left it `None`, silently downgrading cross pod tpm/rpm rate limits, parallel request limits, spend coordination, and the pod lock manager to per pod in memory state. In a multi pod deployment the effective limit becomes roughly N times the configured value

The fix mirrors the escape hatch that already existed for one narrow consumer, `use_redis_transaction_buffer` (`_get_transaction_buffer_redis_cache`): when the configured cache backend is not a plain Redis KV cache and `redis_usage_cache` is not already set, build a standalone `RedisCache` from `REDIS_*` environment variables. The env kwargs plus host or url check plus construction now lives in one shared helper, `_build_redis_usage_cache_from_environment`, used by both paths. When no `REDIS_*` connection info is present, behavior is unchanged

Two scope notes. First, populating `redis_usage_cache` also lets the router attach Redis for its routing state (cooldowns, usage based routing counters) via the existing `router._update_redis_cache` call site; that is the intended meaning of setting `REDIS_*` on a multi pod deployment, but it is a behavior change for semantic cache users who had those env vars set and were getting per pod routing state. Second, the shared helper keeps the precedent's host or url predicate, so a deployment whose only Redis env is `REDIS_CLUSTER_NODES` or `REDIS_SENTINEL_NODES` still gets no fallback; that gap predates this PR (the transaction buffer path has it too) and cluster support needs a `RedisClusterCache` build rather than a wider predicate, so it is left for a follow up

Regression tests in `tests/test_litellm/proxy/test_proxy_server.py` cover the three cases: non Redis backend with `REDIS_*` env builds the usage cache from the environment and attaches it to the spend counter and config caches, non Redis backend without env stays in memory, and a plain Redis backend keeps being reused directly without constructing a second client. The core test fails on the unfixed code

