### PR TITLE
fix(prompt-templates): safely map structured system messages

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -130,19 +130,14 @@ def _system_message_as_user(message: dict) -> dict:
     return converted
 
 
-def _system_message_can_be_merged(message: dict) -> bool:
-    """Only merge when doing so cannot discard message-level metadata."""
-    return not any(key not in {"role", "content"} for key in message)
-
-
 def map_system_message_pt(messages: list) -> list:
     """
     Convert 'system' message to 'user' message if provider doesn't support 'system' role.
 
     Enabled via `completion(...,supports_system_message=False)`
 
-    Merge into a compatible user/assistant message when no metadata would be lost.
-    Otherwise, convert the system message to a standalone user message.
+    Merge into a compatible user/assistant message. Otherwise, convert the system
+    message to a standalone user message.
     """
 
     messages = list(messages)
@@ -159,7 +154,7 @@ def map_system_message_pt(messages: list) -> list:
                     and not next_m.get("function_call")
                 )
                 merged_content = None
-                if can_merge_role and _system_message_can_be_merged(m):
+                if can_merge_role:
                     merged_content = _merge_message_content(
                         m.get("content"), next_m.get("content")
                     )

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -101,18 +101,30 @@ def map_system_message_pt(messages: list) -> list:
     new_messages = []
     for i, m in enumerate(messages):
         if m["role"] == "system":
+            # System content may be a plain string or a list of structured
+            # content parts (e.g. [{"type": "text", "text": "..."}]). Normalize
+            # it to a string so it can be safely merged into adjacent messages.
+            system_content_str = convert_content_list_to_str(m)
             if i < len(messages) - 1:  # Not the last message
                 next_m = messages[i + 1]
                 next_role = next_m["role"]
                 if next_role == "user" or next_role == "assistant":  # Next message is a user or assistant message
                     # Merge system prompt into the next message
-                    next_m["content"] = m["content"] + " " + next_m["content"]
+                    next_content = next_m.get("content")
+                    if isinstance(next_content, list):
+                        # Preserve structured content (e.g. images) by prepending
+                        # the system text as a text part.
+                        next_m["content"] = [
+                            {"type": "text", "text": system_content_str + " "}
+                        ] + next_content
+                    else:
+                        next_m["content"] = system_content_str + " " + (next_content or "")
                 elif next_role == "system":  # Next message is a system message
                     # Append a user message instead of the system message
-                    new_message = {"role": "user", "content": m["content"]}
+                    new_message = {"role": "user", "content": system_content_str}
                     new_messages.append(new_message)
             else:  # Last message
-                new_message = {"role": "user", "content": m["content"]}
+                new_message = {"role": "user", "content": system_content_str}
                 new_messages.append(new_message)
         else:  # Not a system message
             new_messages.append(m)

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5,6 +5,7 @@ import json
 import mimetypes
 import re
 import xml.etree.ElementTree as ET
+from collections.abc import Iterable
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Tuple, TypedDict, Union, cast, overload
 
@@ -87,24 +88,28 @@ DEFAULT_ASSISTANT_CONTINUE_MESSAGE = ChatCompletionAssistantMessage(
 )  # similar to autogen. Only used if `litellm.modify_params=True`.
 
 
-def _merge_message_content(first_content: Any, second_content: Any) -> Any:
-    """Merge string or structured message content without dropping content blocks."""
-    if first_content is None:
-        return copy.deepcopy(second_content)
-    if second_content is None:
-        return copy.deepcopy(first_content)
+def _as_content_blocks(content: Any) -> Optional[List[Any]]:
+    """Return a shallowly copied block list, or None for unsupported content."""
+    if isinstance(content, list):
+        return list(content)
+    if isinstance(content, Iterable) and not isinstance(content, (str, bytes, dict)):
+        return list(content)
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}]
+    return None
+
+
+def _merge_message_content(first_content: Any, second_content: Any) -> Optional[Any]:
+    """Merge known message content types, preserving structured content blocks."""
+    if first_content is None or second_content is None:
+        return None
     if isinstance(first_content, str) and isinstance(second_content, str):
         return f"{first_content} {second_content}"
 
