### PR TITLE
fix(router): don't store max_parallel_requests semaphore in expiring cache

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -462,6 +462,10 @@ class Router:
         self.cache = DualCache(
             redis_cache=redis_cache, in_memory_cache=InMemoryCache()
         )  # use a dual cache (Redis+In-Memory) for tracking cooldowns, usage, etc.
+        # max_parallel_requests semaphores live outside self.cache: cache entries
+        # expire (default_ttl) / evict, which would replace a held semaphore with a
+        # fresh all-permits-free one and over-admit while requests are in flight.
+        self._max_parallel_requests_semaphores: Dict[str, asyncio.Semaphore] = {}
 
         ### SCHEDULER ###
         self.scheduler = Scheduler(polling_interval=polling_interval, redis_cache=redis_cache)
@@ -7824,6 +7828,12 @@ class Router:
         verbose_router_logger.debug(f"\nInitialized Model List {self.get_model_names()}")
         self.model_names = {m["model_name"] for m in model_list}
 
+        # Prune (don't clear) semaphores: a hot-reload with unchanged models must
+        # not reset in-flight concurrency limits, but removed ids must not leak.
+        for _model_id in list(self._max_parallel_requests_semaphores.keys()):
+            if _model_id not in self.model_id_to_deployment_index_map:
+                del self._max_parallel_requests_semaphores[_model_id]
+
         # Note: model_name_to_deployment_indices is already built incrementally
         # by _create_deployment -> _add_model_to_list_and_index_map
 
@@ -8212,6 +8222,7 @@ class Router:
                         self._invalidate_model_group_info_cache()
                         self._invalidate_access_groups_cache()
                         self._update_deployment_indices_after_removal(model_id=deployment_id, removal_idx=removal_idx)
+                        self._max_parallel_requests_semaphores.pop(deployment_id, None)
 
             # if the model_id is not in router
             self.add_deployment(deployment=deployment)
@@ -8245,6 +8256,7 @@ class Router:
                 self._invalidate_model_group_info_cache()
                 self._invalidate_access_groups_cache()
                 self._update_deployment_indices_after_removal(model_id=id, removal_idx=deployment_idx)
+                self._max_parallel_requests_semaphores.pop(id, None)
                 _budget_limiter = self._get_router_deployment_budget_limiter()
                 if _budget_limiter is not None:
                     _budget_limiter.unregister_deployment_budget(model_id=id)
@@ -9785,11 +9797,10 @@ class Router:
         model_id = deployment["model_info"]["id"]
         parent_otel_span: Optional[Span] = _get_parent_otel_span_from_kwargs(kwargs)
         if client_type == "max_parallel_requests":
-            cache_key = "{}_max_parallel_requests_client".format(model_id)
-            client = self.cache.get_cache(key=cache_key, local_only=True, parent_otel_span=parent_otel_span)
+            client = self._max_parallel_requests_semaphores.get(model_id)
             if client is None:
                 InitalizeCachedClient.set_max_parallel_requests_client(litellm_router_instance=self, model=deployment)
-                client = self.cache.get_cache(key=cache_key, local_only=True, parent_otel_span=parent_otel_span)
+                client = self._max_parallel_requests_semaphores.get(model_id)
             return client
         elif client_type == "async":
             if kwargs.get("stream") is True:

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -465,7 +465,7 @@ class Router:
         # max_parallel_requests semaphores live outside self.cache: cache entries
         # expire (default_ttl) / evict, which would replace a held semaphore with a
         # fresh all-permits-free one and over-admit while requests are in flight.
-        self._max_parallel_requests_semaphores: Dict[str, asyncio.Semaphore] = {}
+        self._max_parallel_requests_semaphores: Dict[str, anyio.CapacityLimiter] = {}
 
         ### SCHEDULER ###
         self.scheduler = Scheduler(polling_interval=polling_interval, redis_cache=redis_cache)
@@ -2732,7 +2732,7 @@ class Router:
                 kwargs=kwargs,
                 client_type="max_parallel_requests",
             )
