### PR TITLE
fix(bedrock-invoke): retain clear_tool_uses_20250919 context_management edits and emit context-management-2025-06-27 beta (LIT-3393)

### DIFF
--- a/litellm/anthropic_beta_headers_config.json
+++ b/litellm/anthropic_beta_headers_config.json
@@ -102,7 +102,7 @@
     "computer-use-2025-01-24": "computer-use-2025-01-24",
     "computer-use-2025-11-24": "computer-use-2025-11-24",
     "context-1m-2025-08-07": "context-1m-2025-08-07",
-    "context-management-2025-06-27": null,
+    "context-management-2025-06-27": "context-management-2025-06-27",
     "effort-2025-11-24": "effort-2025-11-24",
     "fast-mode-2026-02-01": null,
     "files-api-2025-04-14": null,

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -489,24 +489,43 @@ class AmazonAnthropicClaudeMessagesConfig(
             if self._supports_tool_search_on_bedrock(model):
                 beta_set.add("tool-search-tool-2025-10-19")
 
+    # Bedrock-InvokeModel-supported ``context_management.edits`` types and the
+    # ``anthropic-beta`` header that each one requires. ``clear_thinking_20251015``
+    # is intentionally absent — it is LiteLLM-internal, consumed via
+    # ``_ensure_thinking_for_clear_thinking_context_management``, and forwarding
+    # the raw edit trips Bedrock's
+    # ``"context_management: Extra inputs are not permitted"`` 400.
+    #
+    # Bedrock InvokeModel DOES support ``clear_tool_uses_20250919`` under the
+    # ``context-management-2025-06-27`` beta. AWS docs:
+    # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-tool-use.md
+    _BEDROCK_INVOKE_SUPPORTED_CONTEXT_MANAGEMENT_EDITS: Dict[str, str] = {
+        "compact_20260112": ANTHROPIC_BETA_HEADER_VALUES.COMPACT_2026_01_12.value,
+        "clear_tool_uses_20250919": ANTHROPIC_BETA_HEADER_VALUES.CONTEXT_MANAGEMENT_2025_06_27.value,
+    }
+
     @staticmethod
     def _filter_context_management_for_bedrock_invoke(
         anthropic_messages_request: Dict,
         beta_set: set,
     ) -> None:
         """
-        Bedrock InvokeModel accepts ``context_management`` only when it carries
-        ``compact_20260112`` edits paired with the ``compact-2026-01-12``
-        anthropic-beta header. Other edit types (notably ``clear_thinking_20251015``,
-        which Claude Code sends on every request) are LiteLLM-internal and would
-        cause Bedrock to 400 with ``"context_management: Extra inputs are not
-        permitted"``.
+        Filter ``context_management.edits`` to the subset that Bedrock InvokeModel
+        accepts and add the matching ``anthropic-beta`` header for each surviving
+        edit type.
 
-        Filter the edits list to the supported subset, add the beta header when
-        compact edits remain, and drop ``context_management`` entirely when no
-        supported edits are left so the safety-net allowlist can pass it through.
+        - ``compact_20260112`` -> ``compact-2026-01-12``
+        - ``clear_tool_uses_20250919`` -> ``context-management-2025-06-27``
 
-        Ref: https://github.com/BerriAI/litellm/issues/27532
+        Other edit types (notably ``clear_thinking_20251015``, which Claude Code
+        sends on every request) are LiteLLM-internal: thinking is injected
+        separately via ``_ensure_thinking_for_clear_thinking_context_management``,
+        and forwarding the raw edit would trip Bedrock's
+        ``"context_management: Extra inputs are not permitted"`` 400.
+
+        Refs:
+          * https://github.com/BerriAI/litellm/issues/27532
+          * https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-tool-use.md
         """
         cm = anthropic_messages_request.get("context_management")
         if not isinstance(cm, dict):
@@ -516,15 +535,17 @@ class AmazonAnthropicClaudeMessagesConfig(
             anthropic_messages_request.pop("context_management", None)
             return
 
-        compact_edits = [e for e in edits if isinstance(e, dict) and e.get("type") == "compact_20260112"]
-        if compact_edits:
-            beta_set.add(ANTHROPIC_BETA_HEADER_VALUES.COMPACT_2026_01_12.value)
-            anthropic_messages_request["context_management"] = {
-                **cm,
-                "edits": compact_edits,
-            }
-        else:
+        supported = AmazonAnthropicClaudeMessagesConfig._BEDROCK_INVOKE_SUPPORTED_CONTEXT_MANAGEMENT_EDITS
+        retained_edits = [e for e in edits if isinstance(e, dict) and e.get("type") in supported]
+        if not retained_edits:
             anthropic_messages_request.pop("context_management", None)
+            return
+
+        beta_set.update(supported[e["type"]] for e in retained_edits)
+        anthropic_messages_request["context_management"] = {
+            **cm,
+            "edits": retained_edits,
+        }
 
     def _get_bedrock_invoke_anthropic_beta_headers(
         self,

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -2090,3 +2090,184 @@ def test_bedrock_clear_thinking_leaves_enabled_thinking_on_non_adaptive_model():
     assert changed is False
     assert request["thinking"] == {"type": "enabled", "budget_tokens": 8000}
     assert "output_config" not in request
+
+
+def test_bedrock_messages_preserves_clear_tool_uses_context_management_and_adds_beta(monkeypatch):
+    """
+    LIT-3393: Bedrock InvokeModel supports automatic tool-call clearing via
+    ``clear_tool_uses_20250919`` under the ``context-management-2025-06-27``
+    beta. Before the LIT-3393 fix, the transformation stripped this edit (only
+    ``compact_20260112`` survived) AND the beta was filtered out by
+    ``filter_and_transform_beta_headers`` for ``bedrock``, producing a Bedrock
+    400 ``"context_management: Extra inputs are not permitted"``.
+
+    Post-fix, the edit must reach the body and the beta must reach
+    ``anthropic_beta``.
+
+    AWS docs ("Automatic tool call clearing (Beta)"):
+    https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-tool-use.md
+    """
+    from litellm.types.router import GenericLiteLLMParams
+    from litellm.anthropic_beta_headers_manager import (
+        reload_beta_headers_config,
+    )
+    monkeypatch.setenv("LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS", "True")
+    reload_beta_headers_config()
+
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+    messages = [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}]
+    optional_params = {
+        "max_tokens": 4096,
+        "context_management": {
+            "edits": [{"type": "clear_tool_uses_20250919"}]
+        },
+    }
+
+    result = cfg.transform_anthropic_messages_request(
+        model="anthropic.claude-haiku-4-5-20251001-v1:0",
+        messages=messages,
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    assert result.get("context_management") == {
+        "edits": [{"type": "clear_tool_uses_20250919"}]
+    }, "clear_tool_uses_20250919 edit must reach Bedrock InvokeModel body"
+    assert "context-management-2025-06-27" in result.get("anthropic_beta", []), (
+        "context-management-2025-06-27 beta must reach the InvokeModel body so "
+        "the tool-call-clearing edit is accepted"
+    )
+
+
+def test_bedrock_messages_preserves_mixed_compact_and_clear_tool_uses_edits(monkeypatch):
+    """
+    LIT-3393: a request mixing ``compact_20260112`` and
+    ``clear_tool_uses_20250919`` must keep BOTH edits and emit BOTH
+    anthropic-beta values (``compact-2026-01-12`` + ``context-management-2025-06-27``).
+    """
+    from litellm.types.router import GenericLiteLLMParams
+    from litellm.anthropic_beta_headers_manager import (
+        reload_beta_headers_config,
+    )
+    monkeypatch.setenv("LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS", "True")
+    reload_beta_headers_config()
+
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+    messages = [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}]
+    optional_params = {
+        "max_tokens": 4096,
+        "context_management": {
+            "edits": [
+                {"type": "compact_20260112"},
+                {"type": "clear_tool_uses_20250919"},
+            ]
+        },
+    }
+
+    result = cfg.transform_anthropic_messages_request(
+        model="anthropic.claude-sonnet-4-6-20250929-v1:0",
+        messages=messages,
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    cm = result.get("context_management")
+    assert cm is not None
+    edit_types = sorted(e.get("type") for e in cm["edits"])
+    assert edit_types == ["clear_tool_uses_20250919", "compact_20260112"]
+
+    betas = result.get("anthropic_beta", [])
+    assert "compact-2026-01-12" in betas
+    assert "context-management-2025-06-27" in betas
+
+
+def test_bedrock_messages_filters_clear_thinking_keeps_clear_tool_uses(monkeypatch):
+    """
+    LIT-3393: ``clear_thinking_20251015`` remains LiteLLM-internal (consumed via
+    thinking-injection) and MUST be stripped from the body, while
+    ``clear_tool_uses_20250919`` (officially supported on Bedrock InvokeModel)
+    survives in the same request.
+    """
+    from litellm.types.router import GenericLiteLLMParams
+    from litellm.anthropic_beta_headers_manager import (
+        reload_beta_headers_config,
+    )
+    monkeypatch.setenv("LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS", "True")
+    reload_beta_headers_config()
+
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+    messages = [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}]
+    optional_params = {
+        "max_tokens": 4096,
+        "context_management": {
+            "edits": [
+                {"type": "clear_thinking_20251015", "keep": "all"},
+                {"type": "clear_tool_uses_20250919"},
+            ]
+        },
+    }
+
+    result = cfg.transform_anthropic_messages_request(
+        model="anthropic.claude-opus-4-7",
+        messages=messages,
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    cm = result.get("context_management")
+    assert cm is not None
+    assert [e.get("type") for e in cm["edits"]] == [
+        "clear_tool_uses_20250919"
+    ], "clear_thinking_20251015 must still be stripped (LiteLLM-internal)"
+
+    betas = result.get("anthropic_beta", [])
+    assert "context-management-2025-06-27" in betas
+    # ``compact-2026-01-12`` was not requested.
+    assert "compact-2026-01-12" not in betas
+
+
+def test_filter_and_transform_beta_headers_passes_context_management_for_bedrock(
+    monkeypatch,
+):
+    """
+    LIT-3393: ``anthropic_beta_headers_config.json`` previously mapped
+    ``bedrock.context-management-2025-06-27`` to ``null``, so
+    ``filter_and_transform_beta_headers`` dropped the header even when the
+    transformation tried to set it. This regression guard locks the bundled
+    mapping in place.
+
+    Pinned to the bundled local config via ``LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS``
+    so the assertion is not subject to whatever the upstream remote currently
+    serves or what previous tests left in the module cache.
+    """
+    from litellm.anthropic_beta_headers_manager import (
+        filter_and_transform_beta_headers,
+        reload_beta_headers_config,
+    )
+
+    monkeypatch.setenv("LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS", "True")
+    reload_beta_headers_config()
+    try:
+        out = filter_and_transform_beta_headers(
+            ["context-management-2025-06-27"],
+            provider="bedrock",
+        )
+        assert out == ["context-management-2025-06-27"]
+
+        # Bedrock_converse genuinely lacks it per AWS docs; this guard prevents
+        # an accidental flip there.
+        out_converse = filter_and_transform_beta_headers(
+            ["context-management-2025-06-27"],
+            provider="bedrock_converse",
+        )
+        assert out_converse == []
+    finally:
+        monkeypatch.delenv("LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS", raising=False)
+        reload_beta_headers_config()
+

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -2092,7 +2092,20 @@ def test_bedrock_clear_thinking_leaves_enabled_thinking_on_non_adaptive_model():
     assert "output_config" not in request
 
 
-def test_bedrock_messages_preserves_clear_tool_uses_context_management_and_adds_beta(monkeypatch):
+@pytest.fixture
+def local_beta_headers_config(monkeypatch):
+    from litellm.anthropic_beta_headers_manager import reload_beta_headers_config
+
+    monkeypatch.setenv("LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS", "True")
+    reload_beta_headers_config()
+    yield
+    monkeypatch.delenv("LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS", raising=False)
+    reload_beta_headers_config()
+
+
+def test_bedrock_messages_preserves_clear_tool_uses_context_management_and_adds_beta(
+    local_beta_headers_config,
+):
     """
     LIT-3393: Bedrock InvokeModel supports automatic tool-call clearing via
     ``clear_tool_uses_20250919`` under the ``context-management-2025-06-27``
@@ -2108,12 +2121,6 @@ def test_bedrock_messages_preserves_clear_tool_uses_context_management_and_adds_
     https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-tool-use.md
     """
     from litellm.types.router import GenericLiteLLMParams
-    from litellm.anthropic_beta_headers_manager import (
-        reload_beta_headers_config,
-    )
-    monkeypatch.setenv("LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS", "True")
-    reload_beta_headers_config()
-
 
     cfg = AmazonAnthropicClaudeMessagesConfig()
     messages = [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}]
@@ -2141,19 +2148,15 @@ def test_bedrock_messages_preserves_clear_tool_uses_context_management_and_adds_
     )
 
 
-def test_bedrock_messages_preserves_mixed_compact_and_clear_tool_uses_edits(monkeypatch):
+def test_bedrock_messages_preserves_mixed_compact_and_clear_tool_uses_edits(
+    local_beta_headers_config,
+):
     """
     LIT-3393: a request mixing ``compact_20260112`` and
     ``clear_tool_uses_20250919`` must keep BOTH edits and emit BOTH
     anthropic-beta values (``compact-2026-01-12`` + ``context-management-2025-06-27``).
     """
     from litellm.types.router import GenericLiteLLMParams
-    from litellm.anthropic_beta_headers_manager import (
-        reload_beta_headers_config,
-    )
-    monkeypatch.setenv("LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS", "True")
-    reload_beta_headers_config()
-
 
     cfg = AmazonAnthropicClaudeMessagesConfig()
     messages = [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}]
