### PR TITLE
fix(guardrails): preserve HTTPException status code in create_guardrail

### DIFF
--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -374,6 +374,8 @@ async def create_guardrail(
             )
 
         return result
+    except HTTPException:
+        raise
     except Exception as e:
         verbose_proxy_logger.exception(f"Error adding guardrail to db: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
@@ -838,12 +838,6 @@ async def test_create_guardrail_endpoint(
 async def test_create_guardrail_config_error_returns_400_not_500(
     mocker, mock_guardrail_registry, mock_in_memory_handler
 ):
-    """
-    A ValueError raised while initializing a newly created guardrail is a
-    client-correctable config error and must surface as a 400. Pre-fix, the
-    inner 400 HTTPException was caught by the outer `except Exception` and
-    re-raised as a 500.
-    """
     mock_prisma_client = mocker.Mock()
     mock_in_memory_handler.initialize_guardrail.side_effect = ValueError("invalid config")
 

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
@@ -834,6 +834,39 @@ async def test_create_guardrail_endpoint(
             )
 
 
+@pytest.mark.asyncio
+async def test_create_guardrail_config_error_returns_400_not_500(
+    mocker, mock_guardrail_registry, mock_in_memory_handler
+):
+    """
+    A ValueError raised while initializing a newly created guardrail is a
+    client-correctable config error and must surface as a 400. Pre-fix, the
+    inner 400 HTTPException was caught by the outer `except Exception` and
+    re-raised as a 500.
+    """
+    mock_prisma_client = mocker.Mock()
+    mock_in_memory_handler.initialize_guardrail.side_effect = ValueError("invalid config")
+
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    mocker.patch(
+        "litellm.proxy.guardrails.guardrail_endpoints.GUARDRAIL_REGISTRY",
+        mock_guardrail_registry,
+    )
+    mocker.patch(
+        "litellm.proxy.guardrails.guardrail_registry.IN_MEMORY_GUARDRAIL_HANDLER",
+        mock_in_memory_handler,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await create_guardrail(MOCK_CREATE_REQUEST, user_api_key_dict=MOCK_ADMIN_USER)
+
+    assert exc_info.value.status_code == 400
+    assert "invalid config" in str(exc_info.value.detail)
+    mock_guardrail_registry.add_guardrail_to_db.assert_called_once_with(
+        guardrail=MOCK_CREATE_REQUEST.guardrail, prisma_client=mocker.ANY
+    )
+
+
 @pytest.mark.parametrize(
     "scenario,expected_result,expected_exception",
     [


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

Note on the CI/CD checkbox: `ruff check` and `ruff format --check` pass clean on `guardrail_endpoints.py`; the test file has pre-existing lint findings (unused imports, stray prints, `== False`/`== True` comparisons) unrelated to this change, which I left alone rather than doing a drive-by cleanup. The new test plus the full test_guardrail_endpoints.py file pass locally. I could not run the full `make pre-commit`/`make lint` chain on this machine since it lacks the MSVC/Rust toolchain `litellm`'s root package now needs to build, so I'm leaving that box for the real CI run to confirm rather than self-certifying something I could not fully verify locally

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Ran a local proxy against a real Postgres database with `python -m litellm.proxy.proxy_cli --config proof_config.yaml --port 4000`, once on `litellm_internal_staging` and once with this fix applied, and hit the real endpoint with a request that names an unsupported guardrail provider both times

Before (on `litellm_internal_staging`, commit bf02a4a):
```
curl -X POST "http://localhost:4000/guardrails" \
  -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" \
  -d '{"guardrail": {"guardrail_name": "bad-guardrail", "litellm_params": {"guardrail": "not-a-real-guardrail-provider", "mode": "pre_call"}}}'

HTTP 500
{"detail":"400: Guardrail configuration error: Unsupported guardrail: not-a-real-guardrail-provider"}
```
The real cause is a client error (unsupported provider name), but it surfaces as a 500 with the original 400 buried inside the detail string

After (this branch):
```
curl -X POST "http://localhost:4000/guardrails" \
  -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" \
  -d '{"guardrail": {"guardrail_name": "bad-guardrail", "litellm_params": {"guardrail": "not-a-real-guardrail-provider", "mode": "pre_call"}}}'

HTTP 400
{"detail":"Guardrail configuration error: Unsupported guardrail: not-a-real-guardrail-provider"}
```
Same request, now a clean 400 with no nested status code

## Type

🐛 Bug Fix
✅ Test

## Changes

`create_guardrail()` raises `HTTPException(status_code=400, ...)` when guardrail initialization fails on a config problem, but that raise happens inside a broad `try/except Exception` that catches `HTTPException` too and re-wraps it as a 500. A client passing a bad guardrail config gets a 500 with the real 400 detail nested inside the message string, instead of a 400 it can branch on directly

Added `except HTTPException: raise` before the broad `except Exception` handler, so an `HTTPException` raised inside the function propagates with its original status code instead of being caught and re-raised as a 500

Added a regression test that forces guardrail initialization to raise a config `ValueError` and asserts the endpoint raises `HTTPException` with status 400, not 500
