### PR TITLE
fix(responses): preserve reasoning_tokens through chat->responses usage translation

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -2018,11 +2018,7 @@ class LiteLLMCompletionResponsesConfig:
         if hasattr(usage, "completion_tokens_details") and usage.completion_tokens_details is not None:
             completion_details = usage.completion_tokens_details
             output_details_dict: dict[str, int] = {}
-            if (
-                hasattr(completion_details, "reasoning_tokens")
-                and completion_details.reasoning_tokens is not None
-                and completion_details.reasoning_tokens > 0
-            ):
+            if hasattr(completion_details, "reasoning_tokens") and completion_details.reasoning_tokens is not None:
                 output_details_dict["reasoning_tokens"] = completion_details.reasoning_tokens
 
             if hasattr(completion_details, "text_tokens") and completion_details.text_tokens is not None:

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -2018,10 +2018,12 @@ class LiteLLMCompletionResponsesConfig:
         if hasattr(usage, "completion_tokens_details") and usage.completion_tokens_details is not None:
             completion_details = usage.completion_tokens_details
             output_details_dict: dict[str, int] = {}
-            if hasattr(completion_details, "reasoning_tokens") and completion_details.reasoning_tokens is not None:
+            if (
+                hasattr(completion_details, "reasoning_tokens")
+                and completion_details.reasoning_tokens is not None
+                and completion_details.reasoning_tokens > 0
+            ):
                 output_details_dict["reasoning_tokens"] = completion_details.reasoning_tokens
-            else:
-                output_details_dict["reasoning_tokens"] = 0
 
             if hasattr(completion_details, "text_tokens") and completion_details.text_tokens is not None:
                 output_details_dict["text_tokens"] = completion_details.text_tokens

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -127,7 +127,7 @@ def mock_responses_api_response(
                 "input_tokens": 36,
                 "input_tokens_details": {"cached_tokens": 0},
                 "output_tokens": 87,
-                "output_tokens_details": {"reasoning_tokens": 0},
+                "output_tokens_details": {},
                 "total_tokens": 123,
             },
             "user": None,

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -1185,7 +1185,7 @@ class ResponsesAPIRequestParams(ResponsesAPIOptionalRequestParams, total=False):
 
 
 class OutputTokensDetails(BaseLiteLLMOpenAIResponseObject):
-    reasoning_tokens: int = 0
+    reasoning_tokens: Optional[int] = None
 
     text_tokens: Optional[int] = None
 

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1955,9 +1955,80 @@ class TestUsageTransformation:
         # Assert
         assert response_usage.output_tokens == 150
         assert response_usage.output_tokens_details is not None
-        assert response_usage.output_tokens_details.reasoning_tokens == 0
+        assert response_usage.output_tokens_details.reasoning_tokens is None
         assert response_usage.output_tokens_details.text_tokens == 50
         assert response_usage.output_tokens_details.image_tokens == 100
+
+    def test_reasoning_tokens_not_forced_to_zero_when_absent(self):
+        # Regression: previously the else branch wrote reasoning_tokens=0 even when
+        # completion_tokens_details had no reasoning (reasoning_tokens=None). That caused
+        # the proxy to always report reasoning_tokens=0 for non-thinking responses.
+        usage = Usage(
+            prompt_tokens=10,
+            completion_tokens=50,
+            total_tokens=60,
+            completion_tokens_details=CompletionTokensDetailsWrapper(
+                text_tokens=50,
+                # reasoning_tokens intentionally absent -> None
+            ),
+        )
+
+        chat_completion_response = ModelResponse(
+            id="test-response-id",
+            created=1234567890,
+            model="claude-haiku-4-5",
+            object="chat.completion",
+            usage=usage,
+            choices=[
+                Choices(
+                    finish_reason="stop",
+                    index=0,
+                    message=Message(content="Hello!", role="assistant"),
+                )
+            ],
+        )
+
+        response_usage = LiteLLMCompletionResponsesConfig._transform_chat_completion_usage_to_responses_usage(
+            chat_completion_response=chat_completion_response
+        )
+
+        assert response_usage.output_tokens_details is not None
+        assert response_usage.output_tokens_details.reasoning_tokens is None
+
+    def test_reasoning_tokens_preserved_when_thinking_occurred(self):
+        # Regression: reasoning_tokens must survive the chat->responses translation
+        # when the provider actually did thinking.
+        usage = Usage(
+            prompt_tokens=100,
+            completion_tokens=612,
+            total_tokens=712,
+            completion_tokens_details=CompletionTokensDetailsWrapper(
+                reasoning_tokens=512,
+                text_tokens=100,
+            ),
+        )
+
+        chat_completion_response = ModelResponse(
+            id="test-response-id",
+            created=1234567890,
+            model="claude-haiku-4-5",
+            object="chat.completion",
+            usage=usage,
+            choices=[
+                Choices(
+                    finish_reason="stop",
+                    index=0,
+                    message=Message(content="Hello!", role="assistant"),
+                )
+            ],
+        )
+
+        response_usage = LiteLLMCompletionResponsesConfig._transform_chat_completion_usage_to_responses_usage(
+            chat_completion_response=chat_completion_response
+        )
+
+        assert response_usage.output_tokens_details is not None
+        assert response_usage.output_tokens_details.reasoning_tokens == 512
 
 
 class TestStreamingIDConsistency:

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1955,7 +1955,7 @@ class TestUsageTransformation:
         # Assert
         assert response_usage.output_tokens == 150
         assert response_usage.output_tokens_details is not None
