### PR TITLE
feat(bedrock): support STS session tags for AssumeRole

### DIFF
--- a/litellm/litellm_core_utils/get_litellm_params.py
+++ b/litellm/litellm_core_utils/get_litellm_params.py
@@ -32,6 +32,7 @@ OPTIONAL_KWARGS_KEYS = frozenset(
         "aws_web_identity_token",
         "aws_sts_endpoint",
         "aws_external_id",
+        "aws_session_tags",
         "aws_bedrock_runtime_endpoint",
         "aws_bedrock_project_id",
         "tpm",

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -97,6 +97,7 @@ class BaseAWSLLM:
             "aws_sts_endpoint",
             "aws_bedrock_runtime_endpoint",
             "aws_external_id",
+            "aws_session_tags",
         ]
 
     def _get_ssl_verify(self, ssl_verify: Optional[Union[bool, str]] = None):
@@ -196,6 +197,7 @@ class BaseAWSLLM:
         aws_web_identity_token: Optional[str] = None,
         aws_sts_endpoint: Optional[str] = None,
         aws_external_id: Optional[str] = None,
+        aws_session_tags: Optional[Dict[str, str]] = None,
         ssl_verify: Optional[Union[bool, str]] = None,
     ):
         """
@@ -305,6 +307,7 @@ class BaseAWSLLM:
                 aws_region_name=aws_region_name,
                 aws_sts_endpoint=aws_sts_endpoint,
                 aws_external_id=aws_external_id,
+                aws_session_tags=aws_session_tags,
                 ssl_verify=ssl_verify,
             )
             return credentials
@@ -927,6 +930,7 @@ class BaseAWSLLM:
         web_identity_token_file: str,
         aws_external_id: Optional[str] = None,
         aws_sts_endpoint: Optional[str] = None,
+        aws_session_tags: Optional[Dict[str, str]] = None,
         ssl_verify: Optional[Union[bool, str]] = None,
     ) -> dict:
         """Handle cross-account role assumption for IRSA."""
@@ -988,6 +992,10 @@ class BaseAWSLLM:
         if aws_external_id is not None:
             assume_role_params["ExternalId"] = aws_external_id
 
+        # Add session Tags parameter if provided (requires sts:TagSession in the role trust policy)
+        if aws_session_tags:
+            assume_role_params["Tags"] = [{"Key": k, "Value": v} for k, v in aws_session_tags.items()]
+
         return sts_client_with_creds.assume_role(**assume_role_params)
 
     def _handle_irsa_same_account(
@@ -996,6 +1004,7 @@ class BaseAWSLLM:
         aws_session_name: str,
         aws_external_id: Optional[str] = None,
         aws_sts_endpoint: Optional[str] = None,
+        aws_session_tags: Optional[Dict[str, str]] = None,
         ssl_verify: Optional[Union[bool, str]] = None,
     ) -> dict:
         """Handle same-account role assumption for IRSA."""
@@ -1028,6 +1037,10 @@ class BaseAWSLLM:
         if aws_external_id is not None:
             assume_role_params["ExternalId"] = aws_external_id
 
+        # Add session Tags parameter if provided (requires sts:TagSession in the role trust policy)
+        if aws_session_tags:
+            assume_role_params["Tags"] = [{"Key": k, "Value": v} for k, v in aws_session_tags.items()]
+
         return sts_client.assume_role(**assume_role_params)
 
     def _extract_credentials_and_ttl(self, sts_response: dict) -> Tuple[Credentials, Optional[int]]:
@@ -1057,6 +1070,7 @@ class BaseAWSLLM:
         aws_region_name: Optional[str] = None,
         aws_sts_endpoint: Optional[str] = None,
         aws_external_id: Optional[str] = None,
+        aws_session_tags: Optional[Dict[str, str]] = None,
         ssl_verify: Optional[Union[bool, str]] = None,
     ) -> Tuple[Credentials, Optional[int]]:
         """
@@ -1086,6 +1100,7 @@ class BaseAWSLLM:
                         web_identity_token_file,
                         aws_external_id,
                         aws_sts_endpoint=aws_sts_endpoint,
+                        aws_session_tags=aws_session_tags,
                         ssl_verify=ssl_verify,
                     )
                 else:
@@ -1094,6 +1109,7 @@ class BaseAWSLLM:
                         aws_session_name,
                         aws_external_id,
                         aws_sts_endpoint=aws_sts_endpoint,
