### PR TITLE
fix(responses-bridge): preserve streaming chunk ID

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -1074,6 +1074,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
 class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
     def __init__(self, streaming_response, sync_stream: bool, json_mode: Optional[bool] = False):
         super().__init__(streaming_response, sync_stream, json_mode)
+        self.response_id: Optional[str] = None
 
     def _handle_string_chunk(
         self, str_line: Union[str, "BaseModel"]
@@ -1381,4 +1382,9 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
             ModelResponseStream: OpenAI-formatted streaming chunk
         """
         verbose_logger.debug(f"Chat provider: transform_streaming_response called with chunk: {chunk}")
-        return OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(chunk)
+        model_response = OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(chunk)
+        if self.response_id is None:
+            self.response_id = model_response.id
+        else:
+            model_response.id = self.response_id
+        return model_response

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -336,6 +336,30 @@ def test_chunk_parser_function_call_added_produces_tool_use():
     assert choice.finish_reason is None
 
 
+def test_chunk_parser_reuses_id_across_response_events():
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        OpenAiResponsesToChatCompletionStreamIterator,
+    )
+
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(
+        streaming_response=None, sync_stream=True
+    )
+
+    events = [
+        {"type": "response.created"},
+        {"type": "response.output_text.delta", "delta": "hello"},
+        {
+            "type": "response.function_call_arguments.delta",
+            "output_index": 0,
+            "delta": '{"city":"Paris"}',
+        },
+    ]
+
+    ids = {iterator.chunk_parser(event).id for event in events}
+
+    assert len(ids) == 1
+
+
 def test_transform_response_with_reasoning_and_output():
     """Test transform_response handles ResponsesAPIResponse with reasoning items and output messages."""
     from unittest.mock import Mock


### PR DESCRIPTION
## Relevant issues

Fixes #32854

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

I do not have access to the affected Bedrock Mantle endpoint, so this draft does not include a live reproduction against the original provider

The focused regression test exercises the Responses-to-Chat streaming conversion used by the affected model

Before the fix, three events processed by the same iterator received three different IDs:

```text
AssertionError: assert 3 == 1

chatcmpl-12ad23ae-f281-4db0-8e64-561e43cbc245
chatcmpl-5465ea76-f76a-409a-89bb-f7f55dbd7a96
chatcmpl-9e76ca60-cb1b-49a0-829a-bf8a9e970c74
```

## Type

Bug Fix

## Changes

`bedrock_mantle/openai.gpt-5.5` is registered as a Responses API model. When it is called through Chat Completions, `OpenAiResponsesToChatCompletionStreamIterator` converts the Responses events into `ModelResponseStream` chunks

Each converted chunk was previously constructed independently without retaining the stream ID. When no ID was supplied during conversion, the default constructor generated a new ID for every chunk

This change retains the ID assigned to the first converted chunk and reuses it for the remainder of the stream. If no upstream ID is available, the first generated fallback ID is retained

A focused regression test covers response creation, text delta, and function-call argument delta events and verifies that all converted chunks share one ID
