### PR TITLE
fix(guardrails): walk reasoning.summary_text and custom_tool_call_output in _content_utils

### DIFF
--- a/litellm/proxy/guardrails/_content_utils.py
+++ b/litellm/proxy/guardrails/_content_utils.py
@@ -32,12 +32,23 @@ def is_text_content_call_type(call_type: str) -> bool:
     return call_type in TEXT_CONTENT_CALL_TYPES
 
 
-TEXT_PART_TYPES: FrozenSet[str] = frozenset({"text", "input_text", "output_text"})
+TEXT_PART_TYPES: FrozenSet[str] = frozenset({"text", "input_text", "output_text", "summary_text"})
+
+# Responses-API item types whose ``output`` field carries user/tool text
+# that guardrails should inspect.  ``function_call_output`` is the
+# built-in shape; ``custom_tool_call_output`` is the custom-tool
+# counterpart (see ``ChatCompletionCustomToolCallOutput``).
+_OUTPUT_ITEM_TYPES: FrozenSet[str] = frozenset({"function_call_output", "custom_tool_call_output"})
 
 
 def _iter_text_parts_in_content(content: Any) -> Iterator[str]:
     """Yield text fragments from a ``message.content`` value (string or
-    multimodal list). Non-text parts (images, audio, …) are skipped."""
+    multimodal list). Non-text parts (images, audio, …) are skipped.
+
+    Also descends into ``reasoning`` items whose ``summary`` list may
+    contain ``summary_text`` parts carrying chain-of-thought text that
+    guardrails need to inspect/redact.
+    """
     if isinstance(content, str):
         if content:
             yield content
@@ -55,6 +66,12 @@ def _iter_text_parts_in_content(content: Any) -> Iterator[str]:
                 text = part.get("text")
                 if isinstance(text, str) and text:
                     yield text
+            elif part.get("type") == "reasoning":
+                # Reasoning items carry a ``summary`` list of
+                # ``{"type": "summary_text", "text": "..."}`` parts.
+                summary = part.get("summary")
+                if isinstance(summary, list):
+                    yield from _iter_text_parts_in_content(summary)
 
 
 def _coerce_input_to_messages(input_value: Any) -> List[Dict[str, Any]]:
@@ -72,8 +89,15 @@ def _coerce_input_to_messages(input_value: Any) -> List[Dict[str, Any]]:
                 messages.append({"role": item.get("role") or "user", "content": [item]})
             elif "content" in item:
                 messages.append({"role": item.get("role") or "user", "content": item["content"]})
-            elif item.get("type") == "function_call_output" and "output" in item:
+            elif item.get("type") in _OUTPUT_ITEM_TYPES and "output" in item:
                 messages.append({"role": item.get("role") or "tool", "content": item["output"]})
+            elif item.get("type") == "reasoning":
+                # Reasoning items carry chain-of-thought text in their
+                # ``summary`` list.  Synthesise a message so guardrails
+                # can inspect/redact that text.
+                summary = item.get("summary")
+                if isinstance(summary, list):
+                    messages.append({"role": "assistant", "content": summary})
     return messages
 
 
@@ -157,8 +181,12 @@ def walk_user_text(data: Dict[str, Any], visit: Callable[[str], str]) -> int:
                         input_value[idx] = {**item, "text": visit(item["text"])}
                 elif "content" in item:
                     item["content"] = _rewrite_content(item["content"])
-                elif item.get("type") == "function_call_output" and "output" in item:
+                elif item.get("type") in _OUTPUT_ITEM_TYPES and "output" in item:
                     item["output"] = _rewrite_content(item["output"])
+                elif item.get("type") == "reasoning":
+                    summary = item.get("summary")
+                    if isinstance(summary, list):
+                        item["summary"] = _rewrite_content(summary)
         return visited
 
     return visited

--- a/tests/test_litellm/proxy/guardrails/test_content_utils.py
+++ b/tests/test_litellm/proxy/guardrails/test_content_utils.py
@@ -524,3 +524,87 @@ def test_apply_redacted_messages_back_skips_input_when_not_string():
     data = {"input": [{"type": "text", "text": "leak"}]}
     apply_redacted_messages_back(data, [{"role": "user", "content": "[REDACTED]"}])
     assert data["input"] == [{"type": "text", "text": "leak"}]
+
+
+# -------------------------------------------------------------------
+# LIT-4303: reasoning.summary_text walking
+# -------------------------------------------------------------------
+
+def test_iter_message_text_walks_reasoning_summary_text():
+    """Reasoning items with summary_text parts should yield their text."""
+    data = {
+        "input": [
+            {"type": "reasoning", "summary": [
+                {"type": "summary_text", "text": "secret-in-cot"},
+            ]},
+        ]
+    }
+    from litellm.proxy.guardrails._content_utils import iter_message_text
+    texts = list(iter_message_text(data))
+    assert "secret-in-cot" in texts
+
+
+def test_walk_user_text_redacts_reasoning_summary_text():
+    """walk_user_text should rewrite text inside reasoning.summary."""
+    data = {
+        "input": [
+            {"type": "reasoning", "summary": [
+                {"type": "summary_text", "text": "SSN-123"},
+            ]},
+        ]
+    }
+    count = walk_user_text(data, lambda t: t.replace("SSN-123", "[REDACTED]"))
+    assert count >= 1
+    assert data["input"][0]["summary"][0]["text"] == "[REDACTED]"
+
+
+def test_build_inspection_messages_reasoning_summary():
+    """build_inspection_messages should include reasoning summary text."""
+    data = {
+        "input": [
+            {"type": "reasoning", "summary": [
+                {"type": "summary_text", "text": "chain-of-thought leak"},
+            ]},
+        ]
+    }
+    msgs = build_inspection_messages(data)
+    assert any("chain-of-thought leak" in m["content"] for m in msgs)
+
+
+# -------------------------------------------------------------------
+# LIT-4302: custom_tool_call_output walking
+# -------------------------------------------------------------------
+
+def test_iter_message_text_walks_custom_tool_call_output():
+    """custom_tool_call_output items should yield their output text."""
+    data = {
+        "input": [
+            {"type": "custom_tool_call_output", "output": "tool-secret"},
+        ]
+    }
+    from litellm.proxy.guardrails._content_utils import iter_message_text
+    texts = list(iter_message_text(data))
+    assert "tool-secret" in texts
+
+
+def test_walk_user_text_redacts_custom_tool_call_output():
+    """walk_user_text should rewrite text inside custom_tool_call_output."""
+    data = {
+        "input": [
+            {"type": "custom_tool_call_output", "output": "PII-data"},
+        ]
+    }
+    count = walk_user_text(data, lambda t: t.replace("PII-data", "[MASKED]"))
+    assert count >= 1
+    assert data["input"][0]["output"] == "[MASKED]"
+
+
+def test_build_inspection_messages_custom_tool_call_output():
+    """build_inspection_messages should include custom_tool_call_output text."""
+    data = {
+        "input": [
+            {"type": "custom_tool_call_output", "output": "custom-tool-leak"},
+        ]
+    }
+    msgs = build_inspection_messages(data)
+    assert any("custom-tool-leak" in m["content"] for m in msgs)


### PR DESCRIPTION
Closes LIT-4303, LIT-4302.

**LIT-4303:** Agents replaying Responses-API output emit `reasoning` items with `summary_text` parts. Guardrails silently skipped these, leaving chain-of-thought PII/secrets unredacted.

**LIT-4302:** `custom_tool_call_output` items (custom-tool counterpart of `function_call_output`) were also silently bypassed.

**Changes:**
- Add `summary_text` to `TEXT_PART_TYPES`
- `_iter_text_parts_in_content` descends into `reasoning.summary`
- `_coerce_input_to_messages` synthesizes messages for both new types
- `walk_user_text` rewrites text inside both new types
- New `_OUTPUT_ITEM_TYPES` frozenset for `function_call_output` + `custom_tool_call_output`

**Tests:** 6 regression tests covering iter, walk, and build_inspection for both content types.