### PR TITLE
test(models): assert capability fields on regional Azure gpt-5.6 entries

### DIFF
--- a/tests/test_litellm/test_gpt_5_6_model_metadata.py
+++ b/tests/test_litellm/test_gpt_5_6_model_metadata.py
@@ -122,6 +122,8 @@ def test_azure_gpt_5_6_regional_model_info(model):
     assert info is not None, f"{model} not found in model_prices_and_context_window.json"
 
     assert info["litellm_provider"] == "azure"
+    assert info["mode"] == "chat"
+
     input_cost, output_cost, cache_read_cost, _ = STANDARD_PRICING[_tier_key(model)]
 
     assert info["input_cost_per_token"] == pytest.approx(input_cost * 1.1)
@@ -131,6 +133,13 @@ def test_azure_gpt_5_6_regional_model_info(model):
     assert info["output_cost_per_token_above_272k_tokens"] == pytest.approx(output_cost * 1.65)
     assert info["input_cost_per_token_priority"] == pytest.approx(input_cost * 2.75)
     assert info["output_cost_per_token_priority"] == pytest.approx(output_cost * 2.75)
+
+    assert info["max_input_tokens"] == 1050000
+    assert info["max_output_tokens"] == 128000
+    assert info["supports_reasoning"] is True
+
+    _, provider, _, _ = get_llm_provider(model=model)
+    assert provider == "azure"
 
 
 def test_gpt_5_6_backup_matches_main():


### PR DESCRIPTION
## Relevant issues

Follow-up to #32678. Greptile flagged that the regional Azure gpt-5.6 metadata test omitted the capability-field assertions the global test makes, and the concern was verified real: mutating a regional entry's capability fields passed every test, since the cost-calc parametrize path only asserts pricing

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This change only adds test assertions, so there is no runtime surface a live proxy call could observe; the honest e2e-equivalent for a test hardening is a mutation run against the real cost map at the exact before and after commits

Before, at `4baf326a39` (this PR's parent commit), the mutation survives:

```
python3 - <<'PYEOF'
import json
for path in ('model_prices_and_context_window.json', 'litellm/model_prices_and_context_window_backup.json'):
    m = json.load(open(path))
    m['azure/eu/gpt-5.6-sol']['supports_reasoning'] = False
    m['azure/eu/gpt-5.6-sol']['max_input_tokens'] = 272000
    json.dump(m, open(path, 'w'), indent=4)
PYEOF
pytest tests/test_litellm/test_gpt_5_6_model_metadata.py -q
```

```
17 passed in 0.23s
```

After, at `2bc11b006b`, the same mutation is killed:

```
FAILED tests/test_litellm/test_gpt_5_6_model_metadata.py::test_azure_gpt_5_6_regional_model_info[azure/eu/gpt-5.6-sol]
1 failed, 16 passed in 0.19s
```

On a clean map at `2bc11b006b`, all 17 tests pass

## Type

✅ Test

## Changes

test_azure_gpt_5_6_regional_model_info now asserts the same capability fields as its global counterpart: mode, max_input_tokens, max_output_tokens, supports_reasoning, and azure routing via get_llm_provider. The above-272k priority pricing assertions stay global-only because the regional entries do not carry those fields, matching the established gpt-5.5 regional pattern