### PR TITLE
fix(guardrails): mask credentials embedded in guardrail_response before persist (LIT-4314)

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -757,6 +757,12 @@ class CustomGuardrail(CustomLogger):
         # raw provider JSON so redaction is not duplicated upstream).
         clean_guardrail_response = redact_nested_match_and_regex_keys(clean_guardrail_response)
 
+        from litellm.litellm_core_utils.sensitive_data_masker import (
+            mask_credentials_in_payload,
+        )
+
+        clean_guardrail_response = mask_credentials_in_payload(clean_guardrail_response)
+
         slg = StandardLoggingGuardrailInformation(
             guardrail_name=self.guardrail_name,
             guardrail_provider=guardrail_provider,

--- a/litellm/litellm_core_utils/sensitive_data_masker.py
+++ b/litellm/litellm_core_utils/sensitive_data_masker.py
@@ -1,6 +1,8 @@
 from collections.abc import Mapping
 from typing import Any, Dict, List, Optional, Set
 
+from pydantic import BaseModel
+
 from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER
 
 
@@ -151,6 +153,39 @@ _error_masker = SensitiveDataMasker(visible_prefix=4, visible_suffix=0)
 
 def mask_sensitive_structure(data: object) -> object:
     return _error_masker.mask(data)
+
+
+def mask_credentials_in_payload(data: object) -> object:
+    """Return a copy of ``data`` where string values under sensitive-named keys
+    are masked but every other value (``None``, ``int``, ``float``, ``bool``,
+    ``bytes``, ``datetime``, tuples, sets, typed objects) is preserved by
+    identity, and dicts/lists are rebuilt structurally.
+
+    Use this for logging payloads that carry response data through to
+    SpendLogs / OTel / Langfuse, where :meth:`SensitiveDataMasker.mask`'s
+    config-dump semantics (``None`` -> ``"None"``, tuples stringified,
+    objects flattened via ``__dict__``) would silently distort the record.
+
+    Sensitive-key detection is delegated to the shared
+    :class:`SensitiveDataMasker` so pattern updates stay in one place.
+    """
+    return _walk_payload(data, key_is_sensitive=False, depth=0)
+
+
+def _walk_payload(node: object, key_is_sensitive: bool, depth: int) -> object:
+    if depth >= DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER:
+        return node
+    if isinstance(node, Mapping):
+        return {k: _walk_payload(v, _default_masker.is_sensitive_key(k), depth + 1) for k, v in node.items()}
+    if isinstance(node, list):
+        return [_walk_payload(item, key_is_sensitive, depth + 1) for item in node]
+    if isinstance(node, tuple):
+        return tuple(_walk_payload(item, key_is_sensitive, depth + 1) for item in node)
+    if isinstance(node, BaseModel):
+        return _walk_payload(node.model_dump(), key_is_sensitive, depth)
+    if key_is_sensitive and isinstance(node, str) and node:
+        return _default_masker._mask_value(node)
+    return node
 
 
 def mask_sensitive_keys(data: Dict[str, Any], sensitive_fields: Set[str]) -> Dict[str, Any]:

--- a/tests/code_coverage_tests/recursive_detector.py
+++ b/tests/code_coverage_tests/recursive_detector.py
@@ -36,6 +36,7 @@ IGNORE_FUNCTIONS = [
     "_collect_argument_paths",  # max depth set.
     "_split_text",  # max depth set.
     "_mask_sequence",  # max depth set.
+    "_walk_payload",  # max depth set (DEFAULT_MAX_RECURSE_DEPTH_SENSITIVE_DATA_MASKER).
     "_delete_nested_value_custom",  # max depth set (bounded by number of path segments).
     "filter_exceptions_from_params",  # max depth set (default 20) to prevent infinite recursion.
     "__getattr__",  # lazy loading pattern in litellm/__init__.py with proper caching to prevent infinite recursion.

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -833,6 +833,173 @@ class TestGuardrailSensitiveFieldStripping:
         assert "sk-secret" not in serialized
 
 
+class TestGuardrailResponseCredentialMasking:
+    """LIT-4314 issue B regression: credentials embedded in guardrail_response
+    (via team callback_vars flowing through data["metadata"]) must be masked at
+    the construction seam so every downstream sink (SpendLogs, OTel, Langfuse,
+    custom loggers) sees masked values rather than plaintext.
+    """
+
+    def _make_guardrail(self):
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        return CustomGuardrail(
+            guardrail_name="test_guardrail",
+            event_hook=GuardrailEventHooks.pre_call,
+        )
+
+    def test_callback_vars_api_key_is_masked(self):
+        import json
+
+        guardrail = self._make_guardrail()
+        request_data: dict = {"metadata": {}}
+        plaintext_key = "lsv2_pt_abcdef1234567890"
+
+        guardrail.add_standard_logging_guardrail_information_to_request_data(
+            guardrail_json_response={
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+                "metadata_snapshot": {
+                    "callback_vars": {
+                        "langsmith_api_key": plaintext_key,
+                        "langsmith_project": "proj-name",
+                    }
+                },
+            },
+            request_data=request_data,
+            guardrail_status="success",
+            duration=1.0,
+        )
+
+        logged = request_data["metadata"]["standard_logging_guardrail_information"][0][
+            "guardrail_response"
+        ]
+
+        masked_key = logged["metadata_snapshot"]["callback_vars"]["langsmith_api_key"]
+        assert masked_key != plaintext_key
+        assert "*" in masked_key
+        assert plaintext_key not in json.dumps(request_data)
+
+        assert logged["model"] == "gpt-4o-mini"
+        assert logged["messages"] == [{"role": "user", "content": "hi"}]
+        assert (
+            logged["metadata_snapshot"]["callback_vars"]["langsmith_project"]
+            == "proj-name"
+        )
+
+    def test_nested_user_api_key_auth_metadata_is_masked(self):
+        import json
+
+        guardrail = self._make_guardrail()
+        request_data: dict = {"metadata": {}}
+        token_value = "1b01552f6e52e0d41963dd6a185bd6b074624e330999534ca7ff5adfdf622dfc"
+
+        guardrail.add_standard_logging_guardrail_information_to_request_data(
+            guardrail_json_response={
+                "evaluated_metadata": {
+                    "user_api_key_auth": {
+                        "token": token_value,
+                        "api_key": token_value,
+                        "metadata": {
+                            "callback_vars": {
+                                "langsmith_api_key": "lsv2_pt_super_secret_value_1234",
+                            }
+                        },
+                    }
+                }
+            },
+            request_data=request_data,
+            guardrail_status="success",
+        )
+
+        serialized = json.dumps(request_data)
+        assert token_value not in serialized
+        assert "lsv2_pt_super_secret_value_1234" not in serialized
+
+    def test_secret_fields_pop_still_runs(self):
+        import json
+
+        guardrail = self._make_guardrail()
+        request_data: dict = {"metadata": {}}
+
+        guardrail.add_standard_logging_guardrail_information_to_request_data(
+            guardrail_json_response={
+                "model": "gpt-4",
+                "secret_fields": {
+                    "raw_headers": {
+                        "authorization": "Bearer sk-live-should-not-appear",
+                    }
+                },
+            },
+            request_data=request_data,
+            guardrail_status="success",
+        )
+
+        serialized = json.dumps(request_data)
+        assert "secret_fields" not in serialized
+        assert "sk-live-should-not-appear" not in serialized
+
+    def test_match_and_regex_redaction_still_runs(self):
+        guardrail = self._make_guardrail()
+        request_data: dict = {"metadata": {}}
+
+        guardrail.add_standard_logging_guardrail_information_to_request_data(
+            guardrail_json_response={
+                "filters": [{"regex": r"\d{3}-\d{2}-\d{4}", "action": "BLOCKED"}]
+            },
+            request_data=request_data,
+            guardrail_status="success",
+        )
+
+        slg = request_data["metadata"]["standard_logging_guardrail_information"][0]
+        assert slg["guardrail_response"]["filters"][0]["regex"] == "[REDACTED]"
+
+    def test_scalar_types_pass_through_unchanged(self):
+        guardrail = self._make_guardrail()
+        request_data: dict = {"metadata": {}}
+
+        guardrail.add_standard_logging_guardrail_information_to_request_data(
+            guardrail_json_response={
+                "flagged": True,
+                "score": 0.94,
+                "tokens_used": 42,
+                "categories": ["pii", "toxicity"],
+            },
+            request_data=request_data,
+            guardrail_status="success",
+        )
+
+        logged = request_data["metadata"]["standard_logging_guardrail_information"][0][
+            "guardrail_response"
+        ]
+        assert logged["flagged"] is True
+        assert logged["score"] == 0.94
+        assert logged["tokens_used"] == 42
+        assert logged["categories"] == ["pii", "toxicity"]
+
+    def test_masking_reveals_prefix_and_suffix(self):
+        guardrail = self._make_guardrail()
+        request_data: dict = {"metadata": {}}
+        plaintext = "lsv2_pt_abcdef1234567890"
+
+        guardrail.add_standard_logging_guardrail_information_to_request_data(
+            guardrail_json_response={
+                "metadata_snapshot": {
+                    "callback_vars": {"langsmith_api_key": plaintext}
+                }
+            },
+            request_data=request_data,
+            guardrail_status="success",
+        )
+
+        masked = request_data["metadata"]["standard_logging_guardrail_information"][0][
+            "guardrail_response"
+        ]["metadata_snapshot"]["callback_vars"]["langsmith_api_key"]
+        assert masked != plaintext
+        assert masked.startswith(plaintext[:4])
+        assert masked.endswith(plaintext[-4:])
+
+
 class TestCustomGuardrailPassthroughSupport:
     """Tests for passthrough endpoint guardrail support - Issue fixes."""
 

--- a/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
+++ b/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
@@ -240,3 +240,78 @@ def test_mask_sensitive_structure_masks_credentials_nested_in_config_shape():
         [{"primary-group": [{"model": "gpt-4o", "api_key": secret}]}]
     )
     assert secret not in str(masked)
+
+
+def test_mask_credentials_in_payload_preserves_none_and_scalars():
+    """The payload variant does not distort JSON-shaped values: None stays None,
+    ints/floats/bools stay themselves, lists stay lists. This is what makes it
+    safe for logging pipelines that persist the record verbatim."""
+    from litellm.litellm_core_utils.sensitive_data_masker import mask_credentials_in_payload
+
+    result = mask_credentials_in_payload(
+        {
+            "reason": None,
+            "confidence": 0.42,
+            "flagged": True,
+            "tokens_used": 17,
+            "categories": ["pii", "toxicity"],
+            "nested": {"end_user_id": None},
+        }
+    )
+    assert result == {
+        "reason": None,
+        "confidence": 0.42,
+        "flagged": True,
+        "tokens_used": 17,
+        "categories": ["pii", "toxicity"],
+        "nested": {"end_user_id": None},
+    }
+
+
+def test_mask_credentials_in_payload_masks_inside_pydantic_models():
+    """A Pydantic model reached during the walk gets dumped to a dict so its
+    sensitive-named string fields are masked. Without this the credentials
+    inside a nested ``UserAPIKeyAuth`` in a guardrail_response reach the
+    logging pipeline unmasked once JSON serialization flattens it."""
+    from pydantic import BaseModel
+
+    from litellm.litellm_core_utils.sensitive_data_masker import mask_credentials_in_payload
+
+    class Auth(BaseModel):
+        token: str = "1b01552f6e52e0d41963dd6a185bd6b074624e330999534ca7ff5adfdf622dfc"
+        team_alias: str = "acme"
+
+    result = mask_credentials_in_payload({"user_api_key_auth": Auth()})
+    auth_dict = result["user_api_key_auth"]
+    assert isinstance(auth_dict, dict)
+    assert auth_dict["team_alias"] == "acme"
+    assert (
+        auth_dict["token"]
+        != "1b01552f6e52e0d41963dd6a185bd6b074624e330999534ca7ff5adfdf622dfc"
+    )
+    assert "*" in auth_dict["token"]
+
+
+def test_mask_credentials_in_payload_masks_only_sensitive_string_leaves():
+    """Sensitive-named string leaves get masked; sibling non-string values
+    (including None) under the same key stay verbatim."""
+    from litellm.litellm_core_utils.sensitive_data_masker import mask_credentials_in_payload
+
+    plaintext = "lsv2_pt_abcdef1234567890"
+    result = mask_credentials_in_payload(
+        {
+            "model": "gpt-4o-mini",
+            "callback_vars": {
+                "langsmith_api_key": plaintext,
+                "langsmith_project": "proj",
+                "extra_token_count": 5,
+            },
+        }
+    )
+    assert result["model"] == "gpt-4o-mini"
+    assert result["callback_vars"]["langsmith_project"] == "proj"
+    assert result["callback_vars"]["extra_token_count"] == 5
+    masked = result["callback_vars"]["langsmith_api_key"]
+    assert masked != plaintext
+    assert masked.startswith(plaintext[:4])
+    assert masked.endswith(plaintext[-4:])


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Contributes to LIT-4314; scope covers the credential-mask piece of the ticket. The sibling `store_prompts_in_spend_logs` gating scope is being addressed in a separate PR.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Reproduction and verification on a live proxy against Postgres, real OpenAI API calls, real Langsmith key from the env

Config, guardrail, and DB per the shared brief (`/tmp/lit4314_config.yaml`, `/tmp/lit4314_guardrail.py`, `postgresql://yucheng@127.0.0.1:5432/litellm_lit4314b`); proxy on port 4001 to avoid collision with a sibling repro on 4000

### Before (unfixed HEAD `1fa200123f`)

Launch:
```
export PYTHONPATH="$(pwd):/tmp"
set -a; source .env; set +a
uv run --no-sync python litellm/proxy/proxy_cli.py \
  --config /tmp/lit4314_config.yaml --port 4001 \
  --detailed_debug --use_v2_migration_resolver
```

Provision + hit:
```
curl -sS -X POST http://localhost:4001/team/new \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d "{\"team_alias\":\"lit4314b-team\",\"metadata\":{\"callback_vars\":{\"langsmith_api_key\":\"$LANGSMITH_API_KEY\",\"langsmith_project\":\"lit4314-repro\"},\"success_callback\":[\"langsmith\"]}}"

curl -sS -X POST http://localhost:4001/key/generate \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d "{\"team_id\":\"<team-id>\",\"models\":[\"gpt-4o-mini\"]}"

curl -sS http://localhost:4001/v1/chat/completions \
  -H "Authorization: Bearer <team-key>" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Say hi in 3 words"}]}'
```

Plaintext count in `LiteLLM_SpendLogs.metadata`:
```
psql -U yucheng -h 127.0.0.1 -d litellm_lit4314b -t -A -c \
  "SELECT metadata FROM \"LiteLLM_SpendLogs\" ORDER BY \"startTime\" DESC LIMIT 1;" \
  | grep -oE 'lsv2_pt_[a-f0-9]+_[a-f0-9]+' | wc -l
```
Output: `5`

That is the same team callback_vars Langsmith key showing up plaintext five times inside one row's `guardrail_information[i].guardrail_response` (via `user_api_key_auth`, `user_api_key_metadata`, `user_api_key_team_metadata`, `user_api_key_auth_metadata`, and the direct `metadata.callback_vars` echo the leaky guardrail hook makes when it snapshots `data["metadata"]`)

### After (fixed HEAD `2b6e25d896`)

Same launch, same curl, same psql, on the fixed binary

Plaintext count:
```
psql -U yucheng -h 127.0.0.1 -d litellm_lit4314b -t -A -c \
  "SELECT metadata FROM \"LiteLLM_SpendLogs\" ORDER BY \"startTime\" DESC LIMIT 1;" \
  | grep -oE 'lsv2_pt_[a-f0-9]+_[a-f0-9]+' | wc -l
```
Output: `0`

Masked count:
```
... | grep -oE 'lsv2\*+' | wc -l
```
Output: `5`

The five plaintext occurrences got replaced by five masked ones. The five reveal-prefix/reveal-suffix strings look like `lsv2*******************************************4124`

Dashboard fields on the same record survive unchanged: `guardrail_name=lit4314-leaky-guard`, `guardrail_status=success`, `duration=3e-06`, `guardrail_mode=pre_call`, `guardrail_provider=lit4314-repro`

## Type

🐛 Bug Fix

## Changes

`add_standard_logging_guardrail_information_to_request_data` (`litellm/integrations/custom_guardrail.py`) is the single seam every production guardrail hook routes through when building `StandardLoggingGuardrailInformation`. That record is what every downstream sink reads: SpendLogs, OTel v2 (`emit_guardrail_span` at line 802), Langfuse (`guardrail_entry["guardrail_response"]` at `litellm/integrations/langfuse/langfuse.py:967`), and any user-configured custom logger

Two narrow scrubs already ran inside this function; neither touched nested credential-shaped keys. `secret_fields` was popped at the top level, and `redact_nested_match_and_regex_keys` only rewrites keys literally named `match` or `regex`. When a guardrail hook echoed `data["metadata"]` back as part of its `guardrail_response`, the four `user_api_key_*` aliases plus the raw `callback_vars` copy all sailed through and got persisted plaintext

The fix runs `SensitiveDataMasker`'s default masker over the response after those two scrubs. It segment-matches key names like `api_key`, `access_token`, `secret`, `authorization`, `credentials`, and reveals only a four-char prefix and four-char suffix on long values (short values get fully starred). Non-sensitive keys (`model`, `messages`, `metadata_snapshot` shape, dashboard fields) pass through unchanged; masking is key-name-scoped, not value-scoped. Because the masker is applied at the construction site, every sink downstream sees the masked record without their needing individual patches

Regression tests in `tests/test_litellm/integrations/test_custom_guardrail.py::TestGuardrailResponseCredentialMasking` cover: a Langsmith-shaped `callback_vars.langsmith_api_key` gets masked and does not appear plaintext anywhere in the serialized record; a nested `user_api_key_auth.metadata.callback_vars.langsmith_api_key` alongside `token`/`api_key` all get masked; and the existing `secret_fields` pop and match/regex redaction still run. Removing the new masker line makes the first regression test fail on the exact assertion that the masked value equals the plaintext, so it kills a real mutation

Follow-ups the ticket calls out that are intentionally out of scope for this PR: sibling PR for `store_prompts_in_spend_logs` gating of `guardrail_response`; ticket to split `callback_vars` transport off `UserAPIKeyAuth.team_metadata` so it never lands in `data["metadata"]` in the first place; ticket to mask `optional_params`/`additional_params`/`litellm_params.api_key` across the wider observability path and to redact by default across sinks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the single guardrail logging seam used by every sink; incorrect masking could hide debug data or miss secrets, but scope is narrow and heavily tested.
> 
> **Overview**
> Fixes **plaintext API keys and tokens** ending up in SpendLogs, OTel, Langfuse, and other sinks when guardrail hooks echo request metadata inside `guardrail_response`.
> 
> **`add_standard_logging_guardrail_information_to_request_data`** now runs **`mask_credentials_in_payload`** after existing `secret_fields` removal and `match`/`regex` redaction, so masking happens once at the shared construction seam for all guardrails.
> 
> **`mask_credentials_in_payload`** (in `sensitive_data_masker.py`) walks nested dicts/lists/tuples and Pydantic models, masks **non-empty string values** under sensitive key names (shared `SensitiveDataMasker` patterns plus **`gcs_path_service_account`**), and leaves scalars/`None`/structure intact—unlike full `SensitiveDataMasker.mask`, which can distort logging payloads. **`_walk_payload`** is depth-bounded and allowlisted in the recursive-function CI check.
> 
> Regression tests cover nested `callback_vars`, `user_api_key_auth`, prefix/suffix masking, and that prior scrubs still apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a40fd6bf306fa725e248567d3420b404fb1062e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->