### PR TITLE
fix(anthropic): translate adaptive thinking/effort to pre-4.6 model support

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -311,12 +311,15 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         if capped_thinking is not None:
             optional_params["thinking"] = capped_thinking
         else:
-            if not supports_thinking and not (litellm.drop_params or drop_params):
+            if not (litellm.drop_params or drop_params):
+                reason = (
+                    "does not support the `effort` / adaptive `thinking` parameter"
+                    if not supports_thinking
+                    else f"cannot fit the minimum thinking budget of "
+                    f"{ANTHROPIC_MIN_THINKING_BUDGET_TOKENS} tokens within max_tokens={max_tokens}"
+                )
                 raise AnthropicError(
-                    message=(
-                        f"{model} does not support the `effort` / adaptive `thinking` parameter. "
-                        "To drop unsupported params, set `litellm.drop_params = True`."
-                    ),
+                    message=(f"{model} {reason}. To drop unsupported params, set `litellm.drop_params = True`."),
                     status_code=400,
                 )
             verbose_logger.warning(DROP_UNSUPPORTED_ADAPTIVE_EFFORT_WARNING, model)

--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -2,7 +2,6 @@ from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
 
 import httpx
 
-import litellm
 from litellm.constants import (
     ANTHROPIC_MIN_THINKING_BUDGET_TOKENS,
     DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
@@ -263,13 +262,17 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
 
     @staticmethod
     def _translate_adaptive_effort_for_non_adaptive_model(
-        model: str, optional_params: Dict, max_tokens: Optional[int], drop_params: bool
+        model: str, optional_params: Dict, max_tokens: Optional[int]
     ) -> None:
         """Translate the 4.6+ adaptive-thinking interface (``thinking.type=adaptive``
         and/or ``output_config.effort``) down to what an older Anthropic model
         supports. Clients like Claude Code send this interface unconditionally, so
         without translation it reaches a pre-4.6 model and Anthropic rejects it with
         "This model does not support the effort parameter".
+
+        The reshape is silent, matching how the messages path already strips
+        unsupported ``output_config`` for older models (bedrock invoke, issue
+        #22797): the goal is to keep the request working, not to fail it.
 
         - 4.6+ (adaptive / ``supports_output_config``): left untouched (early return).
         - Thinking-capable but non-adaptive (``supports_reasoning``): effort is
@@ -278,11 +281,10 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
           Adaptive thinking carries no budget, so the mapped budget is capped below
           ``max_tokens`` (Anthropic requires ``max_tokens > budget_tokens``); when
           ``max_tokens`` can't fit even the minimum budget, thinking is dropped.
-        - No reasoning support: ``thinking``/``output_config.effort`` are dropped
-          (gated on ``drop_params``; raises a clean 400 otherwise).
+        - No reasoning support: ``thinking`` is dropped.
 
-        The residual ``output_config`` (e.g. ``format``) is Anthropic-4.6+-only for
-        these models and is dropped under the same ``drop_params`` gate.
+        Only the consumed ``effort`` key is removed from ``output_config``; any
+        residual (e.g. ``format``) is left for provider subclasses to handle.
         """
         from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 
@@ -311,31 +313,15 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         if capped_thinking is not None:
             optional_params["thinking"] = capped_thinking
         else:
-            if not (litellm.drop_params or drop_params):
-                reason = (
-                    "does not support the `effort` / adaptive `thinking` parameter"
-                    if not supports_thinking
-                    else f"cannot fit the minimum thinking budget of "
-                    f"{ANTHROPIC_MIN_THINKING_BUDGET_TOKENS} tokens within max_tokens={max_tokens}"
-                )
-                raise AnthropicError(
-                    message=(f"{model} {reason}. To drop unsupported params, set `litellm.drop_params = True`."),
-                    status_code=400,
-                )
             verbose_logger.warning(DROP_UNSUPPORTED_ADAPTIVE_EFFORT_WARNING, model)
             optional_params.pop("thinking", None)
 
-        if isinstance(output_config, dict):
+        if isinstance(output_config, dict) and "effort" in output_config:
             residual = {k: v for k, v in output_config.items() if k != "effort"}
-            if residual and not (litellm.drop_params or drop_params):
-                raise AnthropicError(
-                    message=(
-                        f"{model} does not support `output_config`. "
-                        "To drop unsupported params, set `litellm.drop_params = True`."
-                    ),
-                    status_code=400,
-                )
-            optional_params.pop("output_config", None)
+            if residual:
+                optional_params["output_config"] = residual
+            else:
+                optional_params.pop("output_config", None)
 
     @staticmethod
     def _cap_thinking_budget_to_max_tokens(thinking: Dict, max_tokens: Optional[int]) -> Optional[Dict]:
@@ -383,16 +369,10 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
             optional_params=anthropic_messages_optional_request_params,
         )
 