@@ -2185,7 +2188,9 @@ def test_bedrock_messages_preserves_mixed_compact_and_clear_tool_uses_edits(monk
     assert "context-management-2025-06-27" in betas
 
 
-def test_bedrock_messages_filters_clear_thinking_keeps_clear_tool_uses(monkeypatch):
+def test_bedrock_messages_filters_clear_thinking_keeps_clear_tool_uses(
+    local_beta_headers_config,
+):
     """
     LIT-3393: ``clear_thinking_20251015`` remains LiteLLM-internal (consumed via
     thinking-injection) and MUST be stripped from the body, while
@@ -2193,12 +2198,6 @@ def test_bedrock_messages_filters_clear_thinking_keeps_clear_tool_uses(monkeypat
     survives in the same request.
     """
     from litellm.types.router import GenericLiteLLMParams
-    from litellm.anthropic_beta_headers_manager import (
-        reload_beta_headers_config,
-    )
-    monkeypatch.setenv("LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS", "True")
-    reload_beta_headers_config()
-
 
     cfg = AmazonAnthropicClaudeMessagesConfig()
     messages = [{"role": "user", "content": [{"type": "text", "text": "Hi"}]}]
@@ -2233,7 +2232,7 @@ def test_bedrock_messages_filters_clear_thinking_keeps_clear_tool_uses(monkeypat
 
 
 def test_filter_and_transform_beta_headers_passes_context_management_for_bedrock(
-    monkeypatch,
+    local_beta_headers_config,
 ):
     """
     LIT-3393: ``anthropic_beta_headers_config.json`` previously mapped
@@ -2246,28 +2245,19 @@ def test_filter_and_transform_beta_headers_passes_context_management_for_bedrock
     so the assertion is not subject to whatever the upstream remote currently
     serves or what previous tests left in the module cache.
     """
-    from litellm.anthropic_beta_headers_manager import (
-        filter_and_transform_beta_headers,
-        reload_beta_headers_config,
+    from litellm.anthropic_beta_headers_manager import filter_and_transform_beta_headers
+
+    out = filter_and_transform_beta_headers(
+        ["context-management-2025-06-27"],
+        provider="bedrock",
     )
+    assert out == ["context-management-2025-06-27"]
 
-    monkeypatch.setenv("LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS", "True")
-    reload_beta_headers_config()
-    try:
-        out = filter_and_transform_beta_headers(
-            ["context-management-2025-06-27"],
-            provider="bedrock",
-        )
-        assert out == ["context-management-2025-06-27"]
-
-        # Bedrock_converse genuinely lacks it per AWS docs; this guard prevents
-        # an accidental flip there.
-        out_converse = filter_and_transform_beta_headers(
-            ["context-management-2025-06-27"],
-            provider="bedrock_converse",
-        )
-        assert out_converse == []
-    finally:
-        monkeypatch.delenv("LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS", raising=False)
-        reload_beta_headers_config()
+    # Bedrock_converse genuinely lacks it per AWS docs; this guard prevents
+    # an accidental flip there.
+    out_converse = filter_and_transform_beta_headers(
+        ["context-management-2025-06-27"],
+        provider="bedrock_converse",
+    )
+    assert out_converse == []
 


### PR DESCRIPTION
## Relevant issues

Copy of #29206 by @oss-agent-shin, moved to an in-repo litellm_ branch so CircleCI can run. Sister to the compaction fix in #27532

## Linear ticket

Resolves LIT-3393

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`/v1/messages` -> `bedrock/invoke/...` requests that carry `context_management.edits = [{"type": "clear_tool_uses_20250919"}]` had that edit silently stripped from the InvokeModel body, even though Bedrock InvokeModel supports automatic tool call clearing under the `context-management-2025-06-27` beta (see the [AWS docs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-tool-use.md))

The bug is entirely in request construction, so the proof drives `AmazonAnthropicClaudeMessagesConfig.transform_anthropic_messages_request` for `model="anthropic.claude-haiku-4-5-20251001-v1:0"` and prints the `context_management` and `anthropic_beta` fields of the exact InvokeModel body LiteLLM would sign and POST to Bedrock. No live AWS call is needed to observe the strip, matching the evidence approach on #29206. Before was captured at `litellm_internal_staging` HEAD `131aa050bb`, after at `6761d19da8` (this PR)

Before, at `131aa050bb`:

```
===== clear_tool_uses only =====
{
  "context_management": "<absent>",
  "anthropic_beta": "<absent>"
}
===== compact + clear_tool_uses (mixed) =====
{
  "context_management": {
    "edits": [
      {
        "type": "compact_20260112"
      }
    ]
  },
  "anthropic_beta": [
    "compact-2026-01-12"
  ]
}
===== clear_thinking + clear_tool_uses =====
{
  "context_management": "<absent>",
  "anthropic_beta": "<absent>"
}
```

After, at `6761d19da8`:

```
===== clear_tool_uses only =====
{
  "context_management": {
    "edits": [
      {
        "type": "clear_tool_uses_20250919"
      }
    ]
  },
  "anthropic_beta": [
    "context-management-2025-06-27"
  ]
}
===== compact + clear_tool_uses (mixed) =====
{
  "context_management": {
    "edits": [
      {
        "type": "compact_20260112"
      },
      {
        "type": "clear_tool_uses_20250919"
      }
    ]
  },
  "anthropic_beta": [
    "compact-2026-01-12",
    "context-management-2025-06-27"
  ]
}
===== clear_thinking + clear_tool_uses =====
{
  "context_management": {
    "edits": [
      {
        "type": "clear_tool_uses_20250919"
      }
    ]
  },
  "anthropic_beta": [
    "context-management-2025-06-27"
  ]
}
```

Note the third scenario: the LiteLLM internal `clear_thinking_20251015` edit is still stripped (it is consumed via thinking injection in `_ensure_thinking_for_clear_thinking_context_management`), while the Bedrock supported `clear_tool_uses_20250919` now survives alongside its beta

Unit tests:

```
$ python -m pytest tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py -q
77 passed in 3.83s

$ python -m pytest tests/test_litellm/test_anthropic_beta_headers_filtering.py -q
22 passed, 3 warnings in 0.87s
```

## Type

🐛 Bug Fix

## Changes

`litellm/anthropic_beta_headers_config.json` maps `bedrock.context-management-2025-06-27` to `"context-management-2025-06-27"` instead of `null`, so `filter_and_transform_beta_headers(..., provider="bedrock")` stops dropping the beta the transformation adds. `bedrock_converse` stays `null` because per the AWS docs the Converse API genuinely lacks this beta

`_filter_context_management_for_bedrock_invoke` in `litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py` is rewritten around a small allowlist of Bedrock InvokeModel supported edit types, `compact_20260112` -> `compact-2026-01-12` and `clear_tool_uses_20250919` -> `context-management-2025-06-27`. Each supported edit is kept and its matching beta added to the beta set; `context_management` is dropped entirely when nothing survives

Four new tests cover the retained clear_tool_uses edit plus beta, the mixed compact plus clear_tool_uses case, clear_thinking still being stripped while clear_tool_uses survives, and a regression guard locking the JSON mapping in place (pinned to the bundled config via `LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS`). After the first Greptile review, the four tests' beta-headers config setup/teardown moved into a shared `local_beta_headers_config` fixture so the module-level config cache is restored after each test

Two small deviations from #29206 while rebasing onto `litellm_internal_staging`, with identical observable behavior: the allowlist dict references the existing `ANTHROPIC_BETA_HEADER_VALUES` enum members instead of hardcoded strings, and the retained edit filtering is a comprehension rather than an accumulate loop

---

> [!NOTE]
> **Medium Risk**
> Changes only Bedrock Invoke `/v1/messages` request shaping and beta header mapping; scope is narrow with regression tests, but wrong filtering could still break or mis-forward context-management payloads to AWS.
> 
> **Overview**
> Fixes Bedrock **InvokeModel** request building so **`clear_tool_uses_20250919`** `context_management` edits are forwarded (with the **`context-management-2025-06-27`** beta) instead of being dropped like unsupported edits.
> 
> **`anthropic_beta_headers_config.json`** now maps **`bedrock.context-management-2025-06-27`** to a non-null value so **`filter_and_transform_beta_headers`** no longer strips that header for Invoke; **`bedrock_converse`** stays unsupported.
> 
> **`_filter_context_management_for_bedrock_invoke`** is generalized from compact-only filtering to an allowlist: **`compact_20260112`** and **`clear_tool_uses_20250919`**, each paired with its beta; **`clear_thinking_20251015`** remains internal-only and is still removed from the body.
> 
> New unit tests cover clear-tool-uses-only, mixed compact + clear-tool-uses, clear-thinking stripped alongside clear-tool-uses, and the bedrock beta mapping regression guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 056893152b1ca98c834ecb6ab59c2a1503d93a9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>