+                        aws_session_tags=aws_session_tags,
                         ssl_verify=ssl_verify,
                     )
 
@@ -1138,6 +1154,10 @@ class BaseAWSLLM:
         # Add ExternalId parameter if provided
         if aws_external_id is not None:
             assume_role_params["ExternalId"] = aws_external_id
+
+        # Add session Tags parameter if provided (requires sts:TagSession in the role trust policy)
+        if aws_session_tags:
+            assume_role_params["Tags"] = [{"Key": k, "Value": v} for k, v in aws_session_tags.items()]
 
         try:
             sts_response = sts_client.assume_role(**assume_role_params)
@@ -1338,6 +1358,7 @@ class BaseAWSLLM:
             "aws_bedrock_runtime_endpoint", None
         )  # https://bedrock-runtime.{region_name}.amazonaws.com
         aws_external_id = optional_params.pop("aws_external_id", None)
+        aws_session_tags = optional_params.pop("aws_session_tags", None)
 
         credentials: Credentials = self.get_credentials(
             aws_access_key_id=aws_access_key_id,
@@ -1350,6 +1371,7 @@ class BaseAWSLLM:
             aws_web_identity_token=aws_web_identity_token,
             aws_sts_endpoint=aws_sts_endpoint,
             aws_external_id=aws_external_id,
+            aws_session_tags=aws_session_tags,
         )
 
         return Boto3CredentialsInfo(

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -115,7 +115,7 @@ class BaseAWSLLM:
 
         return get_ssl_verify(ssl_verify=ssl_verify)
 
-    def get_cache_key(self, credential_args: Dict[str, Optional[str]]) -> str:
+    def get_cache_key(self, credential_args: Dict[str, Any]) -> str:
         """
         Generate a unique cache key based on the credential arguments.
         """

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -202,6 +202,12 @@ class BaseAWSLLM:
     ):
         """
         Return a boto3.Credentials object
+
+        Note on aws_session_tags: like every aws_* param, this can be supplied
+        per-request by an authenticated caller, and a request value overrides the
+        deployment config value. Deployments that rely on session tags for billing
+        attribution or tag-gated IAM policies should restrict caller-supplied
+        aws_* params so tags stay deployment-controlled.
         """
         # Only config-sourced credentials are expanded against the environment.
         # os.environ/<VAR> references in the model config are resolved at load time,

--- a/litellm/llms/bedrock/chat/converse_handler.py
+++ b/litellm/llms/bedrock/chat/converse_handler.py
@@ -317,6 +317,7 @@ class BedrockConverseLLM(BaseAWSLLM):
         aws_web_identity_token = optional_params.pop("aws_web_identity_token", None)
         aws_sts_endpoint = optional_params.pop("aws_sts_endpoint", None)
         aws_external_id = optional_params.pop("aws_external_id", None)
+        aws_session_tags = optional_params.pop("aws_session_tags", None)
         optional_params.pop("aws_region_name", None)
 
         litellm_params["aws_region_name"] = aws_region_name  # [DO NOT DELETE] important for async calls
@@ -332,6 +333,7 @@ class BedrockConverseLLM(BaseAWSLLM):
             aws_web_identity_token=aws_web_identity_token,
             aws_sts_endpoint=aws_sts_endpoint,
             aws_external_id=aws_external_id,
+            aws_session_tags=aws_session_tags,
         )
 
         ### SET RUNTIME ENDPOINT ###

--- a/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
+++ b/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
@@ -2093,6 +2093,107 @@ def test_assume_role_without_session_tags():
         )
 
 
