### PR TITLE
test(e2e): lower realtime server-VAD threshold to 0.5

### DIFF
--- a/tests/e2e/llm_translation/realtime/test_realtime_pipecat_audio_e2e.py
+++ b/tests/e2e/llm_translation/realtime/test_realtime_pipecat_audio_e2e.py
@@ -96,7 +96,7 @@ SERVER_VAD_SETTINGS = rt_events.SessionProperties(
             noise_reduction=rt_events.InputAudioNoiseReduction(type="near_field"),
             turn_detection=rt_events.TurnDetection(
                 type="server_vad",
-                threshold=0.8,
+                threshold=0.5,
                 prefix_padding_ms=300,
                 silence_duration_ms=700,
             ),


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

Raw realtime websocket probe against a live proxy (localhost:4000) hitting real Azure gpt-realtime, streaming the same PCM16 fixture the test uses, relying on server-VAD auto-response:

```
threshold 0.8:  speech_stopped=True  response.created=True  transcript_chars=0    audio=0        <- empty response
threshold 0.5:  speech_stopped=True  response.created=True  transcript_chars=111  audio=419200   <- real content
```

At 0.8 the audio-input assertions fail because the response is empty; at 0.5 they pass

## Type

✅ Test

## Changes

The pipecat server-VAD audio-input test streams a PCM16 fixture and relies on server VAD to auto-fire a response. At threshold 0.8, azure gpt-realtime fires speech-stop and creates a response, but the committed audio is clipped enough that the response comes back empty, so the audio-input assertions fail deterministically. openai tolerated 0.8; azure did not. Lowering the shared SERVER_VAD_SETTINGS threshold to 0.5 captures the full utterance so the model produces real transcript and audio content