-    def _as_content_blocks(content: Any) -> List[Any]:
-        if isinstance(content, list):
-            return copy.deepcopy(content)
-        if isinstance(content, str):
-            return [{"type": "text", "text": content}]
-        return [{"type": "text", "text": str(content)}]
-
     first_blocks = _as_content_blocks(first_content)
     second_blocks = _as_content_blocks(second_content)
+    if first_blocks is None or second_blocks is None:
+        return None
     if first_blocks and second_blocks:
         last_block = first_blocks[-1]
         if (
@@ -112,10 +117,24 @@ def _merge_message_content(first_content: Any, second_content: Any) -> Any:
             and last_block.get("type") == "text"
             and isinstance(last_block.get("text"), str)
         ):
+            last_block = dict(last_block)
             last_block["text"] += " "
+            first_blocks[-1] = last_block
         else:
             first_blocks.append({"type": "text", "text": " "})
     return first_blocks + second_blocks
+
+
+def _system_message_as_user(message: dict) -> dict:
+    """Convert a system message while preserving message-level metadata."""
+    converted = dict(message)
+    converted["role"] = "user"
+    return converted
+
+
+def _system_message_can_be_merged(message: dict) -> bool:
+    """Only merge when doing so cannot discard message-level metadata."""
+    return not any(key not in {"role", "content"} for key in message)
 
 
 def map_system_message_pt(messages: list) -> list:
@@ -124,36 +143,36 @@ def map_system_message_pt(messages: list) -> list:
 
     Enabled via `completion(...,supports_system_message=False)`
 
-    If next message is a user message or assistant message -> merge system prompt into it
-
-    if next message is system -> append a user message instead of the system message
+    Merge into a compatible user/assistant message when no metadata would be lost.
+    Otherwise, convert the system message to a standalone user message.
     """
 
-    messages = copy.deepcopy(messages)
+    messages = list(messages)
     new_messages = []
     for i, m in enumerate(messages):
         if m["role"] == "system":
             if i < len(messages) - 1:  # Not the last message
                 next_m = messages[i + 1]
                 next_role = next_m["role"]
-                if next_role == "user" or next_role == "assistant":  # Next message is a user or assistant message
-                    # Merge system prompt into the next message
-                    next_m["content"] = _merge_message_content(
+                can_merge_role = next_role == "user" or (
+                    next_role == "assistant"
+                    and next_m.get("content") is not None
+                    and not next_m.get("tool_calls")
+                    and not next_m.get("function_call")
+                )
+                merged_content = None
+                if can_merge_role and _system_message_can_be_merged(m):
+                    merged_content = _merge_message_content(
                         m.get("content"), next_m.get("content")
                     )
-                elif next_role == "system":  # Next message is a system message
-                    # Append a user message instead of the system message
-                    new_message = {
-                        "role": "user",
-                        "content": copy.deepcopy(m.get("content")),
-                    }
-                    new_messages.append(new_message)
+                if merged_content is not None:
+                    next_m = dict(next_m)
+                    next_m["content"] = merged_content
+                    messages[i + 1] = next_m
+                else:
+                    new_messages.append(_system_message_as_user(m))
             else:  # Last message
-                new_message = {
-                    "role": "user",
-                    "content": copy.deepcopy(m.get("content")),
-                }
-                new_messages.append(new_message)
+                new_messages.append(_system_message_as_user(m))
         else:  # Not a system message
             new_messages.append(m)
 

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5,7 +5,7 @@ import json
 import mimetypes
 import re
 import xml.etree.ElementTree as ET
-from collections.abc import Iterable
+from collections.abc import Sequence
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Tuple, TypedDict, Union, cast, overload
 
@@ -90,9 +90,7 @@ DEFAULT_ASSISTANT_CONTINUE_MESSAGE = ChatCompletionAssistantMessage(
 
 def _as_content_blocks(content: Any) -> Optional[List[Any]]:
     """Return a shallowly copied block list, or None for unsupported content."""
-    if isinstance(content, list):
-        return list(content)
-    if isinstance(content, Iterable) and not isinstance(content, (str, bytes, dict)):
+    if isinstance(content, Sequence) and not isinstance(content, (str, bytes)):
         return list(content)
     if isinstance(content, str):
         return [{"type": "text", "text": content}]

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -87,6 +87,37 @@ DEFAULT_ASSISTANT_CONTINUE_MESSAGE = ChatCompletionAssistantMessage(
 )  # similar to autogen. Only used if `litellm.modify_params=True`.
 
 
+def _merge_message_content(first_content: Any, second_content: Any) -> Any:
+    """Merge string or structured message content without dropping content blocks."""
+    if first_content is None:
+        return copy.deepcopy(second_content)
+    if second_content is None:
+        return copy.deepcopy(first_content)
+    if isinstance(first_content, str) and isinstance(second_content, str):
+        return f"{first_content} {second_content}"
+
+    def _as_content_blocks(content: Any) -> List[Any]:
+        if isinstance(content, list):
+            return copy.deepcopy(content)
+        if isinstance(content, str):
+            return [{"type": "text", "text": content}]
+        return [{"type": "text", "text": str(content)}]
+
+    first_blocks = _as_content_blocks(first_content)
+    second_blocks = _as_content_blocks(second_content)
+    if first_blocks and second_blocks:
+        last_block = first_blocks[-1]
+        if (
+            isinstance(last_block, dict)
+            and last_block.get("type") == "text"
+            and isinstance(last_block.get("text"), str)
+        ):
+            last_block["text"] += " "
+        else:
+            first_blocks.append({"type": "text", "text": " "})
+    return first_blocks + second_blocks
+
+
 def map_system_message_pt(messages: list) -> list:
     """
     Convert 'system' message to 'user' message if provider doesn't support 'system' role.
