### PR TITLE
fix(bedrock): flag mapped Claude 4.8+ entries with supports_mid_conversation_system

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -1359,6 +1359,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1393,6 +1394,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1427,6 +1429,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1461,6 +1464,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1661,6 +1665,7 @@
     "jp.anthropic.claude-opus-4-8": {
         "bedrock_converse_supports_strict_tools": false,
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1743,6 +1748,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1777,6 +1783,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1811,6 +1818,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1845,6 +1853,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1879,6 +1888,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1913,6 +1923,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -1359,6 +1359,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1393,6 +1394,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1427,6 +1429,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1461,6 +1464,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1661,6 +1665,7 @@
     "jp.anthropic.claude-opus-4-8": {
         "bedrock_converse_supports_strict_tools": false,
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1743,6 +1748,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1777,6 +1783,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1811,6 +1818,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1845,6 +1853,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1879,6 +1888,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,
@@ -1913,6 +1923,7 @@
             "search_context_size_medium": 0.01
         },
         "supports_adaptive_thinking": true,
+        "supports_mid_conversation_system": true,
         "supports_assistant_prefill": false,
         "supports_computer_use": true,
         "supports_function_calling": true,

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -1974,13 +1974,22 @@ def test_bedrock_invoke_transform_merges_list_content_system_role_into_system():
     ]
 
 
-def test_bedrock_invoke_transform_keeps_mid_conversation_system_role_in_place(local_model_cost_map):
+@pytest.mark.parametrize(
+    "model",
+    [
+        "anthropic.claude-opus-4-8",
+        "jp.anthropic.claude-opus-4-8",
+        "us.anthropic.claude-sonnet-5",
+        "us.anthropic.claude-fable-5",
+    ],
+)
+def test_bedrock_invoke_transform_keeps_mid_conversation_system_role_in_place(local_model_cost_map, model):
     """Regression test for the Bedrock prompt-cache collapse: hoisting a
     mid-conversation ``role: "system"`` message (e.g. Claude Code's
     ``mid-conversation-system-2026-04-07`` reminders) into the top-level
     ``system`` field mutates the cache prefix and invalidates the cached message
-    history, so on models flagged ``supports_mid_conversation_system`` (the Opus
-    4.8 family, which Invoke accepts the role on) such entries must be forwarded
+    history, so on models flagged ``supports_mid_conversation_system`` (Claude
+    4.8+, which Invoke accepts the role on) such entries must be forwarded
     in place. Billing-header blocks must still be stripped from the top-level
     ``system`` field even when nothing is hoisted."""
     from litellm.types.router import GenericLiteLLMParams
