### PR TITLE
fix(anthropic): strip @version suffix in _model_map_lookup_candidates so @default Vertex AI models resolve to adaptive thinking

### DIFF
--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -290,6 +290,13 @@ class AnthropicModelInfo(BaseLLMModelInfo):
             )
 
     @staticmethod
+    def _strip_version_suffix(model: str) -> str:
+        at = model.rfind("@")
+        if at > 0:
+            return model[:at]
+        return model
+
+    @staticmethod
     def _model_map_lookup_candidates(model: str) -> List[str]:
         """Model-map keys to try for ``model``: the id itself, the same id with a
         bedrock/vertex routing prefix removed, the Bedrock base model, and each of
@@ -324,6 +331,7 @@ class AnthropicModelInfo(BaseLLMModelInfo):
                 _DATED_RELEASE_SUFFIX_RE.sub("", cand),
                 _DOTTED_VERSION_RE.sub(r"\1-\2", cand),
                 _strip_bedrock_id_suffixes(cand),
+                AnthropicModelInfo._strip_version_suffix(cand),
             )
         )
         return list(dict.fromkeys((*primary, *normalized)))

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -772,7 +772,6 @@ class TestProxyOAuthHeaderForwarding:
         self,
     ):
         """OAuth Authorization header IS forwarded when x-litellm-api-key was used for proxy auth."""
-        from unittest.mock import patch
 
         from starlette.datastructures import Headers
 
@@ -1724,3 +1723,48 @@ class TestClaudeOpus48AdaptiveThinking:
         from litellm.llms.anthropic.common_utils import AnthropicModelInfo
 
         assert AnthropicModelInfo._is_adaptive_thinking_model(model) is False
+
+
+class TestDefaultSuffixAdaptiveThinking:
+    """@default-suffixed Vertex AI model names (e.g. vertex_ai/claude-opus-4-8@default)
+    must resolve as adaptive thinking. Before the fix, _model_map_lookup_candidates
+    never stripped the @default suffix, so the lookup fell through to the bare
+    model name without @default, which may or may not have the flag, and for
+    provider-prefixed forms the lookup always missed (issue #31760)."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "vertex_ai/claude-opus-4-8@default",
+            "vertex_ai/claude-sonnet-4-6@default",
+            "vertex_ai/claude-opus-4-7@default",
+            "vertex_ai/claude-opus-4-6@default",
+            "vertex_ai/claude-fable-5@default",
+        ],
+    )
+    def test_default_suffix_models_are_adaptive_thinking(
+        self, local_model_cost_map, model: str
+    ) -> None:
+        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+        assert AnthropicModelInfo._is_adaptive_thinking_model(model) is True, (
+            f"{model} not classified as adaptive thinking. "
+            "Check _model_map_lookup_candidates strips @default suffix."
+        )
+
+    @pytest.mark.parametrize(
+        "model,expected_bare",
+        [
+            ("vertex_ai/claude-opus-4-8@default", "claude-opus-4-8"),
+            ("vertex_ai/claude-sonnet-4-6@default", "claude-sonnet-4-6"),
+        ],
+    )
+    def test_lookup_candidates_include_bare_name(
+        self, model: str, expected_bare: str
+    ) -> None:
+        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+        candidates = AnthropicModelInfo._model_map_lookup_candidates(model)
+        assert expected_bare in candidates, (
+            f"Expected '{expected_bare}' in candidates for '{model}', got: {candidates}"
+        )


### PR DESCRIPTION
## Relevant issues

Fixes #31760; also related to #30101

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Proof below was captured on the original PR (#31768) at its head commit 2c7cb1096919a1ccd59de80d21bf6008d0a64448; the commit here is the same change cherry-picked onto litellm_internal_staging. Run the proxy against a Vertex AI `claude-opus-4-8@default` deployment with a local interceptor at `http://localhost:8080`, then:

```bash
curl -s -X POST http://localhost:4001/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-1234" \
  -d '{
    "model": "vertex-opus-4-8-default",
    "messages": [{"role": "user", "content": "Say hi in one word"}],
    "reasoning_effort": "high",
    "max_tokens": 1000
  }'
```

Before the fix the interceptor sees `"thinking": {"type": "enabled"}` and Vertex AI rejects the request with HTTP 400. After the fix:

```json
{
  "model": "claude-opus-4-8@default",
  "messages": [...],
  "max_tokens": 1000,
  "thinking": {
    "type": "adaptive"
  },
  "output_config": {
    "effort": "high"
  }
}
```

The same transformation applies to any `@default`-suffixed Vertex Claude model (`claude-sonnet-4-6@default`, `claude-opus-4-6@default`, `claude-opus-4-7@default`, `claude-fable-5@default`)

## Type

🐛 Bug Fix

## Changes

This is a copy of #31768, originally authored by @deepanshululla, recreated on a `litellm_` branch based off `litellm_internal_staging` so CircleCI can run. The commit is cherry-picked as-is and preserves the original authorship

`_model_map_lookup_candidates` in `litellm/llms/anthropic/common_utils.py` built the list of model-map keys to try for a given model string, but it never stripped `@version` suffixes (e.g. `@default`, `@20250929`). As a result, `vertex_ai/claude-opus-4-8@default` would yield candidates `["vertex_ai/claude-opus-4-8@default", "claude-opus-4-8@default"]`, neither of which exists in `model_cost`, so `_is_adaptive_thinking_model` returned `False`. The proxy then forwarded `thinking.type = "enabled"` to Vertex AI, which requires `"adaptive"` for these endpoints and rejects the request with HTTP 400

The fix adds a `_strip_version_suffix` helper that removes everything from the last `@` onward, and threads it through the normalized candidate pipeline in `_model_map_lookup_candidates`. For `vertex_ai/claude-opus-4-8@default` this produces `["vertex_ai/claude-opus-4-8@default", "claude-opus-4-8@default", "claude-opus-4-8", "vertex_ai/claude-opus-4-8"]`, so the lookup resolves to `claude-opus-4-8` which carries `supports_adaptive_thinking: true`

The `@default` entries in `model_prices_and_context_window.json` that the original PR patched already carry `supports_adaptive_thinking: true` on `litellm_internal_staging`, so only the code and test changes are needed here

Tests cover vertex-prefixed, bare (no-prefix), and dated-suffix (`@20251101`) model forms, and verify the bare model name lands in the lookup candidate chain