### PR TITLE
fix(responses): complete chat bridge reasoning lifecycle

### DIFF
--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -91,6 +91,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         self._final_tool_events_queued: bool = False
         self._sequence_number: int = 0
         self._cached_reasoning_item_id: Optional[str] = None
+        self._sent_reasoning_summary_part_added_event: bool = False
         self._sent_reasoning_summary_text_done_event: bool = False
         self._sent_reasoning_summary_part_done_event: bool = False
         self._reasoning_summary_text: str = ""
@@ -764,6 +765,15 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             )
             event.__dict__["sequence_number"] = self._sequence_number
             self._pending_response_events.append(event)
+            if not self._sent_reasoning_summary_part_added_event:
+                self._sent_reasoning_summary_part_added_event = True
+                self._pending_response_events.append(
+                    BaseLiteLLMOpenAIResponseObject(
+                        type="response.reasoning_summary_part.added",
+                        item_id=self._cached_reasoning_item_id,
+                        summary_index=0,
+                    )
+                )
             return
 
         # Tool-first
@@ -1016,6 +1026,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
                 type=ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA,
                 item_id=self._reasoning_item_id or self._cached_reasoning_item_id or item_id,
                 output_index=0,
+                summary_index=0,
                 delta=reasoning_content,
             )
 

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -72,6 +72,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         self.sent_response_created_event: bool = False
         self.sent_response_in_progress_event: bool = False
         self.sent_output_item_added_event: bool = False
+        self.sent_message_output_item_added_event: bool = False
         self.sent_content_part_added_event: bool = False
         self.sent_output_text_done_event: bool = False
         self.sent_output_content_part_done_event: bool = False
@@ -734,12 +735,9 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
 
     def _ensure_output_item_for_chunk(self, chunk: ModelResponseStream) -> None:
         # Change: Never return a value, just enqueue output item events
-        if self.sent_output_item_added_event:
+        if not chunk.choices:
             return
         delta = chunk.choices[0].delta
-
-        self._sequence_number += 1
-        self.sent_output_item_added_event = True
 
         # Reasoning-first
         if hasattr(delta, "reasoning_content") and delta.reasoning_content:
@@ -747,6 +745,10 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             if self._cached_reasoning_item_id is None:
                 self._cached_reasoning_item_id = f"rs_{uuid.uuid4()}"
             self._reasoning_item_id = self._cached_reasoning_item_id
