### PR TITLE
fix(router): count tools in pre-call context-window check

### DIFF
--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -810,8 +810,9 @@ def _format_object_parameters(parameters, indent):
 def _format_type(props, indent):
     type = props.get("type")
     if type == "string":
-        if "enum" in props:
-            return " | ".join([f'"{item}"' for item in props["enum"]])
+        enum_values = props.get("enum")
+        if enum_values:
+            return " | ".join([f'"{item}"' for item in enum_values])
         return "string"
     elif type == "array":
         # items is required, OpenAI throws an error if it's missing
@@ -819,8 +820,9 @@ def _format_type(props, indent):
     elif type == "object":
         return f"{{\n{_format_object_parameters(props, indent + 2)}\n}}"
     elif type in ["integer", "number"]:
-        if "enum" in props:
-            return " | ".join([f'"{item}"' for item in props["enum"]])
+        enum_values = props.get("enum")
+        if enum_values:
+            return " | ".join([f'"{item}"' for item in enum_values])
         return "number"
     elif type == "boolean":
         return "boolean"

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9868,8 +9868,14 @@ class Router:
                 max_input_tokens = model_info.get("max_input_tokens") if isinstance(model_info, dict) else None
                 if isinstance(max_input_tokens, int):
                     if input_tokens is None:
+                        _tools = (request_kwargs or {}).get("tools")
+                        _tool_choice = (request_kwargs or {}).get("tool_choice")
                         try:
-                            input_tokens = litellm.token_counter(messages=messages)
+                            input_tokens = litellm.token_counter(
+                                messages=messages,
+                                tools=_tools,
+                                tool_choice=_tool_choice,
+                            )
                         except Exception as e:
                             verbose_router_logger.error(
                                 "litellm.router.py::_pre_call_checks: failed to count tokens. Returning initial list of deployments. Got - {}".format(

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -469,6 +469,50 @@ def test_empty_tools():
     print(result)
 
 
+def _tool_with_property_enum(enum_value):
+    return {
+        "type": "function",
+        "function": {
+            "name": "search",
+            "description": "search",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "q", "enum": enum_value},
+                    "count": {"type": "integer", "description": "n", "enum": enum_value},
+                },
+                "required": ["query"],
+            },
+        },
+    }
+
+
+@pytest.mark.parametrize("enum_value", [None, [], {}])
+def test_token_counter_property_enum_null_or_empty_does_not_crash(enum_value):
+    messages = [{"role": "user", "content": "hello"}]
+    tools = [_tool_with_property_enum(enum_value)]
+
+    result = token_counter(model="gpt-4", messages=messages, tools=tools)
+
+    assert isinstance(result, int)
+    assert result > 0
+
+
+def test_token_counter_property_enum_populated_still_counted():
+    messages = [{"role": "user", "content": "hello"}]
+    baseline = token_counter(
+        model="gpt-4",
+        messages=messages,
+        tools=[_tool_with_property_enum(None)],
+    )
+    with_enum = token_counter(
+        model="gpt-4",
+        messages=messages,
+        tools=[_tool_with_property_enum(["alpha", "beta", "gamma"])],
+    )
+    assert with_enum > baseline
+
+
 @pytest.mark.skip(
     reason="Skipping this test temporarily because it relies on a function being called that I am removing."
 )

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -5304,3 +5304,103 @@ class TestRouterRequestTimeoutPropagation:
             )
             == 60
         )
