### PR TITLE
feat(models): refresh GitHub Copilot pricing and metadata

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -20873,257 +20873,297 @@
         ]
     },
     "github_copilot/claude-haiku-4.5": {
+        "cache_read_input_token_cost": 1e-7,
+        "input_cost_per_token": 0.000001,
+        "output_cost_per_token": 0.000005,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000125,
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
+        "max_input_tokens": 136000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/messages"
         ],
         "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_vision": true
-    },
-    "github_copilot/claude-opus-4.5": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
-        "mode": "chat",
-        "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/messages"
-        ],
-        "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
         "supports_vision": true,
-        "supports_output_config": true
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
-    "github_copilot/claude-opus-4.6-fast": {
+    "github_copilot/claude-opus-4.6": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.000025,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000625,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/messages",
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_adaptive_thinking": true
+    },
+    "github_copilot/claude-opus-4.7": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.000025,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000625,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/messages",
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
         "supports_adaptive_thinking": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/claude-opus-4.8": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.000025,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000625,
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
+            "/v1/messages",
             "/v1/chat/completions"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_adaptive_thinking": true,
+        "supports_xhigh_reasoning_effort": true
     },
-    "github_copilot/claude-opus-41": {
+    "github_copilot/claude-opus-5": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.000025,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000625,
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 80000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions"
-        ],
-        "supports_vision": true
-    },
-    "github_copilot/claude-sonnet-4": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
-        "mode": "chat",
-        "supported_endpoints": [
+            "/v1/messages",
             "/v1/chat/completions"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_adaptive_thinking": true,
+        "supports_xhigh_reasoning_effort": true
     },
-    "github_copilot/claude-sonnet-4.5": {
+    "github_copilot/claude-sonnet-4.6": {
+        "cache_read_input_token_cost": 3e-7,
+        "input_cost_per_token": 0.000003,
+        "output_cost_per_token": 0.000015,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000375,
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/messages"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_adaptive_thinking": true
+    },
+    "github_copilot/claude-sonnet-5": {
+        "cache_read_input_token_cost": 2e-7,
+        "input_cost_per_token": 0.000002,
+        "output_cost_per_token": 0.00001,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.0000025,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/messages",
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_adaptive_thinking": true,
+        "supports_xhigh_reasoning_effort": true
     },
     "github_copilot/gemini-2.5-pro": {
+        "cache_read_input_token_cost": 1.25e-7,
+        "input_cost_per_token": 0.00000125,
+        "output_cost_per_token": 0.00001,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
-    "github_copilot/gemini-3-pro-preview": {
+    "github_copilot/gemini-3-flash-preview": {
+        "cache_read_input_token_cost": 5e-8,
+        "input_cost_per_token": 5e-7,
+        "output_cost_per_token": 0.000003,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
-    "github_copilot/gpt-3.5-turbo": {
+    "github_copilot/gemini-3.1-pro-preview": {
+        "cache_read_input_token_cost": 2e-7,
+        "input_cost_per_token": 0.000002,
+        "output_cost_per_token": 0.000012,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+        "input_cost_per_token_above_200k_tokens": 0.000004,
+        "output_cost_per_token_above_200k_tokens": 0.000018,
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 16384,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true
-    },
-    "github_copilot/gpt-3.5-turbo-0613": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 16384,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true
-    },
-    "github_copilot/gpt-4": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 32768,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true
-    },
-    "github_copilot/gpt-4-0613": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 32768,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true
-    },
-    "github_copilot/gpt-4-o-preview": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true
-    },
-    "github_copilot/gpt-4.1": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-4.1-2025-04-14": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-41-copilot": {
-        "litellm_provider": "github_copilot",
-        "mode": "completion"
-    },
-    "github_copilot/gpt-4o": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-4o-2024-05-13": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-4o-2024-08-06": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true
-    },
-    "github_copilot/gpt-4o-2024-11-20": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-4o-mini": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true
-    },
-    "github_copilot/gpt-4o-mini-2024-07-18": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true
-    },
-    "github_copilot/gpt-5": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/responses"
+            "/v1/chat/completions"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
+    },
+    "github_copilot/gemini-3.5-flash": {
+        "cache_read_input_token_cost": 1.5e-7,
+        "input_cost_per_token": 0.0000015,
+        "output_cost_per_token": 0.000009,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
+    },
+    "github_copilot/gemini-3.6-flash": {
+        "cache_read_input_token_cost": 7.5e-8,
+        "input_cost_per_token": 7.5e-7,
+        "output_cost_per_token": 0.00000375,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
+    },
+    "github_copilot/gemini-3.7-flash": {
+        "cache_read_input_token_cost": 7.5e-8,
+        "input_cost_per_token": 7.5e-7,
+        "output_cost_per_token": 0.00000375,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
     "github_copilot/gpt-5-mini": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-5.1": {
+        "cache_read_input_token_cost": 2.5e-8,
+        "input_cost_per_token": 2.5e-7,
+        "output_cost_per_token": 0.000002,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 64000,
@@ -21134,40 +21174,215 @@
             "/v1/responses"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
         "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-5.1-codex-max": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "responses",
-        "supported_endpoints": [
-            "/v1/responses"
-        ],
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-5.2": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/responses"
-        ],
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
     "github_copilot/gpt-5.3-codex": {
+        "cache_read_input_token_cost": 1.75e-7,
+        "input_cost_per_token": 0.00000175,
+        "output_cost_per_token": 0.000014,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.4": {
+        "cache_read_input_token_cost": 2.5e-7,
+        "input_cost_per_token": 0.0000025,
+        "output_cost_per_token": 0.000015,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_272k_tokens": 5e-7,
+        "input_cost_per_token_above_272k_tokens": 0.000005,
+        "output_cost_per_token_above_272k_tokens": 0.0000225,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 922000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/responses",
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.4-mini": {
+        "cache_read_input_token_cost": 7.5e-8,
+        "input_cost_per_token": 7.5e-7,
+        "output_cost_per_token": 0.0000045,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.5": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.00003,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_272k_tokens": 0.000001,
+        "input_cost_per_token_above_272k_tokens": 0.00001,
+        "output_cost_per_token_above_272k_tokens": 0.000045,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 922000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.6-luna": {
+        "cache_read_input_token_cost": 2e-8,
+        "input_cost_per_token": 2e-7,
+        "output_cost_per_token": 0.0000012,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_200k_tokens": 4e-8,
+        "input_cost_per_token_above_200k_tokens": 4e-7,
+        "output_cost_per_token_above_200k_tokens": 0.0000018,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 922000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.6-sol": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.00003,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_272k_tokens": 0.000001,
+        "input_cost_per_token_above_272k_tokens": 0.00001,
+        "output_cost_per_token_above_272k_tokens": 0.000045,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 922000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.6-terra": {
+        "cache_read_input_token_cost": 2e-7,
+        "input_cost_per_token": 0.000002,
+        "output_cost_per_token": 0.000012,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_272k_tokens": 4e-7,
+        "input_cost_per_token_above_272k_tokens": 0.000004,
+        "output_cost_per_token_above_272k_tokens": 0.000018,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 922000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/grok-4.5": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000002,
+        "output_cost_per_token": 0.000006,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_200k_tokens": 0.000001,
+        "input_cost_per_token_above_200k_tokens": 0.000004,
+        "output_cost_per_token_above_200k_tokens": 0.000012,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 372000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true
+    },
+    "github_copilot/mai-code-1.1-flash": {
+        "cache_read_input_token_cost": 2e-8,
+        "input_cost_per_token": 2e-7,
+        "output_cost_per_token": 0.0000012,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 2.5e-7,
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -21177,41 +21392,31 @@
             "/v1/responses"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
         "supports_response_schema": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
-    "github_copilot/mai-code-1-flash": {
-        "cache_read_input_token_cost": 7.5e-08,
-        "input_cost_per_token": 7.5e-07,
+    "github_copilot/mai-code-1-flash-picker": {
+        "cache_read_input_token_cost": 7.5e-8,
+        "input_cost_per_token": 7.5e-7,
+        "output_cost_per_token": 0.0000045,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 4.5e-06,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
         "supported_endpoints": [
-            "/v1/chat/completions"
+            "/v1/responses"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true
-    },
-    "github_copilot/mai-code-1-flash-internal": {
-        "cache_read_input_token_cost": 7.5e-08,
-        "input_cost_per_token": 7.5e-07,
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 4.5e-06,
-        "supported_endpoints": [
-            "/v1/chat/completions"
-        ],
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supports_reasoning": true
     },
     "github_copilot/text-embedding-3-small": {
         "litellm_provider": "github_copilot",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -20873,257 +20873,277 @@
         ]
     },
     "github_copilot/claude-haiku-4.5": {
+        "cache_read_input_token_cost": 1e-7,
+        "input_cost_per_token": 0.000001,
+        "output_cost_per_token": 0.000005,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000125,
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
+        "max_input_tokens": 136000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/messages"
         ],
         "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_vision": true
-    },
-    "github_copilot/claude-opus-4.5": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
-        "mode": "chat",
-        "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/messages"
-        ],
-        "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
         "supports_vision": true,