-        assert response_usage.output_tokens_details.reasoning_tokens is None
+        assert response_usage.output_tokens_details.reasoning_tokens == 0
         assert response_usage.output_tokens_details.text_tokens == 50
         assert response_usage.output_tokens_details.image_tokens == 100
 
@@ -2029,6 +2029,39 @@ class TestUsageTransformation:
 
         assert response_usage.output_tokens_details is not None
         assert response_usage.output_tokens_details.reasoning_tokens == 512
+
+    def test_reasoning_tokens_explicit_zero_preserved(self):
+        usage = Usage(
+            prompt_tokens=10,
+            completion_tokens=50,
+            total_tokens=60,
+            completion_tokens_details=CompletionTokensDetailsWrapper(
+                reasoning_tokens=0,
+                text_tokens=50,
+            ),
+        )
+
+        chat_completion_response = ModelResponse(
+            id="test-response-id",
+            created=1234567890,
+            model="gpt-5.6",
+            object="chat.completion",
+            usage=usage,
+            choices=[
+                Choices(
+                    finish_reason="stop",
+                    index=0,
+                    message=Message(content="Hello!", role="assistant"),
+                )
+            ],
+        )
+
+        response_usage = LiteLLMCompletionResponsesConfig._transform_chat_completion_usage_to_responses_usage(
+            chat_completion_response=chat_completion_response
+        )
+
+        assert response_usage.output_tokens_details is not None
+        assert response_usage.output_tokens_details.reasoning_tokens == 0
 
 
 class TestStreamingIDConsistency:

--- a/tests/test_litellm/test_responses_api_bridge_non_stream.py
+++ b/tests/test_litellm/test_responses_api_bridge_non_stream.py
@@ -269,29 +269,30 @@ def test_transform_usage_with_zero_values():
     """
     Test transformation when token details are explicitly set to 0.
 
-    This ensures 0 values are preserved and not treated as None.
+    cached_tokens=0 is preserved (cache was available; nothing was cached).
+    reasoning_tokens=0 is omitted — it is semantically equivalent to None
+    (no reasoning occurred either way), so the field is absent.
     """
     completion_response = create_mock_completion_response(
         model="gpt-4",
         prompt_tokens=100,
         completion_tokens=50,
         total_tokens=150,
-        cached_tokens=0,  # Explicitly 0
-        reasoning_tokens=0,  # Explicitly 0
+        cached_tokens=0,  # Explicitly 0 — preserved
+        reasoning_tokens=0,  # Explicitly 0 — omitted (indistinguishable from absent)
     )
 
     responses_usage = LiteLLMCompletionResponsesConfig._transform_chat_completion_usage_to_responses_usage(
         completion_response
     )
 
-    # Should preserve 0 values
     assert responses_usage.input_tokens_details is not None
     assert responses_usage.input_tokens_details.cached_tokens == 0
 
-    assert responses_usage.output_tokens_details is not None
-    assert responses_usage.output_tokens_details.reasoning_tokens == 0
+    # reasoning_tokens=0 means no thinking occurred; field is omitted rather than forced to 0
+    assert responses_usage.output_tokens_details is None
 
-    print("✓ Transformation preserves explicit 0 values")
+    print("✓ Transformation omits reasoning_tokens when 0 or absent")
 
 
 def test_input_tokens_details_requires_cached_tokens():
@@ -315,25 +316,23 @@ def test_input_tokens_details_requires_cached_tokens():
     print("✓ InputTokensDetails correctly defaults cached_tokens to 0")
 
 
-def test_output_tokens_details_requires_reasoning_tokens():
+def test_output_tokens_details_reasoning_tokens():
     """
-    Test that OutputTokensDetails has reasoning_tokens as an int with default value 0.
+    Test OutputTokensDetails.reasoning_tokens field semantics.
 
-    This ensures backward compatibility while making the field non-optional.
+    reasoning_tokens is Optional[int] = None: present only when reasoning actually occurred.
     """
-    # Should work with reasoning_tokens=0
-    details1 = OutputTokensDetails(reasoning_tokens=0)
-    assert details1.reasoning_tokens == 0
+    details_explicit_zero = OutputTokensDetails(reasoning_tokens=0)
+    assert details_explicit_zero.reasoning_tokens == 0
 
-    # Should work with reasoning_tokens=100
-    details2 = OutputTokensDetails(reasoning_tokens=100)
-    assert details2.reasoning_tokens == 100
+    details_positive = OutputTokensDetails(reasoning_tokens=100)
+    assert details_positive.reasoning_tokens == 100
 
