### PR TITLE
feat(ui): add session id filter to request logs

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -1910,7 +1910,7 @@ async def ui_view_spend_logs(
             p += 2
             sql_conditions.append(or_clause)
 
-        if session_id is not None:
+        if session_id is not None and isinstance(session_id, str):
             like_escaped_session_id = session_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
             sql_conditions.append(f"session_id LIKE ${p}")
             sql_params.append(f"%{like_escaped_session_id}%")

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -1622,6 +1622,10 @@ async def ui_view_spend_logs(
         default=None,
         description="request_id to get spend logs for specific request_id",
     ),
+    session_id: str | None = fastapi.Query(
+        default=None,
+        description="Filter spend logs by session_id",
+    ),
     team_id: str | None = fastapi.Query(
         default=None,
         description="Filter spend logs by team_id",
@@ -1772,6 +1776,9 @@ async def ui_view_spend_logs(
         if request_id is not None:
             where_conditions["request_id"] = request_id
 
+        if session_id is not None:
+            where_conditions["session_id"] = session_id
+
         if model is not None:
             where_conditions["model"] = model
 
@@ -1887,6 +1894,7 @@ async def ui_view_spend_logs(
             ('"user"', "user"),
             ("api_key", "api_key"),
             ("request_id", "request_id"),
+            ("session_id", "session_id"),
             ("model", "model"),
             ("model_id", "model_id"),
             ("model_group", "model_group"),

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -1624,7 +1624,7 @@ async def ui_view_spend_logs(
     ),
     session_id: str | None = fastapi.Query(
         default=None,
-        description="Filter spend logs by session_id",
+        description="Filter spend logs by session_id (partial string match)",
     ),
     team_id: str | None = fastapi.Query(
         default=None,
@@ -1776,9 +1776,6 @@ async def ui_view_spend_logs(
         if request_id is not None:
             where_conditions["request_id"] = request_id
 
-        if session_id is not None:
-            where_conditions["session_id"] = session_id
-
         if model is not None:
             where_conditions["model"] = model
 
@@ -1894,7 +1891,6 @@ async def ui_view_spend_logs(
             ('"user"', "user"),
             ("api_key", "api_key"),
             ("request_id", "request_id"),
-            ("session_id", "session_id"),
             ("model", "model"),
             ("model_id", "model_id"),
             ("model_group", "model_group"),
@@ -1913,6 +1909,12 @@ async def ui_view_spend_logs(
             sql_params.append(permitted_team_ids)
             p += 2
             sql_conditions.append(or_clause)
+
+        if session_id is not None:
+            like_escaped_session_id = session_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            sql_conditions.append(f"session_id LIKE ${p}")
+            sql_params.append(f"%{like_escaped_session_id}%")
+            p += 1
 
         # Status filter
         if status_filter is not None:

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -1,4 +1,5 @@
 import asyncio
+import collections
 import datetime
 import json
 import os
@@ -85,6 +86,7 @@ def _reconstruct_ui_where_from_sql(sql_query, params):
         '"user"': "user",
         "api_key": "api_key",
         "request_id": "request_id",
+        "session_id": "session_id",
         "model": "model",
         "model_id": "model_id",
         "model_group": "model_group",
@@ -162,7 +164,21 @@ def make_ui_spend_logs_mock_prisma(mock_spend_logs, filter_fn, team_lookup_fn=No
         async def count(self, *args, **kwargs):
             return len(filter_fn(kwargs.get("where", {})))
 
+        async def group_by(self, by, where, count):
+            allowed = set(where["session_id"]["in"])
+            tallied = collections.Counter(
+                log["session_id"]
+                for log in mock_spend_logs
+                if log.get("session_id") in allowed
+            )
+            return [
+                {"session_id": sid, "_count": {"session_id": n}}
+                for sid, n in tallied.items()
+            ]
+
         async def query_raw(self, sql_query, *params):
+            if "mcp_tool_call_count" in sql_query:
+                return []
             filtered = filter_fn(_reconstruct_ui_where_from_sql(sql_query, params))
             total = len(filtered)
             if "COUNT(*)" in sql_query:
@@ -595,6 +611,74 @@ async def test_ui_view_spend_logs_with_user_id(client, monkeypatch):
     assert data["total"] == 1
     assert len(data["data"]) == 1
     assert data["data"][0]["user"] == "test_user_1"
+
+
+@pytest.mark.asyncio
+async def test_ui_view_spend_logs_with_session_id(client, monkeypatch):
+    mock_spend_logs = [
+        {
+            "id": "log1",
+            "request_id": "req1",
+            "api_key": "sk-test-key",
+            "user": "test_user_1",
+            "session_id": "session-abc",
+            "spend": 0.05,
+            "startTime": datetime.datetime.now(timezone.utc).isoformat(),
+            "model": "gpt-4",
+        },
+        {
+            "id": "log2",
+            "request_id": "req2",
+            "api_key": "sk-test-key",
+            "user": "test_user_1",
+            "session_id": "session-abc",
+            "spend": 0.10,
+            "startTime": datetime.datetime.now(timezone.utc).isoformat(),
+            "model": "gpt-4",
+        },
+        {
+            "id": "log3",
+            "request_id": "req3",
+            "api_key": "sk-test-key",
+            "user": "test_user_1",
+            "session_id": "session-other",
+            "spend": 0.02,
+            "startTime": datetime.datetime.now(timezone.utc).isoformat(),
+            "model": "gpt-4",
+        },
+    ]
+
+    def filter_by_session(where):
+        if "session_id" in where:
+            return [
+                log
+                for log in mock_spend_logs
+                if log["session_id"] == where["session_id"]
+            ]
+        return mock_spend_logs
+
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.prisma_client",
+        make_ui_spend_logs_mock_prisma(mock_spend_logs, filter_by_session),
+    )
+
+    start_date, end_date = _default_date_range()
+
+    response = client.get(
+        "/spend/logs/ui",
+        params={
+            "session_id": "session-abc",
+            "start_date": start_date,
+            "end_date": end_date,
+        },
+        headers={"Authorization": "Bearer sk-test"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 2
+    assert {log["request_id"] for log in data["data"]} == {"req1", "req2"}
+    assert all(log["session_id"] == "session-abc" for log in data["data"])
 
 
 # Mock spend logs with distinct values for sorting tests.

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -86,7 +86,6 @@ def _reconstruct_ui_where_from_sql(sql_query, params):
         '"user"': "user",
         "api_key": "api_key",
         "request_id": "request_id",
-        "session_id": "session_id",
         "model": "model",
         "model_id": "model_id",
         "model_group": "model_group",
@@ -100,6 +99,7 @@ def _reconstruct_ui_where_from_sql(sql_query, params):
         alias = re.search(r"user_api_key_alias' LIKE \$(\d+)", cond)
         code = re.search(r"error_code' = \$(\d+)", cond)
         msg = re.search(r"error_message' LIKE \$(\d+)", cond)
+        sess = re.fullmatch(r"session_id LIKE \$(\d+)", cond)
         status = re.fullmatch(r"status = \$(\d+)", cond)
         if gte:
             date_bounds["gte"] = _iso(params[int(gte.group(1)) - 1])
@@ -109,6 +109,8 @@ def _reconstruct_ui_where_from_sql(sql_query, params):
             where["OR"] = where.get("OR", []) + [{"multi_team": True}]
         elif "status = 'success'" in cond:
             where["OR"] = where.get("OR", []) + [{"status": "success"}]
+        elif sess:
+            where["session_id"] = {"contains": str(params[int(sess.group(1)) - 1]).strip("%")}
         elif status:
             where["status"] = {"equals": params[int(status.group(1)) - 1]}
         elif alias:
@@ -165,16 +167,14 @@ def make_ui_spend_logs_mock_prisma(mock_spend_logs, filter_fn, team_lookup_fn=No
             return len(filter_fn(kwargs.get("where", {})))
 
         async def group_by(self, by, where, count):
-            allowed = set(where["session_id"]["in"])
+            col = by[0]
+            allowed = where.get(col, {}).get("in")
             tallied = collections.Counter(
-                log["session_id"]
+                log[col]
                 for log in mock_spend_logs
-                if log.get("session_id") in allowed
+                if log.get(col) is not None and (allowed is None or log[col] in allowed)
             )
-            return [
-                {"session_id": sid, "_count": {"session_id": n}}
-                for sid, n in tallied.items()
-            ]
+            return [{col: value, "_count": {col: n}} for value, n in tallied.items()]
 
         async def query_raw(self, sql_query, *params):
             if "mcp_tool_call_count" in sql_query:
@@ -614,48 +614,47 @@ async def test_ui_view_spend_logs_with_user_id(client, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_ui_view_spend_logs_with_session_id(client, monkeypatch):
-    mock_spend_logs = [
-        {
-            "id": "log1",
-            "request_id": "req1",
+@pytest.mark.parametrize(
+    "session_id_query,expected_request_ids",
+    [
+        ("session-filter-demo-1", {"req1", "req2"}),
+        ("session-filter-demo-2", {"req3"}),
+        ("session-filter", {"req1", "req2", "req3"}),
+        ("demo", {"req1", "req2", "req3"}),
+        ("no-such-session", set()),
+    ],
+)
+async def test_ui_view_spend_logs_with_session_id(
+    client, monkeypatch, session_id_query, expected_request_ids
+):
+    def make_log(request_id, session_id):
+        return {
+            "id": f"log-{request_id}",
+            "request_id": request_id,
             "api_key": "sk-test-key",
             "user": "test_user_1",
-            "session_id": "session-abc",
+            "session_id": session_id,
             "spend": 0.05,
             "startTime": datetime.datetime.now(timezone.utc).isoformat(),
             "model": "gpt-4",
-        },
-        {
-            "id": "log2",
-            "request_id": "req2",
-            "api_key": "sk-test-key",
-            "user": "test_user_1",
-            "session_id": "session-abc",
-            "spend": 0.10,
-            "startTime": datetime.datetime.now(timezone.utc).isoformat(),
-            "model": "gpt-4",
-        },
-        {
-            "id": "log3",
-            "request_id": "req3",
-            "api_key": "sk-test-key",
-            "user": "test_user_1",
-            "session_id": "session-other",
-            "spend": 0.02,
-            "startTime": datetime.datetime.now(timezone.utc).isoformat(),
-            "model": "gpt-4",
-        },
+        }
+
+    mock_spend_logs = [
+        make_log("req1", "session-filter-demo-1"),
+        make_log("req2", "session-filter-demo-1"),
+        make_log("req3", "session-filter-demo-2"),
+        make_log("req4", "unrelated-abc"),
     ]
 
     def filter_by_session(where):
-        if "session_id" in where:
-            return [
-                log
-                for log in mock_spend_logs
-                if log["session_id"] == where["session_id"]
-            ]
-        return mock_spend_logs
+        session_filter = where.get("session_id")
+        if session_filter is None:
+            return mock_spend_logs
+        return [
+            log
+            for log in mock_spend_logs
+            if session_filter["contains"] in log["session_id"]
+        ]
 
     monkeypatch.setattr(
         "litellm.proxy.proxy_server.prisma_client",
@@ -667,7 +666,7 @@ async def test_ui_view_spend_logs_with_session_id(client, monkeypatch):
     response = client.get(
         "/spend/logs/ui",
         params={
-            "session_id": "session-abc",
+            "session_id": session_id_query,
             "start_date": start_date,
             "end_date": end_date,
         },
@@ -676,9 +675,9 @@ async def test_ui_view_spend_logs_with_session_id(client, monkeypatch):
 
     assert response.status_code == 200
     data = response.json()
-    assert data["total"] == 2
-    assert {log["request_id"] for log in data["data"]} == {"req1", "req2"}
-    assert all(log["session_id"] == "session-abc" for log in data["data"])
+    assert data["total"] == len(expected_request_ids)
+    assert {log["request_id"] for log in data["data"]} == expected_request_ids
+    assert all(session_id_query in log["session_id"] for log in data["data"])
 
 
 # Mock spend logs with distinct values for sorting tests.

--- a/ui/litellm-dashboard/eslint-metrics.json
+++ b/ui/litellm-dashboard/eslint-metrics.json
@@ -1,7 +1,7 @@
 {
   "@typescript-eslint/no-explicit-any": 1982,
   "complexity": 128,
-  "local/no-large-inline-object-arg": 512,
+  "local/no-large-inline-object-arg": 519,
   "local/no-long-condition-chain": 233,
   "max-depth": 59,
   "no-console": 15

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -1929,6 +1929,7 @@ interface UiSpendLogsParams {
   api_key?: string;
   team_id?: string;
   request_id?: string;
+  session_id?: string;
   user_id?: string;
   end_user?: string;
   status_filter?: string;

--- a/ui/litellm-dashboard/src/components/view_logs/filter_options.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/filter_options.ts
@@ -64,6 +64,11 @@ export function getLogFilterOptions(accessToken: string): FilterOption[] {
       isSearchable: false,
     },
     {
+      name: FILTER_KEYS.SESSION_ID,
+      label: "Session ID",
+      isSearchable: false,
+    },
+    {
       name: "Model",
       label: "Model",
       customComponent: PaginatedModelSelect,

--- a/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.test.tsx
@@ -218,6 +218,7 @@ describe("useLogFilterLogic", () => {
       { filterKey: "Team ID", paramName: "team_id", value: "team-a" },
       { filterKey: "Key Hash", paramName: "api_key", value: "key-x" },
       { filterKey: "Request ID", paramName: "request_id", value: "req-xyz" },
+      { filterKey: "Session ID", paramName: "session_id", value: "sess-42" },
       { filterKey: "User ID", paramName: "user_id", value: "user-123" },
       { filterKey: "End User", paramName: "end_user", value: "user-a" },
       { filterKey: "Status", paramName: "status_filter", value: "error" },

--- a/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
@@ -30,6 +30,7 @@ export const FILTER_KEYS = {
   TEAM_ID: "Team ID",
   KEY_HASH: "Key Hash",
   REQUEST_ID: "Request ID",
+  SESSION_ID: "Session ID",
   MODEL: "Model",
   /** Exact match on LiteLLM_SpendLogs.model — use for search tools and public model names. */
   PUBLIC_MODEL_OR_SEARCH_TOOL: "Public model / search tool",
@@ -49,6 +50,7 @@ const TEXT_FILTER_KEYS: readonly (keyof LogFilterState)[] = [
   FILTER_KEYS.KEY_HASH,
   FILTER_KEYS.ERROR_MESSAGE,
   FILTER_KEYS.REQUEST_ID,
+  FILTER_KEYS.SESSION_ID,
   FILTER_KEYS.USER_ID,
   FILTER_KEYS.PUBLIC_MODEL_OR_SEARCH_TOOL,
 ];
@@ -62,6 +64,7 @@ export const defaultFilters: LogFilterState = {
   [FILTER_KEYS.TEAM_ID]: "",
   [FILTER_KEYS.KEY_HASH]: "",
   [FILTER_KEYS.REQUEST_ID]: "",
+  [FILTER_KEYS.SESSION_ID]: "",
   [FILTER_KEYS.MODEL]: "",
   [FILTER_KEYS.PUBLIC_MODEL_OR_SEARCH_TOOL]: "",
   [FILTER_KEYS.USER_ID]: "",
@@ -160,6 +163,7 @@ export function useLogFilterLogic({
           api_key: effectiveFilters[FILTER_KEYS.KEY_HASH] || undefined,
           team_id: effectiveFilters[FILTER_KEYS.TEAM_ID] || undefined,
           request_id: effectiveFilters[FILTER_KEYS.REQUEST_ID] || undefined,
+          session_id: effectiveFilters[FILTER_KEYS.SESSION_ID] || undefined,
           user_id: effectiveFilters[FILTER_KEYS.USER_ID] || (filterByCurrentUser ? userID ?? undefined : undefined),
           end_user: effectiveFilters[FILTER_KEYS.END_USER] || undefined,
           status_filter: effectiveFilters[FILTER_KEYS.STATUS] || undefined,

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -48633,6 +48633,8 @@ export interface operations {
                 user_id?: string | null;
                 /** @description request_id to get spend logs for specific request_id */
                 request_id?: string | null;
+                /** @description Filter spend logs by session_id */
+                session_id?: string | null;
                 /** @description Filter spend logs by team_id */
                 team_id?: string | null;
                 /** @description Filter logs with spend greater than or equal to this value */
@@ -48739,6 +48741,8 @@ export interface operations {
                 user_id?: string | null;
                 /** @description request_id to get spend logs for specific request_id */
                 request_id?: string | null;
+                /** @description Filter spend logs by session_id */
+                session_id?: string | null;
                 /** @description Filter spend logs by team_id */
                 team_id?: string | null;
                 /** @description Filter logs with spend greater than or equal to this value */

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -48633,7 +48633,7 @@ export interface operations {
                 user_id?: string | null;
                 /** @description request_id to get spend logs for specific request_id */
                 request_id?: string | null;
-                /** @description Filter spend logs by session_id */
+                /** @description Filter spend logs by session_id (partial string match) */
                 session_id?: string | null;
                 /** @description Filter spend logs by team_id */
                 team_id?: string | null;
@@ -48741,7 +48741,7 @@ export interface operations {
                 user_id?: string | null;
                 /** @description request_id to get spend logs for specific request_id */
                 request_id?: string | null;
-                /** @description Filter spend logs by session_id */
+                /** @description Filter spend logs by session_id (partial string match) */
                 session_id?: string | null;
                 /** @description Filter spend logs by team_id */
                 team_id?: string | null;


### PR DESCRIPTION
> [!NOTE]
> **Copy of #32568 by @thibault-linktree**, pushed to a `litellm_`-prefixed branch so the full CircleCI suite (which doesn't run on fork PRs) executes. Commit authorship is preserved — all commits remain authored by the original author. **Full credit to @thibault-linktree.**

## Relevant issues

Fixes #32585
Original PR: #32568

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🆕 New Feature

## Changes

The Requests logs tab lets you filter by request id but not by session id, so tracking a full conversation means clicking through rows manually. This adds a Session ID filter end to end.

On the backend, `/spend/logs/v2` and `/spend/logs/ui` gain a `session_id` query parameter that does a partial (substring) match on the `session_id` column of `LiteLLM_SpendLogs` (already indexed), following the same pattern as the existing `request_id` filter. The pattern value has `\`, `%`, and `_` escaped before being wrapped in `%…%`, so pasting a session-id prefix matches every request in that conversation.

On the dashboard, the Logs filter panel gains a Session ID text input wired through `FILTER_KEYS`, the debounced text filter list, and `uiSpendLogsCall`, which forwards it as the `session_id` query param. `schema.d.ts` is regenerated for the new parameter.

Tests: a new endpoint test asserts that filtering by session id (full id and substring prefixes) returns only that session's rows (the shared mock prisma helper now also supports the session-count enrichment queries, so endpoint tests can use rows that carry a `session_id`), and the frontend filter mapping test table gains the Session ID → `session_id` case.

## Screenshots / Proof of Fix

The following live-proxy reproduction was captured by the original author (@thibault-linktree) at `9a4652ebdc` against a live proxy (`python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --use_v2_migration_resolver` on localhost:4000 with a local Postgres), hitting the real OpenAI API with real spend.

Three real chat completions across two sessions, using the `x-litellm-session-id` header:

```
chatcmpl-DzYBwiyvPqgfkGKDCLWkaLuRCGfiZ -> First call.
chatcmpl-DzYBxzJOqKPt9xORX3c1EqsDMxTfm -> Second call.
chatcmpl-DzYByXcuTk8q7pj89gjgLYt7DvcQd -> Other session
```

Then the logs endpoint with the new `session_id` filter:

```
== filter session-filter-demo-1 ==
total: 2
chatcmpl-DzYBxzJOqKPt9xORX3c1EqsDMxTfm session-filter-demo-1
chatcmpl-DzYBwiyvPqgfkGKDCLWkaLuRCGfiZ session-filter-demo-1
== filter session-filter-demo-2 ==
total: 1
chatcmpl-DzYByXcuTk8q7pj89gjgLYt7DvcQd session-filter-demo-2
== no session filter ==
total: 3
```

<img width="899" height="461" alt="image" src="https://github.com/user-attachments/assets/e8108be9-ab80-432d-8753-4df545e0d3fd" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive filter on existing spend-log list endpoints and UI; no auth or spend-calculation changes, with LIKE escaping for wildcard safety.
> 
> **Overview**
> Adds **Session ID** filtering for the Requests logs flow so you can narrow paginated spend logs to a conversation instead of hunting by individual request IDs.
> 
> **Backend:** `/spend/logs/ui` and `/spend/logs/v2` accept a new `session_id` query parameter. When set, the raw SQL path applies `session_id LIKE %…%` with `\`, `%`, and `_` escaped in the user input (substring match, not exact equality like `request_id`).
> 
> **Dashboard:** The logs filter panel gets a debounced **Session ID** text field, wired through `FILTER_KEYS`, `uiSpendLogsCall`, and regenerated OpenAPI types in `schema.d.ts`.
> 
> **Tests:** Backend coverage for full/partial session filters on `/spend/logs/ui`, plus mock Prisma helpers for `group_by` and MCP enrichment queries; frontend filter-param mapping includes Session ID → `session_id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a44fdd66321f26d87223112487e72e0a8c24e27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->