### PR TITLE
fix(model_cost): add supports_reasoning: false to Gemini image generation models

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -18782,6 +18782,48 @@
         },
         "web_search_billing_unit": "per_query"
     },
+    "gemini/gemini-3.1-flash-image": {
+        "input_cost_per_token": 2.5e-07,
+        "input_cost_per_token_batches": 1.25e-07,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.045,
+        "output_cost_per_image_token": 6e-05,
+        "output_cost_per_token": 1.5e-06,
+        "output_cost_per_token_batches": 7.5e-07,
+        "rpm": 1000,
+        "tpm": 4000000,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-3.1-flash-image",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_function_calling": false,
+        "supports_prompt_caching": true,
+        "supports_reasoning": false,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.014,
+            "search_context_size_high": 0.014
+        },
+        "web_search_billing_unit": "per_query"
+    },
     "gemini/gemini-3.1-flash-image-preview": {
         "input_cost_per_token": 2.5e-07,
         "input_cost_per_token_batches": 1.25e-07,
@@ -36781,6 +36823,22 @@
         "tpm": 8000000,
         "supports_image_size": false
     },
+    "vertex_ai/gemini-3-pro-image": {
+        "input_cost_per_image": 0.0011,
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_batches": 1e-06,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.134,
+        "output_cost_per_image_token": 0.00012,
+        "output_cost_per_token": 1.2e-05,
+        "output_cost_per_token_batches": 6e-06,
+        "supports_reasoning": false,
+        "source": "https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-pro-image"
+    },
     "vertex_ai/gemini-3-pro-image-preview": {
         "input_cost_per_image": 0.0011,
         "input_cost_per_token": 2e-06,
@@ -36796,6 +36854,20 @@
         "output_cost_per_token_batches": 6e-06,
         "supports_reasoning": false,
         "source": "https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-pro-image"
+    },
+    "vertex_ai/gemini-3.1-flash-image": {
+        "input_cost_per_image": 0.00056,
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.0672,
+        "output_cost_per_image_token": 6e-05,
+        "output_cost_per_token": 3e-06,
+        "supports_reasoning": false,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#gemini-models"
     },
     "vertex_ai/gemini-3.1-flash-image-preview": {
         "input_cost_per_image": 0.00056,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -18696,6 +18696,50 @@
         },
         "supports_image_size": false
     },
+    "gemini/gemini-3-pro-image": {
+        "input_cost_per_image": 0.0011,
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_batches": 1e-06,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.134,
+        "output_cost_per_image_token": 0.00012,
+        "output_cost_per_token": 1.2e-05,
+        "rpm": 1000,
+        "tpm": 4000000,
+        "output_cost_per_token_batches": 6e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-3-pro-image",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_function_calling": false,
+        "supports_prompt_caching": true,
+        "supports_reasoning": false,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.014,
+            "search_context_size_high": 0.014
+        },
+        "web_search_billing_unit": "per_query",
+        "supports_service_tier": true
+    },
     "gemini/gemini-3-pro-image-preview": {
         "input_cost_per_image": 0.0011,
         "input_cost_per_token": 2e-06,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -18727,6 +18727,7 @@
         ],
         "supports_function_calling": false,
         "supports_prompt_caching": true,
+        "supports_reasoning": false,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_vision": true,
@@ -18768,6 +18769,7 @@
         ],
         "supports_function_calling": false,
         "supports_prompt_caching": true,
+        "supports_reasoning": false,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_vision": true,
@@ -36726,6 +36728,7 @@
         "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
+        "supports_reasoning": false,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
@@ -36748,6 +36751,7 @@
         "output_cost_per_image_token": 0.00012,
         "output_cost_per_token": 1.2e-05,
         "output_cost_per_token_batches": 6e-06,
+        "supports_reasoning": false,
         "source": "https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-pro-image"
     },
     "vertex_ai/gemini-3.1-flash-image-preview": {
@@ -36761,6 +36765,7 @@
         "output_cost_per_image": 0.0672,
         "output_cost_per_image_token": 6e-05,
         "output_cost_per_token": 3e-06,
+        "supports_reasoning": false,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#gemini-models"
     },
     "vertex_ai/gemini-3.1-flash-lite-preview": {

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -18737,8 +18737,7 @@
             "search_context_size_medium": 0.014,
             "search_context_size_high": 0.014
         },
-        "web_search_billing_unit": "per_query",
-        "supports_service_tier": true
+        "web_search_billing_unit": "per_query"
     },
     "gemini/gemini-3-pro-image-preview": {
         "input_cost_per_image": 0.0011,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -18814,7 +18814,8 @@
             "search_context_size_medium": 0.014,
             "search_context_size_high": 0.014
         },
-        "web_search_billing_unit": "per_query"
+        "web_search_billing_unit": "per_query",
+        "supports_reasoning": false
     },
     "gemini/gemini-3-pro-image-preview": {
         "input_cost_per_image": 0.0011,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -18847,6 +18847,7 @@
         ],
         "supports_function_calling": false,
         "supports_prompt_caching": true,