-            if rpm_semaphore is not None and isinstance(rpm_semaphore, asyncio.Semaphore):
+            if rpm_semaphore is not None:
                 async with rpm_semaphore:
                     """
                     - Check rpm limits before making the call
@@ -3656,7 +3656,7 @@ class Router:
                 client_type="max_parallel_requests",
             )
 
-            if rpm_semaphore is not None and isinstance(rpm_semaphore, asyncio.Semaphore):
+            if rpm_semaphore is not None:
                 async with rpm_semaphore:
                     """
                     - Check rpm limits before making the call
@@ -3762,7 +3762,7 @@ class Router:
                 client_type="max_parallel_requests",
             )
 
-            if rpm_semaphore is not None and isinstance(rpm_semaphore, asyncio.Semaphore):
+            if rpm_semaphore is not None:
                 async with rpm_semaphore:
                     """
                     - Check rpm limits before making the call
@@ -3876,7 +3876,7 @@ class Router:
                 client_type="max_parallel_requests",
             )
 
-            if rpm_semaphore is not None and isinstance(rpm_semaphore, asyncio.Semaphore):
+            if rpm_semaphore is not None:
                 async with rpm_semaphore:
                     """
                     - Check rpm limits before making the call
@@ -4068,7 +4068,7 @@ class Router:
                 client_type="max_parallel_requests",
             )
 
-            if rpm_semaphore is not None and isinstance(rpm_semaphore, asyncio.Semaphore):
+            if rpm_semaphore is not None:
                 async with rpm_semaphore:
                     """
                     - Check rpm limits before making the call
@@ -4159,7 +4159,7 @@ class Router:
                 client_type="max_parallel_requests",
             )
 
-            if rpm_semaphore is not None and isinstance(rpm_semaphore, asyncio.Semaphore):
+            if rpm_semaphore is not None:
                 async with rpm_semaphore:
                     """
                     - Check rpm limits before making the call
@@ -4416,7 +4416,7 @@ class Router:
                 client_type="max_parallel_requests",
             )
 
-            if rpm_semaphore is not None and isinstance(rpm_semaphore, asyncio.Semaphore):
+            if rpm_semaphore is not None:
                 async with rpm_semaphore:
                     """
                     - Check rpm limits before making the call
@@ -4691,7 +4691,7 @@ class Router:
                 client_type="max_parallel_requests",
             )
 
-            if rpm_semaphore is not None and isinstance(rpm_semaphore, asyncio.Semaphore):
+            if rpm_semaphore is not None:
                 async with rpm_semaphore:
                     """
                     - Check rpm limits before making the call
@@ -4823,7 +4823,7 @@ class Router:
                     client_type="max_parallel_requests",
                 )
 
-                if rpm_semaphore is not None and isinstance(rpm_semaphore, asyncio.Semaphore):
+                if rpm_semaphore is not None:
                     async with rpm_semaphore:
                         """
                         - Check rpm limits before making the call
@@ -4943,7 +4943,7 @@ class Router:
                 client_type="max_parallel_requests",
             )
 
-            if rpm_semaphore is not None and isinstance(rpm_semaphore, asyncio.Semaphore):
+            if rpm_semaphore is not None:
                 async with rpm_semaphore:
                     await self.async_routing_strategy_pre_call_checks(
                         deployment=deployment, parent_otel_span=parent_otel_span
@@ -5056,7 +5056,7 @@ class Router:
                 client_type="max_parallel_requests",
             )
 
-            if rpm_semaphore is not None and isinstance(rpm_semaphore, asyncio.Semaphore):
+            if rpm_semaphore is not None:
                 async with rpm_semaphore:
                     """
                     - Check rpm limits before making the call
@@ -5279,7 +5279,7 @@ class Router:
                 client_type="max_parallel_requests",
             )
 
