### PR TITLE
feat(openrouter): add audio speech and transcription support

### DIFF
--- a/litellm/litellm_core_utils/get_supported_openai_params.py
+++ b/litellm/litellm_core_utils/get_supported_openai_params.py
@@ -136,6 +136,12 @@ def get_supported_openai_params(
         else:
             return litellm.AzureOpenAIConfig().get_supported_openai_params(model=_azure_detection_model)
     elif custom_llm_provider == "openrouter":
+        if request_type == "transcription":
+            from litellm.llms.openrouter.audio_transcription.transformation import (
+                OpenRouterAudioTranscriptionConfig,
+            )
+
+            return OpenRouterAudioTranscriptionConfig().get_supported_openai_params(model=model)
         return litellm.OpenrouterConfig().get_supported_openai_params(model=model)
     elif custom_llm_provider == "vercel_ai_gateway":
         return litellm.VercelAIGatewayConfig().get_supported_openai_params(model=model)

--- a/litellm/llms/openrouter/audio_transcription/__init__.py
+++ b/litellm/llms/openrouter/audio_transcription/__init__.py
@@ -1,0 +1,3 @@
+from litellm.llms.openrouter.audio_transcription.transformation import OpenRouterAudioTranscriptionConfig
+
+__all__ = ["OpenRouterAudioTranscriptionConfig"]

--- a/litellm/llms/openrouter/audio_transcription/transformation.py
+++ b/litellm/llms/openrouter/audio_transcription/transformation.py
@@ -1,0 +1,144 @@
+from typing import Any, Dict, List, Optional, Union
+
+import httpx
+
+from litellm.litellm_core_utils.audio_utils.utils import process_audio_file
+from litellm.llms.base_llm.audio_transcription.transformation import (
+    AudioTranscriptionRequestData,
+    BaseAudioTranscriptionConfig,
+)
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+from litellm.llms.openrouter.common_utils import (
+    OpenRouterException,
+    get_openrouter_endpoint,
+    get_openrouter_headers,
+    raise_openrouter_error,
+)
+from litellm.types.llms.openai import (
+    AllMessageValues,
+    OpenAIAudioTranscriptionOptionalParams,
+)
+from litellm.types.utils import FileTypes, TranscriptionResponse
+
+
+class OpenRouterAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
+    def get_supported_openai_params(self, model: str) -> List[OpenAIAudioTranscriptionOptionalParams]:
+        return [
+            "language",
+            "prompt",
+            "response_format",
+            "temperature",
+            "timestamp_granularities",
+        ]
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        supported_params = set(self.get_supported_openai_params(model))
+        for key, value in non_default_params.items():
+            if value is None:
+                continue
+            if key in supported_params or not drop_params:
+                optional_params[key] = value
+        return optional_params
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        api_key: Optional[str],
+        model: str,
+        optional_params: dict,
+        litellm_params: dict,
+        stream: Optional[bool] = None,
+    ) -> str:
+        return get_openrouter_endpoint(api_base, "audio/transcriptions")
+
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        messages: List[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+    ) -> dict:
+        merged_headers = get_openrouter_headers(api_key=api_key, headers=headers, content_type=None)
+        merged_headers.pop("Content-Type", None)
+        merged_headers.pop("content-type", None)
+        return merged_headers
+
+    def transform_audio_transcription_request(
+        self,
+        model: str,
+        audio_file: FileTypes,
+        optional_params: dict,
+        litellm_params: dict,
+    ) -> AudioTranscriptionRequestData:
+        processed_audio = process_audio_file(audio_file)
+
+        form_fields: Dict[str, Any] = {"model": model}
+        for key in self.get_supported_openai_params(model):
+            value = optional_params.get(key)
+            if value is not None:
+                form_key = "timestamp_granularities[]" if key == "timestamp_granularities" else key
+                form_fields[form_key] = value
+
+        provider_specific_params = self.get_provider_specific_params(
+            model=model,
+            optional_params=optional_params,
+            openai_params=self.get_supported_openai_params(model),
+        )
+        form_fields.update(provider_specific_params)
+
+        files = {
+            "file": (
+                processed_audio.filename,
+                processed_audio.file_content,
+                processed_audio.content_type,
+            )
+        }
+
+        return AudioTranscriptionRequestData(data=form_fields, files=files)
+
+    def transform_audio_transcription_response(
+        self,
+        raw_response: httpx.Response,
+    ) -> TranscriptionResponse:
+        try:
+            response_json = raw_response.json()
+        except ValueError:
+            raise OpenRouterException(
+                message=raw_response.text,
+                status_code=raw_response.status_code,
+                headers=raw_response.headers,
+            )
+
+        raise_openrouter_error(raw_response)
+
+        if not isinstance(response_json, dict):
+            raise OpenRouterException(
+                message="OpenRouter returned a non-object transcription response.",
+                status_code=raw_response.status_code,
+                headers=raw_response.headers,
+            )
+
+        response = TranscriptionResponse(text=response_json.get("text") or "")
+        for key, value in response_json.items():
+            if key != "text":
+                response[key] = value
+        response._hidden_params = response_json
+        return response
+
+    def get_error_class(
+        self, error_message: str, status_code: int, headers: Union[dict, httpx.Headers]
+    ) -> BaseLLMException:
+        return OpenRouterException(
+            message=error_message,
+            status_code=status_code,
+            headers=headers,
+        )

