### PR TITLE
fix(proxy): guard _apply_client_disconnect_metadata against None metadata

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -90,7 +90,17 @@ _CLIENT_DISCONNECTED_ERROR_INFORMATION: StandardLoggingPayloadErrorInformation =
 }
 
 
-def _apply_client_disconnect_metadata(target_metadata: dict[str, object]) -> None:
+def _apply_client_disconnect_metadata(
+    target_metadata: Optional[dict[str, object]],
+) -> None:
+    # `litellm_params.setdefault("metadata", {})` returns None when the
+    # "metadata" key exists with value None (dict.setdefault does not
+    # overwrite an existing key), which previously raised
+    # `TypeError: 'NoneType' object does not support item assignment`
+    # during streaming disconnect cleanup. Guard instead of assigning into
+    # None. See #20428 for the same None-metadata pattern fixed in utils.py.
+    if target_metadata is None:
+        return
     target_metadata["client_disconnected"] = True
     target_metadata["error_information"] = dict(_CLIENT_DISCONNECTED_ERROR_INFORMATION)
 

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -3288,6 +3288,41 @@ class TestStreamingClientDisconnectLogging:
         )
 
     @pytest.mark.asyncio
+    async def test_record_streaming_client_disconnect_metadata_none_no_raise(self):
+        """Regression: `litellm_params["metadata"] = None` must not crash cleanup.
+
+        `dict.setdefault("metadata", {})` returns the existing None (setdefault
+        does not overwrite an existing key), so `_apply_client_disconnect_metadata`
+        received None and raised
+        `TypeError: 'NoneType' object does not support item assignment` during
+        streaming disconnect cleanup. See #20428 for the same None-metadata
+        pattern fixed in utils.py.
+        """
+        from litellm.proxy.common_request_processing import (
+            _record_streaming_client_disconnect_if_needed,
+        )
+
+        mock_logging_obj = MagicMock()
+        mock_logging_obj.model_call_details = {
+            "litellm_params": {"metadata": None},
+            "metadata": None,
+        }
+        mock_request = MagicMock(spec=Request)
+        mock_request.is_disconnected = AsyncMock(return_value=True)
+        request_data = {
+            "litellm_call_id": "test-call-id",
+            "litellm_logging_obj": mock_logging_obj,
+            "metadata": None,
+            "litellm_params": {"metadata": None},
+        }
+
+        recorded = await _record_streaming_client_disconnect_if_needed(
+            mock_request, request_data
+        )
+
+        assert recorded is True
+
+    @pytest.mark.asyncio
     async def test_record_streaming_client_disconnect_no_op_when_connected(self):
         from litellm.proxy.common_request_processing import (
             _record_streaming_client_disconnect_if_needed,


### PR DESCRIPTION
## What

`_apply_client_disconnect_metadata` raises `TypeError: 'NoneType' object does not support item assignment` when any of the four `setdefault("metadata", ...)` targets in `_record_streaming_client_disconnect_if_needed` is `None`.

## Root cause

`dict.setdefault("metadata", {})` returns the **existing** value when the key is present — it does not overwrite. When the key exists with value `None`, `setdefault` returns `None`, and `_apply_client_disconnect_metadata(None)` does `None["client_disconnected"] = True` → `TypeError`.

Surfaces as an unhandled ASGI exception during streaming disconnect cleanup:

```
async_streaming_data_generator (common_request_processing.py:2618)
  → _finalize_streaming_generator_cleanup (:2462)
    → _record_streaming_client_disconnect_if_needed (:116)
      → _apply_client_disconnect_metadata (:94)  ← TypeError
```

## Prior art

#20428 fixed the same None-metadata pattern in `utils.py` (`or {}` fallback) but did not cover `common_request_processing.py`. This PR guards the remaining call site.

## Fix

Guard `_apply_client_disconnect_metadata` against `None` — one location protects all four `setdefault("metadata", ...)` call sites in `_record_streaming_client_disconnect_if_needed`:

```python
def _apply_client_disconnect_metadata(target_metadata: Optional[dict[str, object]]) -> None:
    if target_metadata is None:
        return
    target_metadata["client_disconnected"] = True
    target_metadata["error_information"] = dict(_CLIENT_DISCONNECTED_ERROR_INFORMATION)
```

When `metadata` is `None`, the function is a no-op rather than crashing the streaming cleanup path.

## Test

Adds `test_record_streaming_client_disconnect_metadata_none_no_raise` covering all four `setdefault("metadata", ...)` paths with `metadata=None`. Fails with `TypeError` before the fix; passes after.

## Relevant issues

Resolves #32750