+def _mock_irsa_sts_client():
+    mock_sts_client = MagicMock()
+    expiry = datetime.now(timezone.utc) + timedelta(hours=1)
+    mock_sts_client.assume_role_with_web_identity.return_value = {
+        "Credentials": {
+            "AccessKeyId": "temp-key",
+            "SecretAccessKey": "temp-secret",
+            "SessionToken": "temp-token",
+            "Expiration": expiry,
+        }
+    }
+    mock_sts_client.assume_role.return_value = {
+        "Credentials": {
+            "AccessKeyId": "assumed-key",
+            "SecretAccessKey": "assumed-secret",
+            "SessionToken": "assumed-token",
+            "Expiration": expiry,
+        }
+    }
+    return mock_sts_client
+
+
+def test_irsa_cross_account_assume_role_with_session_tags():
+    """IRSA cross-account path must pass session Tags to the target-role AssumeRole call."""
+    base_aws_llm = BaseAWSLLM()
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+        f.write("test-web-identity-token")
+        token_file = f.name
+
+    try:
+        with patch.dict(
+            os.environ,
+            {
+                "AWS_WEB_IDENTITY_TOKEN_FILE": token_file,
+                "AWS_ROLE_ARN": "arn:aws:iam::111111111111:role/eks-service-account-role",
+                "AWS_REGION": "eu-west-1",
+            },
+            clear=True,
+        ):
+            mock_sts_client = _mock_irsa_sts_client()
+            with patch("boto3.client", return_value=mock_sts_client):
+                base_aws_llm._auth_with_aws_role(
+                    aws_access_key_id=None,
+                    aws_secret_access_key=None,
+                    aws_session_token=None,
+                    aws_role_name="arn:aws:iam::222222222222:role/target-role",
+                    aws_session_name="test-session",
+                    aws_session_tags={"Team": "dept-a"},
+                )
+
+            mock_sts_client.assume_role.assert_called_once_with(
+                RoleArn="arn:aws:iam::222222222222:role/target-role",
+                RoleSessionName="test-session",
+                Tags=[{"Key": "Team", "Value": "dept-a"}],
+            )
+    finally:
+        os.unlink(token_file)
+
+
+def test_irsa_same_account_assume_role_with_session_tags():
+    """IRSA same-account path must pass session Tags to the AssumeRole call."""
+    base_aws_llm = BaseAWSLLM()
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+        f.write("test-web-identity-token")
+        token_file = f.name
+
+    try:
+        with patch.dict(
+            os.environ,
+            {
+                "AWS_WEB_IDENTITY_TOKEN_FILE": token_file,
+                "AWS_ROLE_ARN": "arn:aws:iam::111111111111:role/eks-service-account-role",
+                "AWS_REGION": "eu-west-1",
+            },
+            clear=True,
+        ):
+            mock_sts_client = _mock_irsa_sts_client()
+            with patch("boto3.client", return_value=mock_sts_client):
+                # Same role as AWS_ROLE_ARN -> same-account IRSA path
+                base_aws_llm._auth_with_aws_role(
+                    aws_access_key_id=None,
+                    aws_secret_access_key=None,
+                    aws_session_token=None,
+                    aws_role_name="arn:aws:iam::111111111111:role/eks-service-account-role",
+                    aws_session_name="test-session",
+                    aws_session_tags={"Team": "dept-a"},
+                )
+
+            mock_sts_client.assume_role.assert_called_once_with(
+                RoleArn="arn:aws:iam::111111111111:role/eks-service-account-role",
+                RoleSessionName="test-session",
+                Tags=[{"Key": "Team", "Value": "dept-a"}],
+            )
+    finally:
+        os.unlink(token_file)
+
+
 def test_converse_handler_external_id_extraction():
     """Test that BedrockConverseLLM properly extracts and passes aws_external_id parameter"""
     from litellm.llms.bedrock.chat.converse_handler import BedrockConverseLLM

--- a/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
+++ b/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
@@ -2018,6 +2018,81 @@ def test_assume_role_without_external_id():
         )
 
 
