### PR TITLE
fix(rate-limit-v3): populate x-ratelimit-* remaining/limit values in standard_logging_object for streaming

### DIFF
--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -244,6 +244,10 @@ TPM_RESERVED_SCOPES_KEY = "_litellm_tpm_reserved_scopes"
 # does not double-refund.
 TPM_RESERVATION_RELEASED_KEY = "_litellm_tpm_reservation_released"
 RATE_LIMIT_DESCRIPTORS_KEY = "_litellm_rate_limit_descriptors"
+# Pre-call RateLimitResponse stashed here so streaming success logging can
+# mirror ``x-ratelimit-*`` headers into the SLP. Streaming exits
+# common_request_processing before ``async_post_call_success_hook`` runs.
+RATE_LIMIT_RESPONSE_KEY = "_litellm_proxy_rate_limit_response"
 # Stash keys live ONLY in metadata channels — never at the top level of the
 # request body. Top-level keys are forwarded as body params to upstream
 # providers, which reject unknown fields with 400/429 errors.
@@ -253,6 +257,7 @@ _LITELLM_STASH_KEYS: Tuple[str, ...] = (
     TPM_RESERVED_SCOPES_KEY,
     TPM_RESERVATION_RELEASED_KEY,
     RATE_LIMIT_DESCRIPTORS_KEY,
+    RATE_LIMIT_RESPONSE_KEY,
 )
 
 
@@ -2037,6 +2042,13 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
             else:
                 # add descriptors to request headers
                 data["litellm_proxy_rate_limit_response"] = response
+                # Mirror into metadata so streaming success logging can find
+                # it via ``kwargs["litellm_params"]["metadata"]``.
+                self._stash_value_in_metadata_channels(
+                    data=data,
+                    key=RATE_LIMIT_RESPONSE_KEY,
+                    value=response,
+                )
 
             # ----------------------------------------------------------------
             # TPM token reservation
@@ -2133,6 +2145,13 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                         stored_response.setdefault("statuses", []).extend(tpm_response["statuses"])
                     elif tpm_response["statuses"]:
                         data["litellm_proxy_rate_limit_response"] = tpm_response
+                        # Keep the metadata stash in sync when this is the
+                        # first snapshot written.
+                        self._stash_value_in_metadata_channels(
+                            data=data,
+                            key=RATE_LIMIT_RESPONSE_KEY,
+                            value=tpm_response,
+                        )
 
                     verbose_proxy_logger.debug(f"TPM tokens reserved: {estimated_tokens} for model {requested_model}")
 
@@ -2317,6 +2336,23 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         ]:
             return "total"  # default to total
         return specified_rate_limit_type
