### PR TITLE
Add LiteLLM Relay collector logs

### DIFF
--- a/litellm-rust/Cargo.lock
+++ b/litellm-rust/Cargo.lock
@@ -672,6 +672,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/litellm-rust/crates/core/Cargo.toml
+++ b/litellm-rust/crates/core/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/litellm-rust/crates/core/src/collector/mod.rs
+++ b/litellm-rust/crates/core/src/collector/mod.rs
@@ -1,0 +1,360 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+
+use crate::error::{json_type_name, CoreError, CoreResult};
+
+const COLLECTOR_CALL_TYPE: &str = "litellm-relay";
+const DEFAULT_MODEL: &str = "local-ai-traffic";
+const DEFAULT_API_KEY: &str = "litellm-relay";
+const MAX_REQUEST_ID_HASH_CHARS: usize = 32;
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct CollectorAuthContext {
+    pub key_hash: Option<String>,
+    pub key_alias: Option<String>,
+    pub team_id: Option<String>,
+    pub team_alias: Option<String>,
+    pub organization_id: Option<String>,
+    pub user_id: Option<String>,
+}
+
+pub fn normalize_collector_spend_logs(
+    logs: Vec<Value>,
+    auth_context: CollectorAuthContext,
+    now: &str,
+) -> CoreResult<Vec<Value>> {
+    logs.into_iter()
+        .map(|log| normalize_collector_spend_log(log, &auth_context, now))
+        .collect()
+}
+
+fn normalize_collector_spend_log(
+    log: Value,
+    auth_context: &CollectorAuthContext,
+    now: &str,
+) -> CoreResult<Value> {
+    let input = match log {
+        Value::Object(map) => map,
+        other => {
+            return Err(CoreError::InvalidType {
+                expected: "object",
+                actual: json_type_name(&other),
+            })
+        }
+    };
+
+    let collector_request_id = required_request_id(&input)?;
+    let mut output = default_spend_log(now);
+
+    for (key, value) in input.iter() {
+        if is_collector_passthrough_field(key) {
+            output.insert(key.clone(), value.clone());
+        }
+    }
+
+    output.insert(
+        "request_id".to_string(),
+        json!(collector_request_id_for(auth_context, collector_request_id)),
+    );
+    output.insert("call_type".to_string(), json!(COLLECTOR_CALL_TYPE));
+    output.insert(
+        "api_key".to_string(),
+        json!(auth_context.key_hash.as_deref().unwrap_or(DEFAULT_API_KEY)),
+    );
+    output.insert("spend".to_string(), json!(0.0));
+    output.insert("custom_llm_provider".to_string(), json!(""));
+    output.insert(
+        "team_id".to_string(),
+        optional_string_value(&auth_context.team_id),
+    );
+    output.insert(
+        "organization_id".to_string(),
+        optional_string_value(&auth_context.organization_id),
+    );
+    output.insert(
+        "user".to_string(),
+        optional_string_value(&auth_context.user_id),
+    );
+
+    let metadata = normalize_metadata(input.get("metadata"), auth_context, collector_request_id);
+    output.insert("metadata".to_string(), Value::Object(metadata));
+    output.insert(
+        "request_tags".to_string(),
+        json!(normalize_request_tags(input.get("request_tags"))),
+    );
+
+    Ok(sanitize_json_value(Value::Object(output)))
+}
+
+fn default_spend_log(now: &str) -> Map<String, Value> {
+    let mut output = Map::new();
+    output.insert("request_id".to_string(), json!(""));
+    output.insert("call_type".to_string(), json!(COLLECTOR_CALL_TYPE));
+    output.insert("api_key".to_string(), json!(DEFAULT_API_KEY));
+    output.insert("spend".to_string(), json!(0.0));
+    output.insert("total_tokens".to_string(), json!(0));
+    output.insert("prompt_tokens".to_string(), json!(0));
+    output.insert("completion_tokens".to_string(), json!(0));
+    output.insert("startTime".to_string(), json!(now));
+    output.insert("endTime".to_string(), json!(now));
+    output.insert("model".to_string(), json!(DEFAULT_MODEL));
+    output.insert("api_base".to_string(), json!(""));
+    output.insert("custom_llm_provider".to_string(), json!(""));
+    output.insert("user".to_string(), Value::Null);
+    output.insert("metadata".to_string(), json!({}));
+    output.insert("cache_hit".to_string(), json!("False"));
+    output.insert("cache_key".to_string(), json!(""));
+    output.insert("request_tags".to_string(), json!("[\"litellm-relay\"]"));
+    output.insert("messages".to_string(), json!({}));
+    output.insert("response".to_string(), json!({}));
+    output.insert("proxy_server_request".to_string(), json!({}));
+    output.insert("status".to_string(), json!("success"));
+    output
+}
+
+fn required_request_id(input: &Map<String, Value>) -> CoreResult<&str> {
+    match input.get("request_id") {
+        Some(Value::String(request_id)) if !request_id.trim().is_empty() => Ok(request_id),
+        Some(value) => Err(CoreError::InvalidType {
+            expected: "non-empty string",
+            actual: json_type_name(value),
+        }),
+        None => Err(CoreError::MissingField("request_id")),
+    }
+}
+
+fn collector_request_id_for(
+    auth_context: &CollectorAuthContext,
+    collector_request_id: &str,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(auth_context.key_hash.as_deref().unwrap_or(DEFAULT_API_KEY));
+    hasher.update(b":");
+    hasher.update(collector_request_id);
+    let digest = hasher.finalize();
+    let mut encoded = String::with_capacity(MAX_REQUEST_ID_HASH_CHARS);
+    for byte in digest {
+        encoded.push_str(&format!("{byte:02x}"));
+        if encoded.len() >= MAX_REQUEST_ID_HASH_CHARS {
+            encoded.truncate(MAX_REQUEST_ID_HASH_CHARS);
+            break;
+        }
+    }
+    format!("collector-{encoded}")
+}
+
+fn is_collector_passthrough_field(key: &str) -> bool {
+    matches!(
+        key,
+        "total_tokens"
+            | "prompt_tokens"
+            | "completion_tokens"
+            | "startTime"
+            | "endTime"
+            | "completionStartTime"
+            | "model"
+            | "model_id"
+            | "model_group"
+            | "mcp_namespaced_tool_name"
+            | "agent_id"
+            | "api_base"
+            | "cache_hit"
+            | "cache_key"
+            | "end_user"
+            | "requester_ip_address"
+            | "messages"
+            | "response"
+            | "proxy_server_request"
+            | "session_id"
+            | "request_duration_ms"
+            | "status"
+    )
+}
+
+fn normalize_metadata(
+    metadata: Option<&Value>,
+    auth_context: &CollectorAuthContext,
+    collector_request_id: &str,
+) -> Map<String, Value> {
+    let mut normalized = match metadata {
+        Some(Value::Object(map)) => map.clone(),
+        Some(Value::String(raw)) => {
+            let mut map = Map::new();
+            map.insert("relay_raw_metadata".to_string(), json!(raw));
+            map
+        }
+        Some(Value::Null) | None => Map::new(),
+        Some(raw) => {
+            let mut map = Map::new();
+            map.insert("relay_raw_metadata".to_string(), raw.clone());
+            map
+        }
+    };
+
+    normalized.insert("source".to_string(), json!(DEFAULT_API_KEY));
+    normalized.insert(
+        "collector_request_id".to_string(),
+        json!(collector_request_id),
+    );
+    normalized.insert("relay_request_id".to_string(), json!(collector_request_id));
+    normalized.insert(
+        "user_api_key".to_string(),
+        optional_string_value(&auth_context.key_hash),
+    );
+    normalized.insert(
+        "user_api_key_alias".to_string(),
+        optional_string_value(&auth_context.key_alias),
+    );
+    normalized.insert(
+        "user_api_key_user_id".to_string(),
+        optional_string_value(&auth_context.user_id),
+    );
+    normalized.insert(
+        "user_api_key_team_id".to_string(),
+        optional_string_value(&auth_context.team_id),
+    );
+    normalized.insert(
+        "user_api_key_team_alias".to_string(),
+        optional_string_value(&auth_context.team_alias),
+    );
+    normalized.insert(
+        "user_api_key_org_id".to_string(),
+        optional_string_value(&auth_context.organization_id),
+    );
+    normalized
+}
+
+fn optional_string_value(value: &Option<String>) -> Value {
+    match value {
+        Some(value) => json!(value),
+        None => Value::Null,
+    }
+}
+
+fn normalize_request_tags(value: Option<&Value>) -> String {
+    let mut tags = match value {
+        Some(Value::Array(tags)) => tags.clone(),
+        Some(Value::String(raw)) => match serde_json::from_str::<Value>(raw) {
+            Ok(Value::Array(tags)) => tags,
+            _ if raw.trim().is_empty() => Vec::new(),
+            _ => vec![json!(raw)],
+        },
+        Some(Value::Null) | None => Vec::new(),
+        Some(other) => vec![other.clone()],
+    };
+
+    let has_relay_tag = tags.iter().any(|tag| tag.as_str() == Some(DEFAULT_API_KEY));
+    if !has_relay_tag {
+        tags.push(json!(DEFAULT_API_KEY));
+    }
+
+    serde_json::to_string(&tags).unwrap_or_else(|_| "[\"litellm-relay\"]".to_string())
+}
+
+fn sanitize_json_value(value: Value) -> Value {
+    match value {
+        Value::String(raw) => Value::String(raw.replace('\0', "")),
+        Value::Array(items) => Value::Array(items.into_iter().map(sanitize_json_value).collect()),
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .map(|(key, value)| (key.replace('\0', ""), sanitize_json_value(value)))
+                .collect(),
+        ),
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn auth_context() -> CollectorAuthContext {
+        CollectorAuthContext {
+            key_hash: Some("hashed-key".to_string()),
+            key_alias: Some("relay-key".to_string()),
+            team_id: Some("team-1".to_string()),
+            team_alias: Some("Relay Team".to_string()),
+            organization_id: Some("org-1".to_string()),
+            user_id: Some("user-1".to_string()),
+        }
+    }
+
+    #[test]
+    fn normalizes_collector_log_with_authenticated_attribution() {
+        let logs = vec![json!({
+            "request_id": "raw-request-id",
+            "model": "notion-ai",
+            "api_key": "caller-supplied-key",
+            "team_id": "caller-team",
+            "organization_id": "caller-org",
+            "user": "caller-user",
+            "spend": 10,
+            "custom_llm_provider": "caller-provider",
+            "metadata": {
+                "app": "notion",
+                "source": "caller-source",
+                "user_api_key": "caller-key"
+            },
+            "request_tags": ["notion"],
+            "proxy_server_request": {"body_preview": "hi"},
+            "response": {"body_preview": "hello"}
+        })];
+
+        let normalized =
+            normalize_collector_spend_logs(logs, auth_context(), "2026-07-09T18:00:00+00:00")
+                .expect("collector logs should normalize");
+        let row = normalized[0].as_object().expect("row should be object");
+
+        assert_eq!(row["call_type"], json!("litellm-relay"));
+        assert_eq!(row["api_key"], json!("hashed-key"));
+        assert_eq!(row["team_id"], json!("team-1"));
+        assert_eq!(row["organization_id"], json!("org-1"));
+        assert_eq!(row["user"], json!("user-1"));
+        assert_eq!(row["spend"], json!(0.0));
+        assert_eq!(row["custom_llm_provider"], json!(""));
+        assert_ne!(row["request_id"], json!("raw-request-id"));
+        assert!(row["request_id"]
+            .as_str()
+            .expect("request id should be string")
+            .starts_with("collector-"));
+
+        let metadata = row["metadata"]
+            .as_object()
+            .expect("metadata should be object");
+        assert_eq!(metadata["app"], json!("notion"));
+        assert_eq!(metadata["source"], json!("litellm-relay"));
+        assert_eq!(metadata["collector_request_id"], json!("raw-request-id"));
+        assert_eq!(metadata["user_api_key"], json!("hashed-key"));
+        assert_eq!(metadata["user_api_key_alias"], json!("relay-key"));
+        assert_eq!(metadata["user_api_key_team_alias"], json!("Relay Team"));
+        assert_eq!(row["request_tags"], json!("[\"notion\",\"litellm-relay\"]"));
+    }
+
+    #[test]
+    fn strips_nul_bytes_before_queueing() {
+        let logs = vec![json!({
+            "request_id": "nul-request",
+            "proxy_server_request": {"body_preview": "hello\u{0}world"},
+            "response": {"body_preview": "ok\u{0}"}
+        })];
+
+        let normalized =
+            normalize_collector_spend_logs(logs, auth_context(), "2026-07-09T18:00:00+00:00")
+                .expect("collector logs should normalize");
+        let row_text = serde_json::to_string(&normalized[0]).expect("row should serialize");
+        assert!(!row_text.contains('\0'));
+    }
+
+    #[test]
+    fn rejects_missing_request_id() {
+        let err = normalize_collector_spend_logs(
+            vec![json!({"model": "notion-ai"})],
+            auth_context(),
+            "2026-07-09T18:00:00+00:00",
+        )
+        .expect_err("missing request id should fail");
+
+        assert_eq!(err, CoreError::MissingField("request_id"));
+    }
+}

