### PR TITLE
refactor(ui): convert projects page chart to shadcn/recharts

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectDetailsPage.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectDetailsPage.test.tsx
@@ -43,6 +43,14 @@ const mockProject: ProjectResponse = {
   litellm_budget_table: null,
 };
 
+const rectangleFills = (container: HTMLElement) =>
+  new Set(Array.from(container.querySelectorAll("path.recharts-rectangle")).map((rect) => rect.getAttribute("fill")));
+
+const yAxisTickLabels = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll(".recharts-yAxis-tick-labels .recharts-cartesian-axis-tick-value")).map(
+    (tick) => tick.textContent,
+  );
+
 describe("ProjectDetail", () => {
   const onBack = vi.fn();
 
@@ -157,6 +165,65 @@ describe("ProjectDetail", () => {
       });
       renderWithProviders(<ProjectDetail projectId="proj-1" onBack={onBack} />);
       expect(screen.getByText("No team assigned")).toBeInTheDocument();
+    });
+
+    describe("Spend by Model chart", () => {
+      const multiModelProject: ProjectResponse = {
+        ...mockProject,
+        model_spend: {
+          "claude-sonnet-5": 0.5,
+          "gpt-5.2": 10,
+          "claude-opus-4-8": 2.75,
+          "gpt-5.2-codex": 5.5,
+        },
+      };
+
+      it("should render one cyan bar per model without a legend", () => {
+        mockUseProjectDetails.mockReturnValue({ data: multiModelProject, isLoading: false });
+        const { container } = renderWithProviders(<ProjectDetail projectId="proj-1" onBack={onBack} />);
+
+        expect(container.querySelectorAll(".recharts-bar")).toHaveLength(1);
+        expect(container.querySelectorAll("path.recharts-rectangle")).toHaveLength(4);
+        expect(rectangleFills(container)).toEqual(new Set(["var(--color-cyan-500, #06b6d4)"]));
+        expect(container.querySelector(".recharts-legend-wrapper")).toBeNull();
+      });
+
+      it("should list models on the category axis sorted by spend descending", () => {
+        mockUseProjectDetails.mockReturnValue({ data: multiModelProject, isLoading: false });
+        const { container } = renderWithProviders(<ProjectDetail projectId="proj-1" onBack={onBack} />);
+
+        expect(yAxisTickLabels(container)).toEqual(["gpt-5.2", "gpt-5.2-codex", "claude-opus-4-8", "claude-sonnet-5"]);
+      });
+
+      it("should format value axis ticks as dollars with four decimals", () => {
+        mockUseProjectDetails.mockReturnValue({ data: multiModelProject, isLoading: false });
+        const { container } = renderWithProviders(<ProjectDetail projectId="proj-1" onBack={onBack} />);
+
+        expect(container.querySelector(".recharts-xAxis-tick-labels")?.textContent).toMatch(/\$\d+\.\d{4}/);
+      });
+
+      it("should scale the chart height at 40px per model with a 120px floor", () => {
+        mockUseProjectDetails.mockReturnValue({ data: multiModelProject, isLoading: false });
+        const { container } = renderWithProviders(<ProjectDetail projectId="proj-1" onBack={onBack} />);
+        expect(container.querySelector<HTMLElement>('[data-slot="chart"]')?.style.height).toBe("160px");
+
+        mockUseProjectDetails.mockReturnValue({ data: mockProject, isLoading: false });
+        const { container: singleModelContainer } = renderWithProviders(
+          <ProjectDetail projectId="proj-1" onBack={onBack} />,
+        );
+        expect(singleModelContainer.querySelector<HTMLElement>('[data-slot="chart"]')?.style.height).toBe("120px");
+      });
+
+      it("should show the empty state when no model spend is recorded", () => {
+        mockUseProjectDetails.mockReturnValue({
+          data: { ...mockProject, model_spend: {} },
+          isLoading: false,
+        });
+        const { container } = renderWithProviders(<ProjectDetail projectId="proj-1" onBack={onBack} />);
+
+        expect(screen.getByText("No model spend recorded yet")).toBeInTheDocument();
+        expect(container.querySelector('[data-slot="chart"]')).toBeNull();
+      });
     });
 
     it("should show team information when team data is available", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectDetailsPage.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectDetailsPage.tsx
@@ -16,7 +16,7 @@ import {
   Typography,
 } from "antd";
 import { LoadingOutlined } from "@ant-design/icons";
-import { BarChart } from "@tremor/react";
+import { BarChart } from "@/components/shared/charts";
 import { ArrowLeftIcon, DollarSignIcon, EditIcon, KeyIcon, UsersIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 import DefaultProxyAdminTag from "@/components/common_components/DefaultProxyAdminTag";


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

QA on the project details page (screenshots to follow in a comment):

1. run the proxy (`python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml`) and the dashboard dev server (`npm run dev` in ui/litellm-dashboard)
2. open http://localhost:3000/projects/ (the route works directly even if the Projects nav item is behind the `enableProjectsUI` flag) and click the ID of a project that already has spend; the "Spend by Model" card holds the converted chart
3. if no project has spend, seed one: create a project on that page, generate a key for it with `curl -s http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"project_id": "<project id>"}'`, then send a few completions through that key across two models from your config so multiple bars render, e.g. `for m in gpt-5.2 claude-sonnet-5; do curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer <key>" -H "Content-Type: application/json" -d '{"model": "'$m'", "messages": [{"role": "user", "content": "hi"}]}'; done`, and reload the project page once the spend tracker flushes
4. compare the "Spend by Model" card against staging: horizontal cyan bars sorted highest spend first, model names on the left axis, dollar amounts with four decimals on the bottom axis and in the hover tooltip, no legend, chart height growing 40px per model with a 120px floor
5. a project with no recorded spend still shows the "No model spend recorded yet" empty state

Before (staging, tremor BarChart) and after (this branch, recharts through the shared wrapper) should look near-identical; "cyan" maps to the same cyan-500 the tremor palette used
<img width="1278" height="867" alt="Screenshot 2026-07-10 at 5 58 44 PM" src="https://github.com/user-attachments/assets/e97c29b2-474c-4fdf-bb57-9c6da3d2a75f" />
<img width="1286" height="922" alt="Screenshot 2026-07-10 at 5 58 37 PM" src="https://github.com/user-attachments/assets/08df43f8-372a-4168-8d61-53580ecd7b13" />

## Type

🧹 Refactoring

## Changes

Converts the last tremor chart on the projects page, the "Spend by Model" horizontal BarChart in ProjectDetailsPage, to the shared shadcn/recharts `BarChart` wrapper from #32668. The change is an import swap; every prop stays as-is (vertical layout, single cyan "spend" series, `$` four-decimal valueFormatter on the value axis and tooltip, 140px category axis, legend off, and the dynamic height of 40px per model with a 120px floor carried through the wrapper's `style` prop). The surrounding antd Card, Row/Col grid, and the antd Empty fallback for projects without spend stay untouched; the card was never tremor, so unlike the pilot there is no Card conversion here

One known deviation from tremor: the wrapper renders every category label on the vertical axis (`interval={0}`) instead of thinning them, which is the desired behavior here since the chart already grows 40px per model row

ProjectDetailsPage.test.tsx gains a "Spend by Model chart" block asserting against the real recharts SVG (via the scoped jsdom ResizeObserver mock): one cyan-500 bar series with a rectangle per model and no legend, category ticks sorted by spend descending, `$x.xxxx` value axis ticks, the 40px-per-model/120px-floor container height, and the empty state when `model_spend` is empty