+            if self.sent_output_item_added_event:
+                return
+            self._sequence_number += 1
+            self.sent_output_item_added_event = True
 
             event = OutputItemAddedEvent(
                 type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
@@ -771,6 +773,10 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             return
 
         # Default: message
+        if self.sent_message_output_item_added_event:
+            return
+        self._sequence_number += 1
+        self.sent_message_output_item_added_event = True
         self._cached_item_id = self._cached_item_id or f"msg_{uuid.uuid4()}"
         event = OutputItemAddedEvent(
             type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
@@ -1008,7 +1014,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
 
             return ReasoningSummaryTextDeltaEvent(
                 type=ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA,
-                item_id=f"rs_{hash(str(reasoning_content))}",
+                item_id=self._reasoning_item_id or self._cached_reasoning_item_id or item_id,
                 output_index=0,
                 delta=reasoning_content,
             )

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -1055,6 +1055,8 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
 
         It's unclear how users expect litellm to translate multiple-choices-per-chunk to the responses API output.
         """
+        if not choices:
+            return ""
         choice = choices[0]
         chat_completion_delta: ChatCompletionDelta = choice.delta
         return chat_completion_delta.content or ""

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -2191,8 +2191,6 @@ class TestEnsureOutputItemContentPartAdded:
 
     def _make_iterator(self):
         """Create a minimal LiteLLMCompletionStreamingIterator for testing."""
-        from unittest.mock import MagicMock
-
         from litellm.responses.litellm_completion_transformation.streaming_iterator import (
             LiteLLMCompletionStreamingIterator,
         )
@@ -2201,11 +2199,16 @@ class TestEnsureOutputItemContentPartAdded:
             LiteLLMCompletionStreamingIterator
         )
         iterator.sent_output_item_added_event = False
+        iterator.sent_message_output_item_added_event = False
         iterator.sent_content_part_added_event = False
         iterator._sequence_number = 0
         iterator._cached_item_id = None
         iterator._cached_reasoning_item_id = None
+        iterator._sent_reasoning_summary_part_added_event = False
+        iterator._reasoning_item_id = None
         iterator._reasoning_active = False
+        iterator.sent_annotation_events = False
+        iterator._pending_tool_events = []
         iterator._pending_response_events = []
         return iterator
 
@@ -2252,6 +2255,50 @@ class TestEnsureOutputItemContentPartAdded:
         assert events[1].type == ResponsesAPIStreamEvents.CONTENT_PART_ADDED
         assert events[1].part.type == "output_text"
         assert iterator.sent_content_part_added_event is True
+
+    def test_reasoning_then_text_emits_message_output_item(self):
+        """A text delta after reasoning must open a message item before output_text.delta."""
+        from litellm.types.llms.openai import ResponsesAPIStreamEvents
+
+        iterator = self._make_iterator()
+
+        iterator._ensure_output_item_for_chunk(self._make_reasoning_chunk())
+        iterator._pending_response_events.clear()
+        iterator._ensure_output_item_for_chunk(self._make_text_chunk())
+
+        events = iterator._pending_response_events
+        assert len(events) == 2
+        assert events[0].type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED
+        assert events[0].item.type == "message"
+        assert events[1].type == ResponsesAPIStreamEvents.CONTENT_PART_ADDED
+        assert events[1].item_id == events[0].item.id
+
+    def test_reasoning_delta_uses_stable_item_id_and_summary_index(self):
+        """Reasoning deltas must reference the added reasoning summary part."""
+        from litellm.responses.litellm_completion_transformation.streaming_iterator import (
+            LiteLLMCompletionStreamingIterator,
+        )
+        from litellm.types.llms.openai import ResponsesAPIStreamEvents
+
+        iterator = self._make_iterator()
+        reasoning_chunk = self._make_reasoning_chunk()
+
+        iterator._ensure_output_item_for_chunk(reasoning_chunk)
+        reasoning_item_id = iterator._cached_reasoning_item_id
+        events = iterator._pending_response_events
+        assert events[0].type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED
+        assert events[0].item.id == reasoning_item_id
+        assert events[1].type == "response.reasoning_summary_part.added"
+        assert events[1].item_id == reasoning_item_id
+        assert events[1].summary_index == 0
+
+        delta_event = LiteLLMCompletionStreamingIterator._transform_chat_completion_chunk_to_response_api_chunk(
+            iterator, reasoning_chunk
+        )
+        assert delta_event is not None
+        assert delta_event.type == ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA
+        assert delta_event.item_id == reasoning_item_id
+        assert delta_event.summary_index == 0
 
     def test_emit_response_completed_uses_stream_finish_reason(self):
         """
@@ -2301,7 +2348,7 @@ class TestEnsureOutputItemContentPartAdded:
         assert completed_event.response.output[0].status == "incomplete"
 
     def test_reasoning_item_does_not_emit_content_part_added(self):
-        """Reasoning items should not get a content_part.added event."""
+        """Reasoning items should not get a text content_part.added event."""
         from litellm.types.llms.openai import OutputItemAddedEvent
 
         iterator = self._make_iterator()
@@ -2310,8 +2357,9 @@ class TestEnsureOutputItemContentPartAdded:
         iterator._ensure_output_item_for_chunk(chunk)
 
         events = iterator._pending_response_events
-        assert len(events) == 1
+        assert len(events) == 2
         assert isinstance(events[0], OutputItemAddedEvent)
+        assert events[1].type == "response.reasoning_summary_part.added"
         assert iterator.sent_content_part_added_event is False
 
     def test_only_emits_once(self):

--- a/tests/test_litellm/responses/test_streaming_empty_choices.py
+++ b/tests/test_litellm/responses/test_streaming_empty_choices.py
@@ -1,0 +1,33 @@
+"""
+Test for the empty-choices guard in the Responses API streaming iterator.
+
+Providers such as DeepSeek emit a terminal streaming chunk with "choices": []
+(finish/usage chunk). _get_delta_string_from_streaming_choices must return ""
+for it instead of raising IndexError and killing the /v1/responses stream.
+"""
+
+from litellm.responses.litellm_completion_transformation.streaming_iterator import (
+    LiteLLMCompletionStreamingIterator,
+)
+from litellm.types.utils import Delta, StreamingChoices
+
+
+class TestEmptyChoicesGuard:
+    def test_empty_choices_returns_empty_string(self):
+        """A terminal chunk with choices: [] must not raise IndexError."""
+        result = LiteLLMCompletionStreamingIterator._get_delta_string_from_streaming_choices(
+            None, []
+        )
+        assert result == ""
+
+    def test_non_empty_choices_returns_delta_content(self):
+        """The normal path is unchanged: first choice's delta content is returned."""
+        choice = StreamingChoices(
+            index=0,
+            delta=Delta(content="hello", role="assistant"),
+            finish_reason=None,
+        )
+        result = LiteLLMCompletionStreamingIterator._get_delta_string_from_streaming_choices(
+            None, [choice]
+        )
+        assert result == "hello"


### PR DESCRIPTION
## Summary

Fixes Responses API streaming when the chat-completions bridge receives provider chunks that contain reasoning deltas followed by text deltas, and when terminal usage chunks have `choices: []`.

This combines:
- the empty choices guard from #32519
- stable reasoning item ids for reasoning summary deltas
- `response.reasoning_summary_part.added` before reasoning deltas
- separate message item emission after a reasoning item, so text deltas have a registered message/content part

## Problem

Strict Responses API clients such as Vercel AI SDK / OpenCode track streaming state by `item_id`, `summary_index`, and `content_index`. The current chat-completions -> Responses bridge can emit:

- `response.reasoning_summary_text.delta` without a matching `response.reasoning_summary_part.added`
- text deltas after reasoning without opening a separate message output item
- terminal chunks with `choices: []`, causing `IndexError` on `choices[0]`

These shapes surface as errors like:

- `reasoning part <id>:0 not found`
- `text part <id> not found`
- `IndexError: list index out of range`

## Changes

- Guard `_get_delta_string_from_streaming_choices()` for empty `choices`
- Track reasoning and message output item emission separately
- Emit `response.reasoning_summary_part.added` for reasoning items
- Reuse the cached reasoning item id for `response.reasoning_summary_text.delta`
- Include `summary_index=0` on reasoning deltas
- Add unit coverage for empty choices and reasoning -> text lifecycle

## Tests

```bash
uv run pytest tests/test_litellm/responses/test_streaming_empty_choices.py tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py::TestEnsureOutputItemContentPartAdded -q
# 8 passed

uv run ruff check litellm/responses/litellm_completion_transformation/streaming_iterator.py tests/test_litellm/responses/test_streaming_empty_choices.py
# All checks passed
```

Note: running ruff on the full existing `test_litellm_completion_responses.py` file reports pre-existing unused imports / variables outside this patch scope.
