### PR TITLE
feat(ui): root the gateway breadcrumb in the AI Gateway selector

### DIFF
--- a/ui/litellm-dashboard/src/components/DashboardHeader.test.tsx
+++ b/ui/litellm-dashboard/src/components/DashboardHeader.test.tsx
@@ -47,11 +47,11 @@ describe("DashboardHeader breadcrumb", () => {
     await waitFor(() => expect(screen.getByText("Chat")).toBeInTheDocument());
   });
 
-  it("falls back to the static section crumb when the selector has nothing to switch to", () => {
+  it("keeps the AI Gateway selector at the root even when there is nothing to switch to (discovery)", () => {
     render(<DashboardHeader page="logs" />);
 
-    expect(screen.getByText("Observability")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /AI Gateway/i })).toBeInTheDocument();
     expect(screen.getByText("Logs")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /AI Gateway/i })).not.toBeInTheDocument();
+    expect(screen.queryByText("Observability")).not.toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/components/DashboardHeader.test.tsx
+++ b/ui/litellm-dashboard/src/components/DashboardHeader.test.tsx
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { DashboardHeader } from "./DashboardHeader";
+
+const { mockUsePluginMode, mockUseUISettings, state } = vi.hoisted(() => {
+  const state = {
+    plugins: [] as { name: string; display_name: string; url: string }[],
+    enableChatUI: false,
+  };
+  return {
+    state,
+    mockUsePluginMode: vi.fn(() => ({ mode: "ai-gateway", setMode: vi.fn(), plugins: state.plugins })),
+    mockUseUISettings: vi.fn(() => ({ data: { values: { enable_chat_ui: state.enableChatUI } } })),
+  };
+});
+
+vi.mock("@/contexts/PluginModeContext", () => ({ usePluginMode: mockUsePluginMode }));
+vi.mock("@/app/(dashboard)/hooks/uiSettings/useUISettings", () => ({ useUISettings: mockUseUISettings }));
+vi.mock("next/navigation", () => ({ usePathname: () => "/ui/" }));
+vi.mock("@/utils/migratedPages", () => ({ migratedHref: (seg: string) => `/ui/${seg}` }));
+vi.mock("@/hooks/useWorker", () => ({ useWorker: () => ({ isControlPlane: false, selectedWorker: null }) }));
+vi.mock("@/app/(dashboard)/hooks/useDisableShowPrompts", () => ({ useDisableShowPrompts: () => false }));
+vi.mock("@/components/Navbar/BlogDropdown/BlogDropdown", () => ({ BlogDropdown: () => null }));
+vi.mock("@/components/Navbar/CommunityEngagementButtons/CommunityEngagementButtons", () => ({
+  CommunityEngagementButtons: () => null,
+}));
+vi.mock("@/components/Navbar/NotificationsBell/NotificationsBell", () => ({ NotificationsBell: () => null }));
+vi.mock("@/components/Navbar/WorkerDropdown/WorkerDropdown", () => ({ default: () => null }));
+
+describe("DashboardHeader breadcrumb", () => {
+  afterEach(() => {
+    state.plugins = [];
+    state.enableChatUI = false;
+  });
+
+  it("roots the breadcrumb in the AI Gateway selector (with a Chat option) and drops the static section crumb when the selector is available", async () => {
+    state.enableChatUI = true;
+    render(<DashboardHeader page="logs" />);
+
+    expect(screen.getByText("Logs")).toBeInTheDocument();
+    expect(screen.queryByText("Observability")).not.toBeInTheDocument();
+
+    const selector = screen.getByRole("button", { name: /AI Gateway/i });
+    act(() => {
+      fireEvent.click(selector);
+    });
+    await waitFor(() => expect(screen.getByText("Chat")).toBeInTheDocument());
+  });
+
+  it("falls back to the static section crumb when the selector has nothing to switch to", () => {
+    render(<DashboardHeader page="logs" />);
+
+    expect(screen.getByText("Observability")).toBeInTheDocument();
+    expect(screen.getByText("Logs")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /AI Gateway/i })).not.toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/DashboardHeader.tsx
+++ b/ui/litellm-dashboard/src/components/DashboardHeader.tsx
@@ -13,7 +13,7 @@ import { getBreadcrumb } from "@/components/leftnav";
 import { BlogDropdown } from "@/components/Navbar/BlogDropdown/BlogDropdown";
 import { CommunityEngagementButtons } from "@/components/Navbar/CommunityEngagementButtons/CommunityEngagementButtons";
 import { NotificationsBell } from "@/components/Navbar/NotificationsBell/NotificationsBell";
-import ViewSwitcher, { useViewSwitcherVisible } from "@/components/Navbar/ViewSwitcher";
+import ViewSwitcher from "@/components/Navbar/ViewSwitcher";
 import WorkerDropdown from "@/components/Navbar/WorkerDropdown/WorkerDropdown";
 import { useWorker } from "@/hooks/useWorker";
 import { useDisableShowPrompts } from "@/app/(dashboard)/hooks/useDisableShowPrompts";
@@ -27,8 +27,7 @@ interface DashboardHeaderProps {
 // Top bar for the dashboard shell. Sits only over the content column (the brand
 // lives in the sidebar header); mirrors the design's breadcrumb-left / tools-right layout.
 export function DashboardHeader({ page }: DashboardHeaderProps) {
-  const { section, title } = getBreadcrumb(page);
-  const showSwitcher = useViewSwitcherVisible();
+  const { title } = getBreadcrumb(page);
   const { isControlPlane, selectedWorker } = useWorker();
   const showWorkerSwitch = isControlPlane && selectedWorker !== null;
   const hideCommunityLinks = useDisableShowPrompts();
@@ -45,14 +44,10 @@ export function DashboardHeader({ page }: DashboardHeaderProps) {
     <header className="flex h-14 flex-none items-center justify-between gap-4 border-b border-border bg-background px-4">
       <Breadcrumb className="min-w-0">
         <BreadcrumbList className="flex-nowrap">
-          {showSwitcher ? (
-            <BreadcrumbItem className="flex-none">
-              <ViewSwitcher />
-            </BreadcrumbItem>
-          ) : (
-            section && <BreadcrumbItem className="whitespace-nowrap">{section}</BreadcrumbItem>
-          )}
-          {(showSwitcher || section) && <BreadcrumbSeparator />}
+          <BreadcrumbItem className="flex-none">
+            <ViewSwitcher />
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
           <BreadcrumbItem className="min-w-0">
             <BreadcrumbPage className="truncate">{title}</BreadcrumbPage>
           </BreadcrumbItem>

--- a/ui/litellm-dashboard/src/components/DashboardHeader.tsx
+++ b/ui/litellm-dashboard/src/components/DashboardHeader.tsx
@@ -13,7 +13,7 @@ import { getBreadcrumb } from "@/components/leftnav";
 import { BlogDropdown } from "@/components/Navbar/BlogDropdown/BlogDropdown";
 import { CommunityEngagementButtons } from "@/components/Navbar/CommunityEngagementButtons/CommunityEngagementButtons";
 import { NotificationsBell } from "@/components/Navbar/NotificationsBell/NotificationsBell";
-import ViewSwitcher from "@/components/Navbar/ViewSwitcher";
+import ViewSwitcher, { useViewSwitcherVisible } from "@/components/Navbar/ViewSwitcher";
 import WorkerDropdown from "@/components/Navbar/WorkerDropdown/WorkerDropdown";
 import { useWorker } from "@/hooks/useWorker";
 import { useDisableShowPrompts } from "@/app/(dashboard)/hooks/useDisableShowPrompts";
@@ -28,6 +28,7 @@ interface DashboardHeaderProps {
 // lives in the sidebar header); mirrors the design's breadcrumb-left / tools-right layout.
 export function DashboardHeader({ page }: DashboardHeaderProps) {
   const { section, title } = getBreadcrumb(page);
+  const showSwitcher = useViewSwitcherVisible();
   const { isControlPlane, selectedWorker } = useWorker();
   const showWorkerSwitch = isControlPlane && selectedWorker !== null;
   const hideCommunityLinks = useDisableShowPrompts();
@@ -44,12 +45,14 @@ export function DashboardHeader({ page }: DashboardHeaderProps) {
     <header className="flex h-14 flex-none items-center justify-between gap-4 border-b border-border bg-background px-4">
       <Breadcrumb className="min-w-0">
         <BreadcrumbList className="flex-nowrap">
-          {section && (
-            <>
-              <BreadcrumbItem className="whitespace-nowrap">{section}</BreadcrumbItem>
-              <BreadcrumbSeparator />
-            </>
+          {showSwitcher ? (
+            <BreadcrumbItem className="flex-none">
+              <ViewSwitcher />
+            </BreadcrumbItem>
+          ) : (
+            section && <BreadcrumbItem className="whitespace-nowrap">{section}</BreadcrumbItem>
           )}
+          {(showSwitcher || section) && <BreadcrumbSeparator />}
           <BreadcrumbItem className="min-w-0">
             <BreadcrumbPage className="truncate">{title}</BreadcrumbPage>
           </BreadcrumbItem>
@@ -76,8 +79,6 @@ export function DashboardHeader({ page }: DashboardHeaderProps) {
         {!hideCommunityLinks && <CommunityEngagementButtons />}
         <Separator orientation="vertical" className="mx-1.5 h-5" />
         <NotificationsBell />
-        <Separator orientation="vertical" className="mx-1.5 h-5" />
-        <ViewSwitcher />
       </div>
     </header>
   );

--- a/ui/litellm-dashboard/src/components/Navbar/ViewSwitcher.test.tsx
+++ b/ui/litellm-dashboard/src/components/Navbar/ViewSwitcher.test.tsx
@@ -49,9 +49,23 @@ describe("ViewSwitcher", () => {
     state.setMode.mockClear();
   });
 
-  it("renders nothing with no plugins, chat disabled, and a non-admin user", () => {
-    const { container } = render(<ViewSwitcher />);
-    expect(container.firstChild).toBeNull();
+  it("still renders the selector with a disabled Chat hint when there are no plugins and chat is off", async () => {
+    render(<ViewSwitcher />);
+
+    const button = screen.getByRole("button");
+    expect(button).toHaveTextContent("AI Gateway");
+
+    act(() => {
+      fireEvent.click(button);
+    });
+    await waitFor(() => expect(screen.getByText("Chat")).toBeInTheDocument());
+    expect(screen.getByText(/Admins can enable in Settings/i)).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.getByText("Chat"));
+    });
+    expect(assignSpy).not.toHaveBeenCalled();
+    expect(state.setMode).not.toHaveBeenCalled();
   });
 
   it("labels the button from the active plugin and lists AI Gateway + each plugin", async () => {
@@ -95,7 +109,7 @@ describe("ViewSwitcher", () => {
       fireEvent.click(screen.getByRole("button"));
     });
     await waitFor(() => expect(screen.getByText("Chat")).toBeInTheDocument());
-    expect(screen.queryByText(/Enable in Admin Settings/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Admins can enable in Settings/i)).not.toBeInTheDocument();
 
     act(() => {
       fireEvent.click(screen.getByText("Chat"));
@@ -121,7 +135,7 @@ describe("ViewSwitcher", () => {
     expect(assignSpy).toHaveBeenCalledWith("/ui/");
   });
 
-  it("hides the Chat entry from everyone when disabled", async () => {
+  it("shows Chat as a disabled, non-navigating entry with an admin hint when disabled", async () => {
     state.enableChatUI = false;
     state.plugins = [{ name: "obs", display_name: "Observability", url: "http://localhost:9000" }];
     render(<ViewSwitcher />);
@@ -130,6 +144,12 @@ describe("ViewSwitcher", () => {
       fireEvent.click(screen.getByRole("button"));
     });
     await waitFor(() => expect(screen.getByText("Observability")).toBeInTheDocument());
-    expect(screen.queryByText("Chat")).not.toBeInTheDocument();
+    expect(screen.getByText("Chat")).toBeInTheDocument();
+    expect(screen.getByText(/Admins can enable in Settings/i)).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.getByText("Chat"));
+    });
+    expect(assignSpy).not.toHaveBeenCalled();
   });
 });

--- a/ui/litellm-dashboard/src/components/Navbar/ViewSwitcher.tsx
+++ b/ui/litellm-dashboard/src/components/Navbar/ViewSwitcher.tsx
@@ -11,20 +11,12 @@ import { migratedHref } from "@/utils/migratedPages";
 const GATEWAY = "ai-gateway";
 const CHAT = "chat";
 
-export function useViewSwitcherVisible(): boolean {
-  const { plugins } = usePluginMode();
-  const { data: uiSettings } = useUISettings();
-  return plugins.length > 0 || Boolean(uiSettings?.values?.enable_chat_ui);
-}
-
 export default function ViewSwitcher() {
   const { mode, setMode, plugins } = usePluginMode();
   const { data: uiSettings } = useUISettings();
   const pathname = usePathname();
 
   const chatEnabled = Boolean(uiSettings?.values?.enable_chat_ui);
-
-  if (plugins.length === 0 && !chatEnabled) return null;
 
   const chatHref = migratedHref(CHAT);
   const normalizedPathname = (pathname ?? "").replace(/\/+$/, "");
@@ -37,6 +29,29 @@ export default function ViewSwitcher() {
     ...plugins.map((p) => ({ key: p.name, label: p.display_name })),
   ];
 
+  const chatItem = chatEnabled
+    ? {
+        key: CHAT,
+        label: (
+          <div className="flex items-center justify-between gap-6 py-0.5">
+            <span className="font-medium">Chat</span>
+            {isChatRoute && <CheckOutlined className="text-blue-600" />}
+          </div>
+        ),
+      }
+    : {
+        key: CHAT,
+        disabled: true,
+        label: (
+          <div className="flex max-w-[220px] flex-col py-0.5">
+            <span className="font-medium">Chat</span>
+            <span className="whitespace-normal text-xs leading-snug text-muted-foreground">
+              Admins can enable in Settings
+            </span>
+          </div>
+        ),
+      };
+
   const items: MenuProps["items"] = [
     ...modeEntries.map((e) => ({
       key: e.key,
@@ -47,19 +62,7 @@ export default function ViewSwitcher() {
         </div>
       ),
     })),
-    ...(chatEnabled
-      ? [
-          {
-            key: CHAT,
-            label: (
-              <div className="flex items-center justify-between gap-6 py-0.5">
-                <span className="font-medium">Chat</span>
-                {isChatRoute && <CheckOutlined className="text-blue-600" />}
-              </div>
-            ),
-          },
-        ]
-      : []),
+    chatItem,
   ];
 
   const onClick: MenuProps["onClick"] = ({ key }) => {

--- a/ui/litellm-dashboard/src/components/Navbar/ViewSwitcher.tsx
+++ b/ui/litellm-dashboard/src/components/Navbar/ViewSwitcher.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { usePathname } from "next/navigation";
 import { Dropdown } from "antd";
-import { AppstoreOutlined, CheckOutlined, DownOutlined } from "@ant-design/icons";
+import { AppstoreOutlined, CheckOutlined } from "@ant-design/icons";
+import { ChevronsUpDown } from "lucide-react";
 import type { MenuProps } from "antd";
 import { usePluginMode } from "@/contexts/PluginModeContext";
 import { useUISettings } from "@/app/(dashboard)/hooks/uiSettings/useUISettings";
@@ -9,6 +10,12 @@ import { migratedHref } from "@/utils/migratedPages";
 
 const GATEWAY = "ai-gateway";
 const CHAT = "chat";
+
+export function useViewSwitcherVisible(): boolean {
+  const { plugins } = usePluginMode();
+  const { data: uiSettings } = useUISettings();
+  return plugins.length > 0 || Boolean(uiSettings?.values?.enable_chat_ui);
+}
 
 export default function ViewSwitcher() {
   const { mode, setMode, plugins } = usePluginMode();
@@ -72,11 +79,13 @@ export default function ViewSwitcher() {
     <Dropdown menu={{ items, onClick, selectedKeys: [isChatRoute ? CHAT : mode] }} trigger={["click"]}>
       <button
         type="button"
-        className="flex items-center gap-2 rounded-md border border-gray-200 px-2.5 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+        className="flex h-8 max-w-[220px] items-center gap-1.5 rounded-md border border-border bg-background pl-1.5 pr-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
       >
-        <AppstoreOutlined className="text-gray-500" />
-        <span>{activeLabel}</span>
-        <DownOutlined className="text-[10px] text-gray-400" />
+        <span className="flex size-5 flex-none items-center justify-center rounded bg-muted text-muted-foreground">
+          <AppstoreOutlined className="text-[13px]" />
+        </span>
+        <span className="truncate">{activeLabel}</span>
+        <ChevronsUpDown className="size-3.5 flex-none text-muted-foreground" />
       </button>
     </Dropdown>
   );


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a UI-only change to the gateway top nav, so there is no LLM or proxy call path to exercise. Verified against a local proxy on localhost:4000 with the UI dev server on localhost:3000:

1. Log into the dashboard
2. The top-left breadcrumb root is now the AI Gateway selector pill, followed by the current page (for example "AI Gateway > Virtual Keys")
3. Open the selector. With Chat UI disabled it lists "AI Gateway" (active) and a disabled "Chat" entry reading "Admins can enable in Settings". Turning on Chat UI under Admin Settings makes "Chat" clickable and removes the hint

Screenshots to follow

## Type

🆕 New Feature

## Changes

Moves the existing AI Gateway selector (ViewSwitcher) from the right side of the dashboard top bar to the root of the breadcrumb, so the header reads selector then page to match the redesign. The trigger is restyled to a token-based pill with an app-grid chip and an up/down chevron.

The selector now renders unconditionally so the Chat feature stays discoverable even before any plugins are registered or Chat UI is turned on. The Chat entry is always listed: clickable and navigating when enabled, and disabled with an "Admins can enable in Settings" hint when it is off.

Tests cover the selector sitting at the breadcrumb root, the drop of the now-redundant section crumb, and the enabled versus disabled Chat states

<img width="728" height="70" alt="image" src="https://github.com/user-attachments/assets/17470807-8343-4bbf-bc02-602ab1ccf5bf" />
<img width="673" height="144" alt="image" src="https://github.com/user-attachments/assets/607050b4-68b1-4f1a-84d9-5edf26f0ec70" />
<img width="642" height="161" alt="image" src="https://github.com/user-attachments/assets/46a29ea1-df9e-4bf6-84eb-96b4319f916e" />
<img width="732" height="236" alt="image" src="https://github.com/user-attachments/assets/75c19a3f-6a84-43c0-b160-d3800ebfd9ef" />
