### PR TITLE
feat(deploy): make coordination redis a first-class chart and terraform surface

### DIFF
--- a/helm/litellm-helm/templates/_helpers.tpl
+++ b/helm/litellm-helm/templates/_helpers.tpl
@@ -76,10 +76,13 @@ so fall back to "default" (or an explicit override) to avoid a cyclic dependency
 {{- end }}
 
 {{/*
-Get redis service name
+Get redis service name.
+The bundled Redis subchart only serves sentinel in "replication" architecture
+(it rejects standalone + sentinel outright), and in that mode the sentinel
+Service is named "<release>-redis", not "<release>-redis-master".
 */}}
 {{- define "litellm.redis.serviceName" -}}
-{{- if and (eq .Values.redis.architecture "standalone") .Values.redis.sentinel.enabled -}}
+{{- if .Values.redis.sentinel.enabled -}}
 {{- printf "%s-%s" .Release.Name (default "redis" .Values.redis.nameOverride | trunc 63 | trimSuffix "-") -}}
 {{- else -}}
 {{- printf "%s-%s-master" .Release.Name (default "redis" .Values.redis.nameOverride | trunc 63 | trimSuffix "-") -}}

--- a/helm/litellm-helm/templates/configmap-litellm.yaml
+++ b/helm/litellm-helm/templates/configmap-litellm.yaml
@@ -1,9 +1,22 @@
 {{- if .Values.proxyConfigMap.create }}
+{{- $config := deepCopy .Values.proxy_config }}
+{{- if and .Values.redis.enabled (dig "coordination" "enabled" true .Values.redis) }}
+{{- $generalSettings := (get $config "general_settings") | default dict }}
+{{- if not (hasKey $generalSettings "coordination_redis") }}
+{{- $coordinationRedis := dict "host" "os.environ/REDIS_HOST" "port" "os.environ/REDIS_PORT" "password" "os.environ/REDIS_PASSWORD" }}
+{{- if .Values.redis.sentinel.enabled }}
+{{- $sentinelNode := list (include "litellm.redis.serviceName" .) (include "litellm.redis.port" . | int) }}
+{{- $coordinationRedis = dict "sentinel_nodes" (list $sentinelNode) "service_name" (default "mymaster" .Values.redis.sentinel.masterSet) "password" "os.environ/REDIS_PASSWORD" }}
+{{- end }}
+{{- $_ := set $generalSettings "coordination_redis" $coordinationRedis }}
+{{- $_ := set $config "general_settings" $generalSettings }}
+{{- end }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "litellm.fullname" . }}-config
 data:
   config.yaml: |
-{{ .Values.proxy_config | toYaml | indent 6 }}
+{{ $config | toYaml | indent 6 }}
 {{- end }}

