### PR TITLE
fix(databricks): translate reasoning_effort to thinking for Gemini 2.5

### DIFF
--- a/litellm/llms/base_llm/chat/transformation.py
+++ b/litellm/llms/base_llm/chat/transformation.py
@@ -14,7 +14,6 @@ from typing import (
     Tuple,
     Type,
     Union,
-    cast,
 )
 
 import httpx
@@ -124,7 +123,15 @@ class BaseConfig(ABC):
         if is_thinking_enabled and (
             "max_tokens" not in non_default_params and "max_completion_tokens" not in non_default_params
         ):
-            thinking_token_budget = cast(dict, optional_params["thinking"]).get("budget_tokens", None)
+            # `is_thinking_enabled` is True when `reasoning_effort` is set OR
+            # when `thinking` is set. Providers that pass `reasoning_effort`
+            # through natively (e.g. Databricks-Gemini-3+, Databricks-GPT-5)
+            # never populate an Anthropic-style `thinking` block, so guard
+            # against that case here.
+            thinking = optional_params.get("thinking")
+            if not isinstance(thinking, dict):
+                return
+            thinking_token_budget = thinking.get("budget_tokens", None)
             if thinking_token_budget is not None:
                 optional_params["max_tokens"] = thinking_token_budget + DEFAULT_MAX_TOKENS
 

--- a/litellm/llms/databricks/chat/transformation.py
+++ b/litellm/llms/databricks/chat/transformation.py
@@ -264,6 +264,22 @@ class DatabricksConfig(DatabricksBase, OpenAILikeChatConfig, AnthropicConfig):
             "thinking",
         ]
 
+    @staticmethod
+    def _databricks_model_uses_anthropic_thinking_param(model: str) -> bool:
+        """
+        Per Databricks docs, Claude and Gemini 2.5 endpoints accept the
+        Anthropic-style `thinking={"type":"enabled","budget_tokens":N}` payload
+        and do NOT accept OpenAI's top-level `reasoning_effort`. Gemini 3+ and
+        GPT-5/GPT-OSS accept `reasoning_effort` natively and need no
+        translation.
+        """
+        model_lower = model.lower()
+        if "claude" in model_lower:
+            return True
+        if "gemini-2" in model_lower:
+            return True
+        return False
+
     def convert_anthropic_tool_to_databricks_tool(
         self, tool: Optional[AllAnthropicToolsValues]
     ) -> Optional[DatabricksTool]:
@@ -367,19 +383,24 @@ class DatabricksConfig(DatabricksBase, OpenAILikeChatConfig, AnthropicConfig):
                 "response_format", None
             )  # unsupported for claude models - if json_schema -> convert to tool call
 
-        if "reasoning_effort" in non_default_params and "claude" in model:
+        if (
+            "reasoning_effort" in non_default_params
+            and self._databricks_model_uses_anthropic_thinking_param(model)
+        ):
             reasoning_effort_value = non_default_params.get("reasoning_effort")
             mapped_thinking = AnthropicConfig._map_reasoning_effort(
                 reasoning_effort=reasoning_effort_value,
                 model=model,
                 llm_provider="databricks",
             )
+            is_claude = "claude" in model.lower()
             if mapped_thinking is None:
                 optional_params.pop("thinking", None)
                 optional_params.pop("output_config", None)
             else:
                 optional_params["thinking"] = mapped_thinking
-                if AnthropicConfig._is_adaptive_thinking_model(model):
+                # output_config + adaptive thinking is an Anthropic-only feature.
+                if is_claude and AnthropicConfig._is_adaptive_thinking_model(model):
                     mapped_effort: Optional[str] = None
                     if isinstance(reasoning_effort_value, str):
                         mapped_effort = REASONING_EFFORT_TO_OUTPUT_CONFIG_EFFORT.get(reasoning_effort_value)

