### PR TITLE
ci: authorize the expression package (MIT) in liccheck.ini

### DIFF
--- a/tests/code_coverage_tests/liccheck.ini
+++ b/tests/code_coverage_tests/liccheck.ini
@@ -172,3 +172,4 @@ langgraph: >=1.0.10 # MIT License
 langgraph-prebuilt: >=1.0.8 # MIT License - https://github.com/langchain-ai/langgraph/blob/main/LICENSE
 pytest-rerunfailures: >=15.1 # MPL 2.0 license
 pytest-recording: >=0.13.4 # MIT license
+expression: >=5.6.0 # MIT License - https://github.com/cognitedata/Expression/blob/main/LICENSE


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before: the `code-quality` job failed in `check_licenses` on PR #32794 at commit 0053527ccf, which carries the same `expression>=5.6.0,<6.0` dependency that `litellm_internal_staging` already has ([failing run](https://github.com/BerriAI/litellm/actions/runs/29127898973/job/86477295108))

```
❌ Packages with unknown licenses:
- expression (5.6.0)

❌ Error: Found packages that need verification:
- expression (5.6.0) - Unknown license
```

After: this exact one-line diff was exercised on CI at commit 6239f38e6f (briefly pushed onto PR #32794's branch, then reverted in favor of this standalone PR) and `code-quality` passed ([passing run](https://github.com/BerriAI/litellm/actions/runs/29129615121/job/86482265419)). Running the same script CI runs, locally at that commit:

```
$ uv run --no-sync python ./tests/code_coverage_tests/check_licenses.py
✅ expression: Manually verified - MIT License - https://github.com/cognitedata/Expression/blob/main/LICENSE
...
✅ All dependencies have acceptable licenses.
```

## Type

🚄 Infrastructure

## Changes

`expression` (a runtime dependency in pyproject.toml since the MCP dcr_bridge work) has no entry in the `[Authorized Packages]` section of `tests/code_coverage_tests/liccheck.ini` and no cached entry in `license_cache.json`, so every `code-quality` run resolves its license with a live PyPI metadata fetch. When that fetch fails transiently, `check_licenses.py` reports the package as "Unknown license" and hard-fails the job; PR #32794 hit this while sibling PRs carrying the identical dependency passed the same check minutes apart

This adds the one-line authorization the failing check itself prescribes. `expression` 5.6.0 is MIT licensed, verified against both the PyPI trove classifier (`License :: OSI Approved :: MIT License`) and the [LICENSE file](https://github.com/cognitedata/Expression/blob/main/LICENSE) in the upstream repo