-            if rpm_semaphore is not None and isinstance(rpm_semaphore, asyncio.Semaphore):
+            if rpm_semaphore is not None:
                 async with rpm_semaphore:
                     """
                     - Check rpm limits before making the call
@@ -7828,11 +7828,15 @@ class Router:
         verbose_router_logger.debug(f"\nInitialized Model List {self.get_model_names()}")
         self.model_names = {m["model_name"] for m in model_list}
 
-        # Prune (don't clear) semaphores: a hot-reload with unchanged models must
-        # not reset in-flight concurrency limits, but removed ids must not leak.
         for _model_id in list(self._max_parallel_requests_semaphores.keys()):
-            if _model_id not in self.model_id_to_deployment_index_map:
+            deployment_index = self.model_id_to_deployment_index_map.get(_model_id)
+            if deployment_index is None:
                 del self._max_parallel_requests_semaphores[_model_id]
+            else:
+                InitalizeCachedClient.set_max_parallel_requests_client(
+                    litellm_router_instance=self,
+                    model=self.model_list[deployment_index],
+                )
 
         # Note: model_name_to_deployment_indices is already built incrementally
         # by _create_deployment -> _add_model_to_list_and_index_map
@@ -8222,10 +8226,15 @@ class Router:
                         self._invalidate_model_group_info_cache()
                         self._invalidate_access_groups_cache()
                         self._update_deployment_indices_after_removal(model_id=deployment_id, removal_idx=removal_idx)
-                        self._max_parallel_requests_semaphores.pop(deployment_id, None)
 
             # if the model_id is not in router
             self.add_deployment(deployment=deployment)
+            if _deployment_model_id in self._max_parallel_requests_semaphores:
+                deployment_index = self.model_id_to_deployment_index_map[_deployment_model_id]
+                InitalizeCachedClient.set_max_parallel_requests_client(
+                    litellm_router_instance=self,
+                    model=self.model_list[deployment_index],
+                )
             return deployment
         except Exception as e:
             if self.ignore_invalid_deployments:
@@ -9797,10 +9806,8 @@ class Router:
         model_id = deployment["model_info"]["id"]
         parent_otel_span: Optional[Span] = _get_parent_otel_span_from_kwargs(kwargs)
         if client_type == "max_parallel_requests":
+            InitalizeCachedClient.set_max_parallel_requests_client(litellm_router_instance=self, model=deployment)
             client = self._max_parallel_requests_semaphores.get(model_id)
-            if client is None:
-                InitalizeCachedClient.set_max_parallel_requests_client(litellm_router_instance=self, model=deployment)
-                client = self._max_parallel_requests_semaphores.get(model_id)
             return client
         elif client_type == "async":
             if kwargs.get("stream") is True:

--- a/litellm/router_utils/client_initalization_utils.py
+++ b/litellm/router_utils/client_initalization_utils.py
@@ -27,9 +27,4 @@ class InitalizeCachedClient:
         )
         if calculated_max_parallel_requests:
             semaphore = asyncio.Semaphore(calculated_max_parallel_requests)
-            cache_key = f"{model_id}_max_parallel_requests_client"
-            litellm_router_instance.cache.set_cache(
-                key=cache_key,
-                value=semaphore,
-                local_only=True,
-            )
+            litellm_router_instance._max_parallel_requests_semaphores[model_id] = semaphore

--- a/litellm/router_utils/client_initalization_utils.py
+++ b/litellm/router_utils/client_initalization_utils.py
@@ -1,5 +1,6 @@
-import asyncio
 from typing import TYPE_CHECKING, Any
+
+import anyio
 
 from litellm.utils import calculate_max_parallel_requests
 
@@ -25,6 +26,12 @@ class InitalizeCachedClient:
             tpm=tpm,
             default_max_parallel_requests=litellm_router_instance.default_max_parallel_requests,
         )
-        if calculated_max_parallel_requests:
-            semaphore = asyncio.Semaphore(calculated_max_parallel_requests)
-            litellm_router_instance._max_parallel_requests_semaphores[model_id] = semaphore
+        limiter = litellm_router_instance._max_parallel_requests_semaphores.get(model_id)
+        if calculated_max_parallel_requests is None or calculated_max_parallel_requests == 0:
+            litellm_router_instance._max_parallel_requests_semaphores.pop(model_id, None)
+        elif limiter is None:
+            litellm_router_instance._max_parallel_requests_semaphores[model_id] = anyio.CapacityLimiter(
+                calculated_max_parallel_requests
+            )
+        else:
+            limiter.total_tokens = calculated_max_parallel_requests

--- a/tests/test_litellm/router_utils/test_client_initalization_utils.py
+++ b/tests/test_litellm/router_utils/test_client_initalization_utils.py
@@ -1,0 +1,114 @@
+"""
+Tests that the router's max_parallel_requests semaphore is a process-lifetime
+object tied to the deployment, not an expiring cache entry.
+
+Regression tests: the semaphore used to live in the router's InMemoryCache,
+which force-applies
+default_ttl (600s). On every expiry it was silently recreated with all permits
+free while in-flight requests still held permits on the old object, transiently
+over-admitting up to 2x max_parallel_requests. Before the recreate-on-miss
+existed, expiry disabled concurrency limiting entirely.
+"""
+
+import asyncio
+import os
+import sys
+from typing import Optional
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm import Router
+from litellm.types.router import Deployment
+
+MODEL_ID = "test-deployment-id"
+
+
+def _model_list(max_parallel_requests: int = 1) -> list:
+    return [
+        {
+            "model_name": "gpt-3.5-turbo",
+            "litellm_params": {
+                "model": "gpt-3.5-turbo",
+                "api_key": "fake-key",
+                "max_parallel_requests": max_parallel_requests,
+            },
+            "model_info": {"id": MODEL_ID},
+        }
+    ]
+
+
+def _get_semaphore(router: Router) -> Optional[asyncio.Semaphore]:
+    return router._get_client(
+        deployment=router.model_list[0],
+        kwargs={},
+        client_type="max_parallel_requests",
+    )
+
+
+@pytest.mark.asyncio
+async def test_semaphore_survives_router_cache_expiry():
+    """
+    The semaphore must keep enforcing even if every router cache entry is
+    dropped (InMemoryCache applies default_ttl=600s to entries stored without
+    a ttl, and evicts under size pressure).
+    """
+    router = Router(model_list=_model_list())
+
+    semaphore = _get_semaphore(router)
+    assert isinstance(semaphore, asyncio.Semaphore)
+    await semaphore.acquire()  # an in-flight request holds the only permit
+
+    # simulate the 600s TTL elapsing / size-pressure eviction
+    router.cache.in_memory_cache.cache_dict.clear()
+    router.cache.in_memory_cache.ttl_dict.clear()
+
+    semaphore_after = _get_semaphore(router)
+    assert semaphore_after is semaphore
+    assert semaphore_after.locked()  # the in-flight permit still counts
+    semaphore.release()
+
+
+def test_delete_deployment_drops_semaphore():
+    router = Router(model_list=_model_list())
+    _get_semaphore(router)
+    assert MODEL_ID in router._max_parallel_requests_semaphores
+
+    router.delete_deployment(id=MODEL_ID)
+    assert MODEL_ID not in router._max_parallel_requests_semaphores
+
+
+def test_upsert_deployment_with_new_params_resets_semaphore():
+    router = Router(model_list=_model_list(max_parallel_requests=1))
+    semaphore = _get_semaphore(router)
+
+    router.upsert_deployment(
+        Deployment(
+            model_name="gpt-3.5-turbo",
+            litellm_params={
+                "model": "gpt-3.5-turbo",
+                "api_key": "fake-key",
+                "max_parallel_requests": 2,
+            },  # type: ignore
+            model_info={"id": MODEL_ID},
+        )
+    )
+
+    semaphore_after = _get_semaphore(router)
+    assert semaphore_after is not semaphore
+    assert semaphore_after is not None
+    assert semaphore_after._value == 2  # reflects the updated cap
+
+
+def test_set_model_list_keeps_survivors_and_prunes_removed():
+    router = Router(model_list=_model_list())
+    semaphore = _get_semaphore(router)
+
+    # hot-reload with unchanged models must not reset the semaphore
+    router.set_model_list(_model_list())
+    assert router._max_parallel_requests_semaphores[MODEL_ID] is semaphore
+
+    # removing the deployment must not leak its semaphore
+    router.set_model_list([])
+    assert router._max_parallel_requests_semaphores == {}

--- a/tests/test_litellm/router_utils/test_client_initalization_utils.py
+++ b/tests/test_litellm/router_utils/test_client_initalization_utils.py
@@ -15,6 +15,7 @@ import os
 import sys
 from typing import Optional
 
+import anyio
 import pytest
 
 sys.path.insert(0, os.path.abspath("../../.."))
@@ -25,21 +26,21 @@ from litellm.types.router import Deployment
 MODEL_ID = "test-deployment-id"
 
 
-def _model_list(max_parallel_requests: int = 1) -> list:
+def _model_list(max_parallel_requests: Optional[int] = 1) -> list:
     return [
         {
             "model_name": "gpt-3.5-turbo",
             "litellm_params": {
                 "model": "gpt-3.5-turbo",
                 "api_key": "fake-key",
-                "max_parallel_requests": max_parallel_requests,
+                **({"max_parallel_requests": max_parallel_requests} if max_parallel_requests is not None else {}),
             },
             "model_info": {"id": MODEL_ID},
         }
     ]
 
 
-def _get_semaphore(router: Router) -> Optional[asyncio.Semaphore]:
+def _get_limiter(router: Router) -> Optional[anyio.CapacityLimiter]:
     return router._get_client(
         deployment=router.model_list[0],
         kwargs={},
@@ -56,32 +57,38 @@ async def test_semaphore_survives_router_cache_expiry():
     """
     router = Router(model_list=_model_list())
 
