### PR TITLE
fix(anthropic): honor messages request timeout

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -1879,6 +1879,7 @@ class BaseLLMHTTPHandler:
         litellm_params: GenericLiteLLMParams,
         api_key: Optional[str],
         model: str,
+        timeout: Optional[Union[float, httpx.Timeout]] = None,
     ) -> httpx.Response:
         max_attempts = max(provider_config.max_retry_on_anthropic_messages_http_error, 1)
         litellm_params_dict = dict(litellm_params)
@@ -1891,6 +1892,7 @@ class BaseLLMHTTPHandler:
                     data=signed_json_body or json.dumps(request_body),
                     stream=stream or False,
                     logging_obj=logging_obj,
+                    timeout=timeout,
                 )
                 response.raise_for_status()
                 return response
@@ -1924,6 +1926,29 @@ class BaseLLMHTTPHandler:
                 raise self._handle_error(e=e, provider_config=provider_config)
 
         raise RuntimeError("unreachable: anthropic messages HTTP retry loop exited without return")
+
+    @staticmethod
+    def _resolve_anthropic_messages_timeout(
+        litellm_params: GenericLiteLLMParams,
+        stream: bool,
+        custom_llm_provider: str,
+    ) -> Union[float, httpx.Timeout]:
+        from litellm.litellm_core_utils.completion_timeout import CompletionTimeout
+        from litellm.litellm_core_utils.request_timeout_resolver import (
+            get_configured_request_timeout,
+        )
+        from litellm.utils import supports_httpx_timeout
+
+        model_timeout = litellm_params.get("stream_timeout") if stream else None
+        if model_timeout is None:
+            model_timeout = litellm_params.get("timeout")
+        return CompletionTimeout.resolve(
+            model_timeout,
+            {"request_timeout": litellm_params.get("request_timeout")},
+            custom_llm_provider,
+            global_timeout=get_configured_request_timeout(),
+            supports_httpx_timeout=supports_httpx_timeout,
+        )
 
     async def async_anthropic_messages_handler(
         self,
@@ -2075,6 +2100,11 @@ class BaseLLMHTTPHandler:
             litellm_params=litellm_params,
             api_key=api_key,
             model=model,
+            timeout=self._resolve_anthropic_messages_timeout(
+                litellm_params=litellm_params,
+                stream=stream or False,
+                custom_llm_provider=custom_llm_provider,
+            ),
         )
 
         # used for logging + cost tracking

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -1084,6 +1084,90 @@ def test_sync_delete_responses_sets_json_content_type():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize(
+    "litellm_params_kwargs, stream, global_timeout, expected",
+    [
+        ({"timeout": 12.0}, False, None, 12.0),
+        ({"request_timeout": 30.0}, False, None, 30.0),
+        ({}, False, 1500.0, 1500.0),
+        ({"timeout": 5.0, "stream_timeout": 50.0}, True, None, 50.0),
+    ],
+)
+def test_resolve_anthropic_messages_timeout(
+    monkeypatch, litellm_params_kwargs, stream, global_timeout, expected
+):
+    from litellm.constants import DEFAULT_REQUEST_TIMEOUT_SECONDS
+
+    if global_timeout is None:
+        monkeypatch.setattr(
+            "litellm.request_timeout",
+            float(DEFAULT_REQUEST_TIMEOUT_SECONDS),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            "litellm.request_timeout_explicitly_set",
+            False,
+            raising=False,
+        )
+    else:
+        monkeypatch.setattr("litellm.request_timeout", global_timeout, raising=False)
+        monkeypatch.setattr(
+            "litellm.request_timeout_explicitly_set", True, raising=False
+        )
+
+    resolved = BaseLLMHTTPHandler._resolve_anthropic_messages_timeout(
+        litellm_params=GenericLiteLLMParams(**litellm_params_kwargs),
+        stream=stream,
+        custom_llm_provider="anthropic",
+    )
+
+    assert resolved == expected
+
+
+@pytest.mark.asyncio
+async def test_async_anthropic_messages_handler_forwards_request_timeout(monkeypatch):
+    monkeypatch.setattr(litellm, "callbacks", [])
+    handler = BaseLLMHTTPHandler()
+
+    mock_config = Mock()
+    mock_config.validate_anthropic_messages_environment = Mock(
+        return_value=({"x-api-key": "k"}, "https://api.anthropic.com")
+    )
+    mock_config.should_filter_anthropic_beta_headers = Mock(return_value=False)
+    mock_config.transform_anthropic_messages_request = Mock(
+        return_value={"model": "claude", "messages": []}
+    )
+    mock_config.get_complete_url = Mock(return_value="https://api.anthropic.com/v1/messages")
+    mock_config.sign_request = Mock(return_value=({"x-api-key": "k"}, None))
+    mock_config.max_retry_on_anthropic_messages_http_error = 1
+    expected_response = {"id": "msg_1", "content": []}
+    mock_config.transform_anthropic_messages_response = Mock(return_value=expected_response)
+
+    ok_response = Mock()
+    ok_response.raise_for_status = Mock(return_value=None)
+    mock_client = AsyncMock(spec=AsyncHTTPHandler)
+    mock_client.post = AsyncMock(return_value=ok_response)
+
+    logging_obj = Mock()
+    logging_obj.model_call_details = {}
+    logging_obj.dynamic_success_callbacks = []
+
+    result = await handler.async_anthropic_messages_handler(
+        model="claude",
+        messages=[{"role": "user", "content": "hi"}],
+        anthropic_messages_provider_config=mock_config,
+        anthropic_messages_optional_request_params={},
+        custom_llm_provider="anthropic",
+        litellm_params=GenericLiteLLMParams(request_timeout=0.3),
+        logging_obj=logging_obj,
+        client=mock_client,
+        kwargs={},
+    )
+
+    assert result is expected_response
+    assert mock_client.post.await_args.kwargs["timeout"] == 0.3
+
+
 @pytest.mark.asyncio
 async def test_anthropic_post_uses_prebuilt_body_without_redumping():
     """When the caller passes a pre-serialized (unsigned) body, attempt 0 must
@@ -1894,7 +1978,9 @@ async def test_anthropic_invalid_thinking_signature_retry_resigns_bedrock_reques
     ok_response = httpx.Response(200, json={"id": "msg_1"}, request=httpx.Request("POST", request_url))
 
     class FakeAsyncClient:
-        async def post(self, url, headers, data, stream=False, logging_obj=None):
+        async def post(
+            self, url, headers, data, stream=False, logging_obj=None, timeout=None
+        ):
             posts.append({"headers": dict(headers), "data": data})
             return invalid_signature_response if len(posts) == 1 else ok_response
 


### PR DESCRIPTION
## Relevant issues

Fixes #26752

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

N/A

## Screenshots / Proof of Fix

I verified this with a real LiteLLM proxy request to `/v1/messages` and a local slow Anthropic-compatible HTTP upstream. The local upstream sleeps for `1.25s`, while the model config sets `request_timeout: 0.3`. This keeps the proof deterministic without sending a real provider request

Config used for both runs:

```yaml
model_list:
  - model_name: claude-timeout-proof
    litellm_params:
      model: anthropic/claude-timeout-proof
      api_key: sk-ant-local-proof
      api_base: http://127.0.0.1:8999
      request_timeout: 0.3

general_settings:
  master_key: sk-1234

litellm_settings:
  drop_params: true
  modify_params: true
  num_retries: 0
```

Before fix, at base commit `bf02a4a47f`, the request waited for the slow upstream and returned `200`, showing that the model-level timeout was not applied to the Anthropic `/v1/messages` HTTP request:

```bash
uv run --extra proxy python litellm/proxy/proxy_cli.py --config /private/tmp/litellm_timeout_proof_config.yaml --port 4010 --detailed_debug

curl -sS -w '\nhttp_code=%{http_code}\ntime_total=%{time_total}\n' \
  -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' \
  -H 'anthropic-version: 2023-06-01' \
  --data '{"model":"claude-timeout-proof","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}' \
  http://127.0.0.1:4010/v1/messages
```

```text
{"id":"msg_timeout_proof","type":"message","role":"assistant","model":"claude-timeout-proof","content":[{"type":"text","text":"slow upstream response"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":5,"output_tokens":3}}
http_code=200
time_total=1.946157
```

After fix, at commit `63019add86`, the same request returns a LiteLLM timeout. The response body shows the configured `0.3s` timeout reached the HTTP request path:

```bash
uv run --extra proxy python litellm/proxy/proxy_cli.py --config /private/tmp/litellm_timeout_proof_config.yaml --port 4010 --detailed_debug

curl -sS -w '\nhttp_code=%{http_code}\ntime_total=%{time_total}\n' \
  -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' \
  -H 'anthropic-version: 2023-06-01' \
  --data '{"model":"claude-timeout-proof","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}' \
  http://127.0.0.1:4010/v1/messages
```

```text
{"error":{"message":"litellm.Timeout: Connection timed out. Timeout passed=0.3, time taken=0.302 seconds. Received Model Group=claude-timeout-proof\nAvailable Model Group Fallbacks=None","type":"None","param":"None","code":"408"}}
http_code=408
time_total=1.512531
```

Local regression checks at commit `63019add86`:

```bash
uv run --extra proxy pytest tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py -q
make pre-commit
```

Both passed locally. The targeted regression test also fails if the handler-level `timeout=` handoff is removed, with `assert None == 0.3`

## Type

Bug Fix

## Changes

Anthropic `/v1/messages` now resolves per-request and configured timeouts through the shared completion timeout resolver, then forwards the resolved value into the async HTTP POST helper

Regression coverage checks timeout precedence and the full async `/v1/messages` handler wiring into the HTTP client