+
+    @staticmethod
+    def _merge_ratelimit_statuses_into_additional_headers(
+        additional_headers: Dict[str, Any],
+        statuses: List[RateLimitStatus],
+    ) -> Dict[str, Any]:
+        """
+        Return ``additional_headers`` extended with
+        ``x-ratelimit-{descriptor_key}-{remaining|limit}-{rate_limit_type}``
+        entries. Non-mutating so callers pick their own target dict.
+        """
+        merged: Dict[str, Any] = dict(additional_headers)
+        for status in statuses:
+            prefix = f"x-ratelimit-{status['descriptor_key']}"
+            merged[f"{prefix}-remaining-{status['rate_limit_type']}"] = status["limit_remaining"]
+            merged[f"{prefix}-limit-{status['rate_limit_type']}"] = status["current_limit"]
+        return merged
 
     @staticmethod
     def _stash_value_in_metadata_channels(
@@ -2698,6 +2734,112 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         except Exception as e:
             verbose_proxy_logger.exception(f"Error in rate limit success event: {str(e)}")
 
+    async def async_logging_hook(
+        self,
+        kwargs: dict,
+        result: Any,
+        call_type: str,
+    ) -> Tuple[dict, Any]:
+        """
+        Mirror the pre-call rate-limit snapshot into the SLP so streaming
+        success callbacks see the same ``x-ratelimit-*`` headers the
+        non-streaming path writes via ``async_post_call_success_hook``.
+        Runs in the earlier of the two callback loops inside
+        ``async_success_handler`` so downstream callbacks see the values
+        regardless of registration order. Idempotent for non-streaming.
+        """
+        self._mirror_ratelimit_response_into_logging_payload(
+            kwargs=kwargs,
+            response_obj=result,
+        )
+        return kwargs, result
+
+    def _mirror_ratelimit_response_into_logging_payload(
+        self,
+        kwargs: Any,
+        response_obj: Any,
+    ) -> None:
+        """
+        Copy the stashed ``RateLimitResponse`` into the SLP's
+        ``hidden_params.additional_headers`` and the response object's
+        ``_hidden_params.additional_headers`` (when the latter is a dict).
+        """
+        if not isinstance(kwargs, dict):
+            return
+
+        standard_logging_object = kwargs.get("standard_logging_object")
+        standard_logging_metadata: Optional[Dict[str, Any]] = None
+        if isinstance(standard_logging_object, dict):
+            slp_metadata = standard_logging_object.get("metadata")
+            if isinstance(slp_metadata, dict):
+                standard_logging_metadata = slp_metadata
+
+        statuses = self._narrow_ratelimit_statuses(
+            self._lookup_stashed_value(
+                kwargs=kwargs,
+                standard_logging_metadata=standard_logging_metadata,
+                key=RATE_LIMIT_RESPONSE_KEY,
+            )
+        )
+        if not statuses:
+            return
+
+        if isinstance(standard_logging_object, dict):
+            hidden_params = standard_logging_object.get("hidden_params")
+            if not isinstance(hidden_params, dict):
+                hidden_params = {}
+            existing = hidden_params.get("additional_headers")
+            hidden_params["additional_headers"] = self._merge_ratelimit_statuses_into_additional_headers(
+                additional_headers=existing if isinstance(existing, dict) else {},
+                statuses=statuses,
+            )
+            standard_logging_object["hidden_params"] = hidden_params
+
+        response_hidden = getattr(response_obj, "_hidden_params", None)
+        if isinstance(response_hidden, dict):
+            existing = response_hidden.get("additional_headers")
+            response_hidden["additional_headers"] = self._merge_ratelimit_statuses_into_additional_headers(
+                additional_headers=existing if isinstance(existing, dict) else {},
+                statuses=statuses,
+            )
+
+    @staticmethod
+    def _narrow_ratelimit_statuses(stashed: Any) -> List[RateLimitStatus]:
+        """
+        Narrow a stashed ``RateLimitResponse``-shaped dict to a typed
+        ``statuses`` list. Entries missing any header-write field are dropped;
+        an empty list means "nothing to mirror".
+        """
+        if not isinstance(stashed, dict):
+            return []
+        raw_statuses = stashed.get("statuses")
+        if not isinstance(raw_statuses, list):
+            return []
+        narrowed: List[RateLimitStatus] = []
+        for entry in raw_statuses:
+            if not isinstance(entry, dict):
+                continue
+            descriptor_key = entry.get("descriptor_key")
+            rate_limit_type = entry.get("rate_limit_type")
+            current_limit = entry.get("current_limit")
+            limit_remaining = entry.get("limit_remaining")
+            if (
+                isinstance(descriptor_key, str)
+                and rate_limit_type in ("requests", "tokens", "max_parallel_requests")
+                and isinstance(current_limit, int)
+                and isinstance(limit_remaining, int)
+            ):
+                narrowed.append(
+                    RateLimitStatus(
+                        code=entry.get("code", "OK") if isinstance(entry.get("code"), str) else "OK",
+                        current_limit=current_limit,
+                        limit_remaining=limit_remaining,
+                        rate_limit_type=rate_limit_type,
+                        descriptor_key=descriptor_key,
+                    )
+                )
+        return narrowed
+
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         """
         On failure: decrement max_parallel_requests and refund the upfront
@@ -2838,15 +2980,10 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                     if isinstance(_hidden_params, BaseModel):
                         _hidden_params = _hidden_params.model_dump()
 
-                    _additional_headers = _hidden_params.get("additional_headers", {}) or {}
-
-                    # Add rate limit headers
-                    for status in litellm_proxy_rate_limit_response["statuses"]:
-                        prefix = f"x-ratelimit-{status['descriptor_key']}"
-                        _additional_headers[f"{prefix}-remaining-{status['rate_limit_type']}"] = status[
-                            "limit_remaining"
-                        ]
-                        _additional_headers[f"{prefix}-limit-{status['rate_limit_type']}"] = status["current_limit"]
+                    _additional_headers = self._merge_ratelimit_statuses_into_additional_headers(
+                        additional_headers=_hidden_params.get("additional_headers", {}) or {},
+                        statuses=litellm_proxy_rate_limit_response["statuses"],
+                    )
 
                     setattr(
                         response,

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
@@ -3706,3 +3706,341 @@ async def test_per_tag_untagged_request_governed_by_key_limit_v3(monkeypatch):
         await call({"tags": ["cell-99"]})
     assert exc_info.value.status_code == 429
     assert "tag_per_key" not in str(exc_info.value.detail)
+
+
+# --------------------------------------------------------------------------
+# Streaming success logging mirrors x-ratelimit-* remaining values into
+# standard_logging_object.hidden_params.additional_headers so Prometheus /
+# logging callbacks see them for streams too (non-streaming already gets
+# them via async_post_call_success_hook, which the streaming path skips).
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_streaming_end_to_end_populates_slp_ratelimit_headers(monkeypatch):
+    """
+    End-to-end regression: on a streaming request, the same pre-call +
+    success-callback pair the proxy uses must land ``x-ratelimit-*``
+    remaining/limit values in
+    ``kwargs["standard_logging_object"]["hidden_params"]["additional_headers"]``.
+    """
+    monkeypatch.setenv("LITELLM_RATE_LIMIT_WINDOW_SIZE", "60")
+    _api_key = hash_token("sk-stream-e2e")
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key=_api_key,
+        rpm_limit=100,
+        tpm_limit=10000,
+    )
+    local_cache = DualCache()
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(local_cache)
+    )
+
+    # Real pre-call: populates data and stashes the response into metadata
+    # so the success callback can find it via litellm_params.metadata.
+    data: Dict[str, Any] = {
+        "model": "gpt-4o-mini",
+        "metadata": {},
+        "stream": True,
+    }
+    await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict,
+        cache=local_cache,
+        data=data,
+        call_type="",
+    )
+
+    # Simulate the wrapper handing the pre-call metadata dict to the
+    # completion() call: it becomes kwargs["litellm_params"]["metadata"] by
+    # the time the success callback fires.
+    mock_response = ModelResponse(
+        id="mock-stream-e2e",
+        object="chat.completion",
+        created=int(datetime.now().timestamp()),
+        model="gpt-4o-mini",
+        usage=Usage(prompt_tokens=100, completion_tokens=50, total_tokens=150),
+        choices=[],
+    )
+    mock_kwargs: Dict[str, Any] = {
+        "standard_logging_object": {
+            "metadata": {
+                "user_api_key_hash": _api_key,
+                "user_api_key_user_id": None,
+                "user_api_key_team_id": None,
+                "user_api_key_end_user_id": None,
+            }
+        },
+        "litellm_params": {"metadata": data["metadata"]},
+        "model": "gpt-4o-mini",
+    }
+
+    async def _noop_increment(increment_list, **_):
+        return True
+
+    monkeypatch.setattr(
+        handler.internal_usage_cache.dual_cache,
+        "async_increment_cache_pipeline",
+        _noop_increment,
+    )
+
+    # async_logging_hook runs before async_log_success_event, so any
+    # downstream callback that reads the SLP sees the mirrored values.
+    await handler.async_logging_hook(
+        kwargs=mock_kwargs,
+        result=mock_response,
+        call_type="acompletion",
+    )
+
+    additional_headers = (
+        mock_kwargs["standard_logging_object"]
+        .get("hidden_params", {})
+        .get("additional_headers", {})
+    )
+
+    # api_key-scoped remaining/limit values are the baseline every request
+    # emits and must always reach the SLP.
+    remaining_keys = [
+        k for k in additional_headers if "-remaining-" in k
+    ]
+    assert (
+        remaining_keys
+    ), f"streaming success must populate remaining values, got {additional_headers!r}"
+    limit_keys = [k for k in additional_headers if "-limit-" in k]
+    assert limit_keys, "streaming success must also populate limit values"
+    assert (
+        additional_headers.get("x-ratelimit-api_key-remaining-requests") == 99
+    ), (
+        "api_key remaining requests should reflect the just-consumed slot;"
+        f" got {additional_headers!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_streaming_populates_model_per_key_ratelimit_headers(monkeypatch):
+    """
+    Streaming must land the per-(key, model) remaining/limit values in the
+    SLP under ``x-ratelimit-model_per_key-{remaining|limit}-{requests,tokens}``.
+    """
+    monkeypatch.setenv("LITELLM_RATE_LIMIT_WINDOW_SIZE", "60")
+    _api_key = hash_token("sk-stream-mirror")
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key=_api_key,
+        metadata={
+            "model_rpm_limit": {"gpt-4o-mini": 100},
+            "model_tpm_limit": {"gpt-4o-mini": 10000},
+        },
+    )
+    local_cache = DualCache()
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(local_cache)
+    )
+
+    async def _noop_increment(increment_list, **_):
+        return True
+
+    monkeypatch.setattr(
+        handler.internal_usage_cache.dual_cache,
+        "async_increment_cache_pipeline",
+        _noop_increment,
+    )
+
+    data: Dict[str, Any] = {"model": "gpt-4o-mini", "metadata": {}, "stream": True}
+    await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict,
+        cache=local_cache,
+        data=data,
+        call_type="",
+    )
+
+    mock_response = ModelResponse(
+        id="mock-stream",
+        object="chat.completion",
+        created=int(datetime.now().timestamp()),
+        model="gpt-4o-mini",
+        usage=Usage(prompt_tokens=100, completion_tokens=50, total_tokens=150),
+        choices=[],
+    )
+
+    mock_kwargs: Dict[str, Any] = {
+        "standard_logging_object": {
+            "metadata": {
+                "user_api_key_hash": _api_key,
+                "user_api_key_user_id": None,
+                "user_api_key_team_id": None,
+                "user_api_key_end_user_id": None,
+            }
+        },
+        "litellm_params": {"metadata": data["metadata"]},
+        "model": "gpt-4o-mini",
+    }
+
+    await handler.async_logging_hook(
+        kwargs=mock_kwargs,
+        result=mock_response,
+        call_type="acompletion",
+    )
+
+    hidden_params = mock_kwargs["standard_logging_object"].get("hidden_params") or {}
+    additional_headers = hidden_params.get("additional_headers") or {}
+
+    assert (
+        additional_headers.get("x-ratelimit-model_per_key-remaining-requests") == 99
+    ), f"got {additional_headers!r}"
+    assert additional_headers.get("x-ratelimit-model_per_key-limit-requests") == 100
+
+    # response._hidden_params is also updated for late readers.
+    response_hidden = getattr(mock_response, "_hidden_params", None) or {}
+    response_headers = response_hidden.get("additional_headers") or {}
+    assert response_headers.get("x-ratelimit-model_per_key-remaining-requests") == 99
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_no_mirror_when_no_snapshot(monkeypatch):
+    """
+    No pre-call snapshot (no descriptors matched) -> no fabricated
+    ``x-ratelimit-*`` headers.
+    """
+    monkeypatch.setenv("LITELLM_RATE_LIMIT_WINDOW_SIZE", "60")
+    _api_key = hash_token("sk-stream-no-mirror")
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(DualCache())
+    )
+
+    async def _noop_increment(increment_list, **_):
+        return True
+
+    monkeypatch.setattr(
+        handler.internal_usage_cache.dual_cache,
+        "async_increment_cache_pipeline",
+        _noop_increment,
+    )
+
+    mock_response = ModelResponse(
+        id="mock-stream-none",
+        object="chat.completion",
+        created=int(datetime.now().timestamp()),
+        model="gpt-4o-mini",
+        usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        choices=[],
+    )
+
+    mock_kwargs: Dict[str, Any] = {
+        "standard_logging_object": {
+            "metadata": {
+                "user_api_key_hash": _api_key,
+                "user_api_key_user_id": None,
+                "user_api_key_team_id": None,
+                "user_api_key_end_user_id": None,
+            }
+        },
+        "litellm_params": {"metadata": {}},
+        "model": "gpt-4o-mini",
+    }
+
+    await handler.async_logging_hook(
+        kwargs=mock_kwargs,
+        result=mock_response,
+        call_type="acompletion",
+    )
+
+    hidden_params = mock_kwargs["standard_logging_object"].get("hidden_params") or {}
+    additional_headers = hidden_params.get("additional_headers") or {}
+    ratelimit_keys = [k for k in additional_headers if k.startswith("x-ratelimit-")]
+    assert (
+        not ratelimit_keys
+    ), f"no snapshot must produce no rate-limit headers, got {ratelimit_keys}"
+
+
+@pytest.mark.asyncio
+async def test_streaming_mirror_matches_non_streaming_header_shape(monkeypatch):
+    """
+    Given the same pre-call state, streaming and non-streaming must write
+    the identical ``x-ratelimit-*`` key/value shape to their respective
+    ``additional_headers`` slots.
+    """
+    monkeypatch.setenv("LITELLM_RATE_LIMIT_WINDOW_SIZE", "60")
+    _api_key = hash_token("sk-shape")
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key=_api_key,
+        metadata={
+            "model_rpm_limit": {"gpt-4o-mini": 50},
+            "model_tpm_limit": {"gpt-4o-mini": 5000},
+        },
+    )
+    local_cache = DualCache()
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(local_cache)
+    )
+
+    async def _noop_increment(increment_list, **_):
+        return True
+
+    monkeypatch.setattr(
+        handler.internal_usage_cache.dual_cache,
+        "async_increment_cache_pipeline",
+        _noop_increment,
+    )
+
+    # Drive pre-call once so both paths have the same authoritative snapshot.
+    data: Dict[str, Any] = {"model": "gpt-4o-mini", "metadata": {}}
+    await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict,
+        cache=local_cache,
+        data=data,
+        call_type="",
+    )
+
+    # Non-streaming path: async_post_call_success_hook mutates response._hidden_params.
+    non_stream_response = ModelResponse(
+        id="mock-non-stream",
+        object="chat.completion",
+        created=int(datetime.now().timestamp()),
+        model="gpt-4o-mini",
+        usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        choices=[],
+    )
+    non_stream_response._hidden_params = {}
+    await handler.async_post_call_success_hook(
+        data=data,
+        user_api_key_dict=user_api_key_dict,
+        response=non_stream_response,
+    )
+    non_stream_headers = non_stream_response._hidden_params.get(
+        "additional_headers", {}
+    )
+
+    # Streaming path: async_logging_hook mirrors into standard_logging_object.
+    stream_kwargs: Dict[str, Any] = {
+        "standard_logging_object": {
+            "metadata": {"user_api_key_hash": _api_key}
+        },
+        "litellm_params": {"metadata": data["metadata"]},
+        "model": "gpt-4o-mini",
+    }
+    stream_response = ModelResponse(
+        id="mock-stream",
+        object="chat.completion",
+        created=int(datetime.now().timestamp()),
+        model="gpt-4o-mini",
+        usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        choices=[],
+    )
+    await handler.async_logging_hook(
+        kwargs=stream_kwargs,
+        result=stream_response,
+        call_type="acompletion",
+    )
+    stream_slp_headers = (
+        stream_kwargs["standard_logging_object"]
+        .get("hidden_params", {})
+        .get("additional_headers", {})
+    )
+
+    def _rl_only(headers: Dict[str, Any]) -> Dict[str, Any]:
+        return {k: v for k, v in headers.items() if k.startswith("x-ratelimit-")}
+
+    assert _rl_only(stream_slp_headers) == _rl_only(non_stream_headers), (
+        f"streaming={_rl_only(stream_slp_headers)}"
+        f" non_streaming={_rl_only(non_stream_headers)}"
+    )
+    assert "x-ratelimit-model_per_key-remaining-requests" in stream_slp_headers


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4333

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Same virtual key (`model_rpm_limit={"gpt-4o-mini":100}`, `model_tpm_limit={"gpt-4o-mini":10000}`), same model, real OpenAI traffic, only `stream` changed between requests. A `CustomLogger` probe dumps `kwargs["standard_logging_object"]["hidden_params"]["additional_headers"]` filtered to `x-ratelimit-*`.

**Before (base branch, no fix)**

```
curl -sS http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"say hi in 2 words"}],"stream":false}' > /dev/null
curl -sS -N http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"say hi in 2 words"}],"stream":true}'  > /dev/null

[qa-probe] {"stream": false, "per_key_headers_present": true,  "per_key_ratelimit_headers": {"x-ratelimit-model_per_key-remaining-requests": 99, "x-ratelimit-model_per_key-limit-requests": 100, "x-ratelimit-model_per_key-remaining-tokens": 8972, "x-ratelimit-model_per_key-limit-tokens": 10000}}
[qa-probe] {"stream": true,  "per_key_headers_present": false, "per_key_ratelimit_headers": {}}
```

**After (this PR at HEAD)**

```
[qa-probe] {"stream": false, "per_key_headers_present": true, "per_key_ratelimit_headers": {"x-ratelimit-model_per_key-remaining-requests": 99, "x-ratelimit-model_per_key-limit-requests": 100, "x-ratelimit-model_per_key-remaining-tokens": 8972, "x-ratelimit-model_per_key-limit-tokens": 10000}}
[qa-probe] {"stream": true,  "per_key_headers_present": true, "per_key_ratelimit_headers": {"x-ratelimit-model_per_key-remaining-requests": 98, "x-ratelimit-model_per_key-limit-requests": 100, "x-ratelimit-model_per_key-remaining-tokens": 8956, "x-ratelimit-model_per_key-limit-tokens": 10000}}
```

Streaming now carries the identical key shape the non-streaming path emits; the remaining-requests decrement (99 -> 98) across the two calls confirms counter state is consistent.

### Full live E2E test matrix

All rows below were run against a real proxy on localhost:4000 with Postgres and real OpenAI calls unless marked mock.

| # | test | mode | result |
| --- | --- | --- | --- |
| 1 | base branch, non-streaming headers present | stream=false | pass (pre-existing behavior) |
| 2 | base branch, streaming headers missing | stream=true | bug reproduced |
| 3 | PR HEAD, non-streaming headers present | stream=false | pass, no regression |
| 4 | PR HEAD, streaming headers present | stream=true | pass, bug fixed |
| 5 | RPM-only limit: request headers present, token headers absent | both modes | pass |
| 6 | TPM-only limit: token headers present, request headers absent | both modes | pass |
| 7 | RPM+TPM limit: all four per-key headers present | both modes | pass |
| 8 | callback ordering: probe registered before limiter still sees mirrored headers | stream=true | pass (async_logging_hook runs before success callbacks) |
| 9 | non-streaming idempotency: single success event, no duplicated or list-mangled values | stream=false | pass |
| 10 | failure path emits failure log only, no success headers | broken api_base, stream=true | pass |
| 11 | post-failure recovery: next request logs normally, counters consistent | stream=true | pass |
| 12 | unrelated provider headers preserved after merge (~30 upstream headers intact) | both modes | pass |
| 13 | SLP metadata leak check: stash key absent from standard_logging_object.metadata | all events | pass |
| 14 | raw litellm_params.metadata: stash key visible, same as 5 pre-existing sibling stash keys | all events | confirmed, classified pre-existing family behavior (follow-up LIT-4366) |
| 15 | provider request body: stash key not forwarded upstream | audit + live | pass |
| 16 | cache key unaffected: second request with different stash value still cache-hits | both modes | pass |
| 17 | RPM=1 enforcement: second request 429 | live | pass |
| 18 | 50 concurrent requests against limit: excess correctly blocked (38/50) | live | pass |
| 19 | two keys concurrent: zero cross-key contamination of remaining values | live | pass |
| 20 | cache miss + cache hit, non-streaming: headers present on both | stream=false | pass |
| 21 | cache miss + cache hit, streaming: headers present on both | stream=true | pass (provider headers absent on stream cache hit since no upstream call; pre-existing) |
| 22 | guardrail deferred streaming, allow case: success log with headers, provider headers preserved | stream=true | pass |
| 23 | guardrail deferred streaming, block case: existing guardrail behavior unchanged, no crash, headers on success log | stream=true | pass |
| 24 | post-guardrail recovery: counters decrement normally | stream=true | pass |
| 25 | perf, non-streaming p50/p95/mean, base vs HEAD, 3x30 requests | mock provider | no regression (HEAD within noise) |
| 26 | perf, streaming total latency p50/p95 | mock provider | no regression |
| 27 | perf, streaming TTFT p50 | mock provider | no regression |
| 28 | perf-run stability: no crashes, no callback exceptions | mock provider | pass |
| 29 | Postgres spend-log writes with dict-valued stash present | live | pass, no crash |

Unit tests: four new regression tests in the mapped test file; three fail on the base branch and pass on this PR (mutation check), the fourth is a negative test asserting no headers are fabricated when no rate limit is configured. Full v3 suite (82 tests) passes.

Known coverage gap: a true mid-stream failure (provider emits one valid chunk then dies before [DONE]) was not fully exercised live; the failure-path testing covered pre-stream provider connection failure. The mirror only runs on the success path, so a mid-stream failure routes to the untouched failure handlers either way.

### Known limitations (tracked separately)

Prometheus /metrics gauges still report sys.maxsize for per-key remaining values because prometheus.py reads the v1 metadata contract; this PR delivers the streaming SLP values that read path needs (LIT-2577). The priority-based dynamic rate limiter composes v3 but does not delegate the new hook, so streaming SLP values are still absent under that limiter (LIT-4367). Streaming HTTP response headers sent to the client still omit the per-key values since headers are built before any post-call hook runs (LIT-4368). The internal stash key is visible in raw litellm_params.metadata consumed by whole-dict-dump integrations, shared behavior with the five pre-existing stash keys (LIT-4366).

## Type

🐛 Bug Fix

## Changes

Streaming requests return from `common_request_processing` before `async_post_call_success_hook` runs; that hook is where the v3 rate limiter writes `x-ratelimit-{descriptor_key}-{remaining|limit}-{rate_limit_type}` entries onto `response._hidden_params.additional_headers`. Because streaming never runs the hook, both the response object and the standard logging payload built from it end up with an empty `additional_headers`, and downstream success callbacks (Prometheus, custom loggers, DataDog scrapers) that read the per-key remaining values from `standard_logging_object.hidden_params.additional_headers` see nothing.

Fix in three parts, all in `parallel_request_limiter_v3.py`:

Stash the pre-call `RateLimitResponse` in the metadata channels the async success-logging callback inherits (`data["metadata"]` / `data["litellm_metadata"]`), alongside the existing top-level `data["litellm_proxy_rate_limit_response"]` entry the non-streaming path reads. This is the same transport the five existing `_litellm_*` stash keys in this file already use for pre-call to callback state (reserved tokens, reserved model, reserved scopes, descriptors, released flag), read back through the same `_lookup_stashed_value` helper. The new key is registered in `_LITELLM_STASH_KEYS` so the existing scrubbers strip client-forged values at pre-call entry and strip the key from the top-level body before provider dispatch.

Add `async_logging_hook` to the v3 handler. It fires in a distinct earlier loop inside `async_success_handler` (all callbacks' `async_logging_hook` complete before any `async_log_success_event` starts), so mirroring the pre-call snapshot into `standard_logging_object.hidden_params.additional_headers` and `response._hidden_params.additional_headers` there guarantees every downstream success callback sees the values regardless of registration order. For non-streaming the write is idempotent on top of what `async_post_call_success_hook` already wrote. The hook narrows the stashed value through `_narrow_ratelimit_statuses`, an isinstance-driven validator that returns a typed status list and drops malformed entries, so no cast and no possibility of a malformed stash breaking success logging.

Extract `_merge_ratelimit_statuses_into_additional_headers`. Both callsites (`async_post_call_success_hook` and the new mirror) share the same status-to-header key shape, so a single helper prevents the two paths from drifting.

Tests: four new tests in `tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py`. Three exercise the streaming path end-to-end (real `async_pre_call_hook` then real `async_logging_hook`) and one asserts absence when no rate limits are configured. Mutation check: reverting only the fix file, three of four fail; with the fix all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches proxy rate-limit metadata and success logging for all streaming completions; behavior is additive and idempotent for non-streaming, but incorrect mirroring could mislead observability or double-write headers if stash data were malformed (mitigated by `_narrow_ratelimit_statuses`).
> 
> **Overview**
> **Streaming success logs were missing per-key `x-ratelimit-*` remaining/limit values** that non-streaming requests get from `async_post_call_success_hook`, because streaming returns before that hook runs. Downstream callbacks (Prometheus, custom loggers) read those fields from `standard_logging_object.hidden_params.additional_headers`.
> 
> The v3 parallel request limiter now **stashes the pre-call `RateLimitResponse` in request metadata** (`_litellm_proxy_rate_limit_response`, same scrub/stash pattern as other `_litellm_*` keys) and implements **`async_logging_hook`** to copy validated statuses into the SLP and `response._hidden_params.additional_headers` early in the success callback chain. Header construction is **centralized in `_merge_ratelimit_statuses_into_additional_headers`**, shared with the non-streaming post-call success path.
> 
> Four regression tests cover end-to-end streaming mirroring, per-model headers, parity with non-streaming shape, and no fabricated headers when no limits apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9b942e9dabb3d90315a5ee39086efcde665818d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->