### PR TITLE
fix(anthropic): emit message_start once in Responses stream adapter

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
@@ -75,8 +75,9 @@ class AnthropicResponsesStreamWrapper:
 
         # ---- message_start ----
         if event_type == "response.created":
-            self._sent_message_start = True
-            self._chunk_queue.append(self._make_message_start())
+            if not self._sent_message_start:
+                self._sent_message_start = True
+                self._chunk_queue.append(self._make_message_start())
             return
 
         # ---- content_block_start for a new output message item ----

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_streaming_iterator.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_streaming_iterator.py
@@ -55,6 +55,26 @@ class TestMessageStartEmittedExactlyOnce:
         assert chunks[0]["type"] == "message_start"
 
 
+class TestProcessEventResponseCreatedGuard:
+    """``_process_event`` must emit ``message_start`` exactly once even if
+    ``response.created`` arrives more than once. The guard mirrors the
+    ``__anext__`` fallback's ``_sent_message_start`` flag, so a direct caller
+    and the async fallback can never double-emit. This also exercises the
+    guard's emit-branch, which the async path never reaches because the
+    fallback sets the flag before the upstream stream is consumed."""
+
+    def test_first_response_created_emits_message_start(self):
+        chunks = _process_all([{"type": "response.created"}])
+        assert len(chunks) == 1
+        assert chunks[0]["type"] == "message_start"
+        assert chunks[0]["message"]["model"] == "m"
+
+    def test_second_response_created_is_skipped(self):
+        chunks = _process_all([{"type": "response.created"}, {"type": "response.created"}])
+        message_starts = [c for c in chunks if c["type"] == "message_start"]
+        assert len(message_starts) == 1
+
+
 class TestProcessEventTextDeltaWithoutOutputItemAdded:
     """Streams that skip response.output_item.added (e.g. LMStudio) must still
     open a text block before any delta and never emit index -1."""

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_streaming_iterator.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_streaming_iterator.py
@@ -3,12 +3,11 @@ Tests for AnthropicResponsesStreamWrapper
 (litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py)
 """
 
+import asyncio
 import os
 import sys
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../.."))
-)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../..")))
 
 from litellm.llms.anthropic.experimental_pass_through.responses_adapters.streaming_iterator import (
     AnthropicResponsesStreamWrapper,
@@ -20,6 +19,40 @@ def _process_all(events: list) -> list:
     for event in events:
         wrapper._process_event(event)
     return list(wrapper._chunk_queue)
+
+
+def _drain_async(events: list) -> list:
+    async def _gen():
+        for event in events:
+            yield event
+
+    async def _run() -> list:
+        wrapper = AnthropicResponsesStreamWrapper(responses_stream=_gen(), model="m")
+        return [chunk async for chunk in wrapper]
+
+    return asyncio.run(_run())
+
+
+class TestMessageStartEmittedExactlyOnce:
+    """The ``__anext__`` fallback emits ``message_start`` before consuming the
+    stream, so ``_process_event`` must not emit a second one when
+    ``response.created`` later arrives. Two ``message_start`` events (byte
+    identical, same id) break strict Anthropic SDK clients (e.g. Claude Code)
+    with 'Content block is not a thinking block' once thinking blocks follow."""
+
+    def test_response_created_does_not_duplicate_message_start(self):
+        chunks = _drain_async(
+            [
+                {"type": "response.created"},
+                {"type": "response.output_text.delta", "item_id": "m1", "delta": "hi"},
+            ]
+        )
+        message_starts = [c for c in chunks if c["type"] == "message_start"]
+        assert len(message_starts) == 1
+
+    def test_message_start_is_first_event(self):
+        chunks = _drain_async([{"type": "response.created"}])
+        assert chunks[0]["type"] == "message_start"
 
 
 class TestProcessEventTextDeltaWithoutOutputItemAdded:


### PR DESCRIPTION
## Relevant issues

The exact symptom (a duplicate `message_start` from the Responses API adapter) does not have its own issue, but it is the common root behind several reports in the Anthropic experimental pass-through family. 

Listing them as related rather than `Fixes` since I can only confirm the mechanism, not that each report is solely this bug

Related: #29518, #32357, #30765, #30014, #27946

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

When `/v1/messages` is served through the Responses API adapter, which happens for any deployment whose provider routes through `_RESPONSES_API_PROVIDERS` (for example `custom_llm_provider: openai` pointing at a vLLM backend with a reasoning parser), the stream emits `message_start` twice. The two events are identical and carry the same message id, which makes strict Anthropic SDK clients reset their block tracker; once a `thinking` block follows, later `thinking_delta` events land on an index that is no longer a thinking block and the client aborts with `Content block is not a thinking block`

Repro against a LiteLLM proxy fronting a vLLM backend with reasoning enabled, using a deployment with `custom_llm_provider: openai`

config:

```yaml
model_list:
  - model_name: reasoner
    litellm_params:
      model: openai/<reasoning-model>
      api_base: <vllm-base-url>/v1
      api_key: dummy
      custom_llm_provider: openai
      reasoning_effort: high
```

```
curl -s -N http://127.0.0.1:4000/v1/messages \
  -H "x-api-key: sk-..." -H "anthropic-version: 2023-06-01" -H "content-type: application/json" \
  -d '{"model":"reasoner","max_tokens":500,"stream":true,"thinking":{"type":"enabled","budget_tokens":300},
       "messages":[{"role":"user","content":"What is 17*23? Think step by step, then answer."}]}' \
  | grep "^event: " | sed 's/^event: //' | sort | uniq -c
```

Before the fix: 2 message_start, and the client errors mid-stream with `Content block is not a thinking block`. 
After the fix: 1 message_start, and thinking + text deltas flow to completion

Reproduced on v1.90.0, v1.91.0, v1.92.0-rc.1, and v1.93.0-dev.1 (all broken with custom_llm_provider: openai)

## Type

🐛 Bug Fix

## Changes

The duplicate comes from `AnthropicResponsesStreamWrapper.__anext__`, which emits a fallback `message_start` before it ever consumes the upstream stream, so clients receive a first chunk immediately. When the upstream then yields `response.created`, `_process_event` queued a second `message_start` unconditionally, ignoring the `_sent_message_start` flag that the fallback had already set. The fix guards the `response.created` branch on that same flag, so the event is emitted exactly once regardless of which path fires first