@@ -1994,7 +2003,7 @@ def test_bedrock_invoke_transform_keeps_mid_conversation_system_role_in_place(lo
     ]
 
     result = cfg.transform_anthropic_messages_request(
-        model="anthropic.claude-opus-4-8",
+        model=model,
         messages=copy.deepcopy(messages),
         anthropic_messages_optional_request_params={
             "max_tokens": 256,
@@ -2144,6 +2153,36 @@ def test_bedrock_invoke_transform_keeps_system_in_place_for_unmapped_future_clau
 
     assert result["messages"] == messages
     assert "system" not in result
+
+
+def test_bedrock_claude_4_8_plus_cost_map_entries_carry_mid_conversation_system_flag():
+    """Exact cost-map hits resolve before fallback-generalization rules, so a
+    mapped Bedrock Claude 4.8+ entry without ``supports_mid_conversation_system``
+    silently loses the cache-preserving in-place handling that the
+    ``bedrock-anthropic-claude-mid-conversation-system`` rule grants unmapped
+    ids. Every mapped entry the rule's own pattern matches must carry the flag
+    explicitly."""
+    import re
+
+    import litellm
+
+    cost_map_path = os.path.join(os.path.dirname(litellm.__file__), "model_prices_and_context_window_backup.json")
+    with open(cost_map_path) as f:
+        cost_map = json.load(f)
+    rules = cost_map["fallback_generalizations"]["rules"]
+    pattern = re.compile(
+        next(r["pattern"] for r in rules if r["name"] == "bedrock-anthropic-claude-mid-conversation-system"),
+        re.IGNORECASE,
+    )
+    missing = [
+        key
+        for key, info in cost_map.items()
+        if isinstance(info, dict)
+        and str(info.get("litellm_provider", "")).startswith("bedrock")
+        and pattern.search(key)
+        and info.get("supports_mid_conversation_system") is not True
+    ]
+    assert missing == []
 
 
 def test_as_system_content_blocks_handles_each_shape():


### PR DESCRIPTION
## Relevant issues

Follow-up to #32831

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live two-turn conversation against Bedrock through a local proxy, with a large cached system prompt and a mid-conversation `role: "system"` reminder in turn two. Proxy config and calls:

```yaml
model_list:
  - model_name: sonnet5-bedrock
    litellm_params:
      model: bedrock/invoke/us.anthropic.claude-sonnet-5
      aws_region_name: us-east-1
```

```bash
python litellm/proxy/proxy_cli.py --config qa_config.yaml --port 4000
# call1.json: big system prompt, one user turn with a cache_control breakpoint
# call2.json: same system prompt, then user, system reminder, assistant, user (breakpoint on the last turn)
curl -s http://localhost:4000/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d @call1.json
curl -s http://localhost:4000/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d @call2.json
```

Before (735a5bfc5b): the reminder is hoisted into the top-level `system` field, the prefix changes, and the entire cache is re-written

```
call 1: {"input_tokens": 2, "cache_creation_input_tokens": 8016, "cache_read_input_tokens": 0, "output_tokens": 4}
call 2: {"input_tokens": 2, "cache_creation_input_tokens": 8054, "cache_read_input_tokens": 0, "output_tokens": 3}
```

After (cfe9193334): the reminder stays in place in `messages`, the cached prefix survives, and turn two reads the full cache

```
call 1: {"input_tokens": 2, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 8016, "output_tokens": 4}
call 2: {"input_tokens": 2, "cache_creation_input_tokens": 41, "cache_read_input_tokens": 8016, "output_tokens": 3}
```

One live observation worth noting for reviewers: Bedrock Invoke enforces a position rule for in-place system messages on Sonnet 5 ("role 'system' must follow a 'user' message or an 'assistant' message ending in a server tool result"), which the hoist-all behavior used to mask. Claude Code's mid-conversation reminders follow user turns, so they satisfy the rule

## Type

🐛 Bug Fix

## Changes

#32831 gates in-place handling of mid-conversation `role: "system"` messages on the `supports_mid_conversation_system` cost-map flag, and added the flag to five Opus 4.8 Bedrock entries plus a fallback-generalization rule for unmapped Claude 4.8+ ids. Exact cost-map hits resolve before fallback rules, so the mapped Sonnet 5 and Fable 5 entries (and `jp.anthropic.claude-opus-4-8`, added after #32831) never reached the rule and still hoisted every system message, invalidating the prompt cache for the whole message history on every reminder

This adds `supports_mid_conversation_system: true` to the eleven mapped Bedrock entries the rule's own pattern matches but that were missing the flag: all six `anthropic.claude-sonnet-5` variants, all four `anthropic.claude-fable-5` variants, and `jp.anthropic.claude-opus-4-8`, in both cost map files

Tests: the in-place regression test is parametrized over the newly flagged ids, and a new invariant test asserts that every mapped Bedrock entry matching the `bedrock-anthropic-claude-mid-conversation-system` rule pattern carries the flag explicitly, so future 4.8+ model additions cannot silently reintroduce the hoist-all behavior. Without the cost-map changes the parametrized cases and the invariant test fail; with them the file's 86 tests pass
