### PR TITLE
feat: add LiteLLM Relay collector logs

### DIFF
--- a/gateway/routes/allowlist.py
+++ b/gateway/routes/allowlist.py
@@ -106,7 +106,7 @@ GATEWAY_PATH_PREFIXES: tuple[str, ...] = (
     # Health & ops
     "/health",
     "/metrics",
-    "/watsonx"
+    "/watsonx",
 )
 
 GATEWAY_EXACT_PATHS: frozenset[str] = frozenset(
@@ -118,5 +118,6 @@ GATEWAY_EXACT_PATHS: frozenset[str] = frozenset(
         "/docs/oauth2-redirect",
         "/redoc",
         "/test",
+        "/collector/spend-logs",
     }
 )

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -316,6 +316,12 @@ disable_add_transform_inline_image_block: bool = False
 disable_add_user_agent_to_request_tags: bool = False
 disable_anthropic_gemini_context_caching_transform: bool = False
 disable_vertex_batch_output_transformation: bool = False
+# Raise a 400 when a Responses API request asks for MCP gateway tools
+# (server_url litellm_proxy/...) but zero tools resolve (key/team lacks server
+# access, unknown server name, or allowed_tools matches nothing) and the
+# request carries no other tools. Without this the model is silently called
+# with no tools and hallucinates. Set to False to restore the old behaviour.
+reject_empty_mcp_resolved_tools: bool = True
 extra_spend_tag_headers: Optional[List[str]] = None
 in_memory_llm_clients_cache: "LLMClientCache"
 safe_memory_mode: bool = False

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1623,3 +1623,9 @@ ADVISOR_TOOL_DESCRIPTION: str = (
     "want to verify your reasoning, or face a complex decision. "
     "Describe your question or challenge clearly in the 'question' field."
 )
+
+########################### LiteLLM Relay Collector Constants ###########################
+LITELLM_RELAY_CALL_TYPE = "litellm-relay"
+MAX_COLLECTOR_SPEND_LOGS = 1000
+MAX_COLLECTOR_SPEND_LOG_BYTES = 256 * 1024
+MAX_COLLECTOR_SPEND_LOG_BATCH_BYTES = 10 * 1024 * 1024

--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -1165,12 +1165,18 @@ class ModifyResponseException(Exception):
         request_data: Dict[str, Any],
         guardrail_name: Optional[str] = None,
         detection_info: Optional[Dict[str, Any]] = None,
+        original_response: Optional[Any] = None,
     ):
         self.message = message
         self.model = model
         self.request_data = request_data
         self.guardrail_name = guardrail_name
         self.detection_info = detection_info or {}
+        # The LLM response that was blocked (post-call). Carries the real token
+        # usage the upstream call consumed, so the synthetic block response can
+        # report it instead of discarding it. None for pre-call blocks (the LLM
+        # was never invoked).
+        self.original_response = original_response
         super().__init__(message)
 
 

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 import os
 import sys
 from datetime import datetime, timedelta
@@ -64,6 +65,26 @@ if TYPE_CHECKING:
     from apscheduler.schedulers.asyncio import AsyncIOScheduler
 else:
     AsyncIOScheduler = Any
+
+_DEFAULT_BUDGET_METRICS_PER_REQUEST_TIMEOUT = 5.0
+
+
+def _get_budget_metrics_per_request_timeout() -> float:
+    raw = os.getenv("PROMETHEUS_BUDGET_METRICS_PER_REQUEST_TIMEOUT")
+    if raw is None:
+        return _DEFAULT_BUDGET_METRICS_PER_REQUEST_TIMEOUT
+    try:
+        parsed = float(raw)
+    except ValueError:
+        parsed = None
+    if parsed is None or not math.isfinite(parsed) or parsed <= 0:
+        verbose_logger.debug(
+            "[Non-Blocking] Prometheus: invalid PROMETHEUS_BUDGET_METRICS_PER_REQUEST_TIMEOUT=%r; using default %ss.",
+            raw,
+            _DEFAULT_BUDGET_METRICS_PER_REQUEST_TIMEOUT,
+        )
+        return _DEFAULT_BUDGET_METRICS_PER_REQUEST_TIMEOUT
+    return parsed
 
 
 class PrometheusLogger(CustomLogger):
@@ -1607,7 +1628,15 @@ class PrometheusLogger(CustomLogger):
         _user_spend = _metadata.get("user_api_key_user_spend", None)
         _user_max_budget = _metadata.get("user_api_key_user_max_budget", None)
 
-        results = await asyncio.gather(
+        # Bound the per-request budget-metric emission so that slow Redis/DB
+        # lookups under load cannot consume the whole LoggingWorker watchdog
+        # (LOGGING_WORKER_MAX_TIME_PER_COROUTINE, default 20s) and get the entire
+        # success-logging event cancelled. Budget gauges are also refreshed by the
+        # periodic cron every PROMETHEUS_BUDGET_METRICS_REFRESH_INTERVAL_MINUTES,
+        # so dropping one slow per-request emission only loses sub-cron real-time
+        # detail, not correctness.
+        budget_metrics_timeout = _get_budget_metrics_per_request_timeout()
+        gather_coro = asyncio.gather(
             self._set_api_key_budget_metrics_after_api_request(
                 user_api_key=user_api_key,
                 user_api_key_alias=user_api_key_alias,
@@ -1634,6 +1663,16 @@ class PrometheusLogger(CustomLogger):
             ),
             return_exceptions=True,
         )
+        try:
+            results = await asyncio.wait_for(gather_coro, timeout=budget_metrics_timeout)
+        except asyncio.TimeoutError:
+            verbose_logger.debug(
+                "[Non-Blocking] Prometheus: per-request budget metric emission "
+                "exceeded %ss under load; skipping (values are refreshed by the "
+                "periodic budget-metrics cron job).",
+                budget_metrics_timeout,
+            )
+            return
         for i, r in enumerate(results):
             if isinstance(r, Exception):
                 verbose_logger.debug(

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -132,9 +132,7 @@ class AnthropicMessagesHandler(BaseTranslation):
         def _sse(event_type: str, payload: dict) -> bytes:
             return f"event: {event_type}\ndata: {json.dumps(payload)}\n\n".encode()
 
-        output_tokens = blocked_response_usage(getattr(exc, "original_response", None))[
-            "output_tokens"
-        ]
+        output_tokens = blocked_response_usage(getattr(exc, "original_response", None))["output_tokens"]
         open_index, max_index = self._content_block_state(responses_so_far)
         new_index = (max_index + 1) if max_index is not None else 0
         chunks: list[bytes] = []

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -48,7 +48,10 @@ from litellm.types.utils import (
 )
 
 if TYPE_CHECKING:
-    from litellm.integrations.custom_guardrail import CustomGuardrail
+    from litellm.integrations.custom_guardrail import (
+        CustomGuardrail,
+        ModifyResponseException,
+    )
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
     from litellm.types.llms.anthropic_messages.anthropic_response import (
         AnthropicMessagesResponse,
@@ -69,6 +72,146 @@ class AnthropicMessagesHandler(BaseTranslation):
     def __init__(self):
         super().__init__()
         self.adapter = LiteLLMAnthropicMessagesAdapter()
+
+    def build_block_sse_chunks(
+        self,
+        exc: "ModifyResponseException",
+        stream_started: bool = False,
+        responses_so_far: Optional[list[Any]] = None,
+    ) -> list[bytes]:
+        """
+        Build an Anthropic SSE sequence delivering the guardrail block message
+        and terminating the stream cleanly.
+
+        - ``stream_started`` False (buffered / pre-stream): nothing has been
+          sent, so emit a complete standalone message (message_start ->
+          content_block_* -> message_delta -> message_stop) via
+          FakeAnthropicMessagesStreamIterator, the same converter the
+          /v1/messages pre-stream block handler uses.
+        - ``stream_started`` True (sampling / detect-only end-of-stream): real
+          chunks were already sent, so *continue* the in-progress message --
+          close the open content block, append the block message as a new text
+          block, then end the message. Emitting a second ``message_start`` here
+          would make Anthropic clients reject the stream.
+        """
+        if stream_started:
+            return self._block_continuation_chunks(exc, responses_so_far or [])
+        return self._standalone_block_chunks(exc)
+
+    def _standalone_block_chunks(self, exc: "ModifyResponseException") -> list[bytes]:
+        import uuid
+
+        from litellm.llms.anthropic.experimental_pass_through.messages.fake_stream_iterator import (
+            FakeAnthropicMessagesStreamIterator,
+        )
+        from litellm.types.utils import AnthropicMessagesResponse
+
+        block_response = AnthropicMessagesResponse(
+            id=f"msg_{uuid.uuid4()}",
+            type="message",
+            role="assistant",
+            content=[{"type": "text", "text": exc.message}],
+            model=exc.model,
+            stop_reason="end_turn",
+            usage={"input_tokens": 0, "output_tokens": 0},
+        )
+        return list(FakeAnthropicMessagesStreamIterator(response=block_response))
+
+    def _block_continuation_chunks(self, exc: "ModifyResponseException", responses_so_far: list[Any]) -> list[bytes]:
+        """Continue an already-started message: close the open content block,
+        append the block message as a new text block, then end the message --
+        without a second message_start."""
+
+        def _sse(event_type: str, payload: dict) -> bytes:
+            return f"event: {event_type}\ndata: {json.dumps(payload)}\n\n".encode()
+
+        open_index, max_index = self._content_block_state(responses_so_far)
+        new_index = (max_index + 1) if max_index is not None else 0
+        chunks: list[bytes] = []
+        if open_index is not None:
+            chunks.append(_sse("content_block_stop", {"type": "content_block_stop", "index": open_index}))
+        chunks += [
+            _sse(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": new_index,
+                    "content_block": {"type": "text", "text": ""},
+                },
+            ),
+            _sse(
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": new_index,
+                    "delta": {"type": "text_delta", "text": exc.message},
+                },
+            ),
+            _sse("content_block_stop", {"type": "content_block_stop", "index": new_index}),
+            _sse(
+                "message_delta",
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                    "usage": {"output_tokens": 0},
+                },
+            ),
+            _sse("message_stop", {"type": "message_stop"}),
+        ]
+        return chunks
+
+    @staticmethod
+    def _content_block_state(
+        responses_so_far: list[Any],
+    ) -> tuple[Optional[int], Optional[int]]:
+        """From the SSE chunks already sent to the client, return (open
+        content-block index or None, highest content-block index seen or None).
+
+        A single streamed item may bundle multiple SSE events (raw bytes) or be
+        an already-parsed event dict, so every event across every item is
+        considered -- matching how ``get_streaming_string_so_far`` reads the
+        same stream."""
+        open_indices: set[int] = set()
+        max_index: Optional[int] = None
+        for item in responses_so_far:
+            for data in AnthropicMessagesHandler._iter_sse_events(item):
+                event_type = data.get("type")
+                index = data.get("index")
+                if not isinstance(index, int):
+                    continue
+                if event_type == "content_block_start":
+                    open_indices.add(index)
+                    max_index = index if max_index is None else max(max_index, index)
+                elif event_type == "content_block_stop":
+                    open_indices.discard(index)
+        open_index = max(open_indices) if open_indices else None
+        return open_index, max_index
+
+    @staticmethod
+    def _iter_sse_events(item: Any) -> list[dict]:
+        """Yield the event-data dicts in one stream chunk.
+
+        Handles both formats this stream can carry (see
+        ``get_streaming_string_so_far``): raw SSE ``bytes`` -- which may bundle
+        several events separated by a blank line -- and an already-parsed event
+        ``dict``."""
+        if isinstance(item, dict):
+            return [item]
+        if not isinstance(item, (bytes, bytearray)):
+            return []
+        events: list[dict] = []
+        for block in item.decode("utf-8", errors="replace").split("\n\n"):
+            for line in block.split("\n"):
+                line = line.strip()
+                if not line.startswith("data:"):
+                    continue
+                try:
+                    parsed = json.loads(line[len("data:") :].strip())
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(parsed, dict):
+                    events.append(parsed)
+        return events
 
     def _translate_to_openai(self, data: dict) -> ChatCompletionRequest:
         """Translate Anthropic request to OpenAI chat completion format."""

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -104,6 +104,9 @@ class AnthropicMessagesHandler(BaseTranslation):
         from litellm.llms.anthropic.experimental_pass_through.messages.fake_stream_iterator import (
             FakeAnthropicMessagesStreamIterator,
         )
+        from litellm.llms.base_llm.guardrail_translation.utils import (
+            blocked_response_usage,
+        )
         from litellm.types.utils import AnthropicMessagesResponse
 
         block_response = AnthropicMessagesResponse(
@@ -113,7 +116,7 @@ class AnthropicMessagesHandler(BaseTranslation):
             content=[{"type": "text", "text": exc.message}],
             model=exc.model,
             stop_reason="end_turn",
-            usage={"input_tokens": 0, "output_tokens": 0},
+            usage=blocked_response_usage(getattr(exc, "original_response", None)),
         )
         return list(FakeAnthropicMessagesStreamIterator(response=block_response))
 
@@ -122,9 +125,16 @@ class AnthropicMessagesHandler(BaseTranslation):
         append the block message as a new text block, then end the message --
         without a second message_start."""
 
+        from litellm.llms.base_llm.guardrail_translation.utils import (
+            blocked_response_usage,
+        )
+
         def _sse(event_type: str, payload: dict) -> bytes:
             return f"event: {event_type}\ndata: {json.dumps(payload)}\n\n".encode()
 
+        output_tokens = blocked_response_usage(getattr(exc, "original_response", None))[
+            "output_tokens"
+        ]
         open_index, max_index = self._content_block_state(responses_so_far)
         new_index = (max_index + 1) if max_index is not None else 0
         chunks: list[bytes] = []
@@ -153,7 +163,7 @@ class AnthropicMessagesHandler(BaseTranslation):
                 {
                     "type": "message_delta",
                     "delta": {"stop_reason": "end_turn", "stop_sequence": None},
-                    "usage": {"output_tokens": 0},
+                    "usage": {"output_tokens": output_tokens},
                 },
             ),
             _sse("message_stop", {"type": "message_stop"}),

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -73,6 +73,22 @@ class AnthropicMessagesHandler(BaseTranslation):
         super().__init__()
         self.adapter = LiteLLMAnthropicMessagesAdapter()
 
+    @staticmethod
+    def _build_streaming_usage_response(
+        responses_so_far: list[Any],
+        request_data: Optional[dict],
+    ) -> Optional[ModelResponse]:
+        chunks = tuple(response for response in responses_so_far if isinstance(response, (str, bytes)))
+        if not chunks:
+            return None
+        try:
+            return AnthropicPassthroughLoggingHandler._build_usage_only_response_from_chunks(
+                all_chunks=chunks,
+                model=str((request_data or {}).get("model") or ""),
+            )
+        except (AttributeError, TypeError, ValueError):
+            return None
+
     def build_block_sse_chunks(
         self,
         exc: "ModifyResponseException",
@@ -557,6 +573,8 @@ class AnthropicMessagesHandler(BaseTranslation):
 
         Get the string so far, check the apply guardrail to the string so far, and return the list of responses so far.
         """
+        from litellm.integrations.custom_guardrail import ModifyResponseException
+
         has_ended = self._check_streaming_has_ended(responses_so_far)
         if has_ended:
             # build the model response from the responses_so_far
@@ -581,25 +599,35 @@ class AnthropicMessagesHandler(BaseTranslation):
                 if tool_calls_list:
                     guardrail_inputs["tool_calls"] = tool_calls_list
 
-                _guardrailed_inputs = (
-                    await guardrail_to_apply.apply_guardrail(  # allow rejecting the response, if invalid
+                try:
+                    _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                         inputs=guardrail_inputs,
                         request_data=request_data if request_data is not None else {},
                         input_type="response",
                         logging_obj=litellm_logging_obj,
                     )
-                )
+                except ModifyResponseException as e:
+                    if e.original_response is None:
+                        e.original_response = built_response or self._build_streaming_usage_response(
+                            responses_so_far, request_data
+                        )
+                    raise
             else:
                 verbose_proxy_logger.debug("Skipping output guardrail - model response has no choices")
             return responses_so_far
 
         string_so_far = self.get_streaming_string_so_far(responses_so_far)
-        _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(  # allow rejecting the response, if invalid
-            inputs={"texts": [string_so_far]},
-            request_data=request_data if request_data is not None else {},
-            input_type="response",
-            logging_obj=litellm_logging_obj,
-        )
+        try:
+            _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
+                inputs={"texts": [string_so_far]},
+                request_data=request_data if request_data is not None else {},
+                input_type="response",
+                logging_obj=litellm_logging_obj,
+            )
+        except ModifyResponseException as e:
+            if e.original_response is None:
+                e.original_response = self._build_streaming_usage_response(responses_so_far, request_data)
+            raise
         return responses_so_far
 
     def _prepare_request_data(

--- a/litellm/llms/base_llm/guardrail_translation/base_translation.py
+++ b/litellm/llms/base_llm/guardrail_translation/base_translation.py
@@ -2,7 +2,10 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 if TYPE_CHECKING:
-    from litellm.integrations.custom_guardrail import CustomGuardrail
+    from litellm.integrations.custom_guardrail import (
+        CustomGuardrail,
+        ModifyResponseException,
+    )
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
     from litellm.proxy._types import UserAPIKeyAuth
     from litellm.types.llms.openai import AllMessageValues
@@ -97,6 +100,30 @@ class BaseTranslation(ABC):
         Optional to override in subclasses.
         """
         return responses_so_far
+
+    def build_block_sse_chunks(
+        self,
+        exc: "ModifyResponseException",
+        stream_started: bool = False,
+        responses_so_far: Optional[list[Any]] = None,
+    ) -> Optional[list[bytes]]:
+        """
+        Build the streaming chunks that deliver a guardrail block message and
+        cleanly terminate the stream in this provider's wire format.
+
+        ``stream_started`` is True when real chunks were already sent to the
+        client: the result must *continue* the in-progress message (e.g. close
+        the open content block and append the block message) rather than start
+        a new one, which clients reject. ``responses_so_far`` provides the prior
+        chunks needed to do so. When False, nothing has been sent and a
+        standalone block message is emitted.
+
+        Returns None when the format has no safe terminator; the caller then
+        re-raises ``exc`` so the proxy can surface a clean error instead.
+        Override in provider subclasses that support synthesizing a block
+        stream.
+        """
+        return None
 
     def get_structured_messages(self, data: dict) -> Optional[List["AllMessageValues"]]:
         """

--- a/litellm/llms/base_llm/guardrail_translation/utils.py
+++ b/litellm/llms/base_llm/guardrail_translation/utils.py
@@ -1,9 +1,67 @@
 from __future__ import annotations
 
+import json
 from typing import Any, List, Optional
 
 from litellm.types.llms.anthropic_messages.anthropic_response import AnthropicUsage
 from litellm.types.llms.openai import AllMessageValues
+
+
+def _anthropic_stream_chunk_events(item: Any) -> list[dict]:
+    if isinstance(item, dict):
+        return [item]
+    if isinstance(item, bytes):
+        chunk = item.decode("utf-8", errors="replace")
+    elif isinstance(item, str):
+        chunk = item
+    else:
+        return []
+
+    events: list[dict] = []
+    for block in chunk.split("\n\n"):
+        for line in block.splitlines():
+            stripped = line.strip()
+            if not stripped.startswith("data:"):
+                continue
+            payload = stripped[len("data:") :].strip()
+            if not payload or payload == "[DONE]":
+                continue
+            try:
+                parsed = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict):
+                events.append(parsed)
+    return events
+
+
+def _usage_from_anthropic_stream_chunks(original_response: list[Any]) -> Optional[AnthropicUsage]:
+    input_tokens = 0
+    output_tokens = 0
+    found_usage = False
+
+    for item in original_response:
+        for event in _anthropic_stream_chunk_events(item):
+            event_type = event.get("type")
+            if event_type == "message_start":
+                message = event.get("message") or {}
+                usage_obj = message.get("usage") or {}
+            elif event_type == "message_delta":
+                usage_obj = event.get("usage") or {}
+            else:
+                usage_obj = {}
+            if not isinstance(usage_obj, dict):
+                continue
+            if usage_obj.get("input_tokens") is not None:
+                input_tokens = int(usage_obj.get("input_tokens") or 0)
+                found_usage = True
+            if usage_obj.get("output_tokens") is not None:
+                output_tokens = int(usage_obj.get("output_tokens") or 0)
+                found_usage = True
+
+    if not found_usage:
+        return None
+    return AnthropicUsage(input_tokens=input_tokens, output_tokens=output_tokens)
 
 
 def blocked_response_usage(original_response: Optional[Any]) -> AnthropicUsage:
@@ -17,7 +75,11 @@ def blocked_response_usage(original_response: Optional[Any]) -> AnthropicUsage:
     so usage is zero.
     """
     usage_obj: Any = None
-    if isinstance(original_response, dict):
+    if isinstance(original_response, list):
+        stream_usage = _usage_from_anthropic_stream_chunks(original_response)
+        if stream_usage is not None:
+            return stream_usage
+    elif isinstance(original_response, dict):
         usage_obj = original_response.get("usage")
     elif original_response is not None:
         usage_obj = getattr(original_response, "usage", None)

--- a/litellm/llms/base_llm/guardrail_translation/utils.py
+++ b/litellm/llms/base_llm/guardrail_translation/utils.py
@@ -22,14 +22,14 @@ def blocked_response_usage(original_response: Optional[Any]) -> AnthropicUsage:
     elif original_response is not None:
         usage_obj = getattr(original_response, "usage", None)
 
-    def _tokens(key: str) -> int:
+    def _tokens(key: str, fallback_key: str) -> int:
         if isinstance(usage_obj, dict):
-            return int(usage_obj.get(key, 0) or 0)
-        return int(getattr(usage_obj, key, 0) or 0)
+            return int(usage_obj.get(key, usage_obj.get(fallback_key, 0)) or 0)
+        return int(getattr(usage_obj, key, getattr(usage_obj, fallback_key, 0)) or 0)
 
     return AnthropicUsage(
-        input_tokens=_tokens("input_tokens"),
-        output_tokens=_tokens("output_tokens"),
+        input_tokens=_tokens("input_tokens", "prompt_tokens"),
+        output_tokens=_tokens("output_tokens", "completion_tokens"),
     )
 
 

--- a/litellm/llms/base_llm/guardrail_translation/utils.py
+++ b/litellm/llms/base_llm/guardrail_translation/utils.py
@@ -1,8 +1,36 @@
 from __future__ import annotations
 
-from typing import Any, List
+from typing import Any, List, Optional
 
+from litellm.types.llms.anthropic_messages.anthropic_response import AnthropicUsage
 from litellm.types.llms.openai import AllMessageValues
+
+
+def blocked_response_usage(original_response: Optional[Any]) -> AnthropicUsage:
+    """
+    Token usage for a synthetic guardrail-blocked response.
+
+    A post-call block replaces the LLM's response with the violation message,
+    but the upstream call already consumed tokens -- report that real usage
+    (carried on ``ModifyResponseException.original_response``) rather than
+    discarding it. Pre-call blocks never invoked the LLM (no original_response),
+    so usage is zero.
+    """
+    usage_obj: Any = None
+    if isinstance(original_response, dict):
+        usage_obj = original_response.get("usage")
+    elif original_response is not None:
+        usage_obj = getattr(original_response, "usage", None)
+
+    def _tokens(key: str) -> int:
+        if isinstance(usage_obj, dict):
+            return int(usage_obj.get(key, 0) or 0)
+        return int(getattr(usage_obj, key, 0) or 0)
+
+    return AnthropicUsage(
+        input_tokens=_tokens("input_tokens"),
+        output_tokens=_tokens("output_tokens"),
+    )
 
 
 def effective_skip_system_message_for_guardrail(guardrail_to_apply: Any) -> bool:

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -45,6 +45,7 @@ from litellm.types.llms.openai import (
     AllMessageValues,
     ChatCompletionToolCallChunk,
     ChatCompletionToolParam,
+    ResponsesAPIStreamEvents,
 )
 from litellm.types.responses.main import (
     GenericResponseOutputItem,
@@ -586,7 +587,14 @@ class OpenAIResponsesHandler(BaseTranslation):
         """
         Check if the streaming has ended.
         """
-        return all(response.choices[0].finish_reason is not None for response in responses_so_far)
+        if not responses_so_far:
+            return False
+        terminal_types = {
+            ResponsesAPIStreamEvents.RESPONSE_COMPLETED.value,
+            ResponsesAPIStreamEvents.RESPONSE_FAILED.value,
+            ResponsesAPIStreamEvents.RESPONSE_INCOMPLETE.value,
+        }
+        return responses_so_far[-1].get("type") in terminal_types
 
     def get_streaming_string_so_far(self, responses_so_far: List[Any]) -> str:
         """

