### PR TITLE
fix(proxy): skip base64 image bytes when estimating Responses API TPM

### DIFF
--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -318,8 +318,7 @@ def _chars_from_input_list(items: list) -> int:
             elif isinstance(content, str):
                 total += len(content)
             else:
-                text = item.get("text", "")
-                total += len(text) if isinstance(text, str) else 0
+                total += _chars_from_content_block(item)
         else:
             total += len(str(item))
     return total

--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -267,6 +267,13 @@ _BINARY_CONTENT_BLOCK_TYPES = frozenset(("input_audio", "input_video", "input_fi
 # inflation this PR fixes and zero-cost image batching that bypasses TPM limits.
 _IMAGE_BLOCK_CHAR_FLOOR = 1000
 
+# Text-bearing fields across known Responses API block types:
+#   input_text / output_text → "text"
+#   function_call_output     → "output"
+#   refusal                  → "refusal"
+# Summing all three is safe — each typed block only populates one of them.
+_TEXT_BEARING_FIELDS: tuple[str, ...] = ("text", "output", "refusal")
+
 
 def _chars_from_content_block(block: dict) -> int:
     """Return estimated text char count for one Responses API content block.
@@ -274,16 +281,16 @@ def _chars_from_content_block(block: dict) -> int:
     - ``input_image``: returns a conservative per-image floor so image-heavy
       requests are not zero-cost for TPM reservation purposes.
     - ``input_audio``/``input_video``/``input_file``: returns 0 (no text).
-    - All other types: counts the ``text`` field so tool results, refusals,
-      and future text-bearing blocks still contribute to the estimate.
+    - All other types: sums ``text``, ``output``, and ``refusal`` fields so
+      that ``input_text``, ``output_text``, ``function_call_output``,
+      ``refusal``, and future text-bearing block types are all counted.
     """
     block_type = block.get("type", "")
     if block_type == "input_image":
         return _IMAGE_BLOCK_CHAR_FLOOR
     if block_type in _BINARY_CONTENT_BLOCK_TYPES:
         return 0
-    text = block.get("text", "")
-    return len(text) if isinstance(text, str) else 0
+    return sum(len(v) for field in _TEXT_BEARING_FIELDS if isinstance(v := block.get(field, ""), str))
 
 
 def _chars_from_input_list(items: list) -> int:

--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -256,22 +256,33 @@ _LITELLM_STASH_KEYS: Tuple[str, ...] = (
 )
 
 
-# Block types that carry binary payloads (base64 or URLs) — skip to avoid
-# counting raw blob bytes as text characters.
+# Block types whose binary payload (base64 or URL) should not be counted as
+# text characters.  audio/video/file have no meaningful text representation;
+# image blocks get a conservative floor below instead of 0.
 _BINARY_CONTENT_BLOCK_TYPES = frozenset(
-    ("input_image", "input_audio", "input_video", "input_file")
+    ("input_audio", "input_video", "input_file")
 )
+
+# Conservative per-image char floor used for token pre-reservation.
+# Accurate counting requires image dimensions + detail level (provider-specific);
+# this floor (~250 tokens at 4 chars/token) avoids both the base64-blob
+# inflation this PR fixes and zero-cost image batching that bypasses TPM limits.
+_IMAGE_BLOCK_CHAR_FLOOR = 1000
 
 
 def _chars_from_content_block(block: dict) -> int:
     """Return estimated text char count for one Responses API content block.
 
-    Skips binary-payload types (image/audio/video/file).  Counts the ``text``
-    field for all other block types — known ones (``input_text``, ``output_text``,
-    ``refusal``) and unrecognised future ones — so tool results and other
-    text-bearing blocks still contribute to the estimate.
+    - ``input_image``: returns a conservative per-image floor so image-heavy
+      requests are not zero-cost for TPM reservation purposes.
+    - ``input_audio``/``input_video``/``input_file``: returns 0 (no text).
+    - All other types: counts the ``text`` field so tool results, refusals,
+      and future text-bearing blocks still contribute to the estimate.
     """
-    if block.get("type", "") in _BINARY_CONTENT_BLOCK_TYPES:
+    block_type = block.get("type", "")
+    if block_type == "input_image":
+        return _IMAGE_BLOCK_CHAR_FLOOR
+    if block_type in _BINARY_CONTENT_BLOCK_TYPES:
         return 0
     text = block.get("text", "")
     return len(text) if isinstance(text, str) else 0

--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -259,9 +259,7 @@ _LITELLM_STASH_KEYS: Tuple[str, ...] = (
 # Block types whose binary payload (base64 or URL) should not be counted as
 # text characters.  audio/video/file have no meaningful text representation;
 # image blocks get a conservative floor below instead of 0.
-_BINARY_CONTENT_BLOCK_TYPES = frozenset(
-    ("input_audio", "input_video", "input_file")
-)
+_BINARY_CONTENT_BLOCK_TYPES = frozenset(("input_audio", "input_video", "input_file"))
 
 # Conservative per-image char floor used for token pre-reservation.
 # Accurate counting requires image dimensions + detail level (provider-specific);

--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -256,6 +256,59 @@ _LITELLM_STASH_KEYS: Tuple[str, ...] = (
 )
 
 
+# Block types that carry binary payloads (base64 or URLs) — skip to avoid
+# counting raw blob bytes as text characters.
+_BINARY_CONTENT_BLOCK_TYPES = frozenset(
+    ("input_image", "input_audio", "input_video", "input_file")
+)
+
+
+def _chars_from_content_block(block: dict) -> int:
+    """Return estimated text char count for one Responses API content block.
+
+    Skips binary-payload types (image/audio/video/file).  Counts the ``text``
+    field for all other block types — known ones (``input_text``, ``output_text``,
+    ``refusal``) and unrecognised future ones — so tool results and other
+    text-bearing blocks still contribute to the estimate.
+    """
+    if block.get("type", "") in _BINARY_CONTENT_BLOCK_TYPES:
+        return 0
+    text = block.get("text", "")
+    return len(text) if isinstance(text, str) else 0
+
+
+def _chars_from_input_list(items: list) -> int:
+    """Count text chars from a Responses API ``input`` list, skipping image/audio/video blobs.
+
+    The Responses API sends ``input`` as a list of message objects, each with a
+    ``content`` array whose blocks are typed (``input_text``, ``input_image``,
+    ``input_audio``, …).  Serialising an ``input_image`` block with ``str()``
+    includes the raw base64 payload and massively inflates the char count, causing
+    false-positive 429s on TPM-limited keys.  This helper counts only text content
+    and falls back to ``len(str(item))`` for plain-string items (embeddings format).
+    """
+    total = 0
+    for item in items:
+        if isinstance(item, str):
+            total += len(item)
+        elif isinstance(item, dict):
+            content = item.get("content")
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, str):
+                        total += len(block)
+                    elif isinstance(block, dict):
+                        total += _chars_from_content_block(block)
+            elif isinstance(content, str):
+                total += len(content)
+            else:
+                text = item.get("text", "")
+                total += len(text) if isinstance(text, str) else 0
+        else:
+            total += len(str(item))
+    return total
+
+
 class RateLimitDescriptorRateLimitObject(TypedDict, total=False):
     requests_per_unit: Optional[int]
     tokens_per_unit: Optional[int]
@@ -405,7 +458,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
             case (_, _, str() as t):
                 total_chars = len(t)
             case (_, _, list() as t):
-                total_chars = sum(len(str(item)) for item in t)
+                total_chars = _chars_from_input_list(t)
             case _:
                 total_chars = 0
 


### PR DESCRIPTION
## Summary

Fixes #32865 — TPM limiter counts base64 image bytes as text when estimating Responses API input tokens

The `_estimate_tokens_for_request` method in `parallel_request_limiter_v3.py` handles the `input` field (Responses API / embeddings) by calling `str(item)` on each list element. For embeddings this is fine — each item is a plain string. For Responses API requests, each item is a message object whose `content` array can include `input_image` blocks carrying multi-megabyte base64 payloads. Serialising the entire dict with `str()` included the raw base64 blob, inflating the estimated token count by ~500×–1000× and causing false-positive 429s on any key with a reasonable TPM limit.

- Added module-level `_chars_from_input_list()` helper that walks Responses API message objects and counts only `input_text` / `text` / `output_text` content blocks, skipping `input_image`, `input_audio`, `input_video`, and `input_file` blobs.
- The helper preserves existing behaviour for plain-string lists (embeddings API): `isinstance(item, str)` → `len(item)` as before.
- Changed the `case (_, _, list() as t)` branch to call `_chars_from_input_list(t)` instead of `sum(len(str(item)) for item in t)`.

## Test plan

- [ ] Reproduce with a TPM-limited key (50k) and a Responses API request containing a base64-encoded image — before fix: 429 `Rate limit exceeded`; after fix: request succeeds.
- [ ] Embeddings request (`input: ["text1", "text2"]`) still estimates tokens correctly — no regression.
- [ ] Text-only Responses API request estimates tokens based on the text content.