--- a/helm/litellm-helm/tests/coordination_redis_tests.yaml
+++ b/helm/litellm-helm/tests/coordination_redis_tests.yaml
@@ -1,0 +1,143 @@
+suite: test coordination redis
+templates:
+  - configmap-litellm.yaml
+  - deployment.yaml
+tests:
+  - it: should not render coordination_redis when redis is disabled
+    template: configmap-litellm.yaml
+    set:
+      redis.enabled: false
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: coordination_redis
+
+  - it: should not emit redis env vars when redis is disabled
+    template: deployment.yaml
+    set:
+      redis.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_HOST
+            value: RELEASE-NAME-redis-master
+          any: true
+
+  - it: should render coordination_redis pointing at the bundled redis when enabled
+    template: configmap-litellm.yaml
+    set:
+      redis.enabled: true
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "coordination_redis:\n    host: os.environ/REDIS_HOST\n    password: os.environ/REDIS_PASSWORD\n    port: os.environ/REDIS_PORT\n"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "master_key: os.environ/PROXY_MASTER_KEY"
+
+  - it: should emit redis env vars backing the coordination_redis os.environ refs
+    template: deployment.yaml
+    set:
+      redis.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_HOST
+            value: RELEASE-NAME-redis-master
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PORT
+            value: "6379"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-redis
+                key: redis-password
+
+  - it: should not render coordination_redis when coordination is opted out
+    template: configmap-litellm.yaml
+    set:
+      redis.enabled: true
+      redis.coordination.enabled: false
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: coordination_redis
+
+  - it: should keep emitting redis env vars when coordination is opted out
+    template: deployment.yaml
+    set:
+      redis.enabled: true
+      redis.coordination.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_HOST
+            value: RELEASE-NAME-redis-master
+
+  - it: should not clobber a user supplied coordination_redis block
+    template: configmap-litellm.yaml
+    set:
+      redis.enabled: true
+      proxy_config.general_settings.coordination_redis:
+        url: os.environ/COORDINATION_REDIS_URL
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "coordination_redis:\n    url: os.environ/COORDINATION_REDIS_URL\n"
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "host: os.environ/REDIS_HOST"
+
+  - it: should render sentinel_nodes and service_name in sentinel mode
+    template: configmap-litellm.yaml
+    set:
+      redis.enabled: true
+      redis.architecture: replication
+      redis.sentinel.enabled: true
+    asserts:
+      # The sentinel Service the redis subchart renders is "<release>-redis", and a
+      # plain client cannot speak the sentinel protocol, so host/port must not appear
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "coordination_redis:\n    password: os.environ/REDIS_PASSWORD\n    sentinel_nodes:\n    - - RELEASE-NAME-redis\n      - 26379\n    service_name: mymaster\n"
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "host: os.environ/REDIS_HOST"
+
+  - it: should carry a custom sentinel masterSet into service_name
+    template: configmap-litellm.yaml
+    set:
+      redis.enabled: true
+      redis.architecture: replication
+      redis.sentinel.enabled: true
+      redis.sentinel.masterSet: litellm-master
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "service_name: litellm-master"
+
+  - it: should point REDIS_HOST at the sentinel service in sentinel mode
+    template: deployment.yaml
+    set:
+      redis.enabled: true
+      redis.architecture: replication
+      redis.sentinel.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_HOST
+            value: RELEASE-NAME-redis
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PORT
+            value: "26379"

--- a/helm/litellm-helm/values.yaml
+++ b/helm/litellm-helm/values.yaml
@@ -331,12 +331,28 @@ postgresql:
     # secretKeys:
     #   userPasswordKey: password
 
-# requires cache: true in config file
-# either enable this or pass a secret for REDIS_HOST, REDIS_PORT, REDIS_PASSWORD or REDIS_URL
-# with cache: true to use existing redis instance
+# Redis is the proxy's coordination store: cross-pod tpm/rpm rate limits, spend
+# tracking, and the pod lock manager. Enabling this deploys the bundled Redis
+# subchart, wires REDIS_HOST / REDIS_PORT / REDIS_PASSWORD into the proxy, and
+# renders a `general_settings.coordination_redis` block into the proxy config.
+#
+# To point at an existing Redis instead, leave `enabled: false` and pass a
+# secret for REDIS_HOST, REDIS_PORT, REDIS_PASSWORD or REDIS_URL; the proxy
+# falls back to those env vars for coordination. Set `cache: true` in the proxy
+# config only if you also want LLM response caching, which is independent of
+# coordination
+#
+# When `redis.sentinel.enabled` is set, the coordination block is rendered with
+# `sentinel_nodes` and `service_name` (from `redis.sentinel.masterSet`) instead
+# of host/port, because a plain Redis client cannot talk to the sentinel port
 redis:
   enabled: false
   architecture: standalone
+  coordination:
+    # Set to false to keep the bundled Redis for response caching only and leave
+    # `general_settings.coordination_redis` out of the rendered config. A
+    # `coordination_redis` block you define yourself in `proxy_config` always wins
+    enabled: true
 
 # Prisma migration job settings
 migrationJob:

--- a/helm/litellm/templates/_helpers.tpl
+++ b/helm/litellm/templates/_helpers.tpl
@@ -213,6 +213,10 @@ harmless no-op for the Job and authoritative for the app pods.
 */}}
 - name: DISABLE_SCHEMA_UPDATE
   value: "true"
+{{/* These feed the proxy's coordination Redis (cross-pod rate limits, spend
+     tracking, pod lock manager) via its REDIS_* env fallback. An explicit
+     `general_settings.coordination_redis` block in proxy_config takes
+     precedence over anything emitted here. */}}
 {{- if $root.Values.redis.host }}
 - name: REDIS_HOST
   value: {{ $root.Values.redis.host | quote }}
