### PR TITLE
fix(proxy): add coordination_redis routes to component allowlist

### DIFF
--- a/backend/routes/allowlist.py
+++ b/backend/routes/allowlist.py
@@ -46,6 +46,7 @@ BACKEND_PATH_PREFIXES: tuple[str, ...] = (
     "/fallback",
     "/fallbacks",
     "/cache_settings",
+    "/coordination_redis/",
     "/cost_tracking",
     "/cost/",
     "/credentials",


### PR DESCRIPTION
## Relevant issues

Unblocks PR #32661. 

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

```
$ python3 -m pytest tests/test_litellm/proxy/test_component_allowlists.py::test_gateway_plus_backend_covers_full_app -v
PASSED tests/test_litellm/proxy/test_component_allowlists.py::test_gateway_plus_backend_covers_full_app
1 passed in 3.01s
```

## Type

🐛 Bug Fix

## Changes

PR #32661 adds `/coordination_redis/settings` and `/coordination_redis/settings/test` endpoints but does not add them to `backend/routes/allowlist.py`. The `test_gateway_plus_backend_covers_full_app` test enforces that every registered route appears in either the gateway or backend allowlist, causing that test to fail on #32661 with:

```
AssertionError: 2 route(s) are not exposed on either component.
    /coordination_redis/settings
    /coordination_redis/settings/test
```

Adding `/coordination_redis/` as a prefix entry to the backend allowlist covers both routes. The entry is inert on staging until #32661's routes land (the coverage test only checks registered routes against the allowlist, not the reverse).