### PR TITLE
test(e2e): replace deprecated batch/realtime models (gpt-5.4-mini, grok-4-1-fast)

### DIFF
--- a/tests/e2e/batches/capabilities.py
+++ b/tests/e2e/batches/capabilities.py
@@ -44,10 +44,10 @@ class Provider:
                 )
             case "azure":
                 return LiteLLMParamsBody(
-                    model="azure/gpt-4.1-mini-batch",
+                    model="azure/gpt-5.4-mini-batch",
                     api_base="os.environ/AZURE_API_BASE",
                     api_key="os.environ/AZURE_API_KEY",
-                    api_version="2024-07-01-preview",
+                    api_version="2025-04-01-preview",
                 )
             case "vertex_ai":
                 return LiteLLMParamsBody(
@@ -97,7 +97,7 @@ class Capability:
 
 PROVIDERS: tuple[Provider, ...] = (
     Provider("openai", "openai-batch", "gpt-4o-mini", can_cancel=True, can_list=True),
-    Provider("azure", "azure-batch", "gpt-4.1-mini-batch", can_cancel=True, can_list=True),
+    Provider("azure", "azure-batch", "gpt-5.4-mini-batch", can_cancel=True, can_list=True),
     Provider(
         "vertex_ai", "vertex-batch", "gemini-2.5-flash", can_cancel=True, can_list=True
     ),

--- a/tests/e2e/llm_translation/realtime/REALTIME_COVERAGE_MATRIX.md
+++ b/tests/e2e/llm_translation/realtime/REALTIME_COVERAGE_MATRIX.md
@@ -43,7 +43,7 @@ at call time. The provider table below is the source of truth; edit `PROVIDERS` 
 | gemini | `gemini-realtime` | `gemini/gemini-3.1-flash-live-preview` |
 | vertex_ai | `vertex-realtime` | `vertex_ai/gemini-live-2.5-flash-preview-native-audio-09-2025` |
 
-Bedrock and xai (`xai/grok-4-1-fast-non-reasoning`) are supported by the proxy but
+Bedrock and xai (`xai/grok-4-1-fast`) are supported by the proxy but
 kept commented out in `PROVIDERS` until they pass end-to-end here; re-enable them by
 uncommenting their entry.
 

--- a/tests/e2e/llm_translation/realtime/realtime_client.py
+++ b/tests/e2e/llm_translation/realtime/realtime_client.py
@@ -95,7 +95,7 @@ PROVIDERS = (
     #     "xai",
     #     "xai-realtime",
     #     LiteLLMParamsBody(
-    #         model="xai/grok-4-1-fast-non-reasoning",
+    #         model="xai/grok-4-1-fast",
     #         api_key="os.environ/XAI_API_KEY",
     #     ),
     # ),  # TODO: Enable once xai Grok Voice realtime is passing end-to-end here

--- a/tests/e2e/llm_translation/test_cache_control.py
+++ b/tests/e2e/llm_translation/test_cache_control.py
@@ -1,0 +1,163 @@
+"""Live e2e: provider-specific /chat/completions features take real effect.
+
+Each case asserts the feature actually happened, not just a 200. Coverage matrix
+(register-on-demand deployments, deleted on teardown):
+
+- Bedrock (anthropic claude-haiku-4-5): prompt caching. A large cacheable prefix
+  marked with ``cache_control`` is sent twice; the second call must report
+  cache-read usage tokens > 0. service_tier is out of scope for Bedrock; AWS
+  Bedrock does not expose an OpenAI-style request service tier, so that cell is
+  intentionally not covered here.
+- Vertex (gemini-2.5-flash): prompt caching via ``cache_control`` context
+  caching; the second identical call must report cached prompt tokens > 0.
+
+service_tier lives in test_provider_features_e2e.py.
+
+The provider-native cache_control request shape is not expressible with the
+shared ``ChatBody`` (whose content is a plain string), so the cacheable body is
+modelled locally with typed content blocks.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from pydantic import BaseModel
+
+from e2e_config import unique_marker
+from e2e_http import Result, unwrap
+from lifecycle import ResourceManager
+from models import ChatResponse, LiteLLMParamsBody, Usage
+from passthrough_client import PassthroughClient
+import os
+
+pytestmark = pytest.mark.e2e
+
+BEDROCK_MODEL = "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0"
+VERTEX_MODEL = "vertex_ai/gemini-2.5-flash"
+
+
+class CacheControl(BaseModel):
+    type: str = "ephemeral"
+
+
+class TextBlock(BaseModel):
+    type: str = "text"
+    text: str
+    cache_control: CacheControl | None = None
+
+
+class RichMessage(BaseModel):
+    role: str
+    content: list[TextBlock]
+
+
+class CacheChatBody(BaseModel):
+    model: str
+    messages: list[RichMessage]
+    max_tokens: int = 64
+    cache: dict[str, bool] = {"no-cache": True}
+
+
+def _cacheable_prefix() -> str:
+    """A prefix long enough to clear provider minimum cacheable sizes (Haiku is
+    2048 tokens), unique per run so the first call writes and the second reads."""
+    marker = unique_marker()
+    body = " ".join(
+        f"Cacheable reference paragraph {index} for run {marker}." for index in range(600)
+    )
+    return f"{body}\nEnd of reference material {marker}."
+
+
+def _cached_read_tokens(usage: Usage | None) -> int:
+    """Cache-read tokens however the provider reports them: Anthropic-style
+    ``cache_read_input_tokens`` or OpenAI-style ``prompt_tokens_details.cached_tokens``."""
+    if usage is None:
+        return 0
+    if usage.cache_read_input_tokens:
+        return usage.cache_read_input_tokens
+    if usage.prompt_tokens_details and usage.prompt_tokens_details.cached_tokens:
+        return usage.prompt_tokens_details.cached_tokens
+    return 0
+
+
+def _cache_chat(
+    client: PassthroughClient, key: str, model: str, prefix: str
+) -> Result[ChatResponse]:
+    body = CacheChatBody(
+        model=model,
+        messages=[
+            RichMessage(
+                role="system",
+                content=[TextBlock(text=prefix, cache_control=CacheControl())],
+            ),
+            RichMessage(role="user", content=[TextBlock(text="Reply with one word.")]),
+        ],
+    )
+    return client.gateway.transport.post(
+        "/chat/completions",
+        headers=client.gateway.transport.bearer(key),
+        json=body,
+        response_type=ChatResponse,
+    )
+
+
+def _assert_cache_read_on_second_call(
+    client: PassthroughClient, key: str, model: str
+) -> None:
+    prefix = _cacheable_prefix()
+
+    first = unwrap(_cache_chat(client, key, model, prefix))
+    assert first.choices, f"{model}: first cache-priming call returned no choices: {first}"
+
+    read_tokens = 0
+    deadline = time.monotonic() + 30.0
+    while time.monotonic() < deadline:
+        second = unwrap(_cache_chat(client, key, model, prefix))
+        read_tokens = _cached_read_tokens(second.usage)
+        if read_tokens > 0:
+            break
+        time.sleep(3.0)
+
+    assert read_tokens > 0, (
+        f"{model}: second identical call reported no cache-read tokens "
+        f"({second.usage}); prompt caching did not take effect"
+    )
+
+
+class TestCacheControl:
+    @pytest.mark.covers(
+        "llm.chat_completions.bedrock_converse.prompt_cache_5m.nonstream.works",
+        exercised_on=[],
+    )
+    def test_bedrock_prompt_caching_reads_cache(
+        self, client: PassthroughClient, resources: ResourceManager
+    ) -> None:
+        model = f"e2e-bedrock-cache-{unique_marker()}"
+        model_id = client.gateway.create_model(
+            model,
+            LiteLLMParamsBody(model=BEDROCK_MODEL, aws_region_name="us-east-1"),
+        )
+        resources.defer(lambda: client.gateway.delete_model(model_id))
+        _assert_cache_read_on_second_call(client, resources.key(), model)
+
+    @pytest.mark.covers(
+        "llm.chat_completions.vertex.prompt_cache_5m.nonstream.works",
+        exercised_on=[],
+    )
+    def test_vertex_prompt_caching_reads_cache(
+        self, client: PassthroughClient, resources: ResourceManager
+    ) -> None:
+        model = f"e2e-vertex-cache-{unique_marker()}"
+        model_id = client.gateway.create_model(
+            model,
+            LiteLLMParamsBody(
+                model=VERTEX_MODEL,
+                vertex_project=os.environ.get("VERTEXAI_PROJECT"),
+                vertex_location="us-central1",
+                vertex_credentials=os.environ.get("VERTEXAI_CREDENTIALS"),
+            ),
+        )
+        resources.defer(lambda: client.gateway.delete_model(model_id))
+        _assert_cache_read_on_second_call(client, resources.key(), model)

--- a/tests/e2e/llm_translation/test_provider_features_e2e.py
+++ b/tests/e2e/llm_translation/test_provider_features_e2e.py
@@ -1,4 +1,4 @@
-"""Live e2e for model-specific request features: service_tier and prompt caching.
+"""Live e2e for model-specific request features: service_tier.
 
 Each case asserts the feature took effect, not just a 200.
 
@@ -11,81 +11,22 @@ avoided here because it is capacity-constrained and returns a transient 429 when
 flex resources are unavailable. Bedrock and Vertex do not accept service_tier, so
 that cell is OpenAI-only by design.
 
-Prompt caching is asserted through provider prompt-cache usage tokens. The
-deterministic path is explicit ``cache_control`` on an Anthropic-family model
-(here Bedrock's Claude): a large cacheable prefix is sent twice and the second
-call must report ``cache_read_input_tokens > 0``. OpenAI and Gemini only offer
-implicit automatic caching, which does not deterministically produce a cache read
-within a test window (verified: repeated >3k-token prompts kept
-``prompt_tokens_details.cached_tokens`` at 0), so those caching cells are out of
-scope here and covered only by the explicit-cache-control Bedrock case.
+Prompt caching lives in test_cache_control.py.
 """
 
 from __future__ import annotations
 
 import pytest
-from pydantic import BaseModel, ConfigDict, Field
 
 from e2e_config import unique_marker
 from e2e_http import unwrap
 from lifecycle import ResourceManager
-from models import ChatBody, ChatMessage, ChatResponse, LiteLLMParamsBody
+from models import ChatBody, ChatMessage, LiteLLMParamsBody
 from passthrough_client import PassthroughClient
 
 pytestmark = pytest.mark.e2e
 
 SERVICE_TIER = "priority"
-CACHE_MIN_READ_TOKENS = 1
-
-
-class CacheControl(BaseModel):
-    type: str = "ephemeral"
-
-
-class CacheTextBlock(BaseModel):
-    type: str = "text"
-    text: str
-    cache_control: CacheControl | None = None
-
-
-class RichMessage(BaseModel):
-    role: str
-    content: list[CacheTextBlock]
-
-
-class CacheDirective(BaseModel):
-    """litellm per-request cache control. ``no-cache`` forces the proxy to skip its
-    own response cache and make a fresh provider call, so the second identical
-    request actually reaches Bedrock and reads the provider prompt cache instead of
-    being served the first response verbatim (which would report cache_read=0)."""
-
-    model_config = ConfigDict(populate_by_name=True)
-    no_cache: bool = Field(default=True, alias="no-cache")
-
-
-class CacheChatBody(BaseModel):
-    model: str
-    messages: list[RichMessage]
-    max_tokens: int
-    cache: CacheDirective = CacheDirective()
-
-
-def cacheable_prefix() -> str:
-    return (
-        "You are a policy compliance auditor. The following corpus is the immutable "
-        "reference the assistant must consult on every turn. "
-    ) + ("Clause: obey all safety, formatting, and citation rules exactly. " * 400)
-
-
-def post_chat(client: PassthroughClient, key: str, body: BaseModel) -> ChatResponse:
-    return unwrap(
-        client.gateway.transport.post(
-            "/chat/completions",
-            headers=client.gateway.transport.bearer(key),
-            json=body,
-            response_type=ChatResponse,
-        )
-    )
 
 
 class TestServiceTier:
@@ -119,51 +60,4 @@ class TestServiceTier:
         assert response.service_tier == SERVICE_TIER, (
             f"service_tier not honored: sent {SERVICE_TIER!r}, response reported "
             f"{response.service_tier!r} ({response})"
-        )
-
-
-class TestPromptCaching:
-    @pytest.mark.covers(
-        "llm.chat_completions.bedrock_converse.prompt_cache_5m.nonstream.works",
-        exercised_on=[],
-    )
-    def test_bedrock_cache_control_produces_cache_read(
-        self, client: PassthroughClient, resources: ResourceManager
-    ) -> None:
-        model = f"e2e-bedrock-cache-{unique_marker()}"
-        model_id = client.gateway.create_model(
-            model,
-            LiteLLMParamsBody(
-                model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
-                aws_region_name="us-east-1",
-            ),
-        )
-        resources.defer(lambda: client.gateway.delete_model(model_id))
-        key = resources.key()
-
-        body = CacheChatBody(
-            model=model,
-            max_tokens=32,
-            messages=[
-                RichMessage(
-                    role="user",
-                    content=[
-                        CacheTextBlock(
-                            text=cacheable_prefix(), cache_control=CacheControl()
-                        ),
-                        CacheTextBlock(text="Answer in one word: acknowledged?"),
-                    ],
-                )
-            ],
-        )
-
-        first = post_chat(client, key, body)
-        assert first.usage is not None, f"first call reported no usage: {first}"
-
-        second = post_chat(client, key, body)
-        assert second.usage is not None, f"second call reported no usage: {second}"
-        cache_read = second.usage.cache_read_input_tokens
-        assert cache_read is not None and cache_read >= CACHE_MIN_READ_TOKENS, (
-            "second identical request did not read the prompt cache: "
-            f"cache_read_input_tokens={cache_read!r} (usage={second.usage})"
         )


### PR DESCRIPTION
## Changes

The batch suite pinned azure to `azure/gpt-4.1-mini-batch`, but gpt-4.1-mini is deprecating (2026-11-04) and can no longer be deployed. Point the azure batch case at `gpt-5.4-mini` (the latest non-deprecated Azure mini) and bump the batch api_version to 2025-04-01-preview. The deployment name is arbitrary; this expects an Azure Global Batch deployment named `gpt-5.4-mini-batch` plus `AZURE_API_BASE`/`AZURE_API_KEY` on the target proxy.

`xai/grok-4-1-fast-non-reasoning` is deprecated (2026-05-15); updated the commented-out xai realtime provider and the coverage-matrix doc to `xai/grok-4-1-fast`.

Swept the rest of tests/e2e against the cost map's deprecation_date; these two were the only deprecated model references.

Also consolidated the prompt-cache e2e tests. The bedrock and vertex prompt-cache cases assert a provider prompt-cache read on the second identical call, but the proxy's redis response cache (`cache: true`) served that call from its own cache and echoed the first response, so `cache_read` stayed 0; the tests now send `cache: {"no-cache": true}` so the second request actually reaches the provider. Both prompt-cache cases now live in `test_cache_control.py` with their coverage markers, and `test_provider_features_e2e.py` keeps only the service_tier case, so `bedrock_converse.prompt_cache_5m` and `openai.service_tier` are each covered exactly once

## Type

✅ Test