@@ -226,10 +230,11 @@ harmless no-op for the Job and authoritative for the app pods.
       key: {{ $root.Values.redis.passwordSecret.passwordKey | default "password" }}
 {{- end }}
 {{- if $root.Values.redis.cluster }}
-{{/* The proxy's Cache() reads REDIS_CLUSTER_NODES as JSON and constructs a
-     RedisClusterCache when it's set (litellm/caching/caching.py:169-192).
-     We seed with the single configured endpoint — the cluster client
-     discovers the remaining nodes from CLUSTER SLOTS at startup. */}}
+{{/* The proxy falls back to REDIS_CLUSTER_NODES (JSON) to build a cluster-mode
+     coordination client when `general_settings.coordination_redis` is absent
+     and no plain-Redis response cache is configured. We seed with the single
+     configured endpoint; the cluster client discovers the remaining nodes from
+     CLUSTER SLOTS at startup. */}}
 - name: REDIS_CLUSTER_NODES
   value: {{ printf "[{\"host\":%q,\"port\":%v}]" $root.Values.redis.host (int $root.Values.redis.port) | quote }}
 {{- end }}

--- a/helm/litellm/tests/redis_env_tests.yaml
+++ b/helm/litellm/tests/redis_env_tests.yaml
@@ -1,0 +1,109 @@
+suite: test redis coordination env vars
+templates:
+  - gateway/deployment.yaml
+  - gateway/configmap.yaml
+  - backend/deployment.yaml
+values:
+  - ./values/required.yaml
+tests:
+  - it: gateway omits redis env vars when no host is configured
+    template: gateway/deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_HOST
+            value: redis.example.com
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_CLUSTER_NODES
+          any: true
+
+  - it: gateway emits host, port and password when redis is configured
+    template: gateway/deployment.yaml
+    set:
+      redis.host: redis.example.com
+      redis.port: 6380
+      redis.passwordSecret.name: redis-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_HOST
+            value: redis.example.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PORT
+            value: "6380"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: redis-secret
+                key: password
+
+  - it: backend emits the same redis env vars so both pods coordinate on one redis
+    template: backend/deployment.yaml
+    set:
+      redis.host: redis.example.com
+      redis.passwordSecret.name: redis-secret
+      redis.passwordSecret.passwordKey: redis-password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_HOST
+            value: redis.example.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: redis-secret
+                key: redis-password
+
+  - it: gateway omits REDIS_PASSWORD for an auth-less redis
+    template: gateway/deployment.yaml
+    set:
+      redis.host: redis.example.com
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_PASSWORD
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_HOST
+            value: redis.example.com
+
+  - it: gateway seeds REDIS_CLUSTER_NODES from host and port in cluster mode
+    template: gateway/deployment.yaml
+    set:
+      redis.host: redis.example.com
+      redis.port: 6380
+      redis.cluster: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_CLUSTER_NODES
+            value: '[{"host":"redis.example.com","port":6380}]'
+
+  - it: gateway omits REDIS_CLUSTER_NODES when cluster mode is off
+    template: gateway/deployment.yaml
+    set:
+      redis.host: redis.example.com
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_CLUSTER_NODES
+          any: true

--- a/helm/litellm/values.yaml
+++ b/helm/litellm/values.yaml
@@ -100,7 +100,18 @@ database:
       usernameKey: username
       passwordKey: password
 
-# Optional Redis (caching, rate limiting). Leave host empty to disable.
+# Optional Redis. Leave host empty to disable.
+#
+# This is the proxy's coordination store: cross-pod tpm/rpm rate limits, spend
+# tracking, and the pod lock manager. The chart emits REDIS_HOST / REDIS_PORT /
+# REDIS_PASSWORD, which the proxy picks up through its coordination Redis env
+# fallback. Response caching is separate and off unless you enable it in
+# `proxy_config.litellm_settings.cache`.
+#
+# For full control, define `general_settings.coordination_redis` in
+# `proxy_config` (host/port/password/username/url/ssl/startup_nodes/
+# sentinel_nodes/sentinel_password/service_name, each accepting os.environ/VAR
+# refs). An explicit block overrides these env vars.
 #
 # Set `cluster: true` for Redis Cluster mode (e.g. AWS ElastiCache Cluster,
 # self-hosted Redis Cluster). The chart emits REDIS_CLUSTER_NODES from