--- a/litellm/llms/openrouter/common_utils.py
+++ b/litellm/llms/openrouter/common_utils.py
@@ -1,5 +1,95 @@
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+import litellm
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
+from litellm.secret_managers.main import get_secret, get_secret_str
+
+DEFAULT_OPENROUTER_API_BASE = "https://openrouter.ai/api/v1"
 
 
 class OpenRouterException(BaseLLMException):
     pass
+
+
+def get_openrouter_api_base(api_base: Optional[str] = None) -> str:
+    return (
+        api_base or litellm.api_base or get_secret_str("OPENROUTER_API_BASE") or DEFAULT_OPENROUTER_API_BASE
+    ).rstrip("/")
+
+
+def get_openrouter_endpoint(api_base: Optional[str], endpoint_path: str) -> str:
+    base_url = get_openrouter_api_base(api_base)
+    normalized_path = endpoint_path.strip("/")
+    if not normalized_path:
+        return base_url
+    if base_url.endswith(f"/{normalized_path}"):
+        return base_url
+    return f"{base_url}/{normalized_path}"
+
+
+def get_openrouter_api_key(api_key: Optional[str] = None) -> str:
+    resolved_api_key = (
+        api_key
+        or litellm.api_key
+        or litellm.openrouter_key
+        or get_secret_str("OPENROUTER_API_KEY")
+        or get_secret_str("OR_API_KEY")
+    )
+    if not resolved_api_key:
+        raise ValueError(
+            "OpenRouter API key is required. Set OPENROUTER_API_KEY environment variable or pass api_key parameter."
+        )
+    return resolved_api_key
+
+
+def get_openrouter_headers(
+    api_key: Optional[str] = None,
+    headers: Optional[Dict[str, Any]] = None,
+    content_type: Optional[str] = "application/json",
+) -> Dict[str, Any]:
+    openrouter_headers: Dict[str, Any] = {
+        "Authorization": f"Bearer {get_openrouter_api_key(api_key)}",
+        "HTTP-Referer": get_secret("OR_SITE_URL") or "https://litellm.ai",
+        "X-Title": get_secret("OR_APP_NAME") or "liteLLM",
+    }
+    if content_type is not None:
+        openrouter_headers["Content-Type"] = content_type
+    openrouter_headers.update(headers or {})
+    return openrouter_headers
+
+
+def get_openrouter_error_message(response_json: Union[Dict[str, Any], Any], default: str) -> str:
+    if isinstance(response_json, dict):
+        error = response_json.get("error")
+        if isinstance(error, dict):
+            message = error.get("message")
+            if message:
+                return str(message)
+        if isinstance(error, str):
+            return error
+        message = response_json.get("message")
+        if message:
+            return str(message)
+    return default
+
+
+def raise_openrouter_error(raw_response: httpx.Response) -> None:
+    if 200 <= raw_response.status_code < 300:
+        return
+
+    response_json: Union[Dict[str, Any], Any]
+    try:
+        response_json = raw_response.json()
+    except ValueError:
+        response_json = {}
+
+    raise OpenRouterException(
+        message=get_openrouter_error_message(
+            response_json=response_json,
+            default=raw_response.text,
+        ),
+        status_code=raw_response.status_code,
+        headers=raw_response.headers,
+    )

