### PR TITLE
Fix SSRF bypass in guardrail http_request (#32862)

### DIFF
--- a/litellm/litellm_core_utils/url_utils.py
+++ b/litellm/litellm_core_utils/url_utils.py
@@ -428,6 +428,9 @@ async def async_safe_get(client: Any, url: str, **kwargs: Any) -> Any:
     raise SSRFError("Too many redirects")
 
 
+_ALLOWED_HTTP_METHODS = frozenset({"GET", "POST", "PUT", "DELETE", "PATCH"})
+
+
 async def async_safe_request(client: Any, method: str, url: str, **kwargs: Any) -> Any:
     """
     Multi-method version of async_safe_get with SSRF protection.
@@ -435,8 +438,8 @@ async def async_safe_request(client: Any, method: str, url: str, **kwargs: Any) 
     Validates every hop via ``validate_url`` (DNS resolution, IP blocklist,
     URL rewrite) and follows redirects manually so each target is checked.
 
-    On 301/302 the method is downgraded to GET and the body is stripped per
-    RFC 7231 §6.4.2-3.  307/308 preserve the original method and body.
+    On 301/302/303 the method is downgraded to GET and the body is stripped
+    per RFC 7231 §6.4.2-4.  307/308 preserve the original method and body.
 
     Note: only ``AsyncHTTPHandler.get()`` accepts ``follow_redirects``.
     POST/PUT/DELETE/PATCH use ``build_request`` + ``client.send`` internally,
@@ -444,6 +447,8 @@ async def async_safe_request(client: Any, method: str, url: str, **kwargs: Any) 
     to those methods.
     """
     method = method.upper()
+    if method not in _ALLOWED_HTTP_METHODS:
+        raise ValueError(f"Unsupported HTTP method: {method}")
 
     # Always strip follow_redirects from caller kwargs — we manage it ourselves
     kwargs.pop("follow_redirects", None)
@@ -455,10 +460,7 @@ async def async_safe_request(client: Any, method: str, url: str, **kwargs: Any) 
                 kwargs.pop(k, None)
             kwargs["follow_redirects"] = True
             
-        func = getattr(client, method.lower(), None)
-        if not func:
-            raise ValueError(f"Unsupported HTTP method: {method}")
-        return await func(url, **kwargs)
+        return await getattr(client, method.lower())(url, **kwargs)
 
     caller_headers = kwargs.pop("headers", {}) or {}
 
@@ -472,17 +474,13 @@ async def async_safe_request(client: Any, method: str, url: str, **kwargs: Any) 
                 method_kwargs.pop(k, None)
             method_kwargs["follow_redirects"] = False
 
-        func = getattr(client, method.lower(), None)
-        if not func:
-            raise ValueError(f"Unsupported HTTP method: {method}")
-            
-        response = await func(validated_url, headers=call_headers, **method_kwargs)
+        response = await getattr(client, method.lower())(validated_url, headers=call_headers, **method_kwargs)
 
         if not response.is_redirect:
             return response
 
-        # RFC 7231 §6.4.2-3: 301/302 redirects SHOULD downgrade to GET
-        if response.status_code in (301, 302) and method not in ("GET", "HEAD"):
+        # RFC 7231 §6.4.2-4: 301/302/303 redirects SHOULD downgrade to GET
+        if response.status_code in (301, 302, 303) and method not in ("GET", "HEAD"):
             method = "GET"
             # Strip body arguments for the downgraded GET request
             kwargs.pop("data", None)

--- a/litellm/litellm_core_utils/url_utils.py
+++ b/litellm/litellm_core_utils/url_utils.py
@@ -388,7 +388,7 @@ def safe_get(client: Any, url: str, **kwargs: Any) -> Any:
         kwargs.setdefault("follow_redirects", True)
         return client.get(url, **kwargs)
     kwargs.pop("follow_redirects", None)
-    caller_headers = kwargs.pop("headers", {})
+    caller_headers = kwargs.pop("headers", {}) or {}
     for _ in range(_MAX_REDIRECTS):
         validated_url, original_host = validate_url(url)
         response = client.get(
@@ -411,7 +411,7 @@ async def async_safe_get(client: Any, url: str, **kwargs: Any) -> Any:
         kwargs.setdefault("follow_redirects", True)
         return await client.get(url, **kwargs)
     kwargs.pop("follow_redirects", None)
-    caller_headers = kwargs.pop("headers", {})
+    caller_headers = kwargs.pop("headers", {}) or {}
     for _ in range(_MAX_REDIRECTS):
         validated_url, original_host = validate_url(url)
         response = await client.get(
@@ -426,3 +426,71 @@ async def async_safe_get(client: Any, url: str, **kwargs: Any) -> Any:
         # relative Location headers keep the original hostname.
         url = _extract_redirect_url(response, url)
     raise SSRFError("Too many redirects")
+
+
+async def async_safe_request(client: Any, method: str, url: str, **kwargs: Any) -> Any:
+    """
+    Multi-method version of async_safe_get with SSRF protection.
+
+    Validates every hop via ``validate_url`` (DNS resolution, IP blocklist,
+    URL rewrite) and follows redirects manually so each target is checked.
+
+    On 301/302 the method is downgraded to GET and the body is stripped per
+    RFC 7231 §6.4.2-3.  307/308 preserve the original method and body.
+
+    Note: only ``AsyncHTTPHandler.get()`` accepts ``follow_redirects``.
+    POST/PUT/DELETE/PATCH use ``build_request`` + ``client.send`` internally,
+    which doesn't follow redirects, so we don't pass ``follow_redirects``
+    to those methods.
+    """
+    method = method.upper()
+
+    # Always strip follow_redirects from caller kwargs — we manage it ourselves
+    kwargs.pop("follow_redirects", None)
+
+    if not getattr(litellm, "user_url_validation", True):
+        # SSRF protection disabled — delegate directly, let httpx handle redirects
+        if method == "GET":
+            for k in ("data", "json", "content", "files"):
+                kwargs.pop(k, None)
+            kwargs["follow_redirects"] = True
+            
+        func = getattr(client, method.lower(), None)
+        if not func:
+            raise ValueError(f"Unsupported HTTP method: {method}")
+        return await func(url, **kwargs)
+
+    caller_headers = kwargs.pop("headers", {}) or {}
+
+    for _ in range(_MAX_REDIRECTS):
+        validated_url, original_host = validate_url(url)
+        call_headers = {**caller_headers, "Host": original_host}
+
+        method_kwargs = dict(kwargs)
+        if method == "GET":
+            for k in ("data", "json", "content", "files"):
+                method_kwargs.pop(k, None)
+            method_kwargs["follow_redirects"] = False
+
+        func = getattr(client, method.lower(), None)
+        if not func:
+            raise ValueError(f"Unsupported HTTP method: {method}")
+            
+        response = await func(validated_url, headers=call_headers, **method_kwargs)
+
+        if not response.is_redirect:
+            return response
+
+        # RFC 7231 §6.4.2-3: 301/302 redirects SHOULD downgrade to GET
+        if response.status_code in (301, 302) and method not in ("GET", "HEAD"):
+            method = "GET"
+            # Strip body arguments for the downgraded GET request
+            kwargs.pop("data", None)
+            kwargs.pop("json", None)
+            kwargs.pop("content", None)
+            kwargs.pop("files", None)
+
+        url = _extract_redirect_url(response, url)
+
+    raise SSRFError("Too many redirects")
+

--- a/litellm/proxy/guardrails/guardrail_hooks/custom_code/primitives.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/custom_code/primitives.py
@@ -12,11 +12,10 @@ from urllib.parse import urlparse
 
 import httpx
 
-import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
 from litellm.types.llms.custom_http import httpxSpecialProvider
-from litellm.litellm_core_utils.url_utils import validate_url, SSRFError, _extract_redirect_url, _MAX_REDIRECTS
+from litellm.litellm_core_utils.url_utils import async_safe_request, SSRFError
 
 # =============================================================================
 # Result Types - Used by Starlark code to return guardrail decisions
@@ -470,8 +469,23 @@ async def http_request(
         params={"timeout": httpx.Timeout(timeout=timeout, connect=5.0)},
     )
 
+    # Prepare the arguments for async_safe_request
+    json_body, data_body = _prepare_http_body(body)
+    kwargs: Dict[str, Any] = {}
+    if json_body is not None:
+        kwargs["json"] = json_body
+    if data_body is not None:
+        kwargs["data"] = data_body
+
     try:
-        response = await _execute_http_request_safe(client, method, url, headers, body, timeout)
+        response = await async_safe_request(
+            client=client,
+            method=method,
+            url=url,
+            headers=headers,
+            timeout=timeout,
+            **kwargs
+        )
         return _http_success_response(response)
 
     except SSRFError as e:
@@ -488,69 +502,6 @@ async def http_request(
     except Exception as e:
         verbose_proxy_logger.warning(f"Custom code http_request unexpected error: {e}")
         return _http_error_response(f"Unexpected error: {str(e)}")
-
-
-async def _execute_http_request_safe(
-    client: Any,
-    method: str,
-    url: str,
-    headers: Optional[Dict[str, str]],
-    body: Optional[Any],
-    timeout: float,
-) -> httpx.Response:
-    """Execute the HTTP request with SSRF protection and safe redirect following."""
-    if not getattr(litellm, "user_url_validation", True):
-        # SSRF protection disabled, execute directly with native redirect following
-        return await _execute_http_request(client, method, url, headers, body, timeout, follow_redirects=True)
-
-    caller_headers = headers.copy() if headers else {}
-    
-    for _ in range(_MAX_REDIRECTS):
-        validated_url, original_host = validate_url(url)
-        caller_headers["Host"] = original_host
-        
-        response = await _execute_http_request(
-            client, 
-            method, 
-            validated_url, 
-            caller_headers, 
-            body, 
-            timeout, 
-            follow_redirects=False
-        )
-        
-        if not response.is_redirect:
-            return response
-            
-        url = _extract_redirect_url(response, url)
-        
-    raise SSRFError("Too many redirects")
-
-
-async def _execute_http_request(
-    client: Any,
-    method: str,
-    url: str,
-    headers: Optional[Dict[str, str]],
-    body: Optional[Any],
-    timeout: float,
-    follow_redirects: bool,
-) -> httpx.Response:
-    """Execute the HTTP request using the appropriate client method."""
-    json_body, data_body = _prepare_http_body(body)
-
-    if method == "GET":
-        return await client.get(url=url, headers=headers, follow_redirects=follow_redirects)
-    elif method == "POST":
-        return await client.post(url=url, headers=headers, json=json_body, data=data_body, timeout=timeout, follow_redirects=follow_redirects)
-    elif method == "PUT":
-        return await client.put(url=url, headers=headers, json=json_body, data=data_body, timeout=timeout, follow_redirects=follow_redirects)
-    elif method == "DELETE":
-        return await client.delete(url=url, headers=headers, json=json_body, data=data_body, timeout=timeout, follow_redirects=follow_redirects)
-    elif method == "PATCH":
-        return await client.patch(url=url, headers=headers, json=json_body, data=data_body, timeout=timeout, follow_redirects=follow_redirects)
-    else:
-        raise ValueError(f"Unsupported HTTP method: {method}")
 
 
 async def http_get(

--- a/litellm/proxy/guardrails/guardrail_hooks/custom_code/primitives.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/custom_code/primitives.py
@@ -12,9 +12,11 @@ from urllib.parse import urlparse
 
 import httpx
 
+import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
 from litellm.types.llms.custom_http import httpxSpecialProvider
+from litellm.litellm_core_utils.url_utils import validate_url, SSRFError, _extract_redirect_url, _MAX_REDIRECTS
 
 # =============================================================================
 # Result Types - Used by Starlark code to return guardrail decisions
@@ -469,9 +471,11 @@ async def http_request(
     )
 
     try:
-        response = await _execute_http_request(client, method, url, headers, body, timeout)
+        response = await _execute_http_request_safe(client, method, url, headers, body, timeout)
         return _http_success_response(response)
 
+    except SSRFError as e:
+        return _http_error_response(f"SSRF validation failed: {str(e)}")
     except httpx.TimeoutException as e:
         verbose_proxy_logger.warning(f"Custom code http_request timeout: {e}")
         return _http_error_response(f"Request timeout after {timeout}s")
@@ -486,7 +490,7 @@ async def http_request(
         return _http_error_response(f"Unexpected error: {str(e)}")
 
 
-async def _execute_http_request(
+async def _execute_http_request_safe(
     client: Any,
     method: str,
     url: str,
@@ -494,19 +498,57 @@ async def _execute_http_request(
     body: Optional[Any],
     timeout: float,
 ) -> httpx.Response:
+    """Execute the HTTP request with SSRF protection and safe redirect following."""
+    if not getattr(litellm, "user_url_validation", True):
+        # SSRF protection disabled, execute directly with native redirect following
+        return await _execute_http_request(client, method, url, headers, body, timeout, follow_redirects=True)
+
+    caller_headers = headers.copy() if headers else {}
+    
+    for _ in range(_MAX_REDIRECTS):
+        validated_url, original_host = validate_url(url)
+        caller_headers["Host"] = original_host
+        
+        response = await _execute_http_request(
+            client, 
+            method, 
+            validated_url, 
+            caller_headers, 
+            body, 
+            timeout, 
+            follow_redirects=False
+        )
+        
+        if not response.is_redirect:
+            return response
+            
+        url = _extract_redirect_url(response, url)
+        
+    raise SSRFError("Too many redirects")
+
+
+async def _execute_http_request(
+    client: Any,
+    method: str,
+    url: str,
+    headers: Optional[Dict[str, str]],
+    body: Optional[Any],
+    timeout: float,
+    follow_redirects: bool,
+) -> httpx.Response:
     """Execute the HTTP request using the appropriate client method."""
     json_body, data_body = _prepare_http_body(body)
 
     if method == "GET":
-        return await client.get(url=url, headers=headers)
+        return await client.get(url=url, headers=headers, follow_redirects=follow_redirects)
     elif method == "POST":
-        return await client.post(url=url, headers=headers, json=json_body, data=data_body, timeout=timeout)
+        return await client.post(url=url, headers=headers, json=json_body, data=data_body, timeout=timeout, follow_redirects=follow_redirects)
     elif method == "PUT":
-        return await client.put(url=url, headers=headers, json=json_body, data=data_body, timeout=timeout)
+        return await client.put(url=url, headers=headers, json=json_body, data=data_body, timeout=timeout, follow_redirects=follow_redirects)
     elif method == "DELETE":
-        return await client.delete(url=url, headers=headers, json=json_body, data=data_body, timeout=timeout)
+        return await client.delete(url=url, headers=headers, json=json_body, data=data_body, timeout=timeout, follow_redirects=follow_redirects)
     elif method == "PATCH":
-        return await client.patch(url=url, headers=headers, json=json_body, data=data_body, timeout=timeout)
+        return await client.patch(url=url, headers=headers, json=json_body, data=data_body, timeout=timeout, follow_redirects=follow_redirects)
     else:
         raise ValueError(f"Unsupported HTTP method: {method}")
 


### PR DESCRIPTION
## Relevant issues

Fixes #32862

## Linear ticket



## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

```python
import asyncio
from litellm.proxy.guardrails.guardrail_hooks.custom_code.primitives import http_request

async def test_ssrf():
    # Attempt to hit blocked internal IP
    res = await http_request("http://169.254.169.254/latest/meta-data/iam/security-credentials/")
    print(res)
    # Output: {'status_code': 0, 'body': None, 'headers': {}, 'success': False, 'error': 'SSRF validation failed: URL targets a blocked address (169.254.169.254). If this is a legitimate internal service, add the host to `user_url_allowed_hosts` in general_settings.'}

asyncio.run(test_ssrf())