--- a/terraform/litellm/README.md
+++ b/terraform/litellm/README.md
@@ -178,6 +178,7 @@ only where the underlying cloud forces it.
 | Force destroy of object store    | `s3_force_destroy`                                      | `gcs_force_destroy`                                       |
 | Database deletion protection     | `skip_final_snapshot`                                   | `cloudsql_deletion_protection`                            |
 | `proxy_config` (typed YAML map)  | `proxy_config`                                          | `proxy_config`                                            |
+| Coordination Redis               | `REDIS_*` from ElastiCache (automatic)                  | `REDIS_*` from Memorystore (automatic)                    |
 | Extra plain env per component    | `gateway_extra_env`, `backend_extra_env`                | `gateway_extra_env`, `backend_extra_env`                  |
 | Extra secret-backed env          | `gateway_extra_secrets`, `backend_extra_secrets` (ARNs) | `gateway_extra_secrets`, `backend_extra_secrets` (resource IDs) |
 | Uvicorn `--workers` on gateway   | `gateway_num_workers`                                   | `gateway_num_workers`                                     |
@@ -188,6 +189,19 @@ Each module stamps its own stack-identity tag (`litellm:stack` on AWS,
 `managed-by = "terraform"` onto every taggable / labelable resource and
 merges `var.tags` / `var.labels` on top. Provider `default_tags` on AWS
 merge on top of all of these.
+
+Coordination Redis needs no input on either cloud. Each module provisions the
+managed Redis (ElastiCache on AWS, Memorystore on GCP) and exports `REDIS_HOST`,
+`REDIS_PORT` and `REDIS_SSL` (plus `REDIS_SSL_CA_CERTS` on GCP) into the gateway
+and backend env. The proxy falls back to those variables to build its
+coordination Redis, which backs cross-pod tpm/rpm rate limits, spend tracking
+and the pod lock manager. This is independent of LLM response caching, which
+stays off unless you enable `litellm_settings.cache` in `proxy_config`.
+
+To coordinate through a Redis the module does not manage, set
+`general_settings.coordination_redis` in `var.proxy_config`. An explicit block
+overrides the `REDIS_*` env fallback; see the commented example in each
+stack's `examples/default/terraform.tfvars.example`
 
 OTel is opt-in on both clouds: leave `otel_endpoint` empty and nothing
 OTel-related is added to the container env; set it and both gateway and

--- a/terraform/litellm/aws/examples/default/terraform.tfvars.example
+++ b/terraform/litellm/aws/examples/default/terraform.tfvars.example
@@ -56,6 +56,19 @@ env    = "stage"
 #   general_settings = {
 #     master_key   = "os.environ/LITELLM_MASTER_KEY"
 #     database_url = "os.environ/DATABASE_URL"
+#
+#     # Optional. The module already exports REDIS_HOST / REDIS_PORT / REDIS_SSL
+#     # from the ElastiCache group it provisions, and the proxy falls back to
+#     # those for cross-pod rate limits, spend tracking and the pod lock manager.
+#     # Set this block only to coordinate through a Redis the module does not
+#     # manage; it overrides the REDIS_* env fallback. Cluster mode takes
+#     # `startup_nodes` and sentinel takes `sentinel_nodes` + `service_name`
+#     # coordination_redis = {
+#     #   host     = "os.environ/COORDINATION_REDIS_HOST"
+#     #   port     = "os.environ/COORDINATION_REDIS_PORT"
+#     #   password = "os.environ/COORDINATION_REDIS_PASSWORD"
+#     #   ssl      = true
+#     # }
 #   }
 # }
 

--- a/terraform/litellm/gcp/examples/default/terraform.tfvars.example
+++ b/terraform/litellm/gcp/examples/default/terraform.tfvars.example
@@ -51,6 +51,20 @@ env    = "stage"
 #   general_settings = {
 #     master_key   = "os.environ/LITELLM_MASTER_KEY"
 #     database_url = "os.environ/DATABASE_URL"
+#
+#     # Optional. The module already exports REDIS_HOST / REDIS_PORT / REDIS_SSL
+#     # (plus REDIS_SSL_CA_CERTS) from the Memorystore instance it provisions, and
+#     # the proxy falls back to those for cross-pod rate limits, spend tracking
+#     # and the pod lock manager. Set this block only to coordinate through a
+#     # Redis the module does not manage; it overrides the REDIS_* env fallback.
+#     # Cluster mode takes `startup_nodes` and sentinel takes `sentinel_nodes`
+#     # plus `service_name`
+#     # coordination_redis = {
+#     #   host     = "os.environ/COORDINATION_REDIS_HOST"
+#     #   port     = "os.environ/COORDINATION_REDIS_PORT"
+#     #   password = "os.environ/COORDINATION_REDIS_PASSWORD"
+#     #   ssl      = true
+#     # }
 #   }
 # }
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3861

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

Merge after #32661, which adds the `general_settings.coordination_redis` block this renders. The charts keep working against an older proxy either way, since an unrecognized general_settings key is ignored and the existing REDIS_* env vars still drive the fallback

## Screenshots / Proof of Fix

The deploy artifacts here are chart and module templates, so the proof is tool-native rendering rather than a live proxy

Standalone Redis enabled renders the block into the proxy config

```
$ helm template t helm/litellm-helm --set redis.enabled=true -s templates/configmap-litellm.yaml
      general_settings:
        coordination_redis:
          host: os.environ/REDIS_HOST
          password: os.environ/REDIS_PASSWORD
          port: os.environ/REDIS_PORT
        master_key: os.environ/PROXY_MASTER_KEY
```

Sentinel renders sentinel_nodes and service_name instead of a host and port, because pointing a plain client at a sentinel port does not work

```
$ helm template t helm/litellm-helm --set redis.enabled=true --set redis.architecture=replication --set redis.sentinel.enabled=true -s templates/configmap-litellm.yaml
      general_settings:
        coordination_redis:
          password: os.environ/REDIS_PASSWORD
          sentinel_nodes:
          - - t-redis
            - 26379
          service_name: mymaster
        master_key: os.environ/PROXY_MASTER_KEY
```

Chart tests and lint

```
$ helm unittest -f 'tests/*.yaml' helm/litellm-helm
Test Suites: 9 passed, 9 total
Tests:       64 passed, 64 total

$ helm unittest -f 'tests/*.yaml' helm/litellm
Test Suites: 2 passed, 2 total
Tests:       14 passed, 14 total

$ helm lint helm/litellm-helm --set redis.enabled=true
0 chart(s) failed

$ terraform fmt -recursive -check terraform/litellm/ && echo clean
clean

$ cd terraform/litellm/aws && terraform init -backend=false >/dev/null && terraform validate
Success! The configuration is valid.

$ cd terraform/litellm/gcp && terraform init -backend=false >/dev/null && terraform validate
Success! The configuration is valid.
```

The new suites were mutation tested rather than trusted green: reverting the sentinel helper gate, ignoring `redis.coordination.enabled`, dropping the user-block guard, dropping the cluster gate, always emitting REDIS_PASSWORD, and hardcoding the cluster seed port each fail at least one test

## Type

🚄 Infrastructure

## Changes

The proxy is gaining `general_settings.coordination_redis`, an explicit block for the Redis behind cross-pod rate limits, spend tracking, and the pod lock manager. This makes it a first-class deploy surface

`helm/litellm-helm` renders a coordination_redis stanza into the proxy config when the bundled Redis is enabled, gated on a new `redis.coordination.enabled` value that defaults to true, and skipped entirely when the user already supplies their own block in `proxy_config`. Sentinel deployments render `sentinel_nodes` and `service_name`. The existing REDIS_* deployment env stays for back-compat

`helm/litellm` keeps its external-Redis env wiring; its stale comment claiming the cluster nodes variable feeds `Cache()` is replaced with a description of the coordination fallback, and the values comments name coordination explicitly

The terraform modules already export REDIS_HOST, REDIS_PORT and REDIS_SSL from ElastiCache and Memorystore, so the environment fallback covers them with no resource changes. The README gains a coordination-redis entry and both default examples show the explicit block

This also fixes a pre-existing bug. `litellm.redis.serviceName` gated its sentinel branch on the standalone architecture, but the bundled Redis subchart only serves sentinel in replication mode, and renders no master Service there. REDIS_HOST therefore pointed at a Service that never existed for every sentinel user. The helper now keys off `redis.sentinel.enabled` alone, which changes REDIS_HOST on that path from `<release>-redis-master` to `<release>-redis`; two tests cover it

Neither chart asserted a single Redis environment variable before, so the new suites also cover the existing wiring