--- a/litellm/proxy/anthropic_endpoints/endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/endpoints.py
@@ -12,6 +12,9 @@ from litellm.integrations.custom_guardrail import ModifyResponseException
 from litellm.llms.anthropic.experimental_pass_through.context_management import (
     AnthropicContextManagementError,
 )
+from litellm.llms.base_llm.guardrail_translation.utils import (
+    blocked_response_usage as _blocked_response_usage,
+)
 from litellm.proxy._types import *
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_request_processing import (
@@ -19,7 +22,6 @@ from litellm.proxy.common_request_processing import (
     create_response,
 )
 from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
-from litellm.types.llms.anthropic_messages.anthropic_response import AnthropicUsage
 from litellm.types.utils import TokenCountResponse
 
 router = APIRouter()
@@ -57,33 +59,6 @@ def _strip_total_tokens_from_anthropic_response(response: Any) -> None:
     usage = getattr(response, "usage", None)
     if isinstance(usage, dict) and "total_tokens" in usage:
         usage.pop("total_tokens", None)
-
-
-def _blocked_response_usage(original_response: Optional[Any]) -> AnthropicUsage:
-    """
-    Token usage for a synthetic guardrail-blocked response.
-
-    A post-call block replaces the LLM's response with the violation message,
-    but the upstream call already consumed tokens -- report that real usage
-    (carried on ``ModifyResponseException.original_response``) rather than
-    discarding it. Pre-call blocks never invoked the LLM (no original_response),
-    so usage is zero.
-    """
-    usage_obj: Any = None
-    if isinstance(original_response, dict):
-        usage_obj = original_response.get("usage")
-    elif original_response is not None:
-        usage_obj = getattr(original_response, "usage", None)
-
-    def _tokens(key: str) -> int:
-        if isinstance(usage_obj, dict):
-            return int(usage_obj.get(key, 0) or 0)
-        return int(getattr(usage_obj, key, 0) or 0)
-
-    return AnthropicUsage(
-        input_tokens=_tokens("input_tokens"),
-        output_tokens=_tokens("output_tokens"),
-    )
 
 
 @router.post(

--- a/litellm/proxy/anthropic_endpoints/endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/endpoints.py
@@ -19,6 +19,7 @@ from litellm.proxy.common_request_processing import (
     create_response,
 )
 from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
+from litellm.types.llms.anthropic_messages.anthropic_response import AnthropicUsage
 from litellm.types.utils import TokenCountResponse
 
 router = APIRouter()
@@ -56,6 +57,33 @@ def _strip_total_tokens_from_anthropic_response(response: Any) -> None:
     usage = getattr(response, "usage", None)
     if isinstance(usage, dict) and "total_tokens" in usage:
         usage.pop("total_tokens", None)
+
+
+def _blocked_response_usage(original_response: Optional[Any]) -> AnthropicUsage:
+    """
+    Token usage for a synthetic guardrail-blocked response.
+
+    A post-call block replaces the LLM's response with the violation message,
+    but the upstream call already consumed tokens -- report that real usage
+    (carried on ``ModifyResponseException.original_response``) rather than
+    discarding it. Pre-call blocks never invoked the LLM (no original_response),
+    so usage is zero.
+    """
+    usage_obj: Any = None
+    if isinstance(original_response, dict):
+        usage_obj = original_response.get("usage")
+    elif original_response is not None:
+        usage_obj = getattr(original_response, "usage", None)
+
+    def _tokens(key: str) -> int:
+        if isinstance(usage_obj, dict):
+            return int(usage_obj.get(key, 0) or 0)
+        return int(getattr(usage_obj, key, 0) or 0)
+
+    return AnthropicUsage(
+        input_tokens=_tokens("input_tokens"),
+        output_tokens=_tokens("output_tokens"),
+    )
 
 
 @router.post(
@@ -134,6 +162,10 @@ async def anthropic_response(
 
         from litellm.types.utils import AnthropicMessagesResponse
 
+        # Report the blocked LLM response's real token usage (carried on the
+        # exception) instead of discarding it; zero for pre-call blocks.
+        _usage = _blocked_response_usage(e.original_response)
+
         _anthropic_response = AnthropicMessagesResponse(
             id=f"msg_{str(uuid.uuid4())}",
             type="message",
@@ -141,7 +173,7 @@ async def anthropic_response(
             content=[{"type": "text", "text": e.message}],
             model=e.model,
             stop_reason="end_turn",
-            usage={"input_tokens": 0, "output_tokens": 0},
+            usage=_usage,
         )
 
         if data.get("stream", None) is not None and data["stream"] is True:

--- a/litellm/proxy/collector_endpoints/__init__.py
+++ b/litellm/proxy/collector_endpoints/__init__.py
@@ -1,0 +1,1 @@
+"""Collector endpoints for ingesting external LiteLLM Relay logs."""

--- a/litellm/proxy/collector_endpoints/spend_logs.py
+++ b/litellm/proxy/collector_endpoints/spend_logs.py
@@ -1,0 +1,365 @@
+import hashlib
+import hmac
+import json
+from datetime import datetime, timezone
+from typing import Any, Optional, TypedDict
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+
+from litellm.constants import (
+    LITELLM_ASYNCIO_QUEUE_MAXSIZE,
+    LITELLM_RELAY_CALL_TYPE,
+    MAX_COLLECTOR_SPEND_LOG_BATCH_BYTES,
+    MAX_COLLECTOR_SPEND_LOG_BYTES,
+    MAX_COLLECTOR_SPEND_LOGS,
+)
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+
+class CollectorSpendLogRow(TypedDict, total=False):
+    request_id: str
+    call_type: str
+    api_key: str
+    spend: float
+    total_tokens: int
+    prompt_tokens: int
+    completion_tokens: int
+    startTime: datetime
+    endTime: datetime
+    model: str
+    api_base: str
+    custom_llm_provider: str
+    user: Optional[str]
+    team_id: Optional[str]
+    organization_id: Optional[str]
+    metadata: dict[str, Any]
+    cache_hit: str
+    cache_key: str
+    request_tags: str
+    messages: Any
+    response: Any
+    proxy_server_request: Any
+    status: str
+
+
+class CollectorSpendLogsIngestResponse(TypedDict):
+    enqueued: int
+
+
+class CollectorSpendLogTransformer:
+    PASSTHROUGH_FIELDS = {
+        "total_tokens",
+        "prompt_tokens",
+        "completion_tokens",
+        "startTime",
+        "endTime",
+        "completionStartTime",
+        "model",
+        "model_id",
+        "model_group",
+        "mcp_namespaced_tool_name",
+        "agent_id",
+        "api_base",
+        "cache_hit",
+        "cache_key",
+        "end_user",
+        "requester_ip_address",
+        "messages",
+        "response",
+        "proxy_server_request",
+        "session_id",
+        "request_duration_ms",
+        "status",
+    }
+
+    @staticmethod
+    def transform_collector_events_to_spend_logs(
+        logs: list[dict[str, Any]],
+        user_api_key_dict: Any,
+        now: datetime,
+    ) -> list[CollectorSpendLogRow]:
+        CollectorSpendLogTransformer._validate_raw_batch_size(logs)
+        spend_logs = [
+            CollectorSpendLogTransformer.transform_collector_event_to_spend_log(
+                log=log,
+                user_api_key_dict=user_api_key_dict,
+                now=now,
+            )
+            for log in logs
+        ]
+        CollectorSpendLogTransformer._validate_normalized_batch_size(spend_logs)
+        return spend_logs
+
+    @staticmethod
+    def transform_collector_event_to_spend_log(
+        log: dict[str, Any],
+        user_api_key_dict: Any,
+        now: datetime,
+    ) -> CollectorSpendLogRow:
+        collector_request_id = log.get("request_id")
+        if not isinstance(collector_request_id, str) or not collector_request_id.strip():
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"error": "request_id is required for collector spend-log ingestion"},
+            )
+
+        key_hash = CollectorSpendLogTransformer._get_auth_key_hash(user_api_key_dict)
+        row: CollectorSpendLogRow = {
+            "request_id": CollectorSpendLogTransformer._collector_request_id_for(
+                key_hash,
+                collector_request_id,
+            ),
+            "call_type": LITELLM_RELAY_CALL_TYPE,
+            "api_key": key_hash or LITELLM_RELAY_CALL_TYPE,
+            "spend": 0.0,
+            "total_tokens": 0,
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "startTime": now,
+            "endTime": now,
+            "model": "local-ai-traffic",
+            "api_base": "",
+            "custom_llm_provider": "",
+            "user": getattr(user_api_key_dict, "user_id", None),
+            "team_id": getattr(user_api_key_dict, "team_id", None),
+            "organization_id": CollectorSpendLogTransformer._get_auth_organization_id(user_api_key_dict),
+            "metadata": CollectorSpendLogTransformer._normalize_metadata(
+                log.get("metadata"),
+                user_api_key_dict,
+                collector_request_id,
+            ),
+            "cache_hit": "False",
+            "cache_key": "",
+            "request_tags": CollectorSpendLogTransformer._normalize_request_tags(log.get("request_tags")),
+            "messages": {},
+            "response": {},
+            "proxy_server_request": {},
+            "status": "success",
+        }
+
+        for key in CollectorSpendLogTransformer.PASSTHROUGH_FIELDS:
+            if key in log:
+                row[key] = log[key]
+
+        return CollectorSpendLogTransformer._sanitize_json_value(row)
+
+    @staticmethod
+    def _get_auth_organization_id(user_api_key_dict: Any) -> Optional[str]:
+        return getattr(user_api_key_dict, "organization_id", None) or getattr(user_api_key_dict, "org_id", None)
+
+    @staticmethod
+    def _get_auth_key_hash(user_api_key_dict: Any) -> Optional[str]:
+        return getattr(user_api_key_dict, "api_key", None) or getattr(user_api_key_dict, "token", None)
+
+    @staticmethod
+    def _get_auth_key_alias(user_api_key_dict: Any) -> str:
+        return (
+            getattr(user_api_key_dict, "key_alias", None)
+            or getattr(user_api_key_dict, "key_name", None)
+            or LITELLM_RELAY_CALL_TYPE
+        )
+
+    @staticmethod
+    def _get_auth_team_alias(user_api_key_dict: Any) -> Optional[str]:
+        return getattr(user_api_key_dict, "team_alias", None) or None
+
+    @staticmethod
+    def _collector_request_id_for(key_hash: Optional[str], collector_request_id: str) -> str:
+        digest = hmac.new(
+            (key_hash or LITELLM_RELAY_CALL_TYPE).encode(),
+            collector_request_id.encode(),
+            hashlib.sha256,
+        ).hexdigest()
+        return f"collector-{digest[:32]}"
+
+    @staticmethod
+    def _normalize_metadata(
+        metadata: Any,
+        user_api_key_dict: Any,
+        collector_request_id: str,
+    ) -> dict[str, Any]:
+        if isinstance(metadata, dict):
+            normalized = dict(metadata)
+        elif metadata is None:
+            normalized = {}
+        else:
+            normalized = {"relay_raw_metadata": metadata}
+
+        key_hash = CollectorSpendLogTransformer._get_auth_key_hash(user_api_key_dict)
+        normalized.update(
+            {
+                "source": LITELLM_RELAY_CALL_TYPE,
+                "collector_request_id": collector_request_id,
+                "relay_request_id": collector_request_id,
+                "user_api_key": key_hash,
+                "user_api_key_alias": CollectorSpendLogTransformer._get_auth_key_alias(user_api_key_dict),
+                "user_api_key_user_id": getattr(user_api_key_dict, "user_id", None),
+                "user_api_key_team_id": getattr(user_api_key_dict, "team_id", None),
+                "user_api_key_team_alias": CollectorSpendLogTransformer._get_auth_team_alias(user_api_key_dict),
+                "user_api_key_org_id": CollectorSpendLogTransformer._get_auth_organization_id(user_api_key_dict),
+            }
+        )
+        return normalized
+
+    @staticmethod
+    def _normalize_request_tags(value: Any) -> str:
+        if isinstance(value, str):
+            try:
+                parsed = json.loads(value)
+                if not isinstance(parsed, list):
+                    parsed = [parsed]
+            except json.JSONDecodeError:
+                parsed = [value] if value.strip() else []
+        elif isinstance(value, list):
+            parsed = list(value)
+        elif value is None:
+            parsed = []
+        else:
+            parsed = [value]
+
+        if LITELLM_RELAY_CALL_TYPE not in parsed:
+            parsed.append(LITELLM_RELAY_CALL_TYPE)
+        return json.dumps(parsed, separators=(",", ":"))
+
+    @staticmethod
+    def _sanitize_json_value(value: Any) -> Any:
+        if isinstance(value, str):
+            return value.replace("\x00", "")
+        if not isinstance(value, (dict, list)):
+            return value
+
+        sanitized: Any = {} if isinstance(value, dict) else []
+        stack = [(value, sanitized)]
+        while stack:
+            source, target = stack.pop()
+            if isinstance(source, dict):
+                for key, item in source.items():
+                    sanitized_key = str(key).replace("\x00", "")
+                    if isinstance(item, str):
+                        target[sanitized_key] = item.replace("\x00", "")
+                    elif isinstance(item, dict):
+                        child: dict[str, Any] = {}
+                        target[sanitized_key] = child
+                        stack.append((item, child))
+                    elif isinstance(item, list):
+                        child_list: list[Any] = []
+                        target[sanitized_key] = child_list
+                        stack.append((item, child_list))
+                    else:
+                        target[sanitized_key] = item
+            else:
+                for item in source:
+                    if isinstance(item, str):
+                        target.append(item.replace("\x00", ""))
+                    elif isinstance(item, dict):
+                        child = {}
+                        target.append(child)
+                        stack.append((item, child))
+                    elif isinstance(item, list):
+                        child_list = []
+                        target.append(child_list)
+                        stack.append((item, child_list))
+                    else:
+                        target.append(item)
+        return sanitized
+
+    @staticmethod
+    def _json_size_bytes(value: Any) -> int:
+        return len(json.dumps(value, default=str, separators=(",", ":")).encode())
+
+    @staticmethod
+    def _validate_log_size(log: dict[str, Any]) -> int:
+        encoded_size = CollectorSpendLogTransformer._json_size_bytes(log)
+        if encoded_size > MAX_COLLECTOR_SPEND_LOG_BYTES:
+            raise HTTPException(
+                status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                detail={"error": f"Collector spend-log entry exceeds {MAX_COLLECTOR_SPEND_LOG_BYTES} bytes"},
+            )
+        return encoded_size
+
+    @staticmethod
+    def _validate_batch_size(total_bytes: int) -> None:
+        if total_bytes > MAX_COLLECTOR_SPEND_LOG_BATCH_BYTES:
+            raise HTTPException(
+                status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                detail={"error": f"Collector spend-log batch exceeds {MAX_COLLECTOR_SPEND_LOG_BATCH_BYTES} bytes"},
+            )
+
+    @staticmethod
+    def _validate_raw_batch_size(logs: list[dict[str, Any]]) -> None:
+        total_bytes = 0
+        for log in logs:
+            total_bytes += CollectorSpendLogTransformer._json_size_bytes(log)
+            CollectorSpendLogTransformer._validate_batch_size(total_bytes)
+
+    @staticmethod
+    def _validate_normalized_batch_size(spend_logs: list[dict[str, Any]]) -> None:
+        total_bytes = 0
+        for spend_log in spend_logs:
+            total_bytes += CollectorSpendLogTransformer._validate_log_size(spend_log)
+            CollectorSpendLogTransformer._validate_batch_size(total_bytes)
+
+
+router = APIRouter(include_in_schema=False)
+
+
+@router.post(
+    "/collector/spend-logs",
+    tags=["Collector"],
+)
+async def ingest_collector_spend_logs(
+    payload: dict[str, list[dict[str, Any]]],
+    request: Request,
+    user_api_key_dict: Any = Depends(user_api_key_auth),
+) -> CollectorSpendLogsIngestResponse:
+    """
+    Ingest LiteLLM Relay captures into the existing spend-log batcher so they
+    appear in the Gateway Logs UI without replaying captured traffic.
+    """
+    proxy_logging_obj = getattr(request.app.state, "proxy_logging_obj", None)
+    prisma_client = getattr(request.app.state, "prisma_client", None)
+
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"error": "Prisma Client is not initialized"},
+        )
+    if proxy_logging_obj is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"error": "Proxy logging is not initialized"},
+        )
+
+    logs = payload.get("logs", [])
+    if len(logs) == 0:
+        return {"enqueued": 0}
+    if len(logs) > MAX_COLLECTOR_SPEND_LOGS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": f"Collector spend-log ingestion is limited to {MAX_COLLECTOR_SPEND_LOGS} rows"},
+        )
+
+    async with prisma_client._spend_log_transactions_lock:
+        queued_spend_logs = len(prisma_client.spend_log_transactions)
+    if queued_spend_logs + len(logs) > LITELLM_ASYNCIO_QUEUE_MAXSIZE:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={
+                "error": "Collector spend-log queue is full",
+                "queued": queued_spend_logs,
+                "limit": LITELLM_ASYNCIO_QUEUE_MAXSIZE,
+            },
+        )
+
+    spend_logs = CollectorSpendLogTransformer.transform_collector_events_to_spend_logs(
+        logs=logs,
+        user_api_key_dict=user_api_key_dict,
+        now=datetime.now(timezone.utc),
+    )
+    for spend_log in spend_logs:
+        await proxy_logging_obj.db_spend_update_writer._insert_spend_log_to_db(
+            payload=spend_log,
+            prisma_client=prisma_client,
+        )
+
+    return {"enqueued": len(spend_logs)}

--- a/litellm/proxy/dev_config.yaml
+++ b/litellm/proxy/dev_config.yaml
@@ -211,3 +211,8 @@ litellm_settings:
     sandbox_tool_name: e2b_sandbox
   callbacks:
     - code_interpreter_interception
+
+mcp_servers:
+  deepwiki:
+    url: "https://mcp.deepwiki.com/mcp"
+    transport: "http"

--- a/litellm/proxy/dev_config.yaml
+++ b/litellm/proxy/dev_config.yaml
@@ -211,8 +211,3 @@ litellm_settings:
     sandbox_tool_name: e2b_sandbox
   callbacks:
     - code_interpreter_interception
-
-mcp_servers:
-  deepwiki:
-    url: "https://mcp.deepwiki.com/mcp"
-    transport: "http"

--- a/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
@@ -319,8 +319,9 @@ class UnifiedLLMGuardrails(CustomLogger):
 
         guardrail_to_apply: CustomGuardrail = request_data.pop("guardrail_to_apply", None)
 
-        # Get streaming configuration, with precedence: guardrail attribute ->
-        # guardrail_config dict -> this callback's optional_params.
+        # Get streaming configuration. Resolution order (later wins): default
+        # < guardrail attribute < guardrail_config dict < this callback's
+        # optional_params.
         def _streaming_flag(name: str, default: Any) -> Any:
             value = default
             if guardrail_to_apply is not None:
@@ -336,10 +337,24 @@ class UnifiedLLMGuardrails(CustomLogger):
         # Withhold every chunk until end-of-stream moderation passes, then
         # release the original chunks (clean) or only the block message
         # (blocked) -- moderating the whole response *before* any content
-        # reaches the client. Intended for allow/block guardrails: on release
-        # the original chunks are replayed as-is, so content-rewriting
-        # guardrails (e.g. PII masking) are not applied to a buffered stream.
+        # reaches the client. Only safe for allow/block guardrails: on
+        # release the original chunks are replayed as-is, so a
+        # content-rewriting guardrail (e.g. PII masking) would leak
+        # unredacted content. Guarded below via mask_response_content.
         buffer_until_moderated = _streaming_flag("streaming_buffer_until_moderated", False)
+
+        if (
+            buffer_until_moderated
+            and guardrail_to_apply is not None
+            and getattr(guardrail_to_apply, "mask_response_content", False)
+        ):
+            verbose_proxy_logger.warning(
+                "UnifiedLLMGuardrails: streaming_buffer_until_moderated is disabled for %s "
+                "because mask_response_content=True -- buffered replay would release "
+                "unredacted original chunks instead of the moderated output.",
+                guardrail_to_apply.guardrail_name,
+            )
+            buffer_until_moderated = False
 
         # Buffering can only moderate the assembled response, so it always
         # defers to end-of-stream.

--- a/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
@@ -197,6 +197,10 @@ class UnifiedLLMGuardrails(CustomLogger):
         )
         from litellm.types.guardrails import GuardrailEventHooks
 
+        # Local import avoids a module-level cyclic import with
+        # litellm.integrations.custom_guardrail.
+        from litellm.integrations.custom_guardrail import ModifyResponseException
+
         guardrail_to_apply: CustomGuardrail = data.pop("guardrail_to_apply", None)
 
         if guardrail_to_apply is None:
@@ -238,13 +242,22 @@ class UnifiedLLMGuardrails(CustomLogger):
 
         endpoint_translation = endpoint_guardrail_translation_mappings[CallTypes(call_type)]()
 
