### PR TITLE
build(pre-commit): regenerate eslint-metrics.json instead of failing on drift

### DIFF
--- a/scripts/pre_commit_lint.sh
+++ b/scripts/pre_commit_lint.sh
@@ -76,11 +76,18 @@ EOF
         fi
         # Whole-folder lint budgets, exactly as the frontend-lint job runs them: the
         # counts and the committed metrics file are not diff-scoped, so a local pass
-        # here means the budget step will pass in CI too.
+        # here means the budget step will pass in CI too. Unlike CI (which --checks and
+        # fails), regenerate eslint-metrics.json from the same report — same as the
+        # gen:api block below regenerates schema.d.ts — then flag drift so you re-stage
+        # it, instead of making you run npm run lint:metrics by hand.
         report=$(mktemp)
         npx eslint . -f json -o "$report" || true
-        node scripts/check-lint-budgets.mjs "$report" eslint-budgets.json --check eslint-metrics.json || rc=1
+        node scripts/check-lint-budgets.mjs "$report" eslint-budgets.json --write eslint-metrics.json || rc=1
         rm -f "$report"
+        if ! git diff --quiet -- eslint-metrics.json; then
+            echo "✗ eslint-metrics.json was stale; regenerated it. Stage it and re-run make pre-commit." >&2
+            rc=1
+        fi
         exit $rc
     )
 }

--- a/ui/litellm-dashboard/eslint-metrics.json
+++ b/ui/litellm-dashboard/eslint-metrics.json
@@ -4,5 +4,5 @@
   "local/no-large-inline-object-arg": 512,
   "local/no-long-condition-chain": 233,
   "max-depth": 59,
-  "no-console": 15
+  "no-console": 16
 }

--- a/ui/litellm-dashboard/scripts/check-lint-budgets.mjs
+++ b/ui/litellm-dashboard/scripts/check-lint-budgets.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFileSync, writeFileSync } from "fs";
 import { countBudgetViolations, findDrift } from "./lint-budget-lib.mjs";
 
 const argv = process.argv.slice(2);
@@ -7,6 +7,8 @@ const flags = {};
 for (let i = 0; i < argv.length; i += 1) {
   if (argv[i] === "--check") {
     flags.check = argv[(i += 1)];
+  } else if (argv[i] === "--write") {
+    flags.write = argv[(i += 1)];
   } else {
     positional.push(argv[i]);
   }
@@ -28,6 +30,11 @@ for (const [rule, { max, target }] of Object.entries(budgets)) {
     );
     failed = true;
   }
+}
+
+if (flags.write) {
+  writeFileSync(flags.write, JSON.stringify(counts, null, 2) + "\n");
+  console.log(`Wrote ${flags.write}.`);
 }
 
 if (flags.check) {


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a dev-tooling change to `make pre-commit`, so there is no proxy or LLM behavior to curl; the proof is the script itself. Captured at commit 6d3cc0e7eb by running the real eslint report through both modes after simulating a stale committed metrics file (`no-console` forced to 99)

```
### Simulate a stale committed metrics file (no-console: 16 -> 99)

### OLD behavior: --check just fails and tells you to fix it by hand
no-console: 16 | max: 484 | target: 0 | 468 of headroom
::error::eslint-metrics.json is stale for no-console: committed 99, actual 16.
::error::Run `npm run lint:metrics` and commit eslint-metrics.json.
exit=1

### NEW behavior: --write regenerates the file from the same report
no-console: 16 | max: 484 | target: 0 | 468 of headroom
Wrote eslint-metrics.json.
exit=0
```

A full `make pre-commit` on this branch exits 0, and re-running it leaves no unstaged drift, confirming the regeneration is a no-op once the metrics file is current

## Type

🚄 Infrastructure

## Changes

The dashboard lint-budgets step in `make pre-commit` ran `check-lint-budgets.mjs` in `--check` mode, which fails whenever `eslint-metrics.json` drifts from the actual counts and tells you to run `npm run lint:metrics` and re-stage by hand. That is the same snapshot the block already computes, so making you regenerate it manually is busywork

This adds a `--write <path>` mode to `check-lint-budgets.mjs` that rewrites the metrics file from the eslint report already produced for the budget check, so there is no second eslint run. `pre_commit_lint.sh` now uses `--write`, then `git diff --quiet`s the file and fails asking you to stage it if it changed, mirroring exactly how the `gen:api` block right below it regenerates `schema.d.ts`. When the metrics are already current the regeneration is a no-op and the step passes silently

CI is untouched: `test-litellm-ui-build.yml` still calls `--check`, so a stale committed `eslint-metrics.json` still fails there. The one metrics bump in this PR (`no-console` 15 -> 16) is the new `console.log` in the write path, which stays far under its budget