-        "supports_output_config": true
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
-    "github_copilot/claude-opus-4.6-fast": {
+    "github_copilot/claude-opus-4.6": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.000025,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000625,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/messages",
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_adaptive_thinking": true
+    },
+    "github_copilot/claude-opus-4.7": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.000025,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000625,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/messages",
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
         "supports_adaptive_thinking": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/claude-opus-4.8": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.000025,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000625,
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
+            "/v1/messages",
             "/v1/chat/completions"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_adaptive_thinking": true,
+        "supports_xhigh_reasoning_effort": true
     },
-    "github_copilot/claude-opus-41": {
+    "github_copilot/claude-opus-5": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.000025,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000625,
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 80000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions"
-        ],
-        "supports_vision": true
-    },
-    "github_copilot/claude-sonnet-4": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
-        "mode": "chat",
-        "supported_endpoints": [
+            "/v1/messages",
             "/v1/chat/completions"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_adaptive_thinking": true,
+        "supports_xhigh_reasoning_effort": true
     },
-    "github_copilot/claude-sonnet-4.5": {
+    "github_copilot/claude-sonnet-4.6": {
+        "cache_read_input_token_cost": 3e-7,
+        "input_cost_per_token": 0.000003,
+        "output_cost_per_token": 0.000015,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000375,
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/messages"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_adaptive_thinking": true
+    },
+    "github_copilot/claude-sonnet-5": {
+        "cache_read_input_token_cost": 2e-7,
+        "input_cost_per_token": 0.000002,
+        "output_cost_per_token": 0.00001,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.0000025,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/messages",
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_adaptive_thinking": true,
+        "supports_xhigh_reasoning_effort": true
     },
     "github_copilot/gemini-2.5-pro": {
+        "cache_read_input_token_cost": 1.25e-7,
+        "input_cost_per_token": 0.00000125,
+        "output_cost_per_token": 0.00001,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
-    "github_copilot/gemini-3-pro-preview": {
+    "github_copilot/gemini-3-flash-preview": {
+        "cache_read_input_token_cost": 5e-8,
+        "input_cost_per_token": 5e-7,
+        "output_cost_per_token": 0.000003,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
-    "github_copilot/gpt-3.5-turbo": {
+    "github_copilot/gemini-3.1-pro-preview": {
+        "cache_read_input_token_cost": 2e-7,
+        "input_cost_per_token": 0.000002,
+        "output_cost_per_token": 0.000012,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+        "input_cost_per_token_above_200k_tokens": 0.000004,
+        "output_cost_per_token_above_200k_tokens": 0.000018,
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 16384,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true
-    },
-    "github_copilot/gpt-3.5-turbo-0613": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 16384,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true
-    },
-    "github_copilot/gpt-4": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 32768,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true
-    },
-    "github_copilot/gpt-4-0613": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 32768,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true
-    },
-    "github_copilot/gpt-4-o-preview": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true
-    },
-    "github_copilot/gpt-4.1": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-4.1-2025-04-14": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-41-copilot": {
-        "litellm_provider": "github_copilot",
-        "mode": "completion"
-    },
-    "github_copilot/gpt-4o": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-4o-2024-05-13": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-4o-2024-08-06": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true
-    },
-    "github_copilot/gpt-4o-2024-11-20": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-4o-mini": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true
-    },
-    "github_copilot/gpt-4o-mini-2024-07-18": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true
-    },
-    "github_copilot/gpt-5": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/responses"
+            "/v1/chat/completions"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
+    },
+    "github_copilot/gemini-3.5-flash": {
+        "cache_read_input_token_cost": 1.5e-7,
+        "input_cost_per_token": 0.0000015,
+        "output_cost_per_token": 0.000009,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
+    },
+    "github_copilot/gemini-3.6-flash": {
+        "cache_read_input_token_cost": 1.5e-7,
+        "input_cost_per_token": 0.0000015,
+        "output_cost_per_token": 0.0000075,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
     "github_copilot/gpt-5-mini": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-5.1": {
+        "cache_read_input_token_cost": 2.5e-8,
+        "input_cost_per_token": 2.5e-7,
+        "output_cost_per_token": 0.000002,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 64000,
@@ -21134,40 +21154,214 @@
             "/v1/responses"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
         "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-5.1-codex-max": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "responses",
-        "supported_endpoints": [
-            "/v1/responses"
-        ],
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-5.2": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/responses"
-        ],
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
     "github_copilot/gpt-5.3-codex": {
+        "cache_read_input_token_cost": 1.75e-7,
+        "input_cost_per_token": 0.00000175,
+        "output_cost_per_token": 0.000014,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.4": {
+        "cache_read_input_token_cost": 2.5e-7,
+        "input_cost_per_token": 0.0000025,
+        "output_cost_per_token": 0.000015,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_272k_tokens": 5e-7,
+        "input_cost_per_token_above_272k_tokens": 0.000005,
+        "output_cost_per_token_above_272k_tokens": 0.0000225,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 922000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/responses",
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.4-mini": {
+        "cache_read_input_token_cost": 7.5e-8,
+        "input_cost_per_token": 7.5e-7,
+        "output_cost_per_token": 0.0000045,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.5": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.00003,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_272k_tokens": 0.000001,
+        "input_cost_per_token_above_272k_tokens": 0.00001,
+        "output_cost_per_token_above_272k_tokens": 0.000045,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 922000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.6-luna": {
+        "cache_read_input_token_cost": 2e-8,
+        "input_cost_per_token": 2e-7,
+        "output_cost_per_token": 0.0000012,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_200k_tokens": 4e-8,
+        "input_cost_per_token_above_200k_tokens": 4e-7,
+        "output_cost_per_token_above_200k_tokens": 0.0000018,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 922000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.6-sol": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.00003,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_272k_tokens": 0.000001,
+        "input_cost_per_token_above_272k_tokens": 0.00001,
+        "output_cost_per_token_above_272k_tokens": 0.000045,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 922000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.6-terra": {
+        "cache_read_input_token_cost": 2e-7,
+        "input_cost_per_token": 0.000002,
+        "output_cost_per_token": 0.000012,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_272k_tokens": 4e-7,
+        "input_cost_per_token_above_272k_tokens": 0.000004,
+        "output_cost_per_token_above_272k_tokens": 0.000018,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 922000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/grok-4.5": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000002,
+        "output_cost_per_token": 0.000006,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_200k_tokens": 0.000001,
+        "input_cost_per_token_above_200k_tokens": 0.000004,
+        "output_cost_per_token_above_200k_tokens": 0.000012,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 372000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true
+    },
+    "github_copilot/mai-code-1-flash-picker": {
+        "cache_read_input_token_cost": 7.5e-8,
+        "input_cost_per_token": 7.5e-7,
+        "output_cost_per_token": 0.0000045,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -21177,41 +21371,10 @@
             "/v1/responses"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
         "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/mai-code-1-flash": {
-        "cache_read_input_token_cost": 7.5e-08,
-        "input_cost_per_token": 7.5e-07,
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 4.5e-06,
-        "supported_endpoints": [
-            "/v1/chat/completions"
-        ],
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true
-    },
-    "github_copilot/mai-code-1-flash-internal": {
-        "cache_read_input_token_cost": 7.5e-08,
-        "input_cost_per_token": 7.5e-07,
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 4.5e-06,
-        "supported_endpoints": [
-            "/v1/chat/completions"
-        ],
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true
+        "supports_reasoning": true
     },
     "github_copilot/text-embedding-3-small": {
         "litellm_provider": "github_copilot",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -20951,254 +20951,297 @@
         ]
     },
     "github_copilot/claude-haiku-4.5": {
+        "cache_read_input_token_cost": 1e-7,
+        "input_cost_per_token": 0.000001,
+        "output_cost_per_token": 0.000005,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000125,
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
+        "max_input_tokens": 136000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions"
+            "/v1/chat/completions",
+            "/v1/messages"
         ],
         "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_vision": true