+        "supports_reasoning": false,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_vision": true,
@@ -18888,6 +18889,7 @@
         ],
         "supports_function_calling": false,
         "supports_prompt_caching": true,
+        "supports_reasoning": false,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_vision": true,
@@ -18929,6 +18931,7 @@
         ],
         "supports_function_calling": false,
         "supports_prompt_caching": true,
+        "supports_reasoning": false,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_vision": true,
@@ -36900,6 +36903,7 @@
         "supports_parallel_function_calling": true,
         "supports_pdf_input": true,
         "supports_prompt_caching": true,
+        "supports_reasoning": false,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
@@ -36922,6 +36926,7 @@
         "output_cost_per_image_token": 0.00012,
         "output_cost_per_token": 1.2e-05,
         "output_cost_per_token_batches": 6e-06,
+        "supports_reasoning": false,
         "source": "https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-pro-image"
     },
     "vertex_ai/gemini-3-pro-image-preview": {
@@ -36937,6 +36942,7 @@
         "output_cost_per_image_token": 0.00012,
         "output_cost_per_token": 1.2e-05,
         "output_cost_per_token_batches": 6e-06,
+        "supports_reasoning": false,
         "source": "https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-pro-image"
     },
     "vertex_ai/gemini-3.1-flash-image": {
@@ -36950,6 +36956,7 @@
         "output_cost_per_image": 0.0672,
         "output_cost_per_image_token": 6e-05,
         "output_cost_per_token": 3e-06,
+        "supports_reasoning": false,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#gemini-models"
     },
     "vertex_ai/gemini-3.1-flash-image-preview": {
@@ -36963,6 +36970,7 @@
         "output_cost_per_image": 0.0672,
         "output_cost_per_image_token": 6e-05,
         "output_cost_per_token": 3e-06,
+        "supports_reasoning": false,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#gemini-models"
     },
     "vertex_ai/gemini-3.1-flash-lite-preview": {

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4717,6 +4717,7 @@ class TestValidateEnvironmentTencent:
         "vertex_ai/gemini-3-pro-image-preview",
         "vertex_ai/gemini-3.1-flash-image-preview",
         "gemini/gemini-2.5-flash-image",
+        "gemini/gemini-3-pro-image",
         "gemini/gemini-3-pro-image-preview",
         "gemini/gemini-3.1-flash-image-preview",
     ],

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4714,17 +4714,24 @@ class TestValidateEnvironmentTencent:
     "model",
     [
         "vertex_ai/gemini-2.5-flash-image",
+        "vertex_ai/gemini-3-pro-image",
         "vertex_ai/gemini-3-pro-image-preview",
+        "vertex_ai/gemini-3.1-flash-image",
         "vertex_ai/gemini-3.1-flash-image-preview",
         "gemini/gemini-2.5-flash-image",
         "gemini/gemini-3-pro-image",
         "gemini/gemini-3-pro-image-preview",
+        "gemini/gemini-3.1-flash-image",
         "gemini/gemini-3.1-flash-image-preview",
     ],
 )
 def test_gemini_image_models_do_not_support_reasoning(
     model: str, local_model_cost_map: None
 ) -> None:
+    assert model in litellm.model_cost, (
+        f"{model} is missing from the local model cost map. "
+        "Add its entry to litellm/model_prices_and_context_window_backup.json."
+    )
     assert litellm.supports_reasoning(model) is False, (
         f"{model} incorrectly classified as reasoning-capable. "
         "Add 'supports_reasoning: false' to its model_cost entry."

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4709,3 +4709,22 @@ class TestValidateEnvironmentTencent:
         assert "TENCENT_API_KEY" in result["missing_keys"]
 
 
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "vertex_ai/gemini-2.5-flash-image",
+        "vertex_ai/gemini-3-pro-image-preview",
+        "vertex_ai/gemini-3.1-flash-image-preview",
+        "gemini/gemini-2.5-flash-image",
+        "gemini/gemini-3-pro-image-preview",
+        "gemini/gemini-3.1-flash-image-preview",
+    ],
+)
+def test_gemini_image_models_do_not_support_reasoning(
+    model: str, local_model_cost_map: None
+) -> None:
+    assert litellm.supports_reasoning(model) is False, (
+        f"{model} incorrectly classified as reasoning-capable. "
+        "Add 'supports_reasoning: false' to its model_cost entry."
+    )


### PR DESCRIPTION
Originally authored by @deepanshululla in #31766. This is a copy of that PR onto an internal `litellm_` branch so CircleCI can run; the three original commits are cherry-picked with authorship preserved

## Relevant issues

Fixes #31758

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Proxy started against the real Gemini API with a wildcard `gemini/*` deployment and the packaged cost map, at head commit 43b69d84b3:

```bash
LITELLM_LOCAL_MODEL_COST_MAP=True python litellm/proxy/proxy_cli.py --config proof_config.yaml --port 4010
```

