### PR TITLE
test(mcp): assert get_mcp_servers_by_team returns the team's servers

### DIFF
--- a/tests/test_litellm/proxy/db/mcp_server/test_db.py
+++ b/tests/test_litellm/proxy/db/mcp_server/test_db.py
@@ -1,15 +1,57 @@
-import json
 import os
 import sys
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../.."))  # Adds the parent directory to the system path
 
 from litellm.proxy._experimental.mcp_server.db import get_mcp_servers_by_team
+from litellm.proxy._types import LiteLLM_ObjectPermissionTable, LiteLLM_TeamTable
 
 
-def test_fetch_mcp_servers_by_team():
-    assert True == True
+def _make_prisma_with_team(team_record):
+    """Build a MagicMock prisma_client whose team table returns ``team_record``
+    for find_unique (the only call get_mcp_servers_by_team makes)."""
+    prisma = MagicMock()
+    prisma.db.litellm_teamtable.find_unique = AsyncMock(return_value=team_record)
+    return prisma
+
+
+@pytest.mark.asyncio
+async def test_fetch_mcp_servers_by_team():
+    team_mcp_servers = ["github-mcp", "slack-mcp"]
+    team_record = LiteLLM_TeamTable(team_id="team-1", object_permission_id="perm-1")
+    team_record.object_permission = LiteLLM_ObjectPermissionTable(
+        object_permission_id="perm-1",
+        mcp_servers=team_mcp_servers,
+    )
+    prisma = _make_prisma_with_team(team_record)
+
+    result = await get_mcp_servers_by_team(prisma, "team-1")
+
+    assert result == team_mcp_servers
+    prisma.db.litellm_teamtable.find_unique.assert_awaited_once_with(
+        where={"team_id": "team-1"},
+        include={"object_permission": True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_mcp_servers_by_team_no_team():
+    prisma = _make_prisma_with_team(None)
+
+    result = await get_mcp_servers_by_team(prisma, "missing-team")
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_mcp_servers_by_team_no_object_permission():
+    team_record = LiteLLM_TeamTable(team_id="team-1")
+
+    prisma = _make_prisma_with_team(team_record)
+
+    result = await get_mcp_servers_by_team(prisma, "team-1")
+
+    assert result == []


### PR DESCRIPTION

## Relevant issues

None. Test-only coverage fix found while reading the MCP server DB tests.

## Linear ticket

<!-- external contributor: leaving blank -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This is a unit-test-only change for an internal async DB helper (no LLM call, no
runtime behavior change), so there is no e2e/curl proof to show. The relevant test
subset and linters pass locally:

```
$ uv run --no-sync pytest tests/test_litellm/proxy/db/mcp_server/test_db.py -q -p no:cacheprovider
3 passed

$ uv run --no-sync ruff check tests/test_litellm/proxy/db/mcp_server/test_db.py
All checks passed!

$ uv run --no-sync ruff format --check tests/test_litellm/proxy/db/mcp_server/test_db.py
1 file already formatted
```

Red-before / green-after (proving the new tests actually pin behavior): temporarily
making `get_mcp_servers_by_team` return `None` on the happy path, or dropping its
`object_permission is not None` guard, makes the corresponding new test fail; the
old `assert True == True` could not detect either regression. Those mutations were
reverted, so `db.py` has an empty diff.

## Changes

`test_fetch_mcp_servers_by_team` in
`tests/test_litellm/proxy/db/mcp_server/test_db.py` had a body of `assert True == True`.
It imported `get_mcp_servers_by_team` but never called it, so it exercised zero
production code and could never fail while still counting as coverage for a real
async Prisma query
(`litellm/proxy/_experimental/mcp_server/db.py::get_mcp_servers_by_team`).

This replaces the no-op with real coverage:

- **Happy path:** mocks the team lookup to return a team whose
  `object_permission.mcp_servers` is set, asserts the function returns that list,
  and asserts `find_unique` was awaited once with
  `where={"team_id": ...}, include={"object_permission": True}` (pins the query).
- **Missing team** (`find_unique` returns `None`) -> returns `[]`.
- **Team without object permission** -> returns `[]`.

The mock mirrors the existing sibling test `test_db_credentials.py` (MagicMock
prisma client + `AsyncMock` table method), and the team / object-permission
construction mirrors `test_jwt_mcp_simple.py`. The file's pre-existing unused
`import json` is dropped so ruff passes on the changed file. No production code
changes.
