### PR TITLE
fix(redis): only use SSLConnection when ssl is truthy in connection pool kwargs

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -689,9 +689,8 @@ def get_redis_connection_pool(
         redis_kwargs["credential_provider"] = GCPIAMCredentialProvider(redis_connect_func._gcp_service_account)
 
     connection_class = async_redis.Connection
-    if "ssl" in redis_kwargs:
+    if redis_kwargs.pop("ssl", False):
         connection_class = async_redis.SSLConnection
-        redis_kwargs.pop("ssl", None)
         redis_kwargs["connection_class"] = connection_class
     return async_redis.BlockingConnectionPool(timeout=REDIS_CONNECTION_POOL_TIMEOUT, **redis_kwargs)
 

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -672,3 +672,55 @@ def test_environment_redis_url_used_when_caller_names_no_target(mock_from_url, m
     get_redis_client()
 
     mock_from_url.assert_called_once()
+
+
+@pytest.mark.parametrize("falsy_ssl", [False, None, 0, ""])
+def test_connection_pool_falsy_ssl_uses_plain_connection(falsy_ssl, monkeypatch):
+    """
+    ssl=False must produce a plain (non-TLS) connection pool.
+
+    The admin UI's coordination Redis form always sends ssl explicitly, so a
+    presence check here turns ssl=False into an SSLConnection; the TLS
+    handshake against a plaintext Redis then hangs until the ping timeout and
+    every connection test from the UI fails.
+    """
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.delenv("REDIS_SSL", raising=False)
+    monkeypatch.delenv("REDIS_CLUSTER_NODES", raising=False)
+
+    with patch("litellm._redis.async_redis.BlockingConnectionPool") as mock_pool:
+        get_redis_connection_pool(host="plain-redis.example.com", port=6379, ssl=falsy_ssl)
+
+    call_kwargs = mock_pool.call_args.kwargs
+    assert call_kwargs.get("connection_class") is not async_redis.SSLConnection, (
+        f"ssl={falsy_ssl!r} must not select SSLConnection"
+    )
+    assert "ssl" not in call_kwargs, "ssl must never leak into BlockingConnectionPool kwargs"
+
+
+def test_connection_pool_ssl_true_uses_ssl_connection(monkeypatch):
+    """ssl=True must still opt in to a TLS connection pool."""
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.delenv("REDIS_SSL", raising=False)
+    monkeypatch.delenv("REDIS_CLUSTER_NODES", raising=False)
+
+    with patch("litellm._redis.async_redis.BlockingConnectionPool") as mock_pool:
+        get_redis_connection_pool(host="tls-redis.example.com", port=6380, ssl=True)
+
+    call_kwargs = mock_pool.call_args.kwargs
+    assert call_kwargs.get("connection_class") is async_redis.SSLConnection
+    assert "ssl" not in call_kwargs, "ssl must be consumed, not forwarded to the pool"
+
+
+def test_connection_pool_without_ssl_kwarg_uses_plain_connection(monkeypatch):
+    """Omitting ssl entirely must keep the historical plain-connection default."""
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.delenv("REDIS_SSL", raising=False)
+    monkeypatch.delenv("REDIS_CLUSTER_NODES", raising=False)
+
+    with patch("litellm._redis.async_redis.BlockingConnectionPool") as mock_pool:
+        get_redis_connection_pool(host="plain-redis.example.com", port=6379)
+
+    call_kwargs = mock_pool.call_args.kwargs
+    assert call_kwargs.get("connection_class") is not async_redis.SSLConnection
+    assert "ssl" not in call_kwargs


### PR DESCRIPTION
## Relevant issues

Fixes the coordination Redis connection test and save flow added in #32661; without this, every request the new admin UI form sends against a non-TLS Redis fails

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

Live proxy on localhost:4000 (dev_config with a plaintext Redis on 6379). Before the fix, the exact payload the coordination Redis UI sends (it always includes an explicit `ssl` boolean) times out:

```
$ curl -s -X POST http://localhost:4000/coordination_redis/settings/test \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"settings":{"host":"127.0.0.1","port":6379,"ssl":false}}'
{"status":"unhealthy","error":"Connection timed out after 5.0s"}
```

After the fix, the same request succeeds, and `ssl: true` still attempts TLS and correctly reports the plaintext server as unreachable:

```
$ curl -s -X POST http://localhost:4000/coordination_redis/settings/test \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"settings":{"host":"127.0.0.1","port":6379,"ssl":false}}'
{"status":"healthy","error":null}

$ curl -s -X POST http://localhost:4000/coordination_redis/settings/test \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"settings":{"host":"127.0.0.1","port":6379,"ssl":true}}'
{"status":"unhealthy","error":"Connection timed out after 5.0s"}
```

UI check: on http://localhost:3000/caching, Coordination Redis tab, Test Connection with host 127.0.0.1, port 6379 and the SSL toggle off now shows the success toast instead of "Connection test failed: Connection timed out after 5.0s"

## Type

🐛 Bug Fix

## Changes

`get_redis_connection_pool` in `litellm/_redis.py` chose `SSLConnection` whenever the `ssl` key was present in the kwargs, regardless of its value, so `ssl: false` enabled TLS. The check dates to the original `REDIS_SSL` support (d1217b955a), where the key was only ever set when the env var was literally "true", so presence and truth were the same thing back then. The coordination Redis UI from #32661 is the first caller that always sends an explicit `ssl` boolean, which makes the presence check select TLS against plaintext servers; the handshake hangs until the 5s ping timeout and every connection test and save from the UI fails

The fix switches the check to the value: `if redis_kwargs.pop("ssl", False):`. The pop is unconditional so a falsy `ssl` never leaks into `BlockingConnectionPool` kwargs, which plain `Connection` would reject. `ssl: true` behavior is unchanged

Regression tests in `tests/test_litellm/test_redis.py` assert that each falsy form (`False`, `None`, `0`, `""`) yields a plain connection, that `ssl=True` still selects `SSLConnection`, and that omitting `ssl` keeps the plain default. With the fix reverted, exactly the four falsy cases fail

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to connection-pool construction with explicit regression tests; `ssl=True` behavior is unchanged.
> 
> **Overview**
> **`get_redis_connection_pool`** no longer treats any present `ssl` key as “use TLS.” It now uses **`redis_kwargs.pop("ssl", False)`** so only a **truthy** `ssl` selects `async_redis.SSLConnection`; falsy values (`false`, `null`, `0`, `""`) keep a plain connection and **`ssl` is removed** so it is not passed through to `BlockingConnectionPool`.
> 
> This fixes coordination Redis **test/save** from the admin UI, which always sends an explicit `ssl` boolean—previously `ssl: false` still opened TLS and timed out against plaintext Redis.
> 
> Regression tests cover falsy `ssl`, `ssl=True`, and omitting `ssl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 195c898d909ed650c123cb7fd290f7085157ee8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->