@@ -98,33 +129,30 @@ def map_system_message_pt(messages: list) -> list:
     if next message is system -> append a user message instead of the system message
     """
 
+    messages = copy.deepcopy(messages)
     new_messages = []
     for i, m in enumerate(messages):
         if m["role"] == "system":
-            # System content may be a plain string or a list of structured
-            # content parts (e.g. [{"type": "text", "text": "..."}]). Normalize
-            # it to a string so it can be safely merged into adjacent messages.
-            system_content_str = convert_content_list_to_str(m)
             if i < len(messages) - 1:  # Not the last message
                 next_m = messages[i + 1]
                 next_role = next_m["role"]
                 if next_role == "user" or next_role == "assistant":  # Next message is a user or assistant message
                     # Merge system prompt into the next message
-                    next_content = next_m.get("content")
-                    if isinstance(next_content, list):
-                        # Preserve structured content (e.g. images) by prepending
-                        # the system text as a text part.
-                        next_m["content"] = [
-                            {"type": "text", "text": system_content_str + " "}
-                        ] + next_content
-                    else:
-                        next_m["content"] = system_content_str + " " + (next_content or "")
+                    next_m["content"] = _merge_message_content(
+                        m.get("content"), next_m.get("content")
+                    )
                 elif next_role == "system":  # Next message is a system message
                     # Append a user message instead of the system message
-                    new_message = {"role": "user", "content": system_content_str}
+                    new_message = {
+                        "role": "user",
+                        "content": copy.deepcopy(m.get("content")),
+                    }
                     new_messages.append(new_message)
             else:  # Last message
-                new_message = {"role": "user", "content": system_content_str}
+                new_message = {
+                    "role": "user",
+                    "content": copy.deepcopy(m.get("content")),
+                }
                 new_messages.append(new_message)
         else:  # Not a system message
             new_messages.append(m)

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -155,9 +155,7 @@ def map_system_message_pt(messages: list) -> list:
                 )
                 merged_content = None
                 if can_merge_role:
-                    merged_content = _merge_message_content(
-                        m.get("content"), next_m.get("content")
-                    )
+                    merged_content = _merge_message_content(m.get("content"), next_m.get("content"))
                 if merged_content is not None:
                     next_m = dict(next_m)
                     next_m["content"] = merged_content

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -3241,7 +3241,7 @@ def test_map_system_message_pt_does_not_merge_into_tool_call_assistant(
     assert result == [{"role": "user", "content": "System"}, assistant_message]
 
 
-def test_map_system_message_pt_preserves_system_message_metadata():
+def test_map_system_message_pt_metadata_keeps_existing_merge_shape():
     messages = [
         {
             "role": "system",
@@ -3258,12 +3258,11 @@ def test_map_system_message_pt_preserves_system_message_metadata():
     assert result == [
         {
             "role": "user",
-            "content": [{"type": "text", "text": "System"}],
-            "name": "policy",
-            "cache_control": {"type": "ephemeral"},
-            "provider_extension": {"value": 1},
-        },
-        {"role": "user", "content": "User"},
+            "content": [
+                {"type": "text", "text": "System "},
+                {"type": "text", "text": "User"},
+            ],
+        }
     ]
 
 

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -3190,3 +3190,143 @@ def test_map_system_message_pt_does_not_mutate_input():
     map_system_message_pt(messages)
 
     assert messages == original_messages
+
+
+@pytest.mark.parametrize("next_role", ["tool", "function", "developer", "custom"])
+def test_map_system_message_pt_preserves_system_before_incompatible_role(next_role):
+    messages = [
+        {"role": "system", "content": "System"},
+        {"role": next_role, "content": "Next"},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {"role": "user", "content": "System"},
+        {"role": next_role, "content": "Next"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "assistant_message",
+    [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": None,
+            "function_call": {"name": "lookup", "arguments": "{}"},
+        },
+    ],
+)
+def test_map_system_message_pt_does_not_merge_into_tool_call_assistant(
+    assistant_message,
+):
+    messages = [
+        {"role": "system", "content": "System"},
+        assistant_message,
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [{"role": "user", "content": "System"}, assistant_message]
+
+
+def test_map_system_message_pt_preserves_system_message_metadata():
+    messages = [
+        {
+            "role": "system",
+            "content": [{"type": "text", "text": "System"}],
+            "name": "policy",
+            "cache_control": {"type": "ephemeral"},
+            "provider_extension": {"value": 1},
+        },
+        {"role": "user", "content": "User"},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "System"}],
+            "name": "policy",
+            "cache_control": {"type": "ephemeral"},
+            "provider_extension": {"value": 1},
+        },
+        {"role": "user", "content": "User"},
+    ]
+
+
+def test_map_system_message_pt_preserves_block_metadata_without_mutation():
+    system_block = {
+        "type": "text",
+        "text": "System",
+        "cache_control": {"type": "ephemeral"},
+    }
+    messages = [
+        {"role": "system", "content": [system_block]},
+        {"role": "user", "content": [{"type": "text", "text": "User"}]},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result[0]["content"] == [
+        {
+            "type": "text",
+            "text": "System ",
+            "cache_control": {"type": "ephemeral"},
+        },
+        {"type": "text", "text": "User"},
+    ]
+    assert system_block["text"] == "System"
+
+
+def test_map_system_message_pt_supports_tuple_content():
+    messages = [
+        {"role": "system", "content": ({"type": "text", "text": "System"},)},
+        {"role": "user", "content": ({"type": "text", "text": "User"},)},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "System "},
+                {"type": "text", "text": "User"},
+            ],
+        }
+    ]
+
+
+def test_map_system_message_pt_empty_structured_system_content():
+    messages = [
+        {"role": "system", "content": []},
+        {"role": "user", "content": [{"type": "text", "text": "User"}]},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {"role": "user", "content": [{"type": "text", "text": "User"}]}
+    ]
+
+
+def test_map_system_message_pt_keeps_unmodified_message_identity():
+    unaffected = {"role": "tool", "content": "result", "tool_call_id": "call_1"}
+    messages = [{"role": "system", "content": "System"}, unaffected]
+
+    result = map_system_message_pt(messages)
+
+    assert result[1] is unaffected

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -1,5 +1,6 @@
 import base64
 import json
+from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -3070,7 +3071,7 @@ def test_map_system_message_pt_plain_string_merge():
 
 
 def test_map_system_message_pt_structured_system_content():
-    """System message with list (structured) content must not raise and is merged as text.
+    """System message with list content must not raise and remains structured.
 
     Regression test: previously `m["content"] + " " + next_m["content"]` raised a
     TypeError when either side was a list of content parts.
@@ -3085,7 +3086,15 @@ def test_map_system_message_pt_structured_system_content():
 
     result = map_system_message_pt(messages)
 
-    assert result == [{"role": "user", "content": "You are helpful. Hi"}]
+    assert result == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "You are helpful. "},
+                {"type": "text", "text": "Hi"},
+            ],
+        }
+    ]
 
 
 def test_map_system_message_pt_structured_content_preserves_non_text_parts():
@@ -3116,12 +3125,17 @@ def test_map_system_message_pt_structured_content_preserves_non_text_parts():
 
 
 def test_map_system_message_pt_trailing_structured_system():
-    """A trailing system message with list content becomes a user message string."""
+    """A trailing structured system message becomes a structured user message."""
     messages = [{"role": "system", "content": [{"type": "text", "text": "only sys"}]}]
 
     result = map_system_message_pt(messages)
 
-    assert result == [{"role": "user", "content": "only sys"}]
+    assert result == [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "only sys"}],
+        }
+    ]
 
 
 def test_map_system_message_pt_consecutive_structured_system_messages():
@@ -3135,6 +3149,44 @@ def test_map_system_message_pt_consecutive_structured_system_messages():
     result = map_system_message_pt(messages)
 
     assert result == [
-        {"role": "user", "content": "first"},
+        {"role": "user", "content": [{"type": "text", "text": "first"}]},
         {"role": "user", "content": "second Hi"},
     ]
+
+
+@pytest.mark.parametrize(
+    ("system_content", "user_content"),
+    [
+        ("Follow the instructions.", [{"type": "text", "text": "Write code."}]),
+        ([{"type": "text", "text": "Follow the instructions."}], "Write code."),
+    ],
+)
+def test_map_system_message_pt_mixed_content_types(system_content, user_content):
+    messages = [
+        {"role": "system", "content": system_content},
+        {"role": "user", "content": user_content},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Follow the instructions. "},
+                {"type": "text", "text": "Write code."},
+            ],
+        }
+    ]
+
+
+def test_map_system_message_pt_does_not_mutate_input():
+    messages = [
+        {"role": "system", "content": [{"type": "text", "text": "System"}]},
+        {"role": "user", "content": [{"type": "text", "text": "User"}]},
+    ]
+    original_messages = deepcopy(messages)
+
+    map_system_message_pt(messages)
+
+    assert messages == original_messages

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -3329,3 +3329,56 @@ def test_map_system_message_pt_keeps_unmodified_message_identity():
     result = map_system_message_pt(messages)
 
     assert result[1] is unaffected
+
+
+def test_map_system_message_pt_unsupported_content_uses_standalone_fallback():
+    unsupported_content = {"type": "custom", "value": "System"}
+    messages = [
+        {"role": "system", "content": unsupported_content},
+        {"role": "user", "content": "User"},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {"role": "user", "content": unsupported_content},
+        {"role": "user", "content": "User"},
+    ]
+
+
+def test_map_system_message_pt_none_content_uses_standalone_fallback():
+    messages = [
+        {"role": "system", "content": None},
+        {"role": "user", "content": "User"},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {"role": "user", "content": None},
+        {"role": "user", "content": "User"},
+    ]
+
+
+def test_map_system_message_pt_adds_separator_after_non_text_system_block():
+    image_block = {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,abc"},
+    }
+    messages = [
+        {"role": "system", "content": [image_block]},
+        {"role": "user", "content": [{"type": "text", "text": "User"}]},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {
+            "role": "user",
+            "content": [
+                image_block,
+                {"type": "text", "text": " "},
+                {"type": "text", "text": "User"},
+            ],
+        }
+    ]

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -17,6 +17,7 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
     anthropic_messages_pt,
     convert_to_gemini_tool_call_result,
     make_valid_bedrock_tool_name,
+    map_system_message_pt,
     ollama_pt,
     sanitize_messages_for_tool_calling,
 )
@@ -3054,3 +3055,86 @@ def test_bedrock_converse_messages_pt_document_rejects_url_source():
         _bedrock_converse_messages_pt(
             messages, "anthropic.claude-sonnet-4-6", "bedrock"
         )
+
+
+def test_map_system_message_pt_plain_string_merge():
+    """System string is merged into the following user message (existing behavior)."""
+    messages = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "Hi"},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [{"role": "user", "content": "You are helpful. Hi"}]
+
+
+def test_map_system_message_pt_structured_system_content():
+    """System message with list (structured) content must not raise and is merged as text.
+
+    Regression test: previously `m["content"] + " " + next_m["content"]` raised a
+    TypeError when either side was a list of content parts.
+    """
+    messages = [
+        {
+            "role": "system",
+            "content": [{"type": "text", "text": "You are helpful."}],
+        },
+        {"role": "user", "content": "Hi"},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [{"role": "user", "content": "You are helpful. Hi"}]
+
+
+def test_map_system_message_pt_structured_content_preserves_non_text_parts():
+    """Merging into a structured user message must preserve non-text parts (e.g. images)."""
+    messages = [
+        {"role": "system", "content": [{"type": "text", "text": "Sys"}]},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "look"},
+                {"type": "image_url", "image_url": {"url": "http://x/y.png"}},
+            ],
+        },
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Sys "},
+                {"type": "text", "text": "look"},
+                {"type": "image_url", "image_url": {"url": "http://x/y.png"}},
+            ],
+        }
+    ]
+
+
+def test_map_system_message_pt_trailing_structured_system():
+    """A trailing system message with list content becomes a user message string."""
+    messages = [{"role": "system", "content": [{"type": "text", "text": "only sys"}]}]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [{"role": "user", "content": "only sys"}]
+
+
+def test_map_system_message_pt_consecutive_structured_system_messages():
+    """A system message followed by another system message is appended as a user message."""
+    messages = [
+        {"role": "system", "content": [{"type": "text", "text": "first"}]},
+        {"role": "system", "content": "second"},
+        {"role": "user", "content": "Hi"},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {"role": "user", "content": "first"},
+        {"role": "user", "content": "second Hi"},
+    ]


### PR DESCRIPTION
## Relevant issues

Fixes #23757

## Linear ticket


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`map_system_message_pt` is used when `supports_system_message=False`. The previous implementation directly concatenated message content and crashed when the Anthropic `/v1/messages` adapter supplied OpenAI-compatible structured content blocks.

### Before

Base image `ghcr.io/berriai/litellm-database:v1.93.0-dev.2`, commit `f824783601`:

```console
TypeError: can only concatenate list (not "str") to list
```

Reproducer:

```python
from litellm.litellm_core_utils.prompt_templates.factory import map_system_message_pt

messages = [
    {"role": "system", "content": [{"type": "text", "text": "You are helpful."}]},
    {"role": "user", "content": "Hi"},
]
map_system_message_pt(messages)
```

### After

Commit `b68100db3b` maps the same request without flattening structured content:

```python
[
    {
        "role": "user",
        "content": [
            {"type": "text", "text": "You are helpful. "},
            {"type": "text", "text": "Hi"},
        ],
    }
]
```

Targeted regression suite:

```console
$ python -m pytest -q tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py -k map_system_message_pt
...................                                                      [100%]
19 passed, 80 deselected
```

The patched database image was also built and run locally. The proxy health endpoint and authenticated `/v1/models` endpoint both returned HTTP 200, and the structured request passed this transformation without the reported `TypeError`.

## Type

🐛 Bug Fix

## Changes

`map_system_message_pt` assumed both the system message and its following message used string content. OpenAI-compatible clients can supply structured content lists, causing a `TypeError` before the provider request.

This PR:

- preserves existing string-to-string behavior;
- preserves structured text, image, file, and other content blocks;
- supports mixed string and structured content and iterable block containers;
- avoids mutating caller messages by shallow-copying only changed paths;
- preserves message-level metadata and block-level metadata;
- avoids merging system instructions into assistant tool-call messages;
- converts system messages to standalone user messages before incompatible roles such as tool, function, developer, or custom roles;
- falls back to standalone conversion when content cannot be merged safely instead of dropping or stringifying it.

Tests cover plain strings, structured and mixed content, multimodal blocks, trailing and consecutive system messages, incompatible next roles, assistant tool calls, metadata preservation, iterable content, empty content, immutability, and unaffected-message identity.