-        drop_params = (
-            litellm_params.get("drop_params")
-            if isinstance(litellm_params, dict)
-            else getattr(litellm_params, "drop_params", None)
-        )
         self._translate_adaptive_effort_for_non_adaptive_model(
             model=model,
             optional_params=anthropic_messages_optional_request_params,
             max_tokens=max_tokens,
-            drop_params=bool(drop_params),
         )
 
         system_param = anthropic_messages_optional_request_params.get("system")

--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -2,7 +2,9 @@ from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
 
 import httpx
 
+import litellm
 from litellm.constants import (
+    ANTHROPIC_MIN_THINKING_BUDGET_TOKENS,
     DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
     DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
     DEFAULT_REASONING_EFFORT_XHIGH_THINKING_BUDGET,
@@ -31,6 +33,12 @@ from ...common_utils import (
 )
 
 DEFAULT_ANTHROPIC_API_VERSION = "2023-06-01"
+
+DROP_UNSUPPORTED_ADAPTIVE_EFFORT_WARNING = (
+    "Dropping adaptive `thinking`/`output_config.effort` for model=%s: the model "
+    "does not support extended thinking, or max_tokens is too small to fit the "
+    "minimum thinking budget."
+)
 
 
 class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
@@ -253,6 +261,94 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         existing_output_config.setdefault("effort", effort)
         optional_params["output_config"] = existing_output_config
 
+    @staticmethod
+    def _translate_adaptive_effort_for_non_adaptive_model(
+        model: str, optional_params: Dict, max_tokens: Optional[int], drop_params: bool
+    ) -> None:
+        """Translate the 4.6+ adaptive-thinking interface (``thinking.type=adaptive``
+        and/or ``output_config.effort``) down to what an older Anthropic model
+        supports. Clients like Claude Code send this interface unconditionally, so
+        without translation it reaches a pre-4.6 model and Anthropic rejects it with
+        "This model does not support the effort parameter".
+
+        - 4.6+ (adaptive / ``supports_output_config``): left untouched (early return).
+        - Thinking-capable but non-adaptive (``supports_reasoning``): effort is
+          mapped to legacy ``thinking={type: enabled, budget_tokens}`` via
+          ``AnthropicConfig._map_reasoning_effort``, preserving the caller's intent.
+          Adaptive thinking carries no budget, so the mapped budget is capped below
+          ``max_tokens`` (Anthropic requires ``max_tokens > budget_tokens``); when
+          ``max_tokens`` can't fit even the minimum budget, thinking is dropped.
+        - No reasoning support: ``thinking``/``output_config.effort`` are dropped
+          (gated on ``drop_params``; raises a clean 400 otherwise).
+
+        The residual ``output_config`` (e.g. ``format``) is Anthropic-4.6+-only for
+        these models and is dropped under the same ``drop_params`` gate.
+        """
+        from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+
+        if AnthropicConfig._is_adaptive_thinking_model(model) or AnthropicConfig._model_supports_effort_param(model):
+            return
+
+        output_config = optional_params.get("output_config")
+        thinking = optional_params.get("thinking")
+        effort = output_config.get("effort") if isinstance(output_config, dict) else None
+        adaptive_thinking = isinstance(thinking, dict) and thinking.get("type") == "adaptive"
+        if effort is None and not adaptive_thinking:
+            return
+
+        supports_thinking = AnthropicModelInfo._supports_model_capability(model, "supports_reasoning")
+        legacy_thinking = (
+            AnthropicConfig._map_reasoning_effort(reasoning_effort=effort or "medium", model=model)
+            if supports_thinking
+            else None
+        )
+        capped_thinking = (
+            AnthropicMessagesConfig._cap_thinking_budget_to_max_tokens(legacy_thinking, max_tokens)
+            if legacy_thinking is not None
+            else None
+        )
+
+        if capped_thinking is not None:
+            optional_params["thinking"] = capped_thinking
+        else:
+            if not supports_thinking and not (litellm.drop_params or drop_params):
+                raise AnthropicError(
+                    message=(
+                        f"{model} does not support the `effort` / adaptive `thinking` parameter. "
+                        "To drop unsupported params, set `litellm.drop_params = True`."
+                    ),
+                    status_code=400,
+                )
+            verbose_logger.warning(DROP_UNSUPPORTED_ADAPTIVE_EFFORT_WARNING, model)
+            optional_params.pop("thinking", None)
+
+        if isinstance(output_config, dict):
+            residual = {k: v for k, v in output_config.items() if k != "effort"}
+            if residual and not (litellm.drop_params or drop_params):
+                raise AnthropicError(
+                    message=(
+                        f"{model} does not support `output_config`. "
+                        "To drop unsupported params, set `litellm.drop_params = True`."
+                    ),
+                    status_code=400,
+                )
+            optional_params.pop("output_config", None)
+
+    @staticmethod
+    def _cap_thinking_budget_to_max_tokens(thinking: Dict, max_tokens: Optional[int]) -> Optional[Dict]:
+        """Cap a legacy ``thinking.budget_tokens`` below ``max_tokens`` (Anthropic
+        requires ``max_tokens > budget_tokens``). Returns the (possibly capped)
+        thinking dict, or ``None`` when ``max_tokens`` is too small to fit even the
+        minimum thinking budget and thinking should be dropped."""
+        budget = thinking.get("budget_tokens")
+        if max_tokens is None or not isinstance(budget, int):
+            return thinking
+        if max_tokens <= ANTHROPIC_MIN_THINKING_BUDGET_TOKENS:
+            return None
+        if budget < max_tokens:
+            return thinking
+        return {**thinking, "budget_tokens": max_tokens - 1}
+
     def transform_anthropic_messages_request(
         self,
         model: str,
@@ -282,6 +378,18 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         self._translate_legacy_thinking_for_adaptive_model(
             model=model,
             optional_params=anthropic_messages_optional_request_params,
+        )
+
+        drop_params = (
+            litellm_params.get("drop_params")
+            if isinstance(litellm_params, dict)
+            else getattr(litellm_params, "drop_params", None)
+        )
+        self._translate_adaptive_effort_for_non_adaptive_model(
+            model=model,
+            optional_params=anthropic_messages_optional_request_params,
+            max_tokens=max_tokens,
+            drop_params=bool(drop_params),
         )
 
         system_param = anthropic_messages_optional_request_params.get("system")

--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -274,21 +274,30 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         unsupported ``output_config`` for older models (bedrock invoke, issue
         #22797): the goal is to keep the request working, not to fail it.
 
-        - 4.6+ (adaptive / ``supports_output_config``): left untouched (early return).
-        - Thinking-capable but non-adaptive (``supports_reasoning``): effort is
-          mapped to legacy ``thinking={type: enabled, budget_tokens}`` via
-          ``AnthropicConfig._map_reasoning_effort``, preserving the caller's intent.
-          Adaptive thinking carries no budget, so the mapped budget is capped below
-          ``max_tokens`` (Anthropic requires ``max_tokens > budget_tokens``); when
-          ``max_tokens`` can't fit even the minimum budget, thinking is dropped.
+        ``thinking.type=adaptive`` and ``output_config.effort`` are independent
+        capabilities. Adaptive thinking needs ``supports_adaptive_thinking`` (4.6+);
+        ``output_config.effort`` needs ``supports_output_config``, which some
+        non-adaptive models (e.g. Claude Opus 4.5) advertise on its own. So the two
+        are handled separately:
+
+        - Adaptive-thinking models (4.6+): both are native, left untouched.
+        - ``supports_output_config`` but non-adaptive (Opus 4.5): keep
+          ``output_config.effort`` (native), only drop the unsupported adaptive
+          ``thinking`` block.
+        - Thinking-capable but neither (``supports_reasoning``, e.g. Haiku/Sonnet
+          4.5): map effort to legacy ``thinking={type: enabled, budget_tokens}`` via
+          ``AnthropicConfig._map_reasoning_effort``, capped below ``max_tokens``
+          (Anthropic requires ``max_tokens > budget_tokens``) and dropped when
+          ``max_tokens`` can't fit even the minimum budget.
         - No reasoning support: ``thinking`` is dropped.
 
-        Only the consumed ``effort`` key is removed from ``output_config``; any
-        residual (e.g. ``format``) is left for provider subclasses to handle.
+        For the last two, only the consumed ``effort`` key is removed from
+        ``output_config``; any residual (e.g. ``format``) is left for provider
+        subclasses to handle.
         """
         from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 
-        if AnthropicConfig._is_adaptive_thinking_model(model) or AnthropicConfig._model_supports_effort_param(model):
+        if AnthropicConfig._is_adaptive_thinking_model(model):
             return
 
         output_config = optional_params.get("output_config")
@@ -296,6 +305,11 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         effort = output_config.get("effort") if isinstance(output_config, dict) else None
         adaptive_thinking = isinstance(thinking, dict) and thinking.get("type") == "adaptive"
         if effort is None and not adaptive_thinking:
+            return
+
+        if AnthropicConfig._model_supports_effort_param(model):
+            if adaptive_thinking:
+                optional_params.pop("thinking", None)
             return
 
         supports_thinking = AnthropicModelInfo._supports_model_capability(model, "supports_reasoning")

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_effort.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_effort.py
@@ -128,3 +128,43 @@ def test_thinking_dropped_when_max_tokens_too_small_for_min_budget(monkeypatch):
 
     assert "thinking" not in result
     assert "output_config" not in result
+
+
+def test_non_adaptive_request_without_effort_is_untouched():
+    """A non-adaptive model receiving a request with no adaptive interface (no
+    effort, no adaptive thinking) must pass through untouched."""
+    result = AnthropicMessagesConfig().transform_anthropic_messages_request(
+        model="claude-haiku-4-5",
+        messages=[{"role": "user", "content": "Hello"}],
+        anthropic_messages_optional_request_params={"max_tokens": 1024},
+        litellm_params={},
+        headers={},
+    )
+
+    assert "thinking" not in result
+    assert "output_config" not in result
+
+
+def test_undersized_max_tokens_raises_without_drop_params(monkeypatch):
+    """Thinking-capable model + max_tokens too small for the minimum budget must be
+    gated on drop_params, same as any other unsupported param: raise a clear
+    max_tokens error when drop_params is off (rather than silently dropping)."""
+    monkeypatch.setattr(litellm, "drop_params", False)
+
+    with pytest.raises(Exception, match="max_tokens|drop_params"):
+        _transform(
+            "claude-haiku-4-5", _claude_code_payload(effort="medium", max_tokens=512)
+        )
+
+
+def test_residual_output_config_raises_without_drop_params(monkeypatch):
+    """A residual output_config field (e.g. format) on a pre-4.6 model is
+    unsupported and must raise when drop_params is off, even though the effort was
+    translated to legacy thinking."""
+    monkeypatch.setattr(litellm, "drop_params", False)
+
+    with pytest.raises(Exception, match="output_config|drop_params"):
+        _transform(
+            "claude-haiku-4-5",
+            _claude_code_payload(effort="medium", format={"type": "json_schema"}),
+        )

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_effort.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_effort.py
@@ -1,0 +1,130 @@
+import litellm
+import pytest
+from litellm.constants import (
+    DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
+    DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
+)
+from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+    AnthropicMessagesConfig,
+)
+
+
+def _claude_code_payload(effort="medium", max_tokens=8192, **output_config_extra):
+    """The exact adaptive-thinking shape Claude Code (claude-cli) sends."""
+    output_config = {"effort": effort, **output_config_extra}
+    return {
+        "max_tokens": max_tokens,
+        "thinking": {"type": "adaptive"},
+        "output_config": output_config,
+    }
+
+
+def _transform(model, params, litellm_params=None):
+    return AnthropicMessagesConfig().transform_anthropic_messages_request(
+        model=model,
+        messages=[{"role": "user", "content": "Hello"}],
+        anthropic_messages_optional_request_params=dict(params),
+        litellm_params=litellm_params or {},
+        headers={},
+    )
+
+
+def test_effort_translated_to_legacy_thinking_for_haiku_4_5():
+    """Core regression: Claude Code sends adaptive thinking + effort to Haiku 4.5
+    (thinking-capable, pre-4.6). Effort must be translated to legacy extended
+    thinking rather than forwarded raw (which Anthropic rejects with "This model
+    does not support the effort parameter")."""
+    result = _transform("claude-haiku-4-5", _claude_code_payload(effort="medium"))
+
+    assert result["thinking"] == {
+        "type": "enabled",
+        "budget_tokens": DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
+    }
+    assert "output_config" not in result
+
+
+def test_effort_high_maps_to_high_budget_for_sonnet_4_5():
+    result = _transform("claude-sonnet-4-5", _claude_code_payload(effort="high"))
+
+    assert result["thinking"] == {
+        "type": "enabled",
+        "budget_tokens": DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
+    }
+    assert "output_config" not in result
+
+
+def test_adaptive_effort_passes_through_untouched_for_4_6():
+    """4.6+ natively supports the adaptive interface, so it must not be rewritten."""
+    result = _transform("claude-sonnet-4-6", _claude_code_payload(effort="high"))
+
+    assert result["thinking"] == {"type": "adaptive"}
+    assert result["output_config"] == {"effort": "high"}
+
+
+def test_effort_dropped_for_non_reasoning_model_with_drop_params(monkeypatch):
+    monkeypatch.setattr(litellm, "drop_params", True)
+    result = _transform("claude-3-5-haiku-latest", _claude_code_payload(effort="medium"))
+
+    assert "thinking" not in result
+    assert "output_config" not in result
+
+
+def test_effort_raises_for_non_reasoning_model_without_drop_params(monkeypatch):
+    monkeypatch.setattr(litellm, "drop_params", False)
+
+    with pytest.raises(Exception, match="drop_params"):
+        _transform("claude-3-5-haiku-latest", _claude_code_payload(effort="medium"))
+
+
+def test_drop_params_from_litellm_params_gates_the_drop(monkeypatch):
+    """A per-request drop_params (threaded via litellm_params) must also permit the
+    drop even when the global litellm.drop_params is False."""
+    monkeypatch.setattr(litellm, "drop_params", False)
+    result = _transform(
+        "claude-3-5-haiku-latest",
+        _claude_code_payload(effort="medium"),
+        litellm_params={"drop_params": True},
+    )
+
+    assert "thinking" not in result
+    assert "output_config" not in result
+
+
+def test_effort_translated_but_residual_output_config_dropped_for_haiku_4_5(monkeypatch):
+    """output_config may carry `format` (structured outputs) alongside effort. On a
+    model without output_config support, effort is translated to thinking and the
+    residual output_config is dropped under drop_params."""
+    monkeypatch.setattr(litellm, "drop_params", True)
+    result = _transform(
+        "claude-haiku-4-5",
+        _claude_code_payload(effort="medium", format={"type": "json_schema"}),
+    )
+
+    assert result["thinking"] == {
+        "type": "enabled",
+        "budget_tokens": DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
+    }
+    assert "output_config" not in result
+
+
+def test_budget_capped_below_max_tokens():
+    """Adaptive thinking carries no budget, so the translated legacy budget must be
+    capped below max_tokens (Anthropic requires max_tokens > budget_tokens). A
+    high-effort budget (4096) with max_tokens=3000 must be capped to 2999."""
+    result = _transform(
+        "claude-haiku-4-5", _claude_code_payload(effort="high", max_tokens=3000)
+    )
+
+    assert result["thinking"] == {"type": "enabled", "budget_tokens": 2999}
+
+
+def test_thinking_dropped_when_max_tokens_too_small_for_min_budget(monkeypatch):
+    """When max_tokens can't fit even the minimum thinking budget, thinking is
+    dropped so the request still succeeds rather than being rejected."""
+    monkeypatch.setattr(litellm, "drop_params", True)
+    result = _transform(
+        "claude-haiku-4-5", _claude_code_payload(effort="medium", max_tokens=512)
+    )
+
+    assert "thinking" not in result
+    assert "output_config" not in result

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_effort.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_effort.py
@@ -84,6 +84,35 @@ def test_residual_output_config_preserved_after_effort_translation():
     assert result["output_config"] == {"format": {"type": "json_schema"}}
 
 
+def test_opus_4_5_keeps_effort_but_drops_adaptive_thinking():
+    """Regression: Opus 4.5 advertises supports_output_config (accepts
+    output_config.effort) but is NOT adaptive, so thinking:{type:adaptive} is
+    rejected by Anthropic. The effort must be kept and only the adaptive thinking
+    block dropped, rather than early-returning and forwarding adaptive thinking raw."""
+    result = _transform("claude-opus-4-5", _claude_code_payload(effort="medium"))
+
+    assert result["output_config"] == {"effort": "medium"}
+    assert "thinking" not in result
+
+
+def test_opus_4_5_preserves_native_effort_without_adaptive_thinking():
+    """A caller sending output_config.effort alone (no adaptive thinking) to Opus 4.5
+    must pass through untouched, since the model supports it natively."""
+    result = AnthropicMessagesConfig().transform_anthropic_messages_request(
+        model="claude-opus-4-5",
+        messages=[{"role": "user", "content": "Hello"}],
+        anthropic_messages_optional_request_params={
+            "max_tokens": 8192,
+            "output_config": {"effort": "high"},
+        },
+        litellm_params={},
+        headers={},
+    )
+
+    assert result["output_config"] == {"effort": "high"}
+    assert "thinking" not in result
+
+
 def test_budget_capped_below_max_tokens():
     """Adaptive thinking carries no budget, so the translated legacy budget must be
     capped below max_tokens (Anthropic requires max_tokens > budget_tokens). A

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_effort.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_effort.py
@@ -1,5 +1,3 @@
-import litellm
-import pytest
 from litellm.constants import (
     DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
     DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
@@ -61,40 +59,19 @@ def test_adaptive_effort_passes_through_untouched_for_4_6():
     assert result["output_config"] == {"effort": "high"}
 
 
-def test_effort_dropped_for_non_reasoning_model_with_drop_params(monkeypatch):
-    monkeypatch.setattr(litellm, "drop_params", True)
+def test_thinking_and_effort_dropped_for_non_reasoning_model():
+    """A model with no reasoning support cannot take thinking or effort, so both are
+    silently dropped (no drop_params required) so the request still succeeds."""
     result = _transform("claude-3-5-haiku-latest", _claude_code_payload(effort="medium"))
 
     assert "thinking" not in result
     assert "output_config" not in result
 
 
-def test_effort_raises_for_non_reasoning_model_without_drop_params(monkeypatch):
-    monkeypatch.setattr(litellm, "drop_params", False)
-
-    with pytest.raises(Exception, match="drop_params"):
-        _transform("claude-3-5-haiku-latest", _claude_code_payload(effort="medium"))
-
-
-def test_drop_params_from_litellm_params_gates_the_drop(monkeypatch):
-    """A per-request drop_params (threaded via litellm_params) must also permit the
-    drop even when the global litellm.drop_params is False."""
-    monkeypatch.setattr(litellm, "drop_params", False)
-    result = _transform(
-        "claude-3-5-haiku-latest",
-        _claude_code_payload(effort="medium"),
-        litellm_params={"drop_params": True},
-    )
-
-    assert "thinking" not in result
-    assert "output_config" not in result
-
-
-def test_effort_translated_but_residual_output_config_dropped_for_haiku_4_5(monkeypatch):
-    """output_config may carry `format` (structured outputs) alongside effort. On a
-    model without output_config support, effort is translated to thinking and the
-    residual output_config is dropped under drop_params."""
-    monkeypatch.setattr(litellm, "drop_params", True)
+def test_residual_output_config_preserved_after_effort_translation():
+    """output_config may carry `format` (structured outputs) alongside effort. Only
+    the consumed effort key is removed; the residual is left for provider subclasses
+    (bedrock/vertex) to handle, and effort is translated to legacy thinking."""
     result = _transform(
         "claude-haiku-4-5",
         _claude_code_payload(effort="medium", format={"type": "json_schema"}),
@@ -104,27 +81,22 @@ def test_effort_translated_but_residual_output_config_dropped_for_haiku_4_5(monk
         "type": "enabled",
         "budget_tokens": DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
     }
-    assert "output_config" not in result
+    assert result["output_config"] == {"format": {"type": "json_schema"}}
 
 
 def test_budget_capped_below_max_tokens():
     """Adaptive thinking carries no budget, so the translated legacy budget must be
     capped below max_tokens (Anthropic requires max_tokens > budget_tokens). A
     high-effort budget (4096) with max_tokens=3000 must be capped to 2999."""
-    result = _transform(
-        "claude-haiku-4-5", _claude_code_payload(effort="high", max_tokens=3000)
-    )
+    result = _transform("claude-haiku-4-5", _claude_code_payload(effort="high", max_tokens=3000))
 
     assert result["thinking"] == {"type": "enabled", "budget_tokens": 2999}
 
 
-def test_thinking_dropped_when_max_tokens_too_small_for_min_budget(monkeypatch):
+def test_thinking_dropped_when_max_tokens_too_small_for_min_budget():
     """When max_tokens can't fit even the minimum thinking budget, thinking is
-    dropped so the request still succeeds rather than being rejected."""
-    monkeypatch.setattr(litellm, "drop_params", True)
-    result = _transform(
-        "claude-haiku-4-5", _claude_code_payload(effort="medium", max_tokens=512)
-    )
+    silently dropped so the request still succeeds rather than being rejected."""
+    result = _transform("claude-haiku-4-5", _claude_code_payload(effort="medium", max_tokens=512))
 
     assert "thinking" not in result
     assert "output_config" not in result
@@ -143,28 +115,3 @@ def test_non_adaptive_request_without_effort_is_untouched():
 
     assert "thinking" not in result
     assert "output_config" not in result
-
-
-def test_undersized_max_tokens_raises_without_drop_params(monkeypatch):
-    """Thinking-capable model + max_tokens too small for the minimum budget must be
-    gated on drop_params, same as any other unsupported param: raise a clear
-    max_tokens error when drop_params is off (rather than silently dropping)."""
-    monkeypatch.setattr(litellm, "drop_params", False)
-
-    with pytest.raises(Exception, match="max_tokens|drop_params"):
-        _transform(
-            "claude-haiku-4-5", _claude_code_payload(effort="medium", max_tokens=512)
-        )
-
-
-def test_residual_output_config_raises_without_drop_params(monkeypatch):
-    """A residual output_config field (e.g. format) on a pre-4.6 model is
-    unsupported and must raise when drop_params is off, even though the effort was
-    translated to legacy thinking."""
-    monkeypatch.setattr(litellm, "drop_params", False)
-
-    with pytest.raises(Exception, match="output_config|drop_params"):
-        _transform(
-            "claude-haiku-4-5",
-            _claude_code_payload(effort="medium", format={"type": "json_schema"}),
-        )


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Real `/v1/messages` calls to the gateway hitting the live Anthropic API (no mocks). The `claude-cli` user-agent is what auto-enables `drop_params`, matching how Claude Code actually talks to the gateway

Before (base `fdfb122573`, model `anthropic-haiku-4-5` -> `anthropic/claude-haiku-4-5`)

```
curl -s http://localhost:4000/v1/messages -H 'content-type: application/json' \
  -H 'x-api-key: sk-1234' -H 'user-agent: claude-cli/2.1.206 (external, cli)' \
  -d '{"model":"anthropic-haiku-4-5","max_tokens":8192,"thinking":{"type":"adaptive"},"output_config":{"effort":"medium"},"messages":[{"role":"user","content":"In one sentence, why is the sky blue?"}]}'

{"error":{"message":"{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"This model does not support the effort parameter.\"},\"request_id\":\"req_011CcuEZT7SkY3Vh31RmcMGu\"} ...","code":"400"}}
```

After (this PR, `bd1061c5`)

```
# A) Haiku 4.5, realistic max_tokens: effort translated to legacy extended thinking
curl -s http://localhost:4000/v1/messages -H 'content-type: application/json' \
  -H 'x-api-key: sk-1234' -H 'user-agent: claude-cli/2.1.206 (external, cli)' \
  -d '{"model":"anthropic-haiku-4-5","max_tokens":8192,"thinking":{"type":"adaptive"},"output_config":{"effort":"medium"},"messages":[{"role":"user","content":"In one sentence, why is the sky blue?"}]}'
-> {"stop_reason":"end_turn","content":[{"type":"thinking",...},{"type":"text",...}]}

# B) Haiku 4.5, tiny max_tokens=1024: thinking dropped so the request still succeeds
curl ... '{"model":"anthropic-haiku-4-5","max_tokens":1024,"thinking":{"type":"adaptive"},"output_config":{"effort":"medium"}, ...}'
-> {"stop_reason":"end_turn","content":[{"type":"text",...}]}

# C) Sonnet 4.6 control: native adaptive interface passes through untouched
curl ... '{"model":"anthropic-sonnet-4-6","max_tokens":8192,"thinking":{"type":"adaptive"},"output_config":{"effort":"high"}, ...}'
-> {"stop_reason":"end_turn","content":[{"type":"thinking",...},{"type":"text",...}]}
```

## Type

🐛 Bug Fix

## Changes

Clients like Claude Code speak native Anthropic `/v1/messages` and send the 4.6+ adaptive-thinking interface (`thinking:{type:adaptive}` plus `output_config:{effort:...}`) on every request, regardless of which model the gateway routes to. When that reaches a pre-4.6 Anthropic model such as Haiku 4.5 or Sonnet 4.5, Anthropic rejects it with "This model does not support the effort parameter" and the request fails. The native passthrough previously only capability-gated the OpenAI-style `reasoning_effort` alias; native `output_config` and adaptive `thinking` were forwarded raw

`AnthropicMessagesConfig` now reshapes that interface to what the routed model actually supports. Thinking-capable but non-adaptive models get the effort translated to a legacy `thinking={type: enabled, budget_tokens}` via the existing `_map_reasoning_effort`, preserving the caller's intent. Models with no reasoning support have `thinking` dropped. Because adaptive thinking carries no budget while the legacy form must satisfy Anthropic's `max_tokens > budget_tokens` rule, the translated budget is capped below `max_tokens`, and thinking is dropped when `max_tokens` cannot fit even the minimum budget so the request still succeeds. Models on 4.6+ pass through untouched

The reshape is silent rather than raising, matching how the messages path already strips unsupported `output_config` for older models on bedrock invoke (issue #22797); the goal is to keep the request working, not to fail it. Only the consumed `effort` key is removed from `output_config`; any residual (e.g. `format`) is left for the provider subclasses (bedrock, vertex) to handle, which is what keeps their existing strip and format-to-schema behavior intact. The non-Anthropic branches (Gemini via chat-completion transform, OpenAI/Azure via the Responses API) already performed this translation, so this change is scoped to the Anthropic-native passthrough
