### PR TITLE
chore(lint): emit backend implicit/explicit Any counts for the trend dashboard

### DIFF
--- a/.github/workflows/update-backend-lint-metrics.yml
+++ b/.github/workflows/update-backend-lint-metrics.yml
@@ -1,0 +1,61 @@
+name: Update backend lint metrics
+
+# Refresh backend-lint-metrics.json (the real implicit/explicit Any counts the trend
+# dashboard reads). Report-only: nothing gates on it. Weekly is enough since the counts
+# drift slowly, and it keeps the whole-tree basedpyright pass off every PR. It only opens
+# a PR that a human merges, so a failed or skipped run never blocks anyone.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update-metrics:
+    if: github.repository == 'BerriAI/litellm'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.10.9"
+      - run: uv sync --frozen --group proxy-dev
+      # basedpyright resolves Prisma's generated client only after `prisma generate`, so
+      # mirror test-linting.yml here or the counts drift from what the gates measure.
+      - name: Generate Prisma client
+        env:
+          PRISMA_BINARY_CACHE_DIR: ${{ runner.temp }}/prisma-cache
+        run: uv run --no-sync prisma generate --schema litellm/proxy/schema.prisma
+      - name: Regenerate backend-lint-metrics.json
+        run: (uv run --no-sync basedpyright --outputjson || true) | uv run --no-sync python scripts/lint_metrics.py
+      - name: Open a PR when the counts changed
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          if git diff --quiet -- backend-lint-metrics.json; then
+            echo "backend-lint-metrics.json is unchanged; nothing to do."
+            exit 0
+          fi
+          DATE=$(date +'%Y-%m-%d')
+          BRANCH="backend-lint-metrics-$DATE"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add backend-lint-metrics.json
+          git commit -m "chore(lint): refresh backend-lint-metrics.json ($DATE)"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:$BRANCH"
+          gh pr create --base litellm_internal_staging --head "$BRANCH" \
+            --title "chore(lint): refresh backend lint metrics ($DATE)" \
+            --body "Automated refresh of backend-lint-metrics.json (real implicit/explicit Any counts). Report-only; nothing gates on it."

--- a/backend-lint-metrics.json
+++ b/backend-lint-metrics.json
@@ -1,0 +1,4 @@
+{
+  "reportAny": 26434,
+  "reportExplicitAny": 7252
+}

--- a/scripts/lint_metrics.py
+++ b/scripts/lint_metrics.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Emit the backend implicit/explicit Any counts for the trend dashboard.
+
+Writes ``backend-lint-metrics.json`` as ``{rule: count}`` for ``reportAny`` (implicit
+Any) and ``reportExplicitAny`` (explicit Any). Report-only: nothing gates on it. The
+``basedpyright-code-budget.json`` ``limit`` stopped tracking the real count after its
+limit collapse (it is now a loose ceiling), so this reports the real count instead.
+The counting is reused from ``scripts/type_check_gate.py``, so the numbers match what
+CI measures.
+
+Usage:
+    basedpyright --outputjson | python scripts/lint_metrics.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import type_check_gate
+
+RULES = ("reportAny", "reportExplicitAny")
+METRICS_PATH = Path(__file__).resolve().parent.parent / "backend-lint-metrics.json"
+
+
+def main() -> None:
+    counts = type_check_gate.count_basedpyright(sys.stdin.read())
+    result = {rule: counts.get(rule, 0) for rule in RULES}
+    if not any(result.values()):
+        sys.exit("basedpyright reported no Any diagnostics; it likely crashed. Refusing to write zeros.")
+    METRICS_PATH.write_text(json.dumps(result, indent=2) + "\n")
+    print(f"Wrote {METRICS_PATH.name}: {result}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Relevant issues

Follow-up to the budget collapse in #31883, which replaced `{baseline, slack}` with a single downward-only `limit` in the backend budget files. `limit` is now a loose ceiling (~1.5x the last real count), so anything reading `basedpyright-code-budget.json` to track how many `any`s exist reads a frozen ceiling, not the count

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests (the only new logic is a two-key filter over already-tested `count_basedpyright`; see Changes)
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Build/CI tooling change with no proxy or LLM surface, so the proof is the generator producing the file and the numbers being the real count, not the budget ceiling.

```
$ (basedpyright --outputjson || true) | python scripts/lint_metrics.py
Wrote backend-lint-metrics.json: {'reportAny': 26434, 'reportExplicitAny': 7252}

$ cat backend-lint-metrics.json
{
  "reportAny": 26434,
  "reportExplicitAny": 7252
}
```

These are the real count, not the `limit` from the budget file, which carries ~1.5x headroom:

```
rule                              real count   budget limit
reportAny (implicit any)               26434          37484
reportExplicitAny (explicit any)        7252          10397
```

Both line up with the pre-collapse baselines (~24,989 and ~6,931) plus drift since 2026-07-01, confirming they are measured, not derived. Nothing in the repo reads this file as a gate: the budget ratchet check reads a hardcoded list of the three `*-budget.json` files and never looks at it, and this new workflow is not a required check

## Type

🚄 Infrastructure

## Changes

Adds `backend-lint-metrics.json` at the repo root: a flat `{rule: count}` file holding the real `reportAny` (implicit Any) and `reportExplicitAny` (explicit Any) counts across the tree, for a downstream trend dashboard to read.

`scripts/lint_metrics.py` regenerates it from piped `basedpyright --outputjson`, reusing `type_check_gate.count_basedpyright` so the numbers are exactly the ones CI measures. A weekly scheduled workflow (`update-backend-lint-metrics.yml`) opens a PR when the counts drift, mirroring `auto_update_price_and_context_window.yml` for the PR and `test-linting.yml` for the environment; weekly because a whole-tree basedpyright pass takes minutes and the counts move slowly, so every PR is spared the cost.

The file is report-only and never gates. The budget ceilings and their PR gates are unchanged, the workflow is not a required check, and it only opens a PR that a human merges, so a failed or skipped refresh never blocks anyone. On tests: the only new logic is a two-key extraction over `count_basedpyright`, which is already covered by `tests/test_litellm/test_type_check_gate.py`, so I did not add a separate low-value test for the filter