-    semaphore = _get_semaphore(router)
-    assert isinstance(semaphore, asyncio.Semaphore)
-    await semaphore.acquire()  # an in-flight request holds the only permit
+    limiter = _get_limiter(router)
+    assert isinstance(limiter, anyio.CapacityLimiter)
+    await limiter.acquire()
 
-    # simulate the 600s TTL elapsing / size-pressure eviction
     router.cache.in_memory_cache.cache_dict.clear()
     router.cache.in_memory_cache.ttl_dict.clear()
 
-    semaphore_after = _get_semaphore(router)
-    assert semaphore_after is semaphore
-    assert semaphore_after.locked()  # the in-flight permit still counts
-    semaphore.release()
+    limiter_after = _get_limiter(router)
+    assert limiter_after is limiter
+    assert limiter_after.borrowed_tokens == 1
+    limiter.release()
 
 
 def test_delete_deployment_drops_semaphore():
     router = Router(model_list=_model_list())
-    _get_semaphore(router)
+    _get_limiter(router)
     assert MODEL_ID in router._max_parallel_requests_semaphores
 
     router.delete_deployment(id=MODEL_ID)
     assert MODEL_ID not in router._max_parallel_requests_semaphores
 
 
-def test_upsert_deployment_with_new_params_resets_semaphore():
-    router = Router(model_list=_model_list(max_parallel_requests=1))
-    semaphore = _get_semaphore(router)
+@pytest.mark.asyncio
+async def test_upsert_deployment_resizes_limiter_without_resetting_active_requests():
+    router = Router(model_list=_model_list(max_parallel_requests=2))
+    limiter = _get_limiter(router)
+    assert limiter is not None
+    first_borrower = object()
+    second_borrower = object()
+    waiting_borrower = object()
+    await limiter.acquire_on_behalf_of(first_borrower)
+    await limiter.acquire_on_behalf_of(second_borrower)
 
     router.upsert_deployment(
         Deployment(
@@ -89,26 +96,90 @@ def test_upsert_deployment_with_new_params_resets_semaphore():
             litellm_params={
                 "model": "gpt-3.5-turbo",
                 "api_key": "fake-key",
-                "max_parallel_requests": 2,
+                "max_parallel_requests": 1,
             },  # type: ignore
             model_info={"id": MODEL_ID},
         )
     )
 
-    semaphore_after = _get_semaphore(router)
-    assert semaphore_after is not semaphore
-    assert semaphore_after is not None
-    assert semaphore_after._value == 2  # reflects the updated cap
+    limiter_after = _get_limiter(router)
+    assert limiter_after is limiter
+    assert limiter_after.total_tokens == 1
+    assert limiter_after.borrowed_tokens == 2
+
+    waiting_acquire = asyncio.create_task(limiter_after.acquire_on_behalf_of(waiting_borrower))
+    await asyncio.sleep(0)
+    assert not waiting_acquire.done()
+
+    limiter_after.release_on_behalf_of(first_borrower)
+    await asyncio.sleep(0)
+    assert not waiting_acquire.done()
+
+    limiter_after.release_on_behalf_of(second_borrower)
+    await waiting_acquire
+    limiter_after.release_on_behalf_of(waiting_borrower)
 
 
 def test_set_model_list_keeps_survivors_and_prunes_removed():
     router = Router(model_list=_model_list())
-    semaphore = _get_semaphore(router)
+    limiter = _get_limiter(router)
 
-    # hot-reload with unchanged models must not reset the semaphore
     router.set_model_list(_model_list())
-    assert router._max_parallel_requests_semaphores[MODEL_ID] is semaphore
+    assert router._max_parallel_requests_semaphores[MODEL_ID] is limiter
 
-    # removing the deployment must not leak its semaphore
     router.set_model_list([])
     assert router._max_parallel_requests_semaphores == {}
+
+
+@pytest.mark.asyncio
+async def test_set_model_list_resizes_limiter_without_resetting_active_requests():
+    router = Router(model_list=_model_list(max_parallel_requests=2))
+    limiter = _get_limiter(router)
+    assert limiter is not None
+    first_borrower = object()
+    second_borrower = object()
+    waiting_borrower = object()
+    await limiter.acquire_on_behalf_of(first_borrower)
+    await limiter.acquire_on_behalf_of(second_borrower)
+
+    router.set_model_list(_model_list(max_parallel_requests=1))
+
+    limiter_after = _get_limiter(router)
+    assert limiter_after is limiter
+    assert limiter_after.total_tokens == 1
+    assert limiter_after.borrowed_tokens == 2
+
+    waiting_acquire = asyncio.create_task(limiter_after.acquire_on_behalf_of(waiting_borrower))
+    await asyncio.sleep(0)
+    assert not waiting_acquire.done()
+
+    limiter_after.release_on_behalf_of(first_borrower)
+    await asyncio.sleep(0)
+    assert not waiting_acquire.done()
+
+    limiter_after.release_on_behalf_of(second_borrower)
+    await waiting_acquire
+    limiter_after.release_on_behalf_of(waiting_borrower)
+
+
+def test_set_model_list_preserves_limiter_when_effective_limit_is_unchanged():
+    router = Router(model_list=_model_list(max_parallel_requests=2))
+    limiter = _get_limiter(router)
+    assert limiter is not None
+    reloaded_model_list = _model_list(max_parallel_requests=None)
+    reloaded_model_list[0]["litellm_params"]["rpm"] = 2
+
+    router.set_model_list(reloaded_model_list)
+
+    assert _get_limiter(router) is limiter
+    assert limiter.total_tokens == 2
+
+
+def test_set_model_list_removes_limiter_when_limit_is_disabled():
+    router = Router(model_list=_model_list(max_parallel_requests=1))
+    assert _get_limiter(router) is not None
+
+    router.set_model_list(_model_list(max_parallel_requests=None))
+
+    assert _get_limiter(router) is None
+    assert MODEL_ID not in router._max_parallel_requests_semaphores


### PR DESCRIPTION
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Type
🐛 Bug Fix

## Changes
The per-deployment concurrency semaphore lived in the router's InMemoryCache, which force-applies default_ttl (600s) to entries stored without a ttl. On every expiry the semaphore was silently recreated with all permits free while in-flight requests still held permits on the old object, transiently admitting up to 2x max_parallel_requests. Before the recreate-on-miss existed, expiry disabled concurrency limiting entirely.

Hold the semaphores in a plain dict on the Router keyed by model_id instead: created lazily as before, dropped on delete_deployment / upsert_deployment and pruned on set_model_list so deployment updates still take effect.