### PR TITLE
fix(tests): stop DATABASE_URL env pollution from read-replica tests breaking DB e2e tests

### DIFF
--- a/tests/test_litellm/proxy/db/conftest.py
+++ b/tests/test_litellm/proxy/db/conftest.py
@@ -1,0 +1,65 @@
+import os
+from collections.abc import Generator
+from typing import Optional
+
+import pytest
+
+DB_ENV_KEYS = (
+    "IAM_TOKEN_DB_AUTH",
+    "DATABASE_URL",
+    "DIRECT_URL",
+    "DATABASE_URL_READ_REPLICA",
+    "DATABASE_HOST",
+    "DATABASE_PORT",
+    "DATABASE_USER",
+    "DATABASE_USERNAME",
+    "DATABASE_NAME",
+    "DATABASE_SCHEMA",
+    "DATABASE_PASSWORD",
+    "DATABASE_HOST_READ_REPLICA",
+    "DATABASE_PORT_READ_REPLICA",
+    "DATABASE_USER_READ_REPLICA",
+    "DATABASE_USERNAME_READ_REPLICA",
+    "DATABASE_NAME_READ_REPLICA",
+    "DATABASE_SCHEMA_READ_REPLICA",
+    "DATABASE_PASSWORD_READ_REPLICA",
+)
+
+_db_env_snapshot_key = pytest.StashKey[dict[str, Optional[str]]]()
+
+
+def _db_env_snapshot() -> dict[str, Optional[str]]:
+    return {key: os.environ.get(key) for key in DB_ENV_KEYS}
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_runtest_setup(item: pytest.Item) -> Generator[None, None, None]:
+    item.stash[_db_env_snapshot_key] = _db_env_snapshot()
+    return (yield)
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_runtest_teardown(item: pytest.Item, nextitem: Optional[pytest.Item]) -> Generator[None, None, None]:
+    result = yield
+    before = item.stash[_db_env_snapshot_key]
+    leaked = {key: value for key, value in _db_env_snapshot().items() if value != before[key]}
+    for key, original in before.items():
+        if original is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = original
+    assert not leaked, (
+        f"{item.nodeid} leaked DB env vars past monkeypatch teardown: {leaked}. "
+        "Product code under test writes DATABASE_URL(_READ_REPLICA) into os.environ as a side effect; "
+        "monkeypatch only restores keys it has a record for, so a value written to a previously unset "
+        "key survives the test and poisons every later test in this pytest-xdist worker process "
+        "(DB-backed e2e tests arm themselves on DATABASE_URL and then fail to connect). "
+        "Use the unset_database_url fixture (or monkeypatch.setenv) so restoration is registered."
+    )
+    return result
+
+
+@pytest.fixture
+def unset_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "about-to-be-unset")
+    monkeypatch.delenv("DATABASE_URL")