--- a/litellm-rust/crates/core/src/lib.rs
+++ b/litellm-rust/crates/core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod call_lifecycle;
+pub mod collector;
 pub mod error;
 pub mod ocr;
 pub mod providers;

--- a/litellm-rust/crates/python-bridge/src/lib.rs
+++ b/litellm-rust/crates/python-bridge/src/lib.rs
@@ -1,6 +1,9 @@
 use std::time::Duration;
 
 use litellm_ai_gateway::io::ocr::{ocr as run_ocr, OcrRequest};
+use litellm_core::collector::{
+    normalize_collector_spend_logs as normalize_collector_spend_logs_core, CollectorAuthContext,
+};
 use litellm_core::error::CoreError;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
@@ -178,10 +181,44 @@ fn gil_stats(py: Python<'_>) -> PyResult<Py<PyAny>> {
     Ok(stats.into_any().unbind())
 }
 
+#[pyfunction]
+#[pyo3(signature = (logs, auth_context, now))]
+fn normalize_collector_spend_logs(
+    py: Python<'_>,
+    logs: Py<PyAny>,
+    auth_context: Py<PyAny>,
+    now: String,
+) -> PyResult<Py<PyAny>> {
+    let logs = match py_to_json(py, logs.bind(py))? {
+        Value::Array(logs) => logs,
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "logs must be a list, got {}",
+                match other {
+                    Value::Null => "null",
+                    Value::Bool(_) => "bool",
+                    Value::Number(_) => "number",
+                    Value::String(_) => "string",
+                    Value::Array(_) => "array",
+                    Value::Object(_) => "object",
+                }
+            )))
+        }
+    };
+    let auth_context: CollectorAuthContext =
+        serde_json::from_value(py_to_json(py, auth_context.bind(py))?)
+            .map_err(|err| PyValueError::new_err(err.to_string()))?;
+
+    let result = normalize_collector_spend_logs_core(logs, auth_context, &now)
+        .map_err(core_error_to_pyerr)?;
+    json_to_py(py, Value::Array(result))
+}
+
 #[pymodule]
 fn _native(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(ocr, module)?)?;
     module.add_function(wrap_pyfunction!(aocr, module)?)?;
