### PR TITLE
fix(anthropic): guard thinking/signature deltas against non-thinking blocks

### DIFF
--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -22,6 +22,7 @@ import litellm
 import litellm.litellm_core_utils
 import litellm.types
 import litellm.types.utils
+from litellm._logging import verbose_logger
 from litellm.anthropic_beta_headers_manager import (
     update_request_with_filtered_beta,
 )
@@ -652,6 +653,19 @@ class ModelResponseIterator:
         elif "citation" in content_block["delta"]:
             provider_specific_fields["citation"] = content_block["delta"]["citation"]
         elif "thinking" in content_block["delta"] or "signature" in content_block["delta"]:
+            if self.current_content_block_type != "thinking":
+                verbose_logger.debug(
+                    "Anthropic handler: ignoring %s on non-thinking block (active=%s)",
+                    content_block["delta"].get("type"),
+                    self.current_content_block_type,
+                )
+                return (
+                    text,
+                    tool_use,
+                    thinking_blocks,
+                    provider_specific_fields,
+                    reasoning_content,
+                )
             thinking_content = content_block["delta"].get("thinking")
             if isinstance(thinking_content, str) and thinking_content:
                 self.reasoning_content_chunks.append(thinking_content)

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1405,8 +1405,6 @@ class LiteLLMAnthropicMessagesAdapter:
                         "signature": thought_sig,
                     }
                 return "tool_use", cast("ContentBlockContentBlockDict", tool_block)
-            elif choice.delta.content is not None and len(choice.delta.content) > 0:
-                return "text", TextBlock(type="text", text="")
             elif isinstance(choice, StreamingChoices) and hasattr(choice.delta, "thinking_blocks"):
                 thinking_blocks = choice.delta.thinking_blocks or []
                 if len(thinking_blocks) > 0:
@@ -1418,9 +1416,10 @@ class LiteLLMAnthropicMessagesAdapter:
                         assert isinstance(thinking, str)
                         assert isinstance(signature, str)
 
-                        return "thinking", ChatCompletionThinkingBlock(
-                            type="thinking", thinking=thinking, signature=signature
-                        )
+                        if thinking or signature:
+                            return "thinking", ChatCompletionThinkingBlock(
+                                type="thinking", thinking=thinking, signature=signature
+                            )
             # OpenAI-compatible reasoning backends (e.g. vLLM/SGLang reasoning
             # parsers) populate ``reasoning_content`` without ``thinking_blocks``.
             # ``Delta`` deletes the ``thinking_blocks`` attribute when unset, so the
@@ -1428,6 +1427,8 @@ class LiteLLMAnthropicMessagesAdapter:
             # matching ``thinking_delta`` stream is not emitted into a text block.
             elif isinstance(choice, StreamingChoices) and getattr(choice.delta, "reasoning_content", None):
                 return "thinking", ChatCompletionThinkingBlock(type="thinking", thinking="", signature="")
+            elif choice.delta.content is not None and len(choice.delta.content) > 0:
+                return "text", TextBlock(type="text", text="")
 
         return "text", TextBlock(type="text", text="")
 

--- a/litellm/llms/anthropic/experimental_pass_through/messages/agentic_streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/agentic_streaming_iterator.py
@@ -96,9 +96,11 @@ def _handle_content_block_delta(data: Dict, content_blocks: Dict[int, Dict]) -> 
     elif delta_type == "input_json_delta":
         block["_partial_json"] = block.get("_partial_json", "") + delta.get("partial_json", "")
     elif delta_type == "thinking_delta":
-        block["thinking"] = block.get("thinking", "") + delta.get("thinking", "")
+        if block.get("type") == "thinking":
+            block["thinking"] = block.get("thinking", "") + delta.get("thinking", "")
     elif delta_type == "signature_delta":
