### PR TITLE
fix(proxy): match list/dict guardrail_mode in compliance mode checks

### DIFF
--- a/litellm/proxy/compliance_checks.py
+++ b/litellm/proxy/compliance_checks.py
@@ -49,8 +49,8 @@ class ComplianceChecker:
         - ``None``            → treated as ``pre_call`` (the common default)
         - ``str``             → single mode, e.g. ``"pre_call"``
         - ``list``/``tuple``  → multi-mode guardrail, e.g. ``["pre_call", "post_call"]``
-        - ``dict``            → tag-based ``Mode``; only its ``default`` is trusted
-                                (see below)
+        - ``dict``            → tag-based ``Mode``; matched only when *every*
+                                branch runs in ``mode`` (see below)
 
         A prior implementation compared ``g_mode == mode`` directly, which
         silently failed for the list form (a list never equals a string), so a
@@ -58,14 +58,28 @@ class ComplianceChecker:
         counted for no mode at all and every mode-based compliance check
         reported NON-COMPLIANT.
 
-        For the tag-based ``dict`` form we deliberately look only at ``default``
-        and ignore per-tag overrides. The spend log stores the raw ``Mode`` config,
-        not which tags were active for the audited request, so unioning every tag
-        value would over-report: a guardrail like ``{"default": "pre_call",
-        "tags": {"pii": "post_call"}}`` would be counted as both pre_call and
-        post_call even though only one branch runs per request, letting a
-        pre-call compliance check pass on the strength of a post-call tag
-        override. Trusting only ``default`` is the safe, conservative reading.
+        In practice the ``dict`` branch is defensive. Every guardrail hook logs
+        the already-resolved concrete mode: ``guardrail_mode = event_type`` in
+        ``add_standard_logging_guardrail_information_to_request_data``, so an
+        executed guardrail's spend-log row carries a plain ``str`` and hits the
+        branch above. The raw ``Mode`` dict only survives when the event type
+        cannot be inferred, which does not happen on the standard hook paths.
+
+        For that residual ``dict`` form the spend log stores the raw ``Mode``
+        config, not which branch actually ran for the audited request. So a dict
+        is treated as running in ``mode`` only when it is guaranteed to regardless
+        of routing: the ``default`` AND every per-tag override must all establish
+        ``mode``. A missing ``default`` means an untagged request has no guaranteed
+        mode, so nothing is asserted (returns False).
+
+        Invariant: this never reports ``mode`` satisfied unless it holds for every
+        possible routing branch, so it can never report a request compliant when
+        the guardrail did not run in ``mode`` (no false-COMPLIANT). It may
+        under-report (a guardrail that ran pre-call via its default counts as
+        neither when a divergent tag exists), which is the safe direction for an
+        audit check; ``{"default": "pre_call", "tags": {"pii": "post_call"}}``
+        matches neither mode. The precise fix is to log the resolved event mode
+        and match that; this is the safe interim reading until that is available.
         """
         if g_mode is None:
             return mode == "pre_call"
@@ -75,13 +89,19 @@ class ComplianceChecker:
             return mode in g_mode
         if isinstance(g_mode, dict):
             default = g_mode.get("default")
-            if isinstance(default, str):
-                return default == mode
-            if isinstance(default, (list, tuple, set)):
-                return mode in default
-            # No usable default (e.g. only tag overrides): fall back to the
-            # pre_call convention rather than trusting tag-specific values.
-            return mode == "pre_call"
+            if default is None:
+                return False
+            tags = g_mode.get("tags")
+            tag_branches = list(tags.values()) if isinstance(tags, dict) else []
+
+            def _branch_runs_in_mode(branch: object) -> bool:
+                if isinstance(branch, str):
+                    return branch == mode
+                if isinstance(branch, (list, tuple, set)):
+                    return mode in branch
+                return False
+
+            return all(_branch_runs_in_mode(branch) for branch in [default, *tag_branches])
         return False
 
     def _has_guardrail_intervention(self, guardrails: List[Dict]) -> bool:

--- a/litellm/proxy/compliance_checks.py
+++ b/litellm/proxy/compliance_checks.py
@@ -49,14 +49,23 @@ class ComplianceChecker:
         - ``None``            → treated as ``pre_call`` (the common default)
         - ``str``             → single mode, e.g. ``"pre_call"``
         - ``list``/``tuple``  → multi-mode guardrail, e.g. ``["pre_call", "post_call"]``
-        - ``dict``            → tag-based ``Mode``; modes live in its ``default``
-                                and per-tag values
+        - ``dict``            → tag-based ``Mode``; only its ``default`` is trusted
+                                (see below)
 
         A prior implementation compared ``g_mode == mode`` directly, which
         silently failed for the list form (a list never equals a string), so a
         single guardrail configured with ``mode: [pre_call, post_call]`` was
         counted for no mode at all and every mode-based compliance check
         reported NON-COMPLIANT.
+
+        For the tag-based ``dict`` form we deliberately look only at ``default``
+        and ignore per-tag overrides. The spend log stores the raw ``Mode`` config,
+        not which tags were active for the audited request, so unioning every tag
+        value would over-report: a guardrail like ``{"default": "pre_call",
+        "tags": {"pii": "post_call"}}`` would be counted as both pre_call and
+        post_call even though only one branch runs per request, letting a
+        pre-call compliance check pass on the strength of a post-call tag
+        override. Trusting only ``default`` is the safe, conservative reading.
         """
         if g_mode is None:
             return mode == "pre_call"
