### PR TITLE
fix(ui): rename Virtual Keys 'Key Hash' filter label to 'Key ID'

### DIFF
--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
@@ -578,7 +578,7 @@ export function VirtualKeysTable() {
     },
     {
       name: "Key Hash",
-      label: "Key Hash",
+      label: "Key ID",
       isSearchable: false,
     },
   ];


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests (n/a; one-word display-label rename with no logic change, so a test would only assert a static string)
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

On the Virtual Keys table, the filter that searches by the key token was labeled "Key Hash", while the very column it filters is labeled "Key ID". That mismatch made the filter look like it did something different from the column. This renames the filter's display label (and its "Enter ..." placeholder) to "Key ID" so the two line up. The underlying filter state key and the `keyHash` API param are unchanged, so behavior is identical

To verify, go to http://localhost:4000/ui/?page=api-keys, click Filters, and confirm the last filter now reads "Key ID" instead of "Key Hash"

## Type

🐛 Bug Fix

## Changes

Changed the `label` for the key-token filter in `VirtualKeysTable.tsx` from "Key Hash" to "Key ID". No logic or API changes; only the visible label and placeholder text
