### PR TITLE
refactor(ui): convert caching page charts to shadcn/recharts

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.test.tsx
@@ -55,6 +55,14 @@ const barFills = (card: HTMLElement) =>
     bar.querySelector("path.recharts-rectangle")?.getAttribute("fill"),
   );
 
+const legendFillByCategory = (card: HTMLElement) =>
+  Object.fromEntries(
+    Array.from(card.querySelectorAll('.recharts-legend-wrapper [style*="background-color"]')).map((swatch) => [
+      swatch.parentElement?.textContent,
+      swatch.getAttribute("style")?.match(/background-color:\s*([^;]+);?/)?.[1],
+    ]),
+  );
+
 describe("CacheDashboard cache analytics charts", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -68,23 +76,25 @@ describe("CacheDashboard cache analytics charts", () => {
     expect(screen.getByText("Cached Completion Tokens vs Generated Completion Tokens")).toBeInTheDocument();
   });
 
-  it("renders the requests chart with its categories in order, sky/teal fills, and a legend", async () => {
+  it("renders the requests chart with each category legend-bound to its fill and stacked in order", async () => {
     renderDashboard();
     const { requestsCard } = await findChartCards();
 
-    expect(within(requestsCard).getByText("LLM API requests")).toBeInTheDocument();
-    expect(within(requestsCard).getByText("Cache hit")).toBeInTheDocument();
-    expect(requestsCard.querySelector(".recharts-legend-wrapper")).not.toBeNull();
+    expect(legendFillByCategory(requestsCard)).toEqual({
+      "LLM API requests": "var(--color-sky-500, #0ea5e9)",
+      "Cache hit": "var(--color-teal-500, #14b8a6)",
+    });
     expect(barFills(requestsCard)).toEqual(["var(--color-sky-500, #0ea5e9)", "var(--color-teal-500, #14b8a6)"]);
   });
 
-  it("renders the tokens chart with its categories in order, sky/teal fills, and a legend", async () => {
+  it("renders the tokens chart with each category legend-bound to its fill and stacked in order", async () => {
     renderDashboard();
     const { tokensCard } = await findChartCards();
 
-    expect(within(tokensCard).getByText("Generated Completion Tokens")).toBeInTheDocument();
-    expect(within(tokensCard).getByText("Cached Completion Tokens")).toBeInTheDocument();
-    expect(tokensCard.querySelector(".recharts-legend-wrapper")).not.toBeNull();
+    expect(legendFillByCategory(tokensCard)).toEqual({
+      "Generated Completion Tokens": "var(--color-sky-500, #0ea5e9)",
+      "Cached Completion Tokens": "var(--color-teal-500, #14b8a6)",
+    });
     expect(barFills(tokensCard)).toEqual(["var(--color-sky-500, #0ea5e9)", "var(--color-teal-500, #14b8a6)"]);
   });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.test.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import { renderWithProviders } from "../../../../../tests/test-utils";
+import CacheDashboard from "./cache_dashboard";
+
+const { adminGlobalCacheActivity, cachingHealthCheckCall } = vi.hoisted(() => ({
+  adminGlobalCacheActivity: vi.fn(),
+  cachingHealthCheckCall: vi.fn(),
+}));
+
+vi.mock("@/components/networking", () => ({
+  adminGlobalCacheActivity,
+  cachingHealthCheckCall,
+}));
+
+const cacheActivity = [
+  {
+    api_key: "sk-1",
+    model: "gpt-5.1",
+    call_type: "acompletion",
+    total_rows: 1500,
+    cache_hit_true_rows: 300,
+    cached_completion_tokens: 12000,
+    generated_completion_tokens: 48000,
+  },
+  {
+    api_key: "sk-2",
+    model: "text-embedding-3-large",
+    call_type: "aembedding",
+    total_rows: 700,
+    cache_hit_true_rows: 100,
+    cached_completion_tokens: 2000,
+    generated_completion_tokens: 9000,
+  },
+];
+
+const renderDashboard = () =>
+  renderWithProviders(
+    <CacheDashboard accessToken="sk-test" token="tok" userRole="Admin" userID="u1" premiumUser={false} />,
+  );
+
+const findChartCards = async () => {
+  await screen.findByText("Cache Hits vs API Requests");
+  await waitFor(() => {
+    expect(document.querySelectorAll("path.recharts-rectangle").length).toBeGreaterThan(0);
+  });
+  const cards = Array.from(document.querySelectorAll('[data-slot="card"]'));
+  expect(cards).toHaveLength(2);
+  return { requestsCard: cards[0] as HTMLElement, tokensCard: cards[1] as HTMLElement };
+};
+
+const barFills = (card: HTMLElement) =>
+  Array.from(card.querySelectorAll(".recharts-bar")).map((bar) =>
+    bar.querySelector("path.recharts-rectangle")?.getAttribute("fill"),
+  );
+
+describe("CacheDashboard cache analytics charts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adminGlobalCacheActivity.mockResolvedValue(cacheActivity);
+  });
+
+  it("renders both chart card titles", async () => {
+    renderDashboard();
+
+    expect(await screen.findByText("Cache Hits vs API Requests")).toBeInTheDocument();
+    expect(screen.getByText("Cached Completion Tokens vs Generated Completion Tokens")).toBeInTheDocument();
+  });
+
+  it("renders the requests chart with its categories in order, sky/teal fills, and a legend", async () => {
+    renderDashboard();
+    const { requestsCard } = await findChartCards();
+
+    expect(within(requestsCard).getByText("LLM API requests")).toBeInTheDocument();
+    expect(within(requestsCard).getByText("Cache hit")).toBeInTheDocument();
+    expect(requestsCard.querySelector(".recharts-legend-wrapper")).not.toBeNull();
+    expect(barFills(requestsCard)).toEqual(["var(--color-sky-500, #0ea5e9)", "var(--color-teal-500, #14b8a6)"]);
+  });
+
+  it("renders the tokens chart with its categories in order, sky/teal fills, and a legend", async () => {
+    renderDashboard();
+    const { tokensCard } = await findChartCards();
+
+    expect(within(tokensCard).getByText("Generated Completion Tokens")).toBeInTheDocument();
+    expect(within(tokensCard).getByText("Cached Completion Tokens")).toBeInTheDocument();
+    expect(tokensCard.querySelector(".recharts-legend-wrapper")).not.toBeNull();
+    expect(barFills(tokensCard)).toEqual(["var(--color-sky-500, #0ea5e9)", "var(--color-teal-500, #14b8a6)"]);
+  });
+
+  it("indexes bars by call_type name on the x axis", async () => {
+    renderDashboard();
+    const { requestsCard, tokensCard } = await findChartCards();
+
+    for (const card of [requestsCard, tokensCard]) {
+      expect(within(card).getAllByText("acompletion").length).toBeGreaterThan(0);
+      expect(within(card).getAllByText("aembedding").length).toBeGreaterThan(0);
+    }
+  });
+
+  it("stacks the two categories into one column per call_type", async () => {
+    renderDashboard();
+    const { requestsCard, tokensCard } = await findChartCards();
+
+    for (const card of [requestsCard, tokensCard]) {
+      const rects = Array.from(card.querySelectorAll("path.recharts-rectangle"));
+      expect(rects).toHaveLength(4);
+      const xPositions = rects.map((rect) => rect.getAttribute("d")?.split(",")[0]);
+      expect(new Set(xPositions).size).toBe(2);
+    }
+  });
+
+  it("formats y-axis ticks with compact notation", async () => {
+    renderDashboard();
+    const { requestsCard, tokensCard } = await findChartCards();
+
+    const compactTicks = (card: HTMLElement) =>
+      within(card)
+        .getAllByText(/^\d+(\.\d+)?K$/)
+        .map((tick) => tick.textContent);
+
+    expect(compactTicks(requestsCard).length).toBeGreaterThan(0);
+    expect(compactTicks(tokensCard)).toContain("60K");
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.tsx
@@ -1,5 +1,4 @@
 import {
-  BarChart,
   Card,
   Col,
   DateRangePickerValue,
@@ -7,7 +6,6 @@ import {
   Icon,
   MultiSelect,
   MultiSelectItem,
-  Subtitle,
   Tab,
   TabGroup,
   TabList,
@@ -18,6 +16,8 @@ import {
 import React, { useEffect, useState } from "react";
 import NotificationsManager from "@/components/molecules/notifications_manager";
 import UsageDatePicker from "@/components/shared/usage_date_picker";
+import { BarChart } from "@/components/shared/charts";
+import { Card as ChartCard, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 import { RefreshIcon } from "@heroicons/react/outline";
 import { adminGlobalCacheActivity, cachingHealthCheckCall } from "@/components/networking";
@@ -61,13 +61,13 @@ interface cacheDataItem {
   // Add other properties as needed
 }
 
-interface uiData {
+type uiData = {
   name: string;
   "LLM API requests": number;
   "Cache hit": number;
   "Cached Completion Tokens": number;
   "Generated Completion Tokens": number;
-}
+};
 
 interface CacheHealthResponse {
   status?: string;
@@ -348,29 +348,41 @@ const CacheDashboard: React.FC<CachePageProps> = ({ accessToken, token, userRole
               </Card>
             </div>
 
-            <Subtitle className="mt-4">Cache Hits vs API Requests</Subtitle>
-            <BarChart
-              title="Cache Hits vs API Requests"
-              data={filteredData}
-              stack={true}
-              index="name"
-              valueFormatter={valueFormatterNumbers}
-              categories={["LLM API requests", "Cache hit"]}
-              colors={["sky", "teal"]}
-              yAxisWidth={48}
-            />
+            <ChartCard className="mt-4">
+              <CardHeader>
+                <CardTitle className="text-base font-semibold">Cache Hits vs API Requests</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <BarChart
+                  data={filteredData}
+                  stack={true}
+                  index="name"
+                  valueFormatter={valueFormatterNumbers}
+                  categories={["LLM API requests", "Cache hit"]}
+                  colors={["sky", "teal"]}
+                  yAxisWidth={48}
+                />
+              </CardContent>
+            </ChartCard>
 
-            <Subtitle className="mt-4">Cached Completion Tokens vs Generated Completion Tokens</Subtitle>
-            <BarChart
-              className="mt-6"
-              data={filteredData}
-              stack={true}
-              index="name"
-              valueFormatter={valueFormatterNumbers}
-              categories={["Generated Completion Tokens", "Cached Completion Tokens"]}
-              colors={["sky", "teal"]}
-              yAxisWidth={48}
-            />
+            <ChartCard className="mt-6">
+              <CardHeader>
+                <CardTitle className="text-base font-semibold">
+                  Cached Completion Tokens vs Generated Completion Tokens
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <BarChart
+                  data={filteredData}
+                  stack={true}
+                  index="name"
+                  valueFormatter={valueFormatterNumbers}
+                  categories={["Generated Completion Tokens", "Cached Completion Tokens"]}
+                  colors={["sky", "teal"]}
+                  yAxisWidth={48}
+                />
+              </CardContent>
+            </ChartCard>
           </Card>
         </TabPanel>
         <TabPanel>


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

QA on the caching page (screenshots to follow in a comment):

1. run the proxy (`python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml`) and the dashboard dev server (`npm run dev` in ui/litellm-dashboard)
2. send a few completions so the last 7 days have spend log rows, repeating each request so cache hits show up if caching is enabled, e.g. `for i in 1 2 1 2; do curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-..." -H "Content-Type: application/json" -d "{\"model\": \"gpt-5.2\", \"messages\": [{\"role\": \"user\", \"content\": \"hi $i\"}]}"; done`
3. open http://localhost:3000/caching (the two charts are on the default Cache Analytics tab; the legacy deep link http://localhost:3000/?page=caching redirects there) and compare against staging: "Cache Hits vs API Requests" and "Cached Completion Tokens vs Generated Completion Tokens" as stacked sky/teal bars grouped by call type, y axis with compact counts (1.2K style), legend on top right, tooltip on hover with the same compact formatting
4. check the two headings now render as card titles; the first chart previously relied on a plain subtitle line plus a `title` prop that tremor silently ignored
5. filter by virtual key, model, and date range and confirm both charts re-render with the filtered data, same as before

Before (staging, tremor BarChart) and after (this branch, recharts through the shared wrapper) should look near-identical; sky and teal resolve to the same tailwind-500 palette tremor rendered

<img width="1268" height="903" alt="Screenshot 2026-07-10 at 4 36 23 PM" src="https://github.com/user-attachments/assets/f04031db-c193-4de0-b834-079845449e36" />
<img width="1276" height="918" alt="Screenshot 2026-07-10 at 4 36 09 PM" src="https://github.com/user-attachments/assets/f8775a81-dd1d-49b7-95f6-643cf5d5b02b" />


## Type

🧹 Refactoring

## Changes

Stage PR for the charts track of the shadcn migration (foundation: #32668). Converts the two tremor BarCharts on the caching page's Cache Analytics tab to the shared `BarChart` wrapper; no wrapper changes were needed since every prop these sites pass (data/index/categories/colors/valueFormatter/stack/yAxisWidth/className) is already covered

Each chart moves into its own shadcn Card following the pilot (ScoreChart): the tremor Subtitle headings become CardTitles, which also absorbs the first chart's `title` prop; that prop is not part of tremor's BarChart API and rendered nothing, so the text is now actually visible as the card title. The second chart's `mt-6` spacing is preserved on its Card. Everything else on the page (the outer tremor Card, the filter row, the stat mini cards, the tabs) stays tremor and converts in a later page-level phase

The `uiData` interface becomes a type alias so the row type satisfies the wrapper's `Record<string, unknown>` constraint (interfaces have no implicit index signature)

New colocated test renders the dashboard with a mocked activity fetch and asserts against the real recharts SVG: both card titles, a legend-bound mapping from each category label to its sky/teal fill (read off the legend swatches, so swapping either the categories or the colors fails the test) plus the bar stack order, one stacked column per call type, the `name` index on the x axis, and compact (`60K` style) y-axis tick formatting via `valueFormatterNumbers`