--- a/tests/test_litellm/proxy/db/test_db_url_settings.py
+++ b/tests/test_litellm/proxy/db/test_db_url_settings.py
@@ -51,25 +51,21 @@ _MANAGED_DB_ENV_VARS = (
 
 
 @pytest.fixture(autouse=True)
-def _scrub_db_env():
+def _scrub_db_env(monkeypatch):
     """Start each test from a clean slate and restore the original env afterward.
 
-    ``apply_to_env`` writes ``DATABASE_URL`` straight into ``os.environ``, which
-    ``monkeypatch`` cannot undo. Snapshotting and restoring here keeps a
-    synthesized URL (e.g. ``writer.example.com``) from leaking into later tests
-    that read ``DATABASE_URL`` to decide whether to hit a real database.
+    ``apply_to_env`` writes ``DATABASE_URL`` straight into ``os.environ``.
+    Registering a setenv+delenv pair per var gives ``monkeypatch`` a restore
+    record even for previously unset keys, so a synthesized URL (e.g.
+    ``writer.example.com``) cannot leak into later tests that read
+    ``DATABASE_URL`` to decide whether to hit a real database. Restoring via
+    the same ``monkeypatch`` instance the tests use also keeps undo ordering
+    consistent (a hand-rolled snapshot/restore runs before ``monkeypatch``'s
+    own undo and gets clobbered by it).
     """
-    saved = {var: os.environ.get(var) for var in _MANAGED_DB_ENV_VARS}
     for var in _MANAGED_DB_ENV_VARS:
-        os.environ.pop(var, None)
-    try:
-        yield
-    finally:
-        for var, value in saved.items():
-            if value is None:
-                os.environ.pop(var, None)
-            else:
-                os.environ[var] = value
+        monkeypatch.setenv(var, "scrubbed")
+        monkeypatch.delenv(var)
 
 
 def _stub_iam_token(token: str = "FAKE_TOKEN"):

--- a/tests/test_litellm/proxy/db/test_rds_iam_token_expiry.py
+++ b/tests/test_litellm/proxy/db/test_rds_iam_token_expiry.py
@@ -26,25 +26,13 @@ class TestPrismaWrapperTokenRefresh:
     """Tests for the PrismaWrapper RDS IAM token refresh implementation."""
 
     @pytest.fixture
-    def setup_env(self):
+    def setup_env(self, monkeypatch, unset_database_url):
         """Setup environment variables for testing."""
-        os.environ["DATABASE_HOST"] = "test-host.rds.amazonaws.com"
-        os.environ["DATABASE_PORT"] = "5432"
-        os.environ["DATABASE_USER"] = "test_user"
-        os.environ["DATABASE_NAME"] = "test_db"
-        os.environ["IAM_TOKEN_DB_AUTH"] = "True"
-        yield
-        # Cleanup
-        for key in [
-            "DATABASE_HOST",
-            "DATABASE_PORT",
-            "DATABASE_USER",
-            "DATABASE_NAME",
-            "DATABASE_URL",
-            "IAM_TOKEN_DB_AUTH",
-            "DATABASE_SCHEMA",
-        ]:
-            os.environ.pop(key, None)
+        monkeypatch.setenv("DATABASE_HOST", "test-host.rds.amazonaws.com")
+        monkeypatch.setenv("DATABASE_PORT", "5432")
+        monkeypatch.setenv("DATABASE_USER", "test_user")
+        monkeypatch.setenv("DATABASE_NAME", "test_db")
+        monkeypatch.setenv("IAM_TOKEN_DB_AUTH", "True")
 
     def _generate_mock_token(self, expires_in_seconds: int = 900) -> str:
         """Generate a mock IAM token with expiration info."""
@@ -172,22 +160,12 @@ class TestBackgroundRefreshLoop:
     """Tests for the background refresh loop timing."""
 
     @pytest.fixture
-    def setup_env(self):
+    def setup_env(self, monkeypatch, unset_database_url):
         """Setup environment variables for testing."""
-        os.environ["DATABASE_HOST"] = "test-host.rds.amazonaws.com"
-        os.environ["DATABASE_PORT"] = "5432"
-        os.environ["DATABASE_USER"] = "test_user"
-        os.environ["DATABASE_NAME"] = "test_db"
-        yield
-        # Cleanup
-        for key in [
-            "DATABASE_HOST",
-            "DATABASE_PORT",
-            "DATABASE_USER",
-            "DATABASE_NAME",
-            "DATABASE_URL",
-        ]:
-            os.environ.pop(key, None)
+        monkeypatch.setenv("DATABASE_HOST", "test-host.rds.amazonaws.com")
+        monkeypatch.setenv("DATABASE_PORT", "5432")
+        monkeypatch.setenv("DATABASE_USER", "test_user")
+        monkeypatch.setenv("DATABASE_NAME", "test_db")
 
     @pytest.mark.asyncio
     async def test_calculate_seconds_fallback_when_no_url(self, setup_env):

--- a/tests/test_litellm/proxy/db/test_routing_prisma_wrapper.py
+++ b/tests/test_litellm/proxy/db/test_routing_prisma_wrapper.py
@@ -626,7 +626,7 @@ async def test_getattr_does_not_block_inside_running_loop_on_expired_token(monke
     assert refresh_calls["count"] == 1
 
 
-def test_writer_get_rds_iam_token_defaults_port_when_unset(monkeypatch):
+def test_writer_get_rds_iam_token_defaults_port_when_unset(monkeypatch, unset_database_url):
     """When DATABASE_PORT is unset, the writer must default to the Postgres
     standard port instead of passing `None` through. Passing None to
     `generate_iam_auth_token` makes botocore embed the literal string
@@ -639,7 +639,6 @@ def test_writer_get_rds_iam_token_defaults_port_when_unset(monkeypatch):
     monkeypatch.setenv("DATABASE_USER", "litellm")
     monkeypatch.setenv("DATABASE_NAME", "litellm")
     monkeypatch.delenv("DATABASE_SCHEMA", raising=False)
-    monkeypatch.delenv("DATABASE_URL", raising=False)
 
     captured: Dict[str, Any] = {}
 
@@ -661,7 +660,7 @@ def test_writer_get_rds_iam_token_defaults_port_when_unset(monkeypatch):
     assert ":5432/litellm" in (new_url or "")
 
 
-def test_writer_get_rds_iam_token_uses_database_host_env_vars(monkeypatch):
+def test_writer_get_rds_iam_token_uses_database_host_env_vars(monkeypatch, unset_database_url):
     """Writer's IAM path (no iam_endpoint configured) reads host/port/user/db
     from the legacy DATABASE_HOST/PORT/USER/NAME env vars and writes the URL
     back to DATABASE_URL — this is the pre-read-replica behavior the patch
@@ -673,7 +672,6 @@ def test_writer_get_rds_iam_token_uses_database_host_env_vars(monkeypatch):
     monkeypatch.setenv("DATABASE_USER", "litellm")
     monkeypatch.setenv("DATABASE_NAME", "litellm")
     monkeypatch.setenv("DATABASE_SCHEMA", "public")
-    monkeypatch.delenv("DATABASE_URL", raising=False)
 
     captured: Dict[str, Any] = {}
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This fixes a CI-only test flake, so the proof is the deterministic reproduction of the worker poisoning itself; there is no proxy behavior change to demonstrate

CI occurrences of the flake, all on PRs that touch nothing related: https://github.com/BerriAI/litellm/actions/runs/28994072776/job/86039902861 (first attempt, poisoned worker gw1), https://github.com/BerriAI/litellm/actions/runs/28994072776/job/86048515541 (full job rerun, poisoned worker gw0), https://github.com/BerriAI/litellm/actions/runs/29036129022/job/86181354539 (different branch, same failure). Each shows `1 failed, 4242 passed, ..., 2 rerun` with

```
FAILED tests/test_litellm/proxy/common_utils/test_key_rotation_e2e.py::TestDeprecatedKeyLookupDbE2E::test_deprecated_key_grace_period_cache_hit_path - httpx.ConnectError: All connection attempts failed
{"is_panic":false,"message":"Can't reach database server at `writer.aurora.local`:`5432`...","error_code":"P1001"}
```

`writer.aurora.local` is a fake hostname that only exists in `tests/test_litellm/proxy/db/test_routing_prisma_wrapper.py`

Before, captured at 60729f733e (the branch point). `PYTEST_XDIST_WORKER=gw0` mirrors a CI xdist worker (it disables the single-process litellm module reload in `tests/test_litellm/conftest.py`), and popping `DATABASE_URL` after importing litellm mirrors CI where the proxy-infra job defines no `DATABASE_URL` (locally a `.env` can set one at import time)

```
$ env -u DATABASE_URL PYTEST_XDIST_WORKER=gw0 uv run python -c "
import os, litellm, pytest
os.environ.pop('DATABASE_URL', None)
rc1 = pytest.main(['-q', '-p', 'no:xdist', '-p', 'no:pytest-retry', 'tests/test_litellm/proxy/db/test_routing_prisma_wrapper.py'])
print('routing file exit:', rc1, '| DATABASE_URL now:', os.environ.get('DATABASE_URL'))
rc2 = pytest.main(['-q', '-p', 'no:xdist', '-p', 'no:pytest-retry', 'tests/test_litellm/proxy/common_utils/test_key_rotation_e2e.py::TestDeprecatedKeyLookupDbE2E'])
print('e2e exit:', rc2)
"
39 passed, 3 warnings in 2.45s
routing file exit: 0 | DATABASE_URL now: postgresql://litellm:TOKEN@writer.aurora.local:5432/litellm
...
{"is_panic":false,"message":"Can't reach database server at `writer.aurora.local`:`5432`\n\nPlease make sure your database server is running at `writer.aurora.local`:`5432`.","meta":{"database_host":"writer.aurora.local","database_port":5432},"error_code":"P1001"}
FAILED tests/test_litellm/proxy/common_utils/test_key_rotation_e2e.py::TestDeprecatedKeyLookupDbE2E::test_deprecated_key_grace_period_cache_hit_path
1 failed, 2 warnings in 11.16s
e2e exit: 1
```

That is the exact CI failure, reproduced deterministically in one process: the routing wrapper tests pass but leave the fake URL in `os.environ`, and the DB e2e test, which skips when `DATABASE_URL` is unset, arms itself on the poisoned value and dies

Regression guard demonstration, captured at 60729f733e plus only the new `tests/test_litellm/proxy/db/conftest.py` (no other change): the leaking tests now fail at teardown, at the culprit, instead of poisoning a distant test

```
_ ERROR at teardown of test_writer_get_rds_iam_token_defaults_port_when_unset __
E  AssertionError: tests/test_litellm/proxy/db/test_routing_prisma_wrapper.py::test_writer_get_rds_iam_token_defaults_port_when_unset leaked DB env vars past monkeypatch teardown: {'DATABASE_URL': 'postgresql://litellm:TOKEN@writer.aurora.local:5432/litellm'}. ...
_ ERROR at teardown of test_writer_get_rds_iam_token_uses_database_host_env_vars _
E  AssertionError: ... leaked DB env vars past monkeypatch teardown: {'DATABASE_URL': 'postgresql://litellm:WRITER-TOKEN@writer.aurora.local:5432/litellm?schema=public'}. ...
39 passed, 3 warnings, 2 errors in 2.72s
```

After, captured at 4058667325 (this PR)

```
$ env -u DATABASE_URL PYTEST_XDIST_WORKER=gw0 uv run python -c "
import os, litellm, pytest
os.environ.pop('DATABASE_URL', None)
rc1 = pytest.main(['-q', '-p', 'no:xdist', '-p', 'no:pytest-retry', 'tests/test_litellm/proxy/db/test_routing_prisma_wrapper.py'])
print('routing file exit:', rc1, '| DATABASE_URL now:', os.environ.get('DATABASE_URL'))
rc2 = pytest.main(['-q', '-rs', '-p', 'no:xdist', '-p', 'no:pytest-retry', 'tests/test_litellm/proxy/common_utils/test_key_rotation_e2e.py::TestDeprecatedKeyLookupDbE2E'])
print('e2e exit:', rc2)
"
39 passed, 3 warnings in 2.58s
routing file exit: 0 | DATABASE_URL now: None
SKIPPED [1] tests/test_litellm/proxy/common_utils/test_key_rotation_e2e.py:582: DATABASE_URL not set; skipping DB-backed key-rotation E2E test.
1 skipped, 2 warnings in 0.03s
e2e exit: 0
```

And the CI-shaped run at 4058667325 (2 xdist workers, loadscope, whole db dir plus the e2e file, `DATABASE_URL` unset)

```
$ env -u DATABASE_URL uv run pytest tests/test_litellm/proxy/db/ tests/test_litellm/proxy/common_utils/test_key_rotation_e2e.py -q -n 2 --dist=loadscope -rs
SKIPPED [1] tests/test_litellm/proxy/common_utils/test_key_rotation_e2e.py:582: DATABASE_URL not set; skipping DB-backed key-rotation E2E test.
326 passed, 1 skipped, 17 warnings in 6.64s
```

## Type

🐛 Bug Fix
✅ Test

## Changes

`PrismaWrapper.get_rds_iam_token` (litellm/proxy/db/prisma_client.py:329) writes the freshly minted writer URL into `os.environ["DATABASE_URL"]` as a side effect. Two tests in `tests/test_litellm/proxy/db/test_routing_prisma_wrapper.py` exercise that path with the fake host `writer.aurora.local` and guarded the env var with `monkeypatch.delenv("DATABASE_URL", raising=False)`. When the key is absent, which is the case in the proxy-infra CI job, `delenv(raising=False)` records nothing, so monkeypatch has nothing to restore and the fake URL written by product code survives the test. The pytest-xdist worker process is then permanently poisoned: `TestDeprecatedKeyLookupDbE2E::test_deprecated_key_grace_period_cache_hit_path` skips itself when `DATABASE_URL` is unset, but on a poisoned worker it sees the fake URL, connects Prisma to `writer.aurora.local:5432` and fails with P1001. pytest-rerunfailures reruns the failed test inside the same worker process where `os.environ` is still poisoned, so the two configured reruns can never rescue it; and `--dist=loadscope` assigns the routing module and the single-test e2e class to workers based on runtime timing, so the two only sometimes land on the same worker, which is why unrelated PRs fail intermittently (gw1 in one linked run, gw0 in its rerun)

The fix has two layers. First, a new `tests/test_litellm/proxy/db/conftest.py` makes the bug class impossible for the whole directory: a `pytest_runtest_setup`/`pytest_runtest_teardown` hookwrapper pair snapshots the `DATABASE_*` env keys before any fixture runs and, after all fixture finalizers (including monkeypatch undo) have run, restores the snapshot and fails the test loudly if anything leaked. It has to be a hook pair rather than an autouse fixture because `isolate_host_aws_config` in the parent conftest requests `monkeypatch`, so the shared monkeypatch instance always finalizes after any module-level fixture and a fixture-based guard would compare against pre-undo state. Second, the two leaking tests now use a `unset_database_url` fixture that registers a setenv+delenv pair, giving monkeypatch a restore record even when the key started out unset

Running the guard over the directory also exposed two more latent leaks of the opposite direction (deleting a `DATABASE_URL` that was set at session start, which matters for anyone running with a `.env` and for future CI jobs that set `DATABASE_URL`): the `setup_env` fixtures in `test_rds_iam_token_expiry.py` wrote and popped `os.environ` directly, and `_scrub_db_env` in `test_db_url_settings.py` used a hand-rolled snapshot/restore that runs before monkeypatch undo and gets clobbered by it. Both now route through monkeypatch so restoration ordering is correct

The product-code `os.environ` mutation itself is left alone: the writer wrapper deliberately relies on Prisma re-reading `DATABASE_URL` from env on reconnect, so removing the side effect is a larger refactor than a test flake fix should carry

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test infrastructure and env isolation; no proxy or runtime behavior is modified.
> 
> **Overview**
> Adds **`tests/test_litellm/proxy/db/conftest.py`** with setup/teardown hooks that snapshot all `DATABASE_*` env keys, restore them after fixtures (including `monkeypatch` undo), and **fail the test** if anything still leaked. Also adds an **`unset_database_url`** fixture that registers `setenv`+`delenv` so `monkeypatch` can restore `DATABASE_URL` when it started unset—fixing the case where `PrismaWrapper.get_rds_iam_token` writes a fake URL into `os.environ` and poisons later tests on the same xdist worker.
> 
> Updates **`_scrub_db_env`** in `test_db_url_settings.py` and **`setup_env`** in `test_rds_iam_token_expiry.py` to use `monkeypatch` instead of manual snapshot/pop. The two writer IAM tests in **`test_routing_prisma_wrapper.py`** now depend on **`unset_database_url`** instead of `delenv(..., raising=False)` alone.
> 
> No production code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40586673257a3ff688a7e5fa4ed5652549795087. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->