-    },
-    "github_copilot/claude-opus-4.5": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
-        "mode": "chat",
-        "supported_endpoints": [
-            "/v1/chat/completions"
-        ],
-        "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
         "supports_vision": true,
-        "supports_output_config": true
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
-    "github_copilot/claude-opus-4.6-fast": {
+    "github_copilot/claude-opus-4.6": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.000025,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000625,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/messages",
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_adaptive_thinking": true
+    },
+    "github_copilot/claude-opus-4.7": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.000025,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000625,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/messages",
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
         "supports_adaptive_thinking": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/claude-opus-4.8": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.000025,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000625,
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
+            "/v1/messages",
             "/v1/chat/completions"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_adaptive_thinking": true,
+        "supports_xhigh_reasoning_effort": true
     },
-    "github_copilot/claude-opus-41": {
+    "github_copilot/claude-opus-5": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.000025,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000625,
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 80000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions"
-        ],
-        "supports_vision": true
-    },
-    "github_copilot/claude-sonnet-4": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
-        "mode": "chat",
-        "supported_endpoints": [
-            "/v1/chat/completions"
-        ],
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_vision": true
-    },
-    "github_copilot/claude-sonnet-4.5": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
-        "mode": "chat",
-        "supported_endpoints": [
+            "/v1/messages",
             "/v1/chat/completions"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_adaptive_thinking": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/claude-sonnet-4.6": {
+        "cache_read_input_token_cost": 3e-7,
+        "input_cost_per_token": 0.000003,
+        "output_cost_per_token": 0.000015,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000375,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_adaptive_thinking": true
+    },
+    "github_copilot/claude-sonnet-5": {
+        "cache_read_input_token_cost": 2e-7,
+        "input_cost_per_token": 0.000002,
+        "output_cost_per_token": 0.00001,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.0000025,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/messages",
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_adaptive_thinking": true,
+        "supports_xhigh_reasoning_effort": true
     },
     "github_copilot/gemini-2.5-pro": {
+        "cache_read_input_token_cost": 1.25e-7,
+        "input_cost_per_token": 0.00000125,
+        "output_cost_per_token": 0.00001,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
-    "github_copilot/gemini-3-pro-preview": {
+    "github_copilot/gemini-3-flash-preview": {
+        "cache_read_input_token_cost": 5e-8,
+        "input_cost_per_token": 5e-7,
+        "output_cost_per_token": 0.000003,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
-    "github_copilot/gpt-3.5-turbo": {
+    "github_copilot/gemini-3.1-pro-preview": {
+        "cache_read_input_token_cost": 2e-7,
+        "input_cost_per_token": 0.000002,
+        "output_cost_per_token": 0.000012,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+        "input_cost_per_token_above_200k_tokens": 0.000004,
+        "output_cost_per_token_above_200k_tokens": 0.000018,
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 16384,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true
-    },
-    "github_copilot/gpt-3.5-turbo-0613": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 16384,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true
-    },
-    "github_copilot/gpt-4": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 32768,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true
-    },
-    "github_copilot/gpt-4-0613": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 32768,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true
-    },
-    "github_copilot/gpt-4-o-preview": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true
-    },
-    "github_copilot/gpt-4.1": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-4.1-2025-04-14": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-41-copilot": {
-        "litellm_provider": "github_copilot",
-        "mode": "completion"
-    },
-    "github_copilot/gpt-4o": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-4o-2024-05-13": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-4o-2024-08-06": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true
-    },
-    "github_copilot/gpt-4o-2024-11-20": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-4o-mini": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true
-    },
-    "github_copilot/gpt-4o-mini-2024-07-18": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true
-    },
-    "github_copilot/gpt-5": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/responses"
+            "/v1/chat/completions"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
+    },
+    "github_copilot/gemini-3.5-flash": {
+        "cache_read_input_token_cost": 1.5e-7,
+        "input_cost_per_token": 0.0000015,
+        "output_cost_per_token": 0.000009,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
+    },
+    "github_copilot/gemini-3.6-flash": {
+        "cache_read_input_token_cost": 7.5e-8,
+        "input_cost_per_token": 7.5e-7,
+        "output_cost_per_token": 0.00000375,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
+    },
+    "github_copilot/gemini-3.7-flash": {
+        "cache_read_input_token_cost": 7.5e-8,
+        "input_cost_per_token": 7.5e-7,
+        "output_cost_per_token": 0.00000375,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
     "github_copilot/gpt-5-mini": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-5.1": {
+        "cache_read_input_token_cost": 2.5e-8,
+        "input_cost_per_token": 2.5e-7,
+        "output_cost_per_token": 0.000002,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 64000,
@@ -21209,40 +21252,215 @@
             "/v1/responses"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
         "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-5.1-codex-max": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "responses",
-        "supported_endpoints": [
-            "/v1/responses"
-        ],
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-5.2": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/responses"
-        ],
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
     "github_copilot/gpt-5.3-codex": {
+        "cache_read_input_token_cost": 1.75e-7,
+        "input_cost_per_token": 0.00000175,
+        "output_cost_per_token": 0.000014,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.4": {
+        "cache_read_input_token_cost": 2.5e-7,
+        "input_cost_per_token": 0.0000025,
+        "output_cost_per_token": 0.000015,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_272k_tokens": 5e-7,
+        "input_cost_per_token_above_272k_tokens": 0.000005,
+        "output_cost_per_token_above_272k_tokens": 0.0000225,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 922000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/responses",
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.4-mini": {
+        "cache_read_input_token_cost": 7.5e-8,
+        "input_cost_per_token": 7.5e-7,
+        "output_cost_per_token": 0.0000045,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.5": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.00003,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_272k_tokens": 0.000001,
+        "input_cost_per_token_above_272k_tokens": 0.00001,
+        "output_cost_per_token_above_272k_tokens": 0.000045,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 922000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.6-luna": {
+        "cache_read_input_token_cost": 2e-8,
+        "input_cost_per_token": 2e-7,
+        "output_cost_per_token": 0.0000012,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_200k_tokens": 4e-8,
+        "input_cost_per_token_above_200k_tokens": 4e-7,
+        "output_cost_per_token_above_200k_tokens": 0.0000018,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 922000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.6-sol": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.00003,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_272k_tokens": 0.000001,
+        "input_cost_per_token_above_272k_tokens": 0.00001,
+        "output_cost_per_token_above_272k_tokens": 0.000045,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 922000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.6-terra": {
+        "cache_read_input_token_cost": 2e-7,
+        "input_cost_per_token": 0.000002,
+        "output_cost_per_token": 0.000012,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_272k_tokens": 4e-7,
+        "input_cost_per_token_above_272k_tokens": 0.000004,
+        "output_cost_per_token_above_272k_tokens": 0.000018,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 922000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/grok-4.5": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000002,
+        "output_cost_per_token": 0.000006,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_200k_tokens": 0.000001,
+        "input_cost_per_token_above_200k_tokens": 0.000004,
+        "output_cost_per_token_above_200k_tokens": 0.000012,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 372000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true
+    },
+    "github_copilot/mai-code-1.1-flash": {
+        "cache_read_input_token_cost": 2e-8,
+        "input_cost_per_token": 2e-7,
+        "output_cost_per_token": 0.0000012,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 2.5e-7,
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -21252,41 +21470,31 @@
             "/v1/responses"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
         "supports_response_schema": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
-    "github_copilot/mai-code-1-flash": {
-        "cache_read_input_token_cost": 7.5e-08,
-        "input_cost_per_token": 7.5e-07,
+    "github_copilot/mai-code-1-flash-picker": {
+        "cache_read_input_token_cost": 7.5e-8,
+        "input_cost_per_token": 7.5e-7,
+        "output_cost_per_token": 0.0000045,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 4.5e-06,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
         "supported_endpoints": [
-            "/v1/chat/completions"
+            "/v1/responses"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true
-    },
-    "github_copilot/mai-code-1-flash-internal": {
-        "cache_read_input_token_cost": 7.5e-08,
-        "input_cost_per_token": 7.5e-07,
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 4.5e-06,
-        "supported_endpoints": [
-            "/v1/chat/completions"
-        ],
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true
+        "supports_response_schema": true,
+        "supports_reasoning": true
     },
     "github_copilot/text-embedding-3-small": {
         "litellm_provider": "github_copilot",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -20951,254 +20951,277 @@
         ]
     },
     "github_copilot/claude-haiku-4.5": {
+        "cache_read_input_token_cost": 1e-7,
+        "input_cost_per_token": 0.000001,
+        "output_cost_per_token": 0.000005,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000125,
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
+        "max_input_tokens": 136000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions"
+            "/v1/chat/completions",
+            "/v1/messages"
         ],
         "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_vision": true
-    },
-    "github_copilot/claude-opus-4.5": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
-        "mode": "chat",
-        "supported_endpoints": [
-            "/v1/chat/completions"
-        ],
-        "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
         "supports_vision": true,
-        "supports_output_config": true
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
-    "github_copilot/claude-opus-4.6-fast": {
+    "github_copilot/claude-opus-4.6": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.000025,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000625,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/messages",
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_adaptive_thinking": true
+    },
+    "github_copilot/claude-opus-4.7": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.000025,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000625,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/messages",
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
         "supports_adaptive_thinking": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/claude-opus-4.8": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.000025,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000625,
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
+            "/v1/messages",
             "/v1/chat/completions"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_adaptive_thinking": true,
+        "supports_xhigh_reasoning_effort": true
     },
