### PR TITLE
fix(fine_tuning): copy hyperparameters dict before Azure-specific mutation

### DIFF
--- a/litellm/fine_tuning/main.py
+++ b/litellm/fine_tuning/main.py
@@ -174,7 +174,7 @@ def create_fine_tuning_job(
         optional_params = GenericLiteLLMParams(**kwargs)
 
         # handle hyperparameters
-        hyperparameters = dict(hyperparameters or {})  # original hyperparameters
+        hyperparameters = dict(hyperparameters or {})  # shallow copy; callers' dict is not mutated
 
         # For Azure, extract Azure-specific hyperparameters before creating OpenAI-spec hyperparameters
         azure_specific_hyperparams = {}

--- a/litellm/fine_tuning/main.py
+++ b/litellm/fine_tuning/main.py
@@ -174,7 +174,7 @@ def create_fine_tuning_job(
         optional_params = GenericLiteLLMParams(**kwargs)
 
         # handle hyperparameters
-        hyperparameters = hyperparameters or {}  # original hyperparameters
+        hyperparameters = dict(hyperparameters or {})  # original hyperparameters
 
         # For Azure, extract Azure-specific hyperparameters before creating OpenAI-spec hyperparameters
         azure_specific_hyperparams = {}

--- a/tests/batches_tests/test_fine_tuning_api.py
+++ b/tests/batches_tests/test_fine_tuning_api.py
@@ -622,3 +622,43 @@ async def test_mock_azure_create_fine_tune_job_with_azure_specific_params():
         # Verify the response
         assert response.id == "ft-azure-123"
         assert response.model == "gpt-4.1-mini-2025-04-14"
+
+
+def test_create_fine_tuning_job_does_not_mutate_caller_hyperparameters():
+    from openai.types.fine_tuning.fine_tuning_job import (
+        Hyperparameters as OAIHyperparameters,
+    )
+    from litellm.types.utils import LiteLLMFineTuningJob
+
+    mock_response = LiteLLMFineTuningJob(
+        id="ft-azure-456",
+        model="gpt-4.1-mini-2025-04-14",
+        created_at=1677610602,
+        status="validating_files",
+        fine_tuned_model=None,
+        object="fine_tuning.job",
+        hyperparameters=OAIHyperparameters(n_epochs=2),
+        organization_id="org-123",
+        seed=42,
+        training_file="file-123",
+        result_files=[],
+    )
+
+    params = {"n_epochs": 2, "prompt_loss_weight": 0.25}
+
+    with patch(
+        "litellm.llms.azure.fine_tuning.handler.AzureOpenAIFineTuningAPI.create_fine_tuning_job",
+        return_value=mock_response,
+    ):
+        create_fine_tuning_job(
+            model="gpt-4.1-mini-2025-04-14",
+            training_file="file-123",
+            hyperparameters=params,
+            custom_llm_provider="azure",
+            api_base="https://test.openai.azure.com",
+            api_key="test-key",
+            api_version="2025-04-01-preview",
+        )
+
+    assert "prompt_loss_weight" in params
+    assert params["prompt_loss_weight"] == 0.25


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

Note on the CI/CD checkbox: `ruff check` and `ruff format --check` pass clean on the changed file, and the new test plus the full fine_tuning test file pass locally. I could not run the full `make pre-commit`/`make lint` chain on this machine since it lacks the MSVC/Rust toolchain `litellm`'s root package now needs to build, so I'm leaving that box for the real CI run to confirm rather than self-certifying something I could not fully verify locally

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Called `litellm.create_fine_tuning_job()` directly (real function, not mocked) with `custom_llm_provider="azure"` and a `hyperparameters` dict built once by the caller, once on `litellm_internal_staging` and once with this fix applied. The Azure network call fails immediately on fake credentials in both runs, which happens after the mutation this bug is about, so it does not affect the result

Before (on `litellm_internal_staging`, commit bf02a4a):
```python
params = {"n_epochs": 3, "prompt_loss_weight": 0.05}
litellm.create_fine_tuning_job(
    model="gpt-4o-mini-2024-07-18",
    training_file="file-abc123",
    hyperparameters=params,
    custom_llm_provider="azure",
    api_key="fake", api_base="https://fake.openai.azure.com",
)
print(params)
# {'n_epochs': 3}
```
`prompt_loss_weight` silently disappears from the caller's own dict

After (this branch):
```python
# same call
print(params)
# {'n_epochs': 3, 'prompt_loss_weight': 0.05}
```
Caller's dict is left untouched

## Type

🐛 Bug Fix
✅ Test

## Changes

`create_fine_tuning_job()` does `hyperparameters = hyperparameters or {}` and then, on the Azure path, pops provider-specific keys out of that same object with `hyperparameters.pop(...)`. When the caller passes a real dict, `or {}` evaluates to the caller's own object, so the pops mutate the dict the caller still holds a reference to, not a private copy. A caller building the hyperparameters dict once and reusing or inspecting it after the call sees fields silently removed

Changed the line to `hyperparameters = dict(hyperparameters or {})`, so the function always works on its own shallow copy and the caller's dict is never mutated

Added a regression test that builds a hyperparameters dict, calls `create_fine_tuning_job()` with `custom_llm_provider="azure"` against a mocked Azure client, and asserts the caller's original dict still has all its original keys after the call

Follow-up commit: updated the trailing comment on the changed line, since it described the pre-fix behavior (`# original hyperparameters`) rather than what the line does now

