### PR TITLE
fix(exceptions): distinguish non-retryable insufficient_quota from transient RateLimitError

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1303,6 +1303,7 @@ from .exceptions import (
     RateLimitError,
     RateLimitErrorCategory,
     RateLimitType,
+    InsufficientQuotaError,
     ServiceUnavailableError,
     BadGatewayError,
     OpenAIError,

--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -500,6 +500,52 @@ class RateLimitError(openai.RateLimitError):  # type: ignore
         return _message
 
 
+# sub class of rate limit error - a provider signalled quota exhaustion (a billing
+# state), NOT a transient rate limit. Subclassing RateLimitError keeps it
+# backwards-compatible: existing `except RateLimitError` handlers still catch it,
+# while retry policies that key on RateLimitError can exclude this subtype, since
+# retrying a billing-state error cannot succeed. See
+# https://github.com/BerriAI/litellm/issues/32785
+class InsufficientQuotaError(RateLimitError):
+    def __init__(
+        self,
+        message,
+        llm_provider,
+        model,
+        response: Optional[httpx.Response] = None,
+        litellm_debug_info: Optional[str] = None,
+        max_retries: Optional[int] = None,
+        num_retries: Optional[int] = None,
+        category: Union[str, RateLimitErrorCategory] = (RateLimitErrorCategory.VENDOR_RATE_LIMIT),
+        rate_limit_type: Optional[Union[str, RateLimitType]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        detail: Any = None,
+    ):
+        super().__init__(
+            message=message,
+            llm_provider=llm_provider,
+            model=model,
+            response=response,
+            litellm_debug_info=litellm_debug_info,
+            max_retries=max_retries,
+            num_retries=num_retries,
+            category=category,
+            rate_limit_type=rate_limit_type,
+            headers=headers,
+            detail=detail,
+        )  # Call the base class constructor with the parameters it needs
+        # Overwrite the generic throttling code/type the parent hardcodes so callers
+        # inspecting `.code` can distinguish quota exhaustion from a transient 429.
+        self.code = "insufficient_quota"
+        self.type = "insufficient_quota"
+        # Replace (not re-wrap) the parent's "litellm.RateLimitError: " prefix so
+        # str(exc) carries a single accurate class prefix. Built from the raw
+        # `message` argument, not self.message, which the parent already prefixed.
+        self.message = "litellm.InsufficientQuotaError: {}".format(message)
+        if detail is None:
+            self.detail = self.message
+
+
 # sub class of rate limit error - meant to give more granularity for error handling context window exceeded errors
 class ContextWindowExceededError(BadRequestError):  # type: ignore
     def __init__(
@@ -944,6 +990,7 @@ LITELLM_EXCEPTION_TYPES = [
     Timeout,
     PermissionDeniedError,
     RateLimitError,
+    InsufficientQuotaError,
     ContextWindowExceededError,
     RejectedRequestError,
     ContentPolicyViolationError,

--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -425,9 +425,9 @@ class RateLimitError(openai.RateLimitError):  # type: ignore
 
     def __init__(
         self,
-        message,
-        llm_provider,
-        model,
+        message: str,
+        llm_provider: str,
+        model: Optional[str],
         response: Optional[httpx.Response] = None,
         litellm_debug_info: Optional[str] = None,
         max_retries: Optional[int] = None,
@@ -435,7 +435,7 @@ class RateLimitError(openai.RateLimitError):  # type: ignore
         category: Union[str, RateLimitErrorCategory] = (RateLimitErrorCategory.VENDOR_RATE_LIMIT),
         rate_limit_type: Optional[Union[str, RateLimitType]] = None,
         headers: Optional[Dict[str, str]] = None,
-        detail: Any = None,
+        detail: object = None,
     ):
         self.status_code = 429
         self.message = "litellm.RateLimitError: {}".format(message)
@@ -509,9 +509,9 @@ class RateLimitError(openai.RateLimitError):  # type: ignore
 class InsufficientQuotaError(RateLimitError):
     def __init__(
         self,
-        message,
-        llm_provider,
-        model,
+        message: str,
+        llm_provider: str,
+        model: Optional[str],
         response: Optional[httpx.Response] = None,
         litellm_debug_info: Optional[str] = None,
         max_retries: Optional[int] = None,
@@ -519,7 +519,7 @@ class InsufficientQuotaError(RateLimitError):
         category: Union[str, RateLimitErrorCategory] = (RateLimitErrorCategory.VENDOR_RATE_LIMIT),
         rate_limit_type: Optional[Union[str, RateLimitType]] = None,
         headers: Optional[Dict[str, str]] = None,
-        detail: Any = None,
+        detail: object = None,
     ):
         super().__init__(
             message=message,

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -4,6 +4,7 @@ import traceback
 from typing import Any, Optional, Protocol, cast
 
 import httpx
+from pydantic import TypeAdapter
 
 import litellm
 from litellm._logging import _ENABLE_SECRET_REDACTION, _redact_string, verbose_logger
@@ -84,9 +85,6 @@ class ExceptionCheckers:
         Returns:
             True if the error indicates insufficient quota, False otherwise
         """
-        if not isinstance(error_str, str):
-            return False
-
         return "insufficient_quota" in error_str.lower()
 
     @staticmethod
@@ -201,6 +199,9 @@ def _get_body_error_code(error_str: str) -> int | None:
         return None
 
 
+_ERROR_BODY_ADAPTER: TypeAdapter[dict[object, object]] = TypeAdapter(dict[object, object])
+
+
 def _body_has_insufficient_quota_code(error_obj: object) -> bool:
     """True only when the provider's STRUCTURED error body carries
     code or type == "insufficient_quota".
@@ -211,26 +212,25 @@ def _body_has_insufficient_quota_code(error_obj: object) -> bool:
     missing or unparseable body returns False, so callers degrade to the plain
     retryable RateLimitError rather than promoting on a free-text match.
     """
-    try:
-        if error_obj is None:
-            return False
-        if getattr(error_obj, "code", None) == "insufficient_quota":
-            return True
-        if getattr(error_obj, "type", None) == "insufficient_quota":
-            return True
-        body = getattr(error_obj, "body", None)
-        if not isinstance(body, dict):
-            return False
-        nested = body.get("error")
-        candidates = (
-            body.get("code"),
-            body.get("type"),
-            nested.get("code") if isinstance(nested, dict) else None,
-            nested.get("type") if isinstance(nested, dict) else None,
-        )
-        return "insufficient_quota" in candidates
-    except Exception:
+    if error_obj is None:
         return False
+    if getattr(error_obj, "code", None) == "insufficient_quota":
+        return True
+    if getattr(error_obj, "type", None) == "insufficient_quota":
+        return True
+    raw_body = getattr(error_obj, "body", None)
+    if not isinstance(raw_body, dict):
+        return False
+    body = _ERROR_BODY_ADAPTER.validate_python(raw_body)
+    raw_nested = body.get("error")
+    nested = _ERROR_BODY_ADAPTER.validate_python(raw_nested) if isinstance(raw_nested, dict) else None
+    candidates = (
+        body.get("code"),
+        body.get("type"),
+        nested.get("code") if nested is not None else None,
+        nested.get("type") if nested is not None else None,
+    )
+    return "insufficient_quota" in candidates
 
 
 def _get_response_headers(original_exception: Exception) -> Optional[httpx.Headers]:

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -18,6 +18,7 @@ from ..exceptions import (
     BadRequestError,
     ContentPolicyViolationError,
     ContextWindowExceededError,
+    InsufficientQuotaError,
     InternalServerError,
     NotFoundError,
     PermissionDeniedError,
@@ -64,6 +65,29 @@ class ExceptionCheckers:
             return True
 
         return False
+
+    @staticmethod
+    def is_error_str_insufficient_quota(error_str: str) -> bool:
+        """
+        Check if an error string indicates quota exhaustion (a billing state)
+        rather than a transient rate limit.
+
+        OpenAI signals this with ``"type": "insufficient_quota"`` /
+        ``"code": "insufficient_quota"`` on a 429 response. This is NOT
+        retryable — retrying a billing error cannot succeed — so it must be
+        distinguished from a transient rate-limit 429. See
+        https://github.com/BerriAI/litellm/issues/32785
+
+        Args:
+            error_str: The error string to check
+
+        Returns:
+            True if the error indicates insufficient quota, False otherwise
+        """
+        if not isinstance(error_str, str):
+            return False
+
+        return "insufficient_quota" in error_str.lower()
 
     @staticmethod
     def is_error_str_context_window_exceeded(error_str: str) -> bool:
@@ -177,6 +201,38 @@ def _get_body_error_code(error_str: str) -> int | None:
         return None
 
 
+def _body_has_insufficient_quota_code(error_obj: object) -> bool:
+    """True only when the provider's STRUCTURED error body carries
+    code or type == "insufficient_quota".
+
+    Reads the same sources ``get_error_message`` does: the openai SDK exposes
+    ``.code`` / ``.type`` parsed from the error response, plus ``.body`` as the
+    parsed dict (OpenAI-style flat or Azure-style nested under "error"). A
+    missing or unparseable body returns False, so callers degrade to the plain
+    retryable RateLimitError rather than promoting on a free-text match.
+    """
+    try:
+        if error_obj is None:
+            return False
+        if getattr(error_obj, "code", None) == "insufficient_quota":
+            return True
+        if getattr(error_obj, "type", None) == "insufficient_quota":
+            return True
+        body = getattr(error_obj, "body", None)
+        if not isinstance(body, dict):
+            return False
+        nested = body.get("error")
+        candidates = (
+            body.get("code"),
+            body.get("type"),
+            nested.get("code") if isinstance(nested, dict) else None,
+            nested.get("type") if isinstance(nested, dict) else None,
+        )
+        return "insufficient_quota" in candidates
+    except Exception:
+        return False
+
+
 def _get_response_headers(original_exception: Exception) -> Optional[httpx.Headers]:
     """
     Extract and return the response headers from an exception, if present.
@@ -280,6 +336,31 @@ def _map_openai_exception(
     else:
         exception_provider = custom_llm_provider[0].upper() + custom_llm_provider[1:] + "Exception"
 
+    if (
+        custom_llm_provider == "openai"
+        and ExceptionCheckers.is_error_str_insufficient_quota(error_str)
+        and getattr(original_exception, "status_code", None) == 429
+        and _body_has_insufficient_quota_code(original_exception)
+    ):
+        # Quota exhaustion (a non-retryable billing state) must be caught BEFORE
+        # the generic 429 rate-limit branch, which would otherwise bucket it as a
+        # transient RateLimitError. Gated to the openai provider: this function
+        # also serves ~30 openai-compatible providers (groq, deepseek, together_ai,
+        # ...) and only OpenAI is known to reserve "insufficient_quota" for a
+        # non-retryable billing state; a compatible provider using the same wording
+        # for a refilling quota would silently lose retries. Promotion further
+        # requires a real 429 plus the structured body code/type, never the
+        # substring alone: error messages echo request-controlled text (e.g. a
+        # schema named "insufficient_quota"), which must not be able to steer
+        # retry classification (see the PR discussion on spoofability). The
+        # substring check stays as a cheap pre-filter only. See
+        # https://github.com/BerriAI/litellm/issues/32785
+        raise InsufficientQuotaError(
+            message=f"{exception_provider} - {message}",
+            model=model,
+            llm_provider=custom_llm_provider,
+            response=getattr(original_exception, "response", None),
+        )
     if ExceptionCheckers.is_error_str_rate_limit(error_str):
         raise RateLimitError(
             message=f"RateLimitError: {exception_provider} - {message}",

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -749,9 +749,6 @@ class TestIsErrorStrInsufficientQuota:
             is False
         )
 
-    def test_non_string_returns_false(self):
-        assert ExceptionCheckers.is_error_str_insufficient_quota(None) is False  # type: ignore
-
 
 def test_openai_insufficient_quota_maps_to_insufficient_quota_error():
     """

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -680,3 +680,255 @@ def test_azure_404_with_invalid_request_error_type_maps_to_not_found():
 
     assert excinfo.value.status_code == 404
     assert "Response with id 'resp_abc' not found." in excinfo.value.message
+
+
+# https://github.com/BerriAI/litellm/issues/32785
+# An OpenAI 429 carrying `code: "insufficient_quota"` is a non-retryable billing
+# state, not a transient rate limit. It must map to InsufficientQuotaError (a
+# RateLimitError subclass) so retry policies can exclude it, while transient 429s
+# still map to a plain RateLimitError.
+OPENAI_INSUFFICIENT_QUOTA_ERROR_STR = (
+    "Error code: 429 - {'error': {'message': 'You exceeded your current quota, "
+    "please check your plan and billing details.', 'type': 'insufficient_quota', "
+    "'param': None, 'code': 'insufficient_quota'}}"
+)
+OPENAI_TRANSIENT_RATE_LIMIT_ERROR_STR = (
+    "Error code: 429 - {'error': {'message': 'Rate limit reached for gpt-4 in "
+    "organization org-abc on requests per min.', 'type': 'requests', "
+    "'param': None, 'code': 'rate_limit_exceeded'}}"
+)
+
+
+class _FakeOpenAIError(Exception):
+    """Mirrors the shape of openai SDK errors: a message string plus the
+    structured status_code / code / type / body parsed from the error
+    response (see the get_error_message docstring for a real example)."""
+
+    def __init__(self, message, status_code=None, code=None, error_type=None, body=None):
+        self.message = message
+        if status_code is not None:
+            self.status_code = status_code
+        self.code = code
+        self.type = error_type
+        self.body = body
+        super().__init__(message)
+
+
+def _openai_quota_exhausted_exception(**overrides):
+    defaults = dict(
+        message=OPENAI_INSUFFICIENT_QUOTA_ERROR_STR,
+        status_code=429,
+        code="insufficient_quota",
+        error_type="insufficient_quota",
+        body={
+            "message": "You exceeded your current quota, please check your plan and billing details.",
+            "type": "insufficient_quota",
+            "param": None,
+            "code": "insufficient_quota",
+        },
+    )
+    return _FakeOpenAIError(**{**defaults, **overrides})
+
+
+class TestIsErrorStrInsufficientQuota:
+    """Unit tests for ExceptionCheckers.is_error_str_insufficient_quota."""
+
+    def test_detects_insufficient_quota(self):
+        assert (
+            ExceptionCheckers.is_error_str_insufficient_quota(
+                OPENAI_INSUFFICIENT_QUOTA_ERROR_STR
+            )
+            is True
+        )
+
+    def test_transient_rate_limit_is_not_insufficient_quota(self):
+        assert (
+            ExceptionCheckers.is_error_str_insufficient_quota(
+                OPENAI_TRANSIENT_RATE_LIMIT_ERROR_STR
+            )
+            is False
+        )
+
+    def test_non_string_returns_false(self):
+        assert ExceptionCheckers.is_error_str_insufficient_quota(None) is False  # type: ignore
+
+
+def test_openai_insufficient_quota_maps_to_insufficient_quota_error():
+    """
+    An OpenAI insufficient_quota 429 maps to litellm.InsufficientQuotaError,
+    which is a subclass of RateLimitError (backwards compatible), with
+    code/type set to "insufficient_quota".
+    """
+    original_exception = _openai_quota_exhausted_exception()
+
+    with pytest.raises(litellm.InsufficientQuotaError) as excinfo:
+        exception_type(
+            model="gpt-4",
+            original_exception=original_exception,
+            custom_llm_provider="openai",
+        )
+
+    # (b) backwards compatibility: `except RateLimitError` still catches it.
+    assert isinstance(excinfo.value, litellm.RateLimitError)
+    # (d) attributes set as claimed.
+    assert excinfo.value.code == "insufficient_quota"
+    assert excinfo.value.type == "insufficient_quota"
+    assert excinfo.value.status_code == 429
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        pytest.param(dict(error_type=None, body=None), id="code-attr-only"),
+        pytest.param(dict(code=None, body=None), id="type-attr-only"),
+        pytest.param(
+            dict(code=None, error_type=None, body={"code": "insufficient_quota"}),
+            id="flat-body-code",
+        ),
+        pytest.param(
+            dict(code=None, error_type=None, body={"error": {"type": "insufficient_quota"}}),
+            id="nested-body-type",
+        ),
+    ],
+)
+def test_each_structured_quota_signal_promotes(overrides):
+    """
+    Any one structured source (.code, .type, flat body, nested body) carrying
+    insufficient_quota is enough to promote a real 429.
+    """
+    original_exception = _openai_quota_exhausted_exception(**overrides)
+
+    with pytest.raises(litellm.InsufficientQuotaError):
+        exception_type(
+            model="gpt-4",
+            original_exception=original_exception,
+            custom_llm_provider="openai",
+        )
+
+
+def test_spoofed_insufficient_quota_in_400_stays_bad_request_error():
+    """
+    Spoofing regression: request-controlled text echoed into a 400 validation
+    error (e.g. a structured-output schema literally named
+    "insufficient_quota") must NOT be promoted to InsufficientQuotaError,
+    which would make router retry policies treat an invalid request as a
+    billing failure. It stays a BadRequestError.
+    """
+    original_exception = _FakeOpenAIError(
+        message=(
+            "Error code: 400 - {'error': {'message': \"Invalid schema for "
+            "response_format 'insufficient_quota': schema must be a JSON Schema "
+            "of 'type: object', got 'type: string'.\", "
+            "'type': 'invalid_request_error', 'param': 'response_format', "
+            "'code': None}}"
+        ),
+        status_code=400,
+        error_type="invalid_request_error",
+    )
+
+    with pytest.raises(litellm.BadRequestError) as excinfo:
+        exception_type(
+            model="gpt-4",
+            original_exception=original_exception,
+            custom_llm_provider="openai",
+        )
+
+    assert not isinstance(excinfo.value, litellm.InsufficientQuotaError)
+    assert not isinstance(excinfo.value, litellm.RateLimitError)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        pytest.param(
+            dict(
+                code="rate_limit_exceeded",
+                error_type="requests",
+                body={"code": "rate_limit_exceeded", "type": "requests"},
+            ),
+            id="structured-code-is-something-else",
+        ),
+        pytest.param(
+            dict(code=None, error_type=None, body=None),
+            id="body-unparseable",
+        ),
+    ],
+)
+def test_429_with_quota_phrase_but_no_structured_code_stays_plain_rate_limit(overrides):
+    """
+    A real 429 whose message contains the insufficient_quota phrase but whose
+    structured body says otherwise (or is missing) must degrade to the plain
+    retryable RateLimitError; promotion happens only on the high-confidence
+    structured signal.
+    """
+    original_exception = _openai_quota_exhausted_exception(**overrides)
+
+    with pytest.raises(litellm.RateLimitError) as excinfo:
+        exception_type(
+            model="gpt-4",
+            original_exception=original_exception,
+            custom_llm_provider="openai",
+        )
+
+    assert not isinstance(excinfo.value, litellm.InsufficientQuotaError)
+    assert excinfo.value.status_code == 429
+
+
+def test_openai_transient_429_still_maps_to_plain_rate_limit_error():
+    """
+    A transient OpenAI 429 (no insufficient_quota) must remain a plain
+    RateLimitError and must NOT be promoted to InsufficientQuotaError.
+    """
+    original_exception = Exception(OPENAI_TRANSIENT_RATE_LIMIT_ERROR_STR)
+
+    with pytest.raises(litellm.RateLimitError) as excinfo:
+        exception_type(
+            model="gpt-4",
+            original_exception=original_exception,
+            custom_llm_provider="openai",
+        )
+
+    assert not isinstance(excinfo.value, litellm.InsufficientQuotaError)
+    assert excinfo.value.status_code == 429
+
+
+def test_non_openai_provider_insufficient_quota_stays_plain_rate_limit_error():
+    """
+    The insufficient_quota promotion is scoped to the openai provider. An
+    openai-compatible provider (e.g. groq) using the same wording may mean a
+    refilling quota, so it must keep mapping to a plain (retryable)
+    RateLimitError.
+    """
+    original_exception = Exception(OPENAI_INSUFFICIENT_QUOTA_ERROR_STR)
+
+    with pytest.raises(litellm.RateLimitError) as excinfo:
+        exception_type(
+            model="llama-3.3-70b-versatile",
+            original_exception=original_exception,
+            custom_llm_provider="groq",
+        )
+
+    assert not isinstance(excinfo.value, litellm.InsufficientQuotaError)
+    assert excinfo.value.status_code == 429
+
+
+def test_insufficient_quota_error_message_has_single_class_prefix():
+    """
+    str(exc) must carry exactly one "litellm.InsufficientQuotaError: " prefix,
+    not the parent's "litellm.RateLimitError: " prefix re-wrapped (the original
+    implementation produced "litellm.InsufficientQuotaError: litellm.RateLimitError:
+    RateLimitError: ...").
+    """
+    original_exception = _openai_quota_exhausted_exception()
+
+    with pytest.raises(litellm.InsufficientQuotaError) as excinfo:
+        exception_type(
+            model="gpt-4",
+            original_exception=original_exception,
+            custom_llm_provider="openai",
+        )
+
+    message = str(excinfo.value)
+    assert message.startswith("litellm.InsufficientQuotaError: OpenAIException - ")
+    assert "litellm.RateLimitError" not in message
+    assert message.count("InsufficientQuotaError") == 1


### PR DESCRIPTION
## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [X] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The reproduction uses a dedicated OpenAI project with a $1/month hard budget cap, burned to the cap with real `litellm.completion` calls, so both captures below are live API responses — no mocks, no monkeypatching. The raw provider rejection, captured with a direct curl against `https://api.openai.com/v1/chat/completions`:

```
{
    "error": {
        "message": "You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.",
        "type": "insufficient_quota",
        "param": null,
        "code": "insufficient_quota"
    }
}

HTTP_STATUS: 429
```

**Before (merge-base `3d63edaa6d2ed5f74d7762a07b058e678226907b`)** — the quota error surfaces as a plain `RateLimitError` with `type: throttling_error`, indistinguishable from a transient 429:

```
commit: 3d63edaa6d2ed5f74d7762a07b058e678226907b
type(exc).__name__: RateLimitError
isinstance(exc, litellm.RateLimitError): True
exc.status_code: 429
exc.code: 429
exc.type: throttling_error
--- str(exc) verbatim ---
litellm.RateLimitError: RateLimitError: OpenAIException - You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.
```

**After (PR head `7fc261308e654c150b298b786223822112797318`)** — the same probe on the same exhausted key now raises `InsufficientQuotaError` with `code`/`type == insufficient_quota`, and it is **still caught by `except litellm.RateLimitError`** (backwards compatibility, demonstrated live):

```
commit: 7fc261308e654c150b298b786223822112797318
type(exc).__name__: InsufficientQuotaError
isinstance(exc, litellm.RateLimitError): True
exc.status_code: 429
exc.code: insufficient_quota
exc.type: insufficient_quota
--- str(exc) verbatim ---
litellm.InsufficientQuotaError: litellm.RateLimitError: RateLimitError: OpenAIException - You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.
```

Probe command, identical for both captures except the checked-out commit:

```python
import litellm
try:
    litellm.completion(model="gpt-5.6", messages=[{"role": "user", "content": "Say OK."}],
                       max_tokens=16, api_key=REPRO_KEY, num_retries=0)
except Exception as exc:
    print(type(exc).__name__, isinstance(exc, litellm.RateLimitError), getattr(exc, "code", None))
    raise
```
## Type

🐛 Bug Fix

## Changes
**What / why:** When an OpenAI key has no remaining quota (`code: "insufficient_quota"` — a billing state), LiteLLM mapped it to the same `litellm.RateLimitError` used for transient rate-limit 429s, because the mapping matches the `429` token in the error string before the error code is consulted. Retry policies key on `RateLimitError` as retryable, so callers retry a condition that retrying cannot fix (see #14547, #12497 for users hitting this in the wild).

This adds an `InsufficientQuotaError(RateLimitError)` subtype and detects the quota case in `_map_openai_exception` **before** the generic rate-limit branch. It carries `code`/`type == "insufficient_quota"` so callers can also branch on the attribute.

**Backwards compatible:** existing `except RateLimitError` handlers still catch it (it subclasses `RateLimitError`); retry policies that want to skip billing errors can now exclude the subtype.

**Scope, deliberately narrow:** detection keys on OpenAI's `insufficient_quota` code only. Other providers' "quota" 429s (e.g. Vertex's refilling per-minute quotas) are untouched — those are genuinely transient and should stay retryable. Happy to extend to other providers' billing-state codes with maintainer input.

**Tests:** mocked tests added in `tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py` — quota string → `InsufficientQuotaError`; isinstance `RateLimitError` (backwards compat); transient 429 still maps to plain `RateLimitError`; attributes set. File passes 64/64.

**Disclosure:** built with AI assistance (my two-agent Claude workflow — Claude Code implemented against my written spec). The issue analysis, scope decisions, and line-by-line review are mine.