### PR TITLE
fix(xecguard): use StandardLoggingGuardrailInformation in logging hook

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/xecguard/xecguard.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/xecguard/xecguard.py
@@ -49,7 +49,11 @@ from litellm.llms.custom_httpx.http_handler import (
     httpxSpecialProvider,
 )
 from litellm.types.guardrails import GuardrailEventHooks
-from litellm.types.utils import GenericGuardrailAPIInputs, GuardrailStatus
+from litellm.types.utils import (
+    GenericGuardrailAPIInputs,
+    GuardrailStatus,
+    StandardLoggingGuardrailInformation,
+)
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import (
@@ -243,16 +247,21 @@ class XecGuardGuardrail(CustomGuardrail):
                 "guardrail_intervened" if scan_result.get("decision") == "UNSAFE" else "success"
             )
             end_time = datetime.now()
-            kwargs["standard_logging_object"]["guardrail_information"] = {
-                "duration": (end_time - start_time).total_seconds(),
-                "end_time": end_time.timestamp(),
-                "guardrail_mode": "logging_only",
-                "guardrail_name": "xecguard",
-                "guardrail_response": scan_result,
-                "guardrail_status": guardrail_status,
-                "masked_entity_count": None,
-                "start_time": start_time.timestamp(),
-            }
+            slg = StandardLoggingGuardrailInformation(
+                guardrail_name=self.guardrail_name or "xecguard",
+                guardrail_mode="logging_only",
+                guardrail_response=scan_result,
+                guardrail_status=guardrail_status,
+                start_time=start_time.timestamp(),
+                end_time=end_time.timestamp(),
+                duration=(end_time - start_time).total_seconds(),
+                masked_entity_count=None,
+            )
+            existing = kwargs["standard_logging_object"].get("guardrail_information")
+            if isinstance(existing, list):
+                existing.append(slg)
+            else:
+                kwargs["standard_logging_object"]["guardrail_information"] = [slg]
 
         except Exception as exc:
             verbose_proxy_logger.debug(

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_xecguard.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_xecguard.py
@@ -1644,7 +1644,10 @@ class TestXecGuardLoggingHook:
             )
             assert out_kwargs is kwargs
             assert out_result is result
-        info = kwargs["standard_logging_object"]["guardrail_information"]
+        info_list = kwargs["standard_logging_object"]["guardrail_information"]
+        assert isinstance(info_list, list), "guardrail_information must be a list"
+        assert len(info_list) == 1
+        info = info_list[0]
         assert info["guardrail_mode"] == "logging_only"
         assert info["guardrail_name"] == "xecguard"
         assert info["guardrail_status"] == "success"
@@ -1680,7 +1683,9 @@ class TestXecGuardLoggingHook:
                 result=_build_model_response("x"),
                 call_type="acompletion",
             )
-        info = kwargs["standard_logging_object"]["guardrail_information"]
+        info_list = kwargs["standard_logging_object"]["guardrail_information"]
+        assert isinstance(info_list, list), "guardrail_information must be a list"
+        info = info_list[0]
         assert info["guardrail_status"] == "guardrail_intervened"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes LIT-4335.

XecGuard's `async_logging_hook` wrote a bare dict to `standard_logging_object['guardrail_information']` instead of a properly typed `StandardLoggingGuardrailInformation` wrapped in a list. This broke downstream loggers that expect `List[StandardLoggingGuardrailInformation]`.

**Changes:**
- Construct a proper `StandardLoggingGuardrailInformation` TypedDict
- Wrap in a list / append to existing list (consistent with the base class method)
- Update test assertions to validate list-of-dict shape