+
+
+def _bulky_tool_schema():
+    return {
+        "type": "function",
+        "function": {
+            "name": "run_report",
+            "description": ("Detailed instructions describing every field. " * 30),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    f"field_{i}": {
+                        "type": "string",
+                        "description": (
+                            f"Very detailed description for field {i} with lots of words. " * 6
+                        ),
+                    }
+                    for i in range(30)
+                },
+                "required": [f"field_{i}" for i in range(5)],
+            },
+        },
+    }
+
+
+def _router_with_two_context_windows():
+    return litellm.Router(
+        model_list=[
+            {
+                "model_name": "test-group",
+                "litellm_params": {
+                    "model": "openai/gpt-3.5-turbo",
+                    "api_key": "sk-fake-key-for-test",
+                },
+                "model_info": {"id": "small", "max_input_tokens": 500},
+            },
+            {
+                "model_name": "test-group",
+                "litellm_params": {
+                    "model": "openai/gpt-4",
+                    "api_key": "sk-fake-key-for-test",
+                },
+                "model_info": {"id": "large", "max_input_tokens": 200_000},
+            },
+        ],
+        enable_pre_call_checks=True,
+    )
+
+
+def test_pre_call_checks_max_input_tokens_ignores_short_message_without_tools():
+    router = _router_with_two_context_windows()
+    messages = [{"role": "user", "content": "hi"}]
+
+    result = router._pre_call_checks(
+        model="test-group",
+        healthy_deployments=list(router.model_list),
+        messages=messages,
+        request_kwargs={},
+    )
+
+    remaining_ids = {d["model_info"]["id"] for d in result}
+    assert remaining_ids == {"small", "large"}
+
+
+def test_pre_call_checks_max_input_tokens_counts_tool_schema():
+    router = _router_with_two_context_windows()
+    messages = [{"role": "user", "content": "hi"}]
+    tools = [_bulky_tool_schema()]
+
+    result = router._pre_call_checks(
+        model="test-group",
+        healthy_deployments=list(router.model_list),
+        messages=messages,
+        request_kwargs={"tools": tools},
+    )
+
+    remaining_ids = {d["model_info"]["id"] for d in result}
+    assert remaining_ids == {"large"}, (
+        "The small-context deployment must be filtered out once the tool schema is "
+        f"included in the token count. Got: {remaining_ids}"
+    )
+
+
+def test_pre_call_checks_max_input_tokens_counts_tool_choice_named():
+    router = _router_with_two_context_windows()
+    messages = [{"role": "user", "content": "hi"}]
+    tools = [_bulky_tool_schema()]
+
+    result = router._pre_call_checks(
+        model="test-group",
+        healthy_deployments=list(router.model_list),
+        messages=messages,
+        request_kwargs={
+            "tools": tools,
+            "tool_choice": {"type": "function", "function": {"name": "run_report"}},
+        },
+    )
+
+    remaining_ids = {d["model_info"]["id"] for d in result}
+    assert remaining_ids == {"large"}


### PR DESCRIPTION
## Relevant issues

No existing issue. `Router._pre_call_checks` compares each deployment's `max_input_tokens` against a token count that omits the request's tools, so a request whose tool schema alone exceeds the limit still passes the guard

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The bug lives inside the router's own pre-call filter, so the reproduction runs entirely on \`litellm.Router\`; no LLM API calls are needed. Two model group members, a huge tool schema, one printout of who survives the filter

\`\`\`bash
git checkout $(git merge-base HEAD upstream/litellm_oss_daily_2026_07_10)  # before the fix
python -c \"
import litellm

router = litellm.Router(
    model_list=[
        {'model_name': 'g', 'litellm_params': {'model': 'openai/gpt-3.5-turbo', 'api_key': 'sk-x'},
         'model_info': {'id': 'small', 'max_input_tokens': 500}},
        {'model_name': 'g', 'litellm_params': {'model': 'openai/gpt-4', 'api_key': 'sk-x'},
         'model_info': {'id': 'large', 'max_input_tokens': 200_000}},
    ],
    enable_pre_call_checks=True,
)
tools = [{'type': 'function', 'function': {
    'name': 'run_report',
    'description': 'Detailed instructions describing every field. ' * 30,
    'parameters': {'type': 'object', 'properties': {
        f'field_{i}': {'type': 'string', 'description': 'Very detailed description text. ' * 6}
        for i in range(30)}}}}]
result = router._pre_call_checks(
    model='g',
    healthy_deployments=list(router.model_list),
    messages=[{'role': 'user', 'content': 'hi'}],
    request_kwargs={'tools': tools},
)
print('remaining:', [d['model_info']['id'] for d in result])
\"
# remaining: ['small', 'large']     <-- bug: small deployment survives even though the tool schema busts its 500-token cap

git checkout HEAD@{1}     # apply the fix
# rerun the same snippet
# remaining: ['large']              <-- fixed
\`\`\`

For the null-enum crash, the same setup plus a property with \`enum: null\` raised \`TypeError: 'NoneType' object is not iterable\` from \`_format_type\` before the fix, and returns an int after

## Type

Bug Fix

## Changes

\`litellm/router.py\` reads \`tools\` and \`tool_choice\` out of \`request_kwargs\` and passes them to \`litellm.token_counter\` alongside \`messages\`, so the same total the provider will see drives the \`max_input_tokens\` filter

\`litellm/litellm_core_utils/token_counter.py\` guards \`_format_type\` against \`enum: null\` (a legal JSON schema shape emitted by some client SDKs); it now falls back to the plain type string when the enum value is missing or empty. Once tools are included in the pre-call count, that crash becomes reachable from the router hot path

Regression tests live under \`tests/test_litellm/test_router.py\` and \`tests/test_litellm/litellm_core_utils/test_token_counter.py\` and cover both a \`Router\` where a bulky tool schema now filters out the small-context deployment and a \`token_counter\` call with \`enum: null / [] / {}\` that returns an int instead of raising

@greptileai