### PR TITLE
fix: strip trailing slash from --base-url in lite CLI

### DIFF
--- a/litellm/proxy/client/cli/main.py
+++ b/litellm/proxy/client/cli/main.py
@@ -76,6 +76,10 @@ def cli(ctx: click.Context, base_url: str, api_key: Optional[str]) -> None:
     """LiteLLM Proxy CLI - Manage your LiteLLM proxy server"""
     ctx.ensure_object(dict)
 
+    # Normalize once here so every downstream command (login, agents, http, ...) can safely
+    # do f"{base_url}/some/path" without producing a double slash.
+    base_url = base_url.rstrip("/")
+
     # If no API key provided via flag or environment variable, try to load from saved token.
     # Pass base_url so we only use the stored key when it was issued for this server.
     if api_key is None:

--- a/tests/test_litellm/proxy/client/cli/test_global_options.py
+++ b/tests/test_litellm/proxy/client/cli/test_global_options.py
@@ -1,7 +1,7 @@
 # stdlib imports
 import os
 import sys
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -34,6 +34,35 @@ def test_cli_version_flag(cli_runner):
     assert f"LiteLLM Proxy CLI Version: {litellm_version}" in result.output
     assert "LiteLLM Proxy Server URL: http://localhost:4000" in result.output
     assert "LiteLLM Proxy Server Version: 1.2.3" in result.output
+
+
+def test_base_url_trailing_slash_normalized(cli_runner):
+    """A trailing slash on --base-url must not produce a double slash (e.g. '//sso/cli/start')."""
+    with (
+        patch("webbrowser.open"),
+        patch(
+            "requests.post",
+            return_value=Mock(
+                status_code=200,
+                json=Mock(
+                    return_value={
+                        "login_id": "cli-test-uuid",
+                        "poll_secret": "poll-secret",
+                        "user_code": "ABCD-EFGH",
+                    }
+                ),
+                raise_for_status=Mock(),
+            ),
+        ) as mock_post,
+        patch("requests.get", side_effect=ValueError("stop after start request")),
+    ):
+        cli_runner.invoke(
+            cli, ["--base-url", "https://gateway.litellm-sandbox.ai/", "login"]
+        )
+
+    mock_post.assert_called_once_with(
+        "https://gateway.litellm-sandbox.ai/sso/cli/start", timeout=10
+    )
 
 
 def test_cli_version_command(cli_runner):


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

A trailing slash on `--base-url` (or `LITELLM_PROXY_URL`) produces double-slash request URLs like `https://host//sso/cli/start`, which 404. Fixed by normalizing once in the CLI's top-level group callback.

Real curl proof against a live local proxy, showing the double-slash the bug used to produce is a dead route and the fixed single-slash path is a live one:

```bash
$ curl -s -o /dev/null -w "http://localhost:4000/sso/cli/start -> HTTP %{http_code}\n" -X POST http://localhost:4000/sso/cli/start
http://localhost:4000/sso/cli/start -> HTTP 200

$ curl -s -o /dev/null -w "http://localhost:4000//sso/cli/start -> HTTP %{http_code}\n" -X POST http://localhost:4000//sso/cli/start
http://localhost:4000//sso/cli/start -> HTTP 404
```

Actual CLI behavior before/after, invoking `lite login --base-url http://localhost:4000/` (trailing slash) and inspecting the exact URL requested:

```
before: http://localhost:4000//sso/cli/start
after:  http://localhost:4000/sso/cli/start
```

## Type

🐛 Bug Fix

## Changes

`litellm/proxy/client/cli/main.py`: strip trailing slash from `base_url` once in the `cli` group callback (`ctx.obj["base_url"]`), so every subcommand (`login`, `logout`, agent launchers, `http`, etc.) is covered without touching each call site.

Added a regression test asserting the exact request URL sent by `lite login` when given a trailing-slash `--base-url`.