-    "github_copilot/claude-opus-41": {
+    "github_copilot/claude-opus-5": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.000025,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000625,
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 80000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions"
-        ],
-        "supports_vision": true
-    },
-    "github_copilot/claude-sonnet-4": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
-        "mode": "chat",
-        "supported_endpoints": [
-            "/v1/chat/completions"
-        ],
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_vision": true
-    },
-    "github_copilot/claude-sonnet-4.5": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16000,
-        "max_tokens": 16000,
-        "mode": "chat",
-        "supported_endpoints": [
+            "/v1/messages",
             "/v1/chat/completions"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_adaptive_thinking": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/claude-sonnet-4.6": {
+        "cache_read_input_token_cost": 3e-7,
+        "input_cost_per_token": 0.000003,
+        "output_cost_per_token": 0.000015,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.00000375,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/messages"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_adaptive_thinking": true
+    },
+    "github_copilot/claude-sonnet-5": {
+        "cache_read_input_token_cost": 2e-7,
+        "input_cost_per_token": 0.000002,
+        "output_cost_per_token": 0.00001,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_creation_input_token_cost": 0.0000025,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/messages",
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_adaptive_thinking": true,
+        "supports_xhigh_reasoning_effort": true
     },
     "github_copilot/gemini-2.5-pro": {
+        "cache_read_input_token_cost": 1.25e-7,
+        "input_cost_per_token": 0.00000125,
+        "output_cost_per_token": 0.00001,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
-    "github_copilot/gemini-3-pro-preview": {
+    "github_copilot/gemini-3-flash-preview": {
+        "cache_read_input_token_cost": 5e-8,
+        "input_cost_per_token": 5e-7,
+        "output_cost_per_token": 0.000003,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 64000,
         "max_tokens": 64000,
         "mode": "chat",
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
-    "github_copilot/gpt-3.5-turbo": {
+    "github_copilot/gemini-3.1-pro-preview": {
+        "cache_read_input_token_cost": 2e-7,
+        "input_cost_per_token": 0.000002,
+        "output_cost_per_token": 0.000012,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+        "input_cost_per_token_above_200k_tokens": 0.000004,
+        "output_cost_per_token_above_200k_tokens": 0.000018,
         "litellm_provider": "github_copilot",
-        "max_input_tokens": 16384,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true
-    },
-    "github_copilot/gpt-3.5-turbo-0613": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 16384,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true
-    },
-    "github_copilot/gpt-4": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 32768,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true
-    },
-    "github_copilot/gpt-4-0613": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 32768,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true
-    },
-    "github_copilot/gpt-4-o-preview": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true
-    },
-    "github_copilot/gpt-4.1": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-4.1-2025-04-14": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-41-copilot": {
-        "litellm_provider": "github_copilot",
-        "mode": "completion"
-    },
-    "github_copilot/gpt-4o": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-4o-2024-05-13": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-4o-2024-08-06": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true
-    },
-    "github_copilot/gpt-4o-2024-11-20": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-4o-mini": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true
-    },
-    "github_copilot/gpt-4o-mini-2024-07-18": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 64000,
-        "max_output_tokens": 4096,
-        "max_tokens": 4096,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true
-    },
-    "github_copilot/gpt-5": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/responses"
+            "/v1/chat/completions"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
+    },
+    "github_copilot/gemini-3.5-flash": {
+        "cache_read_input_token_cost": 1.5e-7,
+        "input_cost_per_token": 0.0000015,
+        "output_cost_per_token": 0.000009,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
+    },
+    "github_copilot/gemini-3.6-flash": {
+        "cache_read_input_token_cost": 1.5e-7,
+        "input_cost_per_token": 0.0000015,
+        "output_cost_per_token": 0.0000075,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 936000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
     "github_copilot/gpt-5-mini": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-5.1": {
+        "cache_read_input_token_cost": 2.5e-8,
+        "input_cost_per_token": 2.5e-7,
+        "output_cost_per_token": 0.000002,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 64000,
@@ -21209,40 +21232,214 @@
             "/v1/responses"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
         "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-5.1-codex-max": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
-        "mode": "responses",
-        "supported_endpoints": [
-            "/v1/responses"
-        ],
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/gpt-5.2": {
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/responses"
-        ],
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true
     },
     "github_copilot/gpt-5.3-codex": {
+        "cache_read_input_token_cost": 1.75e-7,
+        "input_cost_per_token": 0.00000175,
+        "output_cost_per_token": 0.000014,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.4": {
+        "cache_read_input_token_cost": 2.5e-7,
+        "input_cost_per_token": 0.0000025,
+        "output_cost_per_token": 0.000015,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_272k_tokens": 5e-7,
+        "input_cost_per_token_above_272k_tokens": 0.000005,
+        "output_cost_per_token_above_272k_tokens": 0.0000225,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 922000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "supported_endpoints": [
+            "/v1/responses",
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.4-mini": {
+        "cache_read_input_token_cost": 7.5e-8,
+        "input_cost_per_token": 7.5e-7,
+        "output_cost_per_token": 0.0000045,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.5": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.00003,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_272k_tokens": 0.000001,
+        "input_cost_per_token_above_272k_tokens": 0.00001,
+        "output_cost_per_token_above_272k_tokens": 0.000045,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 922000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_pdf_input": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.6-luna": {
+        "cache_read_input_token_cost": 2e-8,
+        "input_cost_per_token": 2e-7,
+        "output_cost_per_token": 0.0000012,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_200k_tokens": 4e-8,
+        "input_cost_per_token_above_200k_tokens": 4e-7,
+        "output_cost_per_token_above_200k_tokens": 0.0000018,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 922000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.6-sol": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000005,
+        "output_cost_per_token": 0.00003,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_272k_tokens": 0.000001,
+        "input_cost_per_token_above_272k_tokens": 0.00001,
+        "output_cost_per_token_above_272k_tokens": 0.000045,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 922000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/gpt-5.6-terra": {
+        "cache_read_input_token_cost": 2e-7,
+        "input_cost_per_token": 0.000002,
+        "output_cost_per_token": 0.000012,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_272k_tokens": 4e-7,
+        "input_cost_per_token_above_272k_tokens": 0.000004,
+        "output_cost_per_token_above_272k_tokens": 0.000018,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 922000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true
+    },
+    "github_copilot/grok-4.5": {
+        "cache_read_input_token_cost": 5e-7,
+        "input_cost_per_token": 0.000002,
+        "output_cost_per_token": 0.000006,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
+        "cache_read_input_token_cost_above_200k_tokens": 0.000001,
+        "input_cost_per_token_above_200k_tokens": 0.000004,
+        "output_cost_per_token_above_200k_tokens": 0.000012,
+        "litellm_provider": "github_copilot",
+        "max_input_tokens": 372000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true
+    },
+    "github_copilot/mai-code-1-flash-picker": {
+        "cache_read_input_token_cost": 7.5e-8,
+        "input_cost_per_token": 7.5e-7,
+        "output_cost_per_token": 0.0000045,
+        "source": "https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing",
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 128000,
@@ -21252,41 +21449,10 @@
             "/v1/responses"
         ],
         "supports_function_calling": true,
+        "supports_tool_choice": true,
         "supports_parallel_function_calling": true,
         "supports_response_schema": true,
-        "supports_vision": true
-    },
-    "github_copilot/mai-code-1-flash": {
-        "cache_read_input_token_cost": 7.5e-08,
-        "input_cost_per_token": 7.5e-07,
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 4.5e-06,
-        "supported_endpoints": [
-            "/v1/chat/completions"
-        ],
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true
-    },
-    "github_copilot/mai-code-1-flash-internal": {
-        "cache_read_input_token_cost": 7.5e-08,
-        "input_cost_per_token": 7.5e-07,
-        "litellm_provider": "github_copilot",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 64000,
-        "max_tokens": 64000,
-        "mode": "chat",
-        "output_cost_per_token": 4.5e-06,
-        "supported_endpoints": [
-            "/v1/chat/completions"
-        ],
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true
+        "supports_reasoning": true
     },
     "github_copilot/text-embedding-3-small": {
         "litellm_provider": "github_copilot",

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -184,11 +184,10 @@ def test_openrouter_qwen36_plus_model_info():
 @pytest.mark.parametrize(
     "model",
     [
-        "github_copilot/mai-code-1-flash",
-        "github_copilot/mai-code-1-flash-internal",
+        "github_copilot/mai-code-1-flash-picker",
     ],
 )
-def test_github_copilot_mai_code_1_flash_pricing(model):
+def test_github_copilot_mai_code_1_flash_picker_pricing(model):
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")
 
@@ -196,11 +195,11 @@ def test_github_copilot_mai_code_1_flash_pricing(model):
 
     assert model_info is not None, f"Missing model pricing entry: {model}"
     assert model_info["litellm_provider"] == "github_copilot"
-    assert model_info["mode"] == "chat"
+    assert model_info["mode"] == "responses"
     assert model_info["input_cost_per_token"] == 7.5e-07
     assert model_info["cache_read_input_token_cost"] == 7.5e-08
     assert model_info["output_cost_per_token"] == 4.5e-06
-    assert model_info["supported_endpoints"] == ["/v1/chat/completions"]
+    assert model_info["supported_endpoints"] == ["/v1/responses"]
 
     prompt_usd, completion_usd = cost_per_token(
         model=model,
@@ -216,6 +215,110 @@ def test_github_copilot_mai_code_1_flash_pricing(model):
 
     assert prompt_usd == pytest.approx((800 * 7.5e-07) + (200 * 7.5e-08))
     assert completion_usd == pytest.approx(500 * 4.5e-06)
+
+
+def test_github_copilot_claude_opus_5_pricing():
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    model = "github_copilot/claude-opus-5"
+    model_info = litellm.model_cost.get(model)
+
+    assert model_info is not None, f"Missing model pricing entry: {model}"
+    assert model_info["litellm_provider"] == "github_copilot"
+    assert model_info["mode"] == "chat"
+    assert model_info["max_input_tokens"] == 936000
+    assert model_info["max_output_tokens"] == 64000
+    assert model_info["input_cost_per_token"] == 5e-06
+    assert model_info["cache_read_input_token_cost"] == 5e-07
+    assert model_info["cache_creation_input_token_cost"] == 6.25e-06
+    assert model_info["output_cost_per_token"] == 2.5e-05
+    assert model_info["supported_endpoints"] == [
+        "/v1/messages",
+        "/v1/chat/completions",
+    ]
+    assert model_info["supports_adaptive_thinking"] is True
+    assert model_info["supports_xhigh_reasoning_effort"] is True
+
+    prompt_usd, completion_usd = cost_per_token(
+        model=model,
+        prompt_tokens=1000,
+        completion_tokens=500,
+        custom_llm_provider="github_copilot",
+        usage_object=Usage(
+            prompt_tokens=1000,
+            completion_tokens=500,
+            prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=200),
+        ),
+    )
+
+    assert prompt_usd == pytest.approx((800 * 5e-06) + (200 * 5e-07))
+    assert completion_usd == pytest.approx(500 * 2.5e-05)
+
+
+@pytest.mark.parametrize(
+    (
+        "model,threshold,max_input_tokens,input_cost,cache_read_cost,output_cost,"
+        "long_input_cost,long_cache_read_cost,long_output_cost"
+    ),
+    [
+        ("github_copilot/gpt-5.6-luna", 200000, 922000, 2e-7, 2e-8, 1.2e-6, 4e-7, 4e-8, 1.8e-6),
+        ("github_copilot/gpt-5.6-terra", 272000, 922000, 2e-6, 2e-7, 1.2e-5, 4e-6, 4e-7, 1.8e-5),
+        ("github_copilot/grok-4.5", 200000, 372000, 2e-6, 5e-7, 6e-6, 4e-6, 1e-6, 1.2e-5),
+    ],
+)
+def test_github_copilot_tiered_pricing(
+    model: str,
+    threshold: int,
+    max_input_tokens: int,
+    input_cost: float,
+    cache_read_cost: float,
+    output_cost: float,
+    long_input_cost: float,
+    long_cache_read_cost: float,
+    long_output_cost: float,
+):
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    model_info = litellm.model_cost.get(model)
+    threshold_suffix = f"above_{threshold // 1000}k_tokens"
+
+    assert model_info is not None, f"Missing model pricing entry: {model}"
+    assert model_info["litellm_provider"] == "github_copilot"
+    assert model_info["mode"] == "responses"
+    assert model_info["max_input_tokens"] == max_input_tokens
+    assert model_info["max_output_tokens"] == 128000
+    assert model_info["input_cost_per_token"] == input_cost
+    assert model_info["cache_read_input_token_cost"] == cache_read_cost
+    assert model_info["output_cost_per_token"] == output_cost
+    assert model_info[f"input_cost_per_token_{threshold_suffix}"] == long_input_cost
+    assert model_info[f"cache_read_input_token_cost_{threshold_suffix}"] == long_cache_read_cost
+    assert model_info[f"output_cost_per_token_{threshold_suffix}"] == long_output_cost
+    assert model_info["supported_endpoints"] == ["/v1/responses"]
+    assert model_info["supports_response_schema"] is True
+    assert model_info["supports_vision"] is True
+    assert model_info["supports_reasoning"] is True
+
+    prompt_tokens = threshold + 1000
+    cached_tokens = 200
+    completion_tokens = 500
+    prompt_usd, completion_usd = cost_per_token(
+        model=model,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        custom_llm_provider="github_copilot",
+        usage_object=Usage(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=cached_tokens),
+        ),
+    )
+
+    assert prompt_usd == pytest.approx(
+        ((prompt_tokens - cached_tokens) * long_input_cost) + (cached_tokens * long_cache_read_cost)
+    )
+    assert completion_usd == pytest.approx(completion_tokens * long_output_cost)
 
 
 def test_cost_calculator_with_usage(monkeypatch):

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -184,11 +184,10 @@ def test_openrouter_qwen36_plus_model_info():
 @pytest.mark.parametrize(
     "model",
     [
-        "github_copilot/mai-code-1-flash",
-        "github_copilot/mai-code-1-flash-internal",
+        "github_copilot/mai-code-1-flash-picker",
     ],
 )
-def test_github_copilot_mai_code_1_flash_pricing(model):
+def test_github_copilot_mai_code_1_flash_picker_pricing(model):
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")
 
@@ -196,11 +195,11 @@ def test_github_copilot_mai_code_1_flash_pricing(model):
 
     assert model_info is not None, f"Missing model pricing entry: {model}"
     assert model_info["litellm_provider"] == "github_copilot"
-    assert model_info["mode"] == "chat"
+    assert model_info["mode"] == "responses"
     assert model_info["input_cost_per_token"] == 7.5e-07
     assert model_info["cache_read_input_token_cost"] == 7.5e-08
     assert model_info["output_cost_per_token"] == 4.5e-06
-    assert model_info["supported_endpoints"] == ["/v1/chat/completions"]
+    assert model_info["supported_endpoints"] == ["/v1/responses"]
 
     prompt_usd, completion_usd = cost_per_token(
         model=model,
@@ -216,6 +215,196 @@ def test_github_copilot_mai_code_1_flash_pricing(model):
 
     assert prompt_usd == pytest.approx((800 * 7.5e-07) + (200 * 7.5e-08))
     assert completion_usd == pytest.approx(500 * 4.5e-06)
+
+
+def test_github_copilot_mai_code_1_1_flash_pricing():
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    model = "github_copilot/mai-code-1.1-flash"
+    model_info = litellm.model_cost.get(model)
+
+    assert model_info is not None, f"Missing model pricing entry: {model}"
+    assert model_info["litellm_provider"] == "github_copilot"
+    assert model_info["mode"] == "responses"
+    assert model_info["max_input_tokens"] == 128000
+    assert model_info["max_output_tokens"] == 128000
+    assert model_info["input_cost_per_token"] == 2e-7
+    assert model_info["cache_read_input_token_cost"] == 2e-8
+    assert model_info["cache_creation_input_token_cost"] == 2.5e-7
+    assert model_info["output_cost_per_token"] == 1.2e-6
+    assert model_info["supported_endpoints"] == ["/v1/responses"]
+    assert model_info["supports_response_schema"] is True
+    assert model_info["supports_vision"] is True
+    assert model_info["supports_pdf_input"] is True
+    assert model_info["supports_reasoning"] is True
+
+    prompt_usd, completion_usd = cost_per_token(
+        model=model,
+        prompt_tokens=1000,
+        completion_tokens=500,
+        custom_llm_provider="github_copilot",
+        usage_object=Usage(
+            prompt_tokens=1000,
+            completion_tokens=500,
+            prompt_tokens_details=PromptTokensDetailsWrapper(
+                cached_tokens=200,
+                cache_creation_tokens=100,
+            ),
+        ),
+    )
+
+    assert prompt_usd == pytest.approx((700 * 2e-7) + (200 * 2e-8) + (100 * 2.5e-7))
+    assert completion_usd == pytest.approx(500 * 1.2e-6)
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "github_copilot/gemini-3.6-flash",
+        "github_copilot/gemini-3.7-flash",
+    ],
+)
+def test_github_copilot_gemini_flash_pricing(model: str):
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    model_info = litellm.model_cost.get(model)
+
+    assert model_info is not None, f"Missing model pricing entry: {model}"
+    assert model_info["litellm_provider"] == "github_copilot"
+    assert model_info["mode"] == "chat"
+    assert model_info["max_input_tokens"] == 936000
+    assert model_info["max_output_tokens"] == 64000
+    assert model_info["input_cost_per_token"] == 7.5e-7
+    assert model_info["cache_read_input_token_cost"] == 7.5e-8
+    assert model_info["output_cost_per_token"] == 3.75e-6
+    assert model_info["supported_endpoints"] == ["/v1/chat/completions"]
+    assert model_info["supports_function_calling"] is True
+    assert model_info["supports_tool_choice"] is True
+    assert model_info["supports_parallel_function_calling"] is True
+    assert model_info["supports_vision"] is True
+    assert model_info["supports_pdf_input"] is True
+    assert model_info["supports_reasoning"] is True
+
+    prompt_usd, completion_usd = cost_per_token(
+        model=model,
+        prompt_tokens=1000,
+        completion_tokens=500,
+        custom_llm_provider="github_copilot",
+        usage_object=Usage(
+            prompt_tokens=1000,
+            completion_tokens=500,
+            prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=200),
+        ),
+    )
+
+    assert prompt_usd == pytest.approx((800 * 7.5e-7) + (200 * 7.5e-8))
+    assert completion_usd == pytest.approx(500 * 3.75e-6)
+
+
+def test_github_copilot_claude_opus_5_pricing():
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    model = "github_copilot/claude-opus-5"
+    model_info = litellm.model_cost.get(model)
+
+    assert model_info is not None, f"Missing model pricing entry: {model}"
+    assert model_info["litellm_provider"] == "github_copilot"
+    assert model_info["mode"] == "chat"
+    assert model_info["max_input_tokens"] == 936000
+    assert model_info["max_output_tokens"] == 64000
+    assert model_info["input_cost_per_token"] == 5e-06
+    assert model_info["cache_read_input_token_cost"] == 5e-07
+    assert model_info["cache_creation_input_token_cost"] == 6.25e-06
+    assert model_info["output_cost_per_token"] == 2.5e-05
+    assert model_info["supported_endpoints"] == [
+        "/v1/messages",
+        "/v1/chat/completions",
+    ]
+    assert model_info["supports_adaptive_thinking"] is True
+    assert model_info["supports_xhigh_reasoning_effort"] is True
+
+    prompt_usd, completion_usd = cost_per_token(
+        model=model,
+        prompt_tokens=1000,
+        completion_tokens=500,
+        custom_llm_provider="github_copilot",
+        usage_object=Usage(
+            prompt_tokens=1000,
+            completion_tokens=500,
+            prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=200),
+        ),
+    )
+
+    assert prompt_usd == pytest.approx((800 * 5e-06) + (200 * 5e-07))
+    assert completion_usd == pytest.approx(500 * 2.5e-05)
+
+
+@pytest.mark.parametrize(
+    (
+        "model,threshold,max_input_tokens,input_cost,cache_read_cost,output_cost,"
+        "long_input_cost,long_cache_read_cost,long_output_cost"
+    ),
+    [
+        ("github_copilot/gpt-5.6-luna", 200000, 922000, 2e-7, 2e-8, 1.2e-6, 4e-7, 4e-8, 1.8e-6),
+        ("github_copilot/gpt-5.6-terra", 272000, 922000, 2e-6, 2e-7, 1.2e-5, 4e-6, 4e-7, 1.8e-5),
+        ("github_copilot/grok-4.5", 200000, 372000, 2e-6, 5e-7, 6e-6, 4e-6, 1e-6, 1.2e-5),
+    ],
+)
+def test_github_copilot_tiered_pricing(
+    model: str,
+    threshold: int,
+    max_input_tokens: int,
+    input_cost: float,
+    cache_read_cost: float,
+    output_cost: float,
+    long_input_cost: float,
+    long_cache_read_cost: float,
+    long_output_cost: float,
+):
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    model_info = litellm.model_cost.get(model)
+    threshold_suffix = f"above_{threshold // 1000}k_tokens"
+
+    assert model_info is not None, f"Missing model pricing entry: {model}"
+    assert model_info["litellm_provider"] == "github_copilot"
+    assert model_info["mode"] == "responses"
+    assert model_info["max_input_tokens"] == max_input_tokens
+    assert model_info["max_output_tokens"] == 128000
+    assert model_info["input_cost_per_token"] == input_cost
+    assert model_info["cache_read_input_token_cost"] == cache_read_cost
+    assert model_info["output_cost_per_token"] == output_cost
+    assert model_info[f"input_cost_per_token_{threshold_suffix}"] == long_input_cost
+    assert model_info[f"cache_read_input_token_cost_{threshold_suffix}"] == long_cache_read_cost
+    assert model_info[f"output_cost_per_token_{threshold_suffix}"] == long_output_cost
+    assert model_info["supported_endpoints"] == ["/v1/responses"]
+    assert model_info["supports_response_schema"] is True
+    assert model_info["supports_vision"] is True
+    assert model_info["supports_reasoning"] is True
+
+    prompt_tokens = threshold + 1000
+    cached_tokens = 200
+    completion_tokens = 500
+    prompt_usd, completion_usd = cost_per_token(
+        model=model,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        custom_llm_provider="github_copilot",
+        usage_object=Usage(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=cached_tokens),
+        ),
+    )
+
+    assert prompt_usd == pytest.approx(
+        ((prompt_tokens - cached_tokens) * long_input_cost) + (cached_tokens * long_cache_read_cost)
+    )
+    assert completion_usd == pytest.approx(completion_tokens * long_output_cost)
 
 
 def test_cost_calculator_with_usage(monkeypatch):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Copilot now exposes newer Gemini and GPT-6 Astra models