--- a/litellm/llms/openrouter/text_to_speech/__init__.py
+++ b/litellm/llms/openrouter/text_to_speech/__init__.py
@@ -1,0 +1,3 @@
+from litellm.llms.openrouter.text_to_speech.transformation import OpenRouterTextToSpeechConfig
+
+__all__ = ["OpenRouterTextToSpeechConfig"]

--- a/litellm/llms/openrouter/text_to_speech/transformation.py
+++ b/litellm/llms/openrouter/text_to_speech/transformation.py
@@ -1,0 +1,112 @@
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
+
+import httpx
+
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+from litellm.llms.base_llm.text_to_speech.transformation import (
+    BaseTextToSpeechConfig,
+    TextToSpeechRequestData,
+)
+from litellm.llms.openrouter.common_utils import (
+    OpenRouterException,
+    get_openrouter_endpoint,
+    get_openrouter_headers,
+    raise_openrouter_error,
+)
+from litellm.types.llms.openai import HttpxBinaryResponseContent
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+else:
+    LiteLLMLoggingObj = Any
+
+
+class OpenRouterTextToSpeechConfig(BaseTextToSpeechConfig):
+    def get_supported_openai_params(self, model: str) -> list:
+        return ["voice", "response_format", "speed", "instructions"]
+
+    def _resolve_voice(self, voice: Optional[Union[str, Dict[str, Any]]]) -> Optional[str]:
+        if voice is None:
+            return None
+        if isinstance(voice, str):
+            return voice
+        for key in ("voice_id", "id", "name"):
+            candidate = voice.get(key)
+            if isinstance(candidate, str) and candidate.strip():
+                return candidate
+        raise ValueError("OpenRouter TTS voice must be a string or a dict with voice_id, id, or name.")
+
+    def map_openai_params(
+        self,
+        model: str,
+        optional_params: Dict,
+        voice: Optional[Union[str, Dict[str, Any]]] = None,
+        drop_params: bool = False,
+        kwargs: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[Optional[str], Dict]:
+        mapped_params: Dict[str, Any] = {}
+        supported_params = set(self.get_supported_openai_params(model))
+        for key, value in optional_params.items():
+            if value is None:
+                continue
+            if key in supported_params or not drop_params:
+                mapped_params[key] = value
+        extra_body = (kwargs or {}).get("extra_body")
+        if isinstance(extra_body, dict):
+            for key, value in extra_body.items():
+                if value is not None:
+                    mapped_params[key] = value
+        return self._resolve_voice(voice), mapped_params
+
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+    ) -> dict:
+        return get_openrouter_headers(api_key=api_key, headers=headers)
+
+    def get_complete_url(
+        self,
+        model: str,
+        api_base: Optional[str],
+        litellm_params: dict,
+    ) -> str:
+        return get_openrouter_endpoint(api_base, "audio/speech")
+
+    def transform_text_to_speech_request(
+        self,
+        model: str,
+        input: str,
+        voice: Optional[str],
+        optional_params: Dict,
+        litellm_params: Dict,
+        headers: dict,
+    ) -> TextToSpeechRequestData:
+        request_body: Dict[str, Any] = {
+            "model": model,
+            "input": input,
+        }
+        if voice is not None:
+            request_body["voice"] = voice
+        request_body.update({k: v for k, v in optional_params.items() if v is not None})
+        return TextToSpeechRequestData(dict_body=request_body)
+
+    def transform_text_to_speech_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        logging_obj: LiteLLMLoggingObj,
+    ) -> HttpxBinaryResponseContent:
+        raise_openrouter_error(raw_response)
+        return HttpxBinaryResponseContent(raw_response)
+
+    def get_error_class(
+        self, error_message: str, status_code: int, headers: Union[dict, httpx.Headers]
+    ) -> BaseLLMException:
+        return OpenRouterException(
+            message=error_message,
+            status_code=status_code,
+            headers=headers,
+        )

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -8029,6 +8029,41 @@ def speech(
             client=client,
             _is_async=aspeech or False,
         )
