### PR TITLE
feat(mcp): add dcr_bridge envelope consumer helpers

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/bridge_credentials.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/bridge_credentials.py
@@ -1,15 +1,16 @@
-"""Consumer-side helpers for the DCR-bridge ``oauth_delegate`` envelope.
+"""Producer and consumer helpers for the DCR-bridge ``oauth_delegate`` envelope.
 
 A DCR-bridge ``oauth_delegate`` client presents ONE bearer that is a litellm-signed
 envelope (see :mod:`.envelope`) carrying both a litellm identity and the upstream OAuth
-token. At the MCP admission edge the gateway derives the envelope keys from the proxy
-``master_key``, opens the envelope, admits the request under the recovered identity, and
-forwards the inner upstream token to the upstream MCP server. This module is the pure
-consumer surface; the admission wiring lives in ``user_api_key_auth_mcp.py`` and the
-producer (mint) side lands with the token-endpoint flow.
+token. The gateway token endpoint mints it (producer) at OAuth issuance, and at the MCP
+admission edge the gateway derives the envelope keys from the proxy ``master_key``, opens
+it, admits the request under the recovered identity, and forwards the inner upstream token
+to the upstream MCP server (consumer). This module is the pure surface for both sides; the
+token-endpoint and admission wiring live in their respective call sites.
 """
 
 import hashlib
+import hmac
 from datetime import datetime
 from typing import Literal, TypeAlias
 
@@ -18,8 +19,12 @@ from pydantic import BaseModel, ConfigDict, SecretStr
 from litellm.proxy._experimental.mcp_server.outbound_credentials.envelope import (
     EnvelopeIdentity,
     EnvelopeKeys,
+    EnvelopeMintError,
     OpenedEnvelope,
+    SealedEnvelope,
+    UpstreamTokenGrant,
     is_envelope,
+    mint_envelope,
     open_envelope,
 )
 
@@ -31,15 +36,38 @@ _BEARER_PREFIX = "bearer "
 def envelope_keys_from_master_key(master_key: str) -> EnvelopeKeys:
     """Derive the envelope signing and encryption keys from the proxy master key.
 
-    Domain-separated SHA-256 yields two distinct 64-char (256-bit) hex keys from the one
-    secret, so the producer (mint) and consumer (open) agree on keys without persisting
-    any, and even a short master key still produces a >= 32-byte signing key (HS256's
-    requirement). The derivation is deterministic; rotating ``master_key`` invalidates
-    every outstanding envelope, which is the intended behavior for a signing-key change.
+    Keyed HMAC-SHA256 over two distinct domain labels yields two independent 64-char
+    (256-bit) subkeys from the one secret, so the producer (mint) and consumer (open) agree
+    on keys without persisting any, and even a short master key still produces a >= 32-byte
+    signing key (HS256's requirement). HMAC keys the derivation on ``master_key`` (the
+    standard subkey-from-key construction) rather than hashing a concatenation. The
+    derivation is deterministic; rotating ``master_key`` invalidates every outstanding
+    envelope, which is the intended behavior for a signing-key change.
+
+    ``master_key`` is the proxy's root signing secret and must be high-entropy: a captured
+    envelope is an offline oracle for it, exactly as the existing master-key-signed session
+    tokens already are, so a low-entropy master key compromises the proxy regardless of this
+    path. A password-style slow KDF is deliberately not used here; it is the wrong tradeoff
+    for a per-request high-entropy secret.
     """
-    signing = hashlib.sha256((_SIGNING_KEY_DOMAIN + master_key).encode()).hexdigest()
-    encryption = hashlib.sha256((_ENCRYPTION_KEY_DOMAIN + master_key).encode()).hexdigest()
+    signing = hmac.new(master_key.encode(), _SIGNING_KEY_DOMAIN.encode(), hashlib.sha256).hexdigest()
+    encryption = hmac.new(master_key.encode(), _ENCRYPTION_KEY_DOMAIN.encode(), hashlib.sha256).hexdigest()
     return EnvelopeKeys(signing_key=SecretStr(signing), encryption_key=SecretStr(encryption))
+
+
+def build_bridge_token_response(
+    identity: EnvelopeIdentity,
+    grant: UpstreamTokenGrant,
+    keys: EnvelopeKeys,
+    now: datetime,
+) -> SealedEnvelope | EnvelopeMintError:
+    """Seal ``grant`` for ``identity`` into the client-held bearer the token endpoint returns.
+
+    The producer mirror of :func:`resolve_bridge_envelope`: a thin, pure wrapper over
+    :func:`mint_envelope` that returns the sealed envelope, or the mint error as a value
+    (an oversized grant) for the caller to map onto an OAuth error response.
+    """
+    return mint_envelope(identity, grant, keys, now)
 
 
 class NotBridgeEnvelope(BaseModel):
@@ -76,7 +104,19 @@ def _strip_bearer(value: str) -> str:
     return value
 
 
-def resolve_bridge_envelope(authorization_value: str, keys: EnvelopeKeys, now: datetime) -> BridgeEnvelopeResult:
+def is_bridge_envelope_shaped(authorization_value: str) -> bool:
+    """Cheap, keyless test that an ``Authorization`` value carries an envelope (optional
+    ``Bearer`` scheme stripped). The admission edge engages the bridge arm only for an
+    envelope, so a plain upstream bearer falls through to normal oauth2 admission."""
+    return is_envelope(_strip_bearer(authorization_value))
+
+
+def resolve_bridge_envelope(
+    authorization_value: str,
+    keys: EnvelopeKeys,
+    now: datetime,
+    expected_server_id: str,
+) -> BridgeEnvelopeResult:
     """Classify an ``Authorization`` value presented to a bridge ``oauth_delegate`` server.
 
     Strips an optional ``Bearer`` scheme, then returns ``NotBridgeEnvelope`` for a
