### PR TITLE
fix(health): return structured response from webhook health check branch

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -332,6 +332,7 @@ async def health_services_endpoint(
                 type="user_budget",
                 user_info=user_info,
             )
+            return {"status": "success", "message": "Mock webhook alert sent"}
         elif service == "sqs":
             from litellm.integrations.sqs import SQSLogger
 

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -266,6 +266,36 @@ async def test_health_services_endpoint_sqs(status, error_message):
 
 
 @pytest.mark.asyncio
+async def test_health_services_endpoint_webhook_returns_structured_response():
+    """
+    Regression test: the /health/services webhook branch called
+    proxy_logging_obj.budget_alerts() but had no return statement, so
+    execution fell through to the end of the function and returned None
+    (serialized as JSON null with HTTP 200) instead of a structured
+    {"status": ..., "message": ...} dict like every other service branch.
+    """
+    user_api_key_dict = UserAPIKeyAuth(
+        token="test-token",
+        user_id="test-user",
+        key_alias="test-key-alias",
+        team_id="test-team",
+    )
+    mock_budget_alerts = AsyncMock()
+
+    with patch(
+        "litellm.proxy.proxy_server.proxy_logging_obj.budget_alerts",
+        mock_budget_alerts,
+    ):
+        result = await health_services_endpoint(
+            user_api_key_dict=user_api_key_dict,
+            service="webhook",
+        )
+
+    mock_budget_alerts.assert_awaited_once()
+    assert result == {"status": "success", "message": "Mock webhook alert sent"}
+
+
+@pytest.mark.asyncio
 async def test_health_license_endpoint_with_active_license():
     license_data = {
         "expiration_date": "2099-01-01",


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

Note on the CI/CD checkbox: `ruff check` and `ruff format --check` pass clean on both changed files, and the new test plus the full health-endpoints test file pass locally. I could not run the full `make pre-commit`/`make lint` chain on this machine since it lacks the MSVC/Rust toolchain `litellm`'s root package now needs to build, so I'm leaving that box for the real CI run to confirm rather than self-certifying something I could not fully verify locally

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Ran a local proxy against a real Postgres database with `python -m litellm.proxy.proxy_cli --config proof_config.yaml --port 4000`, once on `litellm_internal_staging` and once with this fix applied, and hit the real endpoint both times

Before (on `litellm_internal_staging`, commit bf02a4a):
```
curl -X GET "http://localhost:4000/health/services?service=webhook" \
  -H "Authorization: Bearer $MASTER_KEY"

null
```
HTTP 200, body is literally `null`

After (this branch):
```
curl -X GET "http://localhost:4000/health/services?service=webhook" \
  -H "Authorization: Bearer $MASTER_KEY"

{"status":"success","message":"Mock webhook alert sent"}
```
HTTP 200, matching the structured response shape every other `service=` branch in this function returns

## Type

🐛 Bug Fix
✅ Test

## Changes

`health_services_endpoint()`'s `service == "webhook"` branch calls `budget_alerts()` and then falls through without a `return`, so the function implicitly returns `None`. FastAPI serializes that as `null` with HTTP 200. Every other branch in the same function returns a structured `{"status": ..., "message": ...}` dict, so a caller relying on that contract to confirm the webhook test actually ran sees `null` on success and has no field to check

Added the missing `return {"status": "success", "message": "Mock webhook alert sent"}` right after the `budget_alerts()` call, matching the shape the other branches already use

Added a regression test that mocks `proxy_logging_obj.budget_alerts`, calls the endpoint with `service="webhook"`, and asserts both that the mock got called once and that the return value is the structured dict rather than `None`. Confirmed it fails against the pre-fix code with `assert None == {...}` and passes with the fix
