### PR TITLE
fix(ci): handle multi-line JSON arrays in close_duplicate_issues.py (#32639)

### DIFF
--- a/.github/scripts/close_duplicate_issues.py
+++ b/.github/scripts/close_duplicate_issues.py
@@ -50,17 +50,27 @@ def fetch_open_issues(repo: str | None) -> list[dict]:
     cmd = ["api", "--paginate", endpoint]
 
     raw = gh(*cmd)
-    # gh --paginate concatenates JSON arrays, so we may get multiple arrays
+    # gh --paginate concatenates raw JSON arrays — e.g. [{...}][{...}]
+    # Some issue bodies may contain embedded newlines, so splitting by line
+    # breaks JSON parsing.  Use raw_decode instead to consume one value at a
+    # time.
     issues = []
-    for line in raw.strip().splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        parsed = json.loads(line)
-        if isinstance(parsed, list):
-            issues.extend(parsed)
-        else:
-            issues.append(parsed)
+    decoder = json.JSONDecoder()
+    idx = 0
+    while idx < len(raw):
+        while idx < len(raw) and raw[idx].isspace():
+            idx += 1
+        if idx >= len(raw):
+            break
+        try:
+            obj, end = decoder.raw_decode(raw, idx)
+            if isinstance(obj, list):
+                issues.extend(obj)
+            else:
+                issues.append(obj)
+            idx = end
+        except json.JSONDecodeError:
+            break
 
     # Filter out pull requests (they also appear in the issues endpoint)
     return [i for i in issues if "pull_request" not in i]


### PR DESCRIPTION
Use `json.JSONDecoder.raw_decode` instead of `splitlines()` + `json.loads()` for parsing `gh --paginate` output.

**Root cause:** `fetch_open_issues` split the raw API output by newlines and assumed each line was a complete JSON array. Issue bodies with embedded newlines break that assumption — a single array gets split across lines, producing fragments that fail `json.loads()` with `JSONDecodeError: Unterminated string`.

**Fix:** Use `json.JSONDecoder.raw_decode` to consume one JSON value at a time from the raw output, correctly handling:
- Concatenated arrays (gh --paginate produces `[...][...]`)
- Multi-line strings in issue bodies
- Whitespace between values

Closes #32639