```bash
for model in gemini/gemini-2.5-flash-image gemini/gemini-3-pro-image gemini/gemini-3-pro-image-preview; do
  echo "=== $model ==="
  curl -s http://localhost:4010/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" \
    -H "Content-Type: application/json" \
    -d "{\"model\":\"$model\",\"messages\":[{\"role\":\"user\",\"content\":\"describe a sunset\"}],\"reasoning_effort\":\"low\"}" \
    | python3 -c "import json,sys; r=json.load(sys.stdin); e=r.get('error'); print(e['message'][:200] if e else 'NO ERROR: request accepted')"
done
```

```
=== gemini/gemini-2.5-flash-image ===
litellm.UnsupportedParamsError: gemini does not support parameters: ['reasoning_effort'], for model=gemini-2.5-flash-image. ...
=== gemini/gemini-3-pro-image ===
litellm.UnsupportedParamsError: gemini does not support parameters: ['reasoning_effort'], for model=gemini-3-pro-image. ...
=== gemini/gemini-3-pro-image-preview ===
litellm.UnsupportedParamsError: gemini does not support parameters: ['reasoning_effort'], for model=gemini-3-pro-image-preview. ...
```

The same models keep working for their actual purpose; a plain image generation request at head commit 43b69d84b3 goes through to Google and returns an image (real API call, real cost):

```
$ curl -s http://localhost:4010/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"gemini/gemini-3-pro-image","messages":[{"role":"user","content":"generate a tiny simple image of a blue square"}]}'
id: 4XBRapHWNe3SjMcPmvrIkAo | model: gemini/gemini-3-pro-image | finish: stop | usage: 1354
```

Before state, captured by checking out both pricing JSONs at the base commit 6d17f9e85c and restarting the proxy: the packaged cost map has no `gemini/gemini-3-pro-image` entry at all, so with `LITELLM_LOCAL_MODEL_COST_MAP=True` the model resolves with no metadata and the rejection of `reasoning_effort` rests solely on the code fallback in `_supports_factory` (no explicit flag in the map). #31758 is the case where that resolution came back true and the param was forwarded to Google, which answered with a 400. This PR pins the behavior in the data so it cannot regress with cost map edits:

```
$ LITELLM_LOCAL_MODEL_COST_MAP=True python -c "
import litellm
for m in ['gemini/gemini-2.5-flash-image','gemini/gemini-3-pro-image','gemini/gemini-3-pro-image-preview']:
    e = litellm.model_cost.get(m)
    print(m, '| entry:', 'present' if e else 'MISSING', '| explicit supports_reasoning:', e.get('supports_reasoning') if e else None)
"
# at base commit 6d17f9e85c:
gemini/gemini-2.5-flash-image | entry: present | explicit supports_reasoning: False
gemini/gemini-3-pro-image | entry: MISSING | explicit supports_reasoning: None
gemini/gemini-3-pro-image-preview | entry: present | explicit supports_reasoning: None
# at head commit 43b69d84b3:
gemini/gemini-2.5-flash-image | entry: present | explicit supports_reasoning: False
gemini/gemini-3-pro-image | entry: present | explicit supports_reasoning: False
gemini/gemini-3-pro-image-preview | entry: present | explicit supports_reasoning: False
```

## Type

🐛 Bug Fix

## Changes

Port of #31766 by @deepanshululla onto `litellm_internal_staging`, with his three commits cherry-picked so the original authorship is preserved

Gemini image generation models do not support reasoning or thinking, yet their cost map entries carried no explicit `supports_reasoning` flag, so `litellm.supports_reasoning()` fell through to provider defaults; when that fallback resolves to true, `reasoning_effort` is forwarded to the provider and rejected with a 400 (#31758). This PR sets `"supports_reasoning": false` explicitly on the affected `gemini/` and `vertex_ai/` image model entries in `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json`, and adds the `gemini/gemini-3-pro-image` entry that was missing from the backup map entirely

On top of the cherry-picked commits there is one small alignment commit that drops a stray `"supports_service_tier": true` from the new backup entry so it stays identical to the corresponding entry in the root map

A follow-up commit after Greptile review closes the remaining backup gap: `gemini/gemini-3.1-flash-image`, `vertex_ai/gemini-3-pro-image`, and `vertex_ai/gemini-3.1-flash-image` carried the flag in the root map but had no entries in the backup map at all, so `LITELLM_LOCAL_MODEL_COST_MAP=True` deployments were still unprotected for those three. Their full entries are now copied into the backup map, identical to the root map line for line

A parametrized regression test in `tests/test_litellm/test_utils.py` pins `litellm.supports_reasoning()` to false for all ten affected models using the local cost map fixture. Because `supports_reasoning()` also returns false for models missing from the map, the test additionally asserts each model is present in `litellm.model_cost`, so dropping one of the backup entries fails the suite instead of passing vacuously