@@ -65,20 +74,14 @@ class ComplianceChecker:
         if isinstance(g_mode, (list, tuple, set)):
             return mode in g_mode
         if isinstance(g_mode, dict):
-            candidates: set = set()
-
-            def _collect(value: object) -> None:
-                if isinstance(value, str):
-                    candidates.add(value)
-                elif isinstance(value, (list, tuple, set)):
-                    candidates.update(v for v in value if isinstance(v, str))
-
-            _collect(g_mode.get("default"))
-            tags = g_mode.get("tags")
-            if isinstance(tags, dict):
-                for tag_value in tags.values():
-                    _collect(tag_value)
-            return mode in candidates
+            default = g_mode.get("default")
+            if isinstance(default, str):
+                return default == mode
+            if isinstance(default, (list, tuple, set)):
+                return mode in default
+            # No usable default (e.g. only tag overrides): fall back to the
+            # pre_call convention rather than trusting tag-specific values.
+            return mode == "pre_call"
         return False
 
     def _has_guardrail_intervention(self, guardrails: List[Dict]) -> bool:

--- a/litellm/proxy/compliance_checks.py
+++ b/litellm/proxy/compliance_checks.py
@@ -35,15 +35,51 @@ class ComplianceChecker:
         If a guardrail doesn't have a mode specified, it's treated as pre-call
         (the most common case).
         """
-        result = []
-        for g in self.guardrails:
-            g_mode = g.get("guardrail_mode")
-            # If no mode specified, default to pre_call
-            if g_mode is None and mode == "pre_call":
-                result.append(g)
-            elif g_mode == mode:
-                result.append(g)
-        return result
+        return [g for g in self.guardrails if self._mode_matches(g.get("guardrail_mode"), mode)]
+
+    @staticmethod
+    def _mode_matches(g_mode: object, mode: str) -> bool:
+        """
+        Return True if a guardrail whose logged ``guardrail_mode`` is ``g_mode``
+        ran in ``mode``.
+
+        ``guardrail_mode`` in a spend log can take several shapes because
+        ``LitellmParams.mode`` is typed ``Union[str, List[str], Mode]``:
+
+        - ``None``            → treated as ``pre_call`` (the common default)
+        - ``str``             → single mode, e.g. ``"pre_call"``
+        - ``list``/``tuple``  → multi-mode guardrail, e.g. ``["pre_call", "post_call"]``
+        - ``dict``            → tag-based ``Mode``; modes live in its ``default``
+                                and per-tag values
+
+        A prior implementation compared ``g_mode == mode`` directly, which
+        silently failed for the list form (a list never equals a string), so a
+        single guardrail configured with ``mode: [pre_call, post_call]`` was
+        counted for no mode at all and every mode-based compliance check
+        reported NON-COMPLIANT.
+        """
+        if g_mode is None:
+            return mode == "pre_call"
+        if isinstance(g_mode, str):
+            return g_mode == mode
+        if isinstance(g_mode, (list, tuple, set)):
+            return mode in g_mode
+        if isinstance(g_mode, dict):
+            candidates: set = set()
+
+            def _collect(value: object) -> None:
+                if isinstance(value, str):
+                    candidates.add(value)
+                elif isinstance(value, (list, tuple, set)):
+                    candidates.update(v for v in value if isinstance(v, str))
+
+            _collect(g_mode.get("default"))
+            tags = g_mode.get("tags")
+            if isinstance(tags, dict):
+                for tag_value in tags.values():
+                    _collect(tag_value)
+            return mode in candidates
+        return False
 
     def _has_guardrail_intervention(self, guardrails: List[Dict]) -> bool:
         """Check if any guardrail intervened (blocked/masked content)."""

--- a/tests/test_litellm/proxy/management_endpoints/test_compliance_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_compliance_endpoints.py
@@ -391,10 +391,11 @@ class TestGdprCompliant:
 # A prior implementation compared `g_mode == mode`, which silently failed for
 # the non-str shapes (a list never equals a string), so multi-mode guardrails
 # were counted for no mode and every mode-based check reported NON-COMPLIANT.
-# For the tag-based dict Mode only `default` is trusted: the spend log does not
-# record which tags were active for the audited request, so counting tag
-# overrides would over-report (a post_call tag override must not make a
-# pre_call-default guardrail count as post_call).
+# For the tag-based dict Mode the spend log does not record which branch ran, so
+# a dict matches a mode only when EVERY branch (default + all tag overrides) runs
+# in that mode. A missing default asserts nothing (the untagged branch has no
+# guaranteed mode). This fails safe: a tag-routed guardrail cannot pass a
+# pre-call check on a default it may not have used, and vice versa.
 # ---------------------------------------------------------------------------
 
 
@@ -420,20 +421,24 @@ class TestModeMatching:
             # tuple / set → membership.
             (("during_call",), "during_call", True),
             ({"pre_call", "post_call"}, "post_call", True),
-            # dict → only `default` is trusted.
+            # dict with no tags → matched on default.
             ({"default": "pre_call"}, "pre_call", True),
             ({"default": "pre_call"}, "post_call", False),
             ({"default": ["pre_call", "post_call"]}, "post_call", True),
-            # dict → per-tag overrides are IGNORED (not in the spend log).
-            ({"default": "pre_call", "tags": {"eu": "post_call"}}, "pre_call", True),
+            # dict with tags → matched only when EVERY branch runs in the mode.
+            ({"default": "pre_call", "tags": {"a": "pre_call"}}, "pre_call", True),
+            ({"default": "pre_call", "tags": {"a": ["pre_call", "post_call"]}}, "pre_call", True),
+            # A divergent tag override means no mode is guaranteed → matches nothing.
+            ({"default": "pre_call", "tags": {"eu": "post_call"}}, "pre_call", False),
             ({"default": "pre_call", "tags": {"eu": "post_call"}}, "post_call", False),
             ({"default": "pre_call", "tags": {"eu": ["during_call"]}}, "during_call", False),
-            # dict → no usable default falls back to the pre_call convention.
-            ({"tags": {"x": "post_call"}}, "pre_call", True),
+            ({"default": ["pre_call", "post_call"], "tags": {"a": "pre_call"}}, "post_call", False),
+            # No usable default → nothing is guaranteed (untagged branch unknown).
+            ({"tags": {"x": "post_call"}}, "pre_call", False),
             ({"tags": {"x": "post_call"}}, "post_call", False),
-            ({}, "pre_call", True),
+            ({}, "pre_call", False),
             ({}, "post_call", False),
-            ({"default": 123}, "pre_call", True),  # junk default → pre_call convention
+            ({"default": 123}, "pre_call", False),  # junk default runs in no mode
             # Unknown / unexpected top-level types never match.
             (5, "pre_call", False),
             (object(), "pre_call", False),
@@ -467,10 +472,11 @@ class TestModeMatching:
         results = {c.check_name: c.passed for c in checker.check_eu_ai_act()}
         assert results["Content screened before LLM"] is True
 
-    def test_dict_tag_override_not_over_counted(self):
-        """A tag override must NOT make the guardrail count for that mode: with
-        default=pre_call and a post_call tag, it counts for pre_call only, so a
-        pre-call compliance check cannot pass on a post-call tag override."""
+    def test_dict_tag_routed_guardrail_not_misclassified(self):
+        """A tag-routed guardrail (default=pre_call, a post_call tag) is not
+        guaranteed to run in either mode, so it counts for neither. A pre-call
+        compliance check therefore cannot pass on the strength of a default the
+        request may not have used."""
         data = ComplianceCheckRequest(
             request_id="req-mode-2",
             user_id="user-1",
@@ -485,8 +491,30 @@ class TestModeMatching:
             ],
         )
         checker = ComplianceChecker(data)
-        assert len(checker._get_guardrails_by_mode("pre_call")) == 1
+        assert len(checker._get_guardrails_by_mode("pre_call")) == 0
         assert len(checker._get_guardrails_by_mode("post_call")) == 0
+        # Fails safe: pre-call screening is not reported as satisfied.
+        results = {c.check_name: c.passed for c in checker.check_eu_ai_act()}
+        assert results["Content screened before LLM"] is False
+
+    def test_dict_all_branches_pre_call_counts(self):
+        """When default and every tag override all run pre_call, the guardrail is
+        guaranteed pre_call regardless of routing, so it counts for pre_call."""
+        data = ComplianceCheckRequest(
+            request_id="req-mode-4",
+            user_id="user-1",
+            model="gpt-4",
+            timestamp="2026-02-17T12:00:00Z",
+            guardrail_information=[
+                {
+                    "guardrail_name": "pii_masking",
+                    "guardrail_mode": {"default": "pre_call", "tags": {"eu": ["pre_call", "post_call"]}},
+                    "guardrail_status": "success",
+                }
+            ],
+        )
+        checker = ComplianceChecker(data)
+        assert len(checker._get_guardrails_by_mode("pre_call")) == 1
 
     def test_none_mode_defaults_to_pre_call(self):
         """A guardrail logged without a mode counts as pre_call only."""
@@ -500,3 +528,36 @@ class TestModeMatching:
         checker = ComplianceChecker(data)
         assert len(checker._get_guardrails_by_mode("pre_call")) == 1
         assert len(checker._get_guardrails_by_mode("post_call")) == 0
+
+    def test_dict_never_reports_false_compliant(self):
+        """Invariant that matters for an audit: a tag-based dict Mode is reported
+        as running in `mode` ONLY when every routing branch (default and each tag)
+        runs in that mode. So a True result can never claim a mode the guardrail
+        would not run in for some request routing (no false-COMPLIANT); the only
+        allowed error direction is under-reporting."""
+
+        def _branch_modes(value):
+            if isinstance(value, str):
+                return {value}
+            if isinstance(value, (list, tuple, set)):
+                return {v for v in value if isinstance(v, str)}
+            return set()
+
+        dict_modes = [
+            {"default": "pre_call"},
+            {"default": ["pre_call", "post_call"]},
+            {"default": "pre_call", "tags": {"a": "pre_call"}},
+            {"default": "pre_call", "tags": {"a": "post_call"}},
+            {"default": "pre_call", "tags": {"a": "pre_call", "b": ["pre_call", "post_call"]}},
+            {"default": ["pre_call", "post_call"], "tags": {"a": "pre_call"}},
+            {"tags": {"a": "post_call"}},
+            {},
+            {"default": 123},
+        ]
+        for g_mode in dict_modes:
+            for mode in ("pre_call", "post_call", "during_call"):
+                if ComplianceChecker._mode_matches(g_mode, mode):
+                    default = g_mode.get("default")
+                    assert default is not None, (g_mode, mode)
+                    branches = [default, *(g_mode.get("tags") or {}).values()]
+                    assert all(mode in _branch_modes(b) for b in branches), (g_mode, mode)

--- a/tests/test_litellm/proxy/management_endpoints/test_compliance_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_compliance_endpoints.py
@@ -7,9 +7,7 @@ import sys
 
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../.."))  # Adds the parent directory to the system path
 
 from litellm.proxy.compliance_checks import ComplianceChecker
 from litellm.types.proxy.compliance_endpoints import ComplianceCheckRequest
@@ -385,3 +383,182 @@ class TestGdprCompliant:
         )
         checks = ComplianceChecker(data).check_gdpr()
         assert all(c.passed for c in checks)
+
+
+# ---------------------------------------------------------------------------
+# guardrail_mode matching — LitellmParams.mode is Union[str, List[str], Mode],
+# so a spend log's guardrail_mode can be None, a str, a list, or a tag dict.
+# ---------------------------------------------------------------------------
+
+
+class TestModeMatching:
+    """ComplianceChecker._mode_matches across every guardrail_mode shape."""
+
+    def test_none_defaults_to_pre_call(self):
+        assert ComplianceChecker._mode_matches(None, "pre_call") is True
+        assert ComplianceChecker._mode_matches(None, "post_call") is False
+
+    def test_str_matches_exactly(self):
+        assert ComplianceChecker._mode_matches("post_call", "post_call") is True
+        assert ComplianceChecker._mode_matches("post_call", "pre_call") is False
+
+    @pytest.mark.parametrize("container", [list, tuple, set])
+    def test_multi_mode_container_matches_any_member(self, container):
+        g_mode = container(["pre_call", "post_call"])
+        assert ComplianceChecker._mode_matches(g_mode, "pre_call") is True
+        assert ComplianceChecker._mode_matches(g_mode, "post_call") is True
+        assert ComplianceChecker._mode_matches(g_mode, "during_call") is False
+
+    def test_dict_default_str(self):
+        assert ComplianceChecker._mode_matches({"default": "post_call"}, "post_call") is True
+        assert ComplianceChecker._mode_matches({"default": "post_call"}, "pre_call") is False
+
+    def test_dict_default_list(self):
+        g_mode = {"default": ["pre_call", "post_call"]}
+        assert ComplianceChecker._mode_matches(g_mode, "pre_call") is True
+        assert ComplianceChecker._mode_matches(g_mode, "post_call") is True
+
+    def test_dict_default_and_tags(self):
+        g_mode = {"default": "pre_call", "tags": {"vip": "post_call", "eu": ["during_call"]}}
+        assert ComplianceChecker._mode_matches(g_mode, "pre_call") is True
+        assert ComplianceChecker._mode_matches(g_mode, "post_call") is True
+        assert ComplianceChecker._mode_matches(g_mode, "during_call") is True
+        assert ComplianceChecker._mode_matches(g_mode, "logging_only") is False
+
+    def test_malformed_mode_does_not_match_and_does_not_raise(self):
+        # Non-str/list/dict junk must return False, never crash.
+        assert ComplianceChecker._mode_matches(5, "pre_call") is False
+        assert ComplianceChecker._mode_matches({"tags": {"x": 123}}, "pre_call") is False
+
+    def test_list_mode_guardrail_counts_for_every_listed_mode(self):
+        """Regression: a guardrail configured with mode ["pre_call", "post_call"]
+        must be counted under BOTH modes. The old `g_mode == mode` compare matched
+        neither (a list never equals a string), so every mode-based EU AI Act
+        check reported NON-COMPLIANT."""
+        data = ComplianceCheckRequest(
+            request_id="req-mode-1",
+            user_id="user-1",
+            model="gpt-4",
+            timestamp="2026-02-17T00:00:00Z",
+            guardrail_information=[
+                {
+                    "guardrail_name": "pii_masking",
+                    "guardrail_mode": ["pre_call", "post_call"],
+                    "guardrail_status": "success",
+                }
+            ],
+        )
+        checker = ComplianceChecker(data)
+        assert len(checker._get_guardrails_by_mode("pre_call")) == 1
+        assert len(checker._get_guardrails_by_mode("post_call")) == 1
+
+        results = {c.check_name: c.passed for c in checker.check_eu_ai_act()}
+        # Pre-call screening is satisfied by the list-mode guardrail.
+        assert results["Content screened before LLM"] is True
+
+
+# ---------------------------------------------------------------------------
+# _mode_matches — targeted unit tests for every guardrail_mode shape.
+#
+# LitellmParams.mode is Union[str, List[str], Mode], and the spend log can
+# therefore carry None / str / list / tuple / set / dict. A prior
+# implementation compared `g_mode == mode`, which silently failed for the
+# non-str shapes (a list never equals a string), so multi-mode guardrails were
+# counted for no mode and every mode-based check reported NON-COMPLIANT. These
+# lock the matching behaviour down per shape.
+# ---------------------------------------------------------------------------
+
+
+class TestModeMatches:
+    """Direct coverage of ComplianceChecker._mode_matches for each shape."""
+
+    @pytest.mark.parametrize(
+        "g_mode, mode, expected",
+        [
+            # None → defaults to pre_call only.
+            (None, "pre_call", True),
+            (None, "post_call", False),
+            (None, "during_call", False),
+            # str → exact match.
+            ("pre_call", "pre_call", True),
+            ("post_call", "pre_call", False),
+            ("during_call", "during_call", True),
+            # list → membership (the regression the fix addresses).
+            (["pre_call", "post_call"], "pre_call", True),
+            (["pre_call", "post_call"], "post_call", True),
+            (["pre_call"], "post_call", False),
+            ([], "pre_call", False),
+            # tuple / set → membership.
+            (("during_call",), "during_call", True),
+            ({"pre_call", "post_call"}, "post_call", True),
+            # dict (tag-based Mode) → modes in `default`.
+            ({"default": "pre_call"}, "pre_call", True),
+            ({"default": "pre_call"}, "post_call", False),
+            ({"default": ["pre_call", "post_call"]}, "post_call", True),
+            # dict → modes also collected from per-tag values.
+            ({"default": "pre_call", "tags": {"eu": "post_call"}}, "post_call", True),
+            ({"default": "pre_call", "tags": {"eu": ["during_call"]}}, "during_call", True),
+            ({"tags": {"x": "post_call"}}, "post_call", True),  # no default key
+            ({}, "pre_call", False),  # empty dict matches nothing
+            # Unknown / unexpected types never match.
+            (123, "pre_call", False),
+            (object(), "pre_call", False),
+        ],
+    )
+    def test_mode_matches(self, g_mode, mode, expected):
+        assert ComplianceChecker._mode_matches(g_mode, mode) is expected
+
+    def test_list_mode_counted_for_each_listed_mode(self):
+        """A single `mode: [pre_call, post_call]` guardrail is counted for BOTH
+        modes (the exact bug: it was previously counted for neither)."""
+        data = ComplianceCheckRequest(
+            request_id="req-mode-1",
+            user_id="user-1",
+            model="gpt-4",
+            timestamp="2026-02-17T12:00:00Z",
+            guardrail_information=[
+                {
+                    "guardrail_name": "pii_masking",
+                    "guardrail_mode": ["pre_call", "post_call"],
+                    "guardrail_status": "success",
+                }
+            ],
+        )
+        checker = ComplianceChecker(data)
+        assert len(checker._get_guardrails_by_mode("pre_call")) == 1
+        assert len(checker._get_guardrails_by_mode("post_call")) == 1
+        assert len(checker._get_guardrails_by_mode("during_call")) == 0
+
+    def test_dict_tag_mode_counted(self):
+        """A tag-based dict Mode is matched via its default and per-tag values."""
+        data = ComplianceCheckRequest(
+            request_id="req-mode-2",
+            user_id="user-1",
+            model="gpt-4",
+            timestamp="2026-02-17T12:00:00Z",
+            guardrail_information=[
+                {
+                    "guardrail_name": "pii_masking",
+                    "guardrail_mode": {"default": "pre_call", "tags": {"eu": "post_call"}},
+                    "guardrail_status": "success",
+                }
+            ],
+        )
+        checker = ComplianceChecker(data)
+        assert len(checker._get_guardrails_by_mode("pre_call")) == 1
+        assert len(checker._get_guardrails_by_mode("post_call")) == 1
+
+    def test_none_mode_defaults_to_pre_call(self):
+        """A guardrail logged without a mode counts as pre_call only."""
+        data = ComplianceCheckRequest(
+            request_id="req-mode-3",
+            user_id="user-1",
+            model="gpt-4",
+            timestamp="2026-02-17T12:00:00Z",
+            guardrail_information=[
+                {"guardrail_name": "pii_masking", "guardrail_status": "success"}
+            ],
+        )
+        checker = ComplianceChecker(data)
+        assert len(checker._get_guardrails_by_mode("pre_call")) == 1
+        assert len(checker._get_guardrails_by_mode("post_call")) == 0

--- a/tests/test_litellm/proxy/management_endpoints/test_compliance_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_compliance_endpoints.py
@@ -387,52 +387,64 @@ class TestGdprCompliant:
 
 # ---------------------------------------------------------------------------
 # guardrail_mode matching — LitellmParams.mode is Union[str, List[str], Mode],
-# so a spend log's guardrail_mode can be None, a str, a list, or a tag dict.
+# so a spend log's guardrail_mode can be None / str / list / tuple / set / dict.
+# A prior implementation compared `g_mode == mode`, which silently failed for
+# the non-str shapes (a list never equals a string), so multi-mode guardrails
+# were counted for no mode and every mode-based check reported NON-COMPLIANT.
+# For the tag-based dict Mode only `default` is trusted: the spend log does not
+# record which tags were active for the audited request, so counting tag
+# overrides would over-report (a post_call tag override must not make a
+# pre_call-default guardrail count as post_call).
 # ---------------------------------------------------------------------------
 
 
 class TestModeMatching:
-    """ComplianceChecker._mode_matches across every guardrail_mode shape."""
+    """Direct coverage of ComplianceChecker._mode_matches for every shape."""
 
-    def test_none_defaults_to_pre_call(self):
-        assert ComplianceChecker._mode_matches(None, "pre_call") is True
-        assert ComplianceChecker._mode_matches(None, "post_call") is False
+    @pytest.mark.parametrize(
+        "g_mode, mode, expected",
+        [
+            # None → defaults to pre_call only.
+            (None, "pre_call", True),
+            (None, "post_call", False),
+            (None, "during_call", False),
+            # str → exact match.
+            ("pre_call", "pre_call", True),
+            ("post_call", "pre_call", False),
+            ("during_call", "during_call", True),
+            # list → membership (the primary regression the fix addresses).
+            (["pre_call", "post_call"], "pre_call", True),
+            (["pre_call", "post_call"], "post_call", True),
+            (["pre_call"], "post_call", False),
+            ([], "pre_call", False),
+            # tuple / set → membership.
+            (("during_call",), "during_call", True),
+            ({"pre_call", "post_call"}, "post_call", True),
+            # dict → only `default` is trusted.
+            ({"default": "pre_call"}, "pre_call", True),
+            ({"default": "pre_call"}, "post_call", False),
+            ({"default": ["pre_call", "post_call"]}, "post_call", True),
+            # dict → per-tag overrides are IGNORED (not in the spend log).
+            ({"default": "pre_call", "tags": {"eu": "post_call"}}, "pre_call", True),
+            ({"default": "pre_call", "tags": {"eu": "post_call"}}, "post_call", False),
+            ({"default": "pre_call", "tags": {"eu": ["during_call"]}}, "during_call", False),
+            # dict → no usable default falls back to the pre_call convention.
+            ({"tags": {"x": "post_call"}}, "pre_call", True),
+            ({"tags": {"x": "post_call"}}, "post_call", False),
+            ({}, "pre_call", True),
+            ({}, "post_call", False),
+            ({"default": 123}, "pre_call", True),  # junk default → pre_call convention
+            # Unknown / unexpected top-level types never match.
+            (5, "pre_call", False),
+            (object(), "pre_call", False),
+        ],
+    )
+    def test_mode_matches(self, g_mode, mode, expected):
+        assert ComplianceChecker._mode_matches(g_mode, mode) is expected
 
-    def test_str_matches_exactly(self):
-        assert ComplianceChecker._mode_matches("post_call", "post_call") is True
-        assert ComplianceChecker._mode_matches("post_call", "pre_call") is False
-
-    @pytest.mark.parametrize("container", [list, tuple, set])
-    def test_multi_mode_container_matches_any_member(self, container):
-        g_mode = container(["pre_call", "post_call"])
-        assert ComplianceChecker._mode_matches(g_mode, "pre_call") is True
-        assert ComplianceChecker._mode_matches(g_mode, "post_call") is True
-        assert ComplianceChecker._mode_matches(g_mode, "during_call") is False
-
-    def test_dict_default_str(self):
-        assert ComplianceChecker._mode_matches({"default": "post_call"}, "post_call") is True
-        assert ComplianceChecker._mode_matches({"default": "post_call"}, "pre_call") is False
-
-    def test_dict_default_list(self):
-        g_mode = {"default": ["pre_call", "post_call"]}
-        assert ComplianceChecker._mode_matches(g_mode, "pre_call") is True
-        assert ComplianceChecker._mode_matches(g_mode, "post_call") is True
-
-    def test_dict_default_and_tags(self):
-        g_mode = {"default": "pre_call", "tags": {"vip": "post_call", "eu": ["during_call"]}}
-        assert ComplianceChecker._mode_matches(g_mode, "pre_call") is True
-        assert ComplianceChecker._mode_matches(g_mode, "post_call") is True
-        assert ComplianceChecker._mode_matches(g_mode, "during_call") is True
-        assert ComplianceChecker._mode_matches(g_mode, "logging_only") is False
-
-    def test_malformed_mode_does_not_match_and_does_not_raise(self):
-        # Non-str/list/dict junk must return False, never crash.
-        assert ComplianceChecker._mode_matches(5, "pre_call") is False
-        assert ComplianceChecker._mode_matches({"tags": {"x": 123}}, "pre_call") is False
-
-    def test_list_mode_guardrail_counts_for_every_listed_mode(self):
+    def test_list_mode_counted_for_each_listed_mode(self):
         """Regression: a guardrail configured with mode ["pre_call", "post_call"]