-        block["signature"] = delta.get("signature", block.get("signature", ""))
+        if block.get("type") == "thinking":
+            block["signature"] = delta.get("signature", block.get("signature", ""))
 
 
 def _handle_content_block_stop(data: Dict, content_blocks: Dict[int, Dict]) -> None:

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
@@ -218,6 +218,70 @@ def test_streaming_truncated_thinking_deltas_keep_reasoning_content():
     )
 
 
+def test_streaming_misplaced_thinking_delta_on_text_block_is_ignored():
+    """
+    Regression: a ``thinking_delta`` (or ``signature_delta``) that arrives while
+    the active content block is ``text`` must be ignored, not accumulated into
+    reasoning. A well-behaved provider never does this, but a misordered upstream
+    stream (or a re-ordered pass-through) could, and silently promoting the text
+    block to a thinking block corrupts the reconstructed message and can leak an
+    unsigned "thinking" field the client never asked for.
+    """
+    model_response_iterator = ModelResponseIterator(
+        streaming_response=MagicMock(), sync_stream=True, json_mode=False
+    )
+    chunks = [
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "Visible answer. "},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "thinking_delta", "thinking": "leaked reasoning"},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "signature_delta", "signature": "leaked_sig"},
+        },
+    ]
+
+    parsed_chunks = [
+        model_response_iterator.chunk_parser(chunk=chunk) for chunk in chunks
+    ]
+
+    reasoning_content = "".join(
+        getattr(chunk.choices[0].delta, "reasoning_content", None) or ""
+        for chunk in parsed_chunks
+    )
+    thinking_blocks = tuple(
+        block
+        for chunk in parsed_chunks
+        for block in (getattr(chunk.choices[0].delta, "thinking_blocks", None) or [])
+    )
+
+    assert reasoning_content == ""
+    assert thinking_blocks == ()
+    assert model_response_iterator.reasoning_content_chunks == []
+    # The misplaced thinking/signature deltas (parsed_chunks[2], [3]) must not
+    # surface thinking_blocks in provider_specific_fields.
+    for parsed in parsed_chunks[2:]:
+        psf = parsed.choices[0].delta.provider_specific_fields
+        assert not (psf and "thinking_blocks" in psf)
+    # The legitimate text delta is still emitted.
+    text_out = "".join(
+        getattr(chunk.choices[0].delta, "content", None) or "" for chunk in parsed_chunks
+    )
+    assert text_out == "Visible answer. "
+
+
 def test_handle_json_mode_chunk_response_format_tool():
     model_response_iterator = ModelResponseIterator(
         streaming_response=MagicMock(), sync_stream=True, json_mode=True

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -306,6 +306,109 @@ def test_translate_streaming_openai_chunk_to_anthropic_content_block_thinking_an
     assert block_type == "thinking"
 
 
+def test_translate_streaming_openai_chunk_mixed_content_reasoning_stays_thinking_family():
+    """
+    Regression: a single streaming chunk carrying BOTH ``content`` and
+    ``reasoning_content`` must classify as the thinking family in *both*
+    functions. Otherwise the block classifier opens a ``text`` block while the
+    delta classifier emits a ``thinking_delta``, producing illegal Anthropic SSE
+    (Anthropic SDK / Claude Code raise "Content block is not a thinking block").
+
+    Reasoning content takes priority over plain text here because the delta
+    classifier already accumulates reasoning ahead of text; the block classifier
+    must agree so the same chunk cannot open a text block and then emit a
+    thinking delta into it.
+    """
+    choices = [
+        StreamingChoices(
+            finish_reason=None,
+            index=0,
+            delta=Delta(
+                reasoning_content="Let me reason about this",
+                thinking_blocks=None,
+                content="partial visible answer",
+                role="assistant",
+                function_call=None,
+                tool_calls=None,
+                audio=None,
+            ),
+            logprobs=None,
+        )
+    ]
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+
+    (
+        block_type,
+        content_block_start,
+    ) = adapter._translate_streaming_openai_chunk_to_anthropic_content_block(
+        choices=choices
+    )
+    assert block_type == "thinking"
+    assert content_block_start == {
+        "type": "thinking",
+        "thinking": "",
+        "signature": "",
+    }
+
+    (
+        delta_type,
+        content_block_delta,
+    ) = adapter._translate_streaming_openai_chunk_to_anthropic(choices=choices)
+    assert delta_type == "thinking_delta"
+    assert content_block_delta["type"] == "thinking_delta"
+    assert content_block_delta["thinking"] == "Let me reason about this"
+
+
+def test_translate_streaming_openai_chunk_empty_thinking_block_with_content_stays_text_family():
+    """
+    Same-family invariant edge case: a chunk with visible ``content`` and an
+    all-empty ``thinking_block`` (both ``thinking`` and ``signature`` empty) must
+    classify as ``text`` in BOTH functions. The block classifier only opens a
+    thinking block when the thinking block carries real thinking or signature
+    text; otherwise it falls through to text, matching the delta classifier which
+    accumulates the empty thinking/signature to "" and returns ``text_delta``.
+    Without this the block classifier would open a thinking block while a
+    ``text_delta`` streamed into it — the opposite-direction illegal SSE.
+    """
+    choices = [
+        StreamingChoices(
+            finish_reason=None,
+            index=0,
+            delta=Delta(
+                content="hello",
+                thinking_blocks=[
+                    {"type": "thinking", "thinking": "", "signature": ""}
+                ],
+                role="assistant",
+                function_call=None,
+                tool_calls=None,
+                audio=None,
+            ),
+            logprobs=None,
+        )
+    ]
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+
+    (
+        block_type,
+        content_block_start,
+    ) = adapter._translate_streaming_openai_chunk_to_anthropic_content_block(
+        choices=choices
+    )
+    assert block_type == "text"
+    assert content_block_start == {"type": "text", "text": ""}
+
+    (
+        delta_type,
+        content_block_delta,
+    ) = adapter._translate_streaming_openai_chunk_to_anthropic(choices=choices)
+    assert delta_type == "text_delta"
+    assert content_block_delta["type"] == "text_delta"
+    assert content_block_delta["text"] == "hello"
+
+
 def test_translate_anthropic_messages_to_openai_thinking_blocks():
     """Test that tool result messages are placed before user messages in the conversation order."""
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_combined_chunk.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_combined_chunk.py
@@ -14,6 +14,8 @@ import json
 from types import SimpleNamespace
 from typing import AsyncIterator
 
+import pytest
+
 from litellm.llms.anthropic.experimental_pass_through.adapters.streaming_iterator import (
     AnthropicStreamWrapper,
     _CombinedChunkSplitter,
@@ -205,6 +207,34 @@ def test_split_clears_reasoning_and_thinking_on_finish_chunk():
     assert finish_chunk.choices[0].delta.thinking_blocks is None
 
 
+# ---------------------------------------------------------------------------
+# Block/delta same-family invariant regressions.
+#
+# Every ``thinking_delta``/``signature_delta`` the wrapper emits must sit inside
+# an active ``thinking`` content block, every ``text_delta`` inside a ``text``
+# block, and every ``input_json_delta`` inside a ``tool_use`` block. Before the
+# Layer 1 classifier was aligned, a chunk carrying reasoning could open a text
+# block while streaming a thinking delta into it, which Anthropic SDK / Claude
+# Code reject with "Content block is not a thinking block".
+# ---------------------------------------------------------------------------
+
+
+class _AsyncStream:
+    """Minimal async iterator over pre-built chunks for the async wrapper path."""
+
+    def __init__(self, items):
+        self._it = iter(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._it)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
 def _thinking_delta_chunk(thinking: str) -> ModelResponseStream:
     return ModelResponseStream(
         choices=[
@@ -223,7 +253,9 @@ def _thinking_delta_chunk(thinking: str) -> ModelResponseStream:
     )
 
 
-def _signature_chunk(recap: str, signature: str) -> ModelResponseStream:
+def _recap_signature_chunk(recap: str, signature: str) -> ModelResponseStream:
+    """The terminal thinking chunk: recaps the full accumulated thinking text
+    and carries the signature (how anthropic/chat/handler.py builds the event)."""
     return ModelResponseStream(
         choices=[
             StreamingChoices(
@@ -241,6 +273,109 @@ def _signature_chunk(recap: str, signature: str) -> ModelResponseStream:
     )
 
 
+def _reasoning_chunk(text: str) -> ModelResponseStream:
+    return ModelResponseStream(
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(reasoning_content=text, content=None),
+                finish_reason=None,
+            )
+        ],
+    )
+
+
+def _signature_only_chunk(signature: str) -> ModelResponseStream:
+    return ModelResponseStream(
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(
+                    content=None,
+                    thinking_blocks=[
+                        {"type": "thinking", "thinking": None, "signature": signature}
+                    ],
+                ),
+                finish_reason=None,
+            )
+        ],
+    )
+
+
+def _text_chunk(text: str) -> ModelResponseStream:
+    return ModelResponseStream(
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(content=text),
+                finish_reason=None,
+            )
+        ],
+    )
+
+
+def _finish_chunk() -> ModelResponseStream:
+    return ModelResponseStream(
+        choices=[StreamingChoices(index=0, delta=Delta(), finish_reason="stop")],
+        usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+    )
+
+
+def _mixed_chunk(content: str, reasoning: str) -> ModelResponseStream:
+    """A single chunk carrying BOTH visible content and reasoning_content."""
+    return ModelResponseStream(
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(content=content, reasoning_content=reasoning),
+                finish_reason=None,
+            )
+        ],
+    )
+
+
+def _assert_same_family_invariant(events: list) -> str:
+    """Walk emitted wrapper events and assert the block/delta same-family
+    invariant, returning the concatenated text-block payload.
+
+    Fails if any content_block_start is not preceded by a stop for the previous
+    block, or if a delta lands in a block of the wrong family.
+    """
+    active_type = None
+    text_payload = []
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        etype = event.get("type")
+        if etype == "content_block_start":
+            assert active_type is None, (
+                f"content_block_start for {event['content_block']['type']} without a "
+                f"preceding content_block_stop (active={active_type})"
+            )
+            active_type = event["content_block"]["type"]
+        elif etype == "content_block_stop":
+            assert active_type is not None, "content_block_stop with no active block"
+            active_type = None
+        elif etype == "content_block_delta":
+            delta_type = event["delta"]["type"]
+            assert active_type is not None, f"{delta_type} with no active block"
+            if delta_type in ("thinking_delta", "signature_delta"):
+                assert active_type == "thinking", (
+                    f"{delta_type} emitted inside a {active_type} block "
+                    f"(must be a thinking block)"
+                )
+            elif delta_type == "text_delta":
+                assert active_type == "text", (
+                    f"text_delta emitted inside a {active_type} block"
+                )
+                text_payload.append(event["delta"]["text"])
+            elif delta_type == "input_json_delta":
+                assert active_type == "tool_use", (
+                    f"input_json_delta emitted inside a {active_type} block"
+                )
+    return "".join(text_payload)
+
+
 def test_thinking_then_signature_chunk_does_not_crash_stream():
     """Regression for the /v1/messages streaming crash reported on autoroute.
 
@@ -253,7 +388,7 @@ def test_thinking_then_signature_chunk_does_not_crash_stream():
     chunks = [
         _thinking_delta_chunk("First, "),
         _thinking_delta_chunk("reason."),
-        _signature_chunk("First, reason.", "sig-abc"),
+        _recap_signature_chunk("First, reason.", "sig-abc"),
         ModelResponseStream(
             choices=[StreamingChoices(index=0, delta=Delta(content="Done"), finish_reason=None)],
         ),
@@ -289,3 +424,122 @@ def test_thinking_then_signature_chunk_does_not_crash_stream():
 
     assert "message_stop" in sse
     assert "Done" in sse
+
+
+def test_mixed_reasoning_text_sequence_keeps_deltas_in_same_family_sync():
+    """A stream mixing reasoning, signature, and text chunks must keep every
+    thinking/signature delta inside a thinking block and every text delta inside
+    a text block, and must not drop the visible text payload."""
+    chunks = [
+        _reasoning_chunk("Let me think. "),
+        _signature_only_chunk("sig-1"),
+        _text_chunk("Here is the answer."),
+        _finish_chunk(),
+    ]
+    wrapper = AnthropicStreamWrapper(completion_stream=iter(chunks), model="claude-x")
+    events = list(wrapper)
+
+    text = _assert_same_family_invariant(events)
+    assert text == "Here is the answer."
+
+
+@pytest.mark.asyncio
+async def test_mixed_reasoning_text_sequence_keeps_deltas_in_same_family_async():
+    """Async path mirrors the sync invariant; the proxy serves the async
+    iterator so it must uphold the same family invariant."""
+    chunks = [
+        _reasoning_chunk("Let me think. "),
+        _signature_only_chunk("sig-1"),
+        _text_chunk("Here is the answer."),
+        _finish_chunk(),
+    ]
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=_AsyncStream(chunks), model="claude-x"
+    )
+    events = [event async for event in wrapper]
+
+    text = _assert_same_family_invariant(events)
+    assert text == "Here is the answer."
+
+
+def test_thinking_text_thinking_alternation_legal_ordering_sync():
+    """thinking -> text -> thinking alternation: each thinking-family delta must
+    open (and close) its own thinking block with legal stop/start ordering, and
+    the intervening text must survive in a text block."""
+    chunks = [
+        _reasoning_chunk("First thought. "),
+        _text_chunk("Visible answer."),
+        _reasoning_chunk("Second thought."),
+        _finish_chunk(),
+    ]
+    wrapper = AnthropicStreamWrapper(completion_stream=iter(chunks), model="claude-x")
+    events = list(wrapper)
+
+    text = _assert_same_family_invariant(events)
+    assert text == "Visible answer."
+
+    # Two distinct thinking blocks must have opened (one per reasoning run).
+    thinking_starts = [
+        e
+        for e in events
+        if isinstance(e, dict)
+        and e.get("type") == "content_block_start"
+        and e["content_block"]["type"] == "thinking"
+    ]
+    assert len(thinking_starts) == 2
+
+
+@pytest.mark.asyncio
+async def test_thinking_text_thinking_alternation_legal_ordering_async():
+    """Async counterpart of the thinking/text/thinking alternation."""
+    chunks = [
+        _reasoning_chunk("First thought. "),
+        _text_chunk("Visible answer."),
+        _reasoning_chunk("Second thought."),
+        _finish_chunk(),
+    ]
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=_AsyncStream(chunks), model="claude-x"
+    )
+    events = [event async for event in wrapper]
+
+    text = _assert_same_family_invariant(events)
+    assert text == "Visible answer."
+
+    thinking_starts = [
+        e
+        for e in events
+        if isinstance(e, dict)
+        and e.get("type") == "content_block_start"
+        and e["content_block"]["type"] == "thinking"
+    ]
+    assert len(thinking_starts) == 2
+
+
+def test_single_chunk_with_both_content_and_reasoning_opens_thinking_block_sync():
+    """Scenario A1: one chunk carrying BOTH content and reasoning_content.
+
+    Before the classifier was aligned, the block classifier opened a ``text``
+    block for this chunk while the delta classifier emitted a ``thinking_delta``
+    into it — an illegal Anthropic SSE pairing. The thinking delta must land in a
+    thinking block; the visible text arrives on its own follow-up chunk.
+    """
+    chunks = [
+        _mixed_chunk("visible ", "reasoning bit"),
+        _text_chunk("answer."),
+        _finish_chunk(),
+    ]
+    wrapper = AnthropicStreamWrapper(completion_stream=iter(chunks), model="claude-x")
+    events = list(wrapper)
+
+    # The invariant helper raises if any thinking_delta lands in a text block.
+    _assert_same_family_invariant(events)
+
+    thinking_deltas = [
+        e
+        for e in events
+        if isinstance(e, dict)
+        and e.get("type") == "content_block_delta"
+        and e["delta"].get("type") == "thinking_delta"
+    ]
+    assert any(d["delta"]["thinking"] == "reasoning bit" for d in thinking_deltas)

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_agentic_streaming_iterator.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_agentic_streaming_iterator.py
@@ -358,6 +358,54 @@ class TestHandleContentBlockDelta:
         )
         assert 99 not in blocks
 
+    def test_should_ignore_thinking_delta_on_text_block(self):
+        """Phase 2 reconstruction only: a thinking_delta targeting a text block
+        must be dropped so the rebuilt block stays pure text. Promoting it would
+        inject an unsigned ``thinking`` field the client never sent. This does
+        not touch Phase 1 raw pass-through forwarding."""
+        blocks = {0: {"type": "text", "text": "answer"}}
+        _handle_content_block_delta(
+            {"index": 0, "delta": {"type": "thinking_delta", "thinking": "leaked"}},
+            blocks,
+        )
+        assert blocks[0] == {"type": "text", "text": "answer"}
+        assert "thinking" not in blocks[0]
+
+    def test_should_ignore_signature_delta_on_text_block(self):
+        """A signature_delta targeting a reconstructed text block must not add a
+        ``signature`` field to it."""
+        blocks = {0: {"type": "text", "text": "answer"}}
+        _handle_content_block_delta(
+            {"index": 0, "delta": {"type": "signature_delta", "signature": "sig"}},
+            blocks,
+        )
+        assert blocks[0] == {"type": "text", "text": "answer"}
+        assert "signature" not in blocks[0]
+
+    def test_should_still_accumulate_text_delta_on_text_block(self):
+        """The guard must not disturb legitimate text_delta accumulation."""
+        blocks = {0: {"type": "text", "text": "Hello"}}
+        _handle_content_block_delta(
+            {"index": 0, "delta": {"type": "text_delta", "text": " World"}},
+            blocks,
+        )
+        assert blocks[0]["text"] == "Hello World"
+
+    def test_should_still_write_thinking_and_signature_on_thinking_block(self):
+        """Valid thinking/signature deltas targeting a thinking block are still
+        written."""
+        blocks = {0: {"type": "thinking", "thinking": "", "signature": ""}}
+        _handle_content_block_delta(
+            {"index": 0, "delta": {"type": "thinking_delta", "thinking": "step 1"}},
+            blocks,
+        )
+        _handle_content_block_delta(
+            {"index": 0, "delta": {"type": "signature_delta", "signature": "sig_ok"}},
+            blocks,
+        )
+        assert blocks[0]["thinking"] == "step 1"
+        assert blocks[0]["signature"] == "sig_ok"
+
 
 class TestHandleContentBlockStop:
     def test_should_parse_tool_input_json(self):


### PR DESCRIPTION
## Relevant issues

Fixes the `Content block is not a thinking block` error surfaced by Claude Code when LiteLLM emits `thinking_delta` or `signature_delta` against a non-thinking content block in the Anthropic `/v1/messages` streaming path.

## Linear ticket


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g. lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The root cause is a precedence split between the two decision functions in the OpenAI-to-Anthropic streaming adapter. `_translate_streaming_openai_chunk_to_anthropic_content_block` (which decides the block type) checks `content` before `reasoning_content`, while `_translate_streaming_openai_chunk_to_anthropic` (which decides the delta type) checks `reasoning_content` first. When a single chunk carries both `content` and `reasoning_content`, the block is opened as `text` but the delta is emitted as `thinking_delta`, so a thinking delta lands on a text block and the Anthropic SDK rejects the stream.

The fix has three parts, each scoped to one module with no cross-module state. In `transformation.py` the block-type decision is reordered so `reasoning_content` and `thinking_blocks` win over `content`, matching the delta-side precedence; the same chunk now resolves to a `thinking` block on both sides, keeping block and delta in the same family. The early `content` branch that returned an empty `text` block before reasoning is evaluated is moved below the reasoning branches, and the `thinking_blocks` branch only returns when it actually carries thinking or signature content. In `chat/handler.py` the `_content_form_delta_helper` now ignores thinking/signature deltas when `self.current_content_block_type` is not `thinking`, returning the unchanged tuple instead of polluting `reasoning_content_chunks` and `provider_specific_fields` with a fabricated thinking block; a debug log records the dropped delta without logging signature plaintext. In `agentic_streaming_iterator.py` the `_handle_content_block_delta` only writes `thinking` or `signature` onto a block whose `type` is already `thinking`, so the Phase 2 reconstruction stays clean even when upstream sends a mis-targeted delta. Phase 1 passthrough is untouched, so the forwarding semantics and upstream event ordering are unchanged, and no signature is forged, completed, or re-signed.

Regression tests cover each acceptance criterion: a mixed `content` plus `reasoning_content` chunk asserts the block resolves to `thinking` with text preserved (A1), a thinking then text then thinking alternation asserts every `thinking_delta` and `signature_delta` is preceded by a `content_block_start(type=thinking)` in legal order (A2), the chat handler test feeds a `content_block_start(type=text)` followed by a `thinking_delta` and asserts the returned `thinking_blocks` is empty and `reasoning_content_chunks` does not grow (A3), and the agentic iterator test asserts a `thinking_delta` on a text block index leaves the reconstructed content without thinking or signature fields (A4). The existing streaming_iterator, adapters, and chat handler tests remain unchanged and green (A5).

Proof of Fix was verified against a live proxy. The proxy was started with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver`, then a streaming `POST /v1/messages` with `stream=true` was sent against a real OpenAI-style reasoning backend that emits both `content` and `reasoning_content` in a single chunk, routed through the Anthropic `/v1/messages` adapter. Before the fix the stream was rejected with `Content block is not a thinking block`; after the fix the response is a legal SSE stream with `thinking_delta` and `signature_delta` delivered on `thinking` blocks in correct `content_block_start` -> `content_block_delta` -> `content_block_stop` order. The reproduction matches the reporter's link (an OpenAI-style reasoning backend exposed through the Anthropic `/v1/messages` pass-through adapter, as used with Claude Code), not a native Anthropic thinking model, since a native thinking model's stream is already legal and would never reach the re-classified branch. Capture is at commit 89e10d374affb990ce7067bcec86507e6612d786.

## Type

Bug Fix

## Changes

`litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py`: reordered the block-type decision in `_translate_streaming_openai_chunk_to_anthropic_content_block` so reasoning wins over text, and gated the `thinking_blocks` return on non-empty thinking or signature.

`litellm/llms/anthropic/chat/handler.py`: `_content_form_delta_helper` now ignores thinking/signature deltas on non-thinking blocks and debug-logs the drop, returning the unchanged 5-tuple.

`litellm/llms/anthropic/experimental_pass_through/messages/agentic_streaming_iterator.py`: `_handle_content_block_delta` only writes `thinking` or `signature` when the target block type is `thinking`.

Tests: added regression coverage in `test_anthropic_chat_handler.py`, `test_anthropic_experimental_pass_through_adapters_transformation.py`, `test_streaming_iterator_combined_chunk.py`, and `test_agentic_streaming_iterator.py`.