### PR TITLE
test(e2e): make dynamic model provisioning robust on split deployments

### DIFF
--- a/tests/e2e/e2e_gateway.py
+++ b/tests/e2e/e2e_gateway.py
@@ -156,22 +156,28 @@ class Gateway:
         not within poll_timeout (a real propagation/config problem, surfaced here
         instead of as a downstream "Invalid model name passed")."""
         deadline = time.monotonic() + self.poll_timeout
+        last_result: Result[ModelsListResponse] | None = None
         while time.monotonic() < deadline:
-            result = self.transport.get(
+            last_result = self.transport.get(
                 "/v1/models",
                 headers=self.transport.master,
                 params=NoBody(),
                 response_type=ModelsListResponse,
             )
-            if isinstance(result, Success) and any(
-                entry.id == model_name for entry in result.data.data
+            if isinstance(last_result, Success) and any(
+                entry.id == model_name for entry in last_result.data.data
             ):
                 return
             time.sleep(self.poll_interval)
+        last_error = (
+            f"; last /v1/models poll did not succeed: {last_result}"
+            if last_result is not None and not isinstance(last_result, Success)
+            else ""
+        )
         raise AssertionError(
             f"model {model_name!r} was created but never became servable on the data "
             f"plane within {self.poll_timeout}s of /model/new (control/data-plane "
-            "propagation or STORE_MODEL_IN_DB reload issue)"
+            f"propagation or STORE_MODEL_IN_DB reload issue){last_error}"
         )
 
     def delete_model(self, model_id: str) -> None:

--- a/tests/e2e/e2e_gateway.py
+++ b/tests/e2e/e2e_gateway.py
@@ -42,6 +42,7 @@ from models import (
     ModelMode,
     ModelNewBody,
     ModelNewResponse,
+    ModelsListResponse,
     OcrBody,
     OcrResponse,
     SpendLogRow,
@@ -125,21 +126,53 @@ class Gateway:
         litellm_params: LiteLLMParamsBody,
         mode: ModelMode | None = None,
     ) -> str:
-        """Register a deployment under `model_name` (id == model_name) and return the
-        model_id. add_deployment runs synchronously in /model/new, so the model is
-        callable as soon as this returns."""
-        return unwrap(
+        """Register a deployment under `model_name` and return its proxy-assigned
+        model_id, once the model is actually servable on the data plane.
+
+        /model/new is a control-plane route; in a split control/data-plane
+        deployment the gateway (data plane, which serves /chat, /ocr, ...) only
+        picks the new model up on its next DB reload, so a call issued the instant
+        this returns can race the reload and 400 with "Invalid model name passed".
+        We therefore poll the data-plane /v1/models until the model appears before
+        handing back, so callers can invoke it immediately. In the monolithic case
+        it is already present on the first poll, so this adds one request."""
+        model_id = unwrap(
             self.transport.post(
                 "/model/new",
                 headers=self.transport.master,
                 json=ModelNewBody(
                     model_name=model_name,
                     litellm_params=litellm_params,
-                    model_info=ModelInfoBody(id=model_name, mode=mode),
+                    model_info=ModelInfoBody(mode=mode),
                 ),
                 response_type=ModelNewResponse,
             )
         ).model_id
+        self._await_model_servable(model_name)
+        return model_id
+
+    def _await_model_servable(self, model_name: str) -> None:
+        """Block until the data plane lists `model_name`, or fail loudly if it does
+        not within poll_timeout (a real propagation/config problem, surfaced here
+        instead of as a downstream "Invalid model name passed")."""
+        deadline = time.monotonic() + self.poll_timeout
+        while time.monotonic() < deadline:
+            result = self.transport.get(
+                "/v1/models",
+                headers=self.transport.master,
+                params=NoBody(),
+                response_type=ModelsListResponse,
+            )
+            if isinstance(result, Success) and any(
+                entry.id == model_name for entry in result.data.data
+            ):
+                return
+            time.sleep(self.poll_interval)
+        raise AssertionError(
+            f"model {model_name!r} was created but never became servable on the data "
+            f"plane within {self.poll_timeout}s of /model/new (control/data-plane "
+            "propagation or STORE_MODEL_IN_DB reload issue)"
+        )
 
     def delete_model(self, model_id: str) -> None:
         result = self.transport.post(

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -394,7 +394,11 @@ ModelMode = Literal["batch", "realtime", "image_generation"]
 
 
 class ModelInfoBody(BaseModel):
-    id: str
+    # id is left unset so the proxy assigns a unique model_id per deployment.
+    # Pinning it to the model_name made re-registrations of a fixed-name model
+    # (e.g. the batch suite's openai-batch) collide on the model_id unique
+    # constraint when a prior run's teardown had not removed the row.
+    id: str | None = None
     mode: ModelMode | None = None
 
 
@@ -408,6 +412,18 @@ class ModelNewBody(BaseModel):
 class ModelNewResponse(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
     model_id: str
+
+
+class ModelListEntry(BaseModel):
+    id: str
+
+
+class ModelsListResponse(BaseModel):
+    """GET /v1/models on the data plane: the deployments the gateway can actually
+    serve right now. Used to confirm a freshly created model has propagated from
+    the control plane before a test calls it."""
+
+    data: tuple[ModelListEntry, ...] = ()
 
 
 class ModelDeleteBody(BaseModel):

--- a/tests/e2e/test_e2e_gateway.py
+++ b/tests/e2e/test_e2e_gateway.py
@@ -22,6 +22,7 @@ from e2e_http import (
     Result,
     StreamingResponse,
     Success,
+    UnknownApiError,
 )
 from models import (
     LiteLLMParamsBody,
@@ -43,6 +44,7 @@ class _RecordingTransport:
 
     posts: list[tuple[str, BaseModel]] = field(default_factory=list)
     servable_after_gets: int = 0
+    models_error: UnknownApiError | None = None
     model_gets: int = 0
     _created: list[str] = field(default_factory=list)
 
@@ -83,6 +85,8 @@ class _RecordingTransport:
     ) -> Result[R]:
         if path == "/v1/models" and response_type is ModelsListResponse:
             self.model_gets += 1
+            if self.models_error is not None:
+                return self.models_error
             visible = self._created if self.model_gets > self.servable_after_gets else []
             return Success(
                 data=response_type.model_validate({"data": [{"id": name} for name in visible]})
@@ -162,9 +166,20 @@ def test_gateway_create_model_fails_loudly_when_never_servable() -> None:
         gateway.create_model("e2e-ghost-model", LiteLLMParamsBody(model="openai/gpt-4o-mini"))
 
 
+def test_gateway_create_model_surfaces_the_last_data_plane_error() -> None:
+    transport = _RecordingTransport(
+        models_error=UnknownApiError(status_code=503, body="data plane down")
+    )
+    gateway = Gateway(transport=transport, poll_timeout=0.05, poll_interval=0.0)
+
+    with pytest.raises(AssertionError, match="data plane down") as excinfo:
+        gateway.create_model("e2e-flaky-model", LiteLLMParamsBody(model="openai/gpt-4o-mini"))
+    assert "503" in str(excinfo.value)
+
+
 def test_batch_client_create_model_registers_a_batch_mode_deployment() -> None:
     transport = _RecordingTransport()
-    client = BatchClient(gateway=Gateway(transport=transport))
+    client = BatchClient(gateway=Gateway(transport=transport, poll_interval=0.0))
 
     model_id = client.create_model(
         "e2e-batch-model", LiteLLMParamsBody(model="openai/gpt-4o-mini")

--- a/tests/e2e/test_e2e_gateway.py
+++ b/tests/e2e/test_e2e_gateway.py
@@ -10,6 +10,7 @@ signature drift fails here instead of in a live stage run.
 
 from dataclasses import dataclass, field
 
+import pytest
 from pydantic import BaseModel
 
 from batches.batch_client import BatchClient
@@ -27,20 +28,30 @@ from models import (
     ModelDeleteBody,
     ModelNewBody,
     ModelNewResponse,
+    ModelsListResponse,
 )
 
 
 @dataclass
 class _RecordingTransport:
     """Typed fake fulfilling the Transport protocol; records every post and
