### PR TITLE
fix(prompt-templates): safely map structured system messages

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5,6 +5,7 @@ import json
 import mimetypes
 import re
 import xml.etree.ElementTree as ET
+from collections.abc import Sequence
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Tuple, TypedDict, Union, cast, overload
 
@@ -87,33 +88,82 @@ DEFAULT_ASSISTANT_CONTINUE_MESSAGE = ChatCompletionAssistantMessage(
 )  # similar to autogen. Only used if `litellm.modify_params=True`.
 
 
+def _as_content_blocks(content: Any) -> list[Any] | None:
+    """Return a shallowly copied block list, or None for unsupported content."""
+    if isinstance(content, Sequence) and not isinstance(content, (str, bytes)):
+        return list(content)
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}]
+    return None
+
+
+def _merge_message_content(first_content: Any, second_content: Any) -> Any | None:
+    """Merge known message content types, preserving structured content blocks."""
+    if first_content is None or second_content is None:
+        return None
+    if isinstance(first_content, str) and isinstance(second_content, str):
+        return f"{first_content} {second_content}"
+
+    first_blocks = _as_content_blocks(first_content)
+    second_blocks = _as_content_blocks(second_content)
+    if first_blocks is None or second_blocks is None:
+        return None
+    if first_blocks and second_blocks:
+        last_block = first_blocks[-1]
+        if (
+            isinstance(last_block, dict)
+            and last_block.get("type") == "text"
+            and isinstance(last_block.get("text"), str)
+        ):
+            last_block = dict(last_block)
+            last_block["text"] += " "
+            first_blocks[-1] = last_block
+        else:
+            first_blocks.append({"type": "text", "text": " "})
+    return first_blocks + second_blocks
+
+
+def _system_message_as_user(message: dict) -> dict:
+    """Convert a system message while preserving message-level metadata."""
+    converted = dict(message)
+    converted["role"] = "user"
+    return converted
+
+
 def map_system_message_pt(messages: list) -> list:
     """
     Convert 'system' message to 'user' message if provider doesn't support 'system' role.
 
     Enabled via `completion(...,supports_system_message=False)`
 
-    If next message is a user message or assistant message -> merge system prompt into it
-
-    if next message is system -> append a user message instead of the system message
+    Merge into a compatible user/assistant message. Otherwise, convert the system
+    message to a standalone user message.
     """
 
+    messages = list(messages)
     new_messages = []
     for i, m in enumerate(messages):
         if m["role"] == "system":
             if i < len(messages) - 1:  # Not the last message
                 next_m = messages[i + 1]
                 next_role = next_m["role"]
-                if next_role == "user" or next_role == "assistant":  # Next message is a user or assistant message
-                    # Merge system prompt into the next message
-                    next_m["content"] = m["content"] + " " + next_m["content"]
-                elif next_role == "system":  # Next message is a system message
-                    # Append a user message instead of the system message
-                    new_message = {"role": "user", "content": m["content"]}
-                    new_messages.append(new_message)
+                can_merge_role = next_role == "user" or (
+                    next_role == "assistant"
+                    and next_m.get("content") is not None
+                    and not next_m.get("tool_calls")
+                    and not next_m.get("function_call")
+                )
+                merged_content = None
+                if can_merge_role:
+                    merged_content = _merge_message_content(m.get("content"), next_m.get("content"))
+                if merged_content is not None:
+                    next_m = dict(next_m)
+                    next_m["content"] = merged_content
+                    messages[i + 1] = next_m
+                else:
+                    new_messages.append(_system_message_as_user(m))
             else:  # Last message
-                new_message = {"role": "user", "content": m["content"]}
-                new_messages.append(new_message)
+                new_messages.append(_system_message_as_user(m))
         else:  # Not a system message
             new_messages.append(m)
 

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -1,5 +1,6 @@
 import base64
 import json
+from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -17,6 +18,7 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
     anthropic_messages_pt,
     convert_to_gemini_tool_call_result,
     make_valid_bedrock_tool_name,
+    map_system_message_pt,
     ollama_pt,
     sanitize_messages_for_tool_calling,
 )
@@ -3054,3 +3056,329 @@ def test_bedrock_converse_messages_pt_document_rejects_url_source():
         _bedrock_converse_messages_pt(
             messages, "anthropic.claude-sonnet-4-6", "bedrock"
         )
