### PR TITLE
fix(search_tools): preserve HTTPException status code in test_search_tool_connection

### DIFF
--- a/litellm/proxy/search_endpoints/search_tool_management.py
+++ b/litellm/proxy/search_endpoints/search_tool_management.py
@@ -583,6 +583,8 @@ async def test_search_tool_connection(request: TestSearchToolConnectionRequest):
             "results_count": (len(response.results) if response and response.results else 0),
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         error_message = str(e)
         error_type = type(e).__name__

--- a/tests/test_litellm/proxy/management_endpoints/search_endpoints/test_search_tool_management.py
+++ b/tests/test_litellm/proxy/management_endpoints/search_endpoints/test_search_tool_management.py
@@ -815,3 +815,21 @@ async def test_list_search_tools_admin_with_restricted_key_still_sees_all():
     assert response.status_code == 200
     names = {t["search_tool_name"] for t in response.json()["search_tools"]}
     assert names == {"db-tool-1", "db-tool-2", "db-tool-3"}
+
+
+@pytest.mark.asyncio
+async def test_test_search_tool_connection_missing_search_provider_returns_400():
+    """
+    Regression: test_search_tool_connection() raised HTTPException(400) for a
+    missing search_provider, but that raise sat inside a try block whose broad
+    `except Exception` caught it and returned an ordinary error-shaped dict, so
+    FastAPI responded 200 even though the request was invalid. The validation
+    failure must propagate as a real HTTP 400.
+    """
+    admin_user = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user")
+
+    with _override_auth(admin_user):
+        response = TestClient(app).post("/search_tools/test_connection", json={"litellm_params": {}})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "search_provider is required in litellm_params"

