### PR TITLE
fix(anthropic): guard file-id discovery against malformed content blocks

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1238,7 +1238,9 @@ def get_file_ids_from_messages(messages: List[AllMessageValues]) -> List[str]:
                 if isinstance(content, str):
                     continue
                 for c in content:
-                    if c["type"] == "file":
+                    if not isinstance(c, dict):
+                        continue
+                    if c.get("type") == "file":
                         file_object = cast(ChatCompletionFileObject, c)
                         file_object_file_field = file_object.get("file")
                         if not isinstance(file_object_file_field, dict):

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
@@ -343,6 +343,32 @@ def test_get_file_ids_from_messages_file_field_not_dict():
     assert get_file_ids_from_messages(messages) == []
 
 
+def test_get_file_ids_from_messages_content_block_without_type():
+    """A content block dict that omits `type` must not raise KeyError."""
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"text": "hi"},
+                {"type": "file", "file": {"file_id": "file-keep"}},
+            ],
+        }
+    ]
+
+    assert get_file_ids_from_messages(messages) == ["file-keep"]
+
+
+def test_get_file_ids_from_messages_non_dict_content_items():
+    """Non-dict content items (e.g. token-id lists forwarded by
+    text_completion, or bare strings) must be skipped, not indexed into."""
+    messages = [
+        {"role": "user", "content": [[1, 2, 3]]},
+        {"role": "user", "content": ["hello"]},
+    ]
+
+    assert get_file_ids_from_messages(messages) == []
+
+
 def test_update_messages_with_model_file_ids_skips_non_openai_file_blocks():
     """`update_messages_with_model_file_ids` is also called on user content
     before provider dispatch. It must tolerate non-OpenAI file blocks the same


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

This change is covered by focused regression tests for content blocks missing `type` and non-dict content items. An end-to-end live-provider reproduction was not run

## Type

Bug Fix

## Changes

`get_file_ids_from_messages` indexed every user content item as a dictionary with a `type` key. Missing keys and non-dict items could therefore raise while Anthropic-family requests were being built

The helper now skips non-dict items and reads `type` safely. Valid file blocks continue to return their file IDs unchanged

Two regression tests cover a block missing `type`, token-id lists, and bare string items
