### PR TITLE
fix(proxy): use path converter for model param in GET/DELETE /fallback routes

### DIFF
--- a/litellm/proxy/management_endpoints/fallback_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/fallback_management_endpoints.py
@@ -190,7 +190,7 @@ async def create_fallback(
 
 
 @router.get(
-    "/fallback/{model}",
+    "/fallback/{model:path}",
     tags=["Fallback Management"],
     dependencies=[Depends(user_api_key_auth)],
     response_model=FallbackGetResponse,
@@ -247,7 +247,7 @@ async def get_fallback(
 
 
 @router.delete(
-    "/fallback/{model}",
+    "/fallback/{model:path}",
     tags=["Fallback Management"],
     dependencies=[Depends(user_api_key_auth)],
     response_model=FallbackDeleteResponse,

--- a/tests/test_litellm/proxy/test_fallback_management_endpoints.py
+++ b/tests/test_litellm/proxy/test_fallback_management_endpoints.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.management_endpoints.fallback_management_endpoints import (
     FallbackCreateRequest,
     create_fallback,
@@ -553,3 +554,95 @@ class TestDeleteFallback:
 
         assert exc_info.value.status_code == 400
         assert "Database storage not enabled" in str(exc_info.value.detail)
+
+
+class TestFallbackRoutingWithSlashInModelName:
+    """
+    Regression tests for GET/DELETE /fallback/{model:path} route matching.
+
+    Model names containing "/" (e.g. "openrouter/gpt-4") previously returned
+    Starlette's default 404 because {model} only matches a single path segment.
+    These tests go through actual HTTP routing, unlike the direct handler
+    tests above.
+    """
+
+    @pytest.fixture
+    def mock_router_with_slash_fallbacks(self):
+        router = MagicMock()
+        router.fallbacks = [{"openrouter/gpt-4": ["gpt-4", "claude-3-haiku"]}]
+        router.context_window_fallbacks = []
+        router.content_policy_fallbacks = []
+        return router
+
+    @pytest.fixture
+    def client(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from litellm.proxy.management_endpoints.fallback_management_endpoints import (
+            router as fallback_router,
+        )
+
+        app = FastAPI()
+        app.include_router(fallback_router)
+        app.dependency_overrides[user_api_key_auth] = lambda: MagicMock()
+        return TestClient(app)
+
+    @pytest.mark.parametrize("path", ["/fallback/openrouter%2Fgpt-4", "/fallback/openrouter/gpt-4"])
+    def test_get_fallback_model_with_slash(self, client, mock_router_with_slash_fallbacks, path):
+        with patch(
+            "litellm.proxy.proxy_server.llm_router",
+            mock_router_with_slash_fallbacks,
+        ):
+            response = client.get(path)
+
+        assert response.status_code == 200
+        assert response.json()["model"] == "openrouter/gpt-4"
+        assert response.json()["fallback_models"] == ["gpt-4", "claude-3-haiku"]
+
+    def test_delete_fallback_model_with_slash(self, client, mock_router_with_slash_fallbacks):
+        mock_prisma_client = MagicMock()
+        mock_prisma_client.db.litellm_config.upsert = AsyncMock()
+        mock_proxy_config = MagicMock()
+        mock_proxy_config.get_config = AsyncMock(
+            return_value={
+                "router_settings": {
+                    "fallbacks": [{"openrouter/gpt-4": ["gpt-4", "claude-3-haiku"]}]
+                }
+            }
+        )
+
+        with (
+            patch(
+                "litellm.proxy.proxy_server.llm_router",
+                mock_router_with_slash_fallbacks,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.prisma_client",
+                mock_prisma_client,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.proxy_config",
+                mock_proxy_config,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.store_model_in_db",
+                True,
+            ),
+        ):
+            response = client.delete("/fallback/openrouter%2Fgpt-4")
+
+        assert response.status_code == 200
+        assert response.json()["model"] == "openrouter/gpt-4"
+        mock_prisma_client.db.litellm_config.upsert.assert_called_once()
+
+    def test_get_fallback_model_without_slash_still_works(self, client, mock_router_with_slash_fallbacks):
+        mock_router_with_slash_fallbacks.fallbacks = [{"gpt-3.5-turbo": ["gpt-4"]}]
+        with patch(
+            "litellm.proxy.proxy_server.llm_router",
+            mock_router_with_slash_fallbacks,
+        ):
+            response = client.get("/fallback/gpt-3.5-turbo")
+
+        assert response.status_code == 200
+        assert response.json()["model"] == "gpt-3.5-turbo"


### PR DESCRIPTION
## Relevant issues

Fixes #32770

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on localhost, config with a slash-named model and a fallback configured for it:

```yaml
model_list:
  - model_name: openrouter/gpt-4
    litellm_params:
      model: openai/gpt-4
      api_key: sk-fake
  - model_name: gpt-4-backup
    litellm_params:
      model: openai/gpt-4
      api_key: sk-fake

router_settings:
  fallbacks:
    - "openrouter/gpt-4": ["gpt-4-backup"]

general_settings:
  master_key: sk-1234
```

Before (main, 3d63edaa6d), the route never matches, encoded or not:

```bash
$ curl -s -w "\nHTTP %{http_code}\n" "http://localhost:4000/fallback/openrouter%2Fgpt-4?fallback_type=general" -H "Authorization: Bearer sk-1234"
{"detail":"Not Found"}
HTTP 404
```

After this change:

```bash
$ curl -s -w "\nHTTP %{http_code}\n" "http://localhost:4000/fallback/openrouter%2Fgpt-4?fallback_type=general" -H "Authorization: Bearer sk-1234"
{"model":"openrouter/gpt-4","fallback_models":["gpt-4-backup"],"fallback_type":"general"}
HTTP 200

$ curl -s -w "\nHTTP %{http_code}\n" "http://localhost:4000/fallback/openrouter/gpt-4?fallback_type=general" -H "Authorization: Bearer sk-1234"
{"model":"openrouter/gpt-4","fallback_models":["gpt-4-backup"],"fallback_type":"general"}
HTTP 200
```

Non-slash names behave exactly as before:

```bash
$ curl -s -w "\nHTTP %{http_code}\n" "http://localhost:4000/fallback/nonexistent?fallback_type=general" -H "Authorization: Bearer sk-1234"
{"detail":{"error":"No general fallbacks configured for model 'nonexistent'"}}
HTTP 404
```

## Type

🐛 Bug Fix

## Changes

`GET /fallback/{model}` and `DELETE /fallback/{model}` declared the model path parameter with Starlette's default `str` converter, which matches a single path segment. Model names containing a slash (`openrouter/gpt-4`) could never match, even URL-encoded, because the ASGI server decodes `%2F` before routing; both endpoints returned the bare routing-level 404 without reaching the handler. `POST /fallback` takes the name in the body, so such fallbacks could be created but never read back or deleted through the API

Both routes now use `{model:path}`, the converter the proxy already uses for other slash-containing identifiers (`/v1/fine_tuning/jobs/{fine_tuning_job_id:path}`, `/v1beta/models/{model_name:path}:generateContent`). FastAPI renders `{model:path}` as `{model}` in the OpenAPI schema, so the documented API surface is unchanged

Added routing-level regression tests that go through `TestClient`; the existing tests call the handler functions directly and bypass routing, which is why this was not caught when the endpoints were added
