### PR TITLE
fix(mcp): rework the dashboard credential-field lifecycle so the OAuth app is upstream-scoped

### DIFF
--- a/ui/litellm-dashboard/eslint-metrics.json
+++ b/ui/litellm-dashboard/eslint-metrics.json
@@ -1,7 +1,7 @@
 {
   "@typescript-eslint/no-explicit-any": 1978,
   "complexity": 129,
-  "local/no-large-inline-object-arg": 514,
+  "local/no-large-inline-object-arg": 512,
   "local/no-long-condition-chain": 233,
   "max-depth": 59,
   "no-console": 15

--- a/ui/litellm-dashboard/eslint-metrics.json
+++ b/ui/litellm-dashboard/eslint-metrics.json
@@ -1,7 +1,7 @@
 {
   "@typescript-eslint/no-explicit-any": 1978,
   "complexity": 129,
-  "local/no-large-inline-object-arg": 512,
+  "local/no-large-inline-object-arg": 514,
   "local/no-long-condition-chain": 233,
   "max-depth": 59,
   "no-console": 15

--- a/ui/litellm-dashboard/src/components/mcp_tools/PassthroughAuthorizeSection.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/PassthroughAuthorizeSection.test.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Form } from "antd";
+import PassthroughAuthorizeSection from "./PassthroughAuthorizeSection";
+
+const WithForm: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [form] = Form.useForm();
+  return <Form form={form}>{children}</Form>;
+};
+
+const noopFlow = { startOAuthFlow: () => {}, status: "idle", error: null, tokenResponse: null };
+
+describe("PassthroughAuthorizeSection credential-class-aware copy", () => {
+  it("shows keep-existing copy when the credential class is unchanged (true_passthrough <-> oauth_delegate)", () => {
+    render(
+      <WithForm>
+        <PassthroughAuthorizeSection
+          authType="oauth_delegate"
+          oauthFlow={noopFlow}
+          isEditing
+          savedAuthType="true_passthrough"
+        />
+      </WithForm>,
+    );
+    expect(screen.getByPlaceholderText("Leave blank to keep the currently saved app (if any)")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Leave blank to keep the currently saved secret (if any)")).toBeInTheDocument();
+  });
+
+  it("shows the discard warning copy when switching from a different class (oauth2 -> true_passthrough)", () => {
+    render(
+      <WithForm>
+        <PassthroughAuthorizeSection
+          authType="true_passthrough"
+          oauthFlow={noopFlow}
+          isEditing
+          savedAuthType="oauth2"
+        />
+      </WithForm>,
+    );
+    expect(screen.getByPlaceholderText("Leave blank to use dynamic client registration")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Leave blank for public clients / PKCE")).toBeInTheDocument();
+    expect(screen.getByText(/Switching the auth type discards the previously saved app/)).toBeInTheDocument();
+  });
+
+  it("shows the keep+warn banner when the upstream may no longer match", () => {
+    render(
+      <WithForm>
+        <PassthroughAuthorizeSection authType="true_passthrough" oauthFlow={noopFlow} appMayNotMatchUpstream />
+      </WithForm>,
+    );
+    expect(screen.getByText(/registered for the previous upstream/)).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/mcp_tools/PassthroughAuthorizeSection.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/PassthroughAuthorizeSection.tsx
@@ -11,13 +11,14 @@ interface PassthroughOAuthFlow {
 
 /**
  * Browser-only Authorize & Fetch for the client-forwarded token modes
- * (true_passthrough / oauth_delegate). LiteLLM never stores upstream
- * credentials for these modes, so the token obtained here lives in this
- * browser session only: it is forwarded per-server for the tools preview and
- * allowlist configuration, and is never written to the server row or the
- * per-user credential store. The optional client credentials cover IdPs
- * without dynamic client registration (e.g. a pre-registered Slack app) and
- * ride the temporary authorize session only.
+ * (true_passthrough / oauth_delegate). Tokens are never stored: the token
+ * obtained here lives in this browser session only, forwarded per-server for
+ * the tools preview and allowlist configuration, and is never written to the
+ * server row or the per-user credential store. The optional OAuth client
+ * credentials cover IdPs without dynamic client registration (e.g. a
+ * pre-registered Slack app); unlike the token they ARE saved onto the server
+ * as declared config, so internal users' Authorize relays through the org's
+ * app instead of dead-ending on upstreams that cannot mint clients.
  */
 export default function PassthroughAuthorizeSection({
   authType,
@@ -35,14 +36,15 @@ export default function PassthroughAuthorizeSection({
   return (
     <div className="rounded-lg border border-dashed border-gray-300 p-4 space-y-2 mb-4">
       <p className="text-sm text-gray-600">
-        Callers bring their own upstream token for this auth type, so LiteLLM stores no upstream credentials. To preview
-        tools and configure the tool allowlist, authorize against the upstream here: the token stays in this browser
-        session only and is never saved to LiteLLM.
+        Callers bring their own upstream token for this auth type, so LiteLLM never stores tokens. To preview tools and
+        configure the tool allowlist, authorize against the upstream here: the token stays in this browser session only
+        and is never saved to LiteLLM. An OAuth app configured below IS saved with the server, so internal users who
+        authorize from the Tools page go through it.
       </p>
       <Form.Item
-        label={<span className="text-sm font-medium text-gray-700">OAuth Client ID (optional, not saved)</span>}
+        label={<span className="text-sm font-medium text-gray-700">OAuth Client ID (optional, saved)</span>}
         name={["credentials", "client_id"]}
-        extra="Only needed when the upstream does not support dynamic client registration (e.g. a pre-registered Slack app). Used for this browser authorization only."
+        extra="Set this to make everyone authorize through a specific app; required for upstreams without dynamic client registration (e.g. a pre-registered Slack app)."
       >
         <Input.Password
           placeholder="Leave blank to use dynamic client registration"
@@ -50,7 +52,7 @@ export default function PassthroughAuthorizeSection({
         />
       </Form.Item>
       <Form.Item
-        label={<span className="text-sm font-medium text-gray-700">OAuth Client Secret (optional, not saved)</span>}
+        label={<span className="text-sm font-medium text-gray-700">OAuth Client Secret (optional, saved)</span>}
         name={["credentials", "client_secret"]}
       >
         <Input.Password
@@ -67,7 +69,8 @@ export default function PassthroughAuthorizeSection({
       {oauthFlow.error && <p className="text-sm text-red-500">{oauthFlow.error}</p>}
       {oauthFlow.status === "success" && oauthFlow.tokenResponse?.access_token && (
         <p className="text-sm text-green-600">
-          Token held for this browser session. Tools can now be previewed and configured; nothing was saved to LiteLLM.
+          Token held for this browser session. Tools can now be previewed and configured; the token was not saved to
+          LiteLLM.
         </p>
       )}
     </div>

--- a/ui/litellm-dashboard/src/components/mcp_tools/PassthroughAuthorizeSection.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/PassthroughAuthorizeSection.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button, Checkbox, Form, Input } from "antd";
-import { isClientForwardedTokenMode } from "./types";
+import { credentialAuthClass, isClientForwardedTokenMode } from "./types";
 
 interface PassthroughOAuthFlow {
   startOAuthFlow: () => void | Promise<void>;
@@ -20,25 +20,31 @@ interface PassthroughOAuthFlow {
  * as declared config, so internal users' Authorize relays through the org's
  * app instead of dead-ending on upstreams that cannot mint clients.
  *
- * Blank fields follow the same convention as the M2M credential fields: on
- * create they mean "no app configured" (dynamic client registration), while on
- * edit the backend's partial update keeps whatever app is already stored, so
- * blanks mean "keep existing". Removing a stored app is therefore an explicit
- * action (the checkbox below, edit only), which saves an explicit-null
- * credential write instead of omitting the field.
+ * Blank fields follow the same convention as the M2M credential fields. On
+ * create they mean "no app configured" (dynamic client registration). On edit
+ * they mean "keep existing" ONLY when the credential class is unchanged: the
+ * backend merges a partial update within the client-forwarded class, so a
+ * true_passthrough <-> oauth_delegate switch keeps the stored app, but a switch
+ * from a different class (e.g. oauth2) replaces it, so blanks then mean "no
+ * app". Removing a stored app is an explicit checkbox (edit only) that writes
+ * an explicit-null credential.
  */
 export default function PassthroughAuthorizeSection({
   authType,
   oauthFlow,
   isEditing = false,
+  savedAuthType,
   removeStoredApp = false,
   onRemoveStoredAppChange,
+  appMayNotMatchUpstream = false,
 }: {
   authType?: string | null;
   oauthFlow: PassthroughOAuthFlow;
   isEditing?: boolean;
+  savedAuthType?: string | null;
   removeStoredApp?: boolean;
   onRemoveStoredAppChange?: (remove: boolean) => void;
+  appMayNotMatchUpstream?: boolean;
 }) {
   if (!isClientForwardedTokenMode(authType)) return null;
   const authorizeButtonLabels: Record<string, string> = {
@@ -46,9 +52,18 @@ export default function PassthroughAuthorizeSection({
     exchanging: "Exchanging authorization code...",
   };
   const authorizeButtonLabel = authorizeButtonLabels[oauthFlow.status] ?? "Authorize & Fetch Tools (browser-only)";
-  const blankMeaning = isEditing
+  // On edit, "keep existing" only holds when the stored credential class is unchanged; a cross-class
+  // switch (e.g. oauth2 -> true_passthrough) replaces credentials, so blanks then mean "no app".
+  const classUnchanged = isEditing && credentialAuthClass(savedAuthType) === credentialAuthClass(authType);
+  const clientIdPlaceholder = classUnchanged
     ? "Leave blank to keep the currently saved app (if any)"
     : "Leave blank to use dynamic client registration";
+  const clientSecretPlaceholder = classUnchanged
+    ? "Leave blank to keep the currently saved secret (if any)"
+    : "Leave blank for public clients / PKCE";
+  const clientIdExtra = classUnchanged
+    ? "Set this to make everyone authorize through a specific app; required for upstreams without dynamic client registration (e.g. a pre-registered Slack app)."
+    : "Switching the auth type discards the previously saved app; enter a client ID here or leave blank to use dynamic client registration.";
   return (
     <div className="rounded-lg border border-dashed border-gray-300 p-4 space-y-2 mb-4">
       <p className="text-sm text-gray-600">
@@ -57,13 +72,19 @@ export default function PassthroughAuthorizeSection({
         and is never saved to LiteLLM. An OAuth app configured below IS saved with the server, so internal users who
         authorize from the Tools page go through it.
       </p>
+      {appMayNotMatchUpstream && (
+        <p className="text-sm text-amber-600">
+          You changed the upstream URL or endpoints; the OAuth app entered here was registered for the previous upstream
+          and may not be valid. Update the client ID, or clear it to use dynamic client registration.
+        </p>
+      )}
       <Form.Item
         label={<span className="text-sm font-medium text-gray-700">OAuth Client ID (optional, saved)</span>}
         name={["credentials", "client_id"]}
-        extra="Set this to make everyone authorize through a specific app; required for upstreams without dynamic client registration (e.g. a pre-registered Slack app)."
+        extra={clientIdExtra}
       >
         <Input.Password
-          placeholder={blankMeaning}
+          placeholder={clientIdPlaceholder}
           disabled={removeStoredApp}
           className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
         />
@@ -73,7 +94,7 @@ export default function PassthroughAuthorizeSection({
         name={["credentials", "client_secret"]}
       >
         <Input.Password
-          placeholder="Leave blank for public clients / PKCE"
+          placeholder={clientSecretPlaceholder}
           disabled={removeStoredApp}
           className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
         />

--- a/ui/litellm-dashboard/src/components/mcp_tools/PassthroughAuthorizeSection.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/PassthroughAuthorizeSection.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, Form, Input } from "antd";
+import { Button, Checkbox, Form, Input } from "antd";
 import { isClientForwardedTokenMode } from "./types";
 
 interface PassthroughOAuthFlow {
@@ -19,13 +19,26 @@ interface PassthroughOAuthFlow {
  * pre-registered Slack app); unlike the token they ARE saved onto the server
  * as declared config, so internal users' Authorize relays through the org's
  * app instead of dead-ending on upstreams that cannot mint clients.
+ *
+ * Blank fields follow the same convention as the M2M credential fields: on
+ * create they mean "no app configured" (dynamic client registration), while on
+ * edit the backend's partial update keeps whatever app is already stored, so
+ * blanks mean "keep existing". Removing a stored app is therefore an explicit
+ * action (the checkbox below, edit only), which saves an explicit-null
+ * credential write instead of omitting the field.
  */
 export default function PassthroughAuthorizeSection({
   authType,
   oauthFlow,
+  isEditing = false,
+  removeStoredApp = false,
+  onRemoveStoredAppChange,
 }: {
   authType?: string | null;
   oauthFlow: PassthroughOAuthFlow;
+  isEditing?: boolean;
+  removeStoredApp?: boolean;
+  onRemoveStoredAppChange?: (remove: boolean) => void;
 }) {
   if (!isClientForwardedTokenMode(authType)) return null;
   const authorizeButtonLabels: Record<string, string> = {
@@ -33,6 +46,9 @@ export default function PassthroughAuthorizeSection({
     exchanging: "Exchanging authorization code...",
   };
   const authorizeButtonLabel = authorizeButtonLabels[oauthFlow.status] ?? "Authorize & Fetch Tools (browser-only)";
+  const blankMeaning = isEditing
+    ? "Leave blank to keep the currently saved app (if any)"
+    : "Leave blank to use dynamic client registration";
   return (
     <div className="rounded-lg border border-dashed border-gray-300 p-4 space-y-2 mb-4">
       <p className="text-sm text-gray-600">
@@ -47,7 +63,8 @@ export default function PassthroughAuthorizeSection({
         extra="Set this to make everyone authorize through a specific app; required for upstreams without dynamic client registration (e.g. a pre-registered Slack app)."
       >
         <Input.Password
-          placeholder="Leave blank to use dynamic client registration"
+          placeholder={blankMeaning}
+          disabled={removeStoredApp}
           className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
         />
       </Form.Item>
@@ -57,9 +74,17 @@ export default function PassthroughAuthorizeSection({
       >
         <Input.Password
           placeholder="Leave blank for public clients / PKCE"
+          disabled={removeStoredApp}
           className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
         />
       </Form.Item>
+      {isEditing && onRemoveStoredAppChange && (
+        <Checkbox checked={removeStoredApp} onChange={(e) => onRemoveStoredAppChange(e.target.checked)}>
+          <span className="text-sm text-gray-700">
+            Remove the saved OAuth app on save (the server goes back to dynamic client registration)
+          </span>
+        </Checkbox>
+      )}
       <Button
         onClick={oauthFlow.startOAuthFlow}
         disabled={oauthFlow.status === "authorizing" || oauthFlow.status === "exchanging"}

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -609,6 +609,226 @@ describe("CreateMCPServer", () => {
       expect(JSON.stringify(payload)).not.toContain("oauth2-minted-tok");
     });
 
+    it("keeps the DCR-minted client out of form.credentials but reuses it via getCredentials", async () => {
+      await selectHttpTransport();
+      const user = userEvent.setup({ delay: null });
+      await user.type(getServerNameInput(), "DCR_Server");
+      await user.type(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
+      await selectAntOption("Authentication", "OAuth");
+
+      await waitFor(() => expect(oauthHook.onTokenReceived).toBeTruthy());
+      await act(async () => {
+        oauthHook.onTokenReceived!(
+          { access_token: "oauth2-tok", token_type: "Bearer" },
+          { clientId: "dcr-client", clientSecret: "dcr-secret" },
+        );
+      });
+
+      // The DCR client must NOT be in the form store (or it could be collected as a CF server's app),
+      // but getCredentials merges it so a re-authorize reuses the registered client instead of re-DCRing.
+      expect(oauthHook.getCredentials?.()?.client_id).toBe("dcr-client");
+    });
+
+    it("persists the DCR client on an oauth2 submit via the ref", async () => {
+      await selectHttpTransport();
+      const user = userEvent.setup({ delay: null });
+      await user.type(getServerNameInput(), "DCR_Submit_Server");
+      await user.type(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
+      await selectAntOption("Authentication", "OAuth");
+
+      await waitFor(() => expect(oauthHook.onTokenReceived).toBeTruthy());
+      await act(async () => {
+        oauthHook.onTokenReceived!(
+          { access_token: "oauth2-tok", token_type: "Bearer" },
+          { clientId: "dcr-client", clientSecret: "dcr-secret" },
+        );
+      });
+
+      const dcrSubmitServer = {
+        server_id: "dcr-submit",
+        server_name: "DCR_Submit_Server",
+        alias: "DCR_Submit_Server",
+        url: "https://example.com/mcp",
+        transport: "http",
+        auth_type: "oauth2",
+        created_at: "2024-01-01T00:00:00Z",
+        created_by: "user-1",
+        updated_at: "2024-01-01T00:00:00Z",
+        updated_by: "user-1",
+      };
+      vi.mocked(networking.createMCPServer).mockResolvedValue(dcrSubmitServer);
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Add MCP Server" }));
+      });
+
+      await waitFor(() => expect(networking.createMCPServer).toHaveBeenCalledTimes(1));
+      const [, payload] = vi.mocked(networking.createMCPServer).mock.calls[0];
+      expect(payload.credentials.client_id).toBe("dcr-client");
+      expect(payload.credentials.client_secret).toBe("dcr-secret");
+    });
+
+    it("preserves the typed app across a switch between the two client-forwarded modes", async () => {
+      await selectHttpTransport();
+      const user = userEvent.setup({ delay: null });
+      await user.type(getServerNameInput(), "CF_Switch_Keep");
+      await user.type(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
+      await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+      await user.type(screen.getByPlaceholderText("Leave blank to use dynamic client registration"), "app-id");
+      await user.type(screen.getByPlaceholderText("Leave blank for public clients / PKCE"), "app-secret");
+
+      await waitFor(() => expect(oauthHook.onTokenReceived).toBeTruthy());
+      await act(async () => {
+        oauthHook.onTokenReceived!({ access_token: "cf-tok", token_type: "Bearer" }, undefined);
+      });
+
+      await selectAntOption("Authentication", "OAuth Delegate (client-supplied upstream token)");
+
+      const switched = {
+        server_id: "cf-switch-keep",
+        server_name: "CF_Switch_Keep",
+        alias: "CF_Switch_Keep",
+        url: "https://example.com/mcp",
+        transport: "http",
+        auth_type: "oauth_delegate",
+        created_at: "2024-01-01T00:00:00Z",
+        created_by: "user-1",
+        updated_at: "2024-01-01T00:00:00Z",
+        updated_by: "user-1",
+      };
+      vi.mocked(networking.createMCPServer).mockResolvedValue(switched);
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Add MCP Server" }));
+      });
+
+      await waitFor(() => expect(networking.createMCPServer).toHaveBeenCalledTimes(1));
+      const [, payload] = vi.mocked(networking.createMCPServer).mock.calls[0];
+      expect(payload.credentials).toEqual({ client_id: "app-id", client_secret: "app-secret" });
+    });
+
+    it("preserves the typed app across a client-forwarded -> oauth2 -> client-forwarded round trip", async () => {
+      await selectHttpTransport();
+      const user = userEvent.setup({ delay: null });
+      await user.type(getServerNameInput(), "CF_Round");
+      await user.type(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
+      await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+      await user.type(screen.getByPlaceholderText("Leave blank to use dynamic client registration"), "app-id");
+      await user.type(screen.getByPlaceholderText("Leave blank for public clients / PKCE"), "app-secret");
+
+      await waitFor(() => expect(oauthHook.onTokenReceived).toBeTruthy());
+      await act(async () => {
+        oauthHook.onTokenReceived!({ access_token: "cf-tok", token_type: "Bearer" }, undefined);
+      });
+
+      await selectAntOption("Authentication", "OAuth");
+      await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+
+      const cfRoundServer = {
+        server_id: "cf-round",
+        server_name: "CF_Round",
+        alias: "CF_Round",
+        url: "https://example.com/mcp",
+        transport: "http",
+        auth_type: "true_passthrough",
+        created_at: "2024-01-01T00:00:00Z",
+        created_by: "user-1",
+        updated_at: "2024-01-01T00:00:00Z",
+        updated_by: "user-1",
+      };
+      vi.mocked(networking.createMCPServer).mockResolvedValue(cfRoundServer);
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Add MCP Server" }));
+      });
+
+      await waitFor(() => expect(networking.createMCPServer).toHaveBeenCalledTimes(1));
+      const [, payload] = vi.mocked(networking.createMCPServer).mock.calls[0];
+      expect(payload.credentials).toEqual({ client_id: "app-id", client_secret: "app-secret" });
+    });
+
+    it("keeps the typed app but warns when the URL changes after a client-forwarded authorize", async () => {
+      await selectHttpTransport();
+      const user = userEvent.setup({ delay: null });
+      await user.type(getServerNameInput(), "CF_Warn");
+      await user.type(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
+      await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+      await user.type(screen.getByPlaceholderText("Leave blank to use dynamic client registration"), "app-id");
+
+      await waitFor(() => expect(oauthHook.onTokenReceived).toBeTruthy());
+      await act(async () => {
+        oauthHook.onTokenReceived!({ access_token: "cf-tok", token_type: "Bearer" }, undefined);
+      });
+
+      await act(async () => {
+        fireEvent.change(screen.getByPlaceholderText("https://your-mcp-server.com"), {
+          target: { value: "https://other.example.com/mcp" },
+        });
+      });
+
+      // Keep + warn: the app stays in the field, and a non-blocking warning appears.
+      expect(screen.getByText(/OAuth app entered here was registered for the previous upstream/)).toBeInTheDocument();
+    });
+
+    it("keeps client_secret when only client_id is edited after a client-forwarded authorize", async () => {
+      await selectHttpTransport();
+      const user = userEvent.setup({ delay: null });
+      await user.type(getServerNameInput(), "CF_Keystroke");
+      await user.type(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
+      await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+      await user.type(screen.getByPlaceholderText("Leave blank to use dynamic client registration"), "app-id");
+      await user.type(screen.getByPlaceholderText("Leave blank for public clients / PKCE"), "app-secret");
+
+      await waitFor(() => expect(oauthHook.onTokenReceived).toBeTruthy());
+      await act(async () => {
+        oauthHook.onTokenReceived!({ access_token: "cf-tok", token_type: "Bearer" }, undefined);
+      });
+
+      // Editing only client_id fires an invalidation whose changedValues carries only the client_id
+      // sub-field; the preserve + deep-merge re-apply must keep client_secret from being dropped.
+      await user.type(screen.getByPlaceholderText("Leave blank to use dynamic client registration"), "2");
+
+      const cfKeystrokeServer = {
+        server_id: "cf-keystroke",
+        server_name: "CF_Keystroke",
+        alias: "CF_Keystroke",
+        url: "https://example.com/mcp",
+        transport: "http",
+        auth_type: "true_passthrough",
+        created_at: "2024-01-01T00:00:00Z",
+        created_by: "user-1",
+        updated_at: "2024-01-01T00:00:00Z",
+        updated_by: "user-1",
+      };
+      vi.mocked(networking.createMCPServer).mockResolvedValue(cfKeystrokeServer);
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Add MCP Server" }));
+      });
+
+      await waitFor(() => expect(networking.createMCPServer).toHaveBeenCalledTimes(1));
+      const [, payload] = vi.mocked(networking.createMCPServer).mock.calls[0];
+      expect(payload.credentials).toEqual({ client_id: "app-id2", client_secret: "app-secret" });
+    });
+
+    it("replaces the token set on re-authorize instead of leaving stale siblings", async () => {
+      await selectHttpTransport();
+      const user = userEvent.setup({ delay: null });
+      await user.type(getServerNameInput(), "Reauth_Server");
+      await user.type(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
+      await selectAntOption("Authentication", "OAuth");
+
+      await waitFor(() => expect(oauthHook.onTokenReceived).toBeTruthy());
+      const firstToken = { access_token: "T1", refresh_token: "R1", scope: "read", token_type: "Bearer" };
+      await act(async () => {
+        oauthHook.onTokenReceived!(firstToken, undefined);
+      });
+      await act(async () => {
+        oauthHook.onTokenReceived!({ access_token: "T2", token_type: "Bearer" }, undefined);
+      });
+
+      const creds = oauthHook.getCredentials?.() ?? {};
+      expect(creds.access_token).toBe("T2");
+      expect(creds.refresh_token).toBeUndefined();
+      expect(creds.scope).toBeUndefined();
+    });
+
     it("should not show auth value field when None auth type is selected", async () => {
       await selectHttpTransport();
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -532,7 +532,7 @@ describe("CreateMCPServer", () => {
         });
       });
 
-      vi.mocked(networking.createMCPServer).mockResolvedValue({
+      const keptAppServer = {
         server_id: "kept-app-server",
         server_name: "CF_Keep_Server",
         alias: "CF_Keep_Server",
@@ -543,7 +543,8 @@ describe("CreateMCPServer", () => {
         created_by: "user-1",
         updated_at: "2024-01-01T00:00:00Z",
         updated_by: "user-1",
-      });
+      };
+      vi.mocked(networking.createMCPServer).mockResolvedValue(keptAppServer);
 
       await act(async () => {
         fireEvent.click(screen.getByRole("button", { name: "Add MCP Server" }));
@@ -583,7 +584,7 @@ describe("CreateMCPServer", () => {
       // into a mode that now persists credentials onto the server row.
       await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
 
-      vi.mocked(networking.createMCPServer).mockResolvedValue({
+      const switchedServer = {
         server_id: "switched-server",
         server_name: "Switch_Server",
         alias: "Switch_Server",
@@ -594,7 +595,8 @@ describe("CreateMCPServer", () => {
         created_by: "user-1",
         updated_at: "2024-01-01T00:00:00Z",
         updated_by: "user-1",
-      });
+      };
+      vi.mocked(networking.createMCPServer).mockResolvedValue(switchedServer);
 
       await act(async () => {
         fireEvent.click(screen.getByRole("button", { name: "Add MCP Server" }));

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -31,6 +31,7 @@ const oauthHook = vi.hoisted(() => ({
     | ((token: Record<string, unknown> | null, registeredClient?: { clientId?: string; clientSecret?: string }) => void)
     | null,
   getCredentials: null as (() => Record<string, unknown> | undefined) | null,
+  getTemporaryPayload: null as (() => Record<string, unknown> | null) | null,
 }));
 vi.mock("@/hooks/useMcpOAuthFlow", () => ({
   useMcpOAuthFlow: (opts: {
@@ -39,9 +40,11 @@ vi.mock("@/hooks/useMcpOAuthFlow", () => ({
       registeredClient?: { clientId?: string; clientSecret?: string },
     ) => void;
     getCredentials?: () => Record<string, unknown> | undefined;
+    getTemporaryPayload?: () => Record<string, unknown> | null;
   }) => {
     oauthHook.onTokenReceived = opts.onTokenReceived;
     oauthHook.getCredentials = opts.getCredentials ?? null;
+    oauthHook.getTemporaryPayload = opts.getTemporaryPayload ?? null;
     return {
       startOAuthFlow: vi.fn(),
       status: "idle",
@@ -627,6 +630,38 @@ describe("CreateMCPServer", () => {
       // The DCR client must NOT be in the form store (or it could be collected as a CF server's app),
       // but getCredentials merges it so a re-authorize reuses the registered client instead of re-DCRing.
       expect(oauthHook.getCredentials?.()?.client_id).toBe("dcr-client");
+      // getTemporaryPayload must mirror getCredentials for oauth2, or a re-authorize's temp session omits
+      // the registered client and useMcpOAuthFlow re-registers instead of reusing it.
+      expect(oauthHook.getTemporaryPayload?.()?.credentials).toMatchObject({ client_id: "dcr-client" });
+    });
+
+    it("clears the DCR ref and the upstream warning when the modal closes so nothing leaks to the next session", async () => {
+      const { rerender } = render(<CreateMCPServer {...defaultProps} />);
+      await selectAntOption("Transport Type", "Streamable HTTP");
+      await waitFor(() => expect(screen.getByPlaceholderText("https://your-mcp-server.com")).toBeInTheDocument());
+      const user = userEvent.setup({ delay: null });
+      await user.type(getServerNameInput(), "Leak_Server");
+      await user.type(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
+      await selectAntOption("Authentication", "OAuth");
+
+      await waitFor(() => expect(oauthHook.onTokenReceived).toBeTruthy());
+      await act(async () => {
+        oauthHook.onTokenReceived!(
+          { access_token: "oauth2-tok", token_type: "Bearer" },
+          { clientId: "leak-client", clientSecret: "leak-secret" },
+        );
+      });
+      // Ref is held while the modal is open.
+      expect(oauthHook.getCredentials?.()?.client_id).toBe("leak-client");
+
+      // A parent dismiss (isModalVisible -> false) that does not route through Cancel/Create must still
+      // clear the DCR ref, or the next server's oauth2 submit would carry this server's registered client.
+      await act(async () => {
+        rerender(<CreateMCPServer {...defaultProps} isModalVisible={false} />);
+      });
+
+      expect(oauthHook.getCredentials?.()?.client_id).toBeUndefined();
+      expect(oauthHook.getTemporaryPayload?.()?.credentials ?? {}).not.toMatchObject({ client_id: "leak-client" });
     });
 
     it("persists the DCR client on an oauth2 submit via the ref", async () => {

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -503,6 +503,110 @@ describe("CreateMCPServer", () => {
       },
     );
 
+    it("preserves admin-entered app credentials when the URL changes after authorize for true_passthrough", async () => {
+      await selectHttpTransport();
+
+      const user = userEvent.setup({ delay: null });
+      await user.type(getServerNameInput(), "CF_Keep_Server");
+      await user.type(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
+
+      await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+
+      await user.type(
+        screen.getByPlaceholderText("Leave blank to use dynamic client registration"),
+        "org-app-client-id",
+      );
+      await user.type(screen.getByPlaceholderText("Leave blank for public clients / PKCE"), "org-app-secret");
+
+      await waitFor(() => expect(oauthHook.onTokenReceived).toBeTruthy());
+      await act(async () => {
+        oauthHook.onTokenReceived!({ access_token: "upstream-tok", token_type: "Bearer" }, undefined);
+      });
+
+      // Editing the URL after authorize invalidates the held token (identity change), but the
+      // declared app is config, not minted material: it must survive the invalidation instead of
+      // being silently reset, or the server would persist without the configured app.
+      await act(async () => {
+        fireEvent.change(screen.getByPlaceholderText("https://your-mcp-server.com"), {
+          target: { value: "https://other.example.com/mcp" },
+        });
+      });
+
+      vi.mocked(networking.createMCPServer).mockResolvedValue({
+        server_id: "kept-app-server",
+        server_name: "CF_Keep_Server",
+        alias: "CF_Keep_Server",
+        url: "https://other.example.com/mcp",
+        transport: "http",
+        auth_type: "true_passthrough",
+        created_at: "2024-01-01T00:00:00Z",
+        created_by: "user-1",
+        updated_at: "2024-01-01T00:00:00Z",
+        updated_by: "user-1",
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Add MCP Server" }));
+      });
+
+      await waitFor(() => expect(networking.createMCPServer).toHaveBeenCalledTimes(1));
+      const [, payload] = vi.mocked(networking.createMCPServer).mock.calls[0];
+      expect(payload.url).toBe("https://other.example.com/mcp");
+      expect(payload.credentials).toEqual({
+        client_id: "org-app-client-id",
+        client_secret: "org-app-secret",
+      });
+      expect(JSON.stringify(payload)).not.toContain("upstream-tok");
+    });
+
+    it("wipes oauth2-minted credentials when the auth type switches to a client-forwarded mode", async () => {
+      await selectHttpTransport();
+
+      const user = userEvent.setup({ delay: null });
+      await user.type(getServerNameInput(), "Switch_Server");
+      await user.type(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
+
+      await selectAntOption("Authentication", "OAuth");
+
+      // The oauth2 onTokenReceived branch writes the fetched token AND the DCR client into
+      // form.credentials; both are minted for the oauth2 identity.
+      await waitFor(() => expect(oauthHook.onTokenReceived).toBeTruthy());
+      await act(async () => {
+        oauthHook.onTokenReceived!(
+          { access_token: "oauth2-minted-tok", refresh_token: "oauth2-minted-refresh", token_type: "Bearer" },
+          { clientId: "dcr-minted-client", clientSecret: "dcr-minted-secret" },
+        );
+      });
+
+      // Switching into a client-forwarded mode changes the identity with auth_type in the changed
+      // values, so the preserve carve-out must NOT apply: the minted material would otherwise ride
+      // into a mode that now persists credentials onto the server row.
+      await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+
+      vi.mocked(networking.createMCPServer).mockResolvedValue({
+        server_id: "switched-server",
+        server_name: "Switch_Server",
+        alias: "Switch_Server",
+        url: "https://example.com/mcp",
+        transport: "http",
+        auth_type: "true_passthrough",
+        created_at: "2024-01-01T00:00:00Z",
+        created_by: "user-1",
+        updated_at: "2024-01-01T00:00:00Z",
+        updated_by: "user-1",
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Add MCP Server" }));
+      });
+
+      await waitFor(() => expect(networking.createMCPServer).toHaveBeenCalledTimes(1));
+      const [, payload] = vi.mocked(networking.createMCPServer).mock.calls[0];
+      expect(payload.credentials).toBeUndefined();
+      expect(JSON.stringify(payload)).not.toContain("dcr-minted-client");
+      expect(JSON.stringify(payload)).not.toContain("oauth2-minted-tok");
+    });
+
     it("should not show auth value field when None auth type is selected", async () => {
       await selectHttpTransport();
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -667,14 +667,18 @@ describe("CreateMCPServer", () => {
       expect(payload.credentials.client_secret).toBe("dcr-secret");
     });
 
+    // These two tests drive multiple antd auth-type switches; use single-shot fireEvent.change for the
+    // text fields (not per-keystroke userEvent.type) and a wider timeout so they do not flake under CI
+    // resource contention. The behavior under test is the credential preserve across the switches.
+    const fillText = (el: HTMLElement, value: string) => fireEvent.change(el, { target: { value } });
+
     it("preserves the typed app across a switch between the two client-forwarded modes", async () => {
       await selectHttpTransport();
-      const user = userEvent.setup({ delay: null });
-      await user.type(getServerNameInput(), "CF_Switch_Keep");
-      await user.type(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
+      fillText(getServerNameInput(), "CF_Switch_Keep");
+      fillText(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
       await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
-      await user.type(screen.getByPlaceholderText("Leave blank to use dynamic client registration"), "app-id");
-      await user.type(screen.getByPlaceholderText("Leave blank for public clients / PKCE"), "app-secret");
+      fillText(screen.getByPlaceholderText("Leave blank to use dynamic client registration"), "app-id");
+      fillText(screen.getByPlaceholderText("Leave blank for public clients / PKCE"), "app-secret");
 
       await waitFor(() => expect(oauthHook.onTokenReceived).toBeTruthy());
       await act(async () => {
@@ -703,16 +707,15 @@ describe("CreateMCPServer", () => {
       await waitFor(() => expect(networking.createMCPServer).toHaveBeenCalledTimes(1));
       const [, payload] = vi.mocked(networking.createMCPServer).mock.calls[0];
       expect(payload.credentials).toEqual({ client_id: "app-id", client_secret: "app-secret" });
-    });
+    }, 60_000);
 
     it("preserves the typed app across a client-forwarded -> oauth2 -> client-forwarded round trip", async () => {
       await selectHttpTransport();
-      const user = userEvent.setup({ delay: null });
-      await user.type(getServerNameInput(), "CF_Round");
-      await user.type(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
+      fillText(getServerNameInput(), "CF_Round");
+      fillText(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
       await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
-      await user.type(screen.getByPlaceholderText("Leave blank to use dynamic client registration"), "app-id");
-      await user.type(screen.getByPlaceholderText("Leave blank for public clients / PKCE"), "app-secret");
+      fillText(screen.getByPlaceholderText("Leave blank to use dynamic client registration"), "app-id");
+      fillText(screen.getByPlaceholderText("Leave blank for public clients / PKCE"), "app-secret");
 
       await waitFor(() => expect(oauthHook.onTokenReceived).toBeTruthy());
       await act(async () => {
@@ -742,7 +745,7 @@ describe("CreateMCPServer", () => {
       await waitFor(() => expect(networking.createMCPServer).toHaveBeenCalledTimes(1));
       const [, payload] = vi.mocked(networking.createMCPServer).mock.calls[0];
       expect(payload.credentials).toEqual({ client_id: "app-id", client_secret: "app-secret" });
-    });
+    }, 60_000);
 
     it("keeps the typed app but warns when the URL changes after a client-forwarded authorize", async () => {
       await selectHttpTransport();

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -202,8 +202,8 @@ describe("CreateMCPServer", () => {
         await waitFor(() => {
           expect(screen.getByRole("button", { name: "Authorize & Fetch Tools (browser-only)" })).toBeInTheDocument();
         });
-        expect(screen.getByText("OAuth Client ID (optional, not saved)")).toBeInTheDocument();
-        expect(screen.getByText("OAuth Client Secret (optional, not saved)")).toBeInTheDocument();
+        expect(screen.getByText("OAuth Client ID (optional, saved)")).toBeInTheDocument();
+        expect(screen.getByText("OAuth Client Secret (optional, saved)")).toBeInTheDocument();
       },
     );
 
@@ -435,6 +435,73 @@ describe("CreateMCPServer", () => {
         undefined,
       );
     });
+
+    it.each([
+      ["true_passthrough", "True Passthrough (no LiteLLM auth)"],
+      ["oauth_delegate", "OAuth Delegate (client-supplied upstream token)"],
+    ])(
+      "persists admin-entered OAuth app credentials on create for %s while the token stays browser-held",
+      async (_authType, optionLabel) => {
+        oauthHook.tokenResponse = { access_token: "upstream-tok", token_type: "Bearer" };
+        await selectHttpTransport();
+
+        const user = userEvent.setup({ delay: null });
+        await user.type(getServerNameInput(), "CF_App_Server");
+        await user.type(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
+
+        await selectAntOption("Authentication", optionLabel);
+
+        // Admin declares the org's pre-registered upstream app; unlike the browser-authorized
+        // token, this is config and must survive onto the server row so internal users'
+        // Tools-page Authorize relays through it (required for non-DCR upstreams like Slack).
+        await user.type(
+          screen.getByPlaceholderText("Leave blank to use dynamic client registration"),
+          "org-app-client-id",
+        );
+        await user.type(screen.getByPlaceholderText("Leave blank for public clients / PKCE"), "org-app-secret");
+
+        await waitFor(() => expect(oauthHook.onTokenReceived).toBeTruthy());
+        await act(async () => {
+          oauthHook.onTokenReceived!({ access_token: "upstream-tok", token_type: "Bearer" }, undefined);
+        });
+
+        const createdServer = {
+          server_id: "new-cf-app-server",
+          server_name: "CF_App_Server",
+          alias: "CF_App_Server",
+          url: "https://example.com/mcp",
+          transport: "http",
+          auth_type: _authType,
+          created_at: "2024-01-01T00:00:00Z",
+          created_by: "user-1",
+          updated_at: "2024-01-01T00:00:00Z",
+          updated_by: "user-1",
+        };
+        vi.mocked(networking.createMCPServer).mockResolvedValue(createdServer);
+
+        const submitButton = screen.getByRole("button", { name: "Add MCP Server" });
+        await act(async () => {
+          fireEvent.click(submitButton);
+        });
+
+        await waitFor(() => expect(networking.createMCPServer).toHaveBeenCalledTimes(1));
+        const [, payload] = vi.mocked(networking.createMCPServer).mock.calls[0];
+
+        // The declared app persists; the browser-authorized token still appears nowhere in the
+        // payload and no per-user DB credential is written.
+        expect(payload.credentials).toEqual({
+          client_id: "org-app-client-id",
+          client_secret: "org-app-secret",
+        });
+        expect(JSON.stringify(payload)).not.toContain("upstream-tok");
+        expect(networking.storeMCPOAuthUserCredential).not.toHaveBeenCalled();
+        expect(setToken).toHaveBeenCalledWith(
+          "new-cf-app-server",
+          expect.objectContaining({ access_token: "upstream-tok" }),
+          undefined,
+        );
+      },
+    );
 
     it("should not show auth value field when None auth type is selected", async () => {
       await selectHttpTransport();

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -18,6 +18,7 @@ import {
   getOAuthAuthorizationIdentity,
   CLEARED_ON_INVALIDATION,
   isHeldOAuthTokenStale,
+  preservedDeclaredAppCredentials,
 } from "./types";
 import OAuthFormFields from "./OAuthFormFields";
 import TruePassthroughWarning from "./TruePassthroughWarning";
@@ -248,7 +249,15 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
     clearTools();
     resetOAuthFlow();
     setAuthorizedIdentity(undefined);
+    const keptAppCredentials = preservedDeclaredAppCredentials(
+      form.getFieldValue("auth_type"),
+      "auth_type" in changedValues,
+      form.getFieldValue("credentials"),
+    );
     form.resetFields([...CLEARED_ON_INVALIDATION]);
+    if (keptAppCredentials) {
+      form.setFieldsValue({ credentials: keptAppCredentials });
+    }
     const preserved = Object.fromEntries(
       CLEARED_ON_INVALIDATION.filter((key) => key in changedValues).map((key) => [key, changedValues[key]]),
     );

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -322,13 +322,11 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
         setTransportType(restoredTransport);
       }
       if (parsed.formValues) {
-        // Strip minted token material from the restored credentials so a stale token never rehydrates
-        // into the form store (defense in depth for pre-fix snapshots); the declared app is kept.
+        // Assign the cleaned credentials (strip minted token material so a stale token never rehydrates);
+        // the declared app the admin typed is kept. Create has no server-side stored app to merge.
         const restoredValues = {
           ...parsed.formValues,
-          ...(parsed.formValues.credentials
-            ? { credentials: withoutMintedTokenCredentials(parsed.formValues.credentials) }
-            : {}),
+          credentials: withoutMintedTokenCredentials(parsed.formValues.credentials),
         };
         setPendingRestoredValues({ values: restoredValues, transport: restoredTransport });
       }

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -204,9 +204,12 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
         url,
         transport: transport === TRANSPORT.OPENAPI ? "http" : transport,
         auth_type: isClientForwardedTokenMode(values.auth_type) ? values.auth_type : AUTH_TYPE.OAUTH2,
+        // Mirror getCredentials: merge the ref-held DCR client for oauth2 so a re-authorize reuses the
+        // registered client (useMcpOAuthFlow keys reuse off credentials.client_id) instead of re-DCRing;
+        // the client-forwarded modes carry only the declared app.
         credentials: isClientForwardedTokenMode(values.auth_type)
           ? preservedDeclaredAppCredentials(values.credentials)
-          : values.credentials,
+          : { ...((values.credentials as Record<string, unknown> | undefined) ?? {}), ...(dcrClientRef.current ?? {}) },
         authorization_url: values.authorization_url,
         token_url: values.token_url,
         registration_url: values.registration_url,
@@ -728,6 +731,8 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
       clearTools();
       resetOAuthFlow();
       setAuthorizedIdentity(undefined);
+      dcrClientRef.current = null;
+      setAppMayNotMatchUpstream(false);
     }
   }, [isModalVisible, form, clearTools, resetOAuthFlow]);
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -19,6 +19,7 @@ import {
   CLEARED_ON_INVALIDATION,
   isHeldOAuthTokenStale,
   preservedDeclaredAppCredentials,
+  withoutMintedTokenCredentials,
 } from "./types";
 import OAuthFormFields from "./OAuthFormFields";
 import TruePassthroughWarning from "./TruePassthroughWarning";
@@ -109,6 +110,14 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
   // was fetched; undefined when no valid token is held. If any mint-relevant field diverges from this,
   // the held token is stale and is discarded so the admin must re-authorize.
   const [authorizedIdentity, setAuthorizedIdentity] = useState<string | undefined>(undefined);
+  // The DCR-minted OAuth client from an interactive (oauth2) Authorize. Held OUT of form.credentials so
+  // it can never be collected as a client-forwarded server's declared app; injected into the payload
+  // only on an oauth2 submit (where persisting the registered client is correct), and cleared on any
+  // invalidation or modal close. An abandoned authorize leaves it null, which is the desired asymmetry.
+  const dcrClientRef = React.useRef<{ client_id: string; client_secret?: string } | null>(null);
+  // Set when the upstream identity (url/endpoints) changed while a declared app is present, so the
+  // section can warn that the saved app may not match the new upstream (the app is kept, not wiped).
+  const [appMayNotMatchUpstream, setAppMayNotMatchUpstream] = useState(false);
 
   // Single hook call shared by MCPConnectionStatus and MCPToolConfiguration to avoid duplicate requests.
   const {
@@ -150,6 +159,9 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
         searchValue,
         aliasManuallyEdited,
         logoUrl,
+        // Persist the identity so invalidation stays armed across the OAuth redirect round trip: a
+        // post-restore url/mode edit must still discard the held token instead of silently keeping it.
+        authorizedIdentity,
       };
       setSecureItem(CREATE_OAUTH_UI_STATE_KEY, JSON.stringify(uiState));
     } catch (err) {
@@ -165,7 +177,12 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
     reset: resetOAuthFlow,
   } = useMcpOAuthFlow({
     accessToken,
-    getCredentials: () => form.getFieldValue("credentials"),
+    // Merge the ref-held DCR client so a re-authorize reuses the registered client instead of
+    // re-registering; the form store itself never holds the DCR client (see onTokenReceived).
+    getCredentials: () => ({
+      ...((form.getFieldValue("credentials") as Record<string, unknown> | undefined) ?? {}),
+      ...(dcrClientRef.current ?? {}),
+    }),
     getTemporaryPayload: () => {
       const values = form.getFieldsValue(true);
       const transport = values.transport || transportType;
@@ -187,7 +204,9 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
         url,
         transport: transport === TRANSPORT.OPENAPI ? "http" : transport,
         auth_type: isClientForwardedTokenMode(values.auth_type) ? values.auth_type : AUTH_TYPE.OAUTH2,
-        credentials: values.credentials,
+        credentials: isClientForwardedTokenMode(values.auth_type)
+          ? preservedDeclaredAppCredentials(values.credentials)
+          : values.credentials,
         authorization_url: values.authorization_url,
         token_url: values.token_url,
         registration_url: values.registration_url,
@@ -217,18 +236,31 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
         return;
       }
 
-      const credentials = {
+      // The DCR-minted client is held in a ref, NOT written into form.credentials, so it can never be
+      // collected as a client-forwarded server's declared app; it is injected into the payload only on
+      // an oauth2 submit. An admin-typed client already lives in form.credentials and is left untouched.
+      dcrClientRef.current = registeredClient?.clientId
+        ? {
+            client_id: registeredClient.clientId,
+            ...(registeredClient.clientSecret && { client_secret: registeredClient.clientSecret }),
+          }
+        : null;
+
+      const current = (form.getFieldValue("credentials") as Record<string, unknown> | undefined) ?? {};
+      const nextCredentials = {
+        ...(preservedDeclaredAppCredentials(current) ?? {}),
+        ...(current.scopes !== undefined && { scopes: current.scopes }),
         access_token: token.access_token,
         ...(token.refresh_token && { refresh_token: token.refresh_token }),
         ...(token.expires_in && { expires_in: token.expires_in }),
         ...(token.scope && { scope: token.scope }),
-        ...(registeredClient?.clientId && { client_id: registeredClient.clientId }),
-        ...(registeredClient?.clientSecret && { client_secret: registeredClient.clientSecret }),
       };
-
-      form.setFieldsValue({ credentials });
-      // Capture the identity AFTER writing the DCR'd credentials so the held token is not spuriously
-      // invalidated by its own credential write.
+      // Path-replace (not deep-merge) so a re-authorize with fewer token fields does not leave stale
+      // siblings from the previous token behind; the admin-typed client keys and scopes are carried
+      // explicitly above.
+      form.setFieldValue("credentials", nextCredentials);
+      // Capture the identity AFTER writing the token so the held token is not spuriously invalidated by
+      // its own credential write.
       setAuthorizedIdentity(getOAuthAuthorizationIdentity(form.getFieldsValue(true)));
 
       NotificationsManager.success(
@@ -249,15 +281,17 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
     clearTools();
     resetOAuthFlow();
     setAuthorizedIdentity(undefined);
-    const keptAppCredentials = preservedDeclaredAppCredentials(
-      form.getFieldValue("auth_type"),
-      "auth_type" in changedValues,
-      form.getFieldValue("credentials"),
-    );
+    dcrClientRef.current = null;
+    // Capture the admin-typed app before resetFields destroys it, then re-apply it: the app is
+    // upstream-scoped config, not minted material, so it survives every invalidation (the token is
+    // what gets discarded). Token-shaped keys are excluded by the helper's key filter.
+    const keptAppCredentials = preservedDeclaredAppCredentials(form.getFieldValue("credentials"));
     form.resetFields([...CLEARED_ON_INVALIDATION]);
     if (keptAppCredentials) {
       form.setFieldsValue({ credentials: keptAppCredentials });
     }
+    // Re-apply the in-flight edit last; rc-field-form deep-merges nested objects, so a changed
+    // credentials sub-field composes with the preserved sibling instead of replacing the object.
     const preserved = Object.fromEntries(
       CLEARED_ON_INVALIDATION.filter((key) => key in changedValues).map((key) => [key, changedValues[key]]),
     );
@@ -285,7 +319,20 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
         setTransportType(restoredTransport);
       }
       if (parsed.formValues) {
-        setPendingRestoredValues({ values: parsed.formValues, transport: restoredTransport });
+        // Strip minted token material from the restored credentials so a stale token never rehydrates
+        // into the form store (defense in depth for pre-fix snapshots); the declared app is kept.
+        const restoredValues = {
+          ...parsed.formValues,
+          ...(parsed.formValues.credentials
+            ? { credentials: withoutMintedTokenCredentials(parsed.formValues.credentials) }
+            : {}),
+        };
+        setPendingRestoredValues({ values: restoredValues, transport: restoredTransport });
+      }
+      if (typeof parsed.authorizedIdentity === "string") {
+        // Re-arm invalidation: without this the remounted form has authorizedIdentity=undefined, so a
+        // post-restore mode/url edit would never fire the stale-token discard.
+        setAuthorizedIdentity(parsed.authorizedIdentity);
       }
       if (parsed.costConfig) {
         setCostConfig(parsed.costConfig);
@@ -511,8 +558,20 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
       const includeCredentials =
         restValues.auth_type && AUTH_TYPES_REQUIRING_CREDENTIALS.includes(restValues.auth_type);
 
-      if (includeCredentials && credentialsPayload && Object.keys(credentialsPayload).length > 0) {
-        payload.credentials = credentialsPayload;
+      // Client-forwarded rows persist ONLY the declared app; strip any token material that lingered in
+      // the form (e.g. from a prior oauth2 authorize on the same session) so it can never reach the row.
+      const submitCredentials = isClientForwardedTokenMode(restValues.auth_type)
+        ? preservedDeclaredAppCredentials(credentialsPayload)
+        : credentialsPayload;
+
+      if (includeCredentials && submitCredentials && Object.keys(submitCredentials).length > 0) {
+        payload.credentials = submitCredentials;
+      }
+
+      // An interactive (oauth2) create persists its DCR-minted client from the ref (kept out of the
+      // form store); reuse a re-authorize's registered client instead of re-registering.
+      if (restValues.auth_type === AUTH_TYPE.OAUTH2 && dcrClientRef.current) {
+        payload.credentials = { ...(payload.credentials ?? {}), ...dcrClientRef.current };
       }
 
       if (accessToken != null) {
@@ -587,6 +646,9 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
     setHasToolAllowlistInteraction(false);
     setAliasManuallyEdited(false);
     setLogoUrl(undefined);
+    setAuthorizedIdentity(undefined);
+    dcrClientRef.current = null;
+    setAppMayNotMatchUpstream(false);
     setModalVisible(false);
   };
 
@@ -674,12 +736,28 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
   const handleFormValuesChange = (changedValues: Record<string, unknown>, allValues: Record<string, unknown>) => {
     // Any change to a mint-relevant field (url, auth_type, oauth_flow_type, client creds/scopes, or the
     // authorization/token/registration endpoints — see getOAuthAuthorizationIdentity) makes a held token
-    // stale, so discard it and force a fresh authorize. When that happens, formValues must be rebuilt
-    // from the form's post-reset state, not the pre-reset allValues snapshot: the snapshot still holds
-    // the discarded token in credentials, and useTestMCPConnection reads formValues for tool preview.
-    if (isHeldOAuthTokenStale(allValues, authorizedIdentity)) {
+    // stale, so discard it and force a fresh authorize. The stale check reads getFieldsValue(true): the
+    // onValuesChange allValues argument holds only MOUNTED paths, so an unmounted identity field (e.g.
+    // an oauth_flow_type initialValue while in a client-forwarded mode) would compare as changed on
+    // every keystroke and churn the held token. When a clear happens, formValues is rebuilt from the
+    // form's post-reset state (not the pre-reset snapshot, which still holds the discarded token).
+    // Editing the client fields is the admin managing/acknowledging the app, so it always dismisses
+    // the "may not match upstream" warning regardless of the stale-token branch below.
+    if ("credentials" in changedValues) {
+      setAppMayNotMatchUpstream(false);
+    }
+    if (isHeldOAuthTokenStale(form.getFieldsValue(true), authorizedIdentity)) {
+      // A url/endpoint change while a declared app is present keeps the app but flags that it may not
+      // match the new upstream (the "keep + warn" behavior); a client-key edit is handled above.
+      const upstreamChanged = ["url", "spec_path", "authorization_url", "token_url", "registration_url"].some(
+        (key) => key in changedValues,
+      );
+      const hasDeclaredApp = preservedDeclaredAppCredentials(form.getFieldValue("credentials")) !== undefined;
       clearHeldOAuthToken(changedValues);
-      setFormValues({ ...form.getFieldsValue(true), ...changedValues });
+      if (upstreamChanged && hasDeclaredApp && !("credentials" in changedValues)) {
+        setAppMayNotMatchUpstream(true);
+      }
+      setFormValues(form.getFieldsValue(true));
       return;
     }
     setFormValues(allValues);
@@ -1006,6 +1084,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
                             error: oauthError,
                             tokenResponse: oauthTokenResponse,
                           }}
+                          appMayNotMatchUpstream={appMayNotMatchUpstream}
                         />
 
                         {shouldShowAuthValueField && (

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -60,6 +60,8 @@ const AUTH_TYPES_REQUIRING_CREDENTIALS = [
   AUTH_TYPE.OAUTH2,
   AUTH_TYPE.OAUTH2_TOKEN_EXCHANGE,
   AUTH_TYPE.AWS_SIGV4,
+  AUTH_TYPE.TRUE_PASSTHROUGH,
+  AUTH_TYPE.OAUTH_DELEGATE,
 ];
 const CREATE_OAUTH_UI_STATE_KEY = "litellm-mcp-oauth-create-state";
 
@@ -209,7 +211,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
         // edit form's onTokenReceived early return.
         setAuthorizedIdentity(getOAuthAuthorizationIdentity(form.getFieldsValue(true)));
         NotificationsManager.success(
-          "Token held for this browser session. Tools can now be previewed and configured; nothing will be saved to LiteLLM.",
+          "Token held for this browser session. Tools can now be previewed and configured; the token is not saved to LiteLLM.",
         );
         return;
       }

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -748,20 +748,23 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
     // form's post-reset state (not the pre-reset snapshot, which still holds the discarded token).
     // Editing the client fields is the admin managing/acknowledging the app, so it always dismisses
     // the "may not match upstream" warning regardless of the stale-token branch below.
+    // Editing the client fields is the admin managing/acknowledging the app, so it dismisses the "may
+    // not match upstream" warning. Otherwise a url/endpoint change while a declared app is present keeps
+    // the app but flags that it may not match the new upstream (the "keep + warn" behavior). This is
+    // independent of the held-token stale check below so it fires even without an authorize this session.
     if ("credentials" in changedValues) {
       setAppMayNotMatchUpstream(false);
-    }
-    if (isHeldOAuthTokenStale(form.getFieldsValue(true), authorizedIdentity)) {
-      // A url/endpoint change while a declared app is present keeps the app but flags that it may not
-      // match the new upstream (the "keep + warn" behavior); a client-key edit is handled above.
+    } else {
       const upstreamChanged = ["url", "spec_path", "authorization_url", "token_url", "registration_url"].some(
         (key) => key in changedValues,
       );
       const hasDeclaredApp = preservedDeclaredAppCredentials(form.getFieldValue("credentials")) !== undefined;
-      clearHeldOAuthToken(changedValues);
-      if (upstreamChanged && hasDeclaredApp && !("credentials" in changedValues)) {
+      if (upstreamChanged && hasDeclaredApp) {
         setAppMayNotMatchUpstream(true);
       }
+    }
+    if (isHeldOAuthTokenStale(form.getFieldsValue(true), authorizedIdentity)) {
+      clearHeldOAuthToken(changedValues);
       setFormValues(form.getFieldsValue(true));
       return;
     }

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
@@ -1519,6 +1519,35 @@ describe("MCPServerEdit (OAuth token persistence on save)", () => {
     expect(payload.credentials).toEqual({ client_id: null, client_secret: null });
   });
 
+  it("warns that the saved app may not match after a URL change on a client-forwarded server", async () => {
+    render(
+      <MCPServerEdit
+        mcpServer={{
+          ...interactiveOAuthServer,
+          auth_type: "true_passthrough",
+          credentials: { client_id: "stored-client" },
+        }}
+        accessToken="access-token"
+        userID="user-1"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    // No warning until the upstream changes.
+    expect(screen.queryByText(/registered for the previous upstream/)).not.toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.change(screen.getByPlaceholderText("https://your-mcp-server.com"), {
+        target: { value: "https://different.example.com/mcp" },
+      });
+    });
+
+    // Keep + warn parity with the create form: the stored app is kept, and the banner appears.
+    expect(screen.getByText(/registered for the previous upstream/)).toBeInTheDocument();
+  });
+
   it("forwards a newly authorized browser-held token for tool loading before the form is saved", async () => {
     // Regression: fetchTools keyed the browser-held decision off the saved mcpServer.auth_type, so
     // after switching the form to true_passthrough and authorizing, the fresh token was not sent as

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import MCPServerEdit from "./mcp_server_edit";
 import * as networking from "../networking";
 import NotificationsManager from "../molecules/notifications_manager";
@@ -1374,6 +1375,51 @@ describe("MCPServerEdit (OAuth token persistence on save)", () => {
       const [, payload] = vi.mocked(networking.updateMCPServer).mock.calls[0];
       expect(payload.credentials).toBeUndefined();
       expect(JSON.stringify(payload)).not.toContain("cf-tok");
+    },
+  );
+
+  it.each([["true_passthrough"], ["oauth_delegate"]])(
+    "persists admin-entered OAuth app credentials in the update payload for the %s mode",
+    async (authType) => {
+      mockOauth.tokenResponse = { access_token: "cf-tok", expires_in: 1800, token_type: "bearer" };
+      vi.mocked(networking.updateMCPServer).mockResolvedValue({
+        ...interactiveOAuthServer,
+        auth_type: authType,
+      });
+
+      render(
+        <MCPServerEdit
+          mcpServer={{ ...interactiveOAuthServer, auth_type: authType }}
+          accessToken="access-token"
+          userID="user-1"
+          onCancel={vi.fn()}
+          onSuccess={vi.fn()}
+          availableAccessGroups={[]}
+        />,
+      );
+
+      const user = userEvent.setup({ delay: null });
+      await user.type(
+        screen.getByPlaceholderText("Leave blank to use dynamic client registration"),
+        "org-app-client-id",
+      );
+      await user.type(screen.getByPlaceholderText("Leave blank for public clients / PKCE"), "org-app-secret");
+
+      await act(async () => {
+        fireEvent.click(screen.getAllByRole("button", { name: "Save Changes" })[0]);
+      });
+
+      await waitFor(() => expect(networking.updateMCPServer).toHaveBeenCalledTimes(1));
+      const [, payload] = vi.mocked(networking.updateMCPServer).mock.calls[0];
+
+      // The declared app is config and persists onto the row; the browser-held token still never
+      // reaches the payload or the per-user credential store.
+      expect(payload.credentials).toMatchObject({
+        client_id: "org-app-client-id",
+        client_secret: "org-app-secret",
+      });
+      expect(JSON.stringify(payload)).not.toContain("cf-tok");
+      expect(networking.storeMCPOAuthUserCredential).not.toHaveBeenCalled();
     },
   );
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
@@ -1582,6 +1582,55 @@ describe("MCPServerEdit (OAuth token persistence on save)", () => {
     expect(document.body.innerHTML).not.toContain("leftover-token");
   });
 
+  it("resets the remove-app checkbox on a server switch so it never deletes the next server's stored app", async () => {
+    vi.mocked(networking.updateMCPServer).mockResolvedValue({
+      ...interactiveOAuthServer,
+      auth_type: "true_passthrough",
+    });
+
+    const { rerender } = render(
+      <MCPServerEdit
+        mcpServer={{ ...interactiveOAuthServer, server_id: "server-A", auth_type: "true_passthrough" }}
+        accessToken="access-token"
+        userID="user-1"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    // Check "remove saved app" on server A.
+    fireEvent.click(screen.getByRole("checkbox", { name: /Remove the saved OAuth app on save/ }));
+    expect(
+      (screen.getByRole("checkbox", { name: /Remove the saved OAuth app on save/ }) as HTMLInputElement).checked,
+    ).toBe(true);
+
+    // Switch the panel to server B without unmounting.
+    rerender(
+      <MCPServerEdit
+        mcpServer={{ ...interactiveOAuthServer, server_id: "server-B", auth_type: "true_passthrough" }}
+        accessToken="access-token"
+        userID="user-1"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    // The checkbox must have reset, so saving server B does not send the explicit-null delete write.
+    expect(
+      (screen.getByRole("checkbox", { name: /Remove the saved OAuth app on save/ }) as HTMLInputElement).checked,
+    ).toBe(false);
+
+    await act(async () => {
+      fireEvent.click(screen.getAllByRole("button", { name: "Save Changes" })[0]);
+    });
+
+    await waitFor(() => expect(networking.updateMCPServer).toHaveBeenCalledTimes(1));
+    const [, payload] = vi.mocked(networking.updateMCPServer).mock.calls[0];
+    expect(payload.credentials).not.toEqual({ client_id: null, client_secret: null });
+  });
+
   it("forwards a newly authorized browser-held token for tool loading before the form is saved", async () => {
     // Regression: fetchTools keyed the browser-held decision off the saved mcpServer.auth_type, so
     // after switching the form to true_passthrough and authorizing, the fresh token was not sent as

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import MCPServerEdit from "./mcp_server_edit";
+import MCPServerEdit, { EDIT_OAUTH_UI_STATE_KEY } from "./mcp_server_edit";
+import { setSecureItem } from "@/utils/secureStorage";
 import * as networking from "../networking";
 import NotificationsManager from "../molecules/notifications_manager";
 import { selectAntOption } from "./testUtils";
@@ -1546,6 +1547,39 @@ describe("MCPServerEdit (OAuth token persistence on save)", () => {
 
     // Keep + warn parity with the create form: the stored app is kept, and the banner appears.
     expect(screen.getByText(/registered for the previous upstream/)).toBeInTheDocument();
+  });
+
+  it("preserves a stored client_id on OAuth-resume restore even when the saved snapshot is token-only", async () => {
+    // Post-redirect restore: the sessionStorage snapshot carries only a minted token (no client keys),
+    // while the loaded server has a stored client_id. The restore must merge the server's declared app
+    // under the snapshot before stripping tokens, so the stored client_id is never cleared to blank.
+    setSecureItem(
+      EDIT_OAUTH_UI_STATE_KEY,
+      JSON.stringify({
+        serverId: "oauth_server_1",
+        formValues: { auth_type: "true_passthrough", credentials: { access_token: "leftover-token" } },
+      }),
+    );
+
+    render(
+      <MCPServerEdit
+        mcpServer={{
+          ...interactiveOAuthServer,
+          auth_type: "true_passthrough",
+          credentials: { client_id: "stored-client" },
+        }}
+        accessToken="access-token"
+        userID="user-1"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    const clientIdField = await screen.findByPlaceholderText("Leave blank to keep the currently saved app (if any)");
+    await waitFor(() => expect((clientIdField as HTMLInputElement).value).toBe("stored-client"));
+    // The leftover minted token must not have rehydrated anywhere.
+    expect(document.body.innerHTML).not.toContain("leftover-token");
   });
 
   it("forwards a newly authorized browser-held token for tool loading before the form is saved", async () => {

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
@@ -1400,7 +1400,7 @@ describe("MCPServerEdit (OAuth token persistence on save)", () => {
 
       const user = userEvent.setup({ delay: null });
       await user.type(
-        screen.getByPlaceholderText("Leave blank to use dynamic client registration"),
+        screen.getByPlaceholderText("Leave blank to keep the currently saved app (if any)"),
         "org-app-client-id",
       );
       await user.type(screen.getByPlaceholderText("Leave blank for public clients / PKCE"), "org-app-secret");
@@ -1444,7 +1444,7 @@ describe("MCPServerEdit (OAuth token persistence on save)", () => {
 
       const user = userEvent.setup({ delay: null });
       await user.type(
-        screen.getByPlaceholderText("Leave blank to use dynamic client registration"),
+        screen.getByPlaceholderText("Leave blank to keep the currently saved app (if any)"),
         "org-app-client-id",
       );
       await user.type(screen.getByPlaceholderText("Leave blank for public clients / PKCE"), "org-app-secret");
@@ -1476,6 +1476,42 @@ describe("MCPServerEdit (OAuth token persistence on save)", () => {
       expect(JSON.stringify(payload)).not.toContain("cf-tok");
     },
   );
+
+  it("sends an explicit-null credential write when removing the saved app for true_passthrough", async () => {
+    vi.mocked(networking.updateMCPServer).mockResolvedValue({
+      ...interactiveOAuthServer,
+      auth_type: "true_passthrough",
+    });
+
+    render(
+      <MCPServerEdit
+        mcpServer={{ ...interactiveOAuthServer, auth_type: "true_passthrough" }}
+        accessToken="access-token"
+        userID="user-1"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    // Blank fields keep the stored app (the backend merges partial credential updates), so the
+    // edit form states that convention and removal is an explicit checkbox that saves nulls.
+    expect(screen.getByPlaceholderText("Leave blank to keep the currently saved app (if any)")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("checkbox", {
+        name: /Remove the saved OAuth app on save/,
+      }),
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getAllByRole("button", { name: "Save Changes" })[0]);
+    });
+
+    await waitFor(() => expect(networking.updateMCPServer).toHaveBeenCalledTimes(1));
+    const [, payload] = vi.mocked(networking.updateMCPServer).mock.calls[0];
+    expect(payload.credentials).toEqual({ client_id: null, client_secret: null });
+  });
 
   it("forwards a newly authorized browser-held token for tool loading before the form is saved", async () => {
     // Regression: fetchTools keyed the browser-held decision off the saved mcpServer.auth_type, so

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
@@ -1403,7 +1403,10 @@ describe("MCPServerEdit (OAuth token persistence on save)", () => {
         screen.getByPlaceholderText("Leave blank to keep the currently saved app (if any)"),
         "org-app-client-id",
       );
-      await user.type(screen.getByPlaceholderText("Leave blank for public clients / PKCE"), "org-app-secret");
+      await user.type(
+        screen.getByPlaceholderText("Leave blank to keep the currently saved secret (if any)"),
+        "org-app-secret",
+      );
 
       await act(async () => {
         fireEvent.click(screen.getAllByRole("button", { name: "Save Changes" })[0]);
@@ -1447,7 +1450,10 @@ describe("MCPServerEdit (OAuth token persistence on save)", () => {
         screen.getByPlaceholderText("Leave blank to keep the currently saved app (if any)"),
         "org-app-client-id",
       );
-      await user.type(screen.getByPlaceholderText("Leave blank for public clients / PKCE"), "org-app-secret");
+      await user.type(
+        screen.getByPlaceholderText("Leave blank to keep the currently saved secret (if any)"),
+        "org-app-secret",
+      );
 
       act(() => {
         mockOauth.onTokenReceived?.({ access_token: "cf-tok", token_type: "bearer" });

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
@@ -1423,6 +1423,60 @@ describe("MCPServerEdit (OAuth token persistence on save)", () => {
     },
   );
 
+  it.each([["true_passthrough"], ["oauth_delegate"]])(
+    "preserves admin-entered app credentials when the URL changes after authorize for the %s mode",
+    async (authType) => {
+      vi.mocked(networking.updateMCPServer).mockResolvedValue({
+        ...interactiveOAuthServer,
+        auth_type: authType,
+      });
+
+      render(
+        <MCPServerEdit
+          mcpServer={{ ...interactiveOAuthServer, auth_type: authType }}
+          accessToken="access-token"
+          userID="user-1"
+          onCancel={vi.fn()}
+          onSuccess={vi.fn()}
+          availableAccessGroups={[]}
+        />,
+      );
+
+      const user = userEvent.setup({ delay: null });
+      await user.type(
+        screen.getByPlaceholderText("Leave blank to use dynamic client registration"),
+        "org-app-client-id",
+      );
+      await user.type(screen.getByPlaceholderText("Leave blank for public clients / PKCE"), "org-app-secret");
+
+      act(() => {
+        mockOauth.onTokenReceived?.({ access_token: "cf-tok", token_type: "bearer" });
+      });
+
+      // The URL edit invalidates the held browser token (removeToken fires), but the declared app
+      // is config and must survive the invalidation into the update payload.
+      await act(async () => {
+        fireEvent.change(screen.getByPlaceholderText("https://your-mcp-server.com"), {
+          target: { value: "https://other.example.com/mcp" },
+        });
+      });
+      expect(mockRemoveToken).toHaveBeenCalledWith("oauth_server_1", "user-1");
+
+      await act(async () => {
+        fireEvent.click(screen.getAllByRole("button", { name: "Save Changes" })[0]);
+      });
+
+      await waitFor(() => expect(networking.updateMCPServer).toHaveBeenCalledTimes(1));
+      const [, payload] = vi.mocked(networking.updateMCPServer).mock.calls[0];
+      expect(payload.url).toBe("https://other.example.com/mcp");
+      expect(payload.credentials).toMatchObject({
+        client_id: "org-app-client-id",
+        client_secret: "org-app-secret",
+      });
+      expect(JSON.stringify(payload)).not.toContain("cf-tok");
+    },
+  );
+
   it("forwards a newly authorized browser-held token for tool loading before the form is saved", async () => {
     // Regression: fetchTools keyed the browser-held decision off the saved mcpServer.auth_type, so
     // after switching the form to true_passthrough and authorizing, the fresh token was not sent as

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -309,7 +309,11 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
     }
     syncedServerIdRef.current = mcpServer.server_id;
     form.setFieldsValue(initialValues);
+    // Reset per-server OAuth UI state so it never carries across a server switch without an unmount: a
+    // stale removeStoredApp would send an explicit-null credential write that deletes the new server's
+    // stored app, and a stale warning would show on a server whose upstream did not change.
     setAppMayNotMatchUpstream(false);
+    setRemoveStoredApp(false);
   }, [mcpServer.server_id, initialValues, form]);
 
   // Initialize cost config from existing server data

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -56,6 +56,8 @@ const AUTH_TYPES_REQUIRING_CREDENTIALS = [
   AUTH_TYPE.OAUTH2,
   AUTH_TYPE.OAUTH2_TOKEN_EXCHANGE,
   AUTH_TYPE.AWS_SIGV4,
+  AUTH_TYPE.TRUE_PASSTHROUGH,
+  AUTH_TYPE.OAUTH_DELEGATE,
 ];
 export const EDIT_OAUTH_UI_STATE_KEY = "litellm-mcp-oauth-edit-state";
 
@@ -202,7 +204,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         };
         setToken(mcpServer.server_id, browserHeldToken, userID);
         NotificationsManager.success(
-          "Token held for this browser session. Tools can now be loaded and configured; nothing was saved to LiteLLM.",
+          "Token held for this browser session. Tools can now be loaded and configured; the token is not saved to LiteLLM.",
         );
         return;
       }

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -309,6 +309,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
     }
     syncedServerIdRef.current = mcpServer.server_id;
     form.setFieldsValue(initialValues);
+    setAppMayNotMatchUpstream(false);
   }, [mcpServer.server_id, initialValues, form]);
 
   // Initialize cost config from existing server data
@@ -346,14 +347,19 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         return;
       }
       if (parsed.formValues) {
-        // Strip minted token material from restored credentials so a stale token never rehydrates into
-        // the form store (defense in depth for pre-fix snapshots); the declared app is kept.
+        // Rebuild credentials from the declared app in EITHER the loaded server or the saved snapshot,
+        // then strip minted token material. Merging the two (server under snapshot) before stripping is
+        // what guarantees a token-only snapshot never clears a stored client_id/client_secret: the
+        // server's declared app survives and only the token keys drop. Assigning the cleaned result (not
+        // spreading the raw snapshot) also ensures a stale token can never rehydrate into the form.
+        const restoredCredentials = withoutMintedTokenCredentials({
+          ...(mcpServer.credentials ?? {}),
+          ...((parsed.formValues.credentials as Record<string, unknown> | undefined) ?? {}),
+        });
         const restoredValues = {
           ...mcpServer,
           ...parsed.formValues,
-          ...(parsed.formValues.credentials
-            ? { credentials: withoutMintedTokenCredentials(parsed.formValues.credentials) }
-            : {}),
+          credentials: restoredCredentials,
         };
         setPendingRestoredValues(restoredValues);
       }
@@ -955,6 +961,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
       }
 
       NotificationsManager.success("MCP Server updated successfully");
+      setAppMayNotMatchUpstream(false);
       onSuccess(updated);
     } catch (error: any) {
       NotificationsManager.fromBackend("Failed to update MCP Server" + (error?.message ? `: ${error.message}` : ""));

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -8,6 +8,7 @@ import {
   getOAuthAuthorizationIdentity,
   CLEARED_ON_INVALIDATION,
   isHeldOAuthTokenStale,
+  preservedDeclaredAppCredentials,
   OAUTH_FLOW,
   MCP_OAUTH2_FLOW_M2M,
   MCP_OAUTH2_FLOW_INTERACTIVE,
@@ -409,7 +410,15 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
     }
     setTools([]);
     resetOAuthFlow();
+    const keptAppCredentials = preservedDeclaredAppCredentials(
+      getEffectiveAuthType(),
+      "auth_type" in changedValues,
+      form.getFieldValue("credentials"),
+    );
     form.resetFields([...CLEARED_ON_INVALIDATION]);
+    if (keptAppCredentials) {
+      form.setFieldsValue({ credentials: keptAppCredentials });
+    }
     const preserved = Object.fromEntries(
       CLEARED_ON_INVALIDATION.filter((key) => key in changedValues).map((key) => [key, changedValues[key]]),
     );

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -9,6 +9,7 @@ import {
   CLEARED_ON_INVALIDATION,
   isHeldOAuthTokenStale,
   preservedDeclaredAppCredentials,
+  withoutMintedTokenCredentials,
   OAUTH_FLOW,
   MCP_OAUTH2_FLOW_M2M,
   MCP_OAUTH2_FLOW_INTERACTIVE,
@@ -183,7 +184,9 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         url,
         transport,
         auth_type: isClientForwardedTokenMode(values.auth_type) ? values.auth_type : AUTH_TYPE.OAUTH2,
-        credentials: values.credentials,
+        credentials: isClientForwardedTokenMode(values.auth_type)
+          ? preservedDeclaredAppCredentials(values.credentials)
+          : values.credentials,
         mcp_access_groups: values.mcp_access_groups || mcpServer.mcp_access_groups,
         static_headers: staticHeaders,
         command: values.command,
@@ -211,14 +214,18 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         return;
       }
 
-      const credentials = {
+      const current = (form.getFieldValue("credentials") as Record<string, unknown> | undefined) ?? {};
+      const nextCredentials = {
+        ...(preservedDeclaredAppCredentials(current) ?? {}),
+        ...(current.scopes !== undefined && { scopes: current.scopes }),
         access_token: token.access_token,
         ...(token.refresh_token && { refresh_token: token.refresh_token }),
         ...(token.expires_in && { expires_in: token.expires_in }),
         ...(token.scope && { scope: token.scope }),
       };
-
-      form.setFieldsValue({ credentials });
+      // Path-replace (not deep-merge) so a re-authorize with fewer token fields does not leave stale
+      // siblings behind; the admin-typed client keys and scopes are carried explicitly above.
+      form.setFieldValue("credentials", nextCredentials);
       // Re-capture after writing credentials so the token is not invalidated by its own credential write.
       authorizedIdentityRef.current = getOAuthAuthorizationIdentity(form.getFieldsValue(true));
 
@@ -336,8 +343,19 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         return;
       }
       if (parsed.formValues) {
-        setPendingRestoredValues({ ...mcpServer, ...parsed.formValues });
+        // Strip minted token material from restored credentials so a stale token never rehydrates into
+        // the form store (defense in depth for pre-fix snapshots); the declared app is kept.
+        const restoredValues = {
+          ...mcpServer,
+          ...parsed.formValues,
+          ...(parsed.formValues.credentials
+            ? { credentials: withoutMintedTokenCredentials(parsed.formValues.credentials) }
+            : {}),
+        };
+        setPendingRestoredValues(restoredValues);
       }
+      // The ref is re-armed by onTokenReceived when the redirect completes the code exchange, so there
+      // is no separate restore-side re-arm here (writing a ref inside an effect is disallowed).
       if (parsed.costConfig) {
         setCostConfig(parsed.costConfig);
       }
@@ -411,11 +429,9 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
     }
     setTools([]);
     resetOAuthFlow();
-    const keptAppCredentials = preservedDeclaredAppCredentials(
-      getEffectiveAuthType(),
-      "auth_type" in changedValues,
-      form.getFieldValue("credentials"),
-    );
+    // The admin-typed app is upstream-scoped config, not minted material, so it survives every
+    // invalidation; only the held token is discarded. Token-shaped keys are excluded by the filter.
+    const keptAppCredentials = preservedDeclaredAppCredentials(form.getFieldValue("credentials"));
     form.resetFields([...CLEARED_ON_INVALIDATION]);
     if (keptAppCredentials) {
       form.setFieldsValue({ credentials: keptAppCredentials });
@@ -862,14 +878,20 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
       const includeCredentials =
         restValues.auth_type && AUTH_TYPES_REQUIRING_CREDENTIALS.includes(restValues.auth_type);
 
-      if (includeCredentials && credentialsPayload && Object.keys(credentialsPayload).length > 0) {
-        payload.credentials = credentialsPayload;
+      // Client-forwarded rows persist ONLY the declared app; strip any token material lingering in the
+      // form (e.g. from a prior oauth2 authorize this session) so it can never reach the row.
+      const submitCredentials = isClientForwardedTokenMode(restValues.auth_type)
+        ? preservedDeclaredAppCredentials(credentialsPayload)
+        : credentialsPayload;
+
+      if (includeCredentials && submitCredentials && Object.keys(submitCredentials).length > 0) {
+        payload.credentials = submitCredentials;
       }
 
-      // Explicit removal of a saved app for the client-forwarded modes. Blank fields are the
-      // keep-existing convention (the backend merges partial credential updates), so removal must be
-      // an explicit-null write: encrypt skips nulls and the merge overrides the stored keys, which
-      // returns the server to dynamic client registration.
+      // Explicit removal of a saved app for the client-forwarded modes, applied AFTER the filter so it
+      // always wins. Blank fields are the keep-existing convention (the backend merges partial
+      // credential updates), so removal must be an explicit-null write: encrypt skips nulls and the
+      // merge overrides the stored keys, returning the server to dynamic client registration.
       if (removeStoredApp && isClientForwardedTokenMode(restValues.auth_type)) {
         payload.credentials = { client_id: null, client_secret: null };
       }
@@ -1061,6 +1083,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                     tokenResponse: oauthTokenResponse,
                   }}
                   isEditing
+                  savedAuthType={mcpServer.auth_type}
                   removeStoredApp={removeStoredApp}
                   onRemoveStoredAppChange={setRemoveStoredApp}
                 />

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -77,6 +77,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
   const [toolsError, setToolsError] = useState<string | null>(null);
   const [searchValue, setSearchValue] = useState<string>("");
   const [aliasManuallyEdited, setAliasManuallyEdited] = useState(false);
+  const [removeStoredApp, setRemoveStoredApp] = useState(false);
   const [allowedTools, setAllowedTools] = useState<string[]>([]);
   const [hasToolAllowlistInteraction, setHasToolAllowlistInteraction] = useState(false);
   const [toolNameToDisplayName, setToolNameToDisplayName] = useState<Record<string, string>>({});
@@ -865,6 +866,14 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         payload.credentials = credentialsPayload;
       }
 
+      // Explicit removal of a saved app for the client-forwarded modes. Blank fields are the
+      // keep-existing convention (the backend merges partial credential updates), so removal must be
+      // an explicit-null write: encrypt skips nulls and the merge overrides the stored keys, which
+      // returns the server to dynamic client registration.
+      if (removeStoredApp && isClientForwardedTokenMode(restValues.auth_type)) {
+        payload.credentials = { client_id: null, client_secret: null };
+      }
+
       const updated = await updateMCPServer(accessToken, payload);
 
       // Persist the token staged via "Authorize & Fetch" (mirrors the create flow's
@@ -1051,6 +1060,9 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                     error: oauthError,
                     tokenResponse: oauthTokenResponse,
                   }}
+                  isEditing
+                  removeStoredApp={removeStoredApp}
+                  onRemoveStoredAppChange={setRemoveStoredApp}
                 />
               </>
             )}

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -79,6 +79,9 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
   const [searchValue, setSearchValue] = useState<string>("");
   const [aliasManuallyEdited, setAliasManuallyEdited] = useState(false);
   const [removeStoredApp, setRemoveStoredApp] = useState(false);
+  // Set when the upstream identity (url/endpoints) changed while a declared app is present, so the
+  // section warns that the saved app may not match the new upstream (the app is kept, not wiped).
+  const [appMayNotMatchUpstream, setAppMayNotMatchUpstream] = useState(false);
   const [allowedTools, setAllowedTools] = useState<string[]>([]);
   const [hasToolAllowlistInteraction, setHasToolAllowlistInteraction] = useState(false);
   const [toolNameToDisplayName, setToolNameToDisplayName] = useState<Record<string, string>>({});
@@ -445,6 +448,21 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
   };
 
   const handleFormValuesChange = (changedValues: Record<string, unknown>) => {
+    // Editing the client fields dismisses the "may not match upstream" warning; otherwise a url/endpoint
+    // change while a declared app is present keeps the app but flags that it may not match the new
+    // upstream (the "keep + warn" behavior). Mirrors the create form; independent of the held-token
+    // stale check so it fires even without an authorize this session (the stored app is for the old url).
+    if ("credentials" in changedValues) {
+      setAppMayNotMatchUpstream(false);
+    } else {
+      const upstreamChanged = ["url", "spec_path", "authorization_url", "token_url", "registration_url"].some(
+        (key) => key in changedValues,
+      );
+      const hasDeclaredApp = preservedDeclaredAppCredentials(form.getFieldValue("credentials")) !== undefined;
+      if (upstreamChanged && hasDeclaredApp) {
+        setAppMayNotMatchUpstream(true);
+      }
+    }
     if (isHeldOAuthTokenStale(form.getFieldsValue(true), authorizedIdentityRef.current)) {
       clearHeldOAuthToken(changedValues);
     }
@@ -1086,6 +1104,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                   savedAuthType={mcpServer.auth_type}
                   removeStoredApp={removeStoredApp}
                   onRemoveStoredAppChange={setRemoveStoredApp}
+                  appMayNotMatchUpstream={appMayNotMatchUpstream}
                 />
               </>
             )}

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.test.tsx
@@ -215,6 +215,12 @@ describe("withoutMintedTokenCredentials", () => {
     };
     expect(withoutMintedTokenCredentials(mixed)).toEqual({ client_id: "a", client_secret: "b", scopes: ["read"] });
   });
+
+  it("returns undefined (not {}) when only minted keys are present, so a restore never blanks the fields", () => {
+    expect(withoutMintedTokenCredentials({ access_token: "t", refresh_token: "r", expires_in: 3600 })).toBeUndefined();
+    // A declared client is always kept, so a stored client_id can never be overwritten with empty.
+    expect(withoutMintedTokenCredentials({ client_id: "x", access_token: "t" })).toEqual({ client_id: "x" });
+  });
 });
 
 describe("credentialAuthClass", () => {

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.test.tsx
@@ -10,6 +10,9 @@ import {
   getOAuthAuthorizationIdentity,
   isHeldOAuthTokenStale,
   oauth2FlowToFormValue,
+  preservedDeclaredAppCredentials,
+  withoutMintedTokenCredentials,
+  credentialAuthClass,
 } from "./types";
 
 describe("getOAuthAuthorizationIdentity", () => {
@@ -178,5 +181,47 @@ describe("oauth2FlowToFormValue", () => {
   it("returns undefined for a null/unset flow so the select shows its placeholder", () => {
     expect(oauth2FlowToFormValue(null)).toBeUndefined();
     expect(oauth2FlowToFormValue(undefined)).toBeUndefined();
+  });
+});
+
+describe("preservedDeclaredAppCredentials", () => {
+  it("keeps only non-empty string declared-app keys and never token-shaped keys", () => {
+    expect(preservedDeclaredAppCredentials(undefined)).toBeUndefined();
+    expect(preservedDeclaredAppCredentials({})).toBeUndefined();
+    expect(preservedDeclaredAppCredentials({ client_id: 123 })).toBeUndefined();
+    expect(preservedDeclaredAppCredentials({ client_id: "" })).toBeUndefined();
+    expect(preservedDeclaredAppCredentials({ client_id: "a", access_token: "t", scopes: ["s"] })).toEqual({
+      client_id: "a",
+    });
+    expect(preservedDeclaredAppCredentials({ client_secret: "s" })).toEqual({ client_secret: "s" });
+    expect(preservedDeclaredAppCredentials({ client_id: "a", client_secret: "b", refresh_token: "r" })).toEqual({
+      client_id: "a",
+      client_secret: "b",
+    });
+  });
+});
+
+describe("withoutMintedTokenCredentials", () => {
+  it("drops token keys and keeps the declared app and other config", () => {
+    expect(withoutMintedTokenCredentials(undefined)).toBeUndefined();
+    const mixed = {
+      client_id: "a",
+      client_secret: "b",
+      access_token: "t",
+      refresh_token: "r",
+      expires_in: 3600,
+      scope: "read",
+      scopes: ["read"],
+    };
+    expect(withoutMintedTokenCredentials(mixed)).toEqual({ client_id: "a", client_secret: "b", scopes: ["read"] });
+  });
+});
+
+describe("credentialAuthClass", () => {
+  it("collapses the client-forwarded modes to one class and leaves others distinct", () => {
+    expect(credentialAuthClass(AUTH_TYPE.TRUE_PASSTHROUGH)).toBe("client_forwarded");
+    expect(credentialAuthClass(AUTH_TYPE.OAUTH_DELEGATE)).toBe("client_forwarded");
+    expect(credentialAuthClass(AUTH_TYPE.OAUTH2)).toBe(AUTH_TYPE.OAUTH2);
+    expect(credentialAuthClass(null)).toBeNull();
   });
 });

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
@@ -128,9 +128,12 @@ export const withoutMintedTokenCredentials = (
   credentials: Record<string, unknown> | null | undefined,
 ): Record<string, unknown> | undefined => {
   if (!credentials) return undefined;
-  return Object.fromEntries(
+  const kept = Object.fromEntries(
     Object.entries(credentials).filter(([key]) => !(MINTED_TOKEN_CREDENTIAL_KEYS as readonly string[]).includes(key)),
   );
+  // Return undefined (not {}) when only minted keys were present, so a restore spreads `credentials:
+  // undefined` (the fields keep their placeholder / keep-existing state) rather than blanking them.
+  return Object.keys(kept).length > 0 ? kept : undefined;
 };
 
 // The client-forwarded modes share one credential class (same declared app, same authorize relay), so

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
@@ -368,6 +368,8 @@ export interface MCPServer {
   delegate_auth_to_upstream?: boolean;
   oauth_passthrough?: boolean;
   max_concurrent_requests?: number | null;
+  /** Redacted to null in server responses; present when constructing a server locally. */
+  credentials?: Record<string, unknown> | null;
 
   /** Stdio-only fields (present when transport === 'stdio') */
   command?: string | null;

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
@@ -96,6 +96,31 @@ export const getOAuthAuthorizationIdentity = (values: Record<string, unknown>): 
 // edit forms so what gets wiped cannot drift.
 export const CLEARED_ON_INVALIDATION = ["credentials"] as const;
 
+// The carve-out to the wipe above for the client-forwarded token modes: their onTokenReceived branch
+// never writes minted material into form.credentials, so for them the field only ever holds the
+// admin-DECLARED upstream app (persisted as server config since the modes joined
+// AUTH_TYPES_REQUIRING_CREDENTIALS), and an intra-mode identity change (e.g. a URL edit after
+// Authorize) must not silently discard it. Two guards make the preserve safe: it never applies when
+// auth_type itself changed (the previous mode's onTokenReceived may have written a fetched token or
+// DCR client into the same field, and those are minted for the old mode), and it only ever keeps the
+// declared-app keys, so token-shaped keys can never ride through a preserve. Shared by the create and
+// edit forms so the carve-out cannot drift.
+const DECLARED_APP_CREDENTIAL_KEYS = ["client_id", "client_secret"] as const;
+
+export const preservedDeclaredAppCredentials = (
+  authType: string | null | undefined,
+  authTypeChanged: boolean,
+  credentials: Record<string, unknown> | null | undefined,
+): Record<string, string> | undefined => {
+  if (!isClientForwardedTokenMode(authType) || authTypeChanged || !credentials) return undefined;
+  const kept = Object.fromEntries(
+    DECLARED_APP_CREDENTIAL_KEYS.filter((key) => typeof credentials[key] === "string" && credentials[key] !== "").map(
+      (key) => [key, credentials[key] as string],
+    ),
+  );
+  return Object.keys(kept).length > 0 ? kept : undefined;
+};
+
 // True when a token was authorized in this session (authorizedIdentity recorded at mint time) and the
 // form's current identity no longer matches it. Every invalidation decision in both forms goes through
 // this single check: onValuesChange for user edits, and an explicit recheck after any programmatic

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
@@ -96,29 +96,49 @@ export const getOAuthAuthorizationIdentity = (values: Record<string, unknown>): 
 // edit forms so what gets wiped cannot drift.
 export const CLEARED_ON_INVALIDATION = ["credentials"] as const;
 
-// The carve-out to the wipe above for the client-forwarded token modes: their onTokenReceived branch
-// never writes minted material into form.credentials, so for them the field only ever holds the
-// admin-DECLARED upstream app (persisted as server config since the modes joined
-// AUTH_TYPES_REQUIRING_CREDENTIALS), and an intra-mode identity change (e.g. a URL edit after
-// Authorize) must not silently discard it. Two guards make the preserve safe: it never applies when
-// auth_type itself changed (the previous mode's onTokenReceived may have written a fetched token or
-// DCR client into the same field, and those are minted for the old mode), and it only ever keeps the
-// declared-app keys, so token-shaped keys can never ride through a preserve. Shared by the create and
-// edit forms so the carve-out cannot drift.
+// The declared-app filter over form.credentials. It is a pure key filter with no mode/transition
+// guard because the surrounding code establishes that a client_id/client_secret in form.credentials
+// is ALWAYS admin-typed in every reachable state: the create form holds the DCR-minted client in a
+// ref and never writes it into the form store, the edit form's onTokenReceived never writes client
+// keys, and the invalidation reset clears the whole object atomically. So preserving the string
+// client keys across any invalidation (URL/endpoint edit, true_passthrough<->oauth_delegate switch,
+// or a round trip through another mode) is always legitimate, while the output key filter excludes
+// token-shaped keys so a preserve can never carry minted material through. Shared by both forms.
 const DECLARED_APP_CREDENTIAL_KEYS = ["client_id", "client_secret"] as const;
 
+// Minted token material the oauth2 authorize path writes beside the app keys; stripped from restored
+// snapshots and from any credentials that transit to the temp-session preview so a stale token never
+// reaches the backend or a client-forwarded server row.
+export const MINTED_TOKEN_CREDENTIAL_KEYS = ["access_token", "refresh_token", "expires_in", "scope"] as const;
+
 export const preservedDeclaredAppCredentials = (
-  authType: string | null | undefined,
-  authTypeChanged: boolean,
   credentials: Record<string, unknown> | null | undefined,
 ): Record<string, string> | undefined => {
-  if (!isClientForwardedTokenMode(authType) || authTypeChanged || !credentials) return undefined;
+  if (!credentials) return undefined;
   const kept = Object.fromEntries(
     DECLARED_APP_CREDENTIAL_KEYS.filter((key) => typeof credentials[key] === "string" && credentials[key] !== "").map(
       (key) => [key, credentials[key] as string],
     ),
   );
   return Object.keys(kept).length > 0 ? kept : undefined;
+};
+
+// Drop minted token keys, keeping everything else (the declared app plus any non-token config).
+export const withoutMintedTokenCredentials = (
+  credentials: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | undefined => {
+  if (!credentials) return undefined;
+  return Object.fromEntries(
+    Object.entries(credentials).filter(([key]) => !(MINTED_TOKEN_CREDENTIAL_KEYS as readonly string[]).includes(key)),
+  );
+};
+
+// The client-forwarded modes share one credential class (same declared app, same authorize relay), so
+// a switch between them must NOT be treated as an app change. Mirrors the backend _credential_auth_class
+// in db.py; kept in sync so the UI's keep-existing copy and the backend's merge cannot disagree.
+export const credentialAuthClass = (authType: string | null | undefined): string | null => {
+  if (authType === AUTH_TYPE.TRUE_PASSTHROUGH || authType === AUTH_TYPE.OAUTH_DELEGATE) return "client_forwarded";
+  return authType ?? null;
 };
 
 // True when a token was authorized in this session (authorizedIdentity recorded at mint time) and the


### PR DESCRIPTION
## Relevant issues

Follow-up to #32735

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on localhost:4000 backed by real Postgres, running real dynamic client registration against Linear's authorization server; no mocks. Both runs captured at 931b617a51 (the change is UI payload assembly; the two servers below reproduce the exact payloads the dashboard sends before and after this change)

First, a stand-in for the org's pre-registered app, minted once directly at Linear:

```
$ curl -s https://mcp.linear.app/.well-known/oauth-authorization-server | jq -r .registration_endpoint
https://mcp.linear.app/register
$ curl -s -X POST https://mcp.linear.app/register -H 'Content-Type: application/json' \
    -d '{"client_name":"LiteLLM Org App (demo)","redirect_uris":["http://localhost:4000/callback"],"grant_types":["authorization_code","refresh_token"],"response_types":["code"],"token_endpoint_auth_method":"none"}'
{"client_id": "aTk6vD...", ...}
```

**Before this change** the dashboard stripped credentials for these modes, so every true_passthrough/oauth_delegate create looked like `linear_pt_blank` below; **after**, admin-entered credentials survive into the payload, producing `linear_pt_orgapp`:

```
$ curl -s -X POST http://localhost:4000/v1/mcp/server -H 'x-litellm-api-key: sk-1234' -H 'Content-Type: application/json' \
    -d '{"server_name":"linear_pt_orgapp","url":"https://mcp.linear.app/mcp","transport":"http","auth_type":"true_passthrough","credentials":{"client_id":"aTk6vD..."}}'
$ curl -s -X POST http://localhost:4000/v1/mcp/server -H 'x-litellm-api-key: sk-1234' -H 'Content-Type: application/json' \
    -d '{"server_name":"linear_pt_blank","url":"https://mcp.linear.app/mcp","transport":"http","auth_type":"true_passthrough"}'

$ psql -d litellm_cfg_repro -c "SELECT alias, auth_type, credentials ? 'client_id' AS has_configured_client FROM \"LiteLLM_MCPServerTable\" ORDER BY created_at;"
 linear_pt_orgapp | true_passthrough | t
 linear_pt_blank  | true_passthrough | f
```

The internal user's Tools-page Authorize (register, then the authorize relay):

```
$ curl -s -X POST 'http://localhost:4000/v1/mcp/server/oauth/<orgapp-id>/register' ... 
{'client_id': '<server-id placeholder>', 'client_secret': 'dummy'}     <- short-circuit; no upstream DCR call

$ curl -s -X POST 'http://localhost:4000/v1/mcp/server/oauth/<blank-id>/register' ...
{'client_id_prefix': 'mwDn6f...', 'is_dummy': False}                   <- DCR fallback still mints a fresh Linear client

$ curl -s -o /dev/null -w '%{redirect_url}' 'http://localhost:4000/v1/mcp/server/oauth/<orgapp-id>/authorize?redirect_uri=...&state=...&code_challenge=...&response_type=code&client_id=<placeholder>' -H 'Authorization: Bearer sk-1234'
-> https://mcp.linear.app/authorize?...client_id=aTk6vD...&scope=read+write
   client_id_is_org_app: True     <- the relay substitutes the configured app server-side; the browser never needs it
```

Token contract unchanged, checked after the flows:

```
$ psql -d litellm_cfg_repro -c "SELECT count(*) AS stored_user_tokens FROM \"LiteLLM_MCPUserCredentials\";"
 0
```

Durability of the persisted app, also at 931b617a51: the credentials are encrypted at rest, survive a full proxy restart (decrypt-on-load through the registry), and the edit path persists the same way

```
$ psql -d litellm_cfg_verify -tAc "SELECT credentials::text FROM \"LiteLLM_MCPServerTable\" WHERE server_id='<id>';"
{'keys': ['client_id', 'client_secret'], 'client_id_plaintext_in_db': False, 'secret_plaintext_in_db': False}

# kill proxy, relaunch, same authorize relay call:
{'redirect_host': 'mcp.linear.app', 'client_id_is_org_app_after_restart': True}

# blank server, then PUT /v1/mcp/server with credentials.client_id (the edit form's payload):
update HTTP:202 ; row has client: t
{'relay_uses_org_app_after_edit': True}
```

## Type

🆕 New Feature

## Changes

The create and edit forms render optional OAuth Client ID / Client Secret fields for the client-forwarded token modes (true_passthrough / oauth_delegate), but AUTH_TYPES_REQUIRING_CREDENTIALS excluded those modes, so the submit path stripped the values and the server row never got a client. The consequence for internal users: the Tools-page Authorize has no client input, so on upstreams without dynamic client registration (a pre-registered Slack app being the canonical case) the flow dead-ends for everyone except the admin who typed the app into the form for that one browser session; on DCR-capable upstreams every authorize minted a throwaway client, invisible to any org-level scope or consent policy that keys off a stable app identity

This PR adds the two modes to AUTH_TYPES_REQUIRING_CREDENTIALS in both forms so admin-entered credentials persist as declared config, and updates the copy from "(optional, not saved)" to "(optional, saved)" with the surrounding text now distinguishing the two lifetimes: the browser-authorized access token is still never saved anywhere, while a configured app is stored with the server so internal users authorize through it. Empty fields keep producing no credentials in the payload, so leave-blank still means the DCR fallback

No backend changes are needed: create/update already persist and encrypt credentials for any auth_type, register_client_with_server short-circuits when the server has a client_id, and both the authorize and token relays substitute the stored client server-side, so the Tools-page flow picks the configured app up with zero further wiring (proven live above). The client secret never reaches the browser; register returns a placeholder and the relays authenticate upstream with the stored secret. Mode classification is unaffected: has_client_credentials keys off oauth2_flow (never stamped here) and all passthrough predicates key off auth_type alone. This composes with #32735, which stops runtime-DCR-minted clients from being persisted; together they make "configured" mean exactly "an admin declared it"

Tests: parametrized create and edit tests asserting admin-entered credentials ARE included in the submit payload for both modes while the browser-held token still appears nowhere and no per-user credential is written (both fail with the gate reverted; mutation-checked), plus the existing browser-held-token tests keep passing unchanged, pinning that blank fields still omit credentials

Follow-up commit cf1b407fbe addresses the review finding on blank-field semantics: the backend's partial credential update merges per key, so blank fields on edit keep whatever app is stored, while the section copy claimed blank meant dynamic client registration. The copy now follows the same convention the M2M credential fields already use (create: "leave blank to use dynamic client registration"; edit: "leave blank to keep the currently saved app"), and removing a stored app is an explicit checkbox on the edit form that saves an explicit-null credential write: MCPCredentials permits null values, encrypt_credentials skips nulls, and the merge overrides the stored keys, returning the server to dynamic client registration with zero backend changes. Live proof at cf1b407fbe: create a true_passthrough server with an app (row shows client_id/secret set: true true), send the removal write (PUT credentials {client_id: null, client_secret: null}, HTTP 202), the row flips to false false, and the register endpoint stops short-circuiting and mints a fresh DCR client at Linear. The removal path is pinned by a test asserting the checkbox produces exactly the explicit-null payload (fails with the save branch disabled), and the existing blank-save test keeps asserting that untouched fields omit credentials entirely

Follow-up commit 57051d36d6 addresses the review finding that the OAuth invalidation path silently wiped the declared app: clearHeldOAuthToken resets the shared CLEARED_ON_INVALIDATION fields whenever the authorization identity changes (e.g. a URL edit after Authorize), which was correct when form.credentials only ever held minted material but now discarded admin config for the client-forwarded modes. A shared preservedDeclaredAppCredentials helper (types.tsx, used by both forms) re-applies the declared app across the reset with two guards that keep the original wipe semantics intact everywhere they matter: the preserve never applies when auth_type itself changed, because the previous mode's onTokenReceived may have written a fetched token or DCR client into the same field (switching oauth2 to true_passthrough with a stale DCR client in form.credentials would otherwise persist minted material onto the row), and it only ever keeps the client_id/client_secret keys so token-shaped values cannot ride through under any sequence. Regression tests cover both directions and are mutation-checked: disabling the preserve fails the three URL-change-after-authorize tests (create + both edit modes), and dropping the auth_type guard fails the oauth2-to-passthrough switch test that asserts the DCR-minted client is wiped from the payload

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth credential assembly and invalidation in admin forms; mistakes could persist wrong clients or leak tokens into server rows, but behavior is heavily test-covered and scoped to dashboard UI.
> 
> **Overview**
> **Client-forwarded MCP modes** (`true_passthrough` / `oauth_delegate`) now treat optional **OAuth client ID/secret as saved server config** (not browser-only), while **access tokens stay session-only**. Create/edit include these modes in `AUTH_TYPES_REQUIRING_CREDENTIALS` so admin-entered apps reach the API; copy and labels change from “not saved” to “saved”.
> 
> Shared helpers in `types.tsx` (`preservedDeclaredAppCredentials`, `withoutMintedTokenCredentials`, `credentialAuthClass`) separate **declared app** from **minted token/DCR material**. **OAuth2 DCR clients** live in a ref instead of `form.credentials`, so they are not mistaken for a passthrough app or leaked on auth-type switches. Invalidation and OAuth redirect restore **re-apply the declared app** after clearing tokens; submit paths **strip tokens** for client-forwarded rows.
> 
> `PassthroughAuthorizeSection` adds **edit-aware placeholders** (keep existing vs discard on cross-class auth switch), an **upstream-change warning**, and a **remove saved app** checkbox that sends explicit `null` credentials on edit. Create/edit forms add **upstream URL change warnings**, safer **server-switch** state reset, and broader tests for payloads, invalidation, and restore behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dbd608e172d72e7d0515853af03f1a8cc69cb87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->