### PR TITLE
fix(datadog): split log batches proactively under intake payload limits

### DIFF
--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -19,7 +19,7 @@ import os
 import time
 import traceback
 from datetime import datetime as datetimeObj
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 import httpx
 from httpx import Response
@@ -50,6 +50,7 @@ from litellm.types.integrations.base_health_check import IntegrationHealthCheckS
 from litellm.types.integrations.datadog import (
     DD_ERRORS,
     DD_MAX_BATCH_SIZE,
+    DD_MAX_PAYLOAD_SIZE_BYTES,
     DataDogStatus,
     DatadogInitParams,
     DatadogPayload,
@@ -384,8 +385,10 @@ class DataDogLogger(
 
     async def _send_with_413_split(self, batch: List) -> List:
         """
-        Send a batch, halving any sub-batch that 413s (payload too large) and retrying the
-        halves, since Datadog enforces a 5MB uncompressed limit per request.
+        Send a batch, halving any sub-batch that exceeds Datadog's intake limits before
+        sending, and halving again on a 413 (payload too large) response, since Datadog
+        enforces a 5MB uncompressed limit per request. The proactive split avoids paying
+        a serialize + gzip + round trip for a payload the intake is guaranteed to reject.
 
         A 413 surfaces as a raised MaskedHTTPStatusError (httpx raise_for_status), not a
         returned response, so both paths are handled. A lone event that still 413s is
@@ -397,6 +400,11 @@ class DataDogLogger(
         while pending:
             chunk = pending.pop()
             if not chunk:
+                continue
+            if len(chunk) > 1 and self._exceeds_intake_limits(chunk):
+                mid = len(chunk) // 2
+                pending.append(chunk[mid:])
+                pending.append(chunk[:mid])
                 continue
             try:
                 response = await self.async_send_compressed_data(chunk)
@@ -435,6 +443,21 @@ class DataDogLogger(
     @staticmethod
     def _undelivered(chunk: List, pending: List[List]) -> List:
         return chunk + [event for remaining in reversed(pending) for event in remaining]
+
+    @staticmethod
+    def _exceeds_intake_limits(chunk: Sequence[DatadogPayload]) -> bool:
+        """
+        True when a chunk would breach Datadog's log intake limits: more than
+        DD_MAX_BATCH_SIZE events per payload, or a serialized size above
+        DD_MAX_PAYLOAD_SIZE_BYTES (held under Datadog's 5MB uncompressed cap so
+        the batch is split before the intake rejects it with a 413).
+        """
+        from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
+
+        if len(chunk) > DD_MAX_BATCH_SIZE:
+            return True
+        payload_size_bytes = sum(len(safe_dumps(event).encode("utf-8")) + 2 for event in chunk) + 2
+        return payload_size_bytes > DD_MAX_PAYLOAD_SIZE_BYTES
 
     async def flush_queue(self):
         if self.flush_lock is None:

--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -456,7 +456,7 @@ class DataDogLogger(
 
         if len(chunk) > DD_MAX_BATCH_SIZE:
             return True
-        payload_size_bytes = sum(len(safe_dumps(event).encode("utf-8")) + 2 for event in chunk) + 2
+        payload_size_bytes = len(safe_dumps(chunk).encode("utf-8"))
         return payload_size_bytes > DD_MAX_PAYLOAD_SIZE_BYTES
 
     async def flush_queue(self):

--- a/litellm/types/integrations/datadog.py
+++ b/litellm/types/integrations/datadog.py
@@ -6,6 +6,7 @@ from typing_extensions import NotRequired, TypedDict
 from litellm.types.integrations.custom_logger import StandardCustomLoggerInitParams
 
 DD_MAX_BATCH_SIZE = 1000
+DD_MAX_PAYLOAD_SIZE_BYTES = 4_000_000
 
 
 class DataDogStatus(str, Enum):

--- a/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
@@ -213,7 +213,7 @@ async def test_oversized_payload_splits_before_any_send(datadog_env):
     await logger.async_send_batch()
 
     assert delivered == events
-    assert len(sent_batches) >= 2
+    assert len(sent_batches) == 3
     assert all(
         len(safe_dumps(batch).encode("utf-8")) <= DD_MAX_PAYLOAD_SIZE_BYTES
         for batch in sent_batches

--- a/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
@@ -6,16 +7,20 @@ from httpx import Request, Response
 
 from litellm.integrations.datadog.datadog import DataDogLogger
 from litellm.llms.custom_httpx.http_handler import MaskedHTTPStatusError
-from litellm.types.integrations.datadog import DD_MAX_BATCH_SIZE, DatadogPayload
+from litellm.types.integrations.datadog import (
+    DD_MAX_BATCH_SIZE,
+    DD_MAX_PAYLOAD_SIZE_BYTES,
+    DatadogPayload,
+)
 
 
-def _payloads(n):
+def _payloads(n, message=None):
     return [
         DatadogPayload(
             ddsource="litellm",
             ddtags="env:test",
             hostname="host",
-            message=f'{{"event": {i}}}',
+            message=f"{message}{i}" if message else f'{{"event": {i}}}',
             service="svc",
             status="info",
         )
@@ -174,6 +179,87 @@ async def test_413_returned_response_also_splits(datadog_env):
     await logger.async_send_batch()
 
     assert sorted(delivered) == [f'{{"event": {i}}}' for i in range(4)]
+    assert logger.log_queue == []
+
+
+def _make_recording_send(sent_batches, delivered):
+    async def _send(data):
+        sent_batches.append(list(data))
+        delivered.extend(data)
+        return Response(
+            202, request=Request("POST", "https://example.com"), text="Accepted"
+        )
+
+    return _send
+
+
+@pytest.mark.asyncio
+async def test_oversized_payload_splits_before_any_send(datadog_env):
+    """Regression for LIT-4325: a batch above Datadog's uncompressed payload limit is
+    split proactively, so the intake never has to reject it with a 413."""
+    from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
+
+    with patch("asyncio.create_task"):
+        logger = DataDogLogger()
+
+    events = _payloads(3, message="x" * 3_000_000)
+    logger.log_queue = list(events)
+    sent_batches: list = []
+    delivered: list = []
+    logger.async_send_compressed_data = AsyncMock(
+        side_effect=_make_recording_send(sent_batches, delivered)
+    )
+
+    await logger.async_send_batch()
+
+    assert delivered == events
+    assert len(sent_batches) >= 2
+    assert all(
+        len(safe_dumps(batch).encode("utf-8")) <= DD_MAX_PAYLOAD_SIZE_BYTES
+        for batch in sent_batches
+    )
+    assert logger.log_queue == []
+
+
+@pytest.mark.asyncio
+async def test_batch_over_max_event_count_splits_before_any_send(datadog_env):
+    """Datadog caps a payload at 1000 events; a queue that grew past that (e.g. after
+    re-queues) must be sent in count-compliant chunks."""
+    with patch("asyncio.create_task"):
+        logger = DataDogLogger()
+
+    events = _payloads(DD_MAX_BATCH_SIZE + 1)
+    logger.log_queue = list(events)
+    sent_batches: list = []
+    delivered: list = []
+    logger.async_send_compressed_data = AsyncMock(
+        side_effect=_make_recording_send(sent_batches, delivered)
+    )
+
+    await logger.async_send_batch()
+
+    assert delivered == events
+    assert all(len(batch) <= DD_MAX_BATCH_SIZE for batch in sent_batches)
+    assert logger.log_queue == []
+
+
+@pytest.mark.asyncio
+async def test_single_event_above_payload_cap_is_still_sent(datadog_env):
+    """A lone event over the byte cap cannot be split further; it must be sent once
+    (Datadog decides), never looped on."""
+    with patch("asyncio.create_task"):
+        logger = DataDogLogger()
+
+    logger.log_queue = _payloads(1, message="x" * (DD_MAX_PAYLOAD_SIZE_BYTES + 1))
+    sent_batches: list = []
+    delivered: list = []
+    send = AsyncMock(side_effect=_make_recording_send(sent_batches, delivered))
+    logger.async_send_compressed_data = send
+
+    await asyncio.wait_for(logger.async_send_batch(), timeout=10)
+
+    assert send.await_count == 1
+    assert len(delivered) == 1
     assert logger.log_queue == []
 
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4325

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

All runs below use a live proxy on localhost:4000 with a real Postgres and real OpenAI gpt-4.1-mini calls costing real money, except where a step says it drives `DataDogLogger` directly; those steps still execute the real serialize, gzip and HTTP send path. Datadog side is the production intake `https://http-intake.logs.us5.datadoghq.com/api/v2/logs` unless marked "local intake" (a stand-in that gunzips and enforces the documented 5MB/413 rule, used before production credentials were available)

### 1. Reproducing the reported issue (pre #29444 code, production Datadog)

The reporter's traceback line numbers match the code before #29444, so that vintage was checked out (`fe108580d7^`) and a 9.18MB queue flushed at production Datadog. The output is the ticket verbatim, including the same `datadog.py:342 -> :541` frames, and the batch is re-queued unchanged on every attempt, which is the retry forever loop behind the reported cluster slowdown

```text
LiteLLM:ERROR: Datadog Error sending batch API - Client error '413 Request Entity Too Large'
  for url 'https://http-intake.logs.us5.datadoghq.com/api/v2/logs'
  File ".../litellm/integrations/datadog/datadog.py", line 342, in async_send_batch
  File ".../litellm/integrations/datadog/datadog.py", line 541, in async_send_compressed_data
litellm.llms.custom_httpx.http_handler.MaskedHTTPStatusError: Client error '413 Request Entity Too Large' ...

flush attempt 1: queue after = 10 events (re-queued)
flush attempt 2: queue after = 10 events (re-queued)
flush attempt 3: queue after = 10 events (re-queued)
```

### 2. Before this PR, current staging (commit dacf1cfb26, live proxy, local intake)

450 real requests in one 60s flush window (~165 answered 200 by OpenAI, the rest 429 upstream; each produces one success or failure event of roughly 20KB). The flush posts all 450 events as one 9.2MB payload, pays the full serialize, gzip and upload cost, gets rejected, and only then halves reactively into two 4.6MB chunks that barely clear the limit

```text
18:41:41 status=413 events=450 uncompressed_bytes=9224058 compressed_bytes=141720
18:41:41 status=202 events=225 uncompressed_bytes=4629595 compressed_bytes=86208
18:41:41 status=202 events=225 uncompressed_bytes=4594463 compressed_bytes=59073
```

### 3. After this PR (commit b206ebde75, live proxy, local intake)

The identical burst is split before sending; the intake never sees an oversized payload and there is no 413

```text
19:05:47 status=202 events=112 uncompressed_bytes=2309919
19:05:47 status=202 events=113 uncompressed_bytes=2318794
19:05:47 status=202 events=112 uncompressed_bytes=2288911
19:05:47 status=202 events=113 uncompressed_bytes=2307131
```

### 4. Production Datadog boundary probes and split verification (commit 91948e8a7e)

Driving `DataDogLogger` directly at the production intake pins the real enforcement: 5,340,948 bytes uncompressed is accepted while 5,496,948 bytes and above draws 413, so the documented 5MB limit is enforced at roughly 5.4MB and the 4MB cap in this PR keeps about 1.4MB of measured headroom. An unfixed-style one-shot POST of 9.18MB draws a real 413; the same queue through this PR's split path is fully delivered

```text
probe 5.34MB one-shot POST  -> 202
probe 5.50MB one-shot POST  -> 413
unfixed-style 9.18MB POST   -> 413
fixed flush of same 9.18MB  -> 202 x4 (1.84MB, 2.75MB, 1.84MB, 2.75MB), queue drained
```

### 5. Full end to end against production Datadog (commit 91948e8a7e, live proxy)

Same live proxy setup with `DD_SITE=us5.datadoghq.com` and no base URL override, real OpenAI burst, one 350 event flush window (~7MB). The proxy splits it proactively and production Datadog accepts every chunk; no 413 appears anywhere in the proxy log

```text
20:53:46 Datadog - about to flush 350 events on https://http-intake.logs.us5.datadoghq.com/api/v2/logs
20:53:46 Datadog: delivered 175 events, status_code=202
20:53:46 Datadog: delivered 175 events, status_code=202
```

### 6. 100MB stress test (commit 91948e8a7e, local intake)

A single 5,000 event batch of 95,963,890 bytes through the real send path, exceeding the byte cap and the 1000 event array limit simultaneously. Delivered as 32 chunks of 156 to 157 events at 2.99MB to 3.01MB each, all 202, zero 413s, queue drained, whole flush in 0.7s

### Setup used for the burst runs

```bash
export DATABASE_URL="postgresql://llmproxy:dbpassword9090@localhost:5433/litellm"
export DD_API_KEY="<key>" DD_SITE="us5.datadoghq.com"   # or DD_BASE_URL=http://127.0.0.1:8126 for the local intake
export DEFAULT_FLUSH_INTERVAL_SECONDS=60
litellm --config dd_repro_config.yaml --port 4000
# config: gpt-4.1-mini via openai, litellm_settings success_callback + failure_callback = ["datadog"], master_key sk-1234
seq 1 450 | xargs -P 80 -I{} curl -s -o /dev/null -w "%{http_code}\n" \
  http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d @req_body.json   # 9.8KB user message, max_tokens 5
```

## Type

🐛 Bug Fix

## Changes

`DataDogLogger` caps a batch at `DD_MAX_BATCH_SIZE` (1000) events but never accounts for bytes, and `async_send_batch` posts the entire queue in one request. Message and response fields are truncated to 10k chars per event, so a single event still runs about 20KB and a busy flush window crosses Datadog's 5MB uncompressed payload limit long before the event count cap matters. Datadog then rejects the whole upload with a 413. Releases before #29444 re-queued the rejected batch and retried it forever, which is the compounding serialize plus gzip plus upload loop behind the cluster slowdown reported in the ticket; since #29444 the batch is halved reactively, but only after the guaranteed rejection already cost a full 5MB+ serialize, gzip and round trip on every oversized flush

This PR makes the split proactive. `_send_with_413_split` now checks each chunk against Datadog's intake limits before sending (more than `DD_MAX_BATCH_SIZE` events, or serialized size above the new `DD_MAX_PAYLOAD_SIZE_BYTES` of 4MB) and halves it without paying the network round trip, reusing the exact halving machinery the 413 path already uses. The size check serializes the chunk with the same `safe_dumps` call the send path uses, so the measured bytes equal the transmitted bytes. The 4MB cap sits under the documented 5MB limit; probing the production intake showed real enforcement at roughly 5.4MB, so the cap keeps about 1.4MB of measured headroom. The reactive 413 handling stays in place as a safety net, including the drop of a lone event that the intake still rejects. The event count check also covers queues that grew past 1000 events through re-queues or service hook appends, which previously went out as arrays above Datadog's 1000 entry limit

Regression tests extend the mapped `tests/test_litellm/integrations/datadog/test_datadog_logger_batching.py`: an oversized payload must be split before any send with every sent chunk under the byte cap and events delivered in order, a queue above `DD_MAX_BATCH_SIZE` must go out in count compliant chunks, and a lone event above the byte cap must be sent once rather than looped on. The first two fail on the unfixed code and pass with the fix

The LLM Observability logger (`datadog_llm_obs.py`) posts to a different intake with its own unbounded `async_send_batch`; it is out of scope here and tracked as LIT-4358
