### PR TITLE
fix(tags): preserve HTTPException status codes in tag CRUD handlers

### DIFF
--- a/litellm/proxy/management_endpoints/tag_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/tag_management_endpoints.py
@@ -241,6 +241,8 @@ async def new_tag(
             "message": f"Tag {tag.name} created successfully",
             "tag": tag_config,
         }
+    except HTTPException:
+        raise
     except Exception as e:
         verbose_proxy_logger.exception(f"Error creating tag: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -371,6 +373,8 @@ async def update_tag(
             "message": f"Tag {tag.name} updated successfully",
             "tag": tag_config,
         }
+    except HTTPException:
+        raise
     except Exception as e:
         verbose_proxy_logger.exception(f"Error updating tag: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -437,6 +441,8 @@ async def info_tag(
             requested_tags[tag_record.tag_name] = tag_dict
 
         return requested_tags
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
@@ -606,6 +612,8 @@ async def delete_tag(
         await TagRepository(prisma_client).table.delete(where={"tag_name": data.name})
 
         return {"message": f"Tag {data.name} deleted successfully"}
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py
@@ -16,7 +16,12 @@ from unittest.mock import patch
 import litellm
 from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
 from litellm.proxy.proxy_server import app
-from litellm.types.tag_management import TagDeleteRequest, TagInfoRequest, TagNewRequest
+from litellm.types.tag_management import (
+    TagDeleteRequest,
+    TagInfoRequest,
+    TagNewRequest,
+    TagUpdateRequest,
+)
 
 client = TestClient(app)
 
@@ -248,6 +253,133 @@ async def test_delete_tag():
     finally:
         # Clean up dependency overrides
         app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_new_tag_duplicate_returns_400_not_500():
+    """
+    Regression test: new_tag() must preserve a 400 for a duplicate tag name
+    instead of letting a bare `except Exception` downgrade it to 500.
+    """
+    from unittest.mock import AsyncMock, Mock
+
+    from litellm.proxy.management_endpoints.tag_management_endpoints import new_tag
+
+    mock_user_auth = UserAPIKeyAuth(
+        user_id="test-user-123",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma,
+        patch("litellm.proxy.proxy_server.llm_router", Mock()),
+    ):
+        mock_db = Mock()
+        mock_prisma.db = mock_db
+        mock_db.litellm_tagtable.find_unique = AsyncMock(return_value=Mock())
+
+        with pytest.raises(HTTPException) as exc_info:
+            await new_tag(
+                tag=TagNewRequest(name="existing-tag"),
+                user_api_key_dict=mock_user_auth,
+            )
+
+    assert exc_info.value.status_code == 400
+    assert "already exists" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_update_tag_missing_returns_404_not_500():
+    """
+    Regression test: update_tag() must preserve a 404 for a missing tag
+    instead of letting a bare `except Exception` downgrade it to 500.
+    """
+    from unittest.mock import AsyncMock, Mock
+
+    from litellm.proxy.management_endpoints.tag_management_endpoints import (
+        update_tag,
+    )
+
+    mock_user_auth = UserAPIKeyAuth(
+        user_id="test-user-123",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+
+    with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma:
+        mock_db = Mock()
+        mock_prisma.db = mock_db
+        mock_db.litellm_tagtable.find_unique = AsyncMock(return_value=None)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await update_tag(
+                tag=TagUpdateRequest(name="missing-tag"),
+                user_api_key_dict=mock_user_auth,
+            )
+
+    assert exc_info.value.status_code == 404
+    assert "not found" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_info_tag_missing_returns_404_not_500():
+    """
+    Regression test: info_tag() must preserve a 404 for missing tags
+    instead of letting a bare `except Exception` downgrade it to 500.
+    """
+    from unittest.mock import AsyncMock, Mock
+
+    from litellm.proxy.management_endpoints.tag_management_endpoints import info_tag
+
+    mock_user_auth = UserAPIKeyAuth(
+        user_id="test-user-123",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+
+    with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma:
+        mock_db = Mock()
+        mock_prisma.db = mock_db
+        mock_db.litellm_tagtable.find_many = AsyncMock(return_value=[])
+
+        with pytest.raises(HTTPException) as exc_info:
+            await info_tag(
+                data=TagInfoRequest(names=["missing-tag"]),
+                user_api_key_dict=mock_user_auth,
+            )
+
+    assert exc_info.value.status_code == 404
+    assert "not found" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_delete_tag_missing_returns_404_not_500():
+    """
+    Regression test: delete_tag() must preserve a 404 for a missing tag
+    instead of letting a bare `except Exception` downgrade it to 500.
+    """
+    from unittest.mock import AsyncMock, Mock
+
+    from litellm.proxy.management_endpoints.tag_management_endpoints import (
+        delete_tag,
+    )
+
+    mock_user_auth = UserAPIKeyAuth(
+        user_id="test-user-123",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+
+    with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma:
+        mock_db = Mock()
+        mock_prisma.db = mock_db
+        mock_db.litellm_tagtable.find_unique = AsyncMock(return_value=None)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_tag(
+                data=TagDeleteRequest(name="missing-tag"),
+                user_api_key_dict=mock_user_auth,
+            )
+
+    assert exc_info.value.status_code == 404
+    assert "not found" in exc_info.value.detail
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py
@@ -257,10 +257,6 @@ async def test_delete_tag():
 
 @pytest.mark.asyncio
 async def test_new_tag_duplicate_returns_400_not_500():
-    """
-    Regression test: new_tag() must preserve a 400 for a duplicate tag name
-    instead of letting a bare `except Exception` downgrade it to 500.
-    """
     from unittest.mock import AsyncMock, Mock
 
     from litellm.proxy.management_endpoints.tag_management_endpoints import new_tag
@@ -290,10 +286,6 @@ async def test_new_tag_duplicate_returns_400_not_500():
 
 @pytest.mark.asyncio
 async def test_update_tag_missing_returns_404_not_500():
-    """
-    Regression test: update_tag() must preserve a 404 for a missing tag
-    instead of letting a bare `except Exception` downgrade it to 500.
-    """
     from unittest.mock import AsyncMock, Mock
 
     from litellm.proxy.management_endpoints.tag_management_endpoints import (
@@ -322,10 +314,6 @@ async def test_update_tag_missing_returns_404_not_500():
 
 @pytest.mark.asyncio
 async def test_info_tag_missing_returns_404_not_500():
-    """
-    Regression test: info_tag() must preserve a 404 for missing tags
-    instead of letting a bare `except Exception` downgrade it to 500.
-    """
     from unittest.mock import AsyncMock, Mock
 
     from litellm.proxy.management_endpoints.tag_management_endpoints import info_tag
@@ -352,10 +340,6 @@ async def test_info_tag_missing_returns_404_not_500():
 
 @pytest.mark.asyncio
 async def test_delete_tag_missing_returns_404_not_500():
-    """
-    Regression test: delete_tag() must preserve a 404 for a missing tag
-    instead of letting a bare `except Exception` downgrade it to 500.
-    """
     from unittest.mock import AsyncMock, Mock
 
     from litellm.proxy.management_endpoints.tag_management_endpoints import (


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

Note on the CI/CD checkbox: `ruff check` and `ruff format --check` pass clean on `tag_management_endpoints.py`; the test file has a few pre-existing unused imports and an unused local variable unrelated to this change, which I left alone rather than doing a drive-by cleanup. The new tests plus the full test_tag_management_endpoints.py file pass locally. I could not run the full `make pre-commit`/`make lint` chain on this machine since it lacks the MSVC/Rust toolchain `litellm`'s root package now needs to build, so I'm leaving that box for the real CI run to confirm rather than self-certifying something I could not fully verify locally

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Ran a local proxy against a real Postgres database with `python -m litellm.proxy.proxy_cli --config proof_config.yaml --port 4000`, once on `litellm_internal_staging` and once with this fix applied, and hit all 4 real endpoints with requests that trigger each handler's existing validation error both times

Before (on `litellm_internal_staging`, commit bf02a4a; a tag named `proof-tag` already exists in all 4 calls below):
```
curl -X POST "http://localhost:4000/tag/new" -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" -d '{"name": "proof-tag"}'
HTTP 500  {"detail":"400: Tag proof-tag already exists"}

curl -X POST "http://localhost:4000/tag/update" -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" -d '{"name": "does-not-exist-tag"}'
HTTP 500  {"detail":"404: Tag does-not-exist-tag not found"}

curl -X POST "http://localhost:4000/tag/info" -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" -d '{"names": ["does-not-exist-tag"]}'
HTTP 500  {"detail":"404: Tags not found: ['does-not-exist-tag']"}

curl -X POST "http://localhost:4000/tag/delete" -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" -d '{"name": "does-not-exist-tag"}'
HTTP 500  {"detail":"404: Tag does-not-exist-tag not found"}
```
All 4 client-correctable errors surface as 500, with the real status code buried inside the detail string

After (this branch, same 4 requests):
```
POST /tag/new     -> HTTP 400  {"detail":"Tag proof-tag already exists"}
POST /tag/update  -> HTTP 404  {"detail":"Tag does-not-exist-tag not found"}
POST /tag/info    -> HTTP 404  {"detail":"Tags not found: ['does-not-exist-tag']"}
POST /tag/delete  -> HTTP 404  {"detail":"Tag does-not-exist-tag not found"}
```
Each now returns its real status code with no nesting

## Type

🐛 Bug Fix
✅ Test

## Changes

`new_tag()`, `update_tag()`, `info_tag()`, and `delete_tag()` each raise `HTTPException` with the correct status code (400 for a duplicate tag, 404 for a missing one), but all 4 raises happen inside a broad `try/except Exception` that also catches `HTTPException` and re-wraps it as a 500. A client hitting an ordinary validation case, like creating a tag that already exists or looking up one that does not, gets a 500 with the real status nested inside the message instead of a status code it can branch on

Added `except HTTPException: raise` before the broad `except Exception` handler in all 4 functions, so an `HTTPException` raised inside any of them propagates with its original status code instead of being caught and re-raised as a 500

Added one regression test per handler that triggers its existing validation error (duplicate name for create, missing tag for update/info/delete) and asserts the real status code (400 or 404) comes back, not 500
