### PR TITLE
fix(bedrock): degrade gracefully on truncated tool-call arguments instead of failing the request

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1685,10 +1685,13 @@ def split_concatenated_json_objects(raw: str) -> List[Dict[str, Any]]:
         A list of parsed dicts – one per JSON object found.  If *raw* is
         empty or whitespace-only, an empty list is returned.
 
-    Raises
-    ------
-    json.JSONDecodeError
-        If the string contains text that cannot be parsed as JSON at all.
+    Trailing text that cannot be parsed as JSON (e.g. a tool-call arguments
+    string truncated by a provider stream that ended mid-call) is ignored:
+    every complete object parsed before it is still returned. The caller
+    treats an empty result as "no usable arguments" and degrades to ``{}``
+    rather than failing the whole request — a malformed historical tool call
+    would otherwise poison every subsequent request in the conversation
+    (https://github.com/BerriAI/litellm/issues/18667).
     """
     import json
 
@@ -1708,7 +1711,11 @@ def split_concatenated_json_objects(raw: str) -> List[Dict[str, Any]]:
         if idx >= length:
             break
 
-        obj, end_idx = decoder.raw_decode(raw, idx)
+        try:
+            obj, end_idx = decoder.raw_decode(raw, idx)
+        except json.JSONDecodeError:
+            # Truncated / unparseable tail: keep what parsed so far.
+            break
         if isinstance(obj, dict):
             results.append(obj)
         else:

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1713,8 +1713,16 @@ def split_concatenated_json_objects(raw: str) -> List[Dict[str, Any]]:
 
         try:
             obj, end_idx = decoder.raw_decode(raw, idx)
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as e:
             # Truncated / unparseable tail: keep what parsed so far.
+            verbose_logger.warning(
+                "split_concatenated_json_objects: discarding unparseable tail of "
+                "tool-call arguments at index %d (%s); %d complete object(s) kept. "
+                "Usually a provider stream that ended mid-tool-call.",
+                idx,
+                e,
+                len(results),
+            )
             break
         if isinstance(obj, dict):
             results.append(obj)

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
@@ -251,10 +251,23 @@ def test_split_concatenated_json_non_dict_value():
     assert result == [{}]
 
 
-def test_split_concatenated_json_invalid_raises():
-    """Completely invalid JSON raises JSONDecodeError."""
-    with pytest.raises(json.JSONDecodeError):
-        split_concatenated_json_objects("not json at all")
+def test_split_concatenated_json_invalid_returns_empty():
+    """Completely invalid JSON yields no objects (caller degrades to {})."""
+    assert split_concatenated_json_objects("not json at all") == []
+
+
+def test_split_concatenated_json_truncated_object_returns_empty():
+    """A single object truncated mid-stream (provider cut the tool-call
+    arguments stream) yields no objects instead of raising — raising here
+    poisons every subsequent request that replays the conversation
+    (https://github.com/BerriAI/litellm/issues/18667)."""
+    assert split_concatenated_json_objects('{"command": ["cat","file.md"]') == []
+
+
+def test_split_concatenated_json_salvages_objects_before_truncated_tail():
+    """Complete objects parsed before a truncated tail are kept."""
+    result = split_concatenated_json_objects('{"a": 1}{"b": [2')
+    assert result == [{"a": 1}]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -3166,3 +3166,51 @@ async def test_bedrock_converse_message_level_cache_point_preserves_ttl_async():
     )
 
     assert _collect_cache_points(result) == [{"type": "default", "ttl": "1h"}]
+
+
+def test_convert_to_bedrock_tool_call_invoke_truncated_arguments_degrade_to_empty_input():
+    """A historical tool call whose arguments JSON was truncated (provider
+    stream ended mid-call) must not fail the whole request: every later turn
+    replays the conversation, so raising here permanently poisons the session
+    (https://github.com/BerriAI/litellm/issues/18667). The call converts with
+    input={} and the paired tool result stays addressable by toolUseId."""
+    tool_calls = [
+        {
+            "id": "tooluse_ALM3Cu9twX9iB0NLzcxhdc",
+            "type": "function",
+            "function": {
+                "name": "shell",
+                # exact truncation shape observed from a Bedrock ConverseStream
+                # that ended before the final input_json delta
+                "arguments": '{"command": ["cat",".glia/project.md"]',
+            },
+        }
+    ]
+
+    result = _convert_to_bedrock_tool_call_invoke(tool_calls)
+
+    assert len(result) == 1
+    tool_use = result[0]["toolUse"]
+    assert tool_use["toolUseId"] == "tooluse_ALM3Cu9twX9iB0NLzcxhdc"
+    assert tool_use["name"] == "shell"
+    assert tool_use["input"] == {}
+
+
+def test_convert_to_bedrock_tool_call_invoke_salvages_complete_objects_before_truncated_tail():
+    """Complete objects before a truncated tail still split into toolUse
+    blocks; the unparseable tail is dropped."""
+    tool_calls = [
+        {
+            "id": "tooluse_1",
+            "type": "function",
+            "function": {
+                "name": "shell",
+                "arguments": '{"command": ["pwd"]}{"command": ["ls", "-',
+            },
+        }
+    ]
+
+    result = _convert_to_bedrock_tool_call_invoke(tool_calls)
+
+    assert len(result) == 1
+    assert result[0]["toolUse"]["input"] == {"command": ["pwd"]}


### PR DESCRIPTION
Withdrawing — we're handling this case on the client side instead. Thanks for the project.