### PR TITLE
fix(ui): separate semantic caching from Redis Type dropdown (#32621)

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/CacheFieldSection.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/CacheFieldSection.tsx
@@ -10,6 +10,7 @@ interface CacheFieldSectionProps {
   embeddingModels: EmbeddingModelOption[];
   gridCols?: string;
   headingLevel?: "h4" | "h5";
+  semanticEnabled?: boolean;
 }
 
 const CacheFieldSection: React.FC<CacheFieldSectionProps> = ({
@@ -19,8 +20,9 @@ const CacheFieldSection: React.FC<CacheFieldSectionProps> = ({
   embeddingModels,
   gridCols = "grid-cols-1 gap-6 sm:grid-cols-2",
   headingLevel = "h4",
+  semanticEnabled = false,
 }) => {
-  const fields = fieldsForSection(section, redisType);
+  const fields = fieldsForSection(section, redisType, semanticEnabled);
   if (fields.length === 0) {
     return null;
   }

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/RedisTypeSelector.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/RedisTypeSelector.tsx
@@ -10,12 +10,11 @@ interface RedisTypeSelectorProps {
 const RedisTypeSelector: React.FC<RedisTypeSelectorProps> = ({ redisType, redisTypeDescriptions, onTypeChange }) => {
   return (
     <div className="space-y-2">
-      <label className="text-sm font-medium text-gray-700">Redis Type</label>
+      <label className="text-sm font-medium text-gray-700">Redis Deployment Type</label>
       <Select value={redisType} onValueChange={onTypeChange}>
         <SelectItem value="node">Node (Single Instance)</SelectItem>
         <SelectItem value="cluster">Cluster</SelectItem>
         <SelectItem value="sentinel">Sentinel</SelectItem>
-        <SelectItem value="semantic">Semantic</SelectItem>
       </Select>
       <p className="text-xs text-gray-500">
         {redisTypeDescriptions[redisType] || "Select the type of Redis deployment you're using"}

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/cacheSettingsFields.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/cacheSettingsFields.ts
@@ -2,7 +2,7 @@ import type { FormItemProps } from "antd";
 
 export type CacheFieldType = "string" | "password" | "integer" | "float" | "boolean" | "list" | "model-select";
 
-export type RedisType = "node" | "cluster" | "sentinel" | "semantic";
+export type RedisType = "node" | "cluster" | "sentinel";
 
 export type CacheSection = "connection" | "cluster" | "sentinel" | "semantic" | "ssl" | "cacheManagement" | "gcp";
 
@@ -19,13 +19,12 @@ export interface CacheField {
   readonly rules?: CacheFieldRule[];
 }
 
-export const REDIS_TYPES: readonly RedisType[] = ["node", "cluster", "sentinel", "semantic"];
+export const REDIS_TYPES: readonly RedisType[] = ["node", "cluster", "sentinel"];
 
 export const REDIS_TYPE_DESCRIPTIONS: Readonly<Record<RedisType, string>> = {
   node: "Standard Redis node/single instance",
   cluster: "Redis Cluster mode for high availability and horizontal scaling",
   sentinel: "Redis Sentinel mode for high availability with automatic failover",
-  semantic: "Semantic caching that reuses responses for similar prompts",
 };
 
 const portRule: CacheFieldRule = {
@@ -177,7 +176,7 @@ export const CACHE_FIELDS: readonly CacheField[] = [
     type: "float",
     section: "semantic",
     helpText: "Similarity threshold for semantic cache",
-    redisType: "semantic",
+    redisType: null,
     defaultValue: 0.8,
     rules: [numberRule],
   },
@@ -187,7 +186,7 @@ export const CACHE_FIELDS: readonly CacheField[] = [
     type: "model-select",
     section: "semantic",
     helpText: "Embedding model for semantic cache",
-    redisType: "semantic",
+    redisType: null,
   },
   {
     name: "ssl",

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/cacheSettingsUtils.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/cacheSettingsUtils.test.ts
@@ -3,12 +3,20 @@ import { buildCachePayload, buildInitialValues, fieldsForSection } from "./cache
 
 describe("fieldsForSection", () => {
   it("should only include a redis-type-specific field when that type is selected", () => {
-    expect(fieldsForSection("cluster", "cluster").map((f) => f.name)).toEqual(["redis_startup_nodes"]);
-    expect(fieldsForSection("cluster", "node")).toEqual([]);
+    expect(fieldsForSection("cluster", "cluster", false).map((f) => f.name)).toEqual(["redis_startup_nodes"]);
+    expect(fieldsForSection("cluster", "node", false)).toEqual([]);
+  });
+
+  it("should include semantic fields only when semanticEnabled is true", () => {
+    expect(fieldsForSection("semantic", "node", false)).toEqual([]);
+    expect(fieldsForSection("semantic", "node", true).map((f) => f.name)).toEqual([
+      "similarity_threshold",
+      "redis_semantic_cache_embedding_model",
+    ]);
   });
 
   it("should include connection fields for every redis type in schema order", () => {
-    expect(fieldsForSection("connection", "node").map((f) => f.name)).toEqual([
+    expect(fieldsForSection("connection", "node", false).map((f) => f.name)).toEqual([
       "url",
       "host",
       "port",
@@ -42,7 +50,7 @@ describe("buildInitialValues", () => {
 
 describe("buildCachePayload", () => {
   it("should tag the payload as redis and drop empty fields and the UI-only redis_type", () => {
-    const payload = buildCachePayload("node", { host: "localhost", port: "6379", username: "" }, { forTesting: false });
+    const payload = buildCachePayload("node", { host: "localhost", port: "6379", username: "" }, false, { forTesting: false });
     expect(payload).toEqual({
       type: "redis",
       host: "localhost",
@@ -58,29 +66,30 @@ describe("buildCachePayload", () => {
     const payload = buildCachePayload(
       "cluster",
       { redis_startup_nodes: '[{"host":"127.0.0.1","port":"7001"}]' },
+      false,
       { forTesting: false },
     );
     expect(payload.redis_startup_nodes).toEqual([{ host: "127.0.0.1", port: "7001" }]);
   });
 
   it("should omit a list field whose textarea holds invalid JSON", () => {
-    const payload = buildCachePayload("cluster", { redis_startup_nodes: "not json" }, { forTesting: false });
+    const payload = buildCachePayload("cluster", { redis_startup_nodes: "not json" }, false, { forTesting: false });
     expect(payload).not.toHaveProperty("redis_startup_nodes");
   });
 
-  it("should send type redis-semantic when saving a semantic cache", () => {
-    const payload = buildCachePayload("semantic", { similarity_threshold: 0.9 }, { forTesting: false });
+  it("should send type redis-semantic when saving with semantic caching enabled", () => {
+    const payload = buildCachePayload("node", { similarity_threshold: 0.9 }, true, { forTesting: false });
     expect(payload.type).toBe("redis-semantic");
     expect(payload.similarity_threshold).toBe(0.9);
   });
 
-  it("should keep type redis when testing a semantic cache so the test endpoint accepts it", () => {
-    const payload = buildCachePayload("semantic", { similarity_threshold: 0.9 }, { forTesting: true });
+  it("should keep type redis when testing with semantic caching enabled so the test endpoint accepts it", () => {
+    const payload = buildCachePayload("node", { similarity_threshold: 0.9 }, true, { forTesting: true });
     expect(payload.type).toBe("redis");
   });
 
   it("should exclude fields that do not belong to the selected redis type", () => {
-    const payload = buildCachePayload("node", { sentinel_nodes: '[["localhost",26379]]' }, { forTesting: false });
+    const payload = buildCachePayload("node", { sentinel_nodes: '[["localhost",26379]]' }, false, { forTesting: false });
     expect(payload).not.toHaveProperty("sentinel_nodes");
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/cacheSettingsUtils.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/cacheSettingsUtils.test.ts
@@ -50,7 +50,9 @@ describe("buildInitialValues", () => {
 
 describe("buildCachePayload", () => {
   it("should tag the payload as redis and drop empty fields and the UI-only redis_type", () => {
-    const payload = buildCachePayload("node", { host: "localhost", port: "6379", username: "" }, false, { forTesting: false });
+    const payload = buildCachePayload("node", { host: "localhost", port: "6379", username: "" }, false, {
+      forTesting: false,
+    });
     expect(payload).toEqual({
       type: "redis",
       host: "localhost",
@@ -89,7 +91,9 @@ describe("buildCachePayload", () => {
   });
 
   it("should exclude fields that do not belong to the selected redis type", () => {
-    const payload = buildCachePayload("node", { sentinel_nodes: '[["localhost",26379]]' }, false, { forTesting: false });
+    const payload = buildCachePayload("node", { sentinel_nodes: '[["localhost",26379]]' }, false, {
+      forTesting: false,
+    });
     expect(payload).not.toHaveProperty("sentinel_nodes");
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/cacheSettingsUtils.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/cacheSettingsUtils.ts
@@ -5,11 +5,11 @@ export type CacheFormValues = Record<string, CacheFormValue>;
 export type CacheSavePayloadValue = string | number | boolean | unknown[];
 export type CacheSavePayload = Record<string, CacheSavePayloadValue>;
 
-export const isFieldVisible = (field: CacheField, redisType: RedisType): boolean =>
-  field.redisType === null || field.redisType === redisType;
+export const isFieldVisible = (field: CacheField, redisType: RedisType, semanticEnabled: boolean): boolean =>
+  field.section === "semantic" ? semanticEnabled : field.redisType === null || field.redisType === redisType;
 
-export const fieldsForSection = (section: CacheSection, redisType: RedisType): CacheField[] =>
-  CACHE_FIELDS.filter((field) => field.section === section && isFieldVisible(field, redisType));
+export const fieldsForSection = (section: CacheSection, redisType: RedisType, semanticEnabled: boolean): CacheField[] =>
+  CACHE_FIELDS.filter((field) => field.section === section && isFieldVisible(field, redisType, semanticEnabled));
 
 const initialValueForField = (field: CacheField, raw: unknown): CacheFormValue => {
   const source = raw ?? field.defaultValue;
@@ -68,11 +68,12 @@ const saveValueForField = (field: CacheField, raw: CacheFormValue): CacheSavePay
 export const buildCachePayload = (
   redisType: RedisType,
   values: CacheFormValues,
+  semanticEnabled: boolean,
   { forTesting }: { forTesting: boolean },
 ): CacheSavePayload => {
-  const type = !forTesting && redisType === "semantic" ? "redis-semantic" : "redis";
+  const type = !forTesting && semanticEnabled ? "redis-semantic" : "redis";
 
-  const entries = CACHE_FIELDS.filter((field) => isFieldVisible(field, redisType)).flatMap((field) => {
+  const entries = CACHE_FIELDS.filter((field) => isFieldVisible(field, redisType, semanticEnabled)).flatMap((field) => {
     const value = saveValueForField(field, values[field.name]);
     return value === undefined ? [] : [[field.name, value] as const];
   });

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/index.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/index.test.tsx
@@ -63,10 +63,11 @@ describe("CacheSettings", () => {
     });
   });
 
-  describe("when the redis type is semantic", () => {
+  describe("when semantic caching is enabled", () => {
     it("should reveal the semantic fields", async () => {
       getCacheSettingsCall.mockResolvedValue({ current_values: { redis_type: "semantic" } });
       renderSettings();
+      await screen.findByText("Semantic Caching");
       expect(await screen.findByText("Similarity Threshold")).toBeInTheDocument();
       expect(screen.getByText("Embedding Model")).toBeInTheDocument();
     });

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/index.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/index.tsx
@@ -117,7 +117,10 @@ const CacheSettings: React.FC<CacheSettingsProps> = ({ accessToken }) => {
 
     setIsSaving(true);
     try {
-      await updateCacheSettingsCall(accessToken, buildCachePayload(redisType, values, semanticEnabled, { forTesting: false }));
+      await updateCacheSettingsCall(
+        accessToken,
+        buildCachePayload(redisType, values, semanticEnabled, { forTesting: false }),
+      );
       NotificationsManager.success("Cache settings updated successfully");
       await loadCacheSettings();
     } catch (error) {

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/index.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_settings/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { Button, Accordion, AccordionHeader, AccordionBody } from "@tremor/react";
-import { Form } from "antd";
+import { Form, Switch } from "antd";
 import { getCacheSettingsCall, testCacheConnectionCall, updateCacheSettingsCall } from "@/components/networking";
 import { fetchAvailableModels, ModelGroup } from "@/components/llm_calls/fetch_models";
 import NotificationsManager from "@/components/molecules/notifications_manager";
@@ -22,6 +22,7 @@ const toRedisType = (value: unknown): RedisType =>
 const CacheSettings: React.FC<CacheSettingsProps> = ({ accessToken }) => {
   const [form] = Form.useForm<CacheFormValues>();
   const [redisType, setRedisType] = useState<RedisType>("node");
+  const [semanticEnabled, setSemanticEnabled] = useState<boolean>(false);
   const [embeddingModels, setEmbeddingModels] = useState<EmbeddingModelOption[]>([]);
   const [isTesting, setIsTesting] = useState<boolean>(false);
   const [isSaving, setIsSaving] = useState<boolean>(false);
@@ -33,8 +34,15 @@ const CacheSettings: React.FC<CacheSettingsProps> = ({ accessToken }) => {
     try {
       const data = (await getCacheSettingsCall(accessToken)) as { current_values?: Record<string, unknown> };
       const currentValues = data.current_values ?? {};
+      const rawRedisType = currentValues.redis_type;
+      if (rawRedisType === "semantic") {
+        setRedisType("node");
+        setSemanticEnabled(true);
+      } else {
+        setRedisType(toRedisType(rawRedisType));
+        setSemanticEnabled(false);
+      }
       form.setFieldsValue(buildInitialValues(currentValues));
-      setRedisType(toRedisType(currentValues.redis_type));
     } catch (error) {
       console.error("Failed to load cache settings:", error);
       NotificationsManager.fromBackend("Failed to load cache settings");
@@ -81,7 +89,7 @@ const CacheSettings: React.FC<CacheSettingsProps> = ({ accessToken }) => {
     try {
       const result = await testCacheConnectionCall(
         accessToken,
-        buildCachePayload(redisType, values, { forTesting: true }),
+        buildCachePayload(redisType, values, semanticEnabled, { forTesting: true }),
       );
       if (result.status === "success") {
         NotificationsManager.success("Cache connection test successful!");
@@ -109,7 +117,7 @@ const CacheSettings: React.FC<CacheSettingsProps> = ({ accessToken }) => {
 
     setIsSaving(true);
     try {
-      await updateCacheSettingsCall(accessToken, buildCachePayload(redisType, values, { forTesting: false }));
+      await updateCacheSettingsCall(accessToken, buildCachePayload(redisType, values, semanticEnabled, { forTesting: false }));
       NotificationsManager.success("Cache settings updated successfully");
       await loadCacheSettings();
     } catch (error) {
@@ -137,6 +145,16 @@ const CacheSettings: React.FC<CacheSettingsProps> = ({ accessToken }) => {
           redisTypeDescriptions={REDIS_TYPE_DESCRIPTIONS}
           onTypeChange={(type) => setRedisType(toRedisType(type))}
         />
+
+        <div className="flex items-center justify-between py-3 px-4 border rounded-lg bg-gray-50">
+          <div>
+            <label className="text-sm font-medium text-gray-700">Semantic Caching</label>
+            <p className="text-xs text-gray-500 mt-0.5">
+              Reuse responses for similar prompts using embedding similarity
+            </p>
+          </div>
+          <Switch checked={semanticEnabled} onChange={setSemanticEnabled} />
+        </div>
 
         <div className="pt-4 border-t border-gray-200">
           <CacheFieldSection
@@ -170,13 +188,14 @@ const CacheSettings: React.FC<CacheSettingsProps> = ({ accessToken }) => {
           </div>
         )}
 
-        {redisType === "semantic" && (
+        {semanticEnabled && (
           <div className="pt-4 border-t border-gray-200">
             <CacheFieldSection
               title="Semantic Configuration"
               section="semantic"
               redisType={redisType}
               embeddingModels={embeddingModels}
+              semanticEnabled={semanticEnabled}
             />
           </div>
         )}


### PR DESCRIPTION
Remove "Semantic" from the Redis Type dropdown (Node, Cluster, Sentinel are network topologies, not caching strategies). Add a standalone Semantic Caching toggle so users can enable it independently of the Redis deployment type.

**Changes:**
- `RedisTypeSelector.tsx`: removed "Semantic" option, renamed label to "Redis Deployment Type"
- `cacheSettingsFields.ts`: updated `RedisType` union to `"node" | "cluster" | "sentinel"`
- `cacheSettingsUtils.ts`: `buildCachePayload`/`isFieldVisible`/`fieldsForSection` now accept `semanticEnabled` parameter
- `CacheFieldSection.tsx`: added optional `semanticEnabled` prop
- `index.tsx`: added `semanticEnabled` state + Switch toggle, semantic section renders based on toggle, not redisType
- Tests updated for new API

**Backward compatible:** existing configs with `redis_type: "semantic"` are migrated on load — `redis_type` maps to "node" deployment + semantic caching enabled.

Closes #32621