+
+
+def test_map_system_message_pt_plain_string_merge():
+    """System string is merged into the following user message (existing behavior)."""
+    messages = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "Hi"},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [{"role": "user", "content": "You are helpful. Hi"}]
+
+
+def test_map_system_message_pt_structured_system_content():
+    """System message with list content must not raise and remains structured.
+
+    Regression test: previously `m["content"] + " " + next_m["content"]` raised a
+    TypeError when either side was a list of content parts.
+    """
+    messages = [
+        {
+            "role": "system",
+            "content": [{"type": "text", "text": "You are helpful."}],
+        },
+        {"role": "user", "content": "Hi"},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "You are helpful. "},
+                {"type": "text", "text": "Hi"},
+            ],
+        }
+    ]
+
+
+def test_map_system_message_pt_structured_content_preserves_non_text_parts():
+    """Merging into a structured user message must preserve non-text parts (e.g. images)."""
+    messages = [
+        {"role": "system", "content": [{"type": "text", "text": "Sys"}]},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "look"},
+                {"type": "image_url", "image_url": {"url": "http://x/y.png"}},
+            ],
+        },
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Sys "},
+                {"type": "text", "text": "look"},
+                {"type": "image_url", "image_url": {"url": "http://x/y.png"}},
+            ],
+        }
+    ]
+
+
+def test_map_system_message_pt_trailing_structured_system():
+    """A trailing structured system message becomes a structured user message."""
+    messages = [{"role": "system", "content": [{"type": "text", "text": "only sys"}]}]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "only sys"}],
+        }
+    ]
+
+
+def test_map_system_message_pt_consecutive_structured_system_messages():
+    """A system message followed by another system message is appended as a user message."""
+    messages = [
+        {"role": "system", "content": [{"type": "text", "text": "first"}]},
+        {"role": "system", "content": "second"},
+        {"role": "user", "content": "Hi"},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {"role": "user", "content": [{"type": "text", "text": "first"}]},
+        {"role": "user", "content": "second Hi"},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("system_content", "user_content"),
+    [
+        ("Follow the instructions.", [{"type": "text", "text": "Write code."}]),
+        ([{"type": "text", "text": "Follow the instructions."}], "Write code."),
+    ],
+)
+def test_map_system_message_pt_mixed_content_types(system_content, user_content):
+    messages = [
+        {"role": "system", "content": system_content},
+        {"role": "user", "content": user_content},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Follow the instructions. "},
+                {"type": "text", "text": "Write code."},
+            ],
+        }
+    ]
+
+
+def test_map_system_message_pt_does_not_mutate_input():
+    messages = [
+        {"role": "system", "content": [{"type": "text", "text": "System"}]},
+        {"role": "user", "content": [{"type": "text", "text": "User"}]},
+    ]
+    original_messages = deepcopy(messages)
+
+    map_system_message_pt(messages)
+
+    assert messages == original_messages
+
+
+@pytest.mark.parametrize("next_role", ["tool", "function", "developer", "custom"])
+def test_map_system_message_pt_preserves_system_before_incompatible_role(next_role):
+    messages = [
+        {"role": "system", "content": "System"},
+        {"role": next_role, "content": "Next"},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {"role": "user", "content": "System"},
+        {"role": next_role, "content": "Next"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "assistant_message",
+    [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": None,
+            "function_call": {"name": "lookup", "arguments": "{}"},
+        },
+    ],
+)
+def test_map_system_message_pt_does_not_merge_into_tool_call_assistant(
+    assistant_message,
+):
+    messages = [
+        {"role": "system", "content": "System"},
+        assistant_message,
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [{"role": "user", "content": "System"}, assistant_message]
+
+
+def test_map_system_message_pt_metadata_keeps_existing_merge_shape():
+    messages = [
+        {
+            "role": "system",
+            "content": [{"type": "text", "text": "System"}],
+            "name": "policy",
+            "cache_control": {"type": "ephemeral"},
+            "provider_extension": {"value": 1},
+        },
+        {"role": "user", "content": "User"},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "System "},
+                {"type": "text", "text": "User"},
+            ],
+        }
+    ]
+
+
+def test_map_system_message_pt_preserves_block_metadata_without_mutation():
+    system_block = {
+        "type": "text",
+        "text": "System",
+        "cache_control": {"type": "ephemeral"},
+    }
+    messages = [
+        {"role": "system", "content": [system_block]},
+        {"role": "user", "content": [{"type": "text", "text": "User"}]},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result[0]["content"] == [
+        {
+            "type": "text",
+            "text": "System ",
+            "cache_control": {"type": "ephemeral"},
+        },
+        {"type": "text", "text": "User"},
+    ]
+    assert system_block["text"] == "System"
+
+
+def test_map_system_message_pt_supports_tuple_content():
+    messages = [
+        {"role": "system", "content": ({"type": "text", "text": "System"},)},
+        {"role": "user", "content": ({"type": "text", "text": "User"},)},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "System "},
+                {"type": "text", "text": "User"},
+            ],
+        }
+    ]
+
+
+def test_map_system_message_pt_empty_structured_system_content():
+    messages = [
+        {"role": "system", "content": []},
+        {"role": "user", "content": [{"type": "text", "text": "User"}]},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {"role": "user", "content": [{"type": "text", "text": "User"}]}
+    ]
+
+
+def test_map_system_message_pt_keeps_unmodified_message_identity():
+    unaffected = {"role": "tool", "content": "result", "tool_call_id": "call_1"}
+    messages = [{"role": "system", "content": "System"}, unaffected]
+
+    result = map_system_message_pt(messages)
+
+    assert result[1] is unaffected
+
+
+def test_map_system_message_pt_unsupported_content_uses_standalone_fallback():
+    unsupported_content = {"type": "custom", "value": "System"}
+    messages = [
+        {"role": "system", "content": unsupported_content},
+        {"role": "user", "content": "User"},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {"role": "user", "content": unsupported_content},
+        {"role": "user", "content": "User"},
+    ]
+
+
+def test_map_system_message_pt_none_content_uses_standalone_fallback():
+    messages = [
+        {"role": "system", "content": None},
+        {"role": "user", "content": "User"},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {"role": "user", "content": None},
+        {"role": "user", "content": "User"},
+    ]
+
+
+def test_map_system_message_pt_adds_separator_after_non_text_system_block():
+    image_block = {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,abc"},
+    }
+    messages = [
+        {"role": "system", "content": [image_block]},
+        {"role": "user", "content": [{"type": "text", "text": "User"}]},
+    ]
+
+    result = map_system_message_pt(messages)
+
+    assert result == [
+        {
+            "role": "user",
+            "content": [
+                image_block,
+                {"type": "text", "text": " "},
+                {"type": "text", "text": "User"},
+            ],
+        }
+    ]