-        response = await endpoint_translation.process_output_response(
-            response=response,  # type: ignore
-            guardrail_to_apply=guardrail_to_apply,
-            litellm_logging_obj=data.get("litellm_logging_obj"),
-            user_api_key_dict=user_api_key_dict,
-            request_data=data,
-        )
+        try:
+            response = await endpoint_translation.process_output_response(
+                response=response,  # type: ignore
+                guardrail_to_apply=guardrail_to_apply,
+                litellm_logging_obj=data.get("litellm_logging_obj"),
+                user_api_key_dict=user_api_key_dict,
+                request_data=data,
+            )
+        except ModifyResponseException as e:
+            # The guardrail blocked the response. Attach the original LLM
+            # response so the endpoint handler can report its real token usage
+            # instead of discarding it (the block replaces the content, but the
+            # upstream call already consumed those tokens).
+            if e.original_response is None:
+                e.original_response = response
+            raise
         # Add guardrail to applied guardrails header
         add_guardrail_to_applied_guardrails_header(request_data=data, guardrail_name=guardrail_to_apply.guardrail_name)
 

--- a/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
@@ -384,6 +384,8 @@ class UnifiedLLMGuardrails(CustomLogger):
         call_type = None
         chunk_counter = 0
         responses_so_far: List[Any] = []
+        responses_yielded: list[Any] = []
+        pending_end_of_stream_items: list[Any] = []
         # Whether any real response chunk has been forwarded to the client.
         # Drives how a block terminates the stream: continue the in-progress
         # message (True) vs emit a standalone block message (False, buffered).
@@ -415,8 +417,16 @@ class UnifiedLLMGuardrails(CustomLogger):
             # moderation runs below.
             if end_of_stream_only:
                 if not buffer_until_moderated:
-                    chunks_yielded = True
-                    yield item
+                    endpoint_translation = endpoint_guardrail_translation_mappings[CallTypes(call_type)]()
+                    stream_has_ended = hasattr(
+                        endpoint_translation, "_check_streaming_has_ended"
+                    ) and endpoint_translation._check_streaming_has_ended(responses_so_far)
+                    if pending_end_of_stream_items or stream_has_ended:
+                        pending_end_of_stream_items.append(item)
+                    else:
+                        chunks_yielded = True
+                        responses_yielded.append(item)
+                        yield item
                 continue
 
             # Process chunk based on sampling rate
@@ -447,6 +457,8 @@ class UnifiedLLMGuardrails(CustomLogger):
                         request_data=request_data,
                     )
                 except ModifyResponseException as e:
+                    if e.original_response is None:
+                        e.original_response = responses_so_far
                     # Guardrail blocked the response mid-stream. Emit a clean
                     # terminating SSE sequence delivering the block message
                     # instead of letting the exception propagate into a bare
@@ -460,7 +472,7 @@ class UnifiedLLMGuardrails(CustomLogger):
                         e,
                         endpoint_translation,
                         stream_started=chunks_yielded,
-                        responses_so_far=responses_so_far[:-1],
+                        responses_so_far=responses_yielded,
                     ):
                         yield block_chunk
                     return
@@ -491,9 +503,11 @@ class UnifiedLLMGuardrails(CustomLogger):
                         return
                     raise
                 chunks_yielded = True
+                responses_yielded.append(original_item)
                 yield original_item
             else:
                 chunks_yielded = True
+                responses_yielded.append(item)
                 yield item
 
         # Stream has ended - do final processing with all collected chunks
@@ -527,7 +541,12 @@ class UnifiedLLMGuardrails(CustomLogger):
                 if buffered_items is not None:
                     for buffered_item in buffered_items:
                         yield buffered_item
+                for pending_item in pending_end_of_stream_items:
+                    responses_yielded.append(pending_item)
+                    yield pending_item
             except ModifyResponseException as e:
+                if e.original_response is None:
+                    e.original_response = responses_so_far
                 # Block detected during end-of-stream processing. Emit a clean
                 # terminating SSE sequence with the block message rather than
                 # propagating into a bare error blob that truncates the stream.
@@ -535,8 +554,8 @@ class UnifiedLLMGuardrails(CustomLogger):
                 async for block_chunk in self._handle_streaming_block(
                     e,
                     endpoint_translation,
-                    stream_started=chunks_yielded,
-                    responses_so_far=responses_so_far,
+                    stream_started=bool(responses_yielded),
+                    responses_so_far=responses_yielded,
                 ):
                     yield block_chunk
                 return

--- a/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
@@ -8,7 +8,7 @@ Unified Guardrail, leveraging LiteLLM's /applyGuardrail endpoint
 
 import copy
 import json
-from typing import Any, AsyncGenerator, List, Optional, Union
+from typing import TYPE_CHECKING, Any, AsyncGenerator, List, Optional, Union
 
 from fastapi import HTTPException
 
@@ -22,6 +22,11 @@ from litellm.llms import load_guardrail_translation_mappings
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.guardrails import GuardrailEventHooks
 from litellm.types.utils import CallTypes, CallTypesLiteral
+
+if TYPE_CHECKING:
+    # Imported lazily at runtime (inside the streaming hook) to avoid a
+    # module-level cyclic import with litellm.integrations.custom_guardrail.
+    from litellm.integrations.custom_guardrail import ModifyResponseException
 
 # Call types that use NDJSON streaming (A2A); guardrail HTTPException is emitted as in-stream error
 A2A_CALL_TYPES = (CallTypes.asend_message, CallTypes.send_message)
@@ -263,6 +268,30 @@ class UnifiedLLMGuardrails(CustomLogger):
 
         return response
 
+    async def _handle_streaming_block(
+        self,
+        exc: "ModifyResponseException",
+        endpoint_translation: Any,
+        stream_started: bool,
+        responses_so_far: list[Any],
+    ) -> AsyncGenerator[Any, None]:
+        """
+        Terminate a streamed response cleanly when a guardrail blocks it.
+
+        Format-agnostic routing: delegates to the provider translation handler's
+        ``build_block_sse_chunks`` (see ``BaseTranslation.build_block_sse_chunks``
+        for the ``stream_started`` / ``responses_so_far`` contract). When the
+        format has no safe terminator the handler returns None and we re-raise
+        ``exc`` so the proxy can surface a clean error.
+        """
+        block_chunks = endpoint_translation.build_block_sse_chunks(
+            exc, stream_started=stream_started, responses_so_far=responses_so_far
+        )
+        if block_chunks is None:
+            raise exc
+        for chunk in block_chunks:
+            yield chunk
+
     async def async_post_call_streaming_iterator_hook(
         self,
         user_api_key_dict: UserAPIKeyAuth,
@@ -284,26 +313,38 @@ class UnifiedLLMGuardrails(CustomLogger):
 
         global endpoint_guardrail_translation_mappings
 
+        # Local import avoids a module-level cyclic import with
+        # litellm.integrations.custom_guardrail.
+        from litellm.integrations.custom_guardrail import ModifyResponseException
+
         guardrail_to_apply: CustomGuardrail = request_data.pop("guardrail_to_apply", None)
 
-        # Get streaming configuration from guardrail or optional_params
-        sampling_rate = 5
-        end_of_stream_only = False  # If True, only apply guardrail at end of stream
+        # Get streaming configuration, with precedence: guardrail attribute ->
+        # guardrail_config dict -> this callback's optional_params.
+        def _streaming_flag(name: str, default: Any) -> Any:
+            value = default
+            if guardrail_to_apply is not None:
+                value = getattr(guardrail_to_apply, name, value)
+                config = getattr(guardrail_to_apply, "guardrail_config", {})
+                if isinstance(config, dict):
+                    value = config.get(name, value)
+            return self.optional_params.get(name, value)
 
-        if guardrail_to_apply is not None:
-            # Check direct attributes on guardrail first
-            sampling_rate = getattr(guardrail_to_apply, "streaming_sampling_rate", sampling_rate)
-            end_of_stream_only = getattr(guardrail_to_apply, "streaming_end_of_stream_only", end_of_stream_only)
+        sampling_rate = _streaming_flag("streaming_sampling_rate", 5)
+        # Only apply the guardrail at end of stream (not per chunk).
+        end_of_stream_only = _streaming_flag("streaming_end_of_stream_only", False)
+        # Withhold every chunk until end-of-stream moderation passes, then
+        # release the original chunks (clean) or only the block message
+        # (blocked) -- moderating the whole response *before* any content
+        # reaches the client. Intended for allow/block guardrails: on release
+        # the original chunks are replayed as-is, so content-rewriting
+        # guardrails (e.g. PII masking) are not applied to a buffered stream.
+        buffer_until_moderated = _streaming_flag("streaming_buffer_until_moderated", False)
 
-            # Also check guardrail_config dict if present
-            guardrail_config = getattr(guardrail_to_apply, "guardrail_config", {})
-            if isinstance(guardrail_config, dict):
-                sampling_rate = guardrail_config.get("streaming_sampling_rate", sampling_rate)
-                end_of_stream_only = guardrail_config.get("streaming_end_of_stream_only", end_of_stream_only)
-
-        # Also check optional_params as fallback
-        sampling_rate = self.optional_params.get("streaming_sampling_rate", sampling_rate)
-        end_of_stream_only = self.optional_params.get("streaming_end_of_stream_only", end_of_stream_only)
+        # Buffering can only moderate the assembled response, so it always
+        # defers to end-of-stream.
+        if buffer_until_moderated:
+            end_of_stream_only = True
 
         if guardrail_to_apply is None:
             async for item in response:
@@ -328,6 +369,10 @@ class UnifiedLLMGuardrails(CustomLogger):
         call_type = None
         chunk_counter = 0
         responses_so_far: List[Any] = []
+        # Whether any real response chunk has been forwarded to the client.
+        # Drives how a block terminates the stream: continue the in-progress
+        # message (True) vs emit a standalone block message (False, buffered).
+        chunks_yielded = False
 
         async for item in response:
             chunk_counter += 1
@@ -349,9 +394,14 @@ class UnifiedLLMGuardrails(CustomLogger):
                     yield remaining_item
                 return
 
-            # If end_of_stream_only mode, yield chunks without processing
+            # If end_of_stream_only mode, yield chunks without processing.
+            # When buffering, withhold them instead -- they are released (or
+            # replaced by the block message) only after end-of-stream
+            # moderation runs below.
             if end_of_stream_only:
-                yield item
+                if not buffer_until_moderated:
+                    chunks_yielded = True
+                    yield item
                 continue
 
             # Process chunk based on sampling rate
@@ -381,6 +431,24 @@ class UnifiedLLMGuardrails(CustomLogger):
                         user_api_key_dict=user_api_key_dict,
                         request_data=request_data,
                     )
+                except ModifyResponseException as e:
+                    # Guardrail blocked the response mid-stream. Emit a clean
+                    # terminating SSE sequence delivering the block message
+                    # instead of letting the exception propagate into a bare
+                    # `data: {"error": ...}` blob (which truncates the stream).
+                    # Chunks have already been forwarded here, so the block
+                    # continues the in-progress message (stream_started=True).
+                    # The current chunk was appended to responses_so_far but not
+                    # yet yielded, so exclude it: the continuation must reflect
+                    # only what the client has actually received.
+                    async for block_chunk in self._handle_streaming_block(
+                        e,
+                        endpoint_translation,
+                        stream_started=chunks_yielded,
+                        responses_so_far=responses_so_far[:-1],
+                    ):
+                        yield block_chunk
+                    return
                 except HTTPException as e:
                     # Response already started (we already yielded chunks); cannot send 400.
                     # For A2A (NDJSON), yield an in-stream JSON-RPC error so the client sees it.
@@ -407,8 +475,10 @@ class UnifiedLLMGuardrails(CustomLogger):
                         yield error_chunk
                         return
                     raise
+                chunks_yielded = True
                 yield original_item
             else:
+                chunks_yielded = True
                 yield item
 
         # Stream has ended - do final processing with all collected chunks
@@ -421,6 +491,15 @@ class UnifiedLLMGuardrails(CustomLogger):
 
             endpoint_translation = endpoint_guardrail_translation_mappings[CallTypes(call_type)]()
 
+            # When buffering, snapshot the original chunks before moderation.
+            # A shallow copy suffices: end-of-stream
+            # process_output_streaming_response builds a separate assembled
+            # response (it does not mutate the individual chunks in place), and
+            # the chunks themselves are replayed verbatim -- so we only need to
+            # preserve the list, not clone every chunk (deepcopy would double
+            # peak memory for large responses).
+            buffered_items = list(responses_so_far) if buffer_until_moderated else None
+
             try:
                 await endpoint_translation.process_output_streaming_response(
                     responses_so_far=responses_so_far,
@@ -429,6 +508,23 @@ class UnifiedLLMGuardrails(CustomLogger):
                     user_api_key_dict=user_api_key_dict,
                     request_data=request_data,
                 )
+                # Moderation passed: release the withheld original chunks.
+                if buffered_items is not None:
+                    for buffered_item in buffered_items:
+                        yield buffered_item
+            except ModifyResponseException as e:
+                # Block detected during end-of-stream processing. Emit a clean
+                # terminating SSE sequence with the block message rather than
+                # propagating into a bare error blob that truncates the stream.
+                # The withheld original chunks are never released.
+                async for block_chunk in self._handle_streaming_block(
+                    e,
+                    endpoint_translation,
+                    stream_started=chunks_yielded,
+                    responses_so_far=responses_so_far,
+                ):
+                    yield block_chunk
+                return
             except HTTPException as e:
                 if call_type is not None and CallTypes(call_type) in A2A_CALL_TYPES:
                     request_id = _get_a2a_request_id(responses_so_far, request_data)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -467,6 +467,9 @@ from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
 from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
     router as pass_through_router,
 )
+from litellm.proxy.collector_endpoints.spend_logs import (
+    router as collector_spend_logs_router,
+)
 from litellm.proxy.public_endpoints import router as public_endpoints_router
 from litellm.proxy.rag_endpoints.endpoints import router as rag_router
 from litellm.proxy.rerank_endpoints.endpoints import router as rerank_router
@@ -875,6 +878,8 @@ async def proxy_startup_event(app: FastAPI):
             proxy_logging_obj=proxy_logging_obj,
             user_api_key_cache=user_api_key_cache,
         )
+    if app is not None:
+        app.state.prisma_client = prisma_client
 
     if prisma_client is not None:
 
@@ -1922,6 +1927,8 @@ store_model_in_db: bool = False
 open_telemetry_logger: Optional[OpenTelemetry] = None
 ### INITIALIZE GLOBAL LOGGING OBJECT ###
 proxy_logging_obj: ProxyLogging = ProxyLogging(user_api_key_cache=user_api_key_cache, premium_user=premium_user)
+app.state.proxy_logging_obj = proxy_logging_obj
+app.state.prisma_client = prisma_client
 ### REDIS QUEUE ###
 async_result = None
 celery_app_conn = None
@@ -15641,6 +15648,7 @@ app.include_router(team_router)
 app.include_router(ui_sso_router)
 app.include_router(organization_router)
 app.include_router(customer_router)
+app.include_router(collector_spend_logs_router)
 app.include_router(spend_management_router)
 app.include_router(caching_router)
 app.include_router(analytics_router)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -8361,6 +8361,22 @@ async def model_info(
     )
 
 