+def test_assume_role_with_session_tags():
+    """Test that assume_role STS call includes Tags parameter when aws_session_tags is provided"""
+    base_aws_llm = BaseAWSLLM()
+
+    # Mock the boto3 STS client
+    mock_sts_client = MagicMock()
+    mock_expiry = datetime.now(timezone.utc) + timedelta(hours=1)
+
+    mock_sts_response = {
+        "Credentials": {
+            "AccessKeyId": "test-access-key",
+            "SecretAccessKey": "test-secret-key",
+            "SessionToken": "test-session-token",
+            "Expiration": mock_expiry,
+        }
+    }
+    mock_sts_client.assume_role.return_value = mock_sts_response
+
+    with patch("boto3.client", return_value=mock_sts_client):
+        # Call _auth_with_aws_role with session tags
+        credentials, ttl = base_aws_llm._auth_with_aws_role(
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+            aws_session_token=None,
+            aws_role_name="arn:aws:iam::123456789012:role/ExampleRole",
+            aws_session_name="test-session",
+            aws_session_tags={"Team": "dept-a", "App": "invoicing"},
+        )
+
+        # Verify assume_role was called with Tags in the STS wire format
+        mock_sts_client.assume_role.assert_called_once_with(
+            RoleArn="arn:aws:iam::123456789012:role/ExampleRole",
+            RoleSessionName="test-session",
+            Tags=[
+                {"Key": "Team", "Value": "dept-a"},
+                {"Key": "App", "Value": "invoicing"},
+            ],
+        )
+
+
+def test_assume_role_without_session_tags():
+    """Test that assume_role STS call excludes Tags parameter when aws_session_tags is not provided"""
+    base_aws_llm = BaseAWSLLM()
+
+    # Mock the boto3 STS client
+    mock_sts_client = MagicMock()
+    mock_expiry = datetime.now(timezone.utc) + timedelta(hours=1)
+
+    mock_sts_response = {
+        "Credentials": {
+            "AccessKeyId": "test-access-key",
+            "SecretAccessKey": "test-secret-key",
+            "SessionToken": "test-session-token",
+            "Expiration": mock_expiry,
+        }
+    }
+    mock_sts_client.assume_role.return_value = mock_sts_response
+
+    with patch("boto3.client", return_value=mock_sts_client):
+        credentials, ttl = base_aws_llm._auth_with_aws_role(
+            aws_access_key_id=None,
+            aws_secret_access_key=None,
+            aws_session_token=None,
+            aws_role_name="arn:aws:iam::123456789012:role/ExampleRole",
+            aws_session_name="test-session",
+            aws_session_tags={},
+        )
+
+        # Empty tags dict behaves like no tags: no Tags parameter sent to STS
+        mock_sts_client.assume_role.assert_called_once_with(
+            RoleArn="arn:aws:iam::123456789012:role/ExampleRole",
+            RoleSessionName="test-session",
+        )
+
+
 def test_converse_handler_external_id_extraction():
     """Test that BedrockConverseLLM properly extracts and passes aws_external_id parameter"""
     from litellm.llms.bedrock.chat.converse_handler import BedrockConverseLLM


### PR DESCRIPTION
Adds `aws_session_tags` (a string-to-string map) to the Bedrock auth params. When set alongside `aws_role_name`, the tags are passed to `sts:AssumeRole` as session Tags.

**Why**: session tags are the mechanism AWS gives you for putting per-team or per-app attribution inside the actual bill. Once the tag keys are activated as cost-allocation tags, Bedrock spend from each deployment shows up sliced by those tags in Cost Explorer and the CUR. Today LiteLLM supports the role and the session name but not the tags, so a role-per-team setup gets identity separation without billing attribution. This came out of building exactly that setup, and issue #25884 describes the same topology (one role per department for billing isolation).

**Usage**:
```yaml
model_list:
  - model_name: claude-sonnet-4-6
    litellm_params:
      model: bedrock/us.anthropic.claude-sonnet-4-6
      aws_region_name: us-west-2
      aws_role_name: arn:aws:iam::<acct>:role/LiteLLMBedrockAccess
      aws_session_name: litellm-dept-a
      aws_session_tags:
        Team: dept-a
        App: records-portal
```
Requires `sts:TagSession` in the target role's trust policy.

**Scope**: applied on the plain AssumeRole path and both IRSA paths (cross-account and same-account). Deliberately not applied to `AssumeRoleWithWebIdentity`, which accepts no Tags parameter (session tags there come from IdP token claims). Mirrors how `aws_external_id` is plumbed, including popping the param in every handler so it never leaks into a request body. Note on caching: assume-role credentials are deliberately not cached in `get_credentials` today, so tags cannot cross-contaminate cached credentials; if that caching is ever added, `get_cache_key` hashes the full args dict and would include the tags automatically.

**Testing**: two new unit tests mirroring the `aws_external_id` pair (tags produce the STS wire format, empty dict omits the parameter); full `test_base_aws_llm.py` passes (126). Also verified end-to-end with a mocked STS client behind a Router configured like the YAML above: the captured `assume_role` call carries RoleArn, RoleSessionName, and both Tags.

**Use of AI assistance**: parts of this change were developed with AI assistance. I've reviewed the code, verified the behavior against the test suite and the mocked end-to-end run above, and take ownership of the implementation.
