### PR TITLE
feat(proxy): optional SSE keepalive comments during streaming silence

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -438,9 +438,7 @@ def _get_sse_keepalive_interval_seconds() -> float:
     try:
         return float(os.getenv("LITELLM_SSE_KEEPALIVE_INTERVAL_SECONDS", "0") or "0")
     except ValueError:
-        verbose_proxy_logger.warning(
-            "Invalid LITELLM_SSE_KEEPALIVE_INTERVAL_SECONDS value; disabling SSE keepalives"
-        )
+        verbose_proxy_logger.warning("Invalid LITELLM_SSE_KEEPALIVE_INTERVAL_SECONDS value; disabling SSE keepalives")
         return 0.0
 
 

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import math
+import os
 import time
 import traceback
 from datetime import datetime
@@ -426,6 +427,55 @@ async def _buffer_first_chunk_honoring_disconnect(
     raise _ClientDisconnectedBeforeFirstChunk()
 
 
+SSE_KEEPALIVE_COMMENT = ": keepalive\n\n"
+
+
+def _get_sse_keepalive_interval_seconds() -> float:
+    """SSE keepalive interval from LITELLM_SSE_KEEPALIVE_INTERVAL_SECONDS.
+
+    0 (the default) disables keepalives entirely.
+    """
+    try:
+        return float(os.getenv("LITELLM_SSE_KEEPALIVE_INTERVAL_SECONDS", "0") or "0")
+    except ValueError:
+        verbose_proxy_logger.warning(
+            "Invalid LITELLM_SSE_KEEPALIVE_INTERVAL_SECONDS value; disabling SSE keepalives"
+        )
+        return 0.0
+
+
+async def _wrap_sse_keepalive(
+    generator: AsyncGenerator[str, None], interval_seconds: float
+) -> AsyncGenerator[str, None]:
+    """Yield SSE comment keepalives whenever ``generator`` is silent for longer
+    than ``interval_seconds``.
+
+    Reasoning models (e.g. gpt-5.x on /v1/responses) can stream nothing for
+    minutes while thinking; idle-timeout middleboxes between the client and
+    the proxy (nginx: 60s default, Envoy/Cilium: 300s, cloud load balancers)
+    then kill the connection mid-turn. SSE comment lines (leading ``:``) are
+    ignored by conforming SSE parsers (https://html.spec.whatwg.org/multipage/server-sent-events.html)
+    so they keep the connection visibly alive without altering the event stream.
+    """
+    ait = generator.__aiter__()
+    next_chunk_task = asyncio.ensure_future(ait.__anext__())
+    try:
+        while True:
+            done, _ = await asyncio.wait({next_chunk_task}, timeout=interval_seconds)
+            if not done:
+                yield SSE_KEEPALIVE_COMMENT
+                continue
+            try:
+                chunk = next_chunk_task.result()
+            except StopAsyncIteration:
+                return
+            yield chunk
+            next_chunk_task = asyncio.ensure_future(ait.__anext__())
+    finally:
+        if not next_chunk_task.done():
+            next_chunk_task.cancel()
+
+
 async def create_response(
     generator: AsyncGenerator[str, None],
     media_type: str,
@@ -564,8 +614,13 @@ async def create_response(
             with tracer.trace(DD_TRACER_STREAMING_CHUNK_YIELD_RESOURCE):
                 yield chunk
 
+    content_generator: AsyncGenerator[str, None] = combined_generator()
+    keepalive_interval = _get_sse_keepalive_interval_seconds()
+    if keepalive_interval > 0 and media_type == "text/event-stream":
+        content_generator = _wrap_sse_keepalive(content_generator, keepalive_interval)
+
     return _UpstreamClosingStreamingResponse(
-        combined_generator(),
+        content_generator,
         media_type=media_type,
         headers=streaming_headers,
         status_code=final_status_code,

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -27,6 +27,8 @@ from litellm.proxy.common_request_processing import (
     _override_openai_response_model,
     _parse_event_data_for_error,
     _UpstreamClosingStreamingResponse,
+    _wrap_sse_keepalive,
+    SSE_KEEPALIVE_COMMENT,
     create_response,
 )
 from litellm.proxy.dd_span_tagger import DDSpanTagger
@@ -4871,3 +4873,79 @@ class TestPreCallWithFallbacksOnLocalRateLimit:
                     },
                     call_type="acompletion",
                 )
+
+
+class TestSSEKeepalive:
+    @pytest.mark.asyncio
+    async def test_keepalive_emitted_during_silence(self):
+        """A silent gap longer than the interval produces keepalive comments."""
+
+        async def slow_gen() -> AsyncGenerator[str, None]:
+            yield "data: first\n\n"
+            await asyncio.sleep(0.3)
+            yield "data: second\n\n"
+
+        chunks = [c async for c in _wrap_sse_keepalive(slow_gen(), 0.05)]
+
+        assert chunks[0] == "data: first\n\n"
+        assert chunks[-1] == "data: second\n\n"
+        assert SSE_KEEPALIVE_COMMENT in chunks[1:-1]
+
+    @pytest.mark.asyncio
+    async def test_fast_stream_passes_through_unchanged(self):
+        """Chunks arriving within the interval are passed through untouched."""
+
+        async def fast_gen() -> AsyncGenerator[str, None]:
+            for i in range(5):
+                yield f"data: {i}\n\n"
+
+        chunks = [c async for c in _wrap_sse_keepalive(fast_gen(), 5.0)]
+
+        assert chunks == [f"data: {i}\n\n" for i in range(5)]
+
+    @pytest.mark.asyncio
+    async def test_upstream_exception_propagates(self):
+        async def failing_gen() -> AsyncGenerator[str, None]:
+            yield "data: ok\n\n"
+            raise ValueError("upstream broke")
+
+        with pytest.raises(ValueError, match="upstream broke"):
+            async for _ in _wrap_sse_keepalive(failing_gen(), 5.0):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_disabled_by_default_via_create_response(self, monkeypatch):
+        """With no env var set, create_response output is byte-identical."""
+        monkeypatch.delenv("LITELLM_SSE_KEEPALIVE_INTERVAL_SECONDS", raising=False)
+
+        async def slow_gen() -> AsyncGenerator[str, None]:
+            yield "data: first\n\n"
+            await asyncio.sleep(0.2)
+            yield "data: second\n\n"
+
+        response = await create_response(
+            generator=slow_gen(), media_type="text/event-stream", headers={}
+        )
+        chunks = [c async for c in response.body_iterator]
+
+        assert chunks == ["data: first\n\n", "data: second\n\n"]
+
+    @pytest.mark.asyncio
+    async def test_enabled_via_env_through_create_response(self, monkeypatch):
+        monkeypatch.setenv("LITELLM_SSE_KEEPALIVE_INTERVAL_SECONDS", "0.05")
+
+        async def slow_gen() -> AsyncGenerator[str, None]:
+            yield "data: first\n\n"
+            await asyncio.sleep(0.3)
+            yield "data: second\n\n"
+
+        response = await create_response(
+            generator=slow_gen(), media_type="text/event-stream", headers={}
+        )
+        chunks = [c async for c in response.body_iterator]
+
+        assert SSE_KEEPALIVE_COMMENT in chunks
+        assert [c for c in chunks if c != SSE_KEEPALIVE_COMMENT] == [
+            "data: first\n\n",
+            "data: second\n\n",
+        ]


### PR DESCRIPTION
## Relevant issues

Addresses #14953 (closed not-planned) — reopening the ask with a working implementation, tests, and e2e proof.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Real call through the proxy running at commit e9f41772c: Azure `gpt-5.6-sol`, `reasoning.effort=high`, `LITELLM_SSE_KEEPALIVE_INTERVAL_SECONDS=3`. The model reasons silently for ~30s and the keepalives land exactly in that gap:

```
$ curl -sS -N http://127.0.0.1:20488/v1/responses -H "Authorization: Bearer sk-..." \
    -d '{"model":"gpt-5.6-sol","input":"Think very carefully: how many primes below 500 have a digit sum of exactly 10?","reasoning":{"effort":"high"},"stream":true,"max_output_tokens":4000}'

data: {"type":"response.created", ...}
data: {"type":"response.in_progress", ...}
: keepalive
: keepalive
: keepalive        <- 10 keepalives over ~30s of reasoning silence
...
data: {"type":"response.output_item.added", ...}
data: {"type":"response.output_text.done", ... correct answer ...}
data: {"type":"response.completed", ...}
```

Without this, the same silence exceeds e.g. Envoy's 300s default `stream_idle_timeout` on longer thinks and the connection is killed mid-turn. We run this in production (LiteLLM gateway fronting Azure GPT-5.6 for Codex CLI users behind a Cilium/Envoy ingress) — the `stream disconnected before completion` retry loops disappear.

Tests: `pytest tests/test_litellm/proxy/test_common_request_processing.py` — 169 passed (5 new in `TestSSEKeepalive`).

## Type

🆕 New Feature

## Changes

- Why: reasoning models stream nothing while thinking (raw CoT is never sent), so `/v1/responses` connections sit wire-silent for minutes; any idle-timeout middlebox between client and proxy (nginx 60s default, Envoy/Cilium 300s, cloud LBs) kills them mid-turn. Users often can't raise those timeouts (shared infra) — same failure class as vercel/ai#12949 and openai/codex#3478.
- Opt-in via `LITELLM_SSE_KEEPALIVE_INTERVAL_SECONDS` (default 0 = disabled, zero behaviour change). When set, SSE streaming responses emit a comment line (`: keepalive`) whenever the upstream generator is silent past the interval.
- SSE comments are spec-mandated ignorable (https://html.spec.whatwg.org/multipage/server-sent-events.html); verified tolerated by OpenAI Codex CLI 0.144 before, between, and after events.
- Implemented in `create_response()` after first-chunk buffering, so first-chunk error sniffing / error-to-JSON status mapping is untouched; disabled path is byte-identical (covered by test).