- LiteLLM lacks their current metadata and pricing

How it solves it:

- Refreshes Gemini Flash metadata and adds Gemini 3.8 Flash
- Adds GPT-6 Astra with tiered pricing metadata and coverage

## Relevant issues


## Linear ticket


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all relevant CI/CD checks locally
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in PR merge, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Source of truth

Model metadata comes from the authenticated `GET https://api.githubcopilot.com/models` API call after exchanging the user GitHub OAuth credential at `GET https://api.github.com/copilot_internal/v2/token`

The retrieval flow is https://gist.github.com/codgician/c81b411794f29ee024f627d87b13b5d8

Model prices come from GitHub's official Copilot pricing documentation: https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing

## Screenshots / Proof of Fix

The authenticated catalog returned 34 models. The requested records were verified directly from the live response:

```text
Gemini 3.6 Flash: 936000 prompt, 64000 output, /chat/completions
Gemini 3.7 Flash: 936000 prompt, 64000 output, /chat/completions
Gemini 3.8 Flash: 983040 prompt, 65536 output, /chat/completions
GPT-6 Astra: 872000 prompt, 128000 output, /responses
Other Copilot entries unchanged: true
Root and backup requested entries matched: true
```

Gemini 3.6, 3.7, and 3.8 use the documented promotional prices of $0.75 input, $0.075 cached input, and $3.75 output per million tokens through December 31, 2026

GPT-6 Astra uses $10 input, $1 cached input, $12.50 cache write, and $50 output per million tokens, with $20 input, $2 cached input, $25 cache write, and $75 output above 272,000 input tokens

## Type

New Feature; Test

## Changes

Refresh `github_copilot/gemini-3.6-flash` and `github_copilot/gemini-3.7-flash`, add `github_copilot/gemini-3.8-flash`, and add `github_copilot/gpt-6-astra`

Map current limits, endpoints, tool support, structured outputs, vision, PDF input, reasoning, and GPT-6 Astra tiered pricing

Keep both model-map copies synchronized and preserve all other Copilot entries unchanged

Add focused cost-calculation coverage for Gemini Flash and GPT-6 Astra

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR