### PR TITLE
fix: add xai-oauth to LlmProviders enum and map to xai provider

### DIFF
--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -694,6 +694,12 @@ def _get_openai_compatible_provider_info(
             api_base,
             dynamic_api_key,
         ) = litellm.JinaAIEmbeddingConfig()._get_openai_compatible_provider_info(api_base, api_key)
+    elif custom_llm_provider == "xai-oauth":
+        custom_llm_provider = "xai"
+        (
+            api_base,
+            dynamic_api_key,
+        ) = litellm.XAIChatConfig()._get_openai_compatible_provider_info(api_base, api_key)
     elif custom_llm_provider == "xai":
         (
             api_base,

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3242,6 +3242,7 @@ class LlmProviders(str, Enum):
     OPENAI_LIKE = "openai_like"  # embedding only
     JINA_AI = "jina_ai"
     XAI = "xai"
+    XAI_OAUTH = "xai-oauth"
     ZAI = "zai"
     CUSTOM_OPENAI = "custom_openai"
     TEXT_COMPLETION_OPENAI = "text-completion-openai"

--- a/tests/test_litellm/litellm_core_utils/test_xai_oauth_routing.py
+++ b/tests/test_litellm/litellm_core_utils/test_xai_oauth_routing.py
@@ -79,3 +79,19 @@ def test_xai_oauth_flag_is_generic_litellm_param():
     assert litellm_params.use_xai_oauth is True
     assert runtime_params["use_xai_oauth"] is True
     assert "use_xai_oauth" not in result
+
+
+def test_xai_oauth_openai_compatible_provider_info():
+    model, custom_llm_provider, dynamic_api_key, api_base = (
+        _get_openai_compatible_provider_info(
+            model="xai-oauth/grok-3-mini",
+            api_base="https://api.x.ai/v1",
+            api_key="api-key",
+            dynamic_api_key=None,
+        )
+    )
+
+    assert model == "grok-3-mini"
+    assert custom_llm_provider == "xai"
+    assert api_base == "https://api.x.ai/v1"
+    assert dynamic_api_key == "api-key"


### PR DESCRIPTION
Fixes #32660.

xai-oauth was missing from LlmProviders enum. Router deployments with custom_llm_provider=xai-oauth failed validation. Added enum entry and remapped to xai in get_llm_provider_logic.