--- a/litellm/llms/databricks/chat/transformation.py
+++ b/litellm/llms/databricks/chat/transformation.py
@@ -273,15 +273,14 @@ class DatabricksConfig(DatabricksBase, OpenAILikeChatConfig, AnthropicConfig):
         GPT-5/GPT-OSS accept `reasoning_effort` natively and need no
         translation.
         """
-        model_lower = model.lower()
-        if "claude" in model_lower:
-            return True
-        # Match gemini-2-5 / gemini-2.5 only — not the broader 2.x range, which
-        # could catch hypothetical future 2.0/2.6/etc variants that may use a
-        # different reasoning contract.
-        if "gemini-2-5" in model_lower or "gemini-2.5" in model_lower:
-            return True
-        return False
+        from litellm.utils import _supports_factory
+
+        normalized = model.lower().replace(".", "-")
+        return _supports_factory(
+            model=normalized,
+            custom_llm_provider="databricks",
+            key="supports_anthropic_thinking_payload",
+        )
 
     def convert_anthropic_tool_to_databricks_tool(
         self, tool: Optional[AllAnthropicToolsValues]

--- a/litellm/llms/databricks/chat/transformation.py
+++ b/litellm/llms/databricks/chat/transformation.py
@@ -276,7 +276,10 @@ class DatabricksConfig(DatabricksBase, OpenAILikeChatConfig, AnthropicConfig):
         model_lower = model.lower()
         if "claude" in model_lower:
             return True
-        if "gemini-2" in model_lower:
+        # Match gemini-2-5 / gemini-2.5 only — not the broader 2.x range, which
+        # could catch hypothetical future 2.0/2.6/etc variants that may use a
+        # different reasoning contract.
+        if "gemini-2-5" in model_lower or "gemini-2.5" in model_lower:
             return True
         return False
 

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -12690,6 +12690,7 @@
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_anthropic_thinking_payload": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-haiku-4-5": {
@@ -12709,6 +12710,7 @@
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_anthropic_thinking_payload": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4": {
@@ -12728,6 +12730,7 @@
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_anthropic_thinking_payload": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4-1": {
@@ -12747,6 +12750,7 @@
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_anthropic_thinking_payload": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4-5": {
@@ -12766,6 +12770,7 @@
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_anthropic_thinking_payload": true,
         "supports_tool_choice": true,
         "supports_output_config": true
     },
@@ -12786,6 +12791,7 @@
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_anthropic_thinking_payload": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-4-1": {
@@ -12805,6 +12811,7 @@
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_anthropic_thinking_payload": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-4-5": {
@@ -12824,6 +12831,7 @@
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_anthropic_thinking_payload": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-2-5-flash": {
@@ -12841,6 +12849,7 @@
         "output_dbu_cost_per_token": 3.5714e-05,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
+        "supports_anthropic_thinking_payload": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-2-5-pro": {
@@ -12858,6 +12867,7 @@
         "output_dbu_cost_per_token": 0.000142857,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
+        "supports_anthropic_thinking_payload": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemma-3-12b": {

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -151,6 +151,7 @@ class ProviderSpecificModelInfo(TypedDict, total=False):
     supports_max_reasoning_effort: Optional[bool]
     supports_output_config: Optional[bool]
     supports_image_size: Optional[bool]
+    supports_anthropic_thinking_payload: Optional[bool]
     bedrock_output_config_effort_ceiling: Optional[Literal["low", "medium", "high", "max", "xhigh"]]
     bedrock_converse_supports_strict_tools: Optional[bool]
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5472,6 +5472,7 @@ def _get_model_info_helper(
                 supports_url_context=_model_info.get("supports_url_context", None),
                 supports_reasoning=_model_info.get("supports_reasoning", None),
                 supports_adaptive_thinking=_model_info.get("supports_adaptive_thinking", None),
+                supports_anthropic_thinking_payload=_model_info.get("supports_anthropic_thinking_payload", None),
                 supports_none_reasoning_effort=_model_info.get("supports_none_reasoning_effort", None),
                 supports_minimal_reasoning_effort=_model_info.get("supports_minimal_reasoning_effort", None),
                 supports_low_reasoning_effort=_model_info.get("supports_low_reasoning_effort", None),

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12690,6 +12690,7 @@
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_anthropic_thinking_payload": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-haiku-4-5": {
@@ -12709,6 +12710,7 @@
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_anthropic_thinking_payload": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4": {
@@ -12728,6 +12730,7 @@
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_anthropic_thinking_payload": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4-1": {
@@ -12747,6 +12750,7 @@
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_anthropic_thinking_payload": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-opus-4-5": {
@@ -12766,6 +12770,7 @@
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_anthropic_thinking_payload": true,
         "supports_tool_choice": true,
         "supports_output_config": true
     },
@@ -12786,6 +12791,7 @@
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_anthropic_thinking_payload": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-4-1": {
@@ -12805,6 +12811,7 @@
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_anthropic_thinking_payload": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-claude-sonnet-4-5": {
@@ -12824,6 +12831,7 @@
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
         "supports_reasoning": true,
+        "supports_anthropic_thinking_payload": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-2-5-flash": {
@@ -12841,6 +12849,7 @@
         "output_dbu_cost_per_token": 3.5714e-05,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
+        "supports_anthropic_thinking_payload": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemini-2-5-pro": {
@@ -12858,6 +12867,7 @@
         "output_dbu_cost_per_token": 0.000142857,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
+        "supports_anthropic_thinking_payload": true,
         "supports_tool_choice": true
     },
     "databricks/databricks-gemma-3-12b": {

--- a/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
+++ b/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
@@ -8,6 +8,11 @@ from fastapi.testclient import TestClient
 sys.path.insert(0, os.path.abspath("../../../../.."))  # Adds the parent directory to the system path
 from unittest.mock import MagicMock, patch
 
+from litellm.constants import (
+    DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
+    DEFAULT_REASONING_EFFORT_LOW_THINKING_BUDGET,
+    DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
+)
 from litellm.llms.databricks.chat.transformation import (
     DatabricksChatResponseIterator,
     DatabricksConfig,
@@ -416,3 +421,114 @@ def test_transform_request_keeps_parallel_tool_calls_for_claude():
     )["messages"]
 
     assert len([m for m in result if m.get("role") == "assistant"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# reasoning_effort translation
+#
+# Databricks foundation-model endpoints take reasoning controls via different
+# payload shapes depending on the underlying model family:
+#
+#   Claude:        Anthropic-style `thinking={"type":"enabled","budget_tokens":N}`
+#   Gemini 2.5:    Same Anthropic-style `thinking` payload as Claude
+#                  (per docs.databricks.com/.../query-reason-models)
+#   Gemini 3+:     Native OpenAI-style top-level `reasoning_effort`
+#   GPT-5/GPT-OSS: Native OpenAI-style top-level `reasoning_effort`
+#
+# LiteLLM should translate `reasoning_effort` into the right shape for the
+# first two families and pass it through unchanged for the latter two.
+# ---------------------------------------------------------------------------
+
+
+def _map_reasoning_effort(model: str, reasoning_effort, **extra_non_default):
+    """Run map_openai_params with reasoning_effort + optional extras.
+
+    `max_tokens` is included by default to mirror real client behavior. Without
+    it the base-class `update_optional_params_with_thinking_tokens` helper
+    KeyErrors on pure pass-through models (a pre-existing issue orthogonal to
+    this fix — `is_thinking_enabled` returns True whenever `reasoning_effort` is
+    set, but the helper then assumes `optional_params["thinking"]` exists).
+    """
+    non_default = {"reasoning_effort": reasoning_effort, "max_tokens": 1024}
+    non_default.update(extra_non_default)
+    return DatabricksConfig().map_openai_params(
+        non_default_params=non_default,
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+
+
+def test_claude_translates_reasoning_effort_to_thinking():
+    """Regression: Claude path must still translate to Anthropic-style thinking."""
+    params = _map_reasoning_effort("databricks-claude-3-7-sonnet", "low")
+    assert params.get("thinking") == {
+        "type": "enabled",
+        "budget_tokens": DEFAULT_REASONING_EFFORT_LOW_THINKING_BUDGET,
+    }
+    assert "reasoning_effort" not in params
+
+
+def test_gemini_2_5_low_translates_to_thinking_budget():
+    params = _map_reasoning_effort("databricks-gemini-2-5-flash", "low")
+    assert params.get("thinking") == {
+        "type": "enabled",
+        "budget_tokens": DEFAULT_REASONING_EFFORT_LOW_THINKING_BUDGET,
+    }
+    assert "reasoning_effort" not in params
+
+
+def test_gemini_2_5_medium_translates_to_thinking_budget():
+    params = _map_reasoning_effort("databricks-gemini-2-5-flash", "medium")
+    assert params.get("thinking") == {
+        "type": "enabled",
+        "budget_tokens": DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
+    }
+    assert "reasoning_effort" not in params
+
+
+def test_gemini_2_5_high_translates_to_thinking_budget():
+    params = _map_reasoning_effort("databricks-gemini-2-5-flash", "high")
+    assert params.get("thinking") == {
+        "type": "enabled",
+        "budget_tokens": DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
+    }
+    assert "reasoning_effort" not in params
+
+
+def test_gemini_2_5_pro_translates_to_thinking_budget():
+    """Cover the gemini-2-5-pro endpoint too, not just flash."""
+    params = _map_reasoning_effort("databricks-gemini-2-5-pro", "high")
+    assert params.get("thinking") == {
+        "type": "enabled",
+        "budget_tokens": DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
+    }
+    assert "reasoning_effort" not in params
+
+
+def test_gemini_2_5_none_drops_thinking_and_reasoning_effort():
+    """`reasoning_effort='none'` mirrors the Claude behavior: no thinking emitted."""
+    params = _map_reasoning_effort("databricks-gemini-2-5-flash", "none")
+    assert "thinking" not in params
+    assert "reasoning_effort" not in params
+
+
+def test_gemini_3_passes_reasoning_effort_through():
+    """Databricks-Gemini-3+ accepts reasoning_effort natively — do not translate."""
+    params = _map_reasoning_effort("databricks-gemini-3-1-pro", "low")
+    assert params.get("reasoning_effort") == "low"
+    assert "thinking" not in params
+
+
+def test_gpt_5_passes_reasoning_effort_through():
+    """Databricks-GPT-5 family accepts reasoning_effort natively."""
+    params = _map_reasoning_effort("databricks-gpt-5-1", "low")
+    assert params.get("reasoning_effort") == "low"
+    assert "thinking" not in params
+
+
+def test_gpt_oss_passes_reasoning_effort_through():
+    """Databricks-GPT-OSS accepts reasoning_effort natively."""
+    params = _map_reasoning_effort("databricks-gpt-oss-120b", "high")
+    assert params.get("reasoning_effort") == "high"
+    assert "thinking" not in params

--- a/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
+++ b/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
@@ -441,15 +441,8 @@ def test_transform_request_keeps_parallel_tool_calls_for_claude():
 
 
 def _map_reasoning_effort(model: str, reasoning_effort, **extra_non_default):
-    """Run map_openai_params with reasoning_effort + optional extras.
-
-    `max_tokens` is included by default to mirror real client behavior. Without
-    it the base-class `update_optional_params_with_thinking_tokens` helper
-    KeyErrors on pure pass-through models (a pre-existing issue orthogonal to
-    this fix — `is_thinking_enabled` returns True whenever `reasoning_effort` is
-    set, but the helper then assumes `optional_params["thinking"]` exists).
-    """
-    non_default = {"reasoning_effort": reasoning_effort, "max_tokens": 1024}
+    """Run map_openai_params with reasoning_effort + optional extras."""
+    non_default = {"reasoning_effort": reasoning_effort}
     non_default.update(extra_non_default)
     return DatabricksConfig().map_openai_params(
         non_default_params=non_default,
@@ -504,6 +497,25 @@ def test_gemini_2_5_pro_translates_to_thinking_budget():
         "budget_tokens": DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
     }
     assert "reasoning_effort" not in params
+
+
+def test_gemini_2_5_with_dot_notation_translates():
+    """A user passing the upstream Google-style `gemini-2.5-...` form should
+    still trigger the Anthropic-thinking translation, not pass through."""
+    params = _map_reasoning_effort("databricks-gemini-2.5-flash", "low")
+    assert params.get("thinking") == {
+        "type": "enabled",
+        "budget_tokens": DEFAULT_REASONING_EFFORT_LOW_THINKING_BUDGET,
+    }
+    assert "reasoning_effort" not in params
+
+
+def test_gemini_2_0_does_not_match():
+    """Guard against over-matching: `gemini-2-0` (hypothetical or future) is
+    NOT a Gemini 2.5 endpoint and must not get the thinking translation."""
+    params = _map_reasoning_effort("databricks-gemini-2-0-flash", "low")
+    assert "thinking" not in params
+    assert params.get("reasoning_effort") == "low"
 
 
 def test_gemini_2_5_none_drops_thinking_and_reasoning_effort():

--- a/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
+++ b/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 sys.path.insert(0, os.path.abspath("../../../../.."))  # Adds the parent directory to the system path
 from unittest.mock import MagicMock, patch
 
+import litellm
 from litellm.constants import (
     DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
     DEFAULT_REASONING_EFFORT_LOW_THINKING_BUDGET,
@@ -18,6 +19,12 @@ from litellm.llms.databricks.chat.transformation import (
     DatabricksConfig,
     _sanitize_empty_content,
 )
+
+
+@pytest.fixture(autouse=True)
+def _use_local_model_cost_map(monkeypatch):
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
 
 
 def test_transform_choices():


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Start the proxy locally against a Databricks workspace with the branch checked out at `fc38503cf6`:

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

Then from another shell, exercise one Anthropic-thinking family (Gemini 2.5), the Claude regression path, and the native pass-through families (Gemini 3+, GPT-5, GPT-OSS), all with `reasoning_effort` set and `max_tokens` intentionally omitted so the previously-broken `KeyError` path also gets hit:

```bash
for m in databricks-gemini-2-5-flash databricks-gemini-2-5-pro databricks-claude-3-7-sonnet databricks-gemini-3-1-pro databricks-gpt-5-1 databricks-gpt-oss-120b; do
  echo "=== $m ==="
  curl -s http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" \
    -H "Content-Type: application/json" \
    -d "{\"model\":\"databricks/$m\",\"messages\":[{\"role\":\"user\",\"content\":\"Why is the sky blue?\"}],\"reasoning_effort\":\"low\"}"
  echo
done
```

Before, on `litellm_internal_staging` (`cd6e8cdf23`), the Gemini 2.5 requests return

```
400 Bad Request: "Invalid JSON payload received. Unknown name \"reasoning_effort\" at 'generation_config': Cannot find field."
```

and the pass-through requests (Gemini 3+, GPT-5, GPT-OSS) return a `500` from `KeyError: 'thinking'` raised at `litellm/llms/base_llm/chat/transformation.py`.

After, on `fc38503cf6`, all six models return `200` with the appropriate reasoning payload attached; the Databricks upstream receives `thinking={"type":"enabled","budget_tokens":1024}` for Claude and Gemini 2.5 and a top-level `reasoning_effort` for Gemini 3+, GPT-5, and GPT-OSS.

## Type

🐛 Bug Fix

## Changes

Calling a Databricks-hosted Gemini 2.5 model (e.g., `databricks/databricks-gemini-2-5-flash`) with the OpenAI-standard `reasoning_effort` parameter fails with a 400 from the upstream Gemini serving API because Databricks routes Gemini 2.5 through an Anthropic-shaped `thinking` contract, but `DatabricksConfig.map_openai_params()` only translated `reasoning_effort` when `"claude" in model`. Setting `litellm.drop_params = True` doesn't help since Databricks reports `reasoning_effort` as supported for every Databricks model

Per Databricks docs ([Query reasoning models](https://docs.databricks.com/aws/en/machine-learning/model-serving/query-reason-models)):

| Family | Reasoning payload Databricks expects |
| --- | --- |
| Claude | Anthropic-style `thinking={"type":"enabled","budget_tokens":N}` |
| Gemini 2.5 | Same Anthropic-style `thinking` payload as Claude |
| Gemini 3+ | OpenAI-style top-level `reasoning_effort` (native) |
| GPT-5 / GPT-OSS | OpenAI-style top-level `reasoning_effort` (native) |

`DatabricksConfig.map_openai_params()` now gates the translation branch on a new `_databricks_model_uses_anthropic_thinking_param()` helper so it fires for Claude and Gemini 2.5, matching only `gemini-2-5` / `gemini-2.5` (not the broader 2.x range). `AnthropicConfig._map_reasoning_effort()` is reused unchanged since it already returns the `{"type":"enabled","budget_tokens":N}` shape that matches the Gemini 2.5 contract exactly. Native pass-through is preserved for Gemini 3+, GPT-5, and GPT-OSS. `get_supported_openai_params()` is left alone since `reasoning_effort` is genuinely supported across the Databricks lineup; only the translation layer varies. The Claude-only `output_config` / adaptive-thinking codepath is now gated on `is_claude` since that behavior is Anthropic-specific and Gemini 2.5 has no adaptive variant

There was also a latent `KeyError` in `BaseConfig.update_optional_params_with_thinking_tokens` that any pass-through model would have hit: `is_thinking_enabled(optional_params)` returns True whenever `reasoning_effort` is set, but the helper then called `cast(dict, optional_params["thinking"])` without checking whether `thinking` was present. Reverting the guard locally makes the three pass-through tests (`test_gemini_3_passes_reasoning_effort_through`, `test_gpt_5_passes_reasoning_effort_through`, `test_gpt_oss_passes_reasoning_effort_through`) fail with the exact `KeyError`. The guard replaces the raw indexing with `optional_params.get("thinking")` plus an `isinstance` early-return, which is a strict widening of the input contract and can't regress Anthropic (whose `map_openai_params` always translates `reasoning_effort` to a `thinking` dict before this call) or Bedrock (whose call site excludes pass-through families before invoking the helper)

Test coverage in `tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py` adds regressions for Claude (still translates), Gemini 2.5 flash and pro at low/medium/high plus dot-notation and `reasoning_effort="none"`, a Gemini 2.0 negative case to guard against over-matching, and native pass-through for Gemini 3+, GPT-5, and GPT-OSS