+    module.add_function(wrap_pyfunction!(normalize_collector_spend_logs, module)?)?;
     module.add_function(wrap_pyfunction!(gil_stats, module)?)?;
     Ok(())
 }

--- a/litellm/proxy/collector_endpoints/__init__.py
+++ b/litellm/proxy/collector_endpoints/__init__.py
@@ -1,0 +1,2 @@
+"""Collector endpoints for ingesting external LiteLLM Relay logs."""
+

--- a/litellm/proxy/collector_endpoints/spend_logs.py
+++ b/litellm/proxy/collector_endpoints/spend_logs.py
@@ -1,0 +1,102 @@
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.rust_bridge.collector import normalize_collector_spend_logs
+
+router = APIRouter()
+
+MAX_COLLECTOR_SPEND_LOGS = 1000
+
+
+def _get_auth_organization_id(user_api_key_dict: UserAPIKeyAuth) -> str | None:
+    return getattr(user_api_key_dict, "organization_id", None) or getattr(
+        user_api_key_dict, "org_id", None
+    )
+
+
+def _get_auth_key_hash(user_api_key_dict: UserAPIKeyAuth) -> str | None:
+    return getattr(user_api_key_dict, "api_key", None) or getattr(
+        user_api_key_dict, "token", None
+    )
+
+
+def _get_auth_key_alias(user_api_key_dict: UserAPIKeyAuth) -> str:
+    return (
+        getattr(user_api_key_dict, "key_alias", None)
+        or getattr(user_api_key_dict, "key_name", None)
+        or "litellm-relay"
+    )
+
+
+def _get_auth_team_alias(user_api_key_dict: UserAPIKeyAuth) -> str | None:
+    return getattr(user_api_key_dict, "team_alias", None) or getattr(
+        user_api_key_dict, "team_id", None
+    )
+
+
+def _get_collector_auth_context(user_api_key_dict: UserAPIKeyAuth) -> Dict[str, Any]:
+    return {
+        "key_hash": _get_auth_key_hash(user_api_key_dict),
+        "key_alias": _get_auth_key_alias(user_api_key_dict),
+        "team_id": getattr(user_api_key_dict, "team_id", None),
+        "team_alias": _get_auth_team_alias(user_api_key_dict),
+        "organization_id": _get_auth_organization_id(user_api_key_dict),
+        "user_id": getattr(user_api_key_dict, "user_id", None),
+    }
+
+
+@router.post(
+    "/collector/spend-logs",
+    tags=["Collector"],
+    include_in_schema=False,
+)
+async def ingest_collector_spend_logs(
+    payload: Dict[str, List[Dict[str, Any]]],
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    """
+    Ingest LiteLLM Relay captures into the existing spend-log batcher so they
+    appear in the Gateway Logs UI without replaying captured traffic.
+    """
+    from litellm.proxy.proxy_server import prisma_client, proxy_logging_obj
+
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"error": "Prisma Client is not initialized"},
+        )
+
+    logs = payload.get("logs", [])
+    if len(logs) == 0:
+        return {"enqueued": 0}
+    if len(logs) > MAX_COLLECTOR_SPEND_LOGS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "error": f"Collector spend-log ingestion is limited to {MAX_COLLECTOR_SPEND_LOGS} rows"
+            },
+        )
+
+    try:
+        spend_logs = normalize_collector_spend_logs(
+            logs=logs,
+            auth_context=_get_collector_auth_context(user_api_key_dict),
+            now=datetime.now(timezone.utc).isoformat(),
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": str(exc)},
+        ) from exc
+
+    for spend_log in spend_logs:
+        await proxy_logging_obj.db_spend_update_writer._insert_spend_log_to_db(
+            payload=spend_log,
+            prisma_client=prisma_client,
+        )
+
+    return {"enqueued": len(spend_logs)}

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -468,6 +468,9 @@ from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
 from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
     router as pass_through_router,
 )
+from litellm.proxy.collector_endpoints.spend_logs import (
+    router as collector_spend_logs_router,
+)
 from litellm.proxy.public_endpoints import router as public_endpoints_router
 from litellm.proxy.rag_endpoints.endpoints import router as rag_router
 from litellm.proxy.rerank_endpoints.endpoints import router as rerank_router
@@ -15790,6 +15793,7 @@ app.include_router(team_router)
 app.include_router(ui_sso_router)
 app.include_router(organization_router)
 app.include_router(customer_router)
+app.include_router(collector_spend_logs_router)
 app.include_router(spend_management_router)
 app.include_router(caching_router)
 app.include_router(analytics_router)

--- a/litellm/rust_bridge/__init__.py
+++ b/litellm/rust_bridge/__init__.py
@@ -4,6 +4,12 @@ from litellm.rust_bridge.loader import (
     get_native_bridge,
     native_bridge_available,
 )
+from litellm.rust_bridge.collector import normalize_collector_spend_logs
 from litellm.rust_bridge.ocr import use_litellm_rust
 
-__all__ = ["get_native_bridge", "native_bridge_available", "use_litellm_rust"]
+__all__ = [
+    "get_native_bridge",
+    "native_bridge_available",
+    "normalize_collector_spend_logs",
+    "use_litellm_rust",
+]

--- a/litellm/rust_bridge/collector.py
+++ b/litellm/rust_bridge/collector.py
@@ -1,0 +1,214 @@
+"""Thin Python wrapper for the native Rust collector bridge."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Protocol, cast
+
+
+class RustCollectorSpendLogs(Protocol):
+    def __call__(
+        self,
+        logs: list[dict[str, Any]],
+        auth_context: dict[str, Any],
+        now: str,
+    ) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+
+def load_rust_collector_spend_logs() -> RustCollectorSpendLogs | None:
+    from litellm.rust_bridge import get_native_bridge
+
+    native_bridge = get_native_bridge()
+    if native_bridge is None:
+        return None
+    return cast(
+        RustCollectorSpendLogs,
+        getattr(native_bridge, "normalize_collector_spend_logs", None),
+    )
+
+
+def normalize_collector_spend_logs(
+    *,
+    logs: list[dict[str, Any]],
+    auth_context: dict[str, Any],
+    now: str,
+) -> list[dict[str, Any]]:
+    rust_normalizer = load_rust_collector_spend_logs()
+    if rust_normalizer is not None:
+        return rust_normalizer(logs=logs, auth_context=auth_context, now=now)
+    return _normalize_collector_spend_logs_python(
+        logs=logs,
+        auth_context=auth_context,
+        now=now,
+    )
+
+
+_COLLECTOR_CALL_TYPE = "litellm-relay"
+_DEFAULT_MODEL = "local-ai-traffic"
+_DEFAULT_API_KEY = "litellm-relay"
+
+
+def _normalize_collector_spend_logs_python(
+    *,
+    logs: list[dict[str, Any]],
+    auth_context: dict[str, Any],
+    now: str,
+) -> list[dict[str, Any]]:
+    return [
+        _normalize_collector_spend_log_python(
+            log=log,
+            auth_context=auth_context,
+            now=now,
+        )
+        for log in logs
+    ]
+
+
+def _normalize_collector_spend_log_python(
+    *,
+    log: dict[str, Any],
+    auth_context: dict[str, Any],
+    now: str,
+) -> dict[str, Any]:
+    collector_request_id = log.get("request_id")
+    if not isinstance(collector_request_id, str) or not collector_request_id.strip():
+        raise ValueError("missing required field: request_id")
+
+    row: dict[str, Any] = {
+        "request_id": _collector_request_id_for(auth_context, collector_request_id),
+        "call_type": _COLLECTOR_CALL_TYPE,
+        "api_key": auth_context.get("key_hash") or _DEFAULT_API_KEY,
+        "spend": 0.0,
+        "total_tokens": 0,
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "startTime": now,
+        "endTime": now,
+        "model": _DEFAULT_MODEL,
+        "api_base": "",
+        "custom_llm_provider": "",
+        "user": auth_context.get("user_id"),
+        "metadata": {},
+        "cache_hit": "False",
+        "cache_key": "",
+        "request_tags": json.dumps([_DEFAULT_API_KEY]),
+        "messages": {},
+        "response": {},
+        "proxy_server_request": {},
+        "status": "success",
+        "team_id": auth_context.get("team_id"),
+        "organization_id": auth_context.get("organization_id"),
+    }
+
+    for key in _PASSTHROUGH_FIELDS:
+        if key in log:
+            row[key] = log[key]
+
+    row["request_id"] = _collector_request_id_for(auth_context, collector_request_id)
+    row["call_type"] = _COLLECTOR_CALL_TYPE
+    row["api_key"] = auth_context.get("key_hash") or _DEFAULT_API_KEY
+    row["spend"] = 0.0
+    row["custom_llm_provider"] = ""
+    row["team_id"] = auth_context.get("team_id")
+    row["organization_id"] = auth_context.get("organization_id")
+    row["user"] = auth_context.get("user_id")
+    row["metadata"] = _normalize_metadata(
+        log.get("metadata"), auth_context, collector_request_id
+    )
+    row["request_tags"] = _normalize_request_tags(log.get("request_tags"))
+    return cast(dict[str, Any], _sanitize_json_value(row))
+
+
+_PASSTHROUGH_FIELDS = {
+    "total_tokens",
+    "prompt_tokens",
+    "completion_tokens",
+    "startTime",
+    "endTime",
+    "completionStartTime",
+    "model",
+    "model_id",
+    "model_group",
+    "mcp_namespaced_tool_name",
+    "agent_id",
+    "api_base",
+    "cache_hit",
+    "cache_key",
+    "end_user",
+    "requester_ip_address",
+    "messages",
+    "response",
+    "proxy_server_request",
+    "session_id",
+    "request_duration_ms",
+    "status",
+}
+
+
+def _collector_request_id_for(
+    auth_context: dict[str, Any], collector_request_id: str
+) -> str:
+    key_hash = auth_context.get("key_hash") or _DEFAULT_API_KEY
+    digest = hashlib.sha256(f"{key_hash}:{collector_request_id}".encode()).hexdigest()
+    return f"collector-{digest[:32]}"
+
+
+def _normalize_metadata(
+    metadata: Any,
+    auth_context: dict[str, Any],
+    collector_request_id: str,
+) -> dict[str, Any]:
+    if isinstance(metadata, dict):
+        normalized = dict(metadata)
+    elif metadata is None:
+        normalized = {}
+    else:
+        normalized = {"relay_raw_metadata": metadata}
+
+    normalized.update(
+        {
+            "source": _DEFAULT_API_KEY,
+            "collector_request_id": collector_request_id,
+            "relay_request_id": collector_request_id,
+            "user_api_key": auth_context.get("key_hash"),
+            "user_api_key_alias": auth_context.get("key_alias"),
+            "user_api_key_user_id": auth_context.get("user_id"),
+            "user_api_key_team_id": auth_context.get("team_id"),
+            "user_api_key_team_alias": auth_context.get("team_alias"),
+            "user_api_key_org_id": auth_context.get("organization_id"),
+        }
+    )
+    return normalized
+
+
+def _normalize_request_tags(value: Any) -> str:
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            parsed = [value] if value.strip() else []
+    elif isinstance(value, list):
+        parsed = list(value)
+    elif value is None:
+        parsed = []
+    else:
+        parsed = [value]
+
+    if _DEFAULT_API_KEY not in parsed:
+        parsed.append(_DEFAULT_API_KEY)
+    return json.dumps(parsed, separators=(",", ":"))
+
+
+def _sanitize_json_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return value.replace("\x00", "")
+    if isinstance(value, list):
+        return [_sanitize_json_value(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            str(key).replace("\x00", ""): _sanitize_json_value(item)
+            for key, item in value.items()
+        }
+    return value

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -86,6 +86,60 @@ def test_compliance_routes_open_to_non_admin_roles(role, route):
     )
 
 
+def test_collector_spend_logs_requires_explicit_allowed_route_for_non_admin_key():
+    """Collector ingestion is a write path and must not be open to every key."""
+    user_obj = LiteLLM_UserTable(
+        user_id="relay_user",
+        user_email="relay@example.com",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+    valid_token = UserAPIKeyAuth(
+        user_id="relay_user",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+
+    with pytest.raises(Exception) as exc_info:
+        RouteChecks.non_proxy_admin_allowed_routes_check(
+            user_obj=user_obj,
+            _user_role=LitellmUserRoles.INTERNAL_USER.value,
+            route="/collector/spend-logs",
+            request=request,
+            valid_token=valid_token,
+            request_data={},
+        )
+
+    assert "Only proxy admin" in str(exc_info.value)
+    assert "Route=/collector/spend-logs" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("allowed_route", ["/collector/spend-logs", "/collector/*"])
+def test_collector_spend_logs_allows_explicit_allowed_route(allowed_route):
+    """Relay keys can be scoped to only the collector ingest endpoint."""
+    user_obj = LiteLLM_UserTable(
+        user_id="relay_user",
+        user_email="relay@example.com",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+    valid_token = UserAPIKeyAuth(
+        user_id="relay_user",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+        allowed_routes=[allowed_route],
+    )
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+
+    RouteChecks.non_proxy_admin_allowed_routes_check(
+        user_obj=user_obj,
+        _user_role=LitellmUserRoles.INTERNAL_USER.value,
+        route="/collector/spend-logs",
+        request=request,
+        valid_token=valid_token,
+        request_data={},
+    )
+
+
 def test_proxy_admin_viewer_config_update_route_rejected():
     """Test that proxy admin viewer users are rejected when trying to call /config/update"""
 

--- a/tests/test_litellm/proxy/collector_endpoints/test_spend_logs.py
+++ b/tests/test_litellm/proxy/collector_endpoints/test_spend_logs.py
@@ -1,0 +1,150 @@
+import asyncio
+import json
+
+from fastapi.testclient import TestClient
+
+import litellm.proxy.proxy_server as ps
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy.proxy_server import app
+
+
+class MockPrismaClient:
+    def __init__(self):
+        self.spend_log_transactions = []
+        self._spend_log_transactions_lock = asyncio.Lock()
+
+
+def test_collector_spend_logs_enqueues_batcher_rows(monkeypatch):
+    prisma_client = MockPrismaClient()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", prisma_client)
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user",
+        api_key="hashed-admin-key",
+        team_id="team-1",
+    )
+
+    try:
+        response = TestClient(app).post(
+            "/collector/spend-logs",
+            json={
+                "logs": [
+                    {
+                        "request_id": "relay-test-request",
+                        "model": "notion-ai",
+                        "metadata": {"app": "notion", "host": "www.notion.so"},
+                        "proxy_server_request": {
+                            "method": "POST",
+                            "body_preview": "hi",
+                        },
+                        "response": {
+                            "status_code": 200,
+                            "body_preview": "hello",
+                        },
+                        "request_duration_ms": 42,
+                    }
+                ]
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json() == {"enqueued": 1}
+        assert len(prisma_client.spend_log_transactions) == 1
+        row = prisma_client.spend_log_transactions[0]
+        assert row["request_id"].startswith("collector-")
+        assert row["request_id"] != "relay-test-request"
+        assert row["call_type"] == "litellm-relay"
+        assert row["model"] == "notion-ai"
+        assert row["spend"] == 0.0
+        assert row["team_id"] == "team-1"
+        assert row["metadata"]["source"] == "litellm-relay"
+        assert row["metadata"]["collector_request_id"] == "relay-test-request"
+        assert row["metadata"]["app"] == "notion"
+        assert row["proxy_server_request"]["body_preview"] == "hi"
+        assert row["response"]["body_preview"] == "hello"
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+def test_collector_spend_logs_attributes_valid_virtual_key(monkeypatch):
+    prisma_client = MockPrismaClient()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", prisma_client)
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="user_1",
+        api_key="hashed-virtual-key",
+        team_id="team_1",
+        team_alias="Relay Team",
+        key_alias="relay-key",
+        organization_id="org_1",
+    )
+
+    try:
+        response = TestClient(app).post(
+            "/collector/spend-logs",
+            json={
+                "logs": [
+                    {
+                        "request_id": "relay-test-request",
+                        "api_key": "client-supplied-key-is-ignored",
+                        "spend": 10,
+                        "team_id": "client-team-is-ignored",
+                        "organization_id": "client-org-is-ignored",
+                        "user": "client-user-is-ignored",
+                        "custom_llm_provider": "client-provider-is-ignored",
+                        "metadata": {
+                            "source": "client-source-is-ignored",
+                            "user_api_key": "client-key-is-ignored",
+                        },
+                    }
+                ]
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+
+        assert response.status_code == 200, response.text
+        row = prisma_client.spend_log_transactions[0]
+        assert row["api_key"] == "hashed-virtual-key"
+        assert row["spend"] == 0.0
+        assert row["team_id"] == "team_1"
+        assert row["organization_id"] == "org_1"
+        assert row["user"] == "user_1"
+        assert row["custom_llm_provider"] == ""
+        assert row["metadata"]["source"] == "litellm-relay"
+        assert row["metadata"]["user_api_key"] == "hashed-virtual-key"
+        assert row["metadata"]["user_api_key_alias"] == "relay-key"
+        assert row["metadata"]["user_api_key_team_alias"] == "Relay Team"
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+def test_collector_spend_logs_strips_nul_bytes(monkeypatch):
+    prisma_client = MockPrismaClient()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", prisma_client)
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="user_1",
+        api_key="hashed-virtual-key",
+    )
+
+    try:
+        response = TestClient(app).post(
+            "/collector/spend-logs",
+            json={
+                "logs": [
+                    {
+                        "request_id": "relay-nul-test",
+                        "proxy_server_request": {"body_preview": "hello\u0000world"},
+                        "response": {"body_preview": "ok\u0000"},
+                    }
+                ]
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+
+        assert response.status_code == 200, response.text
+        row_text = json.dumps(prisma_client.spend_log_transactions[0])
+        assert "\u0000" not in row_text
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.test.tsx
@@ -56,6 +56,22 @@ describe("LogDetailContent", () => {
     expect(screen.getByText("completion")).toBeInTheDocument();
   });
 
+  it("should display relay source with logo in Request Details", () => {
+    render(
+      <LogDetailContent
+        logEntry={createLogEntry({
+          model: "notion-ai",
+          call_type: "litellm-relay",
+          metadata: { status: "success", app: "notion", source: "litellm-relay" },
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Source")).toBeInTheDocument();
+    expect(screen.getByText("N")).toBeInTheDocument();
+    expect(screen.getByText("Notion")).toBeInTheDocument();
+  });
+
   it("should display error alert when request has failed", () => {
     render(
       <LogDetailContent

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
@@ -28,11 +28,14 @@ import {
   TAB_RESPONSE,
   FONT_SIZE_SMALL,
   FONT_FAMILY_MONO,
+  COLOR_BG_LIGHT,
+  SPACING_LARGE,
   SPACING_XLARGE,
   SPACING_MEDIUM,
 } from "./constants";
 import { ToolsSection } from "../ToolsSection";
 import { PrettyMessagesView } from "./PrettyMessagesView";
+import { RelaySourceBadge, getRelaySource } from "../TypeBadges";
 
 const { Text } = Typography;
 
@@ -55,6 +58,8 @@ export function LogDetailContent({ logEntry, isLoadingDetails = false, accessTok
   const metadata = logEntry.metadata || {};
   const hasError = metadata.status === "failure";
   const errorInfo = hasError ? metadata.error_information : null;
+  const isRelayCapture = logEntry.call_type === "litellm-relay";
+  const relaySource = getRelaySource(logEntry);
 
   const hasMessages = checkHasMessages(logEntry.messages);
   const hasResponse = checkHasResponse(logEntry.response);
@@ -118,6 +123,11 @@ export function LogDetailContent({ logEntry, isLoadingDetails = false, accessTok
             <Descriptions.Item label="Model">{logEntry.model}</Descriptions.Item>
             <Descriptions.Item label="Provider">{logEntry.custom_llm_provider || "-"}</Descriptions.Item>
             <Descriptions.Item label="Call Type">{logEntry.call_type}</Descriptions.Item>
+            {isRelayCapture && (
+              <Descriptions.Item label="Source">
+                <RelaySourceBadge source={relaySource} />
+              </Descriptions.Item>
+            )}
             <Descriptions.Item label="Model ID">
               <TruncatedValue value={logEntry.model_id} />
             </Descriptions.Item>
@@ -418,6 +428,7 @@ function RequestResponseSection({
     : totalTokens > 0
       ? (totalSpend * completionTokens) / totalTokens
       : 0;
+  const isRelayCapture = logEntry.call_type === "litellm-relay";
 
   return (
     <div className="bg-white rounded-lg shadow-sm w-full max-w-full overflow-hidden mb-6">
@@ -448,6 +459,9 @@ function RequestResponseSection({
             ),
             children: (
               <div>
+                {isRelayCapture && (
+                  <RelayPayloadPreview request={getRawRequest()} response={getFormattedResponse()} />
+                )}
                 {viewMode === "pretty" ? (
                   <PrettyMessagesView
                     request={getRawRequest()}
@@ -505,6 +519,64 @@ function RequestResponseSection({
           },
         ]}
       />
+    </div>
+  );
+}
+
+function getPreviewText(payload: any): string {
+  if (!payload) return "";
+  if (typeof payload === "string") return payload;
+  if (typeof payload.body === "string") return payload.body;
+  if (typeof payload.body_preview === "string") return payload.body_preview;
+  return JSON.stringify(payload, null, 2);
+}
+
+function PayloadCodeBlock({ value }: { value: string }) {
+  return (
+    <pre
+      className="whitespace-pre-wrap break-words text-xs"
+      style={{
+        margin: 0,
+        maxHeight: 220,
+        overflow: "auto",
+        padding: SPACING_LARGE,
+        background: COLOR_BG_LIGHT,
+        border: "1px solid #e5e7eb",
+        borderRadius: 6,
+        fontFamily: FONT_FAMILY_MONO,
+      }}
+    >
+      {value || "No body captured"}
+    </pre>
+  );
+}
+
+function RelayPayloadPreview({ request, response }: { request: any; response: any }) {
+  const requestBody = getPreviewText(request);
+  const responseBody = getPreviewText(response);
+  return (
+    <div className="mb-4">
+      <Alert
+        type="info"
+        showIcon
+        message="HTTP payload captured by LiteLLM Relay"
+        description="This is the intercepted request and response body stored on the LiteLLM spend log."
+        className="mb-3"
+      />
+      <div className="grid grid-cols-1 gap-3">
+        <Card
+          size="small"
+          title={`Request${request?.method ? ` · ${request.method}` : ""}${request?.path ? ` ${request.path}` : ""}`}
+        >
+          <PayloadCodeBlock value={requestBody} />
+        </Card>
+        <Card
+          size="small"
+          title={`Response${response?.status_code ? ` · ${response.status_code}` : ""}`}
+        >
+          <PayloadCodeBlock value={responseBody} />
+        </Card>
+      </div>
     </div>
   );
 }

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
 import { Button, Drawer, Segmented } from "antd";
 import { CheckOutlined, CopyOutlined, LeftOutlined, RightOutlined } from "@ant-design/icons";
-import { Bot, Sparkles, Wrench } from "lucide-react";
+import { Bot, Cable, Sparkles, Wrench } from "lucide-react";
 import { LogEntry } from "../columns";
-import { AGENT_CALL_TYPES, MCP_CALL_TYPES } from "../constants";
+import { AGENT_CALL_TYPES, MCP_CALL_TYPES, RELAY_CALL_TYPES } from "../constants";
 import { getEventDisplayName } from "../utils";
 import { DrawerHeader } from "./DrawerHeader";
 import { useKeyboardNavigation } from "./useKeyboardNavigation";
@@ -49,6 +49,7 @@ interface TraceEventRowProps {
 function TraceEventRow({ row, isSelected, onClick }: TraceEventRowProps) {
   const isMcp = MCP_CALL_TYPES.includes(row.call_type);
   const isAgent = AGENT_CALL_TYPES.includes(row.call_type);
+  const isRelay = RELAY_CALL_TYPES.includes(row.call_type);
   const durationValue =
     row.request_duration_ms != null
       ? (row.request_duration_ms / 1000).toFixed(3)
@@ -69,6 +70,8 @@ function TraceEventRow({ row, isSelected, onClick }: TraceEventRowProps) {
           <Wrench size={12} className="text-slate-500 shrink-0" />
         ) : isAgent ? (
           <Bot size={12} className="text-slate-500 shrink-0" />
+        ) : isRelay ? (
+          <Cable size={12} className="text-slate-500 shrink-0" />
         ) : (
           <Sparkles size={12} className="text-slate-500 shrink-0" />
         )}
@@ -270,7 +273,7 @@ export function LogDetailsDrawer({
   const sessionDurationSeconds =
     sessionStart && sessionEnd ? ((sessionEnd.getTime() - sessionStart.getTime()) / 1000).toFixed(2) : "0.00";
   const llmCount = sessionLogs.filter(
-    (row) => !MCP_CALL_TYPES.includes(row.call_type) && !AGENT_CALL_TYPES.includes(row.call_type),
+    (row) => !MCP_CALL_TYPES.includes(row.call_type) && !AGENT_CALL_TYPES.includes(row.call_type) && !RELAY_CALL_TYPES.includes(row.call_type),
   ).length;
   const agentCount = sessionLogs.filter((row) => AGENT_CALL_TYPES.includes(row.call_type)).length;
   const mcpCount = sessionLogs.filter((row) => MCP_CALL_TYPES.includes(row.call_type)).length;
@@ -357,7 +360,10 @@ export function LogDetailsDrawer({
                   isSessionMode
                     ? llmCount
                     : logsForList.filter(
-                        (row) => !MCP_CALL_TYPES.includes(row.call_type) && !AGENT_CALL_TYPES.includes(row.call_type),
+                        (row) =>
+                          !MCP_CALL_TYPES.includes(row.call_type) &&
+                          !AGENT_CALL_TYPES.includes(row.call_type) &&
+                          !RELAY_CALL_TYPES.includes(row.call_type),
                       ).length,
                   isSessionMode
                     ? agentCount

--- a/ui/litellm-dashboard/src/components/view_logs/TypeBadges.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/TypeBadges.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { LlmBadge, McpBadge, AgentBadge } from "./TypeBadges";
+import { LlmBadge, McpBadge, AgentBadge, RelayBadge, RelaySourceBadge, getRelaySource } from "./TypeBadges";
 
 describe("TypeBadges", () => {
   describe("LlmBadge", () => {
@@ -41,6 +41,35 @@ describe("TypeBadges", () => {
     it("should render the count when provided", () => {
       render(<AgentBadge count={12} />);
       expect(screen.getByText("12")).toBeInTheDocument();
+    });
+  });
+
+  describe("RelayBadge", () => {
+    it("should render with default 'litellm-relay' text when no count is provided", () => {
+      render(<RelayBadge />);
+      expect(screen.getByText("litellm-relay")).toBeInTheDocument();
+    });
+  });
+
+  describe("RelaySourceBadge", () => {
+    it("should render Notion source with logo text", () => {
+      render(<RelaySourceBadge source="notion" />);
+      expect(screen.getByRole("img", { name: "Notion logo" })).toBeInTheDocument();
+      expect(screen.getByText("Notion")).toBeInTheDocument();
+    });
+
+    it("should render Codex source with logo", () => {
+      render(<RelaySourceBadge source="codex" />);
+      expect(screen.getByRole("img", { name: "Codex logo" })).toBeInTheDocument();
+      expect(screen.getByText("Codex")).toBeInTheDocument();
+    });
+
+    it("should derive source from relay metadata app", () => {
+      expect(getRelaySource({ metadata: { app: "notion" }, model: "local-ai" })).toBe("notion");
+    });
+
+    it("should derive source from relay model when metadata is missing", () => {
+      expect(getRelaySource({ model: "codex-ai" })).toBe("codex");
     });
   });
 });

--- a/ui/litellm-dashboard/src/components/view_logs/TypeBadges.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/TypeBadges.tsx
@@ -1,7 +1,8 @@
 /**
- * Compact type-indicator badges for LLM, Agent, and MCP log entries.
+ * Compact type-indicator badges for LLM, Agent, MCP, and Relay log entries.
  * Used in the request logs table and session type column.
  */
+import { Cable, Code2, Monitor } from "lucide-react";
 
 export const SparkleIcon = ({ size = 12 }: { size?: number }) => (
   <svg
@@ -57,6 +58,10 @@ export const AgentIcon = ({ size = 12 }: { size?: number }) => (
   </svg>
 );
 
+export const RelayIcon = ({ size = 12 }: { size?: number }) => (
+  <Cable size={size} className="flex-shrink-0" />
+);
+
 export const LlmBadge = ({ count }: { count?: number }) => (
   <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-blue-50 text-blue-700 border border-blue-200 rounded-full text-[11px] font-medium whitespace-nowrap">
     <SparkleIcon />
@@ -75,5 +80,98 @@ export const AgentBadge = ({ count }: { count?: number }) => (
   <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-violet-50 text-violet-700 border border-violet-200 rounded-full text-[11px] font-medium whitespace-nowrap">
     <AgentIcon />
     {count != null ? count : "Agent"}
+  </span>
+);
+
+export const RelayBadge = ({ count }: { count?: number }) => (
+  <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-emerald-50 text-emerald-700 border border-emerald-200 rounded-full text-[11px] font-medium whitespace-nowrap">
+    <RelayIcon />
+    {count != null ? count : "litellm-relay"}
+  </span>
+);
+
+type RelaySourceLike = {
+  metadata?: Record<string, any>;
+  model?: string;
+  request_tags?: Record<string, any> | string[] | string;
+};
+
+const RELAY_SOURCE_LABELS: Record<string, string> = {
+  notion: "Notion",
+  codex: "Codex",
+};
+
+const normalizeRelaySource = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (normalized === "litellm-relay") return undefined;
+  if (normalized.includes("notion")) return "notion";
+  if (normalized.includes("codex")) return "codex";
+  return normalized.replace(/-ai$/, "");
+};
+
+const getTagSource = (requestTags: RelaySourceLike["request_tags"]): string | undefined => {
+  if (Array.isArray(requestTags)) {
+    return requestTags.map(normalizeRelaySource).find(Boolean);
+  }
+  if (typeof requestTags === "string") {
+    try {
+      const parsed = JSON.parse(requestTags);
+      return getTagSource(parsed);
+    } catch {
+      return normalizeRelaySource(requestTags);
+    }
+  }
+  return undefined;
+};
+
+export const getRelaySource = (entry: RelaySourceLike): string => {
+  return (
+    normalizeRelaySource(entry.metadata?.app) ||
+    normalizeRelaySource(entry.metadata?.relay_app) ||
+    normalizeRelaySource(entry.metadata?.shadow_source) ||
+    normalizeRelaySource(entry.metadata?.host) ||
+    getTagSource(entry.request_tags) ||
+    normalizeRelaySource(entry.model) ||
+    "unknown"
+  );
+};
+
+export const getRelaySourceLabel = (source: string) => {
+  return RELAY_SOURCE_LABELS[source] || source.charAt(0).toUpperCase() + source.slice(1);
+};
+
+export const RelaySourceLogo = ({ source, size = 16 }: { source: string; size?: number }) => {
+  if (source === "notion") {
+    return (
+      <span
+        aria-label="Notion logo"
+        role="img"
+        className="inline-flex items-center justify-center rounded-sm bg-black text-white font-serif font-semibold leading-none"
+        style={{ width: size, height: size, fontSize: Math.max(9, size - 6) }}
+      >
+        N
+      </span>
+    );
+  }
+  if (source === "codex") {
+    return (
+      <span aria-label="Codex logo" role="img" className="inline-flex">
+        <Code2 size={size} className="flex-shrink-0 text-slate-700" aria-hidden="true" />
+      </span>
+    );
+  }
+  return (
+    <span aria-label={`${getRelaySourceLabel(source)} logo`} role="img" className="inline-flex">
+      <Monitor size={size} className="flex-shrink-0 text-slate-500" aria-hidden="true" />
+    </span>
+  );
+};
+
+export const RelaySourceBadge = ({ source }: { source: string }) => (
+  <span className="inline-flex items-center gap-1.5 px-2 py-0.5 bg-slate-50 text-slate-700 border border-slate-200 rounded-full text-[11px] font-medium whitespace-nowrap">
+    <RelaySourceLogo source={source} />
+    {getRelaySourceLabel(source)}
   </span>
 );

--- a/ui/litellm-dashboard/src/components/view_logs/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/columns.tsx
@@ -5,8 +5,19 @@ import { Tooltip } from "antd";
 import React from "react";
 import { getProviderLogoAndName } from "../provider_info_helpers";
 import { TableHeaderSortDropdown } from "../common_components/TableHeaderSortDropdown/TableHeaderSortDropdown";
-import { AGENT_CALL_TYPES, MCP_CALL_TYPES } from "./constants";
-import { AgentBadge, AgentIcon, LlmBadge, McpBadge, SparkleIcon, WrenchIcon } from "./TypeBadges";
+import { AGENT_CALL_TYPES, MCP_CALL_TYPES, RELAY_CALL_TYPES } from "./constants";
+import {
+  AgentBadge,
+  AgentIcon,
+  LlmBadge,
+  McpBadge,
+  RelayBadge,
+  RelayIcon,
+  RelaySourceBadge,
+  SparkleIcon,
+  WrenchIcon,
+  getRelaySource,
+} from "./TypeBadges";
 
 /** API sort field mapping for /spend/logs/ui endpoint */
 export const LOGS_SORT_FIELD_MAP = {
@@ -130,11 +141,13 @@ export const createColumns = (sortProps?: LogsSortProps): ColumnDef<LogEntry>[] 
       const sessionCount = row.session_total_count || 1;
       const isMcp = MCP_CALL_TYPES.includes(row.call_type);
       const isAgent = AGENT_CALL_TYPES.includes(row.call_type);
-      const sessionLlmCount = row.session_llm_count ?? (isMcp || isAgent ? 0 : sessionCount);
+      const isRelay = RELAY_CALL_TYPES.includes(row.call_type);
+      const sessionLlmCount = row.session_llm_count ?? (isMcp || isAgent || isRelay ? 0 : sessionCount);
       const sessionAgentCount = row.session_agent_count ?? (isAgent ? sessionCount : 0);
       const sessionMcpCount = row.session_mcp_count ?? (isMcp ? sessionCount : 0);
 
       if (isMcp) return <McpBadge />;
+      if (isRelay) return <RelayBadge />;
       if (isAgent && sessionCount <= 1) return <AgentBadge />;
       if (sessionCount <= 1) return <LlmBadge />;
 
@@ -155,6 +168,12 @@ export const createColumns = (sortProps?: LogsSortProps): ColumnDef<LogEntry>[] 
               <WrenchIcon />
             </>
           )}
+          {isRelay && (
+            <>
+              <span className="text-blue-300">·</span>
+              <RelayIcon size={10} />
+            </>
+          )}
         </span>
       );
 
@@ -162,8 +181,21 @@ export const createColumns = (sortProps?: LogsSortProps): ColumnDef<LogEntry>[] 
         sessionLlmCount > 0 && `${sessionLlmCount} LLM`,
         sessionAgentCount > 0 && `${sessionAgentCount} Agent`,
         sessionMcpCount > 0 && `${sessionMcpCount} MCP`,
+        isRelay && "litellm-relay",
       ].filter(Boolean);
       return <Tooltip title={tooltipParts.join(" • ")}>{sessionTypeBadge}</Tooltip>;
+    },
+  },
+  {
+    header: "Source",
+    id: "source",
+    size: 120,
+    cell: (info: any) => {
+      const row = info.row.original;
+      if (!RELAY_CALL_TYPES.includes(row.call_type)) {
+        return <span className="text-slate-400">-</span>;
+      }
+      return <RelaySourceBadge source={getRelaySource(row)} />;
     },
   },
   {

--- a/ui/litellm-dashboard/src/components/view_logs/constants.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/constants.ts
@@ -18,6 +18,9 @@ export const MCP_CALL_TYPES = ["call_mcp_tool", "list_mcp_tools"];
 /** Call types that represent agent/A2A requests (e.g. asend_message). */
 export const AGENT_CALL_TYPES = ["asend_message"];
 
+/** Call types that represent local collector captures from LiteLLM Relay. */
+export const RELAY_CALL_TYPES = ["litellm-relay"];
+
 export const QUICK_SELECT_OPTIONS: { label: string; value: number; unit: string }[] = [
   { label: "Last Minute", value: 1, unit: "minutes" },
   { label: "Last 15 Minutes", value: 15, unit: "minutes" },

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -10,7 +10,7 @@ import { keyInfoV1Call } from "../networking";
 import KeyInfoView from "../templates/key_info_view";
 import AuditLogs from "./audit_logs";
 import { createColumns, LogEntry, type LogsSortField } from "./columns";
-import { AGENT_CALL_TYPES, MCP_CALL_TYPES } from "./constants";
+import { AGENT_CALL_TYPES, MCP_CALL_TYPES, RELAY_CALL_TYPES } from "./constants";
 import { getLogFilterOptions } from "./filter_options";
 import { useLogFilterLogic, defaultFilters, type LogFilterState } from "./log_filter_logic";
 import { LogDetailsDrawer } from "./LogDetailsDrawer";
@@ -154,6 +154,8 @@ export default function SpendLogsTable({ accessToken, token, userRole, userID, p
           acc[log.session_id].mcp += 1;
         } else if (AGENT_CALL_TYPES.includes(log.call_type)) {
           acc[log.session_id].agent += 1;
+        } else if (RELAY_CALL_TYPES.includes(log.call_type)) {
+          // Relay captures are not LLM calls; they get their own Type badge.
         } else {
           acc[log.session_id].llm += 1;
         }
@@ -168,8 +170,9 @@ export default function SpendLogsTable({ accessToken, token, userRole, userID, p
     for (const log of searchedLogs) {
       if (!log.session_id || (log.session_total_count || 1) <= 1) continue;
       const isMcp = MCP_CALL_TYPES.includes(log.call_type);
+      const isRelay = RELAY_CALL_TYPES.includes(log.call_type);
       const existing = sessionRepresentativeMap.get(log.session_id);
-      if (!existing || (existing.isMcp && !isMcp)) {
+      if (!existing || (existing.isMcp && !isMcp && !isRelay)) {
         sessionRepresentativeMap.set(log.session_id, { requestId: log.request_id, isMcp });
       }
     }

--- a/ui/litellm-dashboard/src/components/view_logs/utils.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/utils.ts
@@ -1,4 +1,4 @@
-import { MCP_CALL_TYPES } from "./constants";
+import { MCP_CALL_TYPES, RELAY_CALL_TYPES } from "./constants";
 
 /**
  * Derive a short, human-readable display name for a log entry.
@@ -7,6 +7,7 @@ import { MCP_CALL_TYPES } from "./constants";
 export function getEventDisplayName(callType: string, model: string): string {
   const raw = (model || "").trim();
   const isMcp = MCP_CALL_TYPES.includes(callType);
+  const isRelay = RELAY_CALL_TYPES.includes(callType);
 
   if (isMcp) {
     return (
@@ -17,6 +18,10 @@ export function getEventDisplayName(callType: string, model: string): string {
       raw ||
       "mcp_tool"
     );
+  }
+
+  if (isRelay) {
+    return raw || "litellm-relay";
   }
 
   const lastSegment = raw.split("/").pop() || raw;


### PR DESCRIPTION
## What changed

- Add hidden `POST /internal/collector/events` ingestion for LiteLLM Relay captures, with `/internal/relay/spend-logs` kept as a compatibility alias.
- Store Relay captures in `LiteLLM_SpendLogs` with `call_type=relay_capture`, zero spend, request/response payloads, and key/team/user attribution from the authenticated virtual key.
- Allow non-admin Relay virtual keys to call collector ingestion while preserving normal route checks.
- Add Logs UI support for `Type = litellm-relay`, a top-level `Source` column, Notion/Codex source logos, and source display in the detail drawer.
- Fix the Logs page hydration issues from browser-only state/time defaults and the root `data-scribe-recorder-ready` extension attribute.
- Rebuild the proxy-served static dashboard output.

## Validation

- `uv run pytest tests/test_litellm/proxy/auth/test_route_checks.py -k 'collector or non_admin_config_update_route_rejected' -q`
- `uv run pytest tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py -k relay -q`
- `uv run ruff check litellm/proxy/auth/route_checks.py litellm/proxy/spend_tracking/spend_management_endpoints.py tests/test_litellm/proxy/auth/test_route_checks.py tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py`
- `PATH=/Users/ishaanjaffer/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npx vitest run src/components/view_logs/TypeBadges.test.tsx src/components/view_logs/LogDetailsDrawer/LogDetailContent.test.tsx`
- `PATH=/Users/ishaanjaffer/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run build`
