### PR TITLE
test(proxy): add auth cache staleness exercise

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -1551,6 +1551,7 @@ async def _cache_management_object(
     user_api_key_cache: DualCache,
     proxy_logging_obj: Optional[ProxyLogging],
 ):
+    # ONSITE HINT: This TTL is the refresh window for cached management objects.
     await user_api_key_cache.async_set_cache(
         key=key,
         value=value,

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1011,6 +1011,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
             ## Check CACHE
             try:
                 with tracer.trace("litellm.proxy.auth.get_key_object_check_cache"):
+                    # ONSITE HINT: This cache-only read runs before the DB fallback.
                     valid_token = await get_key_object(
                         hashed_token=hash_token(api_key),
                         prisma_client=prisma_client,
@@ -1191,6 +1192,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
 
             try:
                 with tracer.trace("litellm.proxy.auth.get_key_object_from_db"):
+                    # ONSITE HINT: This DB read only runs after a cache miss.
                     valid_token = await get_key_object(
                         hashed_token=api_key,
                         prisma_client=prisma_client,
@@ -1507,6 +1509,7 @@ async def _user_api_key_auth_builder(  # noqa: PLR0915
 
             # Add hashed token to cache
             asyncio.create_task(
+                # ONSITE HINT: Compare this write-back with the cache and DB branches.
                 _cache_key_object(
                     hashed_token=api_key,
                     user_api_key_obj=valid_token,

--- a/tests/proxy_unit_tests/test_auth_cache_stale_virtual_key.py
+++ b/tests/proxy_unit_tests/test_auth_cache_stale_virtual_key.py
@@ -1,0 +1,201 @@
+import asyncio
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import Request
+from starlette.datastructures import URL
+
+import litellm.proxy.proxy_server as proxy_server
+from litellm.constants import DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL
+from litellm.proxy._types import UserAPIKeyAuth, hash_token
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+
+class FakeTTLCache:
+    def __init__(self) -> None:
+        self.now = 0.0
+        self._values = {}
+
+    async def async_get_cache(self, key, **kwargs):
+        item = self._values.get(key)
+        if item is None:
+            return None
+
+        value, expires_at = item
+        if expires_at is not None and expires_at <= self.now:
+            self._values.pop(key, None)
+            return None
+        return value
+
+    async def async_set_cache(self, key, value, ttl: Optional[float] = None, **kwargs):
+        expires_at = None if ttl is None else self.now + ttl
+        self._values[key] = (value, expires_at)
+
+    def set_cache(self, key, value, ttl: Optional[float] = None, **kwargs):
+        expires_at = None if ttl is None else self.now + ttl
+        self._values[key] = (value, expires_at)
+
+    def delete_cache(self, key):
+        self._values.pop(key, None)
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class FakePrismaClient:
+    def __init__(self, hashed_token: str, token_data: Optional[dict]) -> None:
+        self.hashed_token = hashed_token
+        self.token_data = token_data
+
+    async def get_data(
+        self,
+        token: str,
+        table_name: str,
+        parent_otel_span=None,
+        proxy_logging_obj=None,
+    ):
+        assert table_name == "combined_view"
+        if token != self.hashed_token or self.token_data is None:
+            return None
+        return UserAPIKeyAuth(**self.token_data)
+
+    def update_token(self, **updates) -> None:
+        assert self.token_data is not None
+        self.token_data = {**self.token_data, **updates}
+
+    def delete_token(self) -> None:
+        self.token_data = None
+
+
+def _request() -> Request:
+    request = Request(
+        scope={
+            "type": "http",
+            "method": "POST",
+            "path": "/chat/completions",
+            "headers": [],
+        }
+    )
+    request._url = URL(url="/chat/completions")
+    request._body = b"{}"
+    return request
+
+
+async def _authenticate(
+    *,
+    api_key: str,
+    cache: FakeTTLCache,
+    prisma_client: FakePrismaClient,
+) -> UserAPIKeyAuth:
+    proxy_logging_obj = MagicMock()
+    proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
+    proxy_logging_obj.service_logging_obj = MagicMock()
+    proxy_logging_obj.service_logging_obj.async_service_success_hook = AsyncMock()
+    proxy_logging_obj.service_logging_obj.async_service_failure_hook = AsyncMock()
+    model_max_budget_limiter = MagicMock()
+    model_max_budget_limiter.is_key_within_model_budget = AsyncMock()
+    model_max_budget_limiter.is_end_user_within_model_budget = AsyncMock()
+
+    with (
+        patch.object(proxy_server, "user_api_key_cache", cache),
+        patch.object(proxy_server, "prisma_client", prisma_client),
+        patch.object(proxy_server, "master_key", "sk-master"),
+        patch.object(proxy_server, "general_settings", {}),
+        patch.object(proxy_server, "llm_model_list", []),
+        patch.object(proxy_server, "llm_router", None),
+        patch.object(proxy_server, "proxy_logging_obj", proxy_logging_obj),
+        patch.object(
+            proxy_server, "model_max_budget_limiter", model_max_budget_limiter
+        ),
+        patch(
+            "litellm.proxy.auth.user_api_key_auth.common_checks",
+            new_callable=AsyncMock,
+        ),
+    ):
+        result = await user_api_key_auth(
+            request=_request(),
+            api_key=f"Bearer {api_key}",
+        )
+
+    await asyncio.sleep(0)
+    return result
+
+
+@pytest.mark.asyncio
+async def test_should_refresh_rate_limits_after_cache_ttl_while_key_keeps_calling():
+    api_key = "sk-onsite-rate-limit"
+    hashed_token = hash_token(api_key)
+    cache = FakeTTLCache()
+    prisma_client = FakePrismaClient(
+        hashed_token=hashed_token,
+        token_data={
+            "token": hashed_token,
+            "models": ["gpt-4o"],
+            "rpm_limit": 100,
+        },
+    )
+
+    first_auth = await _authenticate(
+        api_key=api_key,
+        cache=cache,
+        prisma_client=prisma_client,
+    )
+    assert first_auth.rpm_limit == 100
+
+    prisma_client.update_token(rpm_limit=1)
+
+    cache.advance(DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL - 1)
+    stale_auth_before_ttl = await _authenticate(
+        api_key=api_key,
+        cache=cache,
+        prisma_client=prisma_client,
+    )
+    assert stale_auth_before_ttl.rpm_limit == 100
+
+    cache.advance(2)
+    refreshed_auth = await _authenticate(
+        api_key=api_key,
+        cache=cache,
+        prisma_client=prisma_client,
+    )
+
+    assert refreshed_auth.rpm_limit == 1
+
+
+@pytest.mark.asyncio
+async def test_should_stop_serving_deleted_key_after_cache_ttl_while_key_keeps_calling():
+    api_key = "sk-onsite-deleted-key"
+    hashed_token = hash_token(api_key)
+    cache = FakeTTLCache()
+    prisma_client = FakePrismaClient(
+        hashed_token=hashed_token,
+        token_data={
+            "token": hashed_token,
+            "models": ["gpt-4o"],
+            "rpm_limit": 100,
+        },
+    )
+
+    await _authenticate(
+        api_key=api_key,
+        cache=cache,
+        prisma_client=prisma_client,
+    )
+    prisma_client.delete_token()
+
+    cache.advance(DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL - 1)
+    stale_auth_before_ttl = await _authenticate(
+        api_key=api_key,
+        cache=cache,
+        prisma_client=prisma_client,
+    )
+    assert stale_auth_before_ttl.rpm_limit == 100
+
+    cache.advance(2)
+    with pytest.raises(Exception):
+        await _authenticate(
+            api_key=api_key,
+            cache=cache,
+            prisma_client=prisma_client,
+        )


### PR DESCRIPTION
## What changed

This prepares an EM onsite coding exercise from the auth-cache staleness bug without applying the fix.

- Adds ONSITE HINT comments around the relevant cache read, DB fallback, write-back, and TTL code paths.
- Adds an isolated failing unit test suite for stale virtual-key auth cache behavior.
- Keeps the bug in place so the candidate can diagnose and implement the fix live.

## Exercise coverage

The tests cover:

- A virtual-key rate-limit update should take effect after the cache TTL even while the key keeps calling.
- A deleted virtual key should stop being accepted after the cache TTL even while the key keeps calling.

## Validation

- `uv run ruff check litellm/proxy/auth/user_api_key_auth.py litellm/proxy/auth/auth_checks.py tests/proxy_unit_tests/test_auth_cache_stale_virtual_key.py` passes.
- `uv run pytest tests/proxy_unit_tests/test_auth_cache_stale_virtual_key.py -q` fails as expected against the current buggy code:
  - stale RPM remains `100` instead of refreshing to `1`
  - deleted key continues authenticating after the original TTL window

This PR intentionally does not include the fix.