### PR DESCRIPTION
## Relevant issues

Fixes #23757

Replaces #32705, which was closed because it was initially opened against the wrong base branch and accumulated noisy rewritten history. This PR is based directly on `litellm_oss_staging` and contains one clean commit.

## Linear ticket


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks locally (lint, format, targeted unit tests, and 100% changed production-line coverage)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`map_system_message_pt` runs when `supports_system_message=False`. Previously, it directly concatenated `m["content"] + " " + next_m["content"]`, which crashes when the Anthropic `/v1/messages` adapter supplies OpenAI-compatible structured content blocks.

### Before

```console
TypeError: can only concatenate list (not "str") to list
```

### After

Structured content is merged without flattening or dropping blocks:

```python
[
    {
        "role": "user",
        "content": [
            {"type": "text", "text": "You are helpful. "},
            {"type": "text", "text": "Hi"},
        ],
    }
]
```

### Local validation

```console
$ uv run --with ruff --no-sync ruff format --check litellm/litellm_core_utils/prompt_templates/factory.py
1 file already formatted

$ uv run --with ruff --no-sync python scripts/ruff_strict_gate.py --base upstream/litellm_oss_staging
OK: every strict rule is within its codebase ceiling (base upstream/litellm_oss_staging)

$ pytest -q tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py -k map_system_message_pt
......................                                                   [100%]
22 passed, 77 deselected
```

Coverage was measured against executable production lines changed in `factory.py`:

```text
changed executable lines: 39
covered changed executable lines: 39
patch coverage: 100.00%
uncovered changed lines: []
```

## Type

🐛 Bug Fix

## Changes

- Preserve existing string-to-string merge behavior.
- Merge string, list, tuple, and mixed structured content without flattening multimodal blocks.
- Shallow-copy only changed paths, leaving caller input and unaffected message identity intact.
- Preserve block metadata when adding separators.
- Avoid merging system instructions into assistant tool-call messages.
- Convert system messages to standalone user messages before incompatible roles or unsupported content instead of dropping or stringifying them.
- Keep the existing single-message output shape for compatible messages carrying system metadata.
- Add focused tests covering structured/mixed content, multimodal blocks, tool calls, incompatible roles, metadata, fallback behavior, and mutation safety.