--- a/tests/test_litellm/proxy/management_endpoints/search_endpoints/test_search_tool_management.py
+++ b/tests/test_litellm/proxy/management_endpoints/search_endpoints/test_search_tool_management.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 sys.path.insert(
@@ -819,13 +820,6 @@ async def test_list_search_tools_admin_with_restricted_key_still_sees_all():
 
 @pytest.mark.asyncio
 async def test_test_search_tool_connection_missing_search_provider_returns_400():
-    """
-    Regression: test_search_tool_connection() raised HTTPException(400) for a
-    missing search_provider, but that raise sat inside a try block whose broad
-    `except Exception` caught it and returned an ordinary error-shaped dict, so
-    FastAPI responded 200 even though the request was invalid. The validation
-    failure must propagate as a real HTTP 400.
-    """
     admin_user = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user")
 
     with _override_auth(admin_user):
@@ -833,3 +827,21 @@ async def test_test_search_tool_connection_missing_search_provider_returns_400()
 
     assert response.status_code == 400
     assert response.json()["detail"] == "search_provider is required in litellm_params"
+
+
+@pytest.mark.asyncio
+async def test_test_search_tool_connection_provider_auth_failure_returns_400():
+    admin_user = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user")
+    mock_asearch = AsyncMock(
+        side_effect=HTTPException(status_code=400, detail="Authentication failed: Invalid API key")
+    )
+
+    with patch("litellm.search.asearch", mock_asearch), _override_auth(admin_user):
+        response = TestClient(app).post(
+            "/search_tools/test_connection",
+            json={"litellm_params": {"search_provider": "exa", "api_key": "invalid-key"}},
+        )
+
+    mock_asearch.assert_awaited_once()
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Authentication failed: Invalid API key"

--- a/tests/test_litellm/proxy/management_endpoints/search_endpoints/test_search_tool_management.py
+++ b/tests/test_litellm/proxy/management_endpoints/search_endpoints/test_search_tool_management.py
@@ -5,13 +5,13 @@ from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 sys.path.insert(
     0, os.path.abspath("../../../../..")
 )  # Adds the parent directory to the system path
 
+import litellm
 from litellm.proxy._types import (
     LiteLLM_ObjectPermissionTable,
     LiteLLM_TeamTable,
@@ -830,18 +830,20 @@ async def test_test_search_tool_connection_missing_search_provider_returns_400()
 
 
 @pytest.mark.asyncio
-async def test_test_search_tool_connection_provider_auth_failure_returns_400():
+async def test_test_search_tool_connection_provider_failure_returns_structured_error():
     admin_user = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user")
     mock_asearch = AsyncMock(
-        side_effect=HTTPException(status_code=400, detail="Authentication failed: Invalid API key")
+        side_effect=litellm.AuthenticationError(message="Invalid API key", llm_provider="exa_ai", model=None)
     )
 
     with patch("litellm.search.asearch", mock_asearch), _override_auth(admin_user):
         response = TestClient(app).post(
             "/search_tools/test_connection",
-            json={"litellm_params": {"search_provider": "exa", "api_key": "invalid-key"}},
+            json={"litellm_params": {"search_provider": "exa_ai", "api_key": "invalid-key"}},
         )
 
     mock_asearch.assert_awaited_once()
-    assert response.status_code == 400
-    assert response.json()["detail"] == "Authentication failed: Invalid API key"
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "error"
+    assert body["error_type"] == "AuthenticationError"


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

Note on the CI/CD checkbox: `ruff check` and `ruff format --check` pass clean on the changed lines, and the new tests plus the full search_tool_management test file pass locally. I could not run the full `make pre-commit`/`make lint` chain on this machine since it lacks the MSVC/Rust toolchain `litellm`'s root package now needs to build, so I'm leaving that box for the real CI run to confirm rather than self-certifying something I could not fully verify locally

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Ran a local proxy against a real Postgres database with `python -m litellm.proxy.proxy_cli --config proof_config.yaml --port 4000`, once on `litellm_internal_staging` and once with this fix applied, and hit the real endpoint with a request missing the required `search_provider` field both times

Before (on `litellm_internal_staging`, commit bf02a4a):
```
curl -X POST "http://localhost:4000/search_tools/test_connection" \
  -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" \
  -d '{"litellm_params": {"api_key": "invalid-key"}}'

HTTP 200
{"status":"error","message":"400: search_provider is required in litellm_params","error_type":"HTTPException"}
```
HTTP 200 with an error-shaped body, even though this is a request validation failure, not a provider-side error

After (this branch):
```
curl -X POST "http://localhost:4000/search_tools/test_connection" \
  -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" \
  -d '{"litellm_params": {"api_key": "invalid-key"}}'

HTTP 400
{"detail":"search_provider is required in litellm_params"}
```
Same failure now surfaces as HTTP 400

This PR does not change the response for provider-level failures (an invalid API key against a real provider, a provider timeout, and so on). Those still return HTTP 200 with a structured `{"status": "error", ...}` body, matching this endpoint's own documented "Example Response (Failure)" contract in its docstring. `asearch()` wraps every exception it raises through `litellm.exception_type(...)`, so it can never raise a bare `HTTPException`, and this PR's `except HTTPException: raise` guard has no effect on that path. Verified live on this branch: `curl` with `{"litellm_params": {"search_provider": "exa_ai", "api_key": "invalid-key"}}` against a real Exa key returns HTTP 200 with `{"status":"error","error_type":"AuthenticationError",...}`, unchanged from `litellm_internal_staging` by inspection since this diff does not touch that code path

## Type

🐛 Bug Fix
✅ Test

## Changes

`test_search_tool_connection()` raises `HTTPException(status_code=400, ...)` when a required field like `search_provider` is missing from the request, but that raise happens inside a broad `try/except Exception` that catches `HTTPException` too and turns it into a normal 200 response with an error-shaped body. The caller cannot use the HTTP status to tell a malformed request from a successful probe

Added `except HTTPException: raise` before the broad `except Exception` handler, so an `HTTPException` raised inside the function propagates with its original status code instead of being swallowed into a 200

Added a regression test that omits `search_provider` and asserts the endpoint response is 400, not 200

This PR is scoped to requests that never reach the provider: the `search_provider` validation, and any other place this endpoint raises its own `HTTPException` directly. It does not change how provider-level failures are reported; those are already documented as a 200 with a structured error body, and changing that would be a separate, larger contract change

Follow-up commit: dropped the first test's docstring since this repo's `CLAUDE.md` asks not to add comments unless requested, and replaced an earlier second test that mocked `asearch()` raising a bare `HTTPException` (a scenario the real function cannot produce, since it wraps every exception via `litellm.exception_type(...)`) with one that mocks a real `litellm.AuthenticationError` and asserts the documented 200-with-structured-error-body response, codifying the scope boundary above as an actual test