-    answers with a canned success so the test asserts on what was sent."""
+    answers with a canned success so the test asserts on what was sent.
+
+    `get("/v1/models")` reports a created model as servable only after
+    `servable_after_gets` polls, so a test can drive the data-plane wait in
+    create_model."""
 
     posts: list[tuple[str, BaseModel]] = field(default_factory=list)
+    servable_after_gets: int = 0
+    model_gets: int = 0
+    _created: list[str] = field(default_factory=list)
 
     def post[R: BaseModel](
         self, path: str, *, headers: BaseModel, json: BaseModel, response_type: type[R]
     ) -> Result[R]:
         self.posts.append((path, json))
+        if path == "/model/new" and isinstance(json, ModelNewBody):
+            self._created.append(json.model_name)
         payload = (
             {"model_id": "registered-id"} if response_type is ModelNewResponse else {}
         )
@@ -70,7 +81,13 @@ class _RecordingTransport:
         params: BaseModel,
         response_type: type[R],
     ) -> Result[R]:
-        raise AssertionError("get is not part of model management")
+        if path == "/v1/models" and response_type is ModelsListResponse:
+            self.model_gets += 1
+            visible = self._created if self.model_gets > self.servable_after_gets else []
+            return Success(
+                data=response_type.model_validate({"data": [{"id": name} for name in visible]})
+            )
+        raise AssertionError(f"unexpected get: {path}")
 
     def delete[R: BaseModel](
         self, path: str, *, headers: BaseModel, json: BaseModel, response_type: type[R]
@@ -106,7 +123,7 @@ class _RecordingTransport:
 
 def test_gateway_create_model_registers_deployment_and_returns_model_id() -> None:
     transport = _RecordingTransport()
-    gateway = Gateway(transport=transport)
+    gateway = Gateway(transport=transport, poll_interval=0.0)
 
     model_id = gateway.create_model(
         "e2e-test-model", LiteLLMParamsBody(model="openai/gpt-4o-mini")
@@ -117,8 +134,32 @@ def test_gateway_create_model_registers_deployment_and_returns_model_id() -> Non
     assert path == "/model/new"
     assert isinstance(body, ModelNewBody)
     assert body.model_name == "e2e-test-model"
-    assert body.model_info.id == "e2e-test-model"
+    # No pinned model_id: the proxy assigns a unique one, so a fixed-name model
+    # re-registered after a failed teardown can't collide on the id constraint.
+    assert body.model_info.id is None
     assert body.model_info.mode is None
+    # It confirmed data-plane visibility before returning.
+    assert transport.model_gets >= 1
+
+
+def test_gateway_create_model_waits_until_servable_on_the_data_plane() -> None:
+    # The model shows up on /v1/models only on the third poll (simulating the
+    # gateway's delayed DB reload in a split deployment); create_model must keep
+    # polling instead of returning after /model/new.
+    transport = _RecordingTransport(servable_after_gets=2)
+    gateway = Gateway(transport=transport, poll_interval=0.0)
+
+    gateway.create_model("e2e-late-model", LiteLLMParamsBody(model="openai/gpt-4o-mini"))
+
+    assert transport.model_gets == 3
+
+
+def test_gateway_create_model_fails_loudly_when_never_servable() -> None:
+    transport = _RecordingTransport(servable_after_gets=10**9)
+    gateway = Gateway(transport=transport, poll_timeout=0.05, poll_interval=0.0)
+
+    with pytest.raises(AssertionError, match="never became servable"):
+        gateway.create_model("e2e-ghost-model", LiteLLMParamsBody(model="openai/gpt-4o-mini"))
 
 
 def test_batch_client_create_model_registers_a_batch_mode_deployment() -> None:


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both failures were diagnosed from the 2026-07-09 stage e2e run (image `1.0.0-main.20260709072624`, split control/data-plane deployment). The fix is in this branch at `f1ffbe6d94`.

Root cause 1, `model_id` collision. The harness pinned `model_info.id = model_name`, so re-registering a fixed-name deployment collided on the `model_id` unique constraint. The backend surfaced it as a `prisma.errors.UniqueViolationError` swallowed into the generic 500. Reproduced and fixed live against a local proxy (`curl` to `localhost:4000`); the 500 body matches the stage error byte-for-byte:

```
BEFORE (harness pins model_info.id = model_name -> re-register collides)
create #1 (pinned id): HTTP 200
create #2 (pinned id): HTTP 500   <-- collision
  {"error":{"message":"{'error': 'Failed to add model to db. Check your server logs for more details.'}","type":"auth_error","param":"None","code":"500"}}

AFTER (no pinned id -> proxy assigns a unique model_id)
create #1 (no id): HTTP 200
create #2 (no id): HTTP 200   <-- both succeed, distinct model_ids
```

Root cause 2, split-plane propagation. `/model/new` succeeded on the control plane (the stage backend logged 20x `POST /model/new -> 200 OK`), but the gateway had not reloaded the model from the DB when the test called it, so `/chat`, `/embeddings`, `/v1/messages`, `/ocr`, `/responses` returned `Invalid model name passed`. This only shows on a split deployment; a monolithic proxy shares the process, which is why it passes locally. `create_model` now polls the data-plane `/v1/models` until the model is servable before returning. Verified against a local proxy that create-then-immediately-invoke still works (the rust OCR suite registers each provider via `/model/new` then calls `/ocr`):

```
test_rust_ocr_response[mistral]                     PASSED
test_rust_ocr_response[azure-ai]                    PASSED
test_rust_ocr_response[azure-document-intelligence] PASSED
test_rust_ocr_response[vertex-mistral]              PASSED
```

The definitive end-to-end proof is the next stage e2e run going green on the suites that were red purely because of provisioning (batches, embeddings, responses, messages, image, rerank, audio, ocr); that run happens automatically after this merges to staging.

## Type

🐛 Bug Fix

✅ Test

## Changes

`create_model` no longer assumes `/model/new` makes a deployment instantly callable. It polls the data-plane `/v1/models` until the new `model_name` is listed, then returns, and fails loudly with a clear message if the model never becomes servable within `poll_timeout` (a real propagation or `STORE_MODEL_IN_DB` reload problem, surfaced at the source instead of as a downstream `Invalid model name passed`). In the monolithic case the model is present on the first poll, so this adds a single request.

`create_model` also stops setting `model_info.id`, so the proxy assigns a unique `model_id` per deployment. Every suite except batches already used `unique_marker()` names and never collided; batches register fixed names (`openai-batch`, `azure-batch`, `vertex-batch`, `bedrock-batch`), so a leftover row from a crashed or evicted prior run made the next run's create collide on the id constraint and errored every `test_batch_lifecycle` case at setup. With a proxy-assigned id, re-registration is collision-free.

`_await_model_servable` remembers the last `/v1/models` poll result and, when it never returned a `Success` (a 5xx on the data plane or a network partition rather than the model simply not being listed yet), appends it to the timeout `AssertionError` so a split-deployment failure names the real cause instead of always pointing at propagation/reload.

Tests: `test_e2e_gateway.py` gains coverage that `create_model` waits for data-plane visibility, fails loudly when the model never appears, and surfaces the last data-plane error when `/v1/models` keeps erroring; it also asserts `create_model` no longer pins `model_info.id`. The typed fake `Transport` now serves `/v1/models` (and can return a canned error) so a regression in the wait or error-surfacing behavior fails there rather than in a live stage run.
</content>


Link to Devin session: https://app.devin.ai/sessions/226a1a920e6d4e1196a3cd3384140721
Requested by: @mubashir1osmani