+def _blocked_response_usage(original_response: Optional[Any]) -> "litellm.Usage":
+    """
+    Token usage for a synthetic guardrail-blocked response.
+
+    A post-call block replaces the LLM's response with the violation message,
+    but the upstream call already consumed tokens -- report that real usage
+    (carried on ``ModifyResponseException.original_response``) rather than
+    discarding it. Pre-call blocks never invoked the LLM (no original_response),
+    so usage is zero.
+    """
+    usage = getattr(original_response, "usage", None) if original_response is not None else None
+    if isinstance(usage, litellm.Usage):
+        return usage
+    return litellm.Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
+
+
 @router.post(
     "/v1/chat/completions",
     dependencies=[Depends(user_api_key_auth)],
@@ -8467,6 +8483,9 @@ async def chat_completion(
         _chat_response.model = e.model  # type: ignore
         _chat_response.choices[0].message.content = e.message  # type: ignore
         _chat_response.choices[0].finish_reason = "content_filter"  # type: ignore
+        # Report the blocked LLM response's real usage (set before the stream
+        # branch so both paths carry it); zero for pre-call blocks.
+        _chat_response.usage = _blocked_response_usage(e.original_response)  # type: ignore
 
         if data.get("stream", None) is not None and data["stream"] is True:
             _iterator = litellm.utils.ModelResponseIterator(model_response=_chat_response, convert_to_delta=True)
@@ -8488,8 +8507,6 @@ async def chat_completion(
                 media_type="text/event-stream",
                 status_code=200,  # Return 200 for passthrough mode
             )
-        _usage = litellm.Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
-        _chat_response.usage = _usage  # type: ignore
         return _chat_response
     except RejectedRequestError as e:
         _data = e.request_data
@@ -8618,11 +8635,7 @@ async def completion(
             # Set text attribute dynamically for text completion format
             setattr(_text_response.choices[0], "text", e.message)
             _text_response.model = e.model  # type: ignore[assignment]
-            _usage = litellm.Usage(
-                prompt_tokens=0,
-                completion_tokens=0,
-                total_tokens=0,
-            )
+            _usage = _blocked_response_usage(e.original_response)
             # Set usage attribute dynamically (ModelResponse accepts usage in __init__ but it's not in type definition)
             setattr(_text_response, "usage", _usage)
             _iterator = litellm.utils.ModelResponseIterator(model_response=_text_response, convert_to_delta=True)
@@ -8647,11 +8660,7 @@ async def completion(
             _response = litellm.TextCompletionResponse()
             _response.choices[0].text = e.message
             _response.model = e.model  # type: ignore
-            _usage = litellm.Usage(
-                prompt_tokens=0,
-                completion_tokens=0,
-                total_tokens=0,
-            )
+            _usage = _blocked_response_usage(e.original_response)
             _response.usage = _usage  # type: ignore
             return _response
     except RejectedRequestError as e:

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -216,6 +216,35 @@ async def aresponses_api_with_mcp(
     )
     openai_tools = LiteLLM_Proxy_MCP_Handler._transform_mcp_tools_to_openai(original_mcp_tools)
 
+    if (
+        litellm.reject_empty_mcp_resolved_tools
+        and mcp_tools_with_litellm_proxy
+        and not original_mcp_tools
+        and not other_tools
+    ):
+        # The request explicitly asked for MCP tools but none resolved, and
+        # there are no other tools to fall back on. This is almost always a
+        # misconfiguration: the API key/team has no access to the MCP server
+        # (allow_all_keys=false and no object-permission grant), the server
+        # name does not exist, or allowed_tools matches no tool on the server.
+        # Silently calling the model with no tools makes it hallucinate, and
+        # the only trace is a list_mcp_tools spend log with an empty response —
+        # so fail loudly instead.
+        requested_mcp_urls = [tool.get("server_url") for tool in mcp_tools_with_litellm_proxy if isinstance(tool, dict)]
+        raise litellm.BadRequestError(
+            message=(
+                "MCP gateway resolved 0 tools for the requested MCP tool(s) "
+                f"(server_url(s): {requested_mcp_urls}). Likely causes: the API "
+                "key/team does not have access to the MCP server (server has "
+                "allow_all_keys=false and no key/team object-permission grant), "
+                "the server name does not exist, or allowed_tools matches no "
+                "tool on the server. Set litellm.reject_empty_mcp_resolved_tools "
+                "= False to restore the previous silent behaviour."
+            ),
+            model=model,
+            llm_provider=custom_llm_provider or "openai",
+        )
+
     # Combine with other tools
     all_tools = openai_tools + other_tools if (openai_tools or other_tools) else None
 

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -261,7 +261,7 @@ async def aresponses_api_with_mcp(
             pre_processed_mcp_tools=original_mcp_tools,
         )
 
-        return LiteLLM_Proxy_MCP_Handler._create_mcp_streaming_response(
+        mcp_streaming_response = LiteLLM_Proxy_MCP_Handler._create_mcp_streaming_response(
             input=input,
             model=model,
             all_tools=all_tools,
@@ -272,6 +272,16 @@ async def aresponses_api_with_mcp(
             tool_server_map=tool_server_map,
             **kwargs,
         )
+        # Make the initial LLM call eagerly, before any SSE bytes are written,
+        # so a pre-stream failure (e.g. an invalid previous_response_id ->
+        # provider 400 "No tool output found for function call ...") surfaces
+        # as a normal HTTP error instead of an HTTP 200 whose stream emits
+        # mcp_list_tools events with no response.created (which crashes SDK
+        # stream accumulators).
+        await mcp_streaming_response._create_initial_response_iterator()
+        if mcp_streaming_response._initial_creation_error is not None:
+            raise mcp_streaming_response._initial_creation_error
+        return mcp_streaming_response
 
     # Determine if we should auto-execute tools
     should_auto_execute = bool(mcp_tools_with_litellm_proxy) and LiteLLM_Proxy_MCP_Handler._should_auto_execute_tools(

--- a/litellm/responses/mcp/mcp_streaming_iterator.py
+++ b/litellm/responses/mcp/mcp_streaming_iterator.py
@@ -306,10 +306,10 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         # Cache the response ID to ensure consistency across all events
         self._cached_response_id: Optional[str] = None
 
-        # Initial-LLM-call failures are stashed here so they can be surfaced
-        # to the client as an `error` stream event (lazy path) or re-raised
-        # before any SSE bytes are written (eager path in
-        # aresponses_api_with_mcp).
+        # Internal failures (initial LLM call, tool execution, follow-up call)
+        # are stashed here so they can be surfaced to the client as an `error`
+        # stream event, or re-raised before any SSE bytes are written (eager
+        # path in aresponses_api_with_mcp for the initial call).
         self._initial_creation_error: Optional[Exception] = None
         self._stream_error: Optional[Exception] = None
         self._error_event_emitted = False
@@ -456,6 +456,12 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
                     raise
             else:
                 self.phase = "finished"
+                # Tool execution or the follow-up call failed: emit a terminal
+                # `error` event so the client can distinguish a failed stream
+                # from a completed one.
+                if self._stream_error is not None and not self._error_event_emitted:
+                    self._error_event_emitted = True
+                    return self._make_stream_error_event()
                 raise StopAsyncIteration
 
         # Phase 6: Finished
@@ -727,10 +733,20 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
 
             traceback.print_exc()
             self.tool_results = []
+            # Remember the failure. Without this, the follow-up call is made
+            # with function_call items but no function_call_output items and
+            # the provider rejects it with "No tool output found for function
+            # call ...".
+            self._stream_error = e
 
     async def _create_follow_up_iterator(self) -> None:
         """Create the follow-up response iterator with tool results"""
         if not self.collected_response or not hasattr(self, "tool_results"):
+            return
+        # Tool execution already failed; skip the doomed follow-up call (it
+        # would be rejected with "No tool output found for function call ...")
+        # and let __anext__ emit the terminal error event.
+        if self._stream_error is not None:
             return
 
         from litellm.responses.main import aresponses
@@ -772,6 +788,9 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
 
             traceback.print_exc()
             self.follow_up_iterator = None
+            # Surface via a terminal `error` event in __anext__ instead of
+            # silently ending the stream with no terminal event.
+            self._stream_error = e
 
     def __iter__(self):
         return self

--- a/litellm/responses/mcp/mcp_streaming_iterator.py
+++ b/litellm/responses/mcp/mcp_streaming_iterator.py
@@ -5,6 +5,8 @@ from litellm._uuid import uuid
 from litellm.responses.streaming_iterator import BaseResponsesAPIStreamingIterator
 from litellm.types.llms.openai import (
     BaseLiteLLMOpenAIResponseObject,
+    ErrorEvent,
+    ErrorEventError,
     MCPCallArgumentsDeltaEvent,
     MCPCallArgumentsDoneEvent,
     MCPCallCompletedEvent,
@@ -304,6 +306,14 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         # Cache the response ID to ensure consistency across all events
         self._cached_response_id: Optional[str] = None
 
+        # Initial-LLM-call failures are stashed here so they can be surfaced
+        # to the client as an `error` stream event (lazy path) or re-raised
+        # before any SSE bytes are written (eager path in
+        # aresponses_api_with_mcp).
+        self._initial_creation_error: Optional[Exception] = None
+        self._stream_error: Optional[Exception] = None
+        self._error_event_emitted = False
+
     def _extract_mcp_headers_from_params(self) -> None:
         """Extract MCP headers from original request params to pass to tool calls"""
         from typing import Dict, Optional
@@ -367,6 +377,23 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         )
 
         return LiteLLM_Proxy_MCP_Handler._should_auto_execute_tools(self.mcp_tools_with_litellm_proxy)
+
+    def _make_stream_error_event(self) -> ResponsesAPIStreamingResponse:
+        """Build an OpenAI-style `error` stream event from the stashed internal
+        failure, so clients receive a real terminal error instead of a stream
+        that silently ends mid-flow."""
+        err = self._stream_error
+        status_code = getattr(err, "status_code", None)
+        return ErrorEvent(
+            type=ResponsesAPIStreamEvents.ERROR,
+            sequence_number=1,
+            error=ErrorEventError(
+                type="mcp_gateway_error",
+                code=str(status_code) if status_code is not None else "internal_error",
+                message=str(err) if err is not None else "MCP gateway stream failed",
+                param=None,
+            ),
+        )
 
     def __aiter__(self):
         return self
@@ -451,13 +478,17 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
             await self._create_initial_response_iterator()
 
         if self.base_iterator is None:
-            # LLM call failed — still emit MCP discovery events before finishing
-            if self.mcp_discovery_events:
-                self.phase = "mcp_discovery"
-            else:
-                self.phase = "finished"
-                raise StopAsyncIteration
-            return None
+            # The initial LLM call failed. Do NOT emit MCP discovery events: a
+            # stream that starts with mcp_list_tools events and no
+            # response.created violates the Responses API streaming contract
+            # and crashes SDK stream accumulators (openai-node: "expected
+            # 'response.created' event, got response.mcp_list_tools.in_progress").
+            # Surface the failure as an `error` event instead.
+            self.phase = "finished"
+            if self._stream_error is not None:
+                self._error_event_emitted = True
+                return self._make_stream_error_event()
+            raise StopAsyncIteration
 
         if self.base_iterator:
             if hasattr(self.base_iterator, "__anext__"):
@@ -580,8 +611,11 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
 
             traceback.print_exc()
             self.base_iterator = None
-            # Don't set phase to "finished" here — let __anext__ emit any
-            # pre-generated MCP discovery events before ending the iteration.
+            # Stash the failure so aresponses_api_with_mcp can re-raise it
+            # before any SSE bytes are written (eager creation), or so
+            # __anext__ can emit an `error` event instead of ending silently.
+            self._initial_creation_error = e
+            self._stream_error = e
 
     async def _generate_tool_execution_events(self) -> None:
         """Generate tool execution events and execute tools"""

--- a/litellm/responses/mcp/mcp_streaming_iterator.py
+++ b/litellm/responses/mcp/mcp_streaming_iterator.py
@@ -313,6 +313,10 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         self._initial_creation_error: Optional[Exception] = None
         self._stream_error: Optional[Exception] = None
         self._error_event_emitted = False
+        # Highest sequence_number emitted so far; the terminal `error` event
+        # must be numbered after it to keep the stream monotonic for strict
+        # clients.
+        self._last_sequence_number = 0
 
     def _extract_mcp_headers_from_params(self) -> None:
         """Extract MCP headers from original request params to pass to tool calls"""
@@ -386,7 +390,7 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         status_code = getattr(err, "status_code", None)
         return ErrorEvent(
             type=ResponsesAPIStreamEvents.ERROR,
-            sequence_number=1,
+            sequence_number=self._last_sequence_number + 1,
             error=ErrorEventError(
                 type="mcp_gateway_error",
                 code=str(status_code) if status_code is not None else "internal_error",
@@ -399,6 +403,13 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         return self
 
     async def __anext__(self) -> ResponsesAPIStreamingResponse:
+        chunk = await self._anext_impl()
+        sequence_number = getattr(chunk, "sequence_number", None)
+        if isinstance(sequence_number, int) and sequence_number > self._last_sequence_number:
+            self._last_sequence_number = sequence_number
+        return chunk
+
+    async def _anext_impl(self) -> ResponsesAPIStreamingResponse:
         """
         Phase-based streaming:
         1. initial_response - Stream the first LLM response (includes response.created, response.in_progress, response.output_item.added)
@@ -733,6 +744,11 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
 
             traceback.print_exc()
             self.tool_results = []
+            # Drop the queued per-tool events: emitting mcp_call.in_progress
+            # items that never receive a completed/failed terminal event is a
+            # protocol deviation. The terminal `error` event carries the
+            # failure instead.
+            self.tool_execution_events = []
             # Remember the failure. Without this, the follow-up call is made
             # with function_call items but no function_call_output items and
             # the provider rejects it with "No tool output found for function

--- a/tests/mcp_tests/test_aresponses_api_with_mcp.py
+++ b/tests/mcp_tests/test_aresponses_api_with_mcp.py
@@ -278,7 +278,12 @@ async def test_aresponses_api_with_mcp_passes_mcp_server_auth_headers_to_process
 
     async def mock_process(**kwargs):
         captured_process_kwargs.update(kwargs)
-        return ([], {})
+        from mcp.types import Tool as MCPTool
+
+        dummy_tool = MCPTool(
+            name="dummy_tool", description="dummy", inputSchema={"type": "object"}
+        )
+        return ([dummy_tool], {"dummy_tool": "dummy_server"})
 
     mock_response = ResponsesAPIResponse(
         **{

--- a/tests/test_litellm/integrations/test_prometheus_budget_metrics_timeout.py
+++ b/tests/test_litellm/integrations/test_prometheus_budget_metrics_timeout.py
@@ -1,0 +1,168 @@
+"""
+Unit tests for the per-request budget-metric emission timeout in
+PrometheusLogger._increment_remaining_budget_metrics.
+
+A slow Redis/DB lookup in one of the budget branches must not let the gather run
+unbounded; it is wrapped in asyncio.wait_for so the success-logging coroutine
+cannot exceed the LoggingWorker watchdog and get the whole event cancelled.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from prometheus_client import REGISTRY
+
+from litellm.integrations.prometheus import (
+    PrometheusLogger,
+    _DEFAULT_BUDGET_METRICS_PER_REQUEST_TIMEOUT,
+    _get_budget_metrics_per_request_timeout,
+)
+
+TIMEOUT_ENV = "PROMETHEUS_BUDGET_METRICS_PER_REQUEST_TIMEOUT"
+
+
+@pytest.fixture(autouse=True)
+def cleanup_prometheus_registry():
+    collectors = list(REGISTRY._collector_to_names.keys())
+    for collector in collectors:
+        try:
+            REGISTRY.unregister(collector)
+        except Exception:
+            pass
+    yield
+    collectors = list(REGISTRY._collector_to_names.keys())
+    for collector in collectors:
+        try:
+            REGISTRY.unregister(collector)
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def prometheus_logger():
+    return PrometheusLogger()
+
+
+def _call_increment(logger: PrometheusLogger):
+    return logger._increment_remaining_budget_metrics(
+        user_api_team="team-1",
+        user_api_team_alias="team-alias",
+        user_api_key="key-1",
+        user_api_key_alias="key-alias",
+        litellm_params={"metadata": {}},
+        response_cost=0.01,
+        user_id="user-1",
+        user_api_key_org_id="org-1",
+    )
+
+
+def _skip_logged(debug_mock) -> bool:
+    return any("skipping" in str(call.args[0]) for call in debug_mock.call_args_list if call.args)
+
+
+@pytest.mark.asyncio
+async def test_budget_metric_emission_skips_on_timeout(prometheus_logger, monkeypatch):
+    """A branch slower than the timeout is skipped without propagating, and the
+    skip is logged instead of cancelling the success-logging event."""
+    monkeypatch.setenv(TIMEOUT_ENV, "0.05")
+
+    async def _slow_branch(**kwargs):
+        await asyncio.sleep(30)
+
+    prometheus_logger._set_api_key_budget_metrics_after_api_request = _slow_branch
+    prometheus_logger._set_team_budget_metrics_after_api_request = AsyncMock()
+    prometheus_logger._set_user_budget_metrics_after_api_request = AsyncMock()
+    prometheus_logger._set_org_budget_metrics_after_api_request = AsyncMock()
+
+    with patch("litellm.integrations.prometheus.verbose_logger") as mock_logger:
+        await _call_increment(prometheus_logger)
+
+    assert _skip_logged(mock_logger.debug)
+
+
+@pytest.mark.asyncio
+async def test_budget_metric_emission_completes_within_timeout(prometheus_logger, monkeypatch):
+    """With a generous timeout every branch is awaited and no skip is logged."""
+    monkeypatch.setenv(TIMEOUT_ENV, "5.0")
+
+    prometheus_logger._set_api_key_budget_metrics_after_api_request = AsyncMock()
+    prometheus_logger._set_team_budget_metrics_after_api_request = AsyncMock()
+    prometheus_logger._set_user_budget_metrics_after_api_request = AsyncMock()
+    prometheus_logger._set_org_budget_metrics_after_api_request = AsyncMock()
+
+    with patch("litellm.integrations.prometheus.verbose_logger") as mock_logger:
+        await _call_increment(prometheus_logger)
+
+    assert prometheus_logger._set_api_key_budget_metrics_after_api_request.await_count == 1
+    assert prometheus_logger._set_team_budget_metrics_after_api_request.await_count == 1
+    assert prometheus_logger._set_user_budget_metrics_after_api_request.await_count == 1
+    assert prometheus_logger._set_org_budget_metrics_after_api_request.await_count == 1
+    assert not _skip_logged(mock_logger.debug)
+
+
+@pytest.mark.asyncio
+async def test_invalid_timeout_env_falls_back_to_default(prometheus_logger, monkeypatch):
+    """A malformed timeout env value must not raise (which would recreate the
+    failure mode); it falls back to the default and every branch still runs."""
+    monkeypatch.setenv(TIMEOUT_ENV, "not-a-number")
+
+    prometheus_logger._set_api_key_budget_metrics_after_api_request = AsyncMock()
+    prometheus_logger._set_team_budget_metrics_after_api_request = AsyncMock()
+    prometheus_logger._set_user_budget_metrics_after_api_request = AsyncMock()
+    prometheus_logger._set_org_budget_metrics_after_api_request = AsyncMock()
+
+    await _call_increment(prometheus_logger)
+
+    assert prometheus_logger._set_api_key_budget_metrics_after_api_request.await_count == 1
+    assert prometheus_logger._set_org_budget_metrics_after_api_request.await_count == 1
+
+
+@pytest.mark.parametrize("value", ["not-a-number", "0", "-1", "nan", "inf", "-inf"])
+def test_unusable_timeout_env_falls_back_to_default(value, monkeypatch):
+    """Values that parse but disable or unbound the timeout (0, negative, nan,
+    inf) must fall back to the default instead of being used; otherwise they
+    either skip every emission or recreate the unbounded-wait failure mode."""
+    monkeypatch.setenv(TIMEOUT_ENV, value)
+
+    assert _get_budget_metrics_per_request_timeout() == _DEFAULT_BUDGET_METRICS_PER_REQUEST_TIMEOUT
+
+
+@pytest.mark.parametrize("value,expected", [("0.05", 0.05), ("5.0", 5.0), ("30", 30.0)])
+def test_valid_timeout_env_is_used(value, expected, monkeypatch):
+    """A finite positive value is parsed and returned unchanged."""
+    monkeypatch.setenv(TIMEOUT_ENV, value)
+
+    assert _get_budget_metrics_per_request_timeout() == expected
+
+
+def test_missing_timeout_env_uses_default(monkeypatch):
+    """With the env unset the default is returned."""
+    monkeypatch.delenv(TIMEOUT_ENV, raising=False)
+
+    assert _get_budget_metrics_per_request_timeout() == _DEFAULT_BUDGET_METRICS_PER_REQUEST_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_outer_cancellation_still_propagates(prometheus_logger, monkeypatch):
+    """Only asyncio.TimeoutError is swallowed; an outer cancellation (cooperative
+    shutdown / watchdog) injected while awaiting must still propagate."""
+    monkeypatch.setenv(TIMEOUT_ENV, "30")
+
+    started = asyncio.Event()
+
+    async def _slow_branch(**kwargs):
+        started.set()
+        await asyncio.sleep(30)
+
+    prometheus_logger._set_api_key_budget_metrics_after_api_request = _slow_branch
+    prometheus_logger._set_team_budget_metrics_after_api_request = AsyncMock()
+    prometheus_logger._set_user_budget_metrics_after_api_request = AsyncMock()
+    prometheus_logger._set_org_budget_metrics_after_api_request = AsyncMock()
+
+    task = asyncio.create_task(_call_increment(prometheus_logger))
+    await started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py
@@ -58,15 +58,71 @@ class TestAnthropicEndpoints(unittest.TestCase):
         self.assertEqual(result, expected_result)
 
         # Assert safe_dumps was called for dictionary objects
-        mock_safe_dumps.assert_any_call(
-            {"type": "message_start", "message": {"id": "msg_123"}}
+        mock_safe_dumps.assert_any_call({"type": "message_start", "message": {"id": "msg_123"}})
+        mock_safe_dumps.assert_any_call({"type": "content_block_delta", "delta": {"text": "more data"}})
+        assert mock_safe_dumps.call_count == 2  # Called twice, once for each dict object
+
+
+class TestBlockedResponseUsage:
+    """Blocked responses report the blocked LLM response's real usage."""
+
+    def test_uses_original_response_usage(self):
+        from litellm.proxy.anthropic_endpoints.endpoints import _blocked_response_usage
+
+        # original_response is the AnthropicMessagesResponse the LLM produced
+        # before the guardrail blocked it; its usage is real.
+        original = {"usage": {"input_tokens": 31, "output_tokens": 9}}
+        assert _blocked_response_usage(original) == {
+            "input_tokens": 31,
+            "output_tokens": 9,
+        }
+
+    def test_zero_usage_when_no_original_response(self):
+        from litellm.proxy.anthropic_endpoints.endpoints import _blocked_response_usage
+
+        # Pre-call blocks never invoked the LLM -> nothing consumed.
+        assert _blocked_response_usage(None) == {
+            "input_tokens": 0,
+            "output_tokens": 0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_blocked_endpoint_response_carries_original_usage(self):
+        """The /v1/messages block handler reports the blocked response's real
+        usage, carried on ModifyResponseException.original_response."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        import litellm.proxy.anthropic_endpoints.endpoints as ep
+        import litellm.proxy.proxy_server as proxy_server
+        from litellm.integrations.custom_guardrail import ModifyResponseException
+
+        exc = ModifyResponseException(
+            message="blocked by guardrail",
+            model="claude-3-5-sonnet-20240620",
+            request_data={"messages": [{"role": "user", "content": "hi"}]},
+            guardrail_name="rubrik",
+            original_response={"usage": {"input_tokens": 12, "output_tokens": 5}},
         )
-        mock_safe_dumps.assert_any_call(
-            {"type": "content_block_delta", "delta": {"text": "more data"}}
-        )
-        assert (
-            mock_safe_dumps.call_count == 2
-        )  # Called twice, once for each dict object
+
+        with (
+            patch.object(ep, "_read_request_body", new=AsyncMock(return_value={})),
+            patch.object(
+                ep.ProxyBaseLLMRequestProcessing,
+                "base_process_llm_request",
+                new=AsyncMock(side_effect=exc),
+            ),
+            patch.object(proxy_server, "proxy_logging_obj") as mock_logging,
+        ):
+            mock_logging.post_call_failure_hook = AsyncMock()
+            response = await ep.anthropic_response(
+                fastapi_response=MagicMock(),
+                request=MagicMock(),
+                user_api_key_dict=MagicMock(),
+            )
+
+        assert response["content"][0]["text"] == "blocked by guardrail"
+        assert response["usage"] == {"input_tokens": 12, "output_tokens": 5}
+        mock_logging.post_call_failure_hook.assert_awaited_once()
 
 
 class TestEventLoggingBatchEndpoint:
@@ -159,9 +215,7 @@ class TestStripTotalTokens(unittest.TestCase):
 
         # SimpleNamespace mimics the .usage attribute access pattern; the
         # helper's contract: if .usage is dict-shaped, strip total_tokens.
-        response = SimpleNamespace(
-            usage={"input_tokens": 100, "output_tokens": 50, "total_tokens": 150}
-        )
+        response = SimpleNamespace(usage={"input_tokens": 100, "output_tokens": 50, "total_tokens": 150})
         _strip_total_tokens_from_anthropic_response(response)
         assert "total_tokens" not in response.usage
         assert response.usage == {"input_tokens": 100, "output_tokens": 50}

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -86,6 +86,60 @@ def test_compliance_routes_open_to_non_admin_roles(role, route):
     )
 
 
+def test_collector_spend_logs_requires_explicit_allowed_route_for_non_admin_key():
+    """Collector ingestion is a write path and must not be open to every key."""
+    user_obj = LiteLLM_UserTable(
+        user_id="relay_user",
+        user_email="relay@example.com",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+    valid_token = UserAPIKeyAuth(
+        user_id="relay_user",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+
+    with pytest.raises(Exception) as exc_info:
+        RouteChecks.non_proxy_admin_allowed_routes_check(
+            user_obj=user_obj,
+            _user_role=LitellmUserRoles.INTERNAL_USER.value,
+            route="/collector/spend-logs",
+            request=request,
+            valid_token=valid_token,
+            request_data={},
+        )
+
+    assert "Only proxy admin" in str(exc_info.value)
+    assert "Route=/collector/spend-logs" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("allowed_route", ["/collector/spend-logs", "/collector/*"])
+def test_collector_spend_logs_allows_explicit_allowed_route(allowed_route):
+    """Relay keys can be scoped to only the collector ingest endpoint."""
+    user_obj = LiteLLM_UserTable(
+        user_id="relay_user",
+        user_email="relay@example.com",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+    valid_token = UserAPIKeyAuth(
+        user_id="relay_user",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+        allowed_routes=[allowed_route],
+    )
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+
+    RouteChecks.non_proxy_admin_allowed_routes_check(
+        user_obj=user_obj,
+        _user_role=LitellmUserRoles.INTERNAL_USER.value,
+        route="/collector/spend-logs",
+        request=request,
+        valid_token=valid_token,
+        request_data={},
+    )
+
+
 def test_proxy_admin_viewer_config_update_route_rejected():
     """Test that proxy admin viewer users are rejected when trying to call /config/update"""
 

--- a/tests/test_litellm/proxy/collector_endpoints/test_spend_logs.py
+++ b/tests/test_litellm/proxy/collector_endpoints/test_spend_logs.py
@@ -1,0 +1,323 @@
+import asyncio
+import json
+
+from fastapi.testclient import TestClient
+
+import litellm.proxy.proxy_server as ps
+import litellm.proxy.collector_endpoints.spend_logs as collector_spend_logs
+from litellm.constants import MAX_COLLECTOR_SPEND_LOG_BYTES
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy.proxy_server import app
+
+
+class MockPrismaClient:
+    def __init__(self):
+        self.spend_log_transactions = []
+        self._spend_log_transactions_lock = asyncio.Lock()
+
+
+def _set_collector_runtime(monkeypatch, prisma_client):
+    monkeypatch.setattr(ps, "prisma_client", prisma_client)
+    monkeypatch.setattr(app.state, "prisma_client", prisma_client, raising=False)
+
+
+def test_collector_spend_logs_enqueues_batcher_rows(monkeypatch):
+    prisma_client = MockPrismaClient()
+    _set_collector_runtime(monkeypatch, prisma_client)
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user",
+        api_key="hashed-admin-key",
+        team_id="team-1",
+    )
+
+    try:
+        response = TestClient(app).post(
+            "/collector/spend-logs",
+            json={
+                "logs": [
+                    {
+                        "request_id": "relay-test-request",
+                        "model": "notion-ai",
+                        "metadata": {"app": "notion", "host": "www.notion.so"},
+                        "proxy_server_request": {
+                            "method": "POST",
+                            "body_preview": "hi",
+                        },
+                        "response": {
+                            "status_code": 200,
+                            "body_preview": "hello",
+                        },
+                        "request_duration_ms": 42,
+                    }
+                ]
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json() == {"enqueued": 1}
+        assert len(prisma_client.spend_log_transactions) == 1
+        row = prisma_client.spend_log_transactions[0]
+        assert row["request_id"].startswith("collector-")
+        assert row["request_id"] != "relay-test-request"
+        assert row["call_type"] == "litellm-relay"
+        assert row["model"] == "notion-ai"
+        assert row["spend"] == 0.0
+        assert row["team_id"] == "team-1"
+        assert row["metadata"]["source"] == "litellm-relay"
+        assert row["metadata"]["user_api_key_team_alias"] is None
+        assert row["metadata"]["collector_request_id"] == "relay-test-request"
+        assert row["metadata"]["app"] == "notion"
+        assert row["proxy_server_request"]["body_preview"] == "hi"
+        assert row["response"]["body_preview"] == "hello"
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+def test_collector_spend_logs_attributes_valid_virtual_key(monkeypatch):
+    prisma_client = MockPrismaClient()
+    _set_collector_runtime(monkeypatch, prisma_client)
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="user_1",
+        api_key="hashed-virtual-key",
+        team_id="team_1",
+        team_alias="Relay Team",
+        key_alias="relay-key",
+        organization_id="org_1",
+    )
+
+    try:
+        response = TestClient(app).post(
+            "/collector/spend-logs",
+            json={
+                "logs": [
+                    {
+                        "request_id": "relay-test-request",
+                        "api_key": "client-supplied-key-is-ignored",
+                        "spend": 10,
+                        "team_id": "client-team-is-ignored",
+                        "organization_id": "client-org-is-ignored",
+                        "user": "client-user-is-ignored",
+                        "custom_llm_provider": "client-provider-is-ignored",
+                        "metadata": {
+                            "source": "client-source-is-ignored",
+                            "user_api_key": "client-key-is-ignored",
+                        },
+                    }
+                ]
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+
+        assert response.status_code == 200, response.text
+        row = prisma_client.spend_log_transactions[0]
+        assert row["api_key"] == "hashed-virtual-key"
+        assert row["spend"] == 0.0
+        assert row["team_id"] == "team_1"
+        assert row["organization_id"] == "org_1"
+        assert row["user"] == "user_1"
+        assert row["custom_llm_provider"] == ""
+        assert row["metadata"]["source"] == "litellm-relay"
+        assert row["metadata"]["user_api_key"] == "hashed-virtual-key"
+        assert row["metadata"]["user_api_key_alias"] == "relay-key"
+        assert row["metadata"]["user_api_key_team_alias"] == "Relay Team"
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+def test_collector_spend_logs_accepts_json_object_request_tags(monkeypatch):
+    prisma_client = MockPrismaClient()
+    _set_collector_runtime(monkeypatch, prisma_client)
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user",
+        api_key="hashed-admin-key",
+    )
+
+    try:
+        response = TestClient(app).post(
+            "/collector/spend-logs",
+            json={
+                "logs": [
+                    {
+                        "request_id": "relay-json-tags-test",
+                        "request_tags": '{"source":"notion"}',
+                    }
+                ]
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+
+        assert response.status_code == 200, response.text
+        row = prisma_client.spend_log_transactions[0]
+        assert json.loads(row["request_tags"]) == [
+            {"source": "notion"},
+            "litellm-relay",
+        ]
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+def test_collector_spend_logs_strips_nul_bytes(monkeypatch):
+    prisma_client = MockPrismaClient()
+    _set_collector_runtime(monkeypatch, prisma_client)
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="user_1",
+        api_key="hashed-virtual-key",
+    )
+
+    try:
+        response = TestClient(app).post(
+            "/collector/spend-logs",
+            json={
+                "logs": [
+                    {
+                        "request_id": "relay-nul-test",
+                        "proxy_server_request": {"body_preview": "hello\u0000world"},
+                        "response": {"body_preview": "ok\u0000"},
+                    }
+                ]
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+
+        assert response.status_code == 200, response.text
+        row_text = json.dumps(prisma_client.spend_log_transactions[0], default=str)
+        assert "\u0000" not in row_text
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+def test_collector_spend_logs_rejects_oversized_log(monkeypatch):
+    prisma_client = MockPrismaClient()
+    _set_collector_runtime(monkeypatch, prisma_client)
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user",
+        api_key="hashed-admin-key",
+    )
+
+    try:
+        response = TestClient(app).post(
+            "/collector/spend-logs",
+            json={
+                "logs": [
+                    {
+                        "request_id": "large-relay-request",
+                        "proxy_server_request": {"body_preview": "x" * (MAX_COLLECTOR_SPEND_LOG_BYTES + 1)},
+                    }
+                ]
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+
+        assert response.status_code == 413, response.text
+        assert prisma_client.spend_log_transactions == []
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+def test_collector_spend_logs_rejects_normalized_row_over_size_limit(monkeypatch):
+    prisma_client = MockPrismaClient()
+    _set_collector_runtime(monkeypatch, prisma_client)
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user",
+        api_key="hashed-admin-key",
+    )
+
+    try:
+        response = TestClient(app).post(
+            "/collector/spend-logs",
+            json={
+                "logs": [
+                    {
+                        "request_id": "normalized-large-relay-request",
+                        "proxy_server_request": {"body_preview": "x" * (MAX_COLLECTOR_SPEND_LOG_BYTES - 50)},
+                    }
+                ]
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+
+        assert response.status_code == 413, response.text
+        assert prisma_client.spend_log_transactions == []
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+def test_collector_spend_logs_rejects_oversized_batch(monkeypatch):
+    prisma_client = MockPrismaClient()
+    _set_collector_runtime(monkeypatch, prisma_client)
+    monkeypatch.setattr(
+        collector_spend_logs,
+        "MAX_COLLECTOR_SPEND_LOG_BATCH_BYTES",
+        900,
+    )
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user",
+        api_key="hashed-admin-key",
+    )
+
+    try:
+        response = TestClient(app).post(
+            "/collector/spend-logs",
+            json={
+                "logs": [
+                    {
+                        "request_id": f"batch-relay-request-{idx}",
+                        "proxy_server_request": {"body_preview": "x" * 200},
+                    }
+                    for idx in range(5)
+                ]
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+
+        assert response.status_code == 413, response.text
+        assert prisma_client.spend_log_transactions == []
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+def test_collector_spend_logs_rejects_when_queue_is_full(monkeypatch):
+    prisma_client = MockPrismaClient()
+    prisma_client.spend_log_transactions = [{} for _ in range(3)]
+    _set_collector_runtime(monkeypatch, prisma_client)
+    monkeypatch.setattr(
+        collector_spend_logs,
+        "LITELLM_ASYNCIO_QUEUE_MAXSIZE",
+        3,
+    )
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin_user",
+        api_key="hashed-admin-key",
+    )
+
+    try:
+        response = TestClient(app).post(
+            "/collector/spend-logs",
+            json={
+                "logs": [
+                    {
+                        "request_id": "queued-relay-request",
+                    }
+                ]
+            },
+            headers={"Authorization": "Bearer sk-test"},
+        )
+
+        assert response.status_code == 429, response.text
+        assert response.json()["detail"] == {
+            "error": "Collector spend-log queue is full",
+            "queued": 3,
+            "limit": 3,
+        }
+        assert len(prisma_client.spend_log_transactions) == 3
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_anthropic_streaming_block.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_anthropic_streaming_block.py
@@ -217,6 +217,61 @@ async def test_end_of_stream_only_block_does_not_append_after_message_stop():
     assert message_delta_usages[-1] == 5
 
 
+def test_blocked_stream_reports_usage_from_original_chunks():
+    from litellm.integrations.custom_guardrail import ModifyResponseException
+    from litellm.llms.anthropic.chat.guardrail_translation.handler import (
+        AnthropicMessagesHandler,
+    )
+    from litellm.llms.base_llm.guardrail_translation.utils import (
+        blocked_response_usage,
+    )
+
+    original_chunks: List[Any] = [
+        _sse_event(
+            "message_start",
+            {
+                "type": "message_start",
+                "message": {
+                    "id": "msg_orig",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "claude-3-5-sonnet",
+                    "content": [],
+                    "stop_reason": None,
+                    "usage": {"input_tokens": 12, "output_tokens": 0},
+                },
+            },
+        ),
+        {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 5}},
+    ]
+    seen_chunks = [
+        _sse_event(
+            "content_block_start",
+            {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+        )
+    ]
+    exc = ModifyResponseException(
+        message=BLOCK_MESSAGE,
+        model="claude-3-5-sonnet",
+        request_data={},
+        guardrail_name="g",
+        original_response=original_chunks,
+    )
+
+    usage = blocked_response_usage(original_chunks)
+    raw = b"".join(
+        AnthropicMessagesHandler().build_block_sse_chunks(exc, stream_started=True, responses_so_far=seen_chunks)
+    ).decode()
+    message_delta_usages = [
+        payload.get("usage", {}).get("output_tokens")
+        for payload in _parse_sse_payloads(raw)
+        if payload.get("type") == "message_delta"
+    ]
+
+    assert usage == {"input_tokens": 12, "output_tokens": 5}
+    assert message_delta_usages[-1] == 5
+
+
 class TestContentBlockState:
     """`_content_block_state` must reflect the true open/last block index across
     the two chunk formats the stream can carry (multi-event bytes, parsed dict),

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_anthropic_streaming_block.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_anthropic_streaming_block.py
@@ -1,0 +1,275 @@
+"""
+Regression tests for blocking an Anthropic streaming response from the
+unified guardrail post-call streaming iterator hook.
+
+When a guardrail's ``apply_guardrail`` raises ``ModifyResponseException`` while
+(or at the end of) an Anthropic ``/v1/messages`` stream is being relayed, the
+hook must emit a well-formed Anthropic SSE termination sequence carrying the
+block message - NOT a bare ``data: {"error": ...}`` blob that truncates the
+stream and causes the Anthropic SDK parser to discard the response.
+"""
+
+import json
+from typing import Any, List, Literal, Optional
+
+import pytest
+
+from litellm.integrations.custom_guardrail import (
+    CustomGuardrail,
+    ModifyResponseException,
+)
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.guardrails.guardrail_hooks.unified_guardrail.unified_guardrail import (
+    UnifiedLLMGuardrails,
+)
+from litellm.types.utils import GenericGuardrailAPIInputs
+
+BLOCK_MESSAGE = "Blocked by policy: this response was withheld."
+
+
+class _BlockingGuardrail(CustomGuardrail):
+    """Mock guardrail that always blocks by raising ModifyResponseException."""
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional[Any] = None,
+    ) -> GenericGuardrailAPIInputs:
+        raise ModifyResponseException(
+            message=BLOCK_MESSAGE,
+            model="claude-3-5-sonnet",
+            request_data=request_data,
+            guardrail_name=self.guardrail_name,
+        )
+
+
+def _sse_event(event_type: str, data: dict) -> bytes:
+    return f"event: {event_type}\ndata: {json.dumps(data)}\n\n".encode()
+
+
+async def _anthropic_stream(end: bool):
+    """Yield Anthropic SSE byte chunks. If end=True, include a terminating
+    message_delta (stop_reason set) so the hook's end-of-stream path runs."""
+    yield _sse_event(
+        "message_start",
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_orig",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-3-5-sonnet",
+                "content": [],
+                "stop_reason": None,
+                "usage": {"input_tokens": 1, "output_tokens": 0},
+            },
+        },
+    )
+    yield _sse_event(
+        "content_block_start",
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        },
+    )
+    for text in ["This ", "is ", "the ", "original ", "answer."]:
+        yield _sse_event(
+            "content_block_delta",
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": text},
+            },
+        )
+    if end:
+        yield _sse_event("content_block_stop", {"type": "content_block_stop", "index": 0})
+        yield _sse_event(
+            "message_delta",
+            {
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                "usage": {"output_tokens": 5},
+            },
+        )
+        yield _sse_event("message_stop", {"type": "message_stop"})
+
+
+def _decode(chunks: List[Any]) -> str:
+    parts = []
+    for chunk in chunks:
+        parts.append(chunk.decode() if isinstance(chunk, bytes) else str(chunk))
+    return "".join(parts)
+
+
+def _parse_sse_event_types(raw: str) -> List[str]:
+    event_types = []
+    for block in raw.split("\n\n"):
+        for line in block.strip().split("\n"):
+            if line.startswith("data:"):
+                payload = line[len("data:") :].strip()
+                try:
+                    event_types.append(json.loads(payload).get("type"))
+                except json.JSONDecodeError:
+                    pass
+    return event_types
+
+
+async def _run_hook(end: bool, sampling_rate: int = 1) -> str:
+    guardrail = _BlockingGuardrail(guardrail_name="test-blocking-guardrail", event_hook="post_call")
+    # sampling_rate controls how many chunks are forwarded before the block
+    # fires: 1 blocks on the first chunk (nothing sent yet); >1 forwards earlier
+    # chunks first, exercising the mid-stream "continue the message" path.
+    guardrail.streaming_sampling_rate = sampling_rate
+
+    unified_guardrail = UnifiedLLMGuardrails()
+    user_api_key_dict = UserAPIKeyAuth(api_key="test", request_route="/v1/messages")
+    request_data = {
+        "messages": [{"role": "user", "content": "hi"}],
+        "guardrail_to_apply": guardrail,
+        "metadata": {"guardrails": ["test-blocking-guardrail"]},
+    }
+
+    collected: List[Any] = []
+    async for chunk in unified_guardrail.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=user_api_key_dict,
+        response=_anthropic_stream(end=end),
+        request_data=request_data,
+    ):
+        collected.append(chunk)
+    return _decode(collected)
+
+
+def _assert_clean_block_termination(raw: str) -> None:
+    # No bare error blob that would truncate the stream.
+    assert '"error"' not in raw, f"unexpected error blob in stream: {raw!r}"
+    # The block message is delivered as assistant text.
+    assert BLOCK_MESSAGE in raw, f"block message missing from stream: {raw!r}"
+    # A complete, parseable Anthropic SSE termination sequence is present.
+    event_types = _parse_sse_event_types(raw)
+    assert "message_start" in event_types
+    assert "content_block_delta" in event_types
+    # Exactly one message_start: a block must never inject a second
+    # message envelope into an already-started stream (clients reject it).
+    assert event_types.count("message_start") == 1, f"expected a single message_start, got: {event_types}"
+    assert event_types[-1] == "message_stop", f"stream did not end cleanly: {event_types}"
+    # message_delta carries a stop_reason.
+    assert any('"stop_reason"' in block and "message_delta" in block for block in raw.split("\n\n"))
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_block_emits_clean_anthropic_sse():
+    """Per-chunk block: a clean SSE termination with the block message, no error blob."""
+    raw = await _run_hook(end=False)
+    _assert_clean_block_termination(raw)
+
+
+@pytest.mark.asyncio
+async def test_end_of_stream_block_emits_clean_anthropic_sse():
+    """End-of-stream block: same clean SSE termination guarantees."""
+    raw = await _run_hook(end=True)
+    _assert_clean_block_termination(raw)
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_block_after_prior_chunks_continues_message():
+    """Regression: when real chunks were already forwarded (sampling_rate>1),
+    the block must continue the in-progress message, not start a second one."""
+    raw = await _run_hook(end=False, sampling_rate=5)
+    # Some original content was forwarded before the block...
+    assert "message_start" in raw
+    # ...and the block continues that same message (single message_start) with
+    # the block message appended, ending cleanly.
+    _assert_clean_block_termination(raw)
+
+
+class TestContentBlockState:
+    """`_content_block_state` must reflect the true open/last block index across
+    the two chunk formats the stream can carry (multi-event bytes, parsed dict),
+    so a mid-stream block closes/opens the right indices."""
+
+    def _handler(self):
+        from litellm.llms.anthropic.chat.guardrail_translation.handler import (
+            AnthropicMessagesHandler,
+        )
+
+        return AnthropicMessagesHandler()
+
+    def test_multi_event_bytes_chunk_is_fully_parsed(self):
+        # One item bundles start(0) + delta + stop(0): the block is already
+        # closed, so open_index is None (not 0) and max_index is 0.
+        bundled = (
+            _sse_event(
+                "content_block_start",
+                {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+            )
+            + _sse_event(
+                "content_block_delta",
+                {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "hi"}},
+            )
+            + _sse_event("content_block_stop", {"type": "content_block_stop", "index": 0})
+        )
+        open_index, max_index = self._handler()._content_block_state([bundled])
+        assert open_index is None
+        assert max_index == 0
+
+    def test_open_block_across_separate_chunks(self):
+        chunks = [
+            _sse_event(
+                "content_block_start",
+                {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+            ),
+            _sse_event("content_block_stop", {"type": "content_block_stop", "index": 0}),
+            _sse_event(
+                "content_block_start",
+                {"type": "content_block_start", "index": 1, "content_block": {"type": "text", "text": ""}},
+            ),
+        ]
+        open_index, max_index = self._handler()._content_block_state(chunks)
+        assert open_index == 1
+        assert max_index == 1
+
+    def test_dict_format_chunks_are_parsed(self):
+        # The backwards-compat parsed-dict format must be understood too.
+        chunks = [
+            {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+            {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "x"}},
+        ]
+        open_index, max_index = self._handler()._content_block_state(chunks)
+        assert open_index == 0
+        assert max_index == 0
+
+    def test_continuation_closes_open_block_and_appends_after_it(self):
+        from litellm.integrations.custom_guardrail import ModifyResponseException
+
+        handler = self._handler()
+        # Client has seen an open text block at index 0.
+        seen = [
+            _sse_event(
+                "content_block_start",
+                {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+            ),
+            _sse_event(
+                "content_block_delta",
+                {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "partial"}},
+            ),
+        ]
+        exc = ModifyResponseException(
+            message=BLOCK_MESSAGE, model="claude-3-5-sonnet", request_data={}, guardrail_name="g"
+        )
+        raw = b"".join(handler.build_block_sse_chunks(exc, stream_started=True, responses_so_far=seen)).decode()
+        events = _parse_sse_event_types(raw)
+        # No new message envelope, closes block 0, appends block text at index 1.
+        assert "message_start" not in events
+        assert events == [
+            "content_block_stop",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_stop",
+            "message_delta",
+            "message_stop",
+        ]
+        assert BLOCK_MESSAGE in raw
+        assert '"index": 1' in raw

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_anthropic_streaming_block.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_anthropic_streaming_block.py
@@ -117,12 +117,13 @@ def _parse_sse_event_types(raw: str) -> List[str]:
     return event_types
 
 
-async def _run_hook(end: bool, sampling_rate: int = 1) -> str:
+async def _run_hook(end: bool, sampling_rate: int = 1, end_of_stream_only: bool = False) -> str:
     guardrail = _BlockingGuardrail(guardrail_name="test-blocking-guardrail", event_hook="post_call")
     # sampling_rate controls how many chunks are forwarded before the block
     # fires: 1 blocks on the first chunk (nothing sent yet); >1 forwards earlier
     # chunks first, exercising the mid-stream "continue the message" path.
     guardrail.streaming_sampling_rate = sampling_rate
+    guardrail.streaming_end_of_stream_only = end_of_stream_only
 
     unified_guardrail = UnifiedLLMGuardrails()
     user_api_key_dict = UserAPIKeyAuth(api_key="test", request_route="/v1/messages")
@@ -159,6 +160,21 @@ def _assert_clean_block_termination(raw: str) -> None:
     assert any('"stop_reason"' in block and "message_delta" in block for block in raw.split("\n\n"))
 
 
+def _parse_sse_payloads(raw: str) -> List[dict]:
+    payloads = []
+    for block in raw.split("\n\n"):
+        for line in block.strip().split("\n"):
+            if line.startswith("data:"):
+                payload = line[len("data:") :].strip()
+                try:
+                    parsed = json.loads(payload)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(parsed, dict):
+                    payloads.append(parsed)
+    return payloads
+
+
 @pytest.mark.asyncio
 async def test_mid_stream_block_emits_clean_anthropic_sse():
     """Per-chunk block: a clean SSE termination with the block message, no error blob."""
@@ -183,6 +199,22 @@ async def test_mid_stream_block_after_prior_chunks_continues_message():
     # ...and the block continues that same message (single message_start) with
     # the block message appended, ending cleanly.
     _assert_clean_block_termination(raw)
+
+
+@pytest.mark.asyncio
+async def test_end_of_stream_only_block_does_not_append_after_message_stop():
+    raw = await _run_hook(end=True, end_of_stream_only=True)
+    event_types = _parse_sse_event_types(raw)
+    message_delta_usages = [
+        payload.get("usage", {}).get("output_tokens")
+        for payload in _parse_sse_payloads(raw)
+        if payload.get("type") == "message_delta"
+    ]
+
+    assert BLOCK_MESSAGE in raw
+    assert event_types.count("message_stop") == 1
+    assert event_types[-1] == "message_stop"
+    assert message_delta_usages[-1] == 5
 
 
 class TestContentBlockState:

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_streaming_buffer_until_moderated.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_streaming_buffer_until_moderated.py
@@ -166,9 +166,7 @@ async def test_buffered_mode_disabled_for_content_rewriting_guardrail():
     the client would get the unredacted original instead of the moderated
     output. mask_response_content=True must force buffering off so the
     request falls back to the (correctly moderated) non-buffered path."""
-    guardrail = _PassingGuardrail(
-        guardrail_name="masker", event_hook="post_call", mask_response_content=True
-    )
+    guardrail = _PassingGuardrail(guardrail_name="masker", event_hook="post_call", mask_response_content=True)
     raw = await _run(guardrail)
     assert guardrail.streaming_buffer_until_moderated is True  # request asked for buffering
     assert ORIGINAL_MARKER in raw

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_streaming_buffer_until_moderated.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_streaming_buffer_until_moderated.py
@@ -157,3 +157,19 @@ async def test_buffered_clean_releases_all_content():
         raw.rstrip().endswith('event: message_stop\ndata: {"type": "message_stop"}'.rstrip()) or "message_stop" in raw
     )
     assert BLOCK_MESSAGE not in raw
+
+
+@pytest.mark.asyncio
+async def test_buffered_mode_disabled_for_content_rewriting_guardrail():
+    """Buffered replay yields the withheld *original* chunks verbatim, which
+    is unsafe for a guardrail that rewrites response text (e.g. PII masking):
+    the client would get the unredacted original instead of the moderated
+    output. mask_response_content=True must force buffering off so the
+    request falls back to the (correctly moderated) non-buffered path."""
+    guardrail = _PassingGuardrail(
+        guardrail_name="masker", event_hook="post_call", mask_response_content=True
+    )
+    raw = await _run(guardrail)
+    assert guardrail.streaming_buffer_until_moderated is True  # request asked for buffering
+    assert ORIGINAL_MARKER in raw
+    assert BLOCK_MESSAGE not in raw

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_streaming_buffer_until_moderated.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/unified_guardrails/test_streaming_buffer_until_moderated.py
@@ -1,0 +1,159 @@
+"""
+Tests for ``streaming_buffer_until_moderated`` on the unified guardrail
+post-call streaming iterator hook.
+
+With this flag set, the hook must withhold every upstream chunk until
+end-of-stream moderation has run. The decisive guarantee versus the
+detect-only ``streaming_end_of_stream_only`` behavior: when the guardrail
+blocks, the original (objectionable) content is NEVER yielded to the client --
+only the block message is. On a clean response, all original chunks are
+released unchanged after moderation passes.
+"""
+
+import json
+from typing import Any, List, Literal, Optional
+
+import pytest
+
+from litellm.integrations.custom_guardrail import (
+    CustomGuardrail,
+    ModifyResponseException,
+)
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.guardrails.guardrail_hooks.unified_guardrail.unified_guardrail import (
+    UnifiedLLMGuardrails,
+)
+from litellm.types.utils import GenericGuardrailAPIInputs
+
+BLOCK_MESSAGE = "Blocked by policy: this response was withheld."
+ORIGINAL_MARKER = "ORIGINAL-SECRET-ANSWER"
+
+
+class _BlockingGuardrail(CustomGuardrail):
+    """Always blocks at moderation time."""
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional[Any] = None,
+    ) -> GenericGuardrailAPIInputs:
+        raise ModifyResponseException(
+            message=BLOCK_MESSAGE,
+            model="claude-3-5-sonnet",
+            request_data=request_data,
+            guardrail_name=self.guardrail_name,
+        )
+
+
+class _PassingGuardrail(CustomGuardrail):
+    """Never blocks; returns inputs unchanged."""
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional[Any] = None,
+    ) -> GenericGuardrailAPIInputs:
+        return inputs
+
+
+def _sse_event(event_type: str, data: dict) -> bytes:
+    return f"event: {event_type}\ndata: {json.dumps(data)}\n\n".encode()
+
+
+async def _anthropic_stream():
+    """A complete Anthropic /v1/messages SSE stream whose assistant text
+    contains ORIGINAL_MARKER so leakage is unambiguous to assert."""
+    yield _sse_event(
+        "message_start",
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_orig",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-3-5-sonnet",
+                "content": [],
+                "stop_reason": None,
+                "usage": {"input_tokens": 1, "output_tokens": 0},
+            },
+        },
+    )
+    yield _sse_event(
+        "content_block_start",
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        },
+    )
+    for text in ["Here is ", "the ", ORIGINAL_MARKER, " for you."]:
+        yield _sse_event(
+            "content_block_delta",
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": text},
+            },
+        )
+    yield _sse_event("content_block_stop", {"type": "content_block_stop", "index": 0})
+    yield _sse_event(
+        "message_delta",
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+            "usage": {"output_tokens": 5},
+        },
+    )
+    yield _sse_event("message_stop", {"type": "message_stop"})
+
+
+def _decode(chunks: List[Any]) -> str:
+    return "".join(c.decode() if isinstance(c, bytes) else str(c) for c in chunks)
+
+
+async def _run(guardrail: CustomGuardrail) -> str:
+    # Rubrik's real config: end-of-stream-only moderation. Without buffering
+    # this releases every chunk before moderation runs (content leaks on
+    # block); the buffer flag must change that to moderate-then-release.
+    guardrail.streaming_end_of_stream_only = True
+    guardrail.streaming_buffer_until_moderated = True
+    unified = UnifiedLLMGuardrails()
+    user_api_key_dict = UserAPIKeyAuth(api_key="test", request_route="/v1/messages")
+    request_data = {
+        "messages": [{"role": "user", "content": "hi"}],
+        "guardrail_to_apply": guardrail,
+        "metadata": {"guardrails": [guardrail.guardrail_name]},
+    }
+    collected: List[Any] = []
+    async for chunk in unified.async_post_call_streaming_iterator_hook(
+        user_api_key_dict=user_api_key_dict,
+        response=_anthropic_stream(),
+        request_data=request_data,
+    ):
+        collected.append(chunk)
+    return _decode(collected)
+
+
+@pytest.mark.asyncio
+async def test_buffered_block_withholds_original_content():
+    raw = await _run(_BlockingGuardrail(guardrail_name="blk", event_hook="post_call"))
+    # The original content must never reach the client...
+    assert ORIGINAL_MARKER not in raw, f"original content leaked: {raw!r}"
+    # ...only the block message, in a clean terminating stream.
+    assert BLOCK_MESSAGE in raw
+    assert '"error"' not in raw
+
+
+@pytest.mark.asyncio
+async def test_buffered_clean_releases_all_content():
+    raw = await _run(_PassingGuardrail(guardrail_name="pass", event_hook="post_call"))
+    # A clean response is released in full after moderation passes.
+    assert ORIGINAL_MARKER in raw
+    assert (
+        raw.rstrip().endswith('event: message_stop\ndata: {"type": "message_stop"}'.rstrip()) or "message_stop" in raw
+    )
+    assert BLOCK_MESSAGE not in raw

--- a/tests/test_litellm/proxy/test_blocked_response_usage.py
+++ b/tests/test_litellm/proxy/test_blocked_response_usage.py
@@ -1,0 +1,84 @@
+"""
+Token usage on synthetic guardrail-blocked responses for the OpenAI-format
+proxy endpoints (/v1/chat/completions and /v1/completions).
+
+A post-call block replaces the LLM response with the violation message, but the
+upstream call already consumed tokens. `_blocked_response_usage` reports that
+real usage (carried on `ModifyResponseException.original_response`) rather than
+zero; a pre-call block never invoked the LLM, so usage is zero.
+"""
+
+import pytest
+
+import litellm
+from litellm.proxy.proxy_server import _blocked_response_usage
+
+
+def test_uses_original_response_usage():
+    resp = litellm.ModelResponse()
+    resp.usage = litellm.Usage(prompt_tokens=42, completion_tokens=7, total_tokens=49)
+
+    usage = _blocked_response_usage(resp)
+
+    assert usage.prompt_tokens == 42
+    assert usage.completion_tokens == 7
+    assert usage.total_tokens == 49
+
+
+def test_zero_usage_when_no_original_response():
+    usage = _blocked_response_usage(None)
+
+    assert usage.prompt_tokens == 0
+    assert usage.completion_tokens == 0
+    assert usage.total_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_success_hook_attaches_original_response_on_block():
+    """The unified guardrail's post-call success hook must attach the blocked
+    LLM response to ModifyResponseException so its real usage isn't discarded."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    import litellm.proxy.guardrails.guardrail_hooks.unified_guardrail.unified_guardrail as ug
+    from litellm.integrations.custom_guardrail import ModifyResponseException
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.types.utils import CallTypes
+
+    response = litellm.ModelResponse()
+    response.usage = litellm.Usage(prompt_tokens=15, completion_tokens=3, total_tokens=18)
+
+    guardrail = MagicMock()
+    guardrail.should_run_guardrail.return_value = True
+    guardrail.guardrail_name = "rubrik"
+
+    # The translation layer raises a block without pre-setting original_response.
+    translation = MagicMock()
+    translation.process_output_response = AsyncMock(
+        side_effect=ModifyResponseException(
+            message="blocked",
+            model="gpt-4o",
+            request_data={},
+            guardrail_name="rubrik",
+        )
+    )
+
+    unified = ug.UnifiedLLMGuardrails()
+    user_api_key_dict = UserAPIKeyAuth(api_key="test", request_route="/chat/completions")
+    data = {"guardrail_to_apply": guardrail, "model": "gpt-4o"}
+
+    # Inject our translation for the inferred call type (the module global is
+    # cached across tests, so patch it directly rather than the loader).
+    with patch.object(
+        ug,
+        "endpoint_guardrail_translation_mappings",
+        {
+            CallTypes.acompletion: lambda: translation,
+            CallTypes.completion: lambda: translation,
+        },
+    ):
+        with pytest.raises(ModifyResponseException) as excinfo:
+            await unified.async_post_call_success_hook(
+                data=data, user_api_key_dict=user_api_key_dict, response=response
+            )
+
+    assert excinfo.value.original_response is response

--- a/tests/test_litellm/responses/mcp/test_mcp_empty_resolved_tools.py
+++ b/tests/test_litellm/responses/mcp/test_mcp_empty_resolved_tools.py
@@ -40,8 +40,9 @@ def _model_response() -> ResponsesAPIResponse:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("stream", [False, True])
-async def test_zero_resolved_mcp_tools_raises_before_model_call(monkeypatch, stream):
+async def test_zero_resolved_mcp_tools_raises_before_model_call(monkeypatch):
+    # The guard runs before the stream/non-stream branch in
+    # aresponses_api_with_mcp, so one case covers both.
     _patch_resolved_tools(monkeypatch, [])
     aresponses_mock = AsyncMock()
     monkeypatch.setattr(responses_main_module, "aresponses", aresponses_mock)
@@ -50,7 +51,7 @@ async def test_zero_resolved_mcp_tools_raises_before_model_call(monkeypatch, str
         await responses_main_module.aresponses_api_with_mcp(
             input="how many links do i have?",
             model="gpt-4",
-            stream=stream,
+            stream=False,
             tools=[MCP_TOOL],
         )
 

--- a/tests/test_litellm/responses/mcp/test_mcp_empty_resolved_tools.py
+++ b/tests/test_litellm/responses/mcp/test_mcp_empty_resolved_tools.py
@@ -1,0 +1,144 @@
+"""
+Guard tests: a request that explicitly asks for MCP tools via the litellm_proxy
+gateway but resolves zero of them (and has no other tools to fall back on) must
+fail loudly with a 400 instead of silently calling the model with no tools —
+which makes it hallucinate, with the only trace being a "success"
+list_mcp_tools spend log with an empty response.
+"""
+
+import sys
+from unittest.mock import AsyncMock
+
+import pytest
+
+import litellm
+from litellm.responses.mcp.litellm_proxy_mcp_handler import LiteLLM_Proxy_MCP_Handler
+from litellm.types.llms.openai import ResponsesAPIResponse
+
+# See test_mcp_streaming_iterator.py: look the real submodule up in sys.modules
+# to sidestep litellm.responses being shadowed by the re-exported function.
+responses_main_module = sys.modules["litellm.responses.main"]
+
+MCP_TOOL = {
+    "type": "mcp",
+    "server_url": "litellm_proxy/mcp/nonexistent_server",
+    "require_approval": "never",
+    "allowed_tools": ["get_links"],
+}
+
+
+def _patch_resolved_tools(monkeypatch: pytest.MonkeyPatch, resolved_tools: list) -> None:
+    monkeypatch.setattr(
+        LiteLLM_Proxy_MCP_Handler,
+        "_process_mcp_tools_without_openai_transform",
+        AsyncMock(return_value=(resolved_tools, {})),
+    )
+
+
+def _model_response() -> ResponsesAPIResponse:
+    return ResponsesAPIResponse(id="resp-1", created_at=0, output=[])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_zero_resolved_mcp_tools_raises_before_model_call(monkeypatch, stream):
+    _patch_resolved_tools(monkeypatch, [])
+    aresponses_mock = AsyncMock()
+    monkeypatch.setattr(responses_main_module, "aresponses", aresponses_mock)
+
+    with pytest.raises(litellm.BadRequestError) as excinfo:
+        await responses_main_module.aresponses_api_with_mcp(
+            input="how many links do i have?",
+            model="gpt-4",
+            stream=stream,
+            tools=[MCP_TOOL],
+        )
+
+    message = str(excinfo.value)
+    assert "resolved 0 tools" in message
+    assert "litellm_proxy/mcp/nonexistent_server" in message
+    assert "allow_all_keys" in message
+    # The model was never called without its tools.
+    aresponses_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_zero_resolved_mcp_tools_with_function_tools_falls_back(monkeypatch):
+    """Mixed requests keep working: with other (function) tools present, the
+    request proceeds using those tools instead of hard-failing."""
+    _patch_resolved_tools(monkeypatch, [])
+    response = _model_response()
+    aresponses_mock = AsyncMock(return_value=response)
+    monkeypatch.setattr(responses_main_module, "aresponses", aresponses_mock)
+
+    function_tool = {"type": "function", "name": "my_fn", "parameters": {}}
+    result = await responses_main_module.aresponses_api_with_mcp(
+        input="hello",
+        model="gpt-4",
+        stream=False,
+        tools=[MCP_TOOL, function_tool],
+    )
+
+    assert result is response
+    aresponses_mock.assert_called_once()
+    assert aresponses_mock.call_args.kwargs["tools"] == [function_tool]
+
+
+@pytest.mark.asyncio
+async def test_zero_resolved_mcp_tools_flag_off_restores_old_behaviour(monkeypatch):
+    _patch_resolved_tools(monkeypatch, [])
+    response = _model_response()
+    aresponses_mock = AsyncMock(return_value=response)
+    monkeypatch.setattr(responses_main_module, "aresponses", aresponses_mock)
+    monkeypatch.setattr(litellm, "reject_empty_mcp_resolved_tools", False)
+
+    result = await responses_main_module.aresponses_api_with_mcp(
+        input="how many links do i have?",
+        model="gpt-4",
+        stream=False,
+        tools=[MCP_TOOL],
+    )
+
+    assert result is response
+    aresponses_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_resolved_mcp_tools_proceed_to_model_call(monkeypatch):
+    from mcp.types import Tool as MCPTool
+
+    resolved = [MCPTool(name="get_links", description="List links", inputSchema={"type": "object"})]
+    _patch_resolved_tools(monkeypatch, resolved)
+
+    response = _model_response()
+    aresponses_mock = AsyncMock(return_value=response)
+    monkeypatch.setattr(responses_main_module, "aresponses", aresponses_mock)
+
+    result = await responses_main_module.aresponses_api_with_mcp(
+        input="how many links do i have?",
+        model="gpt-4",
+        stream=False,
+        tools=[MCP_TOOL],
+    )
+
+    assert result is response
+    aresponses_mock.assert_called_once()
+    assert aresponses_mock.call_args.kwargs["tools"], "model call must carry the resolved tools"
+
+
+@pytest.mark.asyncio
+async def test_request_without_mcp_tools_is_unaffected(monkeypatch):
+    """Plain function-tool requests never hit the guard."""
+    response = _model_response()
+    aresponses_mock = AsyncMock(return_value=response)
+    monkeypatch.setattr(responses_main_module, "aresponses", aresponses_mock)
+
+    result = await responses_main_module.aresponses_api_with_mcp(
+        input="hello",
+        model="gpt-4",
+        stream=False,
+        tools=[{"type": "function", "name": "my_fn", "parameters": {}}],
+    )
+
+    assert result is response
+    aresponses_mock.assert_called_once()

--- a/tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py
+++ b/tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py
@@ -229,6 +229,9 @@ async def test_tool_execution_failure_emits_error_event_and_skips_follow_up(monk
     assert "mcp server exploded" in error_events[0].error.message
     # The doomed follow-up call was never made.
     aresponses_mock.assert_not_called()
+    # No orphaned per-tool events: a batch failure must not emit
+    # mcp_call.in_progress items that never receive a terminal event.
+    assert all(getattr(c, "type", None) != ResponsesAPIStreamEvents.MCP_CALL_IN_PROGRESS for c in chunks)
 
 
 @pytest.mark.asyncio
@@ -257,6 +260,13 @@ async def test_follow_up_failure_emits_error_event(monkeypatch):
     assert "No tool output found" in error_events[0].error.message
     # Tool-execution events were still streamed before the error surfaced.
     assert any(getattr(c, "type", None) == ResponsesAPIStreamEvents.MCP_CALL_COMPLETED for c in chunks)
+    # The terminal error event keeps sequence numbers monotonic for strict clients.
+    prior_sequence_numbers = [
+        c.sequence_number
+        for c in chunks
+        if isinstance(getattr(c, "sequence_number", None), int) and c is not error_events[0]
+    ]
+    assert error_events[0].sequence_number > max(prior_sequence_numbers)
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py
+++ b/tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py
@@ -143,3 +143,130 @@ async def test_initial_call_success_does_not_emit_error_event(monkeypatch):
     completed = [c for c in chunks if getattr(c, "type", None) == ResponsesAPIStreamEvents.RESPONSE_COMPLETED]
     assert len(completed) == 1
     assert iterator._initial_creation_error is None
+
+
+import types
+from unittest.mock import MagicMock
+
+from mcp.types import CallToolResult, TextContent
+
+
+def _output_item_added_chunk():
+    return SimpleNamespace(type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED)
+
+
+def _function_call(call_id: str, name: str, arguments: str = "{}"):
+    return {"type": "function_call", "call_id": call_id, "name": name, "arguments": arguments}
+
+
+def _mock_mcp_environment(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Patch the MCP tool-call plumbing so _execute_tool_calls can run in tests."""
+    call_tool = AsyncMock(return_value=CallToolResult(content=[TextContent(type="text", text="ok")], isError=False))
+    fake_manager = types.SimpleNamespace(
+        call_tool=call_tool,
+        _get_mcp_server_from_tool_name=MagicMock(return_value=None),
+        get_mcp_server_by_name=MagicMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+        fake_manager,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "litellm.proxy.proxy_server",
+        types.SimpleNamespace(proxy_logging_obj=MagicMock()),
+    )
+    return call_tool
+
+
+def _make_tool_call_iterator() -> MCPEnhancedStreamingIterator:
+    return MCPEnhancedStreamingIterator(
+        base_iterator=_FakeAsyncStream(
+            [
+                _output_item_added_chunk(),
+                _completed_chunk([_function_call("call_1", "read_wiki_contents")]),
+            ]
+        ),
+        mcp_events=[],
+        tool_server_map={"read_wiki_contents": "deepwiki"},
+        mcp_tools_with_litellm_proxy=[{"require_approval": "never"}],
+        user_api_key_auth=None,
+        original_request_params={
+            "model": "gpt-4",
+            "input": "what is berriai/litellm?",
+            "tools": [{"type": "mcp"}],
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_tool_execution_failure_emits_error_event_and_skips_follow_up(monkeypatch):
+    """
+    When tool execution blows up as a batch (not a per-tool error string),
+    the stream used to proceed to a follow-up call carrying function_call
+    items with no outputs — rejected by the provider with "No tool output
+    found for function call ..." — and then end silently. It must instead
+    skip the doomed follow-up and emit a terminal `error` event.
+    """
+    from litellm.responses.mcp.litellm_proxy_mcp_handler import LiteLLM_Proxy_MCP_Handler
+
+    monkeypatch.setattr(
+        LiteLLM_Proxy_MCP_Handler,
+        "_execute_tool_calls",
+        AsyncMock(side_effect=RuntimeError("mcp server exploded")),
+    )
+    aresponses_mock = AsyncMock()
+    monkeypatch.setattr(responses_main_module, "aresponses", aresponses_mock)
+
+    iterator = _make_tool_call_iterator()
+    chunks = [chunk async for chunk in iterator]
+
+    error_events = [c for c in chunks if getattr(c, "type", None) == ResponsesAPIStreamEvents.ERROR]
+    assert len(error_events) == 1
+    assert "mcp server exploded" in error_events[0].error.message
+    # The doomed follow-up call was never made.
+    aresponses_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_follow_up_failure_emits_error_event(monkeypatch):
+    """
+    When the follow-up LLM call after successful tool execution fails, the
+    stream used to end with no terminal event (the client saw tool events
+    and then... nothing). It must emit a terminal `error` event carrying the
+    mapped provider failure.
+    """
+    _mock_mcp_environment(monkeypatch)
+
+    boom = litellm.BadRequestError(
+        message="No tool output found for function call call_1.",
+        model="gpt-4",
+        llm_provider="openai",
+    )
+    monkeypatch.setattr(responses_main_module, "aresponses", AsyncMock(side_effect=boom))
+
+    iterator = _make_tool_call_iterator()
+    chunks = [chunk async for chunk in iterator]
+
+    error_events = [c for c in chunks if getattr(c, "type", None) == ResponsesAPIStreamEvents.ERROR]
+    assert len(error_events) == 1
+    assert error_events[0].error.code == "400"
+    assert "No tool output found" in error_events[0].error.message
+    # Tool-execution events were still streamed before the error surfaced.
+    assert any(getattr(c, "type", None) == ResponsesAPIStreamEvents.MCP_CALL_COMPLETED for c in chunks)
+
+
+@pytest.mark.asyncio
+async def test_tool_call_happy_path_emits_no_error_event(monkeypatch):
+    """Regression guard: the tool-call success path must stay error-free."""
+    _mock_mcp_environment(monkeypatch)
+
+    aresponses_mock = AsyncMock(return_value=_text_only_stream("final answer"))
+    monkeypatch.setattr(responses_main_module, "aresponses", aresponses_mock)
+
+    iterator = _make_tool_call_iterator()
+    chunks = [chunk async for chunk in iterator]
+
+    assert all(getattr(c, "type", None) != ResponsesAPIStreamEvents.ERROR for c in chunks)
+    completed = [c for c in chunks if getattr(c, "type", None) == ResponsesAPIStreamEvents.RESPONSE_COMPLETED]
+    assert completed[-1].response.output[0]["content"][0]["text"] == "final answer"

--- a/tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py
+++ b/tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py
@@ -1,0 +1,145 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import litellm
+from litellm.responses.mcp.mcp_streaming_iterator import MCPEnhancedStreamingIterator
+from litellm.types.llms.openai import ResponsesAPIResponse, ResponsesAPIStreamEvents
+
+# `litellm.__init__` re-exports a function named `responses`, which shadows the
+# `litellm.responses` subpackage as an attribute — `import litellm.responses.main`
+# can resolve to the unrelated third-party `responses` package instead. Look the
+# real submodule up in sys.modules directly to sidestep the shadowing.
+responses_main_module = sys.modules["litellm.responses.main"]
+
+
+class _FakeAsyncStream:
+    """Minimal async iterator yielding pre-built chunks, one per __anext__ call."""
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._chunks:
+            raise StopAsyncIteration
+        return self._chunks.pop(0)
+
+
+def _completed_chunk(output):
+    response = ResponsesAPIResponse(id="resp-1", created_at=0, output=output)
+    return SimpleNamespace(type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED, response=response)
+
+
+def _text_message(text: str):
+    return {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": text}]}
+
+
+def _text_only_stream(text: str) -> _FakeAsyncStream:
+    return _FakeAsyncStream([_completed_chunk([_text_message(text)])])
+
+
+def _make_lazy_iterator(mcp_events=None) -> MCPEnhancedStreamingIterator:
+    """Iterator with no base_iterator: the initial LLM call happens lazily on iteration."""
+    return MCPEnhancedStreamingIterator(
+        base_iterator=None,
+        mcp_events=list(mcp_events or []),
+        tool_server_map={"read_wiki_contents": "deepwiki"},
+        mcp_tools_with_litellm_proxy=[{"require_approval": "never"}],
+        user_api_key_auth=None,
+        original_request_params={
+            "model": "gpt-4",
+            "input": "what is berriai/litellm?",
+            "tools": [{"type": "mcp"}],
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_initial_call_failure_emits_error_event_not_discovery_events(monkeypatch):
+    """
+    Regression test: when the initial LLM call fails (e.g. an invalid
+    previous_response_id -> provider 400 "No tool output found for function
+    call ..."), the stream used to emit the pre-generated mcp_list_tools
+    discovery events with no response.created before them — which violates
+    the Responses API streaming contract and crashes SDK stream accumulators
+    (openai-node: "expected 'response.created' event, got
+    response.mcp_list_tools.in_progress"). The stream must instead surface a
+    single terminal `error` event and end.
+    """
+    aresponses_mock = AsyncMock(
+        side_effect=litellm.BadRequestError(
+            message="No tool output found for function call call_x.",
+            model="gpt-4",
+            llm_provider="openai",
+        )
+    )
+    monkeypatch.setattr(responses_main_module, "aresponses", aresponses_mock)
+
+    discovery_event = SimpleNamespace(type=ResponsesAPIStreamEvents.MCP_LIST_TOOLS_IN_PROGRESS)
+    iterator = _make_lazy_iterator(mcp_events=[discovery_event])
+
+    chunks = [chunk async for chunk in iterator]
+
+    assert len(chunks) == 1
+    error_event = chunks[0]
+    assert error_event.type == ResponsesAPIStreamEvents.ERROR
+    assert error_event.error.code == "400"
+    assert "No tool output found" in error_event.error.message
+    # No discovery events leaked before/after the error.
+    assert discovery_event not in chunks
+
+
+@pytest.mark.asyncio
+async def test_eager_creation_reraises_pre_stream_failure_as_http_error(monkeypatch):
+    """
+    aresponses_api_with_mcp creates the initial response eagerly and re-raises
+    the stashed creation failure, so the proxy returns a real 4xx/5xx before
+    any SSE bytes are written instead of an HTTP 200 with a broken stream.
+    """
+    from litellm.responses.mcp.litellm_proxy_mcp_handler import LiteLLM_Proxy_MCP_Handler
+
+    monkeypatch.setattr(
+        LiteLLM_Proxy_MCP_Handler,
+        "_process_mcp_tools_without_openai_transform",
+        AsyncMock(return_value=([], {})),
+    )
+    boom = litellm.BadRequestError(
+        message="Previous response with id 'resp_bogus' not found.",
+        model="gpt-4",
+        llm_provider="openai",
+    )
+    monkeypatch.setattr(responses_main_module, "aresponses", AsyncMock(side_effect=boom))
+
+    with pytest.raises(litellm.BadRequestError) as excinfo:
+        await responses_main_module.aresponses_api_with_mcp(
+            input="hi",
+            model="gpt-4",
+            stream=True,
+            previous_response_id="resp_bogus",
+            tools=[{"type": "mcp", "server_url": "litellm_proxy/mcp/deepwiki", "require_approval": "never"}],
+        )
+
+    assert "resp_bogus" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_initial_call_success_does_not_emit_error_event(monkeypatch):
+    """Happy path is unchanged: no error event, stream flows as before."""
+    monkeypatch.setattr(
+        responses_main_module,
+        "aresponses",
+        AsyncMock(return_value=_text_only_stream("all good")),
+    )
+
+    iterator = _make_lazy_iterator()
+    chunks = [chunk async for chunk in iterator]
+
+    assert all(getattr(c, "type", None) != ResponsesAPIStreamEvents.ERROR for c in chunks)
+    completed = [c for c in chunks if getattr(c, "type", None) == ResponsesAPIStreamEvents.RESPONSE_COMPLETED]
+    assert len(completed) == 1
+    assert iterator._initial_creation_error is None

--- a/tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py
+++ b/tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py
@@ -101,12 +101,15 @@ async def test_eager_creation_reraises_pre_stream_failure_as_http_error(monkeypa
     the stashed creation failure, so the proxy returns a real 4xx/5xx before
     any SSE bytes are written instead of an HTTP 200 with a broken stream.
     """
+    from mcp.types import Tool as MCPTool
+
     from litellm.responses.mcp.litellm_proxy_mcp_handler import LiteLLM_Proxy_MCP_Handler
 
+    resolved_tool = MCPTool(name="read_wiki_contents", description="read", inputSchema={"type": "object"})
     monkeypatch.setattr(
         LiteLLM_Proxy_MCP_Handler,
         "_process_mcp_tools_without_openai_transform",
-        AsyncMock(return_value=([], {})),
+        AsyncMock(return_value=([resolved_tool], {"read_wiki_contents": "deepwiki"})),
     )
     boom = litellm.BadRequestError(
         message="Previous response with id 'resp_bogus' not found.",

--- a/tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py
+++ b/tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py
@@ -130,24 +130,6 @@ async def test_eager_creation_reraises_pre_stream_failure_as_http_error(monkeypa
     assert "resp_bogus" in str(excinfo.value)
 
 
-@pytest.mark.asyncio
-async def test_initial_call_success_does_not_emit_error_event(monkeypatch):
-    """Happy path is unchanged: no error event, stream flows as before."""
-    monkeypatch.setattr(
-        responses_main_module,
-        "aresponses",
-        AsyncMock(return_value=_text_only_stream("all good")),
-    )
-
-    iterator = _make_lazy_iterator()
-    chunks = [chunk async for chunk in iterator]
-
-    assert all(getattr(c, "type", None) != ResponsesAPIStreamEvents.ERROR for c in chunks)
-    completed = [c for c in chunks if getattr(c, "type", None) == ResponsesAPIStreamEvents.RESPONSE_COMPLETED]
-    assert len(completed) == 1
-    assert iterator._initial_creation_error is None
-
-
 import types
 from unittest.mock import MagicMock
 

--- a/ui/litellm-dashboard/eslint-metrics.json
+++ b/ui/litellm-dashboard/eslint-metrics.json
@@ -1,5 +1,5 @@
 {
-  "@typescript-eslint/no-explicit-any": 2018,
+  "@typescript-eslint/no-explicit-any": 2017,
   "complexity": 127,
   "max-depth": 61
 }

--- a/ui/litellm-dashboard/eslint-metrics.json
+++ b/ui/litellm-dashboard/eslint-metrics.json
@@ -1,5 +1,5 @@
 {
-  "@typescript-eslint/no-explicit-any": 2013,
-  "complexity": 126,
+  "@typescript-eslint/no-explicit-any": 2019,
+  "complexity": 127,
   "max-depth": 61
 }

--- a/ui/litellm-dashboard/eslint-metrics.json
+++ b/ui/litellm-dashboard/eslint-metrics.json
@@ -1,5 +1,5 @@
 {
-  "@typescript-eslint/no-explicit-any": 2017,
-  "complexity": 127,
+  "@typescript-eslint/no-explicit-any": 2013,
+  "complexity": 126,
   "max-depth": 61
 }

--- a/ui/litellm-dashboard/eslint-metrics.json
+++ b/ui/litellm-dashboard/eslint-metrics.json
@@ -1,5 +1,5 @@
 {
-  "@typescript-eslint/no-explicit-any": 2019,
+  "@typescript-eslint/no-explicit-any": 2018,
   "complexity": 127,
   "max-depth": 61
 }

--- a/ui/litellm-dashboard/scripts/gen-api-types.mjs
+++ b/ui/litellm-dashboard/scripts/gen-api-types.mjs
@@ -26,6 +26,8 @@ const python = (process.env.LITELLM_PYTHON ?? "python3").split(" ");
 // The dashboard calls internal UI routes that the public /openapi.json hides via
 // include_in_schema=False. Force them in so they get typed here; this mutates a
 // throwaway interpreter, so the spec the proxy actually serves is unchanged.
+// Collector ingestion routes are machine-to-machine write APIs and should stay
+// out of dashboard client types even though other hidden UI routes are included.
 // Python 3.13 strips a docstring's common leading indentation at compile time
 // while 3.12 keeps it, so the same model yields differently-indented descriptions
 // depending on the interpreter — enough to make this output non-reproducible
@@ -37,7 +39,7 @@ const dumpSpec = [
   "from fastapi.routing import APIRoute",
   "for route in app.routes:",
   "    if isinstance(route, APIRoute):",
-  "        route.include_in_schema = True",
+  "        route.include_in_schema = not route.path.startswith('/collector/')",
   "app.openapi_schema = None",
   "def normalize(node):",
   "    if isinstance(node, dict):",

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.test.tsx
@@ -68,7 +68,7 @@ describe("LogDetailContent", () => {
     );
 
     expect(screen.getByText("Source")).toBeInTheDocument();
-    expect(screen.getByRole("img", { name: "Notion logo" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Notion logo")).toBeInTheDocument();
     expect(screen.getByText("Notion")).toBeInTheDocument();
   });
 

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.test.tsx
@@ -56,6 +56,22 @@ describe("LogDetailContent", () => {
     expect(screen.getByText("completion")).toBeInTheDocument();
   });
 
+  it("should display relay source with logo in Request Details", () => {
+    render(
+      <LogDetailContent
+        logEntry={createLogEntry({
+          model: "notion-ai",
+          call_type: "litellm-relay",
+          metadata: { status: "success", app: "notion", source: "litellm-relay" },
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Source")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Notion logo" })).toBeInTheDocument();
+    expect(screen.getByText("Notion")).toBeInTheDocument();
+  });
+
   it("should display error alert when request has failed", () => {
     render(
       <LogDetailContent

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
@@ -28,11 +28,14 @@ import {
   TAB_RESPONSE,
   FONT_SIZE_SMALL,
   FONT_FAMILY_MONO,
+  COLOR_BG_LIGHT,
+  SPACING_LARGE,
   SPACING_XLARGE,
   SPACING_MEDIUM,
 } from "./constants";
 import { ToolsSection } from "../ToolsSection";
 import { PrettyMessagesView } from "./PrettyMessagesView";
+import { RelaySourceBadge, getRelaySource } from "../TypeBadges";
 
 const { Text } = Typography;
 
@@ -55,6 +58,8 @@ export function LogDetailContent({ logEntry, isLoadingDetails = false, accessTok
   const metadata = logEntry.metadata || {};
   const hasError = metadata.status === "failure";
   const errorInfo = hasError ? metadata.error_information : null;
+  const isRelayCapture = logEntry.call_type === "litellm-relay";
+  const relaySource = getRelaySource(logEntry);
 
   const hasMessages = checkHasMessages(logEntry.messages);
   const hasResponse = checkHasResponse(logEntry.response);
@@ -118,6 +123,11 @@ export function LogDetailContent({ logEntry, isLoadingDetails = false, accessTok
             <Descriptions.Item label="Model">{logEntry.model}</Descriptions.Item>
             <Descriptions.Item label="Provider">{logEntry.custom_llm_provider || "-"}</Descriptions.Item>
             <Descriptions.Item label="Call Type">{logEntry.call_type}</Descriptions.Item>
+            {isRelayCapture && (
+              <Descriptions.Item label="Source">
+                <RelaySourceBadge source={relaySource} />
+              </Descriptions.Item>
+            )}
             <Descriptions.Item label="Model ID">
               <TruncatedValue value={logEntry.model_id} />
             </Descriptions.Item>
@@ -418,6 +428,7 @@ function RequestResponseSection({
     : totalTokens > 0
       ? (totalSpend * completionTokens) / totalTokens
       : 0;
+  const isRelayCapture = logEntry.call_type === "litellm-relay";
 
   return (
     <div className="bg-white rounded-lg shadow w-full max-w-full overflow-hidden mb-6">
@@ -448,6 +459,7 @@ function RequestResponseSection({
             ),
             children: (
               <div>
+                {isRelayCapture && <RelayPayloadPreview request={getRawRequest()} response={getFormattedResponse()} />}
                 {viewMode === "pretty" ? (
                   <PrettyMessagesView
                     request={getRawRequest()}
@@ -505,6 +517,61 @@ function RequestResponseSection({
           },
         ]}
       />
+    </div>
+  );
+}
+
+function getPreviewText(payload: any): string {
+  if (!payload) return "";
+  if (typeof payload === "string") return payload;
+  if (typeof payload.body === "string") return payload.body;
+  if (typeof payload.body_preview === "string") return payload.body_preview;
+  return JSON.stringify(payload, null, 2);
+}
+
+function PayloadCodeBlock({ value }: { value: string }) {
+  return (
+    <pre
+      className="whitespace-pre-wrap break-words text-xs"
+      style={{
+        margin: 0,
+        maxHeight: 220,
+        overflow: "auto",
+        padding: SPACING_LARGE,
+        background: COLOR_BG_LIGHT,
+        border: "1px solid #e5e7eb",
+        borderRadius: 6,
+        fontFamily: FONT_FAMILY_MONO,
+      }}
+    >
+      {value || "No body captured"}
+    </pre>
+  );
+}
+
+function RelayPayloadPreview({ request, response }: { request: any; response: any }) {
+  const requestBody = getPreviewText(request);
+  const responseBody = getPreviewText(response);
+  return (
+    <div className="mb-4">
+      <Alert
+        type="info"
+        showIcon
+        message="HTTP payload captured by LiteLLM Relay"
+        description="This is the intercepted request and response body stored on the LiteLLM spend log."
+        className="mb-3"
+      />
+      <div className="grid grid-cols-1 gap-3">
+        <Card
+          size="small"
+          title={`Request${request?.method ? ` · ${request.method}` : ""}${request?.path ? ` ${request.path}` : ""}`}
+        >
+          <PayloadCodeBlock value={requestBody} />
+        </Card>
+        <Card size="small" title={`Response${response?.status_code ? ` · ${response.status_code}` : ""}`}>
+          <PayloadCodeBlock value={responseBody} />
+        </Card>
+      </div>
     </div>
   );
 }

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
@@ -39,6 +39,14 @@ import { RelaySourceBadge, getRelaySource } from "../TypeBadges";
 
 const { Text } = Typography;
 
+const getObjectRequestTags = (requestTags: LogEntry["request_tags"]): Record<string, unknown> | undefined => {
+  if (!requestTags || Array.isArray(requestTags) || typeof requestTags !== "object") {
+    return undefined;
+  }
+
+  return requestTags;
+};
+
 export interface LogDetailContentProps {
   logEntry: LogEntry;
   /** When true, log details (messages/response) are still being lazy-loaded. */
@@ -56,6 +64,7 @@ export interface LogDetailContentProps {
  */
 export function LogDetailContent({ logEntry, isLoadingDetails = false, accessToken }: LogDetailContentProps) {
   const metadata = logEntry.metadata || {};
+  const requestTags = getObjectRequestTags(logEntry.request_tags);
   const hasError = metadata.status === "failure";
   const errorInfo = hasError ? metadata.error_information : null;
   const isRelayCapture = logEntry.call_type === "litellm-relay";
@@ -112,9 +121,7 @@ export function LogDetailContent({ logEntry, isLoadingDetails = false, accessTok
       )}
 
       {/* Tags */}
-      {logEntry.request_tags && Object.keys(logEntry.request_tags).length > 0 && (
-        <TagsSection tags={logEntry.request_tags} />
-      )}
+      {requestTags && Object.keys(requestTags).length > 0 && <TagsSection tags={requestTags} />}
 
       {/* Request Details */}
       <div className="bg-white rounded-lg shadow w-full max-w-full overflow-hidden mb-6">
@@ -242,7 +249,7 @@ function ErrorDescription({ errorInfo }: { errorInfo: any }) {
   );
 }
 
-function TagsSection({ tags }: { tags: Record<string, any> }) {
+function TagsSection({ tags }: { tags: Record<string, unknown> }) {
   return (
     <div className="bg-white rounded-lg shadow w-full max-w-full overflow-hidden p-4 mb-6">
       <Text strong style={{ display: "block", marginBottom: 8, fontSize: 16 }}>

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
 import { Button, Drawer } from "antd";
 import { CheckOutlined, CopyOutlined, LeftOutlined, RightOutlined } from "@ant-design/icons";
-import { Bot, Sparkles, Wrench } from "lucide-react";
+import { Bot, Cable, Sparkles, Wrench } from "lucide-react";
 import { LogEntry } from "../columns";
-import { AGENT_CALL_TYPES, MCP_CALL_TYPES } from "../constants";
+import { AGENT_CALL_TYPES, MCP_CALL_TYPES, RELAY_CALL_TYPES } from "../constants";
 import { getEventDisplayName } from "../utils";
 import { DrawerHeader } from "./DrawerHeader";
 import { useKeyboardNavigation } from "./useKeyboardNavigation";
@@ -49,12 +49,22 @@ interface TraceEventRowProps {
 function TraceEventRow({ row, isSelected, onClick }: TraceEventRowProps) {
   const isMcp = MCP_CALL_TYPES.includes(row.call_type);
   const isAgent = AGENT_CALL_TYPES.includes(row.call_type);
-  const durationValue =
-    row.request_duration_ms != null
-      ? (row.request_duration_ms / 1000).toFixed(3)
-      : row.startTime && row.endTime
-        ? ((Date.parse(row.endTime) - Date.parse(row.startTime)) / 1000).toFixed(3)
-        : "-";
+  const isRelay = RELAY_CALL_TYPES.includes(row.call_type);
+  let durationValue = "-";
+  if (row.request_duration_ms != null) {
+    durationValue = (row.request_duration_ms / 1000).toFixed(3);
+  } else if (row.startTime && row.endTime) {
+    durationValue = ((Date.parse(row.endTime) - Date.parse(row.startTime)) / 1000).toFixed(3);
+  }
+
+  let eventIcon = <Sparkles size={12} className="text-slate-500 shrink-0" />;
+  if (isMcp) {
+    eventIcon = <Wrench size={12} className="text-slate-500 shrink-0" />;
+  } else if (isAgent) {
+    eventIcon = <Bot size={12} className="text-slate-500 shrink-0" />;
+  } else if (isRelay) {
+    eventIcon = <Cable size={12} className="text-slate-500 shrink-0" />;
+  }
 
   return (
     <button
@@ -65,13 +75,7 @@ function TraceEventRow({ row, isSelected, onClick }: TraceEventRowProps) {
       onClick={onClick}
     >
       <div className="flex items-center gap-1">
-        {isMcp ? (
-          <Wrench size={12} className="text-slate-500 flex-shrink-0" />
-        ) : isAgent ? (
-          <Bot size={12} className="text-slate-500 flex-shrink-0" />
-        ) : (
-          <Sparkles size={12} className="text-slate-500 flex-shrink-0" />
-        )}
+        {eventIcon}
         <span className="text-xs font-medium text-slate-900 truncate">
           {getEventDisplayName(row.call_type, row.model)}
         </span>
@@ -274,11 +278,19 @@ export function LogDetailsDrawer({
   const sessionDurationSeconds =
     sessionStart && sessionEnd ? ((sessionEnd.getTime() - sessionStart.getTime()) / 1000).toFixed(2) : "0.00";
   const llmCount = sessionLogs.filter(
-    (row) => !MCP_CALL_TYPES.includes(row.call_type) && !AGENT_CALL_TYPES.includes(row.call_type),
+    (row) =>
+      !MCP_CALL_TYPES.includes(row.call_type) &&
+      !AGENT_CALL_TYPES.includes(row.call_type) &&
+      !RELAY_CALL_TYPES.includes(row.call_type),
   ).length;
   const agentCount = sessionLogs.filter((row) => AGENT_CALL_TYPES.includes(row.call_type)).length;
   const mcpCount = sessionLogs.filter((row) => MCP_CALL_TYPES.includes(row.call_type)).length;
-  const logsForList = isSessionMode ? sessionLogs : currentLog ? [currentLog] : [];
+  let logsForList: LogEntry[] = [];
+  if (isSessionMode) {
+    logsForList = sessionLogs;
+  } else if (currentLog) {
+    logsForList = [currentLog];
+  }
   const leftPanelId = isSessionMode ? sessionId || "" : currentLog?.request_id || "";
   const leftPanelDisplayId = leftPanelId.length > 14 ? `${leftPanelId.slice(0, 11)}...` : leftPanelId;
 
@@ -361,7 +373,10 @@ export function LogDetailsDrawer({
                   isSessionMode
                     ? llmCount
                     : logsForList.filter(
-                        (row) => !MCP_CALL_TYPES.includes(row.call_type) && !AGENT_CALL_TYPES.includes(row.call_type),
+                        (row) =>
+                          !MCP_CALL_TYPES.includes(row.call_type) &&
+                          !AGENT_CALL_TYPES.includes(row.call_type) &&
+                          !RELAY_CALL_TYPES.includes(row.call_type),
                       ).length,
                   isSessionMode
                     ? agentCount

--- a/ui/litellm-dashboard/src/components/view_logs/TypeBadges.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/TypeBadges.test.tsx
@@ -1,6 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { LlmBadge, McpBadge, AgentBadge } from "./TypeBadges";
+import {
+  LlmBadge,
+  McpBadge,
+  AgentBadge,
+  RelayBadge,
+  RelaySourceBadge,
+  RelayTypeBadge,
+  getRelaySource,
+} from "./TypeBadges";
 
 describe("TypeBadges", () => {
   describe("LlmBadge", () => {
@@ -41,6 +49,45 @@ describe("TypeBadges", () => {
     it("should render the count when provided", () => {
       render(<AgentBadge count={12} />);
       expect(screen.getByText("12")).toBeInTheDocument();
+    });
+  });
+
+  describe("RelayBadge", () => {
+    it("should render with default 'litellm-relay' text when no count is provided", () => {
+      render(<RelayBadge />);
+      expect(screen.getByText("litellm-relay")).toBeInTheDocument();
+    });
+  });
+
+  describe("RelaySourceBadge", () => {
+    it("should render Notion source with logo", () => {
+      render(<RelaySourceBadge source="notion" />);
+      expect(screen.getByRole("img", { name: "Notion logo" })).toBeInTheDocument();
+      expect(screen.getByText("Notion")).toBeInTheDocument();
+    });
+
+    it("should render Codex source with logo", () => {
+      render(<RelaySourceBadge source="codex" />);
+      expect(screen.getByRole("img", { name: "Codex logo" })).toBeInTheDocument();
+      expect(screen.getByText("Codex")).toBeInTheDocument();
+    });
+
+    it("should derive source from relay metadata app", () => {
+      expect(getRelaySource({ metadata: { app: "notion" }, model: "local-ai" })).toBe("notion");
+    });
+
+    it("should derive source from relay model when metadata is missing", () => {
+      expect(getRelaySource({ model: "codex-ai" })).toBe("codex");
+    });
+  });
+
+  describe("RelayTypeBadge", () => {
+    it("should render relay type next to the captured app", () => {
+      render(<RelayTypeBadge source="notion" />);
+
+      expect(screen.getByText("litellm-relay")).toBeInTheDocument();
+      expect(screen.getByRole("img", { name: "Notion logo" })).toBeInTheDocument();
+      expect(screen.getByText("Notion")).toBeInTheDocument();
     });
   });
 });

--- a/ui/litellm-dashboard/src/components/view_logs/TypeBadges.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/TypeBadges.tsx
@@ -1,7 +1,9 @@
 /**
- * Compact type-indicator badges for LLM, Agent, and MCP log entries.
+ * Compact type-indicator badges for LLM, Agent, MCP, and Relay log entries.
  * Used in the request logs table and session type column.
  */
+import { Cable, Monitor } from "lucide-react";
+import { resolveLogoSrc } from "@/lib/assetPaths";
 
 export const SparkleIcon = ({ size = 12 }: { size?: number }) => (
   <svg
@@ -57,6 +59,8 @@ export const AgentIcon = ({ size = 12 }: { size?: number }) => (
   </svg>
 );
 
+export const RelayIcon = ({ size = 12 }: { size?: number }) => <Cable size={size} className="flex-shrink-0" />;
+
 export const LlmBadge = ({ count }: { count?: number }) => (
   <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-blue-50 text-blue-700 border border-blue-200 rounded-full text-[11px] font-medium whitespace-nowrap">
     <SparkleIcon />
@@ -75,5 +79,99 @@ export const AgentBadge = ({ count }: { count?: number }) => (
   <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-violet-50 text-violet-700 border border-violet-200 rounded-full text-[11px] font-medium whitespace-nowrap">
     <AgentIcon />
     {count != null ? count : "Agent"}
+  </span>
+);
+
+export const RelayBadge = ({ count }: { count?: number }) => (
+  <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-emerald-50 text-emerald-700 border border-emerald-200 rounded-full text-[11px] font-medium whitespace-nowrap">
+    <RelayIcon />
+    {count != null ? count : "litellm-relay"}
+  </span>
+);
+
+type RelaySourceLike = {
+  metadata?: Record<string, any>;
+  model?: string;
+  request_tags?: Record<string, any> | string[] | string;
+};
+
+const RELAY_SOURCE_LABELS: Record<string, string> = {
+  notion: "Notion",
+  codex: "Codex",
+};
+
+const RELAY_SOURCE_LOGOS: Record<string, string> = {
+  notion: "/ui/assets/logos/notion.svg",
+  codex: "/ui/assets/logos/openai_small.svg",
+};
+
+const normalizeRelaySource = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (normalized === "litellm-relay") return undefined;
+  if (normalized.includes("notion")) return "notion";
+  if (normalized.includes("codex")) return "codex";
+  return normalized.replace(/-ai$/, "");
+};
+
+const getTagSource = (requestTags: RelaySourceLike["request_tags"]): string | undefined => {
+  if (Array.isArray(requestTags)) {
+    return requestTags.map(normalizeRelaySource).find(Boolean);
+  }
+  if (typeof requestTags === "string") {
+    try {
+      const parsed = JSON.parse(requestTags);
+      return getTagSource(parsed);
+    } catch {
+      return normalizeRelaySource(requestTags);
+    }
+  }
+  return undefined;
+};
+
+export const getRelaySource = (entry: RelaySourceLike): string => {
+  return (
+    normalizeRelaySource(entry.metadata?.app) ||
+    normalizeRelaySource(entry.metadata?.relay_app) ||
+    normalizeRelaySource(entry.metadata?.shadow_source) ||
+    normalizeRelaySource(entry.metadata?.host) ||
+    getTagSource(entry.request_tags) ||
+    normalizeRelaySource(entry.model) ||
+    "unknown"
+  );
+};
+
+export const getRelaySourceLabel = (source: string) => {
+  return RELAY_SOURCE_LABELS[source] || source.charAt(0).toUpperCase() + source.slice(1);
+};
+
+export const RelaySourceLogo = ({ source, size = 16 }: { source: string; size?: number }) => {
+  const logo = RELAY_SOURCE_LOGOS[source];
+  if (logo) {
+    return (
+      <span aria-label={`${getRelaySourceLabel(source)} logo`} role="img" className="inline-flex">
+        <img src={resolveLogoSrc(logo)} alt="" className="flex-shrink-0" style={{ width: size, height: size }} />
+      </span>
+    );
+  }
+  return (
+    <span aria-label={`${getRelaySourceLabel(source)} logo`} role="img" className="inline-flex">
+      <Monitor size={size} className="flex-shrink-0 text-slate-500" aria-hidden="true" />
+    </span>
+  );
+};
+
+export const RelaySourceBadge = ({ source }: { source: string }) => (
+  <span className="inline-flex items-center gap-1.5 px-2 py-0.5 bg-slate-50 text-slate-700 border border-slate-200 rounded-full text-[11px] font-medium whitespace-nowrap">
+    <RelaySourceLogo source={source} />
+    {getRelaySourceLabel(source)}
+  </span>
+);
+
+export const RelayTypeBadge = ({ source }: { source: string }) => (
+  <span className="inline-flex items-center gap-1.5 whitespace-nowrap">
+    <RelayBadge />
+    <RelaySourceBadge source={source} />
   </span>
 );

--- a/ui/litellm-dashboard/src/components/view_logs/columns.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/columns.test.tsx
@@ -42,6 +42,7 @@ describe("view logs columns", () => {
     expect(screen.getByText("litellm-relay")).toBeInTheDocument();
     expect(screen.getAllByText("Notion").length).toBeGreaterThan(0);
     expect(screen.getAllByRole("img", { name: "Notion logo" }).length).toBeGreaterThan(0);
+    expect(screen.queryByRole("columnheader", { name: "Source" })).not.toBeInTheDocument();
     expect(screen.queryByText("LLM")).not.toBeInTheDocument();
   });
 

--- a/ui/litellm-dashboard/src/components/view_logs/columns.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/columns.test.tsx
@@ -45,6 +45,28 @@ describe("view logs columns", () => {
     expect(screen.queryByText("LLM")).not.toBeInTheDocument();
   });
 
+  it("should render collector rows with relay metadata as relay logs", () => {
+    const legacyCollectorLog = {
+      ...baseLog,
+      request_id: "collector-01f159da",
+      call_type: "completion",
+      metadata: {
+        ...baseLog.metadata,
+        app: "codex",
+        source: "litellm-relay",
+      },
+      model: "codex-ai",
+      request_tags: ["litellm-relay", "codex"],
+    };
+
+    render(<DataTable data={[legacyCollectorLog]} columns={createColumns()} />);
+
+    expect(screen.getByText("litellm-relay")).toBeInTheDocument();
+    expect(screen.getAllByText("Codex").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("img", { name: "Codex logo" }).length).toBeGreaterThan(0);
+    expect(screen.queryByText("LLM")).not.toBeInTheDocument();
+  });
+
   it("should fall back to row api_key when relay metadata does not include a key hash", () => {
     render(<DataTable data={[baseLog]} columns={createColumns()} />);
 

--- a/ui/litellm-dashboard/src/components/view_logs/columns.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/columns.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { createColumns, LogEntry } from "./columns";
+import { DataTable } from "./table";
+
+const baseLog: LogEntry = {
+  request_id: "req-1",
+  api_key: "hashed-relay-key",
+  team_id: "",
+  model: "notion-ai",
+  model_id: "",
+  api_base: "https://www.notion.so",
+  call_type: "litellm-relay",
+  spend: 0,
+  total_tokens: 0,
+  prompt_tokens: 0,
+  completion_tokens: 0,
+  startTime: "2026-07-09T22:36:30.141Z",
+  endTime: "2026-07-09T22:36:30.220Z",
+  custom_llm_provider: "",
+  metadata: {
+    app: "notion",
+    status: "success",
+    status_code: 200,
+    user_api_key: null,
+    user_api_key_alias: "relay-key",
+    user_api_key_team_alias: null,
+  },
+  cache_hit: "False",
+  cache_key: "",
+  request_tags: { source: "notion" },
+  messages: {},
+  response: {},
+  proxy_server_request: {},
+  status: "success",
+};
+
+describe("view logs columns", () => {
+  it("should render relay type with captured app logo and name", () => {
+    render(<DataTable data={[baseLog]} columns={createColumns()} />);
+
+    expect(screen.getByText("litellm-relay")).toBeInTheDocument();
+    expect(screen.getAllByText("Notion").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("img", { name: "Notion logo" }).length).toBeGreaterThan(0);
+    expect(screen.queryByText("LLM")).not.toBeInTheDocument();
+  });
+
+  it("should fall back to row api_key when relay metadata does not include a key hash", () => {
+    render(<DataTable data={[baseLog]} columns={createColumns()} />);
+
+    expect(screen.getByText("hashed-relay-key")).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/view_logs/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/columns.tsx
@@ -68,7 +68,7 @@ export type LogEntry = {
   metadata?: Record<string, any>;
   cache_hit: string;
   cache_key?: string;
-  request_tags?: Record<string, any>;
+  request_tags?: Record<string, any> | string[] | string;
   requester_ip_address?: string;
   messages: string | any[] | Record<string, any>;
   response: string | any[] | Record<string, any>;
@@ -116,6 +116,33 @@ const SortableHeader = ({
   </div>
 );
 
+const requestTagsIncludeRelay = (requestTags: LogEntry["request_tags"]): boolean => {
+  if (!requestTags) return false;
+  if (Array.isArray(requestTags)) {
+    return requestTags.some((tag) => String(tag).toLowerCase() === "litellm-relay");
+  }
+  if (typeof requestTags === "string") {
+    try {
+      return requestTagsIncludeRelay(JSON.parse(requestTags));
+    } catch {
+      return requestTags.toLowerCase().includes("litellm-relay");
+    }
+  }
+  return Object.entries(requestTags).some(
+    ([key, value]) =>
+      key.toLowerCase().includes("litellm-relay") || String(value).toLowerCase().includes("litellm-relay"),
+  );
+};
+
+const isRelayLog = (row: LogEntry): boolean => {
+  return (
+    RELAY_CALL_TYPES.includes(row.call_type) ||
+    row.metadata?.source === "litellm-relay" ||
+    requestTagsIncludeRelay(row.request_tags) ||
+    (row.request_id?.startsWith("collector-") && getRelaySource(row) !== "unknown")
+  );
+};
+
 export const createColumns = (sortProps?: LogsSortProps): ColumnDef<LogEntry>[] => [
   {
     header: sortProps
@@ -142,7 +169,7 @@ export const createColumns = (sortProps?: LogsSortProps): ColumnDef<LogEntry>[] 
       const sessionCount = row.session_total_count || 1;
       const isMcp = MCP_CALL_TYPES.includes(row.call_type);
       const isAgent = AGENT_CALL_TYPES.includes(row.call_type);
-      const isRelay = RELAY_CALL_TYPES.includes(row.call_type);
+      const isRelay = isRelayLog(row);
       const sessionLlmCount = row.session_llm_count ?? (isMcp || isAgent || isRelay ? 0 : sessionCount);
       const sessionAgentCount = row.session_agent_count ?? (isAgent ? sessionCount : 0);
       const sessionMcpCount = row.session_mcp_count ?? (isMcp ? sessionCount : 0);
@@ -193,7 +220,7 @@ export const createColumns = (sortProps?: LogsSortProps): ColumnDef<LogEntry>[] 
     size: 120,
     cell: (info: any) => {
       const row = info.row.original;
-      if (!RELAY_CALL_TYPES.includes(row.call_type)) {
+      if (!isRelayLog(row)) {
         return <span className="text-slate-400">-</span>;
       }
       return <RelaySourceBadge source={getRelaySource(row)} />;

--- a/ui/litellm-dashboard/src/components/view_logs/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/columns.tsx
@@ -6,8 +6,19 @@ import React, { useState } from "react";
 import { getProviderLogoAndName } from "../provider_info_helpers";
 import { TableHeaderSortDropdown } from "../common_components/TableHeaderSortDropdown/TableHeaderSortDropdown";
 import { TimeCell } from "./time_cell";
-import { AGENT_CALL_TYPES, MCP_CALL_TYPES } from "./constants";
-import { AgentBadge, AgentIcon, LlmBadge, McpBadge, SparkleIcon, WrenchIcon } from "./TypeBadges";
+import { AGENT_CALL_TYPES, MCP_CALL_TYPES, RELAY_CALL_TYPES } from "./constants";
+import {
+  AgentBadge,
+  AgentIcon,
+  LlmBadge,
+  McpBadge,
+  RelayIcon,
+  RelaySourceBadge,
+  RelayTypeBadge,
+  SparkleIcon,
+  WrenchIcon,
+  getRelaySource,
+} from "./TypeBadges";
 
 /** API sort field mapping for /spend/logs/ui endpoint */
 export const LOGS_SORT_FIELD_MAP = {
@@ -125,17 +136,19 @@ export const createColumns = (sortProps?: LogsSortProps): ColumnDef<LogEntry>[] 
   {
     header: "Type",
     id: "type",
-    size: 90,
+    size: 240,
     cell: (info: any) => {
       const row = info.row.original;
       const sessionCount = row.session_total_count || 1;
       const isMcp = MCP_CALL_TYPES.includes(row.call_type);
       const isAgent = AGENT_CALL_TYPES.includes(row.call_type);
-      const sessionLlmCount = row.session_llm_count ?? (isMcp || isAgent ? 0 : sessionCount);
+      const isRelay = RELAY_CALL_TYPES.includes(row.call_type);
+      const sessionLlmCount = row.session_llm_count ?? (isMcp || isAgent || isRelay ? 0 : sessionCount);
       const sessionAgentCount = row.session_agent_count ?? (isAgent ? sessionCount : 0);
       const sessionMcpCount = row.session_mcp_count ?? (isMcp ? sessionCount : 0);
 
       if (isMcp) return <McpBadge />;
+      if (isRelay) return <RelayTypeBadge source={getRelaySource(row)} />;
       if (isAgent && sessionCount <= 1) return <AgentBadge />;
       if (sessionCount <= 1) return <LlmBadge />;
 
@@ -156,6 +169,12 @@ export const createColumns = (sortProps?: LogsSortProps): ColumnDef<LogEntry>[] 
               <WrenchIcon />
             </>
           )}
+          {isRelay && (
+            <>
+              <span className="text-blue-300">·</span>
+              <RelayIcon size={10} />
+            </>
+          )}
         </span>
       );
 
@@ -163,8 +182,21 @@ export const createColumns = (sortProps?: LogsSortProps): ColumnDef<LogEntry>[] 
         sessionLlmCount > 0 && `${sessionLlmCount} LLM`,
         sessionAgentCount > 0 && `${sessionAgentCount} Agent`,
         sessionMcpCount > 0 && `${sessionMcpCount} MCP`,
+        isRelay && "litellm-relay",
       ].filter(Boolean);
       return <Tooltip title={tooltipParts.join(" • ")}>{sessionTypeBadge}</Tooltip>;
+    },
+  },
+  {
+    header: "Source",
+    id: "source",
+    size: 120,
+    cell: (info: any) => {
+      const row = info.row.original;
+      if (!RELAY_CALL_TYPES.includes(row.call_type)) {
+        return <span className="text-slate-400">-</span>;
+      }
+      return <RelaySourceBadge source={getRelaySource(row)} />;
     },
   },
   {
@@ -307,19 +339,25 @@ export const createColumns = (sortProps?: LogsSortProps): ColumnDef<LogEntry>[] 
     header: "Team Name",
     accessorKey: "metadata.user_api_key_team_alias",
     size: 150,
-    cell: (info: any) => (
-      <Tooltip title={String(info.getValue() || "-")}>
-        <span className="max-w-[15ch] truncate block">{String(info.getValue() || "-")}</span>
-      </Tooltip>
-    ),
+    cell: (info: any) => {
+      const row = info.row.original;
+      const value =
+        info.getValue() || row.metadata?.user_api_key_team_id || row.team_id || (row.api_key ? "No team" : "-");
+      return (
+        <Tooltip title={String(value)}>
+          <span className="max-w-[15ch] truncate block">{String(value)}</span>
+        </Tooltip>
+      );
+    },
   },
   {
     header: "Key Hash",
     accessorKey: "metadata.user_api_key",
     size: 110,
     cell: (info: any) => {
-      const value = String(info.getValue() || "-");
-      const onKeyHashClick = info.row.original.onKeyHashClick;
+      const row = info.row.original;
+      const value = String(info.getValue() || row.api_key || "-");
+      const onKeyHashClick = row.onKeyHashClick;
 
       return (
         <Tooltip title={value}>

--- a/ui/litellm-dashboard/src/components/view_logs/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/columns.tsx
@@ -13,7 +13,6 @@ import {
   LlmBadge,
   McpBadge,
   RelayIcon,
-  RelaySourceBadge,
   RelayTypeBadge,
   SparkleIcon,
   WrenchIcon,
@@ -212,18 +211,6 @@ export const createColumns = (sortProps?: LogsSortProps): ColumnDef<LogEntry>[] 
         isRelay && "litellm-relay",
       ].filter(Boolean);
       return <Tooltip title={tooltipParts.join(" • ")}>{sessionTypeBadge}</Tooltip>;
-    },
-  },
-  {
-    header: "Source",
-    id: "source",
-    size: 120,
-    cell: (info: any) => {
-      const row = info.row.original;
-      if (!isRelayLog(row)) {
-        return <span className="text-slate-400">-</span>;
-      }
-      return <RelaySourceBadge source={getRelaySource(row)} />;
     },
   },
   {

--- a/ui/litellm-dashboard/src/components/view_logs/constants.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/constants.ts
@@ -18,6 +18,9 @@ export const MCP_CALL_TYPES = ["call_mcp_tool", "list_mcp_tools"];
 /** Call types that represent agent/A2A requests (e.g. asend_message). */
 export const AGENT_CALL_TYPES = ["asend_message"];
 
+/** Call types that represent local collector captures from LiteLLM Relay. */
+export const RELAY_CALL_TYPES = ["litellm-relay"];
+
 export const QUICK_SELECT_OPTIONS: { label: string; value: number; unit: string }[] = [
   { label: "Last Minute", value: 1, unit: "minutes" },
   { label: "Last 15 Minutes", value: 15, unit: "minutes" },

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -10,7 +10,7 @@ import { keyInfoV1Call } from "../networking";
 import KeyInfoView from "../templates/key_info_view";
 import AuditLogs from "./audit_logs";
 import { createColumns, LogEntry, type LogsSortField } from "./columns";
-import { AGENT_CALL_TYPES, MCP_CALL_TYPES } from "./constants";
+import { AGENT_CALL_TYPES, MCP_CALL_TYPES, RELAY_CALL_TYPES } from "./constants";
 import { getLogFilterOptions } from "./filter_options";
 import { useLogFilterLogic, defaultFilters, type LogFilterState } from "./log_filter_logic";
 import { LogDetailsDrawer } from "./LogDetailsDrawer";
@@ -154,6 +154,8 @@ export default function SpendLogsTable({ accessToken, token, userRole, userID, p
           acc[log.session_id].mcp += 1;
         } else if (AGENT_CALL_TYPES.includes(log.call_type)) {
           acc[log.session_id].agent += 1;
+        } else if (RELAY_CALL_TYPES.includes(log.call_type)) {
+          // Relay captures are not LLM calls; they get their own Type badge.
         } else {
           acc[log.session_id].llm += 1;
         }
@@ -163,14 +165,22 @@ export default function SpendLogsTable({ accessToken, token, userRole, userID, p
     );
 
     // Build a single-pass map of session_id → representative request_id.
-    // Prefers an LLM row over an MCP row as the representative.
-    const sessionRepresentativeMap = new Map<string, { requestId: string; isMcp: boolean }>();
+    // Prefer higher-signal execution rows over collector/tool rows.
+    const sessionRepresentativeMap = new Map<string, { requestId: string; priority: number }>();
     for (const log of searchedLogs) {
       if (!log.session_id || (log.session_total_count || 1) <= 1) continue;
       const isMcp = MCP_CALL_TYPES.includes(log.call_type);
+      const isRelay = RELAY_CALL_TYPES.includes(log.call_type);
+      const isAgent = AGENT_CALL_TYPES.includes(log.call_type);
+      let priority = 2;
+      if (isRelay || isMcp) {
+        priority = 0;
+      } else if (isAgent) {
+        priority = 1;
+      }
       const existing = sessionRepresentativeMap.get(log.session_id);
-      if (!existing || (existing.isMcp && !isMcp)) {
-        sessionRepresentativeMap.set(log.session_id, { requestId: log.request_id, isMcp });
+      if (!existing || priority > existing.priority) {
+        sessionRepresentativeMap.set(log.session_id, { requestId: log.request_id, priority });
       }
     }
 

--- a/ui/litellm-dashboard/src/components/view_logs/utils.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/utils.ts
@@ -1,4 +1,4 @@
-import { MCP_CALL_TYPES } from "./constants";
+import { MCP_CALL_TYPES, RELAY_CALL_TYPES } from "./constants";
 
 /**
  * Derive a short, human-readable display name for a log entry.
@@ -7,6 +7,7 @@ import { MCP_CALL_TYPES } from "./constants";
 export function getEventDisplayName(callType: string, model: string): string {
   const raw = (model || "").trim();
   const isMcp = MCP_CALL_TYPES.includes(callType);
+  const isRelay = RELAY_CALL_TYPES.includes(callType);
 
   if (isMcp) {
     return (
@@ -17,6 +18,10 @@ export function getEventDisplayName(callType: string, model: string): string {
       raw ||
       "mcp_tool"
     );
+  }
+
+  if (isRelay) {
+    return raw || "litellm-relay";
   }
 
   const lastSegment = raw.split("/").pop() || raw;

--- a/uv.lock
+++ b/uv.lock
@@ -7076,11 +7076,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What
- Add pure-Python `POST /collector/spend-logs` ingestion for LiteLLM Relay captures.
- Transform collector events into zero-spend LiteLLM spend-log rows and enqueue through the existing spend-log batcher.
- Attribute user/team/org/key fields from the authenticated LiteLLM key, not caller payloads.
- Namespace collector request IDs as `collector-*` and preserve the original Relay request ID in metadata.
- Add Logs UI support for `litellm-relay` rows, source badges/logos, and request/response payload previews.

## Safety
- Non-admin keys require explicit `allowed_routes` for `/collector/spend-logs` or `/collector/*`.
- Caller-supplied `api_key`, `team_id`, `organization_id`, `user`, `spend`, and `custom_llm_provider` are ignored.
- Per-row and aggregate batch byte caps reject oversized collector payloads before enqueue.
- The collector route is hidden from OpenAPI/dashboard generated API types.

## Review fixes
- Refactored collector normalization into `CollectorSpendLogTransformer` with static methods.
- Removed the janky dependency setter/router factory; the endpoint reads initialized runtime objects from `request.app.state`.
- Fixed JSON-object `request_tags` ingestion so it wraps non-list JSON before appending `litellm-relay`.
- Updated `soupsieve` in `uv.lock` to clear the OSV advisory.
- Ran Prettier and refreshed `eslint-metrics.json` for the Logs UI changes.

## Tests
- `uv run ruff check litellm/constants.py litellm/proxy/collector_endpoints/spend_logs.py litellm/proxy/proxy_server.py tests/test_litellm/proxy/collector_endpoints/test_spend_logs.py tests/test_litellm/proxy/auth/test_route_checks.py`
- `uv run ruff format --check litellm/proxy/collector_endpoints/spend_logs.py tests/test_litellm/proxy/collector_endpoints/test_spend_logs.py litellm/proxy/proxy_server.py`
- `uv run pytest tests/test_litellm/proxy/collector_endpoints/test_spend_logs.py -q`
- `uv run pytest tests/test_litellm/proxy/auth/test_route_checks.py -k 'collector or non_admin_config_update_route_rejected' -q`
- `uv lock --check`
- `uv run python - <<'PY' ... assert '/collector/spend-logs' not in app.openapi().get('paths', {})`
- `npx prettier --check <changed view_logs files>`
- `npx eslint --no-warn-ignored --pass-on-unpruned-suppressions <changed view_logs files>`
- `node scripts/check-lint-budgets.mjs <generated report> eslint-budgets.json --check eslint-metrics.json`
- `npx vitest run src/components/view_logs/TypeBadges.test.tsx src/components/view_logs/LogDetailsDrawer/LogDetailContent.test.tsx src/components/view_logs/index.test.tsx`
- `npm run build`