+    elif custom_llm_provider == "openrouter":
+        if text_to_speech_provider_config is None:
+            raise litellm.BadRequestError(
+                message="OpenRouter Text-to-Speech configuration not found",
+                model=model,
+                llm_provider=custom_llm_provider,
+            )
+
+        openrouter_voice = voice.strip() if isinstance(voice, str) else None
+        if openrouter_voice is None or not openrouter_voice:
+            raise litellm.BadRequestError(
+                message="'voice' is required to be passed as a string for OpenRouter TTS",
+                model=model,
+                llm_provider=custom_llm_provider,
+            )
+
+        if api_base is not None:
+            litellm_params_dict["api_base"] = api_base
+        if api_key is not None:
+            litellm_params_dict["api_key"] = api_key
+
+        response = base_llm_http_handler.text_to_speech_handler(
+            model=model,
+            input=input,
+            voice=openrouter_voice,
+            text_to_speech_provider_config=text_to_speech_provider_config,
+            text_to_speech_optional_params=optional_params,
+            custom_llm_provider=custom_llm_provider,
+            litellm_params=litellm_params_dict,
+            logging_obj=logging_obj,
+            timeout=timeout,
+            extra_headers=extra_headers,
+            client=client,
+            _is_async=aspeech or False,
+        )
     elif custom_llm_provider == "vertex_ai" or custom_llm_provider == "vertex_ai_beta":
         from litellm.llms.vertex_ai.text_to_speech.transformation import (
             VertexAITextToSpeechConfig,

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8109,6 +8109,12 @@ class ProviderConfigManager:
             )
 
             return VertexAIAudioTranscriptionConfig()
+        elif litellm.LlmProviders.OPENROUTER == provider:
+            from litellm.llms.openrouter.audio_transcription.transformation import (
+                OpenRouterAudioTranscriptionConfig,
+            )
+
+            return OpenRouterAudioTranscriptionConfig()
         return None
 
     @staticmethod
@@ -8921,6 +8927,12 @@ class ProviderConfigManager:
             )
 
             return AWSPollyTextToSpeechConfig()
+        elif litellm.LlmProviders.OPENROUTER == provider:
+            from litellm.llms.openrouter.text_to_speech.transformation import (
+                OpenRouterTextToSpeechConfig,
+            )
+
+            return OpenRouterTextToSpeechConfig()
         return None
 
     @staticmethod

