### PR TITLE
test(mcp): lock server_id resolution in the MCP OAuth broker flow

### DIFF
--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -1659,6 +1659,43 @@ class TestTemporaryMCPSessionEndpoints:
         assert exc_info.value.status_code == 403
 
     @pytest.mark.asyncio
+    async def test_get_cached_temporary_mcp_server_resolves_real_server_by_server_id(self):
+        """Regression for LIT-4169: the user-side OAuth flow (authorize/register/token)
+        calls these endpoints with the real server_id, a stable hash the UI puts in the
+        path that the name resolver cannot match. When the temp-session cache misses,
+        resolution must fall back to get_mcp_server_by_id so the flow finds the server
+        instead of 404ing with the OAuth server unresolved"""
+        from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+            _get_cached_temporary_mcp_server_or_404,
+        )
+
+        server_id = "dcc61bddefd721c993ff57291cac2b98"
+        registry_server = generate_mock_mcp_server_config_record(server_id=server_id)
+        admin_auth = generate_mock_user_api_key_auth(
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
+
+        mock_manager = MagicMock()
+        mock_manager.get_mcp_server_by_id.side_effect = lambda sid: registry_server if sid == server_id else None
+        mock_manager.get_mcp_server_by_name.side_effect = lambda name, client_ip=None: None
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_cached_temporary_mcp_server",
+                return_value=None,
+            ) as get_cached,
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+                mock_manager,
+            ),
+        ):
+            result = await _get_cached_temporary_mcp_server_or_404(server_id, admin_auth)
+
+        assert result is registry_server
+        get_cached.assert_awaited_once_with(server_id)
+        mock_manager.get_mcp_server_by_id.assert_called_once_with(server_id)
+
+    @pytest.mark.asyncio
     async def test_add_session_mcp_server_caches_and_redacts_credentials(self):
         from litellm.proxy.management_endpoints.mcp_management_endpoints import (
             TEMPORARY_MCP_SERVER_TTL_SECONDS,


### PR DESCRIPTION
## Relevant issues

Relates to #30997. That bug (MCP OAuth returning "MCP server authorization url is not set" when the UI puts the server_id in the path) is already resolved on `litellm_internal_staging`: the user-side OAuth handlers in `mcp_management_endpoints.py` resolve the server through `_get_cached_temporary_mcp_server_or_404`, which falls back to `get_mcp_server_by_id` when the temp-session cache misses. This PR adds the regression coverage that was missing for that server_id path

## Linear ticket

Resolves LIT-4169

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The `/v1/mcp/server/oauth/{server_id}/...` flow the LiteLLM UI drives already resolves by server_id on current `litellm_internal_staging`. Reproduced against a live proxy on localhost with one oauth2 MCP server configured

Config used

```yaml
mcp_servers:
  lit4169_oauth_server:
    transport: http
    auth_type: oauth2
    oauth2_flow: authorization_code
    authorization_url: "https://provider.example.com/oauth/authorize"
    token_url: "https://provider.example.com/oauth/token"
    client_id: "test_client_id_lit4169"
    client_secret: "test_secret"
    scopes: ["read"]
```

The server loads with `server_id=dcc61bddefd721c993ff57291cac2b98` (a stable hash, exactly what the UI sends in the path)

```bash
# 1) register with the server_id in the path (UI step 1)
curl -s -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -o /dev/stdout -w "\nHTTP %{http_code}\n" \
  -X POST "http://localhost:4169/v1/mcp/server/oauth/dcc61bddefd721c993ff57291cac2b98/register" \
  -d '{"client_name":"lit4169-test","grant_types":["authorization_code"],"response_types":["code"]}'
# {"client_id":"dcc61bddefd721c993ff57291cac2b98","client_secret":"dummy","redirect_uris":["http://localhost:4169/callback"]}
# HTTP 200

# 2) authorize with the server_id in the path (UI step 2)
curl -s -H "Authorization: Bearer sk-1234" -D - -o /dev/null -w "HTTP %{http_code}\n" \
  "http://localhost:4169/v1/mcp/server/oauth/dcc61bddefd721c993ff57291cac2b98/authorize?redirect_uri=http://localhost:3000/callback&state=s&client_id=test_client_id_lit4169"
# location: https://provider.example.com/oauth/authorize?client_id=test_client_id_lit4169&redirect_uri=...&state=...&response_type=code&scope=read
# HTTP 307
```

A genuinely unknown id still 404s, so resolution is real and not a blanket pass

```bash
curl -s -H "Authorization: Bearer sk-1234" -o /dev/stdout -w "\nHTTP %{http_code}\n" \
  "http://localhost:4169/v1/mcp/server/oauth/totally_bogus_id_zzz/authorize?redirect_uri=http://x/cb&state=s"
# {"detail":{"error":"MCP server totally_bogus_id_zzz not found"}}
# HTTP 404
```

The new test locks this behavior. Mutating the resolver to drop the `get_mcp_server_by_id` branch makes the handler 404 with `MCP server dcc61bddefd721c993ff57291cac2b98 not found`, and the test fails on that mutation

## Type

✅ Test

## Changes

Adds `test_get_cached_temporary_mcp_server_resolves_real_server_by_server_id` to `TestTemporaryMCPSessionEndpoints`. It drives `_get_cached_temporary_mcp_server_or_404` with the temp-session cache empty and a hash server_id the name resolver cannot match, then asserts the server still resolves via `get_mcp_server_by_id`. The assertions are arg-sensitive (`get_mcp_server_by_id` is called with the exact server_id, `get_mcp_server_by_name` returns None for it) so the test fails if the server_id fallback is removed
