### PR TITLE
feat(ui): add /teams/[teamid] team detail route

### DIFF
--- a/ui/litellm-dashboard/eslint-metrics.json
+++ b/ui/litellm-dashboard/eslint-metrics.json
@@ -1,5 +1,5 @@
 {
-  "@typescript-eslint/no-explicit-any": 1978,
+  "@typescript-eslint/no-explicit-any": 1977,
   "complexity": 129,
   "local/no-large-inline-object-arg": 513,
   "local/no-long-condition-chain": 233,

--- a/ui/litellm-dashboard/src/app/(dashboard)/teams/[teamid]/TeamDetailPage.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/teams/[teamid]/TeamDetailPage.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useAllTeams } from "@/app/(dashboard)/hooks/teams/useTeams";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import LoadingScreen from "@/components/common_components/LoadingScreen";
+import { fetchAvailableModelsForTeamOrKey } from "@/components/key_team_helpers/fetch_available_models_team_key";
+import TeamInfoView from "@/components/team/TeamInfo";
+import { migratedHref } from "@/utils/migratedPages";
+import { ArrowLeftOutlined } from "@ant-design/icons";
+import { useQueryClient } from "@tanstack/react-query";
+import { Button } from "antd";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+function teamIdFromPathname(pathname: string): string {
+  const segments = pathname.replace(/\/+$/, "").split("/");
+  return decodeURIComponent(segments[segments.length - 1] ?? "");
+}
+
+export default function TeamDetailPage() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { isLoading: authLoading, isAuthorized, accessToken, userId, userRole, premiumUser } = useAuthorized();
+  const [teamId] = useState(() => (typeof window === "undefined" ? "" : teamIdFromPathname(window.location.pathname)));
+  const [userModels, setUserModels] = useState<string[]>([]);
+
+  const { data: teams, isPending } = useAllTeams();
+
+  useEffect(() => {
+    if (!accessToken || !userId || !userRole) {
+      return;
+    }
+    fetchAvailableModelsForTeamOrKey(userId, userRole, accessToken)
+      .then((models) => {
+        if (models) {
+          setUserModels(models);
+        }
+      })
+      .catch((error) => console.error("Error fetching user models:", error));
+  }, [accessToken, userId, userRole]);
+
+  const backToTeams = () => router.push(migratedHref("teams"));
+
+  if (authLoading || !isAuthorized) {
+    return <LoadingScreen />;
+  }
+  if (!teamId || isPending) {
+    return <LoadingScreen />;
+  }
+
+  const team = teams?.find((t) => t.team_id === teamId);
+  if (!team) {
+    return (
+      <div className="p-4">
+        <Button type="text" icon={<ArrowLeftOutlined />} onClick={backToTeams} className="mb-4">
+          Back to Teams
+        </Button>
+        <p className="text-sm text-gray-700">Team not found</p>
+      </div>
+    );
+  }
+
+  const isTeamAdmin = (team.members_with_roles ?? []).some((m) => m.user_id === userId && m.role === "admin");
+
+  return (
+    <TeamInfoView
+      teamId={teamId}
+      accessToken={accessToken}
+      is_team_admin={isTeamAdmin}
+      is_proxy_admin={userRole === "Admin"}
+      userModels={userModels}
+      editTeam={false}
+      premiumUser={premiumUser ?? undefined}
+      onClose={backToTeams}
+      onUpdate={() => queryClient.invalidateQueries({ queryKey: ["teams"] })}
+    />
+  );
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/teams/[teamid]/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/teams/[teamid]/page.tsx
@@ -1,0 +1,9 @@
+import TeamDetailPage from "./TeamDetailPage";
+
+export function generateStaticParams() {
+  return [{ teamid: "placeholder" }];
+}
+
+export default function TeamDetailRoute() {
+  return <TeamDetailPage />;
+}

--- a/ui/litellm-dashboard/src/components/OldTeams.test.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.test.tsx
@@ -7,6 +7,11 @@ import { fetchMCPAccessGroups, getGuardrailsList, teamCreateCall } from "./netwo
 import OldTeams from "./OldTeams";
 import { teamListCall } from "@/app/(dashboard)/hooks/teams/useTeams";
 
+const { mockRouterPush } = vi.hoisted(() => ({ mockRouterPush: vi.fn() }));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}));
+
 const mockTeamInfoView = vi.fn();
 const mockUseOrganizations = vi.fn();
 