--- a/tests/test_litellm/llms/openrouter/audio/test_openrouter_audio_transformation.py
+++ b/tests/test_litellm/llms/openrouter/audio/test_openrouter_audio_transformation.py
@@ -1,0 +1,286 @@
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+import litellm
+import litellm.main as litellm_main
+from litellm.litellm_core_utils.get_supported_openai_params import get_supported_openai_params
+from litellm.llms.openrouter.audio_transcription.transformation import (
+    OpenRouterAudioTranscriptionConfig,
+)
+from litellm.llms.openrouter.common_utils import OpenRouterException
+from litellm.llms.openrouter.text_to_speech.transformation import (
+    OpenRouterTextToSpeechConfig,
+)
+from litellm.types.llms.openai import HttpxBinaryResponseContent
+from litellm.types.utils import LlmProviders
+from litellm.utils import ProviderConfigManager
+
+
+def _clear_openrouter_keys(monkeypatch):
+    monkeypatch.setattr(litellm, "api_key", None)
+    monkeypatch.setattr(litellm, "openrouter_key", None)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OR_API_KEY", raising=False)
+
+
+def test_provider_config_manager_registers_openrouter_audio_configs():
+    assert isinstance(
+        ProviderConfigManager.get_provider_text_to_speech_config(
+            model="hexgrad/kokoro-82m",
+            provider=LlmProviders.OPENROUTER,
+        ),
+        OpenRouterTextToSpeechConfig,
+    )
+    assert isinstance(
+        ProviderConfigManager.get_provider_audio_transcription_config(
+            model="openai/whisper-large-v3",
+            provider=LlmProviders.OPENROUTER,
+        ),
+        OpenRouterAudioTranscriptionConfig,
+    )
+
+
+def test_get_supported_openai_params_returns_openrouter_transcription_params():
+    assert get_supported_openai_params(
+        model="openai/whisper-large-v3",
+        custom_llm_provider="openrouter",
+        request_type="transcription",
+    ) == [
+        "language",
+        "prompt",
+        "response_format",
+        "temperature",
+        "timestamp_granularities",
+    ]
+
+
+def test_litellm_speech_routes_openrouter_to_shared_tts_handler(monkeypatch):
+    sentinel = object()
+    captured_kwargs = {}
+
+    def fake_text_to_speech_handler(**kwargs):
+        captured_kwargs.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(
+        litellm_main.base_llm_http_handler,
+        "text_to_speech_handler",
+        fake_text_to_speech_handler,
+    )
+
+    response = litellm.speech(
+        model="openrouter/hexgrad/kokoro-82m",
+        input="hello",
+        voice="af_alloy",
+        api_key="test-key",
+    )
+
+    assert response is sentinel
+    assert captured_kwargs["custom_llm_provider"] == "openrouter"
+    assert captured_kwargs["model"] == "hexgrad/kokoro-82m"
+    assert captured_kwargs["voice"] == "af_alloy"
+    assert captured_kwargs["litellm_params"]["api_key"] == "test-key"
+    assert isinstance(captured_kwargs["text_to_speech_provider_config"], OpenRouterTextToSpeechConfig)
+
+
+def test_litellm_speech_requires_openrouter_voice():
+    with pytest.raises(litellm.BadRequestError, match="'voice' is required"):
+        litellm.speech(
+            model="openrouter/hexgrad/kokoro-82m",
+            input="hello",
+            api_key="test-key",
+        )
+
+
+class TestOpenRouterTextToSpeechConfig:
+    def setup_method(self):
+        self.config = OpenRouterTextToSpeechConfig()
+        self.logging_obj = Mock()
+
+    def test_validate_environment_sets_openrouter_headers(self):
+        headers = self.config.validate_environment(
+            headers={"X-Custom": "value"},
+            model="hexgrad/kokoro-82m",
+            api_key="test-key",
+        )
+
+        assert headers["Authorization"] == "Bearer test-key"
+        assert headers["HTTP-Referer"] == "https://litellm.ai"
+        assert headers["X-Title"] == "liteLLM"
+        assert headers["Content-Type"] == "application/json"
+        assert headers["X-Custom"] == "value"
+
+    def test_validate_environment_raises_without_api_key(self, monkeypatch):
+        _clear_openrouter_keys(monkeypatch)
+
+        with pytest.raises(ValueError, match="OpenRouter API key is required"):
+            self.config.validate_environment(
+                headers={},
+                model="hexgrad/kokoro-82m",
+                api_key=None,
+            )
+
+    def test_get_complete_url(self):
+        assert (
+            self.config.get_complete_url(
+                model="hexgrad/kokoro-82m",
+                api_base="https://openrouter.ai/api/v1/",
+                litellm_params={},
+            )
+            == "https://openrouter.ai/api/v1/audio/speech"
+        )
+
+    def test_map_openai_params_normalizes_voice_dict_and_extra_body(self):
+        voice, params = self.config.map_openai_params(
+            model="hexgrad/kokoro-82m",
+            optional_params={"response_format": "mp3"},
+            voice={"voice_id": "af_alloy"},
+            kwargs={"extra_body": {"sample_rate": 24000}},
+        )
+
+        assert voice == "af_alloy"
+        assert params == {"response_format": "mp3", "sample_rate": 24000}
+
+    def test_transform_text_to_speech_request_preserves_openai_fields(self):
+        request_data = self.config.transform_text_to_speech_request(
+            model="hexgrad/kokoro-82m",
+            input="Narrate this scene",
+            voice="af_alloy",
+            optional_params={
+                "response_format": "mp3",
+                "speed": 1,
+                "instructions": "Warm narration",
+            },
+            litellm_params={},
+            headers={},
+        )
+
+        body = request_data["dict_body"]
+        assert body["model"] == "hexgrad/kokoro-82m"
+        assert body["input"] == "Narrate this scene"
+        assert body["voice"] == "af_alloy"
+        assert body["response_format"] == "mp3"
+        assert body["speed"] == 1
+        assert body["instructions"] == "Warm narration"
+
+    def test_transform_text_to_speech_response_returns_binary_content(self):
+        raw_response = httpx.Response(
+            200,
+            content=b"audio-bytes",
+            request=httpx.Request("POST", "https://openrouter.ai/api/v1/audio/speech"),
+        )
+
+        result = self.config.transform_text_to_speech_response(
+            model="hexgrad/kokoro-82m",
+            raw_response=raw_response,
+            logging_obj=self.logging_obj,
+        )
+
+        assert isinstance(result, HttpxBinaryResponseContent)
+        assert result.response.content == b"audio-bytes"
+
+
+class TestOpenRouterAudioTranscriptionConfig:
+    def setup_method(self):
+        self.config = OpenRouterAudioTranscriptionConfig()
+
+    def test_validate_environment_sets_multipart_safe_headers(self):
+        headers = self.config.validate_environment(
+            headers={"Content-Type": "application/json", "X-Custom": "value"},
+            model="openai/whisper-large-v3",
+            messages=[],
+            optional_params={},
+            litellm_params={},
+            api_key="test-key",
+        )
+
+        assert headers["Authorization"] == "Bearer test-key"
+        assert headers["HTTP-Referer"] == "https://litellm.ai"
+        assert headers["X-Title"] == "liteLLM"
+        assert headers["X-Custom"] == "value"
+        assert "Content-Type" not in headers
+        assert "content-type" not in headers
+
+    def test_validate_environment_raises_without_api_key(self, monkeypatch):
+        _clear_openrouter_keys(monkeypatch)
+
+        with pytest.raises(ValueError, match="OpenRouter API key is required"):
+            self.config.validate_environment(
+                headers={},
+                model="openai/whisper-large-v3",
+                messages=[],
+                optional_params={},
+                litellm_params={},
+                api_key=None,
+            )
+
+    def test_get_complete_url(self):
+        assert (
+            self.config.get_complete_url(
+                api_base="https://openrouter.ai/api/v1/",
+                api_key="test-key",
+                model="openai/whisper-large-v3",
+                optional_params={},
+                litellm_params={},
+            )
+            == "https://openrouter.ai/api/v1/audio/transcriptions"
+        )
+
+    def test_transform_audio_transcription_request_preserves_openai_fields(self):
+        request_data = self.config.transform_audio_transcription_request(
+            model="openai/whisper-large-v3",
+            audio_file=("sample.wav", b"RIFF....", "audio/wav"),
+            optional_params={
+                "language": "en",
+                "prompt": "Product narration",
+                "response_format": "verbose_json",
+                "temperature": 0,
+                "timestamp_granularities": ["word"],
+            },
+            litellm_params={},
+        )
+
+        assert request_data.data["model"] == "openai/whisper-large-v3"
+        assert request_data.data["language"] == "en"
+        assert request_data.data["prompt"] == "Product narration"
+        assert request_data.data["response_format"] == "verbose_json"
+        assert request_data.data["temperature"] == 0
+        assert request_data.data["timestamp_granularities[]"] == ["word"]
+        assert request_data.files["file"][0] == "sample.wav"
+        assert request_data.files["file"][1] == b"RIFF...."
+        assert request_data.files["file"][2] == "audio/wav"
+
+    def test_transform_audio_transcription_response_preserves_words(self):
+        raw_response = httpx.Response(
+            200,
+            json={
+                "text": "hello world",
+                "language": "en",
+                "words": [
+                    {"word": "hello", "start": 0.0, "end": 0.4},
+                    {"word": "world", "start": 0.5, "end": 0.9},
+                ],
+                "usage": {"duration": 1.0},
+            },
+            request=httpx.Request("POST", "https://openrouter.ai/api/v1/audio/transcriptions"),
+        )
+
+        response = self.config.transform_audio_transcription_response(raw_response)
+
+        assert response.text == "hello world"
+        assert response["language"] == "en"
+        assert response["words"][0] == {"word": "hello", "start": 0.0, "end": 0.4}
+        assert response["usage"] == {"duration": 1.0}
+        assert response._hidden_params["words"][1]["word"] == "world"
+
+    def test_transform_audio_transcription_response_raises_openrouter_error(self):
+        raw_response = httpx.Response(
+            401,
+            json={"error": {"message": "bad key"}},
+            request=httpx.Request("POST", "https://openrouter.ai/api/v1/audio/transcriptions"),
+        )
+
+        with pytest.raises(OpenRouterException, match="bad key"):
+            self.config.transform_audio_transcription_response(raw_response)


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