@@ -84,12 +124,21 @@ def resolve_bridge_envelope(authorization_value: str, keys: EnvelopeKeys, now: d
     recovered identity and the upstream ``Authorization`` value to forward for a valid
     envelope, and ``BridgeEnvelopeInvalid`` for an envelope-shaped bearer that will not
     open. Never raises: it is total over hostile input via :func:`open_envelope`.
+
+    ``expected_server_id`` is the ``server_id`` of the MCP server the request targets; an
+    opened envelope whose sealed ``server_id`` does not match is rejected as
+    ``BridgeEnvelopeInvalid``. Binding here (rather than leaving it to the caller) prevents
+    replaying an envelope minted for one server against another, which would forward the
+    first server's upstream credential across a server boundary. The comparison is constant
+    time so a mismatch does not leak the expected id through timing.
     """
     candidate = _strip_bearer(authorization_value)
     if not is_envelope(candidate):
         return NotBridgeEnvelope()
     opened = open_envelope(candidate, keys, now)
     if not isinstance(opened, OpenedEnvelope):
+        return BridgeEnvelopeInvalid()
+    if not hmac.compare_digest(opened.identity.server_id, expected_server_id):
         return BridgeEnvelopeInvalid()
     grant = opened.grant
     upstream_authorization = f"{grant.token_type} {grant.access_token.get_secret_value()}"

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/bridge_credentials.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/bridge_credentials.py
@@ -38,7 +38,9 @@ _BEARER_PREFIX = "bearer "
 _SCRYPT_N = 2**15
 _SCRYPT_R = 8
 _SCRYPT_P = 1
-_SCRYPT_MAXMEM = 128 * _SCRYPT_N * _SCRYPT_R * 2
+# scrypt's working-set is ~128 * N * r * p bytes; cap at twice that so the maxmem ceiling scales
+# with every work factor and a future p or r bump does not trip "memory limit exceeded".
+_SCRYPT_MAXMEM = 128 * _SCRYPT_N * _SCRYPT_R * _SCRYPT_P * 2
 _DERIVED_KEY_BYTES = 32
 
 

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/bridge_credentials.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/bridge_credentials.py
@@ -12,6 +12,7 @@ token-endpoint and admission wiring live in their respective call sites.
 import hashlib
 import hmac
 from datetime import datetime
+from functools import lru_cache
 from typing import Literal, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, SecretStr
@@ -28,30 +29,51 @@ from litellm.proxy._experimental.mcp_server.outbound_credentials.envelope import
     open_envelope,
 )
 
-_SIGNING_KEY_DOMAIN = "litellm-mcp-bridge:envelope-signing:"
-_ENCRYPTION_KEY_DOMAIN = "litellm-mcp-bridge:envelope-encryption:"
+_SIGNING_KEY_DOMAIN = b"litellm-mcp-bridge:envelope-signing:"
+_ENCRYPTION_KEY_DOMAIN = b"litellm-mcp-bridge:envelope-encryption:"
 _BEARER_PREFIX = "bearer "
 
+# scrypt work factors (RFC 7914). n=2**15 with r=8/p=1 costs ~50ms and ~32MB per derivation, which
+# makes offline guessing of a candidate master key memory-hard rather than a bare hash comparison.
+_SCRYPT_N = 2**15
+_SCRYPT_R = 8
+_SCRYPT_P = 1
+_SCRYPT_MAXMEM = 128 * _SCRYPT_N * _SCRYPT_R * 2
+_DERIVED_KEY_BYTES = 32
 
+
+@lru_cache(maxsize=8)
 def envelope_keys_from_master_key(master_key: str) -> EnvelopeKeys:
     """Derive the envelope signing and encryption keys from the proxy master key.
 
-    Keyed HMAC-SHA256 over two distinct domain labels yields two independent 64-char
-    (256-bit) subkeys from the one secret, so the producer (mint) and consumer (open) agree
-    on keys without persisting any, and even a short master key still produces a >= 32-byte
-    signing key (HS256's requirement). HMAC keys the derivation on ``master_key`` (the
-    standard subkey-from-key construction) rather than hashing a concatenation. The
-    derivation is deterministic; rotating ``master_key`` invalidates every outstanding
-    envelope, which is the intended behavior for a signing-key change.
-
-    ``master_key`` is the proxy's root signing secret and must be high-entropy: a captured
-    envelope is an offline oracle for it, exactly as the existing master-key-signed session
-    tokens already are, so a low-entropy master key compromises the proxy regardless of this
-    path. A password-style slow KDF is deliberately not used here; it is the wrong tradeoff
-    for a per-request high-entropy secret.
+    A memory-hard scrypt KDF (RFC 7914) over two distinct domain-label salts yields two
+    independent 256-bit subkeys from the one secret, so the producer (mint) and consumer
+    (open) agree on keys without persisting any. scrypt is used rather than a bare hash or
+    HMAC so that a captured envelope is not a cheap offline oracle for the master key: each
+    candidate guess costs a full memory-hard derivation, which is what protects a deployment
+    whose master key is weaker than it should be. The result is cached (the master key is
+    fixed for a process), so the KDF runs once per key and adds nothing to the per-request
+    admission path. The derivation is deterministic; rotating ``master_key`` invalidates
+    every outstanding envelope, which is the intended behavior for a signing-key change.
     """
-    signing = hmac.new(master_key.encode(), _SIGNING_KEY_DOMAIN.encode(), hashlib.sha256).hexdigest()
-    encryption = hmac.new(master_key.encode(), _ENCRYPTION_KEY_DOMAIN.encode(), hashlib.sha256).hexdigest()
+    signing = hashlib.scrypt(
+        master_key.encode(),
+        salt=_SIGNING_KEY_DOMAIN,
+        n=_SCRYPT_N,
+        r=_SCRYPT_R,
+        p=_SCRYPT_P,
+        maxmem=_SCRYPT_MAXMEM,
+        dklen=_DERIVED_KEY_BYTES,
+    ).hex()
+    encryption = hashlib.scrypt(
+        master_key.encode(),
+        salt=_ENCRYPTION_KEY_DOMAIN,
+        n=_SCRYPT_N,
+        r=_SCRYPT_R,
+        p=_SCRYPT_P,
+        maxmem=_SCRYPT_MAXMEM,
+        dklen=_DERIVED_KEY_BYTES,
+    ).hex()
     return EnvelopeKeys(signing_key=SecretStr(signing), encryption_key=SecretStr(encryption))
 
 

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/bridge_credentials.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/bridge_credentials.py
@@ -10,7 +10,6 @@ token-endpoint and admission wiring live in their respective call sites.
 """
 
 import hashlib
-import hmac
 from datetime import datetime
 from functools import lru_cache
 from typing import Literal, TypeAlias
@@ -31,7 +30,6 @@ from litellm.proxy._experimental.mcp_server.outbound_credentials.envelope import
 
 _SIGNING_KEY_DOMAIN = b"litellm-mcp-bridge:envelope-signing:"
 _ENCRYPTION_KEY_DOMAIN = b"litellm-mcp-bridge:envelope-encryption:"
-_BEARER_PREFIX = "bearer "
 
 # scrypt work factors (RFC 7914). n=2**15 with r=8/p=1 costs ~50ms and ~32MB per derivation, which
 # makes offline guessing of a candidate master key memory-hard rather than a bare hash comparison.
@@ -123,8 +121,9 @@ BridgeEnvelopeResult: TypeAlias = NotBridgeEnvelope | BridgeEnvelopeAdmitted | B
 
 
 def _strip_bearer(value: str) -> str:
-    if value[: len(_BEARER_PREFIX)].lower() == _BEARER_PREFIX:
-        return value[len(_BEARER_PREFIX) :]
+    parts = value.split(None, 1)
+    if len(parts) == 2 and parts[0].lower() == "bearer":
+        return parts[1]
     return value
 
 
@@ -153,8 +152,9 @@ def resolve_bridge_envelope(
     opened envelope whose sealed ``server_id`` does not match is rejected as
     ``BridgeEnvelopeInvalid``. Binding here (rather than leaving it to the caller) prevents
     replaying an envelope minted for one server against another, which would forward the
-    first server's upstream credential across a server boundary. The comparison is constant
-    time so a mismatch does not leak the expected id through timing.
+    first server's upstream credential across a server boundary. ``server_id`` is not a
+    secret (the caller targets that server), so a plain equality check is sufficient and,
+    unlike ``hmac.compare_digest`` on ``str``, does not raise on a non-ASCII server_id.
     """
     candidate = _strip_bearer(authorization_value)
     if not is_envelope(candidate):
@@ -162,7 +162,7 @@ def resolve_bridge_envelope(
     opened = open_envelope(candidate, keys, now)
     if not isinstance(opened, OpenedEnvelope):
         return BridgeEnvelopeInvalid()
-    if not hmac.compare_digest(opened.identity.server_id, expected_server_id):
+    if opened.identity.server_id != expected_server_id:
         return BridgeEnvelopeInvalid()
     grant = opened.grant
     upstream_authorization = f"{grant.token_type} {grant.access_token.get_secret_value()}"

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/bridge_credentials.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/bridge_credentials.py
@@ -1,0 +1,96 @@
+"""Consumer-side helpers for the DCR-bridge ``oauth_delegate`` envelope.
+
+A DCR-bridge ``oauth_delegate`` client presents ONE bearer that is a litellm-signed
+envelope (see :mod:`.envelope`) carrying both a litellm identity and the upstream OAuth
+token. At the MCP admission edge the gateway derives the envelope keys from the proxy
+``master_key``, opens the envelope, admits the request under the recovered identity, and
+forwards the inner upstream token to the upstream MCP server. This module is the pure
+consumer surface; the admission wiring lives in ``user_api_key_auth_mcp.py`` and the
+producer (mint) side lands with the token-endpoint flow.
+"""
+
+import hashlib
+from datetime import datetime
+from typing import Literal, TypeAlias
+
+from pydantic import BaseModel, ConfigDict, SecretStr
+
+from litellm.proxy._experimental.mcp_server.outbound_credentials.envelope import (
+    EnvelopeIdentity,
+    EnvelopeKeys,
+    OpenedEnvelope,
+    is_envelope,
+    open_envelope,
+)
+
+_SIGNING_KEY_DOMAIN = "litellm-mcp-bridge:envelope-signing:"
+_ENCRYPTION_KEY_DOMAIN = "litellm-mcp-bridge:envelope-encryption:"
+_BEARER_PREFIX = "bearer "
+
+
+def envelope_keys_from_master_key(master_key: str) -> EnvelopeKeys:
+    """Derive the envelope signing and encryption keys from the proxy master key.
+
+    Domain-separated SHA-256 yields two distinct 64-char (256-bit) hex keys from the one
+    secret, so the producer (mint) and consumer (open) agree on keys without persisting
+    any, and even a short master key still produces a >= 32-byte signing key (HS256's
+    requirement). The derivation is deterministic; rotating ``master_key`` invalidates
+    every outstanding envelope, which is the intended behavior for a signing-key change.
+    """
+    signing = hashlib.sha256((_SIGNING_KEY_DOMAIN + master_key).encode()).hexdigest()
+    encryption = hashlib.sha256((_ENCRYPTION_KEY_DOMAIN + master_key).encode()).hexdigest()
+    return EnvelopeKeys(signing_key=SecretStr(signing), encryption_key=SecretStr(encryption))
+
+
+class NotBridgeEnvelope(BaseModel):
+    """The bearer is not an envelope; admission continues on its normal path."""
+
+    model_config = ConfigDict(frozen=True)
+    tag: Literal["not_bridge_envelope"] = "not_bridge_envelope"
+
+
+class BridgeEnvelopeAdmitted(BaseModel):
+    """A valid envelope: the identity to admit under and the full upstream ``Authorization``
+    value (``token_type access_token``) to forward to the upstream MCP server."""
+
+    model_config = ConfigDict(frozen=True)
+    tag: Literal["admitted"] = "admitted"
+    identity: EnvelopeIdentity
+    upstream_authorization: SecretStr
+
+
+class BridgeEnvelopeInvalid(BaseModel):
+    """The bearer is envelope-shaped but did not open (expired, tampered, wrong key);
+    admission must fail closed rather than fall through to normal validation."""
+
+    model_config = ConfigDict(frozen=True)
+    tag: Literal["invalid"] = "invalid"
+
+
+BridgeEnvelopeResult: TypeAlias = NotBridgeEnvelope | BridgeEnvelopeAdmitted | BridgeEnvelopeInvalid
+
+
+def _strip_bearer(value: str) -> str:
+    if value[: len(_BEARER_PREFIX)].lower() == _BEARER_PREFIX:
+        return value[len(_BEARER_PREFIX) :]
+    return value
+
+
+def resolve_bridge_envelope(authorization_value: str, keys: EnvelopeKeys, now: datetime) -> BridgeEnvelopeResult:
+    """Classify an ``Authorization`` value presented to a bridge ``oauth_delegate`` server.
+
+    Strips an optional ``Bearer`` scheme, then returns ``NotBridgeEnvelope`` for a
+    non-envelope bearer (normal admission continues), ``BridgeEnvelopeAdmitted`` with the
+    recovered identity and the upstream ``Authorization`` value to forward for a valid
+    envelope, and ``BridgeEnvelopeInvalid`` for an envelope-shaped bearer that will not
+    open. Never raises: it is total over hostile input via :func:`open_envelope`.
+    """
+    candidate = _strip_bearer(authorization_value)
+    if not is_envelope(candidate):
+        return NotBridgeEnvelope()
+    opened = open_envelope(candidate, keys, now)
+    if not isinstance(opened, OpenedEnvelope):
+        return BridgeEnvelopeInvalid()
+    grant = opened.grant
+    upstream_authorization = f"{grant.token_type} {grant.access_token.get_secret_value()}"
+    return BridgeEnvelopeAdmitted(identity=opened.identity, upstream_authorization=SecretStr(upstream_authorization))

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_bridge_credentials.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_bridge_credentials.py
@@ -150,6 +150,26 @@ def test_resolve_matching_server_binding_is_admitted():
     assert isinstance(result, BridgeEnvelopeAdmitted)
 
 
+def test_resolve_non_ascii_server_id_stays_total_and_does_not_raise():
+    """The server-binding check must not raise on a non-ASCII server_id (an admin can register a
+    unicode server_id); it stays total and returns a typed result. A matching non-ASCII id admits,
+    a mismatching one is BridgeEnvelopeInvalid, and neither raises."""
+    keys = envelope_keys_from_master_key(_MASTER_KEY)
+    unicode_identity = EnvelopeIdentity(user_id=_IDENTITY.user_id, server_id="srv-café")
+    token = _sealed_token(keys, identity=unicode_identity)
+    assert isinstance(resolve_bridge_envelope(token, keys, _NOW, "srv-café"), BridgeEnvelopeAdmitted)
+    assert isinstance(resolve_bridge_envelope(token, keys, _NOW, "srv-cafe"), BridgeEnvelopeInvalid)
+
+
+def test_resolve_strips_bearer_with_extra_whitespace():
+    """A Bearer scheme separated by extra spaces or a tab still yields the envelope, so a client
+    using non-minimal but legal whitespace is not misclassified as a non-envelope."""
+    keys = envelope_keys_from_master_key(_MASTER_KEY)
+    token = _sealed_token(keys)
+    for header in (f"Bearer  {token}", f"Bearer\t{token}", f"  Bearer {token}"):
+        assert isinstance(resolve_bridge_envelope(header, keys, _NOW, _SERVER_ID), BridgeEnvelopeAdmitted)
+
+
 def test_admitted_result_repr_never_leaks_upstream_token():
     keys = envelope_keys_from_master_key(_MASTER_KEY)
     result = resolve_bridge_envelope(_sealed_token(keys), keys, _NOW, _SERVER_ID)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_bridge_credentials.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_bridge_credentials.py
@@ -69,6 +69,15 @@ def test_key_derivation_signing_key_meets_hs256_floor_for_short_master_key():
     assert len(keys.signing_key.get_secret_value()) >= 32
 
 
+def test_key_derivation_is_cached_so_the_memory_hard_kdf_runs_once_per_key():
+    """The scrypt KDF is intentionally expensive to resist offline guessing, so it must be cached:
+    repeated calls for the same master key return the identical object rather than re-deriving,
+    keeping the per-request admission path free. Returning a distinct object each call would mean
+    the cache was dropped and every open would pay the memory-hard cost."""
+    first = envelope_keys_from_master_key("sk-cache-probe-key-9988776655")
+    assert envelope_keys_from_master_key("sk-cache-probe-key-9988776655") is first
+
+
 def test_derived_keys_round_trip_mint_and_open():
     keys = envelope_keys_from_master_key(_MASTER_KEY)
     result = resolve_bridge_envelope(_sealed_token(keys), keys, _NOW, _SERVER_ID)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_bridge_credentials.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_bridge_credentials.py
@@ -1,0 +1,127 @@
+"""Spec tests for the DCR-bridge envelope consumer helpers.
+
+These pin the two consumer contracts the admission edge depends on: the master-key key
+derivation is deterministic, domain-separated, and always yields a >= 32-byte signing key
+(so mint and open agree without persisting keys), and the ``Authorization`` classifier is
+total over the three cases admission branches on (non-envelope, valid envelope, and
+envelope-shaped-but-unopenable), never leaking the recovered upstream token in a repr.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from pydantic import SecretStr
+
+from litellm.proxy._experimental.mcp_server.outbound_credentials.bridge_credentials import (
+    BridgeEnvelopeAdmitted,
+    BridgeEnvelopeInvalid,
+    NotBridgeEnvelope,
+    envelope_keys_from_master_key,
+    resolve_bridge_envelope,
+)
+from litellm.proxy._experimental.mcp_server.outbound_credentials.envelope import (
+    ENVELOPE_PREFIX,
+    EnvelopeIdentity,
+    EnvelopeKeys,
+    SealedEnvelope,
+    UpstreamTokenGrant,
+    mint_envelope,
+)
+
+_NOW = datetime(2026, 7, 9, 12, 0, 0, tzinfo=timezone.utc)
+_MASTER_KEY = "sk-master-key-for-derivation-tests-0123456789"
+_ACCESS_TOKEN = "upstream-access-token-do-not-leak-8f14e45fceea"
+_IDENTITY = EnvelopeIdentity(user_id="user-123", server_id="srv-456")
+
+
+def _grant() -> UpstreamTokenGrant:
+    return UpstreamTokenGrant(access_token=SecretStr(_ACCESS_TOKEN), token_type="Bearer", expires_in=600)
+
+
+def _sealed_token(keys: EnvelopeKeys, now: datetime = _NOW) -> str:
+    sealed = mint_envelope(_IDENTITY, _grant(), keys, now)
+    assert isinstance(sealed, SealedEnvelope)
+    return sealed.token.get_secret_value()
+
+
+def test_key_derivation_is_deterministic():
+    assert envelope_keys_from_master_key(_MASTER_KEY) == envelope_keys_from_master_key(_MASTER_KEY)
+
+
+def test_key_derivation_signing_and_encryption_differ():
+    keys = envelope_keys_from_master_key(_MASTER_KEY)
+    assert keys.signing_key.get_secret_value() != keys.encryption_key.get_secret_value()
+
+
+def test_key_derivation_differs_by_master_key():
+    a = envelope_keys_from_master_key(_MASTER_KEY)
+    b = envelope_keys_from_master_key(_MASTER_KEY + "x")
+    assert a.signing_key.get_secret_value() != b.signing_key.get_secret_value()
+    assert a.encryption_key.get_secret_value() != b.encryption_key.get_secret_value()
+
+
+def test_key_derivation_signing_key_meets_hs256_floor_for_short_master_key():
+    keys = envelope_keys_from_master_key("x")
+    assert len(keys.signing_key.get_secret_value()) >= 32
+
+
+def test_derived_keys_round_trip_mint_and_open():
+    keys = envelope_keys_from_master_key(_MASTER_KEY)
+    result = resolve_bridge_envelope(_sealed_token(keys), keys, _NOW)
+    assert isinstance(result, BridgeEnvelopeAdmitted)
+    assert result.identity == _IDENTITY
+
+
+def test_resolve_non_envelope_is_not_bridge_envelope():
+    keys = envelope_keys_from_master_key(_MASTER_KEY)
+    assert isinstance(resolve_bridge_envelope("Bearer sk-some-litellm-key", keys, _NOW), NotBridgeEnvelope)
+    assert isinstance(resolve_bridge_envelope("plain-token", keys, _NOW), NotBridgeEnvelope)
+
+
+def test_resolve_valid_envelope_returns_identity_and_upstream_authorization():
+    keys = envelope_keys_from_master_key(_MASTER_KEY)
+    result = resolve_bridge_envelope(_sealed_token(keys), keys, _NOW)
+    assert isinstance(result, BridgeEnvelopeAdmitted)
+    assert result.identity == _IDENTITY
+    assert result.upstream_authorization.get_secret_value() == f"Bearer {_ACCESS_TOKEN}"
+
+
+def test_resolve_strips_optional_bearer_scheme_before_detection():
+    keys = envelope_keys_from_master_key(_MASTER_KEY)
+    token = _sealed_token(keys)
+    assert token.startswith(ENVELOPE_PREFIX)
+    bare = resolve_bridge_envelope(token, keys, _NOW)
+    prefixed = resolve_bridge_envelope(f"Bearer {token}", keys, _NOW)
+    lower = resolve_bridge_envelope(f"bearer {token}", keys, _NOW)
+    assert isinstance(bare, BridgeEnvelopeAdmitted)
+    assert isinstance(prefixed, BridgeEnvelopeAdmitted)
+    assert isinstance(lower, BridgeEnvelopeAdmitted)
+    assert prefixed.upstream_authorization.get_secret_value() == bare.upstream_authorization.get_secret_value()
+
+
+def test_resolve_expired_envelope_is_invalid_not_admitted():
+    keys = envelope_keys_from_master_key(_MASTER_KEY)
+    token = _sealed_token(keys, now=_NOW)
+    later = _NOW + timedelta(seconds=601)
+    assert isinstance(resolve_bridge_envelope(token, keys, later), BridgeEnvelopeInvalid)
+
+
+def test_resolve_envelope_minted_under_a_different_master_key_is_invalid():
+    minted = envelope_keys_from_master_key(_MASTER_KEY)
+    other = envelope_keys_from_master_key("a-completely-different-master-key")
+    assert isinstance(resolve_bridge_envelope(_sealed_token(minted), other, _NOW), BridgeEnvelopeInvalid)
+
+
+def test_resolve_tampered_envelope_is_invalid():
+    keys = envelope_keys_from_master_key(_MASTER_KEY)
+    token = _sealed_token(keys)
+    tampered = token[:-4] + ("aaaa" if token[-4:] != "aaaa" else "bbbb")
+    result = resolve_bridge_envelope(tampered, keys, _NOW)
+    assert isinstance(result, BridgeEnvelopeInvalid)
+
+
+def test_admitted_result_repr_never_leaks_upstream_token():
+    keys = envelope_keys_from_master_key(_MASTER_KEY)
+    result = resolve_bridge_envelope(_sealed_token(keys), keys, _NOW)
+    assert isinstance(result, BridgeEnvelopeAdmitted)
+    assert _ACCESS_TOKEN not in repr(result)
+    assert _ACCESS_TOKEN not in str(result)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_bridge_credentials.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_bridge_credentials.py
@@ -1,10 +1,11 @@
-"""Spec tests for the DCR-bridge envelope consumer helpers.
+"""Spec tests for the DCR-bridge envelope producer and consumer helpers.
 
-These pin the two consumer contracts the admission edge depends on: the master-key key
-derivation is deterministic, domain-separated, and always yields a >= 32-byte signing key
-(so mint and open agree without persisting keys), and the ``Authorization`` classifier is
-total over the three cases admission branches on (non-envelope, valid envelope, and
-envelope-shaped-but-unopenable), never leaking the recovered upstream token in a repr.
+These pin the contracts the token endpoint and admission edge depend on: the master-key
+key derivation is deterministic, domain-separated (keyed HMAC), and always yields a
+>= 32-byte signing key; the ``Authorization`` classifier is total over the cases admission
+branches on (non-envelope, valid envelope bound to this server, envelope-shaped-but-
+unopenable, and envelope minted for a different server); the producer helper round-trips
+through the consumer; and no path leaks the upstream token in a repr.
 """
 
 from datetime import datetime, timedelta, timezone
@@ -15,13 +16,16 @@ from litellm.proxy._experimental.mcp_server.outbound_credentials.bridge_credenti
     BridgeEnvelopeAdmitted,
     BridgeEnvelopeInvalid,
     NotBridgeEnvelope,
+    build_bridge_token_response,
     envelope_keys_from_master_key,
+    is_bridge_envelope_shaped,
     resolve_bridge_envelope,
 )
 from litellm.proxy._experimental.mcp_server.outbound_credentials.envelope import (
     ENVELOPE_PREFIX,
     EnvelopeIdentity,
     EnvelopeKeys,
+    EnvelopeTooLarge,
     SealedEnvelope,
     UpstreamTokenGrant,
     mint_envelope,
@@ -31,14 +35,15 @@ _NOW = datetime(2026, 7, 9, 12, 0, 0, tzinfo=timezone.utc)
 _MASTER_KEY = "sk-master-key-for-derivation-tests-0123456789"
 _ACCESS_TOKEN = "upstream-access-token-do-not-leak-8f14e45fceea"
 _IDENTITY = EnvelopeIdentity(user_id="user-123", server_id="srv-456")
+_SERVER_ID = _IDENTITY.server_id
 
 
 def _grant() -> UpstreamTokenGrant:
     return UpstreamTokenGrant(access_token=SecretStr(_ACCESS_TOKEN), token_type="Bearer", expires_in=600)
 
 
-def _sealed_token(keys: EnvelopeKeys, now: datetime = _NOW) -> str:
-    sealed = mint_envelope(_IDENTITY, _grant(), keys, now)
+def _sealed_token(keys: EnvelopeKeys, now: datetime = _NOW, identity: EnvelopeIdentity = _IDENTITY) -> str:
+    sealed = mint_envelope(identity, _grant(), keys, now)
     assert isinstance(sealed, SealedEnvelope)
     return sealed.token.get_secret_value()
 
@@ -66,20 +71,20 @@ def test_key_derivation_signing_key_meets_hs256_floor_for_short_master_key():
 
 def test_derived_keys_round_trip_mint_and_open():
     keys = envelope_keys_from_master_key(_MASTER_KEY)
-    result = resolve_bridge_envelope(_sealed_token(keys), keys, _NOW)
+    result = resolve_bridge_envelope(_sealed_token(keys), keys, _NOW, _SERVER_ID)
     assert isinstance(result, BridgeEnvelopeAdmitted)
     assert result.identity == _IDENTITY
 
 
 def test_resolve_non_envelope_is_not_bridge_envelope():
     keys = envelope_keys_from_master_key(_MASTER_KEY)
-    assert isinstance(resolve_bridge_envelope("Bearer sk-some-litellm-key", keys, _NOW), NotBridgeEnvelope)
-    assert isinstance(resolve_bridge_envelope("plain-token", keys, _NOW), NotBridgeEnvelope)
+    assert isinstance(resolve_bridge_envelope("Bearer sk-some-litellm-key", keys, _NOW, _SERVER_ID), NotBridgeEnvelope)
+    assert isinstance(resolve_bridge_envelope("plain-token", keys, _NOW, _SERVER_ID), NotBridgeEnvelope)
 
 
 def test_resolve_valid_envelope_returns_identity_and_upstream_authorization():
     keys = envelope_keys_from_master_key(_MASTER_KEY)
-    result = resolve_bridge_envelope(_sealed_token(keys), keys, _NOW)
+    result = resolve_bridge_envelope(_sealed_token(keys), keys, _NOW, _SERVER_ID)
     assert isinstance(result, BridgeEnvelopeAdmitted)
     assert result.identity == _IDENTITY
     assert result.upstream_authorization.get_secret_value() == f"Bearer {_ACCESS_TOKEN}"
@@ -89,9 +94,9 @@ def test_resolve_strips_optional_bearer_scheme_before_detection():
     keys = envelope_keys_from_master_key(_MASTER_KEY)
     token = _sealed_token(keys)
     assert token.startswith(ENVELOPE_PREFIX)
-    bare = resolve_bridge_envelope(token, keys, _NOW)
-    prefixed = resolve_bridge_envelope(f"Bearer {token}", keys, _NOW)
-    lower = resolve_bridge_envelope(f"bearer {token}", keys, _NOW)
+    bare = resolve_bridge_envelope(token, keys, _NOW, _SERVER_ID)
+    prefixed = resolve_bridge_envelope(f"Bearer {token}", keys, _NOW, _SERVER_ID)
+    lower = resolve_bridge_envelope(f"bearer {token}", keys, _NOW, _SERVER_ID)
     assert isinstance(bare, BridgeEnvelopeAdmitted)
     assert isinstance(prefixed, BridgeEnvelopeAdmitted)
     assert isinstance(lower, BridgeEnvelopeAdmitted)
@@ -102,26 +107,83 @@ def test_resolve_expired_envelope_is_invalid_not_admitted():
     keys = envelope_keys_from_master_key(_MASTER_KEY)
     token = _sealed_token(keys, now=_NOW)
     later = _NOW + timedelta(seconds=601)
-    assert isinstance(resolve_bridge_envelope(token, keys, later), BridgeEnvelopeInvalid)
+    assert isinstance(resolve_bridge_envelope(token, keys, later, _SERVER_ID), BridgeEnvelopeInvalid)
 
 
 def test_resolve_envelope_minted_under_a_different_master_key_is_invalid():
     minted = envelope_keys_from_master_key(_MASTER_KEY)
     other = envelope_keys_from_master_key("a-completely-different-master-key")
-    assert isinstance(resolve_bridge_envelope(_sealed_token(minted), other, _NOW), BridgeEnvelopeInvalid)
+    assert isinstance(resolve_bridge_envelope(_sealed_token(minted), other, _NOW, _SERVER_ID), BridgeEnvelopeInvalid)
 
 
 def test_resolve_tampered_envelope_is_invalid():
     keys = envelope_keys_from_master_key(_MASTER_KEY)
     token = _sealed_token(keys)
     tampered = token[:-4] + ("aaaa" if token[-4:] != "aaaa" else "bbbb")
-    result = resolve_bridge_envelope(tampered, keys, _NOW)
+    result = resolve_bridge_envelope(tampered, keys, _NOW, _SERVER_ID)
     assert isinstance(result, BridgeEnvelopeInvalid)
+
+
+def test_resolve_envelope_minted_for_another_server_is_invalid():
+    """An envelope sealed for server A must be rejected when presented to server B, so a
+    captured or misrouted envelope cannot forward one server's upstream credential to
+    another. The valid access token stays sealed; the mismatch alone fails the resolve."""
+    keys = envelope_keys_from_master_key(_MASTER_KEY)
+    other_server_identity = EnvelopeIdentity(user_id=_IDENTITY.user_id, server_id="srv-OTHER")
+    token = _sealed_token(keys, identity=other_server_identity)
+    result = resolve_bridge_envelope(token, keys, _NOW, _SERVER_ID)
+    assert isinstance(result, BridgeEnvelopeInvalid)
+
+
+def test_resolve_matching_server_binding_is_admitted():
+    keys = envelope_keys_from_master_key(_MASTER_KEY)
+    result = resolve_bridge_envelope(_sealed_token(keys), keys, _NOW, "srv-456")
+    assert isinstance(result, BridgeEnvelopeAdmitted)
 
 
 def test_admitted_result_repr_never_leaks_upstream_token():
     keys = envelope_keys_from_master_key(_MASTER_KEY)
-    result = resolve_bridge_envelope(_sealed_token(keys), keys, _NOW)
+    result = resolve_bridge_envelope(_sealed_token(keys), keys, _NOW, _SERVER_ID)
     assert isinstance(result, BridgeEnvelopeAdmitted)
     assert _ACCESS_TOKEN not in repr(result)
     assert _ACCESS_TOKEN not in str(result)
+
+
+def test_build_bridge_token_response_round_trips_through_the_consumer():
+    keys = envelope_keys_from_master_key(_MASTER_KEY)
+    sealed = build_bridge_token_response(_IDENTITY, _grant(), keys, _NOW)
+    assert isinstance(sealed, SealedEnvelope)
+    assert sealed.token.get_secret_value().startswith(ENVELOPE_PREFIX)
+    result = resolve_bridge_envelope(sealed.token.get_secret_value(), keys, _NOW, _SERVER_ID)
+    assert isinstance(result, BridgeEnvelopeAdmitted)
+    assert result.identity == _IDENTITY
+    assert result.upstream_authorization.get_secret_value() == f"Bearer {_ACCESS_TOKEN}"
+
+
+def test_build_bridge_token_response_oversized_grant_returns_error_value():
+    keys = envelope_keys_from_master_key(_MASTER_KEY)
+    huge = UpstreamTokenGrant(access_token=SecretStr("x" * 20000), token_type="Bearer")
+    result = build_bridge_token_response(_IDENTITY, huge, keys, _NOW)
+    assert isinstance(result, EnvelopeTooLarge)
+
+
+def test_build_bridge_token_response_repr_never_leaks_upstream_token():
+    keys = envelope_keys_from_master_key(_MASTER_KEY)
+    sealed = build_bridge_token_response(_IDENTITY, _grant(), keys, _NOW)
+    assert isinstance(sealed, SealedEnvelope)
+    assert _ACCESS_TOKEN not in repr(sealed)
+    assert _ACCESS_TOKEN not in str(sealed)
+
+
+def test_is_bridge_envelope_shaped_detects_envelope_with_and_without_bearer():
+    keys = envelope_keys_from_master_key(_MASTER_KEY)
+    token = _sealed_token(keys)
+    assert is_bridge_envelope_shaped(token) is True
+    assert is_bridge_envelope_shaped(f"Bearer {token}") is True
+    assert is_bridge_envelope_shaped(f"bearer {token}") is True
+
+
+def test_is_bridge_envelope_shaped_rejects_non_envelope_bearer():
+    assert is_bridge_envelope_shaped("Bearer sk-some-litellm-key") is False
+    assert is_bridge_envelope_shaped("plain-upstream-token") is False
+    assert is_bridge_envelope_shaped("") is False


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Part of LIT-4338 (based on the envelope module PR so the review diff is only this change; the admission wiring that calls these helpers lands in the follow-up that carries the dcr_bridge server flag and the producer, since it needs both)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR is a pure, deliberately unwired consumer module (nothing imports it yet; the admission edge that calls it lands in the follow-up that also carries the server-side dcr_bridge flag). There is no endpoint to drive, so the contract is pinned by 12 unit tests: the key derivation is deterministic, domain-separated, and yields a >= 32-byte signing key even from a short master key; and the Authorization classifier returns the right one of three results for a non-envelope, a valid envelope, and an envelope-shaped-but-unopenable bearer, never leaking the recovered upstream token in a repr

```
pytest tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_bridge_credentials.py -q
12 passed
pytest tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/ -q
314 passed
```

## Type

🆕 New Feature

## Changes

Adds the consumer-side helpers the MCP admission edge will use to accept a DCR-bridge oauth_delegate envelope: the single client bearer that carries both a litellm identity and the encrypted upstream OAuth token

envelope_keys_from_master_key derives the signing and encryption keys from the proxy master key with domain-separated SHA-256, so the producer (mint) and consumer (open) agree on keys without persisting any and a short master key still meets the HS256 key-length floor. resolve_bridge_envelope classifies an Authorization value for a bridge server: it strips an optional Bearer scheme, then returns NotBridgeEnvelope for a non-envelope bearer (normal admission continues), BridgeEnvelopeAdmitted with the recovered identity and the upstream Authorization value to forward for a valid envelope, and BridgeEnvelopeInvalid for an envelope-shaped bearer that will not open so admission can fail closed. It never raises; it is total over hostile input via the envelope module's open_envelope

The result type is a frozen tagged union, keys and the clock are passed in rather than read from globals, and the recovered upstream token is held as a SecretStr so it cannot reach a log through a repr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential packaging and master-key-derived crypto for MCP admission, but the module is not wired yet and behavior is heavily specified by tests.
> 
> **Overview**
> Adds **`bridge_credentials`**, a pure (unwired) layer on top of the existing **`envelope`** module for DCR-bridge **`oauth_delegate`**: one client bearer that seals LiteLLM identity plus upstream OAuth for minting at the token endpoint and opening at MCP admission.
> 
> **`envelope_keys_from_master_key`** derives separate signing and encryption keys from the proxy **`master_key`** via domain-separated **scrypt** (cached per process), so mint/open agree without stored keys and master-key rotation invalidates outstanding envelopes. **`build_bridge_token_response`** wraps **`mint_envelope`** for the producer; **`resolve_bridge_envelope`** and **`is_bridge_envelope_shaped`** classify **`Authorization`** (optional **`Bearer`** strip) into **`NotBridgeEnvelope`**, **`BridgeEnvelopeAdmitted`** (identity + upstream **`Authorization`** as **`SecretStr`**), or **`BridgeEnvelopeInvalid`**, with **`expected_server_id`** binding to block cross-server replay. Invalid envelope-shaped tokens fail closed; non-envelopes fall through to normal admission.
> 
> Spec tests cover derivation, round-trip, expiry/tamper/wrong-key, server binding (including non-ASCII **`server_id`**), whitespace handling, oversized grants, and no upstream token leakage in **`repr`**/**`str`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0053527ccff26b8b7653fd41e944be5ef13e6e22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->