-        must be counted under BOTH modes. The old `g_mode == mode` compare matched
+        is counted under BOTH modes. The old `g_mode == mode` compare matched
         neither (a list never equals a string), so every mode-based EU AI Act
         check reported NON-COMPLIANT."""
         data = ComplianceCheckRequest(
@@ -451,86 +463,14 @@ class TestModeMatching:
         checker = ComplianceChecker(data)
         assert len(checker._get_guardrails_by_mode("pre_call")) == 1
         assert len(checker._get_guardrails_by_mode("post_call")) == 1
-
+        assert len(checker._get_guardrails_by_mode("during_call")) == 0
         results = {c.check_name: c.passed for c in checker.check_eu_ai_act()}
-        # Pre-call screening is satisfied by the list-mode guardrail.
         assert results["Content screened before LLM"] is True
 
-
-# ---------------------------------------------------------------------------
-# _mode_matches — targeted unit tests for every guardrail_mode shape.
-#
-# LitellmParams.mode is Union[str, List[str], Mode], and the spend log can
-# therefore carry None / str / list / tuple / set / dict. A prior
-# implementation compared `g_mode == mode`, which silently failed for the
-# non-str shapes (a list never equals a string), so multi-mode guardrails were
-# counted for no mode and every mode-based check reported NON-COMPLIANT. These
-# lock the matching behaviour down per shape.
-# ---------------------------------------------------------------------------
-
-
-class TestModeMatches:
-    """Direct coverage of ComplianceChecker._mode_matches for each shape."""
-
-    @pytest.mark.parametrize(
-        "g_mode, mode, expected",
-        [
-            # None → defaults to pre_call only.
-            (None, "pre_call", True),
-            (None, "post_call", False),
-            (None, "during_call", False),
-            # str → exact match.
-            ("pre_call", "pre_call", True),
-            ("post_call", "pre_call", False),
-            ("during_call", "during_call", True),
-            # list → membership (the regression the fix addresses).
-            (["pre_call", "post_call"], "pre_call", True),
-            (["pre_call", "post_call"], "post_call", True),
-            (["pre_call"], "post_call", False),
-            ([], "pre_call", False),
-            # tuple / set → membership.
-            (("during_call",), "during_call", True),
-            ({"pre_call", "post_call"}, "post_call", True),
-            # dict (tag-based Mode) → modes in `default`.
-            ({"default": "pre_call"}, "pre_call", True),
-            ({"default": "pre_call"}, "post_call", False),
-            ({"default": ["pre_call", "post_call"]}, "post_call", True),
-            # dict → modes also collected from per-tag values.
-            ({"default": "pre_call", "tags": {"eu": "post_call"}}, "post_call", True),
-            ({"default": "pre_call", "tags": {"eu": ["during_call"]}}, "during_call", True),
-            ({"tags": {"x": "post_call"}}, "post_call", True),  # no default key
-            ({}, "pre_call", False),  # empty dict matches nothing
-            # Unknown / unexpected types never match.
-            (123, "pre_call", False),
-            (object(), "pre_call", False),
-        ],
-    )
-    def test_mode_matches(self, g_mode, mode, expected):
-        assert ComplianceChecker._mode_matches(g_mode, mode) is expected
-
-    def test_list_mode_counted_for_each_listed_mode(self):
-        """A single `mode: [pre_call, post_call]` guardrail is counted for BOTH
-        modes (the exact bug: it was previously counted for neither)."""
-        data = ComplianceCheckRequest(
-            request_id="req-mode-1",
-            user_id="user-1",
-            model="gpt-4",
-            timestamp="2026-02-17T12:00:00Z",
-            guardrail_information=[
-                {
-                    "guardrail_name": "pii_masking",
-                    "guardrail_mode": ["pre_call", "post_call"],
-                    "guardrail_status": "success",
-                }
-            ],
-        )
-        checker = ComplianceChecker(data)
-        assert len(checker._get_guardrails_by_mode("pre_call")) == 1
-        assert len(checker._get_guardrails_by_mode("post_call")) == 1
-        assert len(checker._get_guardrails_by_mode("during_call")) == 0
-
-    def test_dict_tag_mode_counted(self):
-        """A tag-based dict Mode is matched via its default and per-tag values."""
+    def test_dict_tag_override_not_over_counted(self):
+        """A tag override must NOT make the guardrail count for that mode: with
+        default=pre_call and a post_call tag, it counts for pre_call only, so a
+        pre-call compliance check cannot pass on a post-call tag override."""
         data = ComplianceCheckRequest(
             request_id="req-mode-2",
             user_id="user-1",
@@ -546,7 +486,7 @@ class TestModeMatches:
         )
         checker = ComplianceChecker(data)
         assert len(checker._get_guardrails_by_mode("pre_call")) == 1
-        assert len(checker._get_guardrails_by_mode("post_call")) == 1
+        assert len(checker._get_guardrails_by_mode("post_call")) == 0
 
     def test_none_mode_defaults_to_pre_call(self):
         """A guardrail logged without a mode counts as pre_call only."""
@@ -555,9 +495,7 @@ class TestModeMatches:
             user_id="user-1",
             model="gpt-4",
             timestamp="2026-02-17T12:00:00Z",
-            guardrail_information=[
-                {"guardrail_name": "pii_masking", "guardrail_status": "success"}
-            ],
+            guardrail_information=[{"guardrail_name": "pii_masking", "guardrail_status": "success"}],
         )
         checker = ComplianceChecker(data)
         assert len(checker._get_guardrails_by_mode("pre_call")) == 1


### PR DESCRIPTION
guardrail_mode can be a str, list, or tag-based dict, but the mode matcher compared it with ==, so a guardrail configured with mode: [pre_call, post_call] matched no mode and every mode-based compliance check reported NON-COMPLIANT. Mode matching now handles all shapes, with targeted tests.