-    # Should work without reasoning_tokens (defaults to 0)
-    details3 = OutputTokensDetails()
-    assert details3.reasoning_tokens == 0
+    # Default is None — absence means reasoning did not occur (or was not tracked)
+    details_default = OutputTokensDetails()
+    assert details_default.reasoning_tokens is None
 
-    print("✓ OutputTokensDetails correctly defaults reasoning_tokens to 0")
+    print("✓ OutputTokensDetails.reasoning_tokens defaults to None")
 
 
 def test_all_providers_transformation_scenarios():
@@ -419,7 +418,7 @@ if __name__ == "__main__":
     test_transform_usage_with_both_token_details()
     test_transform_usage_with_zero_values()
     test_input_tokens_details_requires_cached_tokens()
-    test_output_tokens_details_requires_reasoning_tokens()
+    test_output_tokens_details_reasoning_tokens()
     test_all_providers_transformation_scenarios()
 
     print("\n" + "=" * 60)

--- a/tests/test_litellm/test_responses_api_bridge_non_stream.py
+++ b/tests/test_litellm/test_responses_api_bridge_non_stream.py
@@ -270,8 +270,8 @@ def test_transform_usage_with_zero_values():
     Test transformation when token details are explicitly set to 0.
 
     cached_tokens=0 is preserved (cache was available; nothing was cached).
-    reasoning_tokens=0 is omitted — it is semantically equivalent to None
-    (no reasoning occurred either way), so the field is absent.
+    reasoning_tokens=0 is preserved the same way: an explicit provider-reported
+    zero passes through, while an absent value (None) is omitted.
     """
     completion_response = create_mock_completion_response(
         model="gpt-4",
@@ -279,7 +279,7 @@ def test_transform_usage_with_zero_values():
         completion_tokens=50,
         total_tokens=150,
         cached_tokens=0,  # Explicitly 0 — preserved
-        reasoning_tokens=0,  # Explicitly 0 — omitted (indistinguishable from absent)
+        reasoning_tokens=0,  # Explicitly 0 — preserved
     )
 
     responses_usage = LiteLLMCompletionResponsesConfig._transform_chat_completion_usage_to_responses_usage(
@@ -289,10 +289,10 @@ def test_transform_usage_with_zero_values():
     assert responses_usage.input_tokens_details is not None
     assert responses_usage.input_tokens_details.cached_tokens == 0
 
-    # reasoning_tokens=0 means no thinking occurred; field is omitted rather than forced to 0
-    assert responses_usage.output_tokens_details is None
+    assert responses_usage.output_tokens_details is not None
+    assert responses_usage.output_tokens_details.reasoning_tokens == 0
 
-    print("✓ Transformation omits reasoning_tokens when 0 or absent")
+    print("✓ Transformation preserves explicit reasoning_tokens=0 and omits absent values")
 
 
 def test_input_tokens_details_requires_cached_tokens():


### PR DESCRIPTION
## Relevant issues

Fixes #31759

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Start the proxy with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`, then run:

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"20 heads 56 legs, chickens and cows?"}],"reasoning_effort":"low","max_tokens":2000}' \
  | python3 -c "import json,sys; r=json.load(sys.stdin); ct=r['usage'].get('completion_tokens_details',{}); print('reasoning_tokens:', ct.get('reasoning_tokens'))"
```

Before the fix the chat->responses bridge reported `reasoning_tokens: 0` even when the model actually produced thinking tokens; after the fix the real count comes through. See #31770 for the original run logs demonstrating this end to end

## Type

Bug Fix

## Changes

This PR is a copy of #31770 rebased onto `litellm_internal_staging` so CircleCI can run on it. Originally authored by @deepanshululla in #31770; the commits were cherry-picked with the original authorship preserved

Root cause: `_transform_chat_completion_usage_to_responses_usage` in `litellm/responses/litellm_completion_transformation/transformation.py` had an unconditional `else: output_details_dict["reasoning_tokens"] = 0` that fired whenever `completion_tokens_details.reasoning_tokens` was `None` or absent, so a real reasoning token count from the underlying chat completion was replaced with 0. The field is now written whenever the provider reports a count (including an explicit 0) and omitted only when the value is absent, using the same `is not None` guard as the sibling `text_tokens` and `image_tokens` fields (this guard symmetry was tightened in a follow-up commit after Greptile review)

Secondary fix: `OutputTokensDetails.reasoning_tokens` in `litellm/types/llms/openai.py` defaulted to `int = 0`, so any re-instantiation without an explicit value would silently zero out a real count. It is now `Optional[int] = None`. Relatedly, `mock_responses_api_response` in `litellm/responses/main.py` hardcoded `"output_tokens_details": {"reasoning_tokens": 0}` and now sends `{}`

Tests: three regression tests in `tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py` cover reasoning token preservation, omission when absent, and pass-through of an explicit zero, and existing assertions in that file and `tests/test_litellm/test_responses_api_bridge_non_stream.py` that encoded the old `int = 0` default were updated