### PR TITLE
fix(bedrock_mantle): use consistent chunk ID across streaming SSE events

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -1074,6 +1074,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
 class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
     def __init__(self, streaming_response, sync_stream: bool, json_mode: Optional[bool] = False):
         super().__init__(streaming_response, sync_stream, json_mode)
+        self.response_id: Optional[str] = None
 
     def _handle_string_chunk(
         self, str_line: Union[str, "BaseModel"]
@@ -1381,4 +1382,9 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
             ModelResponseStream: OpenAI-formatted streaming chunk
         """
         verbose_logger.debug(f"Chat provider: transform_streaming_response called with chunk: {chunk}")
-        return OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(chunk)
+        model_response = OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(chunk)
+        if self.response_id is None:
+            self.response_id = model_response.id
+        else:
+            model_response.id = self.response_id
+        return model_response

--- a/litellm/llms/bedrock_mantle/chat/transformation.py
+++ b/litellm/llms/bedrock_mantle/chat/transformation.py
@@ -19,12 +19,46 @@ from litellm.llms.bedrock_mantle.common_utils import (
     BEDROCK_MANTLE_DEFAULT_REGION,
     BedrockMantleAuthMixin,
 )
+from litellm.llms.openai.chat.gpt_transformation import (
+    OpenAIChatCompletionStreamingHandler,
+)
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.router import GenericLiteLLMParams
+from litellm.types.utils import ModelResponseStream
 
 from ..common_utils import mantle_base_segment
 from ...openai_like.chat.transformation import OpenAILikeChatConfig
+
+
+class BedrockMantleStreamingHandler(OpenAIChatCompletionStreamingHandler):
+    """Ensures all chunks in a single streaming response share the same ID.
+
+    Bedrock Mantle's OpenAI-compatible endpoint returns a unique ID per SSE
+    chunk instead of reusing one ID for the entire stream (violating the
+    OpenAI spec). The openai-go SDK's ChatCompletionAccumulator checks
+    cc.ID != chunk.ID and silently drops every chunk after the first when
+    IDs don't match. See https://github.com/BerriAI/litellm/issues/32854
+    """
+
+    def __init__(
+        self,
+        streaming_response: Any,
+        sync_stream: bool,
+        json_mode: Optional[bool] = False,
+    ):
+        super().__init__(
+            streaming_response=streaming_response,
+            sync_stream=sync_stream,
+            json_mode=json_mode,
+        )
+        self._consistent_id: Optional[str] = None
+
+    def chunk_parser(self, chunk: dict) -> ModelResponseStream:
+        if self._consistent_id is None:
+            self._consistent_id = chunk.get("id")
+        chunk["id"] = self._consistent_id
+        return super().chunk_parser(chunk)
 
 
 class BedrockMantleChatConfig(BedrockMantleAuthMixin, OpenAILikeChatConfig):
@@ -110,11 +144,7 @@ class BedrockMantleChatConfig(BedrockMantleAuthMixin, OpenAILikeChatConfig):
         sync_stream: bool,
         json_mode: Optional[bool] = False,
     ) -> Any:
-        from litellm.llms.openai.chat.gpt_transformation import (
-            OpenAIChatCompletionStreamingHandler,
-        )
-
-        return OpenAIChatCompletionStreamingHandler(
+        return BedrockMantleStreamingHandler(
             streaming_response=streaming_response,
             sync_stream=sync_stream,
             json_mode=json_mode,

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -336,6 +336,35 @@ def test_chunk_parser_function_call_added_produces_tool_use():
     assert choice.finish_reason is None
 
 
+def test_chunk_parser_reuses_id_across_response_events():
+    """Regression: all chunks in a stream must share the same ID.
+
+    Without this, openai-go's ChatCompletionAccumulator silently drops
+    chunks when IDs don't match. See https://github.com/BerriAI/litellm/issues/32854
+    """
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        OpenAiResponsesToChatCompletionStreamIterator,
+    )
+
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(
+        streaming_response=None, sync_stream=True
+    )
+
+    events = [
+        {"type": "response.created"},
+        {"type": "response.output_text.delta", "delta": "hello"},
+        {
+            "type": "response.function_call_arguments.delta",
+            "output_index": 0,
+            "delta": '{"city":"Paris"}',
+        },
+    ]
+
+    ids = {iterator.chunk_parser(event).id for event in events}
+
+    assert len(ids) == 1, f"all chunks must share one ID, got {ids}"
+
+
 def test_transform_response_with_reasoning_and_output():
     """Test transform_response handles ResponsesAPIResponse with reasoning items and output messages."""
     from unittest.mock import Mock

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -685,3 +685,73 @@ def test_gemma_4_models_register_under_bedrock_mantle(local_cost_map, model_id):
     resolved_model, provider, _, _ = litellm.get_llm_provider(full_model_name)
     assert provider == "bedrock_mantle"
     assert resolved_model == model_id
+
+
+class TestBedrockMantleStreamingChunkIdConsistency:
+    """Regression test for https://github.com/BerriAI/litellm/issues/32854
+
+    Bedrock Mantle returns a unique chunk ID per SSE event. The OpenAI spec
+    requires all chunks in one streaming response to share the same ID.
+    Clients like openai-go's ChatCompletionAccumulator silently drop chunks
+    when IDs don't match, breaking tool call accumulation and content
+    streaming.
+    """
+
+    def test_all_chunks_share_same_id(self):
+        from litellm.llms.bedrock_mantle.chat.transformation import (
+            BedrockMantleStreamingHandler,
+        )
+
+        chunks = [
+            {"id": "chatcmpl-aaa111", "object": "chat.completion.chunk", "model": "gpt-oss-120b",
+             "choices": [{"index": 0, "delta": {"role": "assistant", "content": "Hello"}, "finish_reason": None}]},
+            {"id": "chatcmpl-bbb222", "object": "chat.completion.chunk", "model": "gpt-oss-120b",
+             "choices": [{"index": 0, "delta": {"content": " world"}, "finish_reason": None}]},
+            {"id": "chatcmpl-ccc333", "object": "chat.completion.chunk", "model": "gpt-oss-120b",
+             "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}]},
+        ]
+
+        handler = BedrockMantleStreamingHandler(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        parsed = [handler.chunk_parser(c) for c in chunks]
+
+        ids = [r.id for r in parsed]
+        assert all(chunk_id == "chatcmpl-aaa111" for chunk_id in ids), (
+            f"all chunks must share the first chunk's ID, got {ids}"
+        )
+
+    def test_single_chunk_preserves_id(self):
+        from litellm.llms.bedrock_mantle.chat.transformation import (
+            BedrockMantleStreamingHandler,
+        )
+
+        chunk = {
+            "id": "chatcmpl-only",
+            "object": "chat.completion.chunk",
+            "model": "gpt-oss-120b",
+            "choices": [{"index": 0, "delta": {"content": "hi"}, "finish_reason": "stop"}],
+        }
+
+        handler = BedrockMantleStreamingHandler(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        result = handler.chunk_parser(chunk)
+        assert result.id == "chatcmpl-only"
+
+    def test_config_returns_mantle_streaming_handler(self):
+        from litellm.llms.bedrock_mantle.chat.transformation import (
+            BedrockMantleChatConfig,
+            BedrockMantleStreamingHandler,
+        )
+
+        cfg = BedrockMantleChatConfig()
+        handler = cfg.get_model_response_iterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+        assert isinstance(handler, BedrockMantleStreamingHandler)


### PR DESCRIPTION
## Relevant issues

Fixes #32854
Related: #16584, #16596

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

To verify the fix, run a streaming request through a litellm proxy configured with a `bedrock_mantle/` model and observe the SSE chunks:

```bash
# Chat completions path (direct bedrock_mantle)
curl -sN http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"bedrock-mantle-model","messages":[{"role":"user","content":"Say hello"}],"stream":true}' \
  | grep -o '"id":"[^"]*"' | sort -u

# Responses API bridge path (mode:"responses" models like openai.gpt-5.5 called via chat completions)
curl -sN http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"bedrock_mantle/openai.gpt-5.5","messages":[{"role":"user","content":"Say hello"}],"stream":true}' \
  | grep -o '"id":"[^"]*"' | sort -u
```

Before the fix, every chunk has a different ID on both paths. After the fix, all chunks share the first chunk's ID.

## Type

🐛 Bug Fix

## Changes

Two separate code paths produce inconsistent chunk IDs for `bedrock_mantle/` streaming, both breaking the openai-go SDK's `ChatCompletionAccumulator` which checks `cc.ID != chunk.ID` and silently drops every chunk after the first when IDs don't match.

**Path 1 — Direct chat completions (`BedrockMantleChatConfig`):**

Regular `bedrock_mantle/` models go through `llm_http_handler` → `BedrockMantleChatConfig.get_model_response_iterator()`. The upstream Bedrock Mantle API returns a unique ID per SSE chunk. Fix: added `BedrockMantleStreamingHandler` extending `OpenAIChatCompletionStreamingHandler` that captures the first chunk's raw `id` field and stamps it on all subsequent chunks before calling `super().chunk_parser()`.

**Path 2 — Responses API bridge (`OpenAiResponsesToChatCompletionStreamIterator`):**

Models with `mode: "responses"` (e.g. `bedrock_mantle/openai.gpt-5.5`) called via `/v1/chat/completions` route through the Responses API bridge in `completion_extras`. The bridge's `translate_responses_chunk_to_openai_stream()` creates a new `ModelResponseStream` per chunk, each getting a fresh UUID from the default constructor. Fix: capture the first converted chunk's ID in `self.response_id` and reuse it for all subsequent chunks.

**Path already OK — `bedrock/chat/mantle/` (Anthropic Messages API):**

This path uses its own `ModelResponseIterator` which generates a consistent `response_id` at init time. No fix needed.

PR #16596 (Nov 2025) fixed the same root cause for `bedrock/` (Converse API) but neither `bedrock_mantle/` path was patched.

4 regression tests total: 3 for the streaming handler (multi-chunk, single-chunk, config wiring) and 1 for the Responses→Chat bridge (ID consistency across event types).
