### PR TITLE
feat(mcp): dcr_bridge discovery facade and register relay

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -989,6 +989,21 @@ async def _persist_dcr_client_registration(
         return "failed"
 
 
+_MAX_UPSTREAM_ERROR_CHARS = 500
+
+
+def _safe_upstream_error_detail(response: httpx.Response) -> str:
+    """Bounded plaintext summary of an upstream registration failure for the client.
+
+    RFC 7591 error bodies are small JSON objects (``error`` / ``error_description``); relaying the
+    text lets the client read the real reason instead of a bare 500, and the length bound keeps a
+    hostile or oversized upstream body from bloating the gateway response."""
+    body = response.text
+    if not body:
+        return response.reason_phrase or "upstream registration failed"
+    return body[:_MAX_UPSTREAM_ERROR_CHARS]
+
+
 async def register_client_with_server(
     request: Request,
     mcp_server: MCPServer,
@@ -1050,6 +1065,8 @@ async def register_client_with_server(
             status_code=502,
             detail="MCP upstream registration endpoint returned no response",
         )
+    if bridge_relay and response.status_code >= 400:
+        raise HTTPException(status_code=response.status_code, detail=_safe_upstream_error_detail(response))
     response.raise_for_status()
 
     token_response = response.json()

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -1024,7 +1024,7 @@ async def register_client_with_server(
     if bridge_relay and not client_redirect_uris:
         raise HTTPException(
             status_code=400,
-            detail={"error": "redirect_uris is required to register a client with this server"},
+            detail="redirect_uris is required to register a client with this server",
         )
 
     register_data = {
@@ -1814,6 +1814,7 @@ async def register_client(request: Request, mcp_server_name: Optional[str] = Non
                 response_types=data.get("response_types", []),
                 token_endpoint_auth_method=data.get("token_endpoint_auth_method", ""),
                 fallback_client_id=resolved.server_name or resolved.name,
+                client_redirect_uris=data.get("redirect_uris"),
             )
         return dummy_return
 

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -499,16 +499,20 @@ def _raise_unless_oauth2_discovery_server(
     mcp_server_name: Optional[str],
     description: str,
 ) -> None:
-    """404 a NAMED discovery request unless it resolves to an oauth2 server.
+    """404 a NAMED discovery request unless it resolves to an oauth2 or DCR-bridge server.
 
     A named server that is unknown (or hidden from the caller) and one that exists
     but is non-oauth2 both return the same 404, so the well-known discovery paths
     cannot be used to enumerate non-OAuth server names. Root discovery (no name) is
     unaffected, and pass-through servers are resolved by the caller before this runs.
+    DCR-bridge servers are admitted because they serve the gateway's own authorization
+    server metadata (the register, authorize, and token relays).
     """
     if mcp_server_name is None:
         return
     if mcp_server is not None and mcp_server.auth_type == MCPAuth.oauth2:
+        return
+    if mcp_server is not None and mcp_server.is_dcr_bridge:
         return
     raise HTTPException(
         status_code=404,
@@ -735,7 +739,17 @@ async def exchange_token_with_server(
             detail="MCP upstream token endpoint returned no response",
         )
 
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        if "invalid_target" in exc.response.text:
+            verbose_logger.warning(
+                "MCP server %s: the upstream authorization server rejected the token request with "
+                "invalid_target; it may require RFC 8707 resource indicators, which the gateway "
+                "does not send yet (tracked as LIT-4339)",
+                mcp_server.server_id,
+            )
+        raise
     token_response = response.json()
     access_token = token_response["access_token"]
 
@@ -984,6 +998,7 @@ async def register_client_with_server(
     token_endpoint_auth_method: Optional[str],
     fallback_client_id: Optional[str] = None,
     persist_credentials: bool = False,
+    client_redirect_uris: Optional[list] = None,
 ):
     _raise_if_not_oauth2(mcp_server)
     request_base_url = get_request_base_url(request)
@@ -1005,12 +1020,19 @@ async def register_client_with_server(
     if mcp_server.registration_url is None:
         return dummy_return
 
+    bridge_relay = _dcr_bridge_relays_client_registration(mcp_server)
+    if bridge_relay and not client_redirect_uris:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "redirect_uris is required to register a client with this server"},
+        )
+
     register_data = {
         "client_name": client_name,
-        "redirect_uris": [f"{request_base_url}/callback"],
-        "grant_types": grant_types or [],
-        "response_types": response_types or [],
-        "token_endpoint_auth_method": token_endpoint_auth_method or "",
+        "redirect_uris": client_redirect_uris if bridge_relay else [f"{request_base_url}/callback"],
+        "grant_types": grant_types or (["authorization_code", "refresh_token"] if bridge_relay else []),
+        "response_types": response_types or (["code"] if bridge_relay else []),
+        "token_endpoint_auth_method": token_endpoint_auth_method or ("none" if bridge_relay else ""),
     }
     headers = {
         "Content-Type": "application/json",
@@ -1032,7 +1054,7 @@ async def register_client_with_server(
 
     token_response = response.json()
 
-    if persist_credentials:
+    if persist_credentials and not bridge_relay:
         persistence_result = await _persist_dcr_client_registration(mcp_server, token_response)
         if persistence_result == "reused":
             return dummy_return
@@ -1456,6 +1478,13 @@ async def _build_oauth_protected_resource_response(
     else:
         resource_url = f"{request_base_url}/mcp"
 
+    if mcp_server is not None and mcp_server_name and mcp_server.is_dcr_bridge:
+        return {
+            "authorization_servers": [f"{request_base_url}/{mcp_server_name}"],
+            "resource": resource_url,
+            "scopes_supported": (mcp_server.scopes if mcp_server.scopes else []),
+        }
+
     # Pass-through branch: proxy the upstream's own metadata so discovery
     # directs the client at the real IdP (Okta, Keycloak, …) instead of us.
     if mcp_server is not None and (
@@ -1799,4 +1828,5 @@ async def register_client(request: Request, mcp_server_name: Optional[str] = Non
         response_types=data.get("response_types", []),
         token_endpoint_auth_method=data.get("token_endpoint_auth_method", ""),
         fallback_client_id=mcp_server_name,
+        client_redirect_uris=data.get("redirect_uris"),
     )

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -2630,10 +2630,16 @@ class MCPServerManager:
 
             return prefixed_or_original_tools
 
-        except MCPUpstreamAuthError:
+        except MCPUpstreamAuthError as upstream_auth_error:
             # Pass-through 401 must surface to single-server routes so the
             # client triggers the upstream OAuth flow. The multi-server
             # aggregator catches this explicitly to keep absorbing.
+            if server.is_dcr_bridge and upstream_auth_error.www_authenticate is not None:
+                raise MCPUpstreamAuthError(
+                    status_code=upstream_auth_error.status_code,
+                    www_authenticate=None,
+                    server_name=upstream_auth_error.server_name,
+                ) from upstream_auth_error
             raise
         except HTTPException as e:
             # A v2 resolver auth challenge (token_exchange's RFC 9728 401, authorization_code's
@@ -2643,9 +2649,10 @@ class MCPServerManager:
             # Non-auth HTTP errors stay absorbed so one misconfigured server can't blank the listing.
             if e.status_code in (401, 403):
                 headers = e.headers or {}
+                challenge_header = headers.get("WWW-Authenticate") or headers.get("www-authenticate")
                 raise MCPUpstreamAuthError(
                     status_code=e.status_code,
-                    www_authenticate=headers.get("WWW-Authenticate") or headers.get("www-authenticate"),
+                    www_authenticate=None if server.is_dcr_bridge else challenge_header,
                     server_name=server.name,
                 ) from e
             verbose_logger.warning(f"Failed to get tools from server {server.name}: {str(e)}")

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -3700,6 +3700,17 @@ if MCP_AVAILABLE:
                 and not _scope_has_authorization_header(scope)
                 and not _client_has_per_server_auth_header(server, mcp_server_auth_headers)
             ):
+                if server.is_dcr_bridge:
+                    raise HTTPException(
+                        status_code=401,
+                        detail="Unauthorized",
+                        headers={
+                            "www-authenticate": _get_passthrough_www_authenticate(
+                                scope=scope,
+                                server_name=server_name,
+                            )
+                        },
+                    )
                 upstream_status, upstream_www_authenticate = await _probe_upstream_auth(server.url or "", "")
                 if upstream_status == 401 and upstream_www_authenticate:
                     raise HTTPException(

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -3818,6 +3818,135 @@ async def test_token_non_bridge_keeps_gateway_callback():
     assert data["redirect_uri"] == "https://litellm.example.com/callback"
 
 
+def _named_as_metadata_response(server):
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _build_oauth_authorization_server_response,
+    )
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+
+    global_mcp_server_manager.registry.clear()
+    global_mcp_server_manager.registry[server.server_id] = server
+    try:
+        with patch(
+            "litellm.proxy._experimental.mcp_server.discoverable_endpoints.IPAddressUtils.get_mcp_client_ip",
+            return_value=None,
+        ):
+            return _build_oauth_authorization_server_response(
+                request=_bridge_mock_request(),
+                mcp_server_name=server.server_name,
+            )
+    finally:
+        global_mcp_server_manager.registry.clear()
+
+
+def test_oauth_authorization_server_metadata_served_for_bridge_server():
+    """Bridge servers get the gateway's AS metadata (the register, authorize, and token relays),
+    which is what makes the DCR front door discoverable to standard MCP clients."""
+    result = _named_as_metadata_response(_bridge_server())
+
+    assert result["authorization_endpoint"] == "https://litellm.example.com/bridge_srv/authorize"
+    assert result["token_endpoint"] == "https://litellm.example.com/bridge_srv/token"
+    assert result["registration_endpoint"] == "https://litellm.example.com/bridge_srv/register"
+
+
+def test_oauth_authorization_server_404_for_non_bridge_client_forwarded_server():
+    """Without dcr_bridge a client-forwarded server keeps 404ing AS-metadata discovery: verbatim
+    upstream discovery is the contract and the gateway must not advertise itself as its AS."""
+    with pytest.raises(HTTPException) as exc:
+        _named_as_metadata_response(_bridge_server(dcr_bridge=None))
+
+    assert exc.value.status_code == 404
+
+
+async def _bridge_register_response(server, request_payload, persist_credentials=False):
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        register_client_with_server,
+    )
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "client_id": "upstream-issued-client",
+        "redirect_uris": request_payload.get("redirect_uris", []),
+        "token_endpoint_auth_method": "none",
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_async_client = MagicMock()
+    mock_async_client.post = AsyncMock(return_value=mock_response)
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
+            return_value=mock_async_client,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.discoverable_endpoints._persist_dcr_client_registration",
+            new_callable=AsyncMock,
+        ) as mock_persist,
+        patch(
+            "litellm.proxy._experimental.mcp_server.discoverable_endpoints._reuse_persisted_dcr_client_if_available",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+    ):
+        response = await register_client_with_server(
+            request=_bridge_mock_request(),
+            mcp_server=server,
+            client_name=request_payload.get("client_name", ""),
+            grant_types=request_payload.get("grant_types"),
+            response_types=request_payload.get("response_types"),
+            token_endpoint_auth_method=request_payload.get("token_endpoint_auth_method"),
+            persist_credentials=persist_credentials,
+            client_redirect_uris=request_payload.get("redirect_uris"),
+        )
+    return response, mock_async_client, mock_persist
+
+
+@pytest.mark.asyncio
+async def test_register_bridge_relay_forwards_client_redirect_uris():
+    """The bridge relay arm registers the client's own redirect_uris upstream with public-client
+    defaults and relays the upstream response verbatim, so the upstream AS enforces the redirect
+    binding for that client and the auth code never transits the gateway."""
+    import json
+
+    response, mock_async_client, _ = await _bridge_register_response(
+        _bridge_server(),
+        {"client_name": "Claude", "redirect_uris": [_BRIDGE_CLIENT_REDIRECT]},
+    )
+
+    posted = mock_async_client.post.call_args.kwargs["json"]
+    assert posted["redirect_uris"] == [_BRIDGE_CLIENT_REDIRECT]
+    assert posted["grant_types"] == ["authorization_code", "refresh_token"]
+    assert posted["response_types"] == ["code"]
+    assert posted["token_endpoint_auth_method"] == "none"
+
+    payload = json.loads(response.body.decode("utf-8"))
+    assert payload["client_id"] == "upstream-issued-client"
+
+
+@pytest.mark.asyncio
+async def test_register_bridge_relay_requires_redirect_uris():
+    with pytest.raises(HTTPException) as exc:
+        await _bridge_register_response(_bridge_server(), {"client_name": "Claude"})
+
+    assert exc.value.status_code == 400
+    assert "redirect_uris" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_register_bridge_relay_never_persists():
+    """Relayed registrations belong to individual clients; persisting one as the server's own DCR
+    client would hand every future caller the first client's identity."""
+    _, _, mock_persist = await _bridge_register_response(
+        _bridge_server(),
+        {"client_name": "Claude", "redirect_uris": [_BRIDGE_CLIENT_REDIRECT]},
+        persist_credentials=True,
+    )
+
+    mock_persist.assert_not_called()
+
+
 async def _exchange_persistence_attempted_for_auth_type(auth_type) -> bool:
     """Run exchange_token_with_server for a server of ``auth_type`` and report whether it attempted
     to persist the exchanged token server-side. The client-forwarded token modes must not persist:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -3866,6 +3866,7 @@ async def _bridge_register_response(server, request_payload, persist_credentials
     )
 
     mock_response = MagicMock()
+    mock_response.status_code = 201
     mock_response.json.return_value = {
         "client_id": "upstream-issued-client",
         "redirect_uris": request_payload.get("redirect_uris", []),
@@ -3932,6 +3933,94 @@ async def test_register_bridge_relay_requires_redirect_uris():
 
     assert exc.value.status_code == 400
     assert "redirect_uris" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_register_bridge_relay_surfaces_upstream_error_not_500():
+    """A bridge relay registration the upstream rejects must surface the upstream status and its
+    RFC 7591 error body to the client, not a bare 500 that hides the real reason."""
+    import httpx
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        register_client_with_server,
+    )
+
+    error_response = MagicMock()
+    error_response.status_code = 400
+    error_response.text = '{"error":"invalid_redirect_uri","error_description":"redirect_uri not allowed"}'
+    error_response.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError("bad", request=MagicMock(), response=error_response)
+    )
+    mock_async_client = MagicMock()
+    mock_async_client.post = AsyncMock(return_value=error_response)
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
+            return_value=mock_async_client,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.discoverable_endpoints._reuse_persisted_dcr_client_if_available",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await register_client_with_server(
+                request=_bridge_mock_request(),
+                mcp_server=_bridge_server(),
+                client_name="Claude",
+                grant_types=None,
+                response_types=None,
+                token_endpoint_auth_method=None,
+                client_redirect_uris=[_BRIDGE_CLIENT_REDIRECT],
+            )
+
+    assert exc.value.status_code == 400
+    assert "invalid_redirect_uri" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_register_non_bridge_upstream_error_still_raises_500():
+    """Non-bridge DCR keeps its pre-change behavior: raise_for_status propagates so the flag-off
+    contract is byte-identical; only the bridge relay arm relays the upstream status."""
+    import httpx
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        register_client_with_server,
+    )
+
+    error_response = MagicMock()
+    error_response.status_code = 400
+    error_response.text = '{"error":"invalid_client_metadata"}'
+    error_response.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError("bad", request=MagicMock(), response=error_response)
+    )
+    mock_async_client = MagicMock()
+    mock_async_client.post = AsyncMock(return_value=error_response)
+
+    oauth2_server = _bridge_server(auth_type=MCPAuth.oauth2, dcr_bridge=None)
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
+            return_value=mock_async_client,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.discoverable_endpoints._reuse_persisted_dcr_client_if_available",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+    ):
+        with pytest.raises(httpx.HTTPStatusError):
+            await register_client_with_server(
+                request=_bridge_mock_request(),
+                mcp_server=oauth2_server,
+                client_name="Claude",
+                grant_types=None,
+                response_types=None,
+                token_endpoint_auth_method=None,
+            )
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_oauth_passthrough.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_oauth_passthrough.py
@@ -571,3 +571,53 @@ async def test_oauth_protected_resource_true_passthrough_returns_upstream_metada
         assert result["resource"] == "https://upstream.example.com/mcp"
     finally:
         global_mcp_server_manager.registry.clear()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("auth_type", [MCPAuth.true_passthrough, MCPAuth.oauth_delegate])
+@pytest.mark.parametrize("use_standard_pattern", [True, False])
+async def test_oauth_protected_resource_dcr_bridge_returns_gateway_facade(auth_type, use_standard_pattern):
+    """With dcr_bridge on, discovery flips from the upstream-verbatim contract to the gateway
+    facade: resource is the gateway URL the client dialed and authorization_servers names the
+    gateway's per-server AS, so DCR-only clients (which enforce the RFC 9728 resource match)
+    can register and sign in through the gateway. No upstream metadata fetch happens."""
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+
+    global_mcp_server_manager.registry.clear()
+    bridge_server = MCPServer(
+        server_id="bridge-1",
+        name="sample_docs",
+        server_name="sample_docs",
+        alias="sample_docs",
+        url="https://upstream.example.com/mcp",
+        transport=MCPTransport.http,
+        auth_type=auth_type,
+        dcr_bridge=True,
+        scopes=["read"],
+        registration_url="https://okta.example.com/register",
+    )
+    global_mcp_server_manager.registry[bridge_server.server_id] = bridge_server
+
+    try:
+        with patch.object(discoverable_endpoints, "get_async_httpx_client") as mock_client_factory:
+            result = await _build_oauth_protected_resource_response(
+                request=_make_request(),
+                mcp_server_name="sample_docs",
+                use_standard_pattern=use_standard_pattern,
+            )
+    finally:
+        global_mcp_server_manager.registry.clear()
+
+    expected_resource = (
+        "https://gateway.example.com/mcp/sample_docs"
+        if use_standard_pattern
+        else "https://gateway.example.com/sample_docs/mcp"
+    )
+    assert result == {
+        "authorization_servers": ["https://gateway.example.com/sample_docs"],
+        "resource": expected_resource,
+        "scopes_supported": ["read"],
+    }
+    mock_client_factory.assert_not_called()

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -6679,6 +6679,67 @@ class TestMCPToolsListAuthSurfacing:
         assert await manager._get_tools_from_server(server) == []
 
     @pytest.mark.asyncio
+    async def test_get_tools_from_server_suppresses_upstream_challenge_for_dcr_bridge(self):
+        """A dcr_bridge server must never relay the upstream's own WWW-Authenticate: it points
+        clients at the upstream protected-resource metadata, which fails the RFC 9728 resource
+        match against the gateway URL they dialed. Stripping it makes the single-server route
+        fabricate the gateway well-known challenge, whose content is the bridge facade."""
+        from litellm.proxy._experimental.mcp_server.exceptions import (
+            MCPUpstreamAuthError,
+        )
+        from litellm.types.mcp import MCPAuth
+
+        manager = MCPServerManager()
+        bridge_server = MCPServer(
+            server_id="bridge-srv",
+            name="bridge-srv",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.true_passthrough,
+            dcr_bridge=True,
+        )
+        upstream_challenge = 'Bearer resource_metadata="https://upstream.example/.well-known/oauth-protected-resource"'
+        client = MagicMock()
+        client.list_tools = AsyncMock(side_effect=_upstream_status_error(401, upstream_challenge))
+        manager._create_mcp_client = AsyncMock(return_value=client)
+
+        with pytest.raises(MCPUpstreamAuthError) as exc_info:
+            await manager._get_tools_from_server(bridge_server)
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.www_authenticate is None
+        assert exc_info.value.server_name == "bridge-srv"
+
+    @pytest.mark.asyncio
+    async def test_get_tools_from_server_suppresses_resolver_challenge_for_dcr_bridge(self):
+        """The client-build-time HTTPException conversion path applies the same suppression."""
+        from litellm.proxy._experimental.mcp_server.exceptions import (
+            MCPUpstreamAuthError,
+        )
+        from litellm.types.mcp import MCPAuth
+
+        manager = MCPServerManager()
+        bridge_server = MCPServer(
+            server_id="bridge-srv",
+            name="bridge-srv",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth_delegate,
+            dcr_bridge=True,
+        )
+        manager._create_mcp_client = AsyncMock(
+            side_effect=HTTPException(
+                status_code=401,
+                detail="Unauthorized",
+                headers={"WWW-Authenticate": 'Bearer resource_metadata="https://upstream.example/prm"'},
+            )
+        )
+
+        with pytest.raises(MCPUpstreamAuthError) as exc_info:
+            await manager._get_tools_from_server(bridge_server)
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.www_authenticate is None
+
+    @pytest.mark.asyncio
     async def test_aggregate_list_tools_absorbs_unauthenticated_server(self):
         from litellm.proxy._experimental.mcp_server.exceptions import (
             MCPUpstreamAuthError,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_stale_session.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_stale_session.py
@@ -1401,6 +1401,76 @@ async def test_handle_streamable_http_mcp_true_passthrough_without_token_surface
 
 
 @pytest.mark.asyncio
+async def test_handle_streamable_http_mcp_true_passthrough_dcr_bridge_challenges_with_gateway_metadata():
+    """With dcr_bridge on, the missing-token challenge names the GATEWAY's well-known instead of
+    relaying the upstream's: the gateway is the authorization server for bridge clients, and the
+    upstream's own challenge would point them at metadata that fails the RFC 9728 resource match.
+    The upstream probe is skipped entirely; the gateway can answer authoritatively."""
+    from fastapi import HTTPException
+
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            handle_streamable_http_mcp,
+            session_manager_stateful,
+        )
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    probe_client = MagicMock()
+    probe_client.post = AsyncMock()
+
+    scope = _passthrough_mode_scope("tp_bridge_server")
+    receive = AsyncMock(
+        return_value={
+            "type": "http.request",
+            "body": b'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}',
+            "more_body": False,
+        }
+    )
+    send = AsyncMock()
+    user_auth = MagicMock()
+    user_auth.user_id = None
+    bridge_server = _build_passthrough_mode_server("tp_bridge_server", MCPAuth.true_passthrough).model_copy(
+        update={"dcr_bridge": True}
+    )
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.extract_mcp_auth_context",
+            new_callable=AsyncMock,
+            return_value=(user_auth, None, ["tp_bridge_server"], None, None, None),
+        ),
+        patch("litellm.proxy._experimental.mcp_server.server.set_auth_context"),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server._SESSION_MANAGERS_INITIALIZED",
+            True,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.get_async_httpx_client",
+            return_value=probe_client,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager.get_mcp_server_by_name",
+            return_value=bridge_server,
+        ),
+        patch.object(
+            session_manager_stateful,
+            "handle_request",
+            new_callable=AsyncMock,
+        ) as mock_handle_request,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await handle_streamable_http_mcp(scope, receive, send)
+
+    assert mock_handle_request.await_count == 0
+    assert exc_info.value.status_code == 401
+    challenge = exc_info.value.headers["www-authenticate"]
+    assert "/.well-known/oauth-protected-resource/tp_bridge_server/mcp" in challenge
+    assert "upstream.example.com" not in challenge
+    probe_client.post.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_handle_streamable_http_mcp_true_passthrough_with_token_skips_probe_and_challenge():
     """When the true_passthrough caller already carries an Authorization the
     gateway must forward without probing or challenging. Guards the


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4337 (PR 3 of the stack, based on #32747 so the review diff is only this change; retargets when the base merges). PR 1 is #32745 (field plumbing), PR 2 is #32747 (relay redirect handling + S256)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy from this branch on localhost:4010, two true_passthrough servers pointing at the real Linear MCP upstream: `linear_bridge` with `dcr_bridge: true` and `linear_plain` without. The relayed registration below hit Linear's real DCR endpoint and the authorize redirect targets Linear's real authorization server

1. First contact on the bridge server challenges with the GATEWAY's well-known (this is what lets a DCR-only client start discovery against us)

```
curl -si -X POST http://localhost:4010/linear_bridge/mcp -d '{"jsonrpc":"2.0","id":1,"method":"initialize",...}'
HTTP/1.1 401 Unauthorized
www-authenticate: Bearer resource_metadata="http://localhost:4010/.well-known/oauth-protected-resource/linear_bridge/mcp"
```

2. The gateway PRM is the facade: resource is the gateway URL the client dialed, so the RFC 9728 resource match passes

```
curl -s http://localhost:4010/.well-known/oauth-protected-resource/linear_bridge/mcp
{"authorization_servers":["http://localhost:4010/linear_bridge"],"resource":"http://localhost:4010/linear_bridge/mcp","scopes_supported":["read","write"]}
```

3. AS metadata serves the gateway's register, authorize, and token relays; the same request on the flagless server stays 404

```
curl -s http://localhost:4010/.well-known/oauth-authorization-server/linear_bridge/mcp
"authorization_endpoint": "http://localhost:4010/linear_bridge/authorize"
"token_endpoint": "http://localhost:4010/linear_bridge/token"
"registration_endpoint": "http://localhost:4010/linear_bridge/register"
```

4. Registration is relayed to the real upstream: Linear issued a real client_id for the client's own redirect URI

```
curl -s -X POST http://localhost:4010/linear_bridge/register -d '{"client_name":"litellm-bridge-e2e","redirect_uris":["https://claude.ai/api/mcp/auth_callback"],...}'
{'client_id': 'reYo70KW6a1P0VMd', 'redirect_uris': ['https://claude.ai/api/mcp/auth_callback'], 'token_endpoint_auth_method': 'none'}
```

5. The authorize relay 307s to Linear's real AS with the client's parameters verbatim, and rejects the PKCE downgrade

```
curl -si "http://localhost:4010/linear_bridge/authorize?client_id=reYo70KW6a1P0VMd&redirect_uri=https%3A%2F%2Fclaude.ai%2F...&code_challenge=...&code_challenge_method=S256"
location: https://mcp.linear.app/authorize?client_id=reYo70KW6a1P0VMd&redirect_uri=https%3A%2F%2Fclaude.ai%2Fapi%2Fmcp%2Fauth_callback&state=e2e-state&response_type=code&code_challenge=...&code_challenge_method=S256&scope=read+write

curl -s ".../authorize?client_id=...&redirect_uri=..." (no PKCE)
{"detail":{"error":"This server requires PKCE: send code_challenge with code_challenge_method=S256 on the authorization request"}} HTTP 400
```

6. The flag-off contract is untouched, byte for byte: `linear_plain` still relays Linear's own challenge and metadata verbatim

```
curl -si -X POST http://localhost:4010/linear_plain/mcp -d '{"jsonrpc":"2.0","id":1,"method":"initialize",...}'
www-authenticate: Bearer realm="OAuth", resource_metadata="https://mcp.linear.app/.well-known/oauth-protected-resource/mcp", error="invalid_token", ...
curl -s http://localhost:4010/.well-known/oauth-protected-resource/linear_plain/mcp
{"resource":"https://mcp.linear.app/mcp","authorization_servers":["https://mcp.linear.app"],...}
```

This is the complete DCR handshake a client like Claude Desktop performs, minus the human browser login at Linear. To finish the loop interactively: add `http://localhost:4010/linear_bridge/mcp` as a custom connector in Claude Desktop with Auto-register, sign in when Linear's page opens, and tools list

## Type

🆕 New Feature

## Changes

This PR turns the dcr_bridge flag on: with it set, a client-forwarded server serves a gateway-hosted OAuth front door so DCR-only MCP clients (Claude Desktop, claude.ai connectors, MCP Inspector) can register and sign in through the gateway. Without it, nothing changes; the verbatim upstream discovery contract that deployments with IdP-pre-registered clients rely on is pinned byte for byte by existing and new tests

Discovery: the protected-resource metadata builder returns the gateway facade for bridge servers (resource is the gateway URL the client dialed, authorization_servers names the gateway's per-server AS) instead of proxying upstream metadata, and the named-discovery gate admits bridge servers to the authorization-server metadata that advertises the register, authorize, and token relays. The 401 challenge paths follow: the true_passthrough missing-token preflight answers authoritatively with the gateway well-known and skips the upstream probe (the gateway is the AS here, so no round trip is needed), and the tools-listing challenge conversion strips a relayed upstream WWW-Authenticate for bridge servers so the fabricated gateway challenge takes over

Registration: the register relay gains a client_redirect_uris passthrough. In the bridge relay arm it registers the client's own redirect URIs upstream with public-client defaults (code and refresh grants, token_endpoint_auth_method none), relays the upstream response verbatim, requires redirect_uris, and never persists the result as the server's own DCR client, since a relayed registration belongs to one client and persisting it would hand every future caller the first client's identity

The token relay also logs an actionable hint when an upstream AS rejects the exchange with invalid_target (an AS that requires RFC 8707 resource indicators, tracked as LIT-4339)

Tests: gateway-facade PRM for both modes and both URL patterns with no upstream fetch, AS metadata served for bridge and still 404 for flagless, register relay forwarding and required redirect_uris and never-persist, challenge suppression on both listing conversion paths, the bridge preflight challenge with no upstream probe, and the flag-off preflight relay pin

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth discovery, registration relay, and 401 challenge behavior on the MCP proxy auth path; mistakes could break MCP client login or leak wrong IdP metadata, but scope is gated on `dcr_bridge` with extensive regression tests.
> 
> **Overview**
> When **`dcr_bridge`** is enabled on a client-forwarded MCP server, the gateway acts as the OAuth front door for DCR-only clients instead of proxying upstream discovery verbatim.
> 
> **Discovery** returns a gateway **protected-resource** facade (`resource` = the URL the client dialed, `authorization_servers` = the per-server gateway AS) and allows **authorization-server** well-known metadata for bridge servers. **401** paths use the gateway challenge: true_passthrough preflight skips the upstream probe and issues gateway well-known metadata; tool-listing strips upstream `WWW-Authenticate` so the route can fabricate the bridge challenge.
> 
> **Registration relay** forwards the client’s `redirect_uris` upstream with public-client defaults, requires `redirect_uris`, relays upstream errors via `_safe_upstream_error_detail`, and **does not** persist relayed registrations. Register routes pass through `client_redirect_uris` from the request body.
> 
> **Token relay** logs a warning when upstream returns `invalid_target` (RFC 8707 resource indicators, LIT-4339).
> 
> Servers without `dcr_bridge` keep prior behavior; tests lock the flag-off contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 849ceb0c19d5f40833b421097f8f5521f991df53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->