See Slack #pr-review from the template if this waits on maintainer review

## Screenshots / Proof of Fix

Pending live OpenRouter curl proof. This shell does not have `OPENROUTER_API_KEY`, so I could not run the paid end-to-end proxy smoke before opening this draft

The implementation was checked against the current OpenRouter TTS and STT docs. TTS uses `/api/v1/audio/speech` with raw audio responses, and STT uses OpenAI-compatible multipart uploads to `/api/v1/audio/transcriptions`

## Type

New Feature
Test

## Changes

Adds OpenRouter audio transcription and text-to-speech configs using the shared LiteLLM audio handlers. The STT path sends OpenAI-compatible multipart requests, preserves JSON response fields like words and usage, and exposes transcription params through `get_supported_openai_params`

Adds OpenRouter TTS routing through `litellm.speech`, requiring a string voice like the OpenAI-compatible endpoint, forwarding response format, speed, instructions, and provider extra body fields, and returning raw binary audio responses

Validated with `uv run ruff check litellm/llms/openrouter/audio_transcription litellm/llms/openrouter/text_to_speech litellm/llms/openrouter/common_utils.py litellm/main.py litellm/utils.py litellm/litellm_core_utils/get_supported_openai_params.py tests/test_litellm/llms/openrouter/audio`, `uv run ruff format --check litellm/llms/openrouter/audio_transcription litellm/llms/openrouter/text_to_speech litellm/llms/openrouter/common_utils.py litellm/main.py litellm/utils.py litellm/litellm_core_utils/get_supported_openai_params.py tests/test_litellm/llms/openrouter/audio`, `uv run pytest tests/test_litellm/llms/openrouter/audio -v`, `uv run pytest tests/test_litellm/llms/openrouter -v`, and `make pre-commit`