### PR TITLE
refactor(ui): colocate admin-panel, organizations, router-settings, and old-usage views into _components/

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -851,7 +851,7 @@
       "count": 1
     }
   },
-  "src/components/AdminPanel.tsx": {
+  "src/app/(dashboard)/admin-panel/_components/AdminPanel.tsx": {
     "no-restricted-imports": {
       "count": 1
     },
@@ -1520,7 +1520,7 @@
       "count": 1
     }
   },
-  "src/components/general_settings.tsx": {
+  "src/app/(dashboard)/router-settings/_components/general_settings.tsx": {
     "no-nested-ternary": {
       "count": 3
     },
@@ -2028,7 +2028,7 @@
       "count": 1
     }
   },
-  "src/components/organizations.tsx": {
+  "src/app/(dashboard)/organizations/_components/organizations.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -2371,7 +2371,7 @@
       "count": 1
     }
   },
-  "src/components/usage.tsx": {
+  "src/app/(dashboard)/old-usage/_components/usage.tsx": {
     "no-restricted-imports": {
       "count": 2
     },

--- a/ui/litellm-dashboard/src/app/(dashboard)/admin-panel/_components/AdminPanel.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/admin-panel/_components/AdminPanel.test.tsx
@@ -8,34 +8,34 @@ const mockGetAllowedIPs = vi.fn();
 const mockAddAllowedIP = vi.fn();
 const mockDeleteAllowedIP = vi.fn();
 
-vi.mock("./networking", () => ({
+vi.mock("@/components/networking", () => ({
   getSSOSettings: (...args: unknown[]) => mockGetSSOSettings(...args),
   getAllowedIPs: (...args: unknown[]) => mockGetAllowedIPs(...args),
   addAllowedIP: (...args: unknown[]) => mockAddAllowedIP(...args),
   deleteAllowedIP: (...args: unknown[]) => mockDeleteAllowedIP(...args),
 }));
 
-vi.mock("./constants", () => ({
+vi.mock("@/components/constants", () => ({
   useBaseUrl: () => "http://localhost:4000",
 }));
 
-vi.mock("./Settings/AdminSettings/SSOSettings/SSOSettings", () => ({
+vi.mock("@/components/Settings/AdminSettings/SSOSettings/SSOSettings", () => ({
   default: () => <div>SSO Settings</div>,
 }));
 
-vi.mock("./Settings/AdminSettings/UISettings/UISettings", () => ({
+vi.mock("@/components/Settings/AdminSettings/UISettings/UISettings", () => ({
   default: () => <div>UI Settings</div>,
 }));
 
-vi.mock("./SCIM", () => ({
+vi.mock("@/components/SCIM", () => ({
   default: () => <div>SCIM Config</div>,
 }));
 
-vi.mock("./SSOModals", () => ({
+vi.mock("@/components/SSOModals", () => ({
   default: () => <div>SSO Modals</div>,
 }));
 
-vi.mock("./UIAccessControlForm", () => ({
+vi.mock("@/components/UIAccessControlForm", () => ({
   default: () => <div>UI Access Control Form</div>,
 }));
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/admin-panel/_components/AdminPanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/admin-panel/_components/AdminPanel.tsx
@@ -16,18 +16,18 @@ import {
 } from "@tremor/react";
 import { Alert, Button as Button2, Form, Input, Modal, Space, Tabs, Typography } from "antd";
 import React, { useEffect, useState } from "react";
-import NewBadge from "./common_components/NewBadge";
-import { useBaseUrl } from "./constants";
-import NotificationsManager from "./molecules/notifications_manager";
-import { addAllowedIP, deleteAllowedIP, getAllowedIPs, getSSOSettings } from "./networking";
-import SCIMConfig from "./SCIM";
-import LoggingSettings from "./Settings/AdminSettings/LoggingSettings/LoggingSettings";
-import SSOSettings from "./Settings/AdminSettings/SSOSettings/SSOSettings";
-import UISettings from "./Settings/AdminSettings/UISettings/UISettings";
-import HashicorpVault from "./Settings/AdminSettings/HashicorpVault/HashicorpVault";
-import PluginSettings from "./Settings/AdminSettings/PluginSettings/PluginSettings";
-import SSOModals from "./SSOModals";
-import UIAccessControlForm from "./UIAccessControlForm";
+import NewBadge from "@/components/common_components/NewBadge";
+import { useBaseUrl } from "@/components/constants";
+import NotificationsManager from "@/components/molecules/notifications_manager";
+import { addAllowedIP, deleteAllowedIP, getAllowedIPs, getSSOSettings } from "@/components/networking";
+import SCIMConfig from "@/components/SCIM";
+import LoggingSettings from "@/components/Settings/AdminSettings/LoggingSettings/LoggingSettings";
+import SSOSettings from "@/components/Settings/AdminSettings/SSOSettings/SSOSettings";
+import UISettings from "@/components/Settings/AdminSettings/UISettings/UISettings";
+import HashicorpVault from "@/components/Settings/AdminSettings/HashicorpVault/HashicorpVault";
+import PluginSettings from "@/components/Settings/AdminSettings/PluginSettings/PluginSettings";
+import SSOModals from "@/components/SSOModals";
+import UIAccessControlForm from "@/components/UIAccessControlForm";
 
 const { Title, Paragraph, Text } = Typography;
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/admin-panel/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/admin-panel/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import AdminPanel from "@/components/AdminPanel";
+import AdminPanel from "./_components/AdminPanel";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import useProxySettings from "@/app/(dashboard)/hooks/proxySettings/useProxySettings";
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/old-usage/_components/usage.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/old-usage/_components/usage.tsx
@@ -14,9 +14,9 @@ import {
 
 import React, { useState, useEffect } from "react";
 
-import ViewUserSpend from "./view_user_spend";
-import { ProxySettings } from "./user_dashboard";
-import UsageDatePicker from "./shared/usage_date_picker";
+import ViewUserSpend from "@/components/view_user_spend";
+import { ProxySettings } from "@/components/user_dashboard";
+import UsageDatePicker from "@/components/shared/usage_date_picker";
 import {
   Grid,
   Col,
@@ -48,8 +48,8 @@ import {
   adminGlobalActivity,
   adminGlobalActivityPerModel,
   getProxyUISettings,
-} from "./networking";
-import TopKeyView from "./UsagePage/components/EntityUsage/TopKeyView";
+} from "@/components/networking";
+import TopKeyView from "@/components/UsagePage/components/EntityUsage/TopKeyView";
 import { MoneyCell } from "@/components/shared/table_cells";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/old-usage/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/old-usage/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Usage from "@/components/usage";
+import Usage from "./_components/usage";
 import { DeprecationBanner } from "@/components/DeprecationBanner";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/organizations.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/organizations.test.tsx
@@ -3,11 +3,11 @@ import { render } from "@testing-library/react";
 import React from "react";
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("./vector_store_management/VectorStoreSelector", () => ({
+vi.mock("@/components/vector_store_management/VectorStoreSelector", () => ({
   __esModule: true,
   default: () => null,
 }));
-vi.mock("./mcp_server_management/MCPServerSelector", () => ({
+vi.mock("@/components/mcp_server_management/MCPServerSelector", () => ({
   __esModule: true,
   default: () => null,
 }));

--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/organizations.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/organizations.tsx
@@ -28,16 +28,21 @@ import { Form, Input, Modal, Select as Select2, Tooltip } from "antd";
 import { useQueryClient } from "@tanstack/react-query";
 import React, { useState } from "react";
 import { DateCell, IdCell, MoneyCell } from "@/components/shared/table_cells";
-import DeleteResourceModal from "./common_components/DeleteResourceModal";
-import TableIconActionButton from "./common_components/IconActionButton/TableIconActionButtons/TableIconActionButton";
-import { getModelDisplayName } from "./key_team_helpers/fetch_available_models_team_key";
-import MCPServerSelector from "./mcp_server_management/MCPServerSelector";
-import { ModelSelect } from "./ModelSelect/ModelSelect";
-import NotificationsManager from "./molecules/notifications_manager";
-import { Organization, organizationCreateCall, organizationDeleteCall, organizationListCall } from "./networking";
-import OrganizationInfoView from "./organization/organization_view";
-import NumericalInput from "./shared/numerical_input";
-import VectorStoreSelector from "./vector_store_management/VectorStoreSelector";
+import DeleteResourceModal from "@/components/common_components/DeleteResourceModal";
+import TableIconActionButton from "@/components/common_components/IconActionButton/TableIconActionButtons/TableIconActionButton";
+import { getModelDisplayName } from "@/components/key_team_helpers/fetch_available_models_team_key";
+import MCPServerSelector from "@/components/mcp_server_management/MCPServerSelector";
+import { ModelSelect } from "@/components/ModelSelect/ModelSelect";
+import NotificationsManager from "@/components/molecules/notifications_manager";
+import {
+  Organization,
+  organizationCreateCall,
+  organizationDeleteCall,
+  organizationListCall,
+} from "@/components/networking";
+import OrganizationInfoView from "@/components/organization/organization_view";
+import NumericalInput from "@/components/shared/numerical_input";
+import VectorStoreSelector from "@/components/vector_store_management/VectorStoreSelector";
 
 interface OrganizationsTableProps {
   userRole: string;

--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import OrganizationsTable from "@/components/organizations";
+import OrganizationsTable from "./_components/organizations";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 
 export default function OrganizationsPage() {

--- a/ui/litellm-dashboard/src/app/(dashboard)/router-settings/_components/general_settings.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/router-settings/_components/general_settings.tsx
@@ -13,14 +13,14 @@ import {
   Switch,
 } from "@tremor/react";
 import { TabPanel, TabPanels, TabGroup, TabList, Tab } from "@tremor/react";
-import { getGeneralSettingsCall, updateConfigFieldSetting, deleteConfigFieldSetting } from "./networking";
+import { getGeneralSettingsCall, updateConfigFieldSetting, deleteConfigFieldSetting } from "@/components/networking";
 import { InputNumber } from "antd";
 import { TrashIcon } from "@heroicons/react/outline";
 import { StatusBadge } from "@/components/shared/table_cells";
 
-import RouterSettings from "./router_settings";
-import Fallbacks from "./Settings/RouterSettings/Fallbacks/Fallbacks";
-import RoutingGroups from "./routing_groups";
+import RouterSettings from "@/components/router_settings";
+import Fallbacks from "@/components/Settings/RouterSettings/Fallbacks/Fallbacks";
+import RoutingGroups from "@/components/routing_groups";
 interface GeneralSettingsPageProps {
   accessToken: string | null;
   userRole: string | null;

--- a/ui/litellm-dashboard/src/app/(dashboard)/router-settings/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/router-settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import GeneralSettings from "@/components/general_settings";
+import GeneralSettings from "./_components/general_settings";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 
 export default function RouterSettingsPage() {

--- a/ui/litellm-dashboard/tests/CreateKeyPage.expiredToken.test.tsx
+++ b/ui/litellm-dashboard/tests/CreateKeyPage.expiredToken.test.tsx
@@ -108,13 +108,15 @@ vi.mock("@/components/navbar", () => ({ default: stub("navbar") }));
 vi.mock("@/components/user_dashboard", () => ({ default: stub("user-dashboard") }));
 vi.mock("@/components/templates/model_dashboard", () => ({ default: stub("model-dashboard") }));
 vi.mock("@/components/teams", () => ({ default: stub("teams") }));
-vi.mock("@/components/organizations", () => ({
+vi.mock("@/app/(dashboard)/organizations/_components/organizations", () => ({
   default: stub("organizations"),
   fetchOrganizations: vi.fn(), // consumed in effects
 }));
 vi.mock("@/components/admins", () => ({ default: stub("admin-panel") }));
 vi.mock("@/components/settings", () => ({ default: stub("settings") }));
-vi.mock("@/components/general_settings", () => ({ default: stub("general-settings") }));
+vi.mock("@/app/(dashboard)/router-settings/_components/general_settings", () => ({
+  default: stub("general-settings"),
+}));
 vi.mock("@/components/pass_through_settings", () => ({ default: stub("pass-through-settings") }));
 vi.mock("@/components/budgets/budget_panel", () => ({ default: stub("budget-panel") }));
 vi.mock("@/components/view_logs", () => ({ default: stub("spend-logs") }));
@@ -123,7 +125,7 @@ vi.mock("@/components/new_usage", () => ({ default: stub("new-usage") }));
 vi.mock("@/components/api_ref", () => ({ default: stub("api-ref") }));
 vi.mock("@/components/chat_ui/ChatUI", () => ({ default: stub("chat-ui") }));
 vi.mock("@/components/leftnav", () => ({ default: stub("sidebar") }));
-vi.mock("@/components/usage", () => ({ default: stub("usage") }));
+vi.mock("@/app/(dashboard)/old-usage/_components/usage", () => ({ default: stub("usage") }));
 vi.mock("@/components/cache_dashboard", () => ({ default: stub("cache-dashboard") }));
 vi.mock("@/components/guardrails", () => ({ default: stub("guardrails") }));
 vi.mock("@/components/prompts", () => ({ default: stub("prompts") }));


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Pure relocation with no behavior change; the proof is that each page still renders and its shared dependencies still resolve. On a live proxy, load each and screenshot:

1. `http://localhost:4000/ui/admin-panel` renders admin settings (SSO / IP access / SCIM tabs)
2. `http://localhost:4000/ui/organizations` renders the organizations table (create/edit org modal opens; org info view opens)
3. `http://localhost:4000/ui/router-settings` renders general/router settings
4. `http://localhost:4000/ui/old-usage` renders the legacy usage report

Local checks: `npx vitest run` on the moved suites (AdminPanel, organizations) plus the legacy CreateKeyPage test pass with 25 tests, `npm run build` compiles every route, and `make pre-commit` passes.

## Type

🧹 Refactoring

## Changes

Continues the colocation follow-up to the App Router migration, moving into the "extract from src/components" bucket. Where the earlier PRs renamed existing local component folders, these four segments rendered their page view straight out of the shared src/components dump; this pulls each self-contained view into the owning route's `_components/` folder

The four views (AdminPanel, organizations, general_settings, usage) were each verified to have no importer other than their own page. The only other references were dead defensive `vi.mock` stubs in the legacy CreateKeyPage test (left over from the pre-migration god-component); those are repointed to the new paths. Relative imports inside each moved file are rewritten from `./x` to `@/components/x`, because their genuinely shared dependencies (networking, the selector components, the settings trees) stay in `@/components`; only the page-owned view moves. The two views that had a colocated test (AdminPanel, organizations) move their test alongside them, with the test's `vi.mock` paths rewritten to keep matching the source's now-absolute imports

Grandfathered lint suppressions for the four files (tremor, react-hooks, and similar, all pre-existing) are re-keyed to the new paths with counts unchanged; fixing those underlying violations is a separate effort out of scope for a file move

Two larger extract candidates were left for their own PRs to keep review tractable: `UsagePage` (28 files) and `settings` (51 files) are mechanical but big, and several other views (view_logs, claude_code_plugins, the AIHub/model-hub pair) are genuinely shared across features and need a split decision rather than a straight move
