### PR TITLE
fix(prometheus): skip budget metric DB/cache lookups when gauges are NoOpMetric

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1618,6 +1618,14 @@ class PrometheusLogger(CustomLogger):
         user_id: Optional[str] = None,
         user_api_key_org_id: Optional[str] = None,
     ):
+        if (
+            isinstance(self.litellm_remaining_team_budget_metric, NoOpMetric)
+            and isinstance(self.litellm_remaining_api_key_budget_metric, NoOpMetric)
+            and isinstance(self.litellm_remaining_user_budget_metric, NoOpMetric)
+            and isinstance(self.litellm_remaining_org_budget_metric, NoOpMetric)
+        ):
+            return
+
         _metadata = litellm_params.get("metadata") or {}
         _team_spend = _metadata.get("user_api_key_team_spend", None)
         _team_max_budget = _metadata.get("user_api_key_team_max_budget", None)
@@ -3332,6 +3340,9 @@ class PrometheusLogger(CustomLogger):
             - looks up team info from db if not available in metadata
         - Set team budget metrics
         """
+        if isinstance(self.litellm_remaining_team_budget_metric, NoOpMetric):
+            return
+
         if user_api_team:
             team_object = await self._assemble_team_object(
                 team_id=user_api_team,
@@ -3453,6 +3464,9 @@ class PrometheusLogger(CustomLogger):
         - Fetches org info via cache (get_org_object)
         - Sets org budget metrics
         """
+        if isinstance(self.litellm_remaining_org_budget_metric, NoOpMetric):
+            return
+
         if not org_id:
             return
 
@@ -3582,6 +3596,9 @@ class PrometheusLogger(CustomLogger):
         key_max_budget: Optional[float],
         key_spend: Optional[float],
     ):
