### PR TITLE
fix(spend-logs): honor store_prompts_in_spend_logs for guardrail_information (LIT-4314)

### DIFF
--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -136,7 +136,7 @@ def _get_spend_logs_metadata(
     clean_metadata["vector_store_request_metadata"] = _get_vector_store_request_for_spend_logs_payload(
         vector_store_request_metadata
     )
-    clean_metadata["guardrail_information"] = guardrail_information
+    clean_metadata["guardrail_information"] = _sanitize_guardrail_information_for_spend_logs(guardrail_information)
     clean_metadata["usage_object"] = usage_object
     clean_metadata["model_map_information"] = model_map_information
     clean_metadata["cold_storage_object_key"] = cold_storage_object_key
@@ -866,6 +866,34 @@ def _redact_prompt_leaks_in_error_string(text: str) -> str:
             # carrier, leave intact and resume after the key match.
             pos = v_start
     return "".join(out)
+
+
+def _sanitize_guardrail_information_for_spend_logs(
+    guardrail_information: Optional[List[StandardLoggingGuardrailInformation]],
+) -> Optional[List[StandardLoggingGuardrailInformation]]:
+    """
+    When ``store_prompts_in_spend_logs`` is False, redact ``guardrail_request``
+    and ``guardrail_response`` before they land in ``LiteLLM_SpendLogs.metadata``.
+
+    Guardrail hooks may echo the LLM request payload back into
+    ``guardrail_response``, which would otherwise leak the raw prompt/response
+    into the metadata JSON column regardless of the flag. Every other typed
+    field on the entry (name, provider, mode, status, timings, action,
+    violation_categories, risk_score, masked_entity_count, ...) is preserved
+    so guardrail dashboards keep working.
+    """
+    if guardrail_information is None or _should_store_prompts_and_responses_in_spend_logs():
+        return guardrail_information
+    return [_redact_prompt_fields_in_guardrail_entry(entry) for entry in guardrail_information]
+
+
+def _redact_prompt_fields_in_guardrail_entry(
+    entry: StandardLoggingGuardrailInformation,
+) -> StandardLoggingGuardrailInformation:
+    redacted: StandardLoggingGuardrailInformation = {**entry}
+    redacted["guardrail_request"] = REDACTED_BY_LITELM_STRING
+    redacted["guardrail_response"] = REDACTED_BY_LITELM_STRING
+    return redacted
 
 
 def _sanitize_error_information_for_spend_logs(

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -887,13 +887,20 @@ def _sanitize_guardrail_information_for_spend_logs(
     return [_redact_prompt_fields_in_guardrail_entry(entry) for entry in guardrail_information]
 
 
+_PROMPT_CARRYING_GUARDRAIL_FIELDS = (
+    "guardrail_request",
+    "guardrail_response",
+    "match_details",
+    "classification",
+)
+
+
 def _redact_prompt_fields_in_guardrail_entry(
     entry: StandardLoggingGuardrailInformation,
 ) -> StandardLoggingGuardrailInformation:
     return {
         **entry,
-        **({"guardrail_request": REDACTED_BY_LITELM_STRING} if "guardrail_request" in entry else {}),
-        **({"guardrail_response": REDACTED_BY_LITELM_STRING} if "guardrail_response" in entry else {}),
+        **{key: REDACTED_BY_LITELM_STRING for key in _PROMPT_CARRYING_GUARDRAIL_FIELDS if key in entry},
     }
 
 

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -890,10 +890,11 @@ def _sanitize_guardrail_information_for_spend_logs(
 def _redact_prompt_fields_in_guardrail_entry(
     entry: StandardLoggingGuardrailInformation,
 ) -> StandardLoggingGuardrailInformation:
-    redacted: StandardLoggingGuardrailInformation = {**entry}
-    redacted["guardrail_request"] = REDACTED_BY_LITELM_STRING
-    redacted["guardrail_response"] = REDACTED_BY_LITELM_STRING
-    return redacted
+    return {
+        **entry,
+        "guardrail_request": REDACTED_BY_LITELM_STRING,
+        "guardrail_response": REDACTED_BY_LITELM_STRING,
+    }
 
 
 def _sanitize_error_information_for_spend_logs(

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -872,19 +872,28 @@ def _sanitize_guardrail_information_for_spend_logs(
     guardrail_information: Optional[List[StandardLoggingGuardrailInformation]],
 ) -> Optional[List[StandardLoggingGuardrailInformation]]:
     """
-    When ``store_prompts_in_spend_logs`` is False, redact ``guardrail_request``
-    and ``guardrail_response`` before they land in ``LiteLLM_SpendLogs.metadata``.
+    When ``store_prompts_in_spend_logs`` is False, redact prompt-carrying fields
+    (``guardrail_request``, ``guardrail_response``, ``match_details``,
+    ``classification``) before they land in ``LiteLLM_SpendLogs.metadata``.
 
     Guardrail hooks may echo the LLM request payload back into
-    ``guardrail_response``, which would otherwise leak the raw prompt/response
-    into the metadata JSON column regardless of the flag. Every other typed
-    field on the entry (name, provider, mode, status, timings, action,
-    violation_categories, risk_score, masked_entity_count, ...) is preserved
-    so guardrail dashboards keep working.
+    ``guardrail_response``, and two first-party hooks
+    (``block_code_execution``, ``litellm_content_filter``) inline user-prompt
+    substrings into ``match_details`` / ``classification`` too, so the flag
+    must cover all four fields. Every other typed field on the entry (name,
+    provider, mode, status, timings, action, violation_categories, risk_score,
+    masked_entity_count, ...) is preserved so guardrail dashboards keep
+    working.
+
+    ``guardrail_information`` is typed ``Optional[List[...]]`` but at least
+    one writer (``xecguard``) assigns a bare dict, so normalize to a list
+    here to match OTEL's defensive read pattern; otherwise iteration would
+    yield the dict's keys and crash the whole spend-log write.
     """
     if guardrail_information is None or _should_store_prompts_and_responses_in_spend_logs():
         return guardrail_information
-    return [_redact_prompt_fields_in_guardrail_entry(entry) for entry in guardrail_information]
+    entries = [guardrail_information] if isinstance(guardrail_information, dict) else guardrail_information
+    return [_redact_prompt_fields_in_guardrail_entry(entry) for entry in entries if isinstance(entry, dict)]
 
 
 _PROMPT_CARRYING_GUARDRAIL_FIELDS = (

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -892,8 +892,8 @@ def _redact_prompt_fields_in_guardrail_entry(
 ) -> StandardLoggingGuardrailInformation:
     return {
         **entry,
-        "guardrail_request": REDACTED_BY_LITELM_STRING,
-        "guardrail_response": REDACTED_BY_LITELM_STRING,
+        **({"guardrail_request": REDACTED_BY_LITELM_STRING} if "guardrail_request" in entry else {}),
+        **({"guardrail_response": REDACTED_BY_LITELM_STRING} if "guardrail_response" in entry else {}),
     }
 
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2698,7 +2698,7 @@ class StandardLoggingGuardrailInformation(TypedDict, total=False):
     guardrail_name: Optional[str]
     guardrail_provider: Optional[str]
     guardrail_mode: Optional[Union[GuardrailEventHooks, List[GuardrailEventHooks], GuardrailMode]]
-    guardrail_request: Optional[Union[dict, str]]
+    guardrail_request: Optional[Union[str, dict]]
     guardrail_response: Optional[Union[dict, str, List[dict]]]
     guardrail_status: GuardrailStatus
     start_time: Optional[float]
@@ -2729,10 +2729,10 @@ class StandardLoggingGuardrailInformation(TypedDict, total=False):
     confidence_score: Optional[float]
     """For LLM-judge guardrails: confidence score 0.0-1.0"""
 
-    classification: Optional[Union[dict, str]]
+    classification: Optional[Union[str, dict]]
     """For LLM-judge guardrails: structured classification output"""
 
-    match_details: Optional[Union[List[dict], str]]
+    match_details: Optional[Union[str, List[dict]]]
     """Detailed match information for each detected pattern"""
 
     patterns_checked: Optional[int]

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2729,10 +2729,10 @@ class StandardLoggingGuardrailInformation(TypedDict, total=False):
     confidence_score: Optional[float]
     """For LLM-judge guardrails: confidence score 0.0-1.0"""
 
-    classification: Optional[dict]
+    classification: Optional[Union[dict, str]]
     """For LLM-judge guardrails: structured classification output"""
 
-    match_details: Optional[List[dict]]
+    match_details: Optional[Union[List[dict], str]]
     """Detailed match information for each detected pattern"""
 
     patterns_checked: Optional[int]

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2698,7 +2698,7 @@ class StandardLoggingGuardrailInformation(TypedDict, total=False):
     guardrail_name: Optional[str]
     guardrail_provider: Optional[str]
     guardrail_mode: Optional[Union[GuardrailEventHooks, List[GuardrailEventHooks], GuardrailMode]]
-    guardrail_request: Optional[dict]
+    guardrail_request: Optional[Union[dict, str]]
     guardrail_response: Optional[Union[dict, str, List[dict]]]
     guardrail_status: GuardrailStatus
     start_time: Optional[float]

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -1265,6 +1265,42 @@ def test_get_spend_logs_metadata_guardrail_info_fallback_from_metadata():
 
 
 @patch("litellm.proxy.spend_tracking.spend_tracking_utils._should_store_prompts_and_responses_in_spend_logs")
+def test_sanitize_guardrail_information_redacts_all_prompt_carrying_fields_when_flag_false(
+    mock_should_store,
+):
+    """
+    match_details and classification are declared as structured metadata but
+    in-tree writers (litellm_content_filter, block_code_execution) inline
+    raw prompt content into them, so they leak the same way
+    guardrail_request/guardrail_response do. Redaction must cover all four.
+    """
+    mock_should_store.return_value = False
+    guardrail_info = [
+        {
+            "guardrail_name": "demo-echo-guard",
+            "guardrail_status": "success",
+            "guardrail_request": {"messages": [{"role": "user", "content": "hi"}]},
+            "guardrail_response": {"evaluated_input": "hi"},
+            "match_details": [{"type": "pattern", "snippet": "hi", "action_taken": "log"}],
+            "classification": {"intent": "x", "evidence": [{"match": "hi"}]},
+            "guardrail_action": "NONE",
+        }
+    ]
+
+    result = _sanitize_guardrail_information_for_spend_logs(guardrail_info)
+
+    assert result is not None
+    entry = result[0]
+    assert entry["guardrail_request"] == REDACTED_BY_LITELM_STRING
+    assert entry["guardrail_response"] == REDACTED_BY_LITELM_STRING
+    assert entry["match_details"] == REDACTED_BY_LITELM_STRING
+    assert entry["classification"] == REDACTED_BY_LITELM_STRING
+    assert entry["guardrail_name"] == "demo-echo-guard"
+    assert entry["guardrail_status"] == "success"
+    assert entry["guardrail_action"] == "NONE"
+
+
+@patch("litellm.proxy.spend_tracking.spend_tracking_utils._should_store_prompts_and_responses_in_spend_logs")
 def test_sanitize_guardrail_information_redacts_prompt_fields_when_flag_false(
     mock_should_store,
 ):

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -1357,6 +1357,33 @@ def test_sanitize_guardrail_information_none_passthrough(mock_should_store):
     assert _sanitize_guardrail_information_for_spend_logs(None) is None
 
 
+@patch("litellm.proxy.spend_tracking.spend_tracking_utils._should_store_prompts_and_responses_in_spend_logs")
+def test_sanitize_guardrail_information_preserves_absent_prompt_fields(mock_should_store):
+    """
+    Entries that never carried guardrail_request or guardrail_response must
+    not gain those keys after sanitization; consumers keying on presence
+    (`"guardrail_request" in entry`) would otherwise flip from absent to
+    the sentinel string.
+    """
+    mock_should_store.return_value = False
+    guardrail_info = [
+        {
+            "guardrail_name": "demo-echo-guard",
+            "guardrail_status": "success",
+            "guardrail_response": {"verdict": "allow", "evaluated_input": "hi"},
+        }
+    ]
+
+    result = _sanitize_guardrail_information_for_spend_logs(guardrail_info)
+
+    assert result is not None
+    entry = result[0]
+    assert "guardrail_request" not in entry
+    assert entry["guardrail_response"] == REDACTED_BY_LITELM_STRING
+    assert entry["guardrail_name"] == "demo-echo-guard"
+    assert entry["guardrail_status"] == "success"
+
+
 @patch("litellm.proxy.proxy_server.master_key", "sk-master")
 @patch(
     "litellm.proxy.proxy_server.general_settings",

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -1277,7 +1277,7 @@ def test_sanitize_guardrail_information_redacts_prompt_fields_when_flag_false(
     mock_should_store.return_value = False
     guardrail_info = [
         {
-            "guardrail_name": "claude-code-access-guard",
+            "guardrail_name": "demo-echo-guard",
             "guardrail_provider": "custom",
             "guardrail_mode": "pre_call",
             "guardrail_status": "success",
@@ -1306,7 +1306,7 @@ def test_sanitize_guardrail_information_redacts_prompt_fields_when_flag_false(
     entry = result[0]
     assert entry["guardrail_request"] == REDACTED_BY_LITELM_STRING
     assert entry["guardrail_response"] == REDACTED_BY_LITELM_STRING
-    assert entry["guardrail_name"] == "claude-code-access-guard"
+    assert entry["guardrail_name"] == "demo-echo-guard"
     assert entry["guardrail_provider"] == "custom"
     assert entry["guardrail_mode"] == "pre_call"
     assert entry["guardrail_status"] == "success"
@@ -1370,7 +1370,7 @@ def test_get_logging_payload_redacts_guardrail_prompt_fields_when_flag_false():
     """
     guardrail_info = [
         {
-            "guardrail_name": "claude-code-access-guard",
+            "guardrail_name": "demo-echo-guard",
             "guardrail_provider": "custom",
             "guardrail_status": "success",
             "guardrail_request": {"messages": [{"role": "user", "content": "secret"}]},
@@ -1400,7 +1400,7 @@ def test_get_logging_payload_redacts_guardrail_prompt_fields_when_flag_false():
     stored = metadata_result["guardrail_information"][0]
     assert stored["guardrail_request"] == REDACTED_BY_LITELM_STRING
     assert stored["guardrail_response"] == REDACTED_BY_LITELM_STRING
-    assert stored["guardrail_name"] == "claude-code-access-guard"
+    assert stored["guardrail_name"] == "demo-echo-guard"
     assert stored["guardrail_status"] == "success"
 
 

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -1394,6 +1394,57 @@ def test_sanitize_guardrail_information_none_passthrough(mock_should_store):
 
 
 @patch("litellm.proxy.spend_tracking.spend_tracking_utils._should_store_prompts_and_responses_in_spend_logs")
+def test_sanitize_guardrail_information_normalizes_bare_dict_input(mock_should_store):
+    """
+    Regression: xecguard (xecguard.py:246) assigns a bare dict to
+    standard_logging_object["guardrail_information"] even though the typed
+    contract is Optional[List[...]]. Without defensive normalization here,
+    the for-loop would iterate the dict's string keys and _redact...
+    would TypeError on {**"guardrail_name"}, taking down the entire
+    spend-log write via update_database's broad except.
+    """
+    mock_should_store.return_value = False
+    bare_dict_entry = {
+        "guardrail_name": "xecguard",
+        "guardrail_status": "success",
+        "guardrail_response": {"decision": "SAFE", "raw_prompt": "hi"},
+        "start_time": 1.0,
+        "end_time": 2.0,
+        "duration": 1.0,
+    }
+
+    result = _sanitize_guardrail_information_for_spend_logs(bare_dict_entry)
+
+    assert result is not None
+    assert isinstance(result, list)
+    assert len(result) == 1
+    entry = result[0]
+    assert entry["guardrail_response"] == REDACTED_BY_LITELM_STRING
+    assert entry["guardrail_name"] == "xecguard"
+    assert entry["guardrail_status"] == "success"
+    assert entry["start_time"] == 1.0
+
+
+@patch("litellm.proxy.spend_tracking.spend_tracking_utils._should_store_prompts_and_responses_in_spend_logs")
+def test_sanitize_guardrail_information_drops_non_dict_items_in_list(mock_should_store):
+    """
+    A stray non-dict item in the list (e.g. from a buggy caller that
+    accidentally appends a string) should be silently skipped instead of
+    crashing the spend-log write.
+    """
+    mock_should_store.return_value = False
+    mixed_input = [
+        {"guardrail_name": "x", "guardrail_response": {"leak": "hi"}},
+        "not-a-dict",
+        None,
+    ]
+
+    result = _sanitize_guardrail_information_for_spend_logs(mixed_input)
+
+    assert result == [{"guardrail_name": "x", "guardrail_response": REDACTED_BY_LITELM_STRING}]
+
+
+@patch("litellm.proxy.spend_tracking.spend_tracking_utils._should_store_prompts_and_responses_in_spend_logs")
 def test_sanitize_guardrail_information_preserves_absent_prompt_fields(mock_should_store):
     """
     Entries that never carried guardrail_request or guardrail_response must

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -33,6 +33,7 @@ from litellm.proxy.spend_tracking.spend_tracking_utils import (
     _is_master_key,
     _redact_prompt_leaks_in_error_string,
     _sanitize_error_information_for_spend_logs,
+    _sanitize_guardrail_information_for_spend_logs,
     _sanitize_request_body_for_spend_logs_payload,
     _should_store_prompts_and_responses_in_spend_logs,
     get_logging_payload,
@@ -1263,6 +1264,146 @@ def test_get_spend_logs_metadata_guardrail_info_fallback_from_metadata():
     assert result["guardrail_information"] is None
 
 
+@patch("litellm.proxy.spend_tracking.spend_tracking_utils._should_store_prompts_and_responses_in_spend_logs")
+def test_sanitize_guardrail_information_redacts_prompt_fields_when_flag_false(
+    mock_should_store,
+):
+    """
+    LIT-4314 Issue A regression: with store_prompts_in_spend_logs=False,
+    guardrail_request and guardrail_response must be redacted before they
+    land in LiteLLM_SpendLogs.metadata, while every other field on the
+    entry is preserved bit-for-bit.
+    """
+    mock_should_store.return_value = False
+    guardrail_info = [
+        {
+            "guardrail_name": "claude-code-access-guard",
+            "guardrail_provider": "custom",
+            "guardrail_mode": "pre_call",
+            "guardrail_status": "success",
+            "guardrail_request": {
+                "messages": [{"role": "user", "content": "Say hi in 3 words"}],
+            },
+            "guardrail_response": {
+                "evaluated_input": "Say hi in 3 words",
+                "verdict": "allow",
+            },
+            "start_time": 1_700_000_000.0,
+            "end_time": 1_700_000_000.5,
+            "duration": 0.5,
+            "guardrail_id": "gd-42",
+            "masked_entity_count": {"EMAIL": 1},
+            "violation_categories": ["prompt_injection"],
+            "risk_score": 3.5,
+            "guardrail_action": "NONE",
+        }
+    ]
+
+    result = _sanitize_guardrail_information_for_spend_logs(guardrail_info)
+
+    assert result is not None
+    assert len(result) == 1
+    entry = result[0]
+    assert entry["guardrail_request"] == REDACTED_BY_LITELM_STRING
+    assert entry["guardrail_response"] == REDACTED_BY_LITELM_STRING
+    assert entry["guardrail_name"] == "claude-code-access-guard"
+    assert entry["guardrail_provider"] == "custom"
+    assert entry["guardrail_mode"] == "pre_call"
+    assert entry["guardrail_status"] == "success"
+    assert entry["start_time"] == 1_700_000_000.0
+    assert entry["end_time"] == 1_700_000_000.5
+    assert entry["duration"] == 0.5
+    assert entry["guardrail_id"] == "gd-42"
+    assert entry["masked_entity_count"] == {"EMAIL": 1}
+    assert entry["violation_categories"] == ["prompt_injection"]
+    assert entry["risk_score"] == 3.5
+    assert entry["guardrail_action"] == "NONE"
+
+    assert guardrail_info[0]["guardrail_request"] == {
+        "messages": [{"role": "user", "content": "Say hi in 3 words"}],
+    }
+    assert guardrail_info[0]["guardrail_response"] == {
+        "evaluated_input": "Say hi in 3 words",
+        "verdict": "allow",
+    }
+
+
+@patch("litellm.proxy.spend_tracking.spend_tracking_utils._should_store_prompts_and_responses_in_spend_logs")
+def test_sanitize_guardrail_information_passthrough_when_flag_true(
+    mock_should_store,
+):
+    """
+    When store_prompts_in_spend_logs=True the sanitizer must be a no-op so
+    operators who explicitly opted in still see full guardrail payloads.
+    """
+    mock_should_store.return_value = True
+    guardrail_info = [
+        {
+            "guardrail_name": "content_filter",
+            "guardrail_status": "success",
+            "guardrail_request": {"messages": [{"role": "user", "content": "hi"}]},
+            "guardrail_response": {"verdict": "allow"},
+        }
+    ]
+
+    result = _sanitize_guardrail_information_for_spend_logs(guardrail_info)
+
+    assert result == guardrail_info
+
+
+@patch("litellm.proxy.spend_tracking.spend_tracking_utils._should_store_prompts_and_responses_in_spend_logs")
+def test_sanitize_guardrail_information_none_passthrough(mock_should_store):
+    mock_should_store.return_value = False
+    assert _sanitize_guardrail_information_for_spend_logs(None) is None
+
+
+@patch("litellm.proxy.proxy_server.master_key", "sk-master")
+@patch(
+    "litellm.proxy.proxy_server.general_settings",
+    {"store_prompts_in_spend_logs": False},
+)
+def test_get_logging_payload_redacts_guardrail_prompt_fields_when_flag_false():
+    """
+    End-to-end wire-in check: get_logging_payload -> _get_spend_logs_metadata
+    -> sanitizer. Without the wire-in at line 139, the raw guardrail_response
+    lands in payload["metadata"] verbatim.
+    """
+    guardrail_info = [
+        {
+            "guardrail_name": "claude-code-access-guard",
+            "guardrail_provider": "custom",
+            "guardrail_status": "success",
+            "guardrail_request": {"messages": [{"role": "user", "content": "secret"}]},
+            "guardrail_response": {"evaluated_input": "secret"},
+        }
+    ]
+    kwargs = {
+        "model": "gpt-4o-mini",
+        "litellm_call_id": "test-call-id",
+        "litellm_params": {
+            "metadata": {
+                "user_api_key": "test-key",
+                "standard_logging_guardrail_information": guardrail_info,
+            },
+            "proxy_server_request": {},
+        },
+    }
+
+    payload = get_logging_payload(
+        kwargs=kwargs,
+        response_obj={},
+        start_time=datetime.datetime.now(tz=timezone.utc),
+        end_time=datetime.datetime.now(tz=timezone.utc),
+    )
+
+    metadata_result = json.loads(payload["metadata"])
+    stored = metadata_result["guardrail_information"][0]
+    assert stored["guardrail_request"] == REDACTED_BY_LITELM_STRING
+    assert stored["guardrail_response"] == REDACTED_BY_LITELM_STRING
+    assert stored["guardrail_name"] == "claude-code-access-guard"
+    assert stored["guardrail_status"] == "success"
+
+
 def test_get_logging_payload_guardrail_info_when_no_standard_logging_payload():
     """
     When a guardrail blocks a request before the LLM call, the standard_logging_object
@@ -1295,7 +1436,10 @@ def test_get_logging_payload_guardrail_info_when_no_standard_logging_payload():
     }
 
     with patch("litellm.proxy.proxy_server.master_key", "sk-master"):
-        with patch("litellm.proxy.proxy_server.general_settings", {}):
+        with patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {"store_prompts_in_spend_logs": True},
+        ):
             payload = get_logging_payload(
                 kwargs=kwargs,
                 response_obj={},


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4314

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

`store_prompts_in_spend_logs: false` was already gating the request body, response body, vector-store text, and provider error strings, but not `guardrail_information`. `_get_spend_logs_metadata` in `litellm/proxy/spend_tracking/spend_tracking_utils.py` was assigning the incoming list through verbatim, so any guardrail hook that echoes the LLM request into its `guardrail_response` (a common pattern for custom guardrails, and one that many first-party guardrails hit implicitly) leaked the raw prompt into `LiteLLM_SpendLogs.metadata`. Users then saw it in the Logs UI Metadata panel.

Reviewing every field on `StandardLoggingGuardrailInformation` while writing the fix surfaced two more leak surfaces on the same code path that the docstrings didn't obviously call out. `litellm_content_filter` writes `classification = dict(CompetitorIntentDetection)`, whose `evidence[*].match` field is a substring pulled straight from the user's normalized prompt (`competitor_intent/base.py:184-194`). `block_code_execution` writes `match_details = [dict(d) for d in detections]`, where each detection carries the fenced code block extracted from the user's message (`block_code_execution.py:571`). Both bypassed `store_prompts_in_spend_logs` the same way `guardrail_response` did, so the redaction set on this PR covers all four: `guardrail_request`, `guardrail_response`, `match_details`, `classification`.

Reproduced against a live proxy with `store_prompts_in_spend_logs: false`, a real OpenAI `gpt-4o-mini` call, and a minimal `CustomGuardrail` (`/tmp/lit4314_guardrail.py`) that mirrors the real-world shape: it calls `add_standard_logging_guardrail_information_to_request_data` with a `guardrail_response` embedding `evaluated_input`, plus a `tracing_detail` populating `match_details[0].snippet` and `classification.evidence[0].match` with the raw prompt (exactly the shape `litellm_content_filter` and `block_code_execution` emit in-tree). Config: `/tmp/lit4314_config.yaml`. DB: `postgresql://yucheng@127.0.0.1:5432/litellm_lit4314`.

### Before (bug present, base `1fa200123f`)

```bash
curl -sS http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer <team-scoped-key>" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"secret prompt LEAKME"}]}'

psql -U yucheng -h 127.0.0.1 -d litellm_lit4314 -t -A -c \
  "SELECT metadata FROM \"LiteLLM_SpendLogs\" ORDER BY \"startTime\" DESC LIMIT 1;" \
  | jq '.guardrail_information[0]'
```

```json
{
  "duration": 0.000005,
  "end_time": 1783643750.901457,
  "start_time": 1783643750.901453,
  "match_details": [
    {
      "type": "pattern",
      "snippet": "[{'role': 'user', 'content': 'secret prompt LEAKME'}]",
      "action_taken": "log_only"
    }
  ],
  "classification": {
    "intent": "competitor_comparison",
    "evidence": [
      {
        "key": "competitor",
        "type": "entity",
        "match": "[{'role': 'user', 'content': 'secret prompt LEAKME'}]",
        "value": "acme"
      }
    ],
    "confidence": 0.75
  },
  "guardrail_mode": "pre_call",
  "guardrail_name": "lit4314-leaky-guard",
  "guardrail_status": "success",
  "guardrail_provider": "lit4314-repro",
  "guardrail_response": {
    "verdict": "allow",
    "evaluated_input": [
      { "role": "user", "content": "secret prompt LEAKME" }
    ]
  },
  "masked_entity_count": null
}
```

Raw prompt `"secret prompt LEAKME"` lands in the metadata column verbatim across four separate fields despite the flag being false.

### After (fix, HEAD `648ef296ba`, same flag `false`)

Same curl + psql pair against restarted proxy on the fix commit:

```json
{
  "duration": 0.000006,
  "end_time": 1783643821.580168,
  "start_time": 1783643821.580163,
  "match_details": "REDACTED_BY_LITELM",
  "classification": "REDACTED_BY_LITELM",
  "guardrail_mode": "pre_call",
  "guardrail_name": "lit4314-leaky-guard",
  "guardrail_status": "success",
  "guardrail_request": "REDACTED_BY_LITELM",
  "guardrail_provider": "lit4314-repro",
  "guardrail_response": "REDACTED_BY_LITELM",
  "masked_entity_count": null
}
```

All four prompt-carrying fields are the sentinel; `guardrail_name`, `guardrail_provider`, `guardrail_mode`, `guardrail_status`, `start_time`, `end_time`, `duration`, `masked_entity_count` are preserved bit-for-bit.

### Positive path (flag flipped to `true`, same fixed commit)

With `store_prompts_in_spend_logs: true`, operators who opt in still see the full guardrail payload; the sanitizer is a no-op in that case:

```json
{
  "guardrail_name": "lit4314-leaky-guard",
  "guardrail_status": "success",
  "guardrail_provider": "lit4314-repro",
  "guardrail_response": {
    "verdict": "allow",
    "evaluated_input": [
      { "role": "user", "content": "Say hi in 3 words" }
    ]
  }
}
```

## Type

Bug Fix

## Changes

`litellm/proxy/spend_tracking/spend_tracking_utils.py`
- New `_sanitize_guardrail_information_for_spend_logs` helper, placed next to the existing per-field sanitizers. Reads `_should_store_prompts_and_responses_in_spend_logs`; when False, returns a list of shape-preserving copies where each key in `_PROMPT_CARRYING_GUARDRAIL_FIELDS` (`guardrail_request`, `guardrail_response`, `match_details`, `classification`) that the entry actually carried is replaced with `REDACTED_BY_LITELM_STRING`. Entries that never carried a given key do not gain it after sanitization. When the flag is True or the input is None, the input is returned unchanged.
- `_get_spend_logs_metadata` now routes `guardrail_information` through that helper (the single choke point for every spend-log write path).
- Defensive normalization at the sanitizer entry point: `xecguard.py:246` assigns a bare dict to `standard_logging_object["guardrail_information"]` even though the typed contract is `Optional[List[...]]`. Without normalization the iterator would walk the dict's keys and raise `TypeError`, which `update_database`'s broad `except` swallows, silently dropping the spend-log row. The sanitizer now wraps a bare dict as a single-item list and skips any non-dict items, mirroring OTEL's existing pattern at `opentelemetry.py:1751-1753` for the same field. Root cause on the writer side is tracked as a separate ticket (see follow-ups).

`litellm/types/utils.py`
- Widen `StandardLoggingGuardrailInformation.guardrail_request` from `Optional[dict]` to `Optional[Union[dict, str]]`, `classification` from `Optional[dict]` to `Optional[Union[dict, str]]`, and `match_details` from `Optional[List[dict]]` to `Optional[Union[List[dict], str]]` so the redaction sentinel satisfies the TypedDict without a cast. `guardrail_response` already accepted `str`.

`tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py`
- Unit tests on the sanitizer covering: all four prompt-carrying fields redacted while every metadata field is preserved bit-for-bit; passthrough when the flag is True; passthrough on `None`; shape preservation (a key that was never present must not appear on the output as the sentinel); bare-dict input normalized to a list; non-dict items skipped.
- End-to-end test on `get_logging_payload -> _get_spend_logs_metadata -> _sanitize_guardrail_information_for_spend_logs` that fails if the wire-in in `_get_spend_logs_metadata` is reverted (mutation-checked).

## Follow-ups (out of scope for this PR)

Issue B: credential masking in `guardrail_information` (Bedrock/Presidio-style provider bodies embedded in `guardrail_response` still carry API keys / bearer tokens even when prompts are redacted); tracked as a sibling PR.

Issue C: split `callback_vars` transport from `UserAPIKeyAuth.team_metadata`; separate ticket.

Issue D: `optional_params` / `additional_params` unmasked flattening and `litellm_params.api_key` unmasked across observability sinks; separate ticket.

LIT-4335: fix xecguard's writer to append into a list via `add_standard_logging_guardrail_information_to_request_data` instead of overwriting `standard_logging_object["guardrail_information"]` with a bare dict, so the type contract on `StandardLoggingPayload.guardrail_information` (`Optional[List[...]]`) holds at runtime. Discovered while shipping this PR; the defensive normalization here is a belt-and-suspenders mitigation until the writer is fixed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what is persisted in LiteLLM_SpendLogs.metadata (privacy-sensitive), but follows the existing store_prompts gating pattern and is covered by targeted tests; opt-in true still stores full guardrail payloads.
> 
> **Overview**
> When **`store_prompts_in_spend_logs`** is false, spend-log metadata no longer stores raw user content inside **`guardrail_information`**. **`_get_spend_logs_metadata`** now runs guardrail entries through **`_sanitize_guardrail_information_for_spend_logs`**, which replaces **`guardrail_request`**, **`guardrail_response`**, **`match_details`**, and **`classification`** with **`REDACTED_BY_LITELM_STRING`** while leaving other guardrail fields (name, status, timings, risk score, etc.) unchanged.
> 
> The sanitizer is a no-op when the flag is true or input is **`None`**, does not add redaction keys for fields that were absent, wraps a bare dict as a single-entry list (defensive against malformed writers), and skips non-dict list items so spend-log writes do not fail. **`StandardLoggingGuardrailInformation`** types are widened so string redaction sentinels type-check.
> 
> Tests cover unit behavior, **`get_logging_payload`** end-to-end, and an existing guardrail UI test now opts into **`store_prompts_in_spend_logs: true`** so it still expects full payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 648ef296baf7ff244872fe29c1360ec856c1d888. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->