@@ -17,6 +22,7 @@ vi.mock("./networking", () => ({
   v2TeamListCall: vi.fn(),
   getGuardrailsList: vi.fn().mockResolvedValue({ guardrails: [] }),
   getPoliciesList: vi.fn().mockResolvedValue({ policies: [] }),
+  serverRootPath: "",
 }));
 
 vi.mock("@/app/(dashboard)/hooks/teams/useTeams", () => ({
@@ -575,16 +581,16 @@ describe("OldTeams - helper functions", () => {
   });
 });
 
-describe("OldTeams - premium props", () => {
+describe("OldTeams - team id navigation", () => {
   beforeEach(() => {
-    mockTeamInfoView.mockClear();
+    vi.clearAllMocks();
     vi.mocked(fetchAvailableModelsForTeamOrKey).mockResolvedValue([]);
     vi.mocked(fetchMCPAccessGroups).mockResolvedValue([]);
     vi.mocked(getGuardrailsList).mockResolvedValue({ guardrails: [] });
     mockUseOrganizations.mockReturnValue({ data: [] });
   });
 
-  it("passes premiumUser flag to TeamInfoView", async () => {
+  it("navigates to the team detail route when clicking the team ID", async () => {
     vi.mocked(teamListCall).mockResolvedValue({
       teams: [
         {
@@ -614,9 +620,7 @@ describe("OldTeams - premium props", () => {
       fireEvent.click(teamIdElement);
     });
 
-    await waitFor(() => expect(mockTeamInfoView).toHaveBeenCalled());
-
-    expect(mockTeamInfoView).toHaveBeenLastCalledWith(expect.objectContaining({ premiumUser: true }));
+    expect(mockRouterPush).toHaveBeenCalledWith(expect.stringContaining("teams/team-123456789"));
   });
 });
 

--- a/ui/litellm-dashboard/src/components/OldTeams.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.tsx
@@ -1,6 +1,7 @@
 import { useOrganizations } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
 import AvailableTeamsPanel from "@/components/team/available_teams";
-import TeamInfoView from "@/components/team/TeamInfo";
+import { migratedHref } from "@/utils/migratedPages";
+import { useRouter } from "next/navigation";
 import TeamSSOSettings from "@/components/TeamSSOSettings";
 import { isProxyAdminRole } from "@/utils/roles";
 import { InfoCircleOutlined, PlusOutlined, TeamOutlined, ReloadOutlined } from "@ant-design/icons";
@@ -75,7 +76,6 @@ interface EditTeamModalProps {
   onSubmit: (data: FormData) => void; // Assuming FormData is the type of data to be submitted
 }
 
-import { updateExistingKeys } from "@/utils/dataUtils";
 import DeleteResourceModal from "./common_components/DeleteResourceModal";
 import { Member, teamCreateCall } from "./networking";
 import { ModelSelect } from "./ModelSelect/ModelSelect";
@@ -228,8 +228,7 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
   const [editModalVisible, setEditModalVisible] = useState(false);
 
   const [selectedTeam, setSelectedTeam] = useState<null | any>(null);
-  const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
-  const [editTeam, setEditTeam] = useState<boolean>(false);
+  const router = useRouter();
 
   const [isTeamModalVisible, setIsTeamModalVisible] = useState(false);
   const [isAddMemberModalVisible, setIsAddMemberModalVisible] = useState(false);
@@ -582,19 +581,6 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
     }
   };
 
-  const is_team_admin = (team: any) => {
-    if (team == null || team.members_with_roles == null) {
-      return false;
-    }
-    for (let i = 0; i < team.members_with_roles.length; i++) {
-      let member = team.members_with_roles[i];
-      if (member.user_id == userID && member.role == "admin") {
-        return true;
-      }
-    }
-    return false;
-  };
-
   const handleSearchChange = (value: string) => {
     if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
     setIsSearching(true);
@@ -672,7 +658,11 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
         width: 170,
         ellipsis: true,
         render: (id: string) => (
-          <IdCell value={id} onClick={(teamId) => setSelectedTeamId(teamId)} dataTestId="team-id-cell" />
+          <IdCell
+            value={id}
+            onClick={(teamId) => router.push(migratedHref(`teams/${encodeURIComponent(teamId)}/`))}
+            dataTestId="team-id-cell"
+          />
         ),
       },
       {
@@ -813,10 +803,7 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
                   variant="Edit"
                   tooltipText="Edit team"
                   dataTestId="edit-team-button"
-                  onClick={() => {
-                    setSelectedTeamId(record.team_id);
-                    setEditTeam(true);
-                  }}
+                  onClick={() => router.push(migratedHref(`teams/${encodeURIComponent(record.team_id)}/`))}
                 />
                 <TableIconActionButton
                   variant="Delete"
@@ -988,59 +975,27 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
 
   return (
     <Content style={{ padding: token.paddingLG, paddingInline: token.paddingLG * 2 }}>
-      {selectedTeamId ? (
-        <TeamInfoView
-          teamId={selectedTeamId}
-          onUpdate={(data) => {
-            setTeams((teams) => {
-              if (teams == null) {
-                return teams;
-              }
-              return teams.map((team) => {
-                if (data.team_id === team.team_id) {
-                  return updateExistingKeys(team, data);
-                }
-                return team;
-              });
-            });
-            fetchTeamsV2();
-          }}
-          onClose={() => {
-            setSelectedTeamId(null);
-            setEditTeam(false);
-          }}
-          accessToken={accessToken}
-          is_team_admin={is_team_admin(teams?.find((team) => team.team_id === selectedTeamId))}
-          is_proxy_admin={userRole == "Admin"}
-          userModels={userModels}
-          editTeam={editTeam}
-          premiumUser={premiumUser}
-        />
-      ) : (
-        <>
-          <Flex justify="space-between" align="center" style={{ marginBottom: 16 }}>
-            <Space direction="vertical" size={0}>
-              <Title level={2} style={{ margin: 0 }}>
-                <TeamOutlined style={{ marginRight: 8 }} />
-                Teams
-              </Title>
-              <Text type="secondary">Manage teams, members, and their access to models and budgets</Text>
-            </Space>
-            {canCreateOrManageTeams(userRole, userID, organizations) && (
-              <Button
-                type="primary"
-                icon={<PlusOutlined />}
-                onClick={() => setIsTeamModalVisible(true)}
-                data-testid="create-team-button"
-              >
-                Create Team
-              </Button>
-            )}
-          </Flex>
+      <Flex justify="space-between" align="center" style={{ marginBottom: 16 }}>
+        <Space direction="vertical" size={0}>
+          <Title level={2} style={{ margin: 0 }}>
+            <TeamOutlined style={{ marginRight: 8 }} />
+            Teams
+          </Title>
+          <Text type="secondary">Manage teams, members, and their access to models and budgets</Text>
+        </Space>
+        {canCreateOrManageTeams(userRole, userID, organizations) && (
+          <Button
+            type="primary"
+            icon={<PlusOutlined />}
+            onClick={() => setIsTeamModalVisible(true)}
+            data-testid="create-team-button"
+          >
+            Create Team
+          </Button>
+        )}
+      </Flex>
 
-          <Tabs items={tabItems} />
-        </>
-      )}
+      <Tabs items={tabItems} />
 
       {canCreateOrManageTeams(userRole, userID, organizations) && (
         <Modal


### PR DESCRIPTION
## Relevant issues

Stacked on #32706 (api-keys detail route). Base branch is `litellm_add_api_key_detail_page`; it will retarget to `litellm_internal_staging` once #32706 merges.

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Verified with `make pre-commit` (green) and `next build` (compiles; emits the `teams/placeholder` shell the SPA fallback serves). Behaviour is identical to the api-keys detail route from the base PR: on a single-container proxy, clicking a team's Team ID routes to `/ui/teams/<team-id>` and renders the team detail (settings/members/keys); refresh and deep-link resolve via the existing `SPAStaticFiles` fallback (no backend change here); the back button returns to the list; a bogus id shows an explicit "Team not found".

```
$ npm run build   # Compiled successfully; out/teams/placeholder/index.html emitted
```

## Type

🆕 New Feature

## Changes

Mirrors the `/api-keys/[keyid]` detail route onto Teams. Clicking a team's Team ID in the teams table (and the row Edit action) now navigates to a dedicated `/teams/[teamid]` route via `migratedHref`, instead of swapping an inline `TeamInfoView`. `TeamDetailPage` reads the id from `window.location`, resolves the team from the teams list (for the team-admin check and an explicit not-found guard), fetches the available models, and renders the existing `TeamInfoView`; the back button returns to `/teams`

The inline swap in `OldTeams` and its now-unused `selectedTeamId`/`editTeam` state and `is_team_admin` helper are removed (that helper's `any` param also drops the `no-explicit-any` count by one). No backend change is needed: the `SPAStaticFiles` fallback added in the base PR already serves the `/ui/teams/*` shell for the runtime-created team id, so the same click, refresh, and deep-link behaviour applies