+        if isinstance(self.litellm_remaining_api_key_budget_metric, NoOpMetric):
+            return
+
         if user_api_key:
             user_api_key_dict = await self._assemble_key_object(
                 user_api_key=user_api_key,
@@ -3642,6 +3659,9 @@ class PrometheusLogger(CustomLogger):
             - looks up user info from db if not available in metadata
         - Set user budget metrics
         """
+        if isinstance(self.litellm_remaining_user_budget_metric, NoOpMetric):
+            return
+
         if user_id:
             user_object = await self._assemble_user_object(
                 user_id=user_id,

--- a/tests/test_litellm/integrations/test_prometheus_budget_metric_guard.py
+++ b/tests/test_litellm/integrations/test_prometheus_budget_metric_guard.py
@@ -1,0 +1,359 @@
+"""
+Unit tests for the NoOpMetric guard in _increment_remaining_budget_metrics
+and the per-entity guards in _set_*_budget_metrics_after_api_request.
+
+Regression tests that the specific bug can never happen again:
+when budget gauges are excluded from prometheus_metrics_config (and therefore
+created as NoOpMetric instances), the DB/cache lookup helpers must not be called.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from prometheus_client import REGISTRY
+
+import litellm
+from litellm.integrations.prometheus import PrometheusLogger
+from litellm.types.integrations.prometheus import NoOpMetric
+
+_BUDGET_EXCLUDED_CONFIG = [
+    {
+        "group": "core-only",
+        "metrics": [
+            "litellm_requests_metric",
+            "litellm_total_tokens_metric",
+        ],
+    }
+]
+
+
+@pytest.fixture(autouse=True)
+def cleanup_prometheus_registry():
+    old_config = litellm.prometheus_metrics_config
+    for collector in list(REGISTRY._collector_to_names.keys()):
+        try:
+            REGISTRY.unregister(collector)
+        except Exception:
+            pass
+    yield
+    litellm.prometheus_metrics_config = old_config
+    for collector in list(REGISTRY._collector_to_names.keys()):
+        try:
+            REGISTRY.unregister(collector)
+        except Exception:
+            pass
+
+
+def make_logger_with_budget_metrics_disabled() -> PrometheusLogger:
+    litellm.prometheus_metrics_config = _BUDGET_EXCLUDED_CONFIG
+    return PrometheusLogger()
+
+
+def make_logger_with_all_metrics_enabled() -> PrometheusLogger:
+    litellm.prometheus_metrics_config = None
+    return PrometheusLogger()
+
+
+COMMON_KWARGS = dict(
+    user_api_team="team-123",
+    user_api_team_alias="my-team",
+    user_api_key="hashed-key",
+    user_api_key_alias="my-key",
+    litellm_params={"metadata": {}},
+    response_cost=0.001,
+    user_id="user-1",
+    user_api_key_org_id="org-1",
+)
+
+
+class TestBudgetGaugesAreNoopWhenExcluded:
+    def test_team_gauge_is_noop(self):
+        logger = make_logger_with_budget_metrics_disabled()
+        assert isinstance(logger.litellm_remaining_team_budget_metric, NoOpMetric)
+
+    def test_api_key_gauge_is_noop(self):
+        logger = make_logger_with_budget_metrics_disabled()
+        assert isinstance(logger.litellm_remaining_api_key_budget_metric, NoOpMetric)
+
+    def test_user_gauge_is_noop(self):
+        logger = make_logger_with_budget_metrics_disabled()
+        assert isinstance(logger.litellm_remaining_user_budget_metric, NoOpMetric)
+
+    def test_org_gauge_is_noop(self):
+        logger = make_logger_with_budget_metrics_disabled()
+        assert isinstance(logger.litellm_remaining_org_budget_metric, NoOpMetric)
+
+    def test_gauges_are_real_when_all_metrics_enabled(self):
+        logger = make_logger_with_all_metrics_enabled()
+        assert not isinstance(logger.litellm_remaining_team_budget_metric, NoOpMetric)
+        assert not isinstance(logger.litellm_remaining_api_key_budget_metric, NoOpMetric)
+        assert not isinstance(logger.litellm_remaining_user_budget_metric, NoOpMetric)
+        assert not isinstance(logger.litellm_remaining_org_budget_metric, NoOpMetric)
+
+
+class TestTopLevelGuard:
+    @pytest.mark.asyncio
+    async def test_no_db_lookups_when_all_budget_gauges_are_noop(self):
+        """Regression: _increment_remaining_budget_metrics must return early
+        without any I/O when all four budget gauges are NoOpMetric."""
+        logger = make_logger_with_budget_metrics_disabled()
+
+        assemble_team = AsyncMock(return_value=MagicMock())
+        assemble_key = AsyncMock(return_value=MagicMock())
+        assemble_user = AsyncMock(return_value=MagicMock())
+
+        with (
+            patch.object(logger, "_assemble_team_object", assemble_team),
+            patch.object(logger, "_assemble_key_object", assemble_key),
+            patch.object(logger, "_assemble_user_object", assemble_user),
+        ):
+            await logger._increment_remaining_budget_metrics(**COMMON_KWARGS)
+
+        assemble_team.assert_not_called()
+        assemble_key.assert_not_called()
+        assemble_user.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_db_lookups_run_when_budget_gauges_are_real(self):
+        """When budget gauges are real Prometheus metrics, the assemble helpers
+        must be called so I/O proceeds normally."""
+        logger = make_logger_with_all_metrics_enabled()
+
+        assemble_team = AsyncMock(
+            return_value=MagicMock(
+                team_id="team-123",
+                team_alias="my-team",
+                spend=0.001,
+                max_budget=None,
+                budget_reset_at=None,
+            )
+        )
+        assemble_key = AsyncMock(
+            return_value=MagicMock(
+                token="hashed-key",
+                key_alias="my-key",
+                spend=0.001,
+                max_budget=None,
+                budget_reset_at=None,
+            )
+        )
+        assemble_user = AsyncMock(
+            return_value=MagicMock(
+                user_id="user-1",
+                spend=0.001,
+                max_budget=None,
+                budget_reset_at=None,
+                user_email=None,
+                user_alias=None,
+            )
+        )
+
+        with (
+            patch.object(logger, "_assemble_team_object", assemble_team),
+            patch.object(logger, "_assemble_key_object", assemble_key),
+            patch.object(logger, "_assemble_user_object", assemble_user),
+            patch.object(logger, "_set_team_budget_metrics", MagicMock()),
+            patch.object(logger, "_set_key_budget_metrics", MagicMock()),
+            patch.object(logger, "_set_user_budget_metrics", MagicMock()),
+            patch.object(logger, "_set_org_budget_metrics_after_api_request", AsyncMock()),
+        ):
+            await logger._increment_remaining_budget_metrics(**COMMON_KWARGS)
+
+        assemble_team.assert_called_once()
+        assemble_key.assert_called_once()
+        assemble_user.assert_called_once()
+
+
+class TestPerEntityGuards:
+    @pytest.mark.asyncio
+    async def test_team_guard_skips_lookup_when_team_gauge_is_noop(self):
+        """Per-entity guard: team assemble helper is not called when team gauge is NoOp,
+        even when key and user gauges are real."""
+        logger = make_logger_with_all_metrics_enabled()
+        logger.litellm_remaining_team_budget_metric = NoOpMetric()
+
+        assemble_team = AsyncMock(return_value=MagicMock())
+        assemble_key = AsyncMock(
+            return_value=MagicMock(
+                token="hashed-key",
+                key_alias="my-key",
+                spend=0.001,
+                max_budget=None,
+                budget_reset_at=None,
+            )
+        )
+        assemble_user = AsyncMock(
+            return_value=MagicMock(
+                user_id="user-1",
+                spend=0.001,
+                max_budget=None,
+                budget_reset_at=None,
+                user_email=None,
+                user_alias=None,
+            )
+        )
+
+        with (
+            patch.object(logger, "_assemble_team_object", assemble_team),
+            patch.object(logger, "_assemble_key_object", assemble_key),
+            patch.object(logger, "_assemble_user_object", assemble_user),
+            patch.object(logger, "_set_team_budget_metrics", MagicMock()),
+            patch.object(logger, "_set_key_budget_metrics", MagicMock()),
+            patch.object(logger, "_set_user_budget_metrics", MagicMock()),
+            patch.object(logger, "_set_org_budget_metrics_after_api_request", AsyncMock()),
+        ):
+            await logger._increment_remaining_budget_metrics(**COMMON_KWARGS)
+
+        assemble_team.assert_not_called()
+        assemble_key.assert_called_once()
+        assemble_user.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_key_guard_skips_lookup_when_key_gauge_is_noop(self):
+        """Per-entity guard: key assemble helper is not called when key gauge is NoOp,
+        even when team and user gauges are real."""
+        logger = make_logger_with_all_metrics_enabled()
+        logger.litellm_remaining_api_key_budget_metric = NoOpMetric()
+
+        assemble_team = AsyncMock(
+            return_value=MagicMock(
+                team_id="team-123",
+                team_alias="my-team",
+                spend=0.001,
+                max_budget=None,
+                budget_reset_at=None,
+            )
+        )
+        assemble_key = AsyncMock(return_value=MagicMock())
+        assemble_user = AsyncMock(
+            return_value=MagicMock(
+                user_id="user-1",
+                spend=0.001,
+                max_budget=None,
+                budget_reset_at=None,
+                user_email=None,
+                user_alias=None,
+            )
+        )
+
+        with (
+            patch.object(logger, "_assemble_team_object", assemble_team),
+            patch.object(logger, "_assemble_key_object", assemble_key),
+            patch.object(logger, "_assemble_user_object", assemble_user),
+            patch.object(logger, "_set_team_budget_metrics", MagicMock()),
+            patch.object(logger, "_set_key_budget_metrics", MagicMock()),
+            patch.object(logger, "_set_user_budget_metrics", MagicMock()),
+            patch.object(logger, "_set_org_budget_metrics_after_api_request", AsyncMock()),
+        ):
+            await logger._increment_remaining_budget_metrics(**COMMON_KWARGS)
+
+        assemble_key.assert_not_called()
+        assemble_team.assert_called_once()
+        assemble_user.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_user_guard_skips_lookup_when_user_gauge_is_noop(self):
+        """Per-entity guard: user assemble helper is not called when user gauge is NoOp,
+        even when team and key gauges are real."""
+        logger = make_logger_with_all_metrics_enabled()
+        logger.litellm_remaining_user_budget_metric = NoOpMetric()
+
+        assemble_team = AsyncMock(
+            return_value=MagicMock(
+                team_id="team-123",
+                team_alias="my-team",
+                spend=0.001,
+                max_budget=None,
+                budget_reset_at=None,
+            )
+        )
+        assemble_key = AsyncMock(
+            return_value=MagicMock(
+                token="hashed-key",
+                key_alias="my-key",
+                spend=0.001,
+                max_budget=None,
+                budget_reset_at=None,
+            )
+        )
+        assemble_user = AsyncMock(return_value=MagicMock())
+
+        with (
+            patch.object(logger, "_assemble_team_object", assemble_team),
+            patch.object(logger, "_assemble_key_object", assemble_key),
+            patch.object(logger, "_assemble_user_object", assemble_user),
+            patch.object(logger, "_set_team_budget_metrics", MagicMock()),
+            patch.object(logger, "_set_key_budget_metrics", MagicMock()),
+            patch.object(logger, "_set_user_budget_metrics", MagicMock()),
+            patch.object(logger, "_set_org_budget_metrics_after_api_request", AsyncMock()),
+        ):
+            await logger._increment_remaining_budget_metrics(**COMMON_KWARGS)
+
+        assemble_user.assert_not_called()
+        assemble_team.assert_called_once()
+        assemble_key.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_set_team_budget_metrics_directly_skips_when_gauge_is_noop(self):
+        """_set_team_budget_metrics_after_api_request returns early when team gauge is NoOp."""
+        logger = make_logger_with_budget_metrics_disabled()
+        assemble_team = AsyncMock(return_value=MagicMock())
+
+        with patch.object(logger, "_assemble_team_object", assemble_team):
+            await logger._set_team_budget_metrics_after_api_request(
+                user_api_team="team-123",
+                user_api_team_alias="my-team",
+                team_spend=0.5,
+                team_max_budget=10.0,
+                response_cost=0.001,
+            )
+
+        assemble_team.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_api_key_budget_metrics_directly_skips_when_gauge_is_noop(self):
+        """_set_api_key_budget_metrics_after_api_request returns early when key gauge is NoOp."""
+        logger = make_logger_with_budget_metrics_disabled()
+        assemble_key = AsyncMock(return_value=MagicMock())
+
+        with patch.object(logger, "_assemble_key_object", assemble_key):
+            await logger._set_api_key_budget_metrics_after_api_request(
+                user_api_key="hashed-key",
+                user_api_key_alias="my-key",
+                response_cost=0.001,
+                key_max_budget=10.0,
+                key_spend=0.5,
+            )
+
+        assemble_key.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_user_budget_metrics_directly_skips_when_gauge_is_noop(self):
+        """_set_user_budget_metrics_after_api_request returns early when user gauge is NoOp."""
+        logger = make_logger_with_budget_metrics_disabled()
+        assemble_user = AsyncMock(return_value=MagicMock())
+
+        with patch.object(logger, "_assemble_user_object", assemble_user):
+            await logger._set_user_budget_metrics_after_api_request(
+                user_id="user-1",
+                user_spend=0.5,
+                user_max_budget=10.0,
+                response_cost=0.001,
+            )
+
+        assemble_user.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_org_budget_metrics_directly_skips_when_gauge_is_noop(self):
+        """_set_org_budget_metrics_after_api_request returns early when org gauge is NoOp.
+        The guard fires before any import of auth_checks, so prisma_client is never touched."""
+        logger = make_logger_with_budget_metrics_disabled()
+
+        set_org_metrics = MagicMock()
+        with patch.object(logger, "_set_org_budget_metrics", set_org_metrics):
+            await logger._set_org_budget_metrics_after_api_request(
+                org_id="org-1",
+                response_cost=0.001,
+            )
+
+        set_org_metrics.assert_not_called()


### PR DESCRIPTION
## Relevant issues

Copy of #31860 onto a litellm_ branch so CircleCI can run. Originally authored by @deepanshululla in #31860; his commit is cherry-picked here with authorship preserved

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The end-to-end verification below was captured by the original author on #31860 at commit 464ed01 (the identical change cherry-picked here). It was run against a live dev stack hot-swapped with this change, with budget metrics excluded from `prometheus_metrics_config`, and all four budget gauges (`litellm_remaining_team/api_key/user/org_budget_metric`) confirmed absent from Prometheus

A real completion request was made:

```bash
curl -s http://localhost:8000/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"ai-gateway-low-intelligence-general","messages":[{"role":"user","content":"say hi in 3 words"}],"max_tokens":20}'
# {"model":"gemini-3.1-flash-lite","choices":[{"message":{"content":"Hello, how are?",...}}],...}
```

PrometheusLogger's success hook fired (confirmed via "Prometheus: log_success_fallback_event" in debug logs). Grepping the 120-second log window for `_assemble_team_object`, `_assemble_key_object`, `_assemble_user_object`, `_assemble_org_object`, `get_team_from_cache`, and `get_key_object` produced zero hits, while non-budget metrics (`litellm_total_tokens_metric_total`) were populated normally, confirming the logger ran end-to-end and only the budget path was skipped

## Type

🐛 Bug Fix

## Changes

`_increment_remaining_budget_metrics` (prometheus.py) was called unconditionally on every successful LLM API request and always fanned out four async DB/cache lookups (team, key, user, org) regardless of whether the target Prometheus gauges were real metrics or NoOpMetric instances (created when the operator excludes them via `prometheus_metrics_config`). The lookups completed successfully but the results were silently discarded when `.set()` was called on a NoOpMetric, wasting I/O on every request

This PR adds two layers of guards. A top-level early return in `_increment_remaining_budget_metrics` exits immediately when all four budget gauges are NoOpMetric, short-circuiting the entire asyncio.gather fan-out. Per-entity guards at the top of each `_set_*_budget_metrics_after_api_request` helper use `isinstance(..., NoOpMetric)` to handle partial disabling (e.g., team budget enabled but key budget disabled) without the inner I/O

14 unit tests in `tests/test_litellm/integrations/test_prometheus_budget_metric_guard.py` cover: NoOpMetric construction when metrics are excluded; top-level guard skips all three assemble helpers; real gauges still trigger all helpers; per-entity guards for each of team/key/user/org in isolation; direct call of each `_set_*` helper skips the lookup when its gauge is NoOpMetric

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only short-circuit on the Prometheus success path; behavior when budget gauges are enabled is unchanged, with broad unit test coverage.
> 
> **Overview**
> Fixes wasted **DB/cache I/O on every successful proxy request** when operators exclude remaining-budget gauges via `prometheus_metrics_config` (those metrics become `NoOpMetric`, so lookups ran but `.set()` was a no-op).
> 
> **`_increment_remaining_budget_metrics`** now returns immediately when all four remaining budget gauges (team, API key, user, org) are `NoOpMetric`, avoiding the `asyncio.gather` fan-out entirely.
> 
> Each **`_set_*_budget_metrics_after_api_request`** helper gets its own early return when its corresponding remaining budget gauge is `NoOpMetric`, so partial metric filtering still skips only the disabled entity lookups.
> 
> Adds **`test_prometheus_budget_metric_guard.py`** with regression tests for full skip, normal I/O when gauges are real, per-entity guards, and direct calls to each setter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d578d3d1f1859ff2b78ef98378cfc4e3ee54138a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->