### PR TITLE
ci(ui): only run the UI build when dashboard files change

### DIFF
--- a/.github/workflows/test-litellm-ui-build.yml
+++ b/.github/workflows/test-litellm-ui-build.yml
@@ -22,9 +22,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
+          fetch-depth: 0
           persist-credentials: false
 
+      - name: Detect UI changes
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if git diff --name-only "$BASE_SHA"...HEAD -- . | grep -q .; then
+            echo "ui_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ui_changed=false" >> "$GITHUB_OUTPUT"
+            echo "No ui/litellm-dashboard changes in this PR; skipping build."
+          fi
+
       - name: Setup Node.js
+        if: steps.changed.outputs.ui_changed == 'true'
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "20"
@@ -32,9 +46,11 @@ jobs:
           cache-dependency-path: ui/litellm-dashboard/package-lock.json
 
       - name: Install dependencies
+        if: steps.changed.outputs.ui_changed == 'true'
         run: npm ci
 
       - name: Build
+        if: steps.changed.outputs.ui_changed == 'true'
         run: npm run build
 
   frontend-lint:


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

The `build-ui` job ran a full `npm ci` + `npm run build` (a ~10-minute `next build`) on every PR, backend-only ones included, even though nothing it builds had changed. This gates it the same way `frontend-lint` already gates itself: the job still runs on every PR so the required check reports a result and never strands, but the install and build steps only execute when a file under `ui/litellm-dashboard/` actually changed.

The detection step runs from the job's `working-directory` (`ui/litellm-dashboard`), so `git diff --name-only "$BASE_SHA"...HEAD -- .` is already scoped to the dashboard; it needs `fetch-depth: 0` on the checkout so the base commit is present for the diff.

Behavior:

```
PR touches ui/litellm-dashboard/**   -> ui_changed=true  -> Setup + npm ci + npm run build run (unchanged)
PR touches only backend/docs         -> ui_changed=false -> steps skipped, job reports success in seconds
```

This is a CI-only change; the logic mirrors the existing `frontend-lint` job in the same repo, and both workflow files parse as valid YAML.

## Type

🚄 Infrastructure

## Changes

Add a "Detect UI changes" step to `build-ui` and gate `Setup Node`, `Install dependencies`, and `Build` on its `ui_changed` output. Add `fetch-depth: 0` to the checkout so the PR base commit is available to diff against.

The job intentionally still runs on every PR rather than using a workflow-level `paths:` filter; a `paths:` filter would leave the required check pending forever on PRs that don't touch the UI, which is the stranding problem this repo already solved for backend tests in #32532. Keeping the job and gating its steps avoids that.
