### PR TITLE
fix(proxy): resolve real provider and creation timestamp for /v1/models

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -8203,6 +8203,7 @@ async def model_list(
     from litellm.proxy.utils import (
         create_model_info_response,
         get_available_models_for_user,
+        resolve_model_provider_and_created_at,
     )
 
     # Validate scope parameter if provided
@@ -8277,12 +8278,14 @@ async def model_list(
         # public name is what the client sees as the model id.
         model_data = []
         for response_id, lookup_id in TeamModelNameTranslator.listing_entries(all_models, llm_router, settings):
+            provider, created = resolve_model_provider_and_created_at(llm_router, lookup_id)
             model_info = create_model_info_response(
                 model_id=lookup_id,
-                provider="openai",
+                provider=provider,
                 include_metadata=include_metadata or False,
                 fallback_type=fallback_type,
                 llm_router=llm_router,
+                created=created,
             )
             model_info["id"] = response_id
             model_data.append(model_info)
@@ -8317,12 +8320,14 @@ async def model_list(
     # public name is what the client sees as the model id.
     model_data = []
     for response_id, lookup_id in TeamModelNameTranslator.listing_entries(all_models, llm_router, settings):
+        provider, created = resolve_model_provider_and_created_at(llm_router, lookup_id)
         model_info = create_model_info_response(
             model_id=lookup_id,
-            provider="openai",
+            provider=provider,
             include_metadata=include_metadata or False,
             fallback_type=fallback_type,
             llm_router=llm_router,
+            created=created,
         )
         model_info["id"] = response_id
         model_data.append(model_info)
@@ -8420,6 +8425,8 @@ async def model_info(
 
     # Use the actual litellm model from the deployment to get provider info
     _, provider, _, _ = litellm.get_llm_provider(model=deployment.litellm_params.model)
+    created_at = deployment.model_info.created_at
+    created = int(created_at.timestamp()) if created_at is not None else None
 
     response_id = internal_to_public.get(resolved_model_id, model_id)
     return create_model_info_response(
@@ -8428,6 +8435,7 @@ async def model_info(
         include_metadata=False,
         fallback_type=None,
         llm_router=llm_router,
+        created=created,
     )
 
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -6092,12 +6092,38 @@ async def get_available_models_for_user(
     return all_models
 
 
+def resolve_model_provider_and_created_at(llm_router: Optional["Router"], model_id: str) -> Tuple[str, Optional[int]]:
+    """
+    Resolve the (owned_by, created) pair for an OpenAI-compatible model object from
+    the model group's backing deployment.
+
+    Falls back to ("openai", None) when no deployment is found (wildcard routes,
+    access groups) or provider parsing fails; callers substitute
+    DEFAULT_MODEL_CREATED_AT_TIME for a None created (config-defined models, and
+    DB models on OSS, have no real creation timestamp - `created_at` is only
+    populated for DB models on Enterprise, in ProxyConfig.get_model_info_with_id).
+    """
+    if llm_router is None:
+        return "openai", None
+    deployment = llm_router.get_deployment_by_model_group_name(model_id)
+    if deployment is None:
+        return "openai", None
+    try:
+        _, provider, _, _ = litellm.get_llm_provider(model=deployment.litellm_params.model)
+    except litellm.exceptions.BadRequestError:
+        provider = "openai"
+    created_at = deployment.model_info.created_at
+    created = int(created_at.timestamp()) if created_at is not None else None
+    return provider, created
+
+
 def create_model_info_response(
     model_id: str,
     provider: str,
     include_metadata: bool = False,
     fallback_type: Optional[str] = None,
     llm_router: Optional["Router"] = None,
+    created: Optional[int] = None,
 ) -> ModelInfoResponse:
     """
     Create a standardized OpenAI-compatible model object.
@@ -6111,7 +6137,7 @@ def create_model_info_response(
     base: ModelInfoResponse = {
         "id": model_id,
         "object": "model",
-        "created": DEFAULT_MODEL_CREATED_AT_TIME,
+        "created": created if created is not None else DEFAULT_MODEL_CREATED_AT_TIME,
         "owned_by": provider,
     }
 

--- a/tests/test_litellm/proxy/proxy_server/test_routes_models.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_models.py
@@ -130,3 +130,47 @@ def test_get_model_by_id_not_found(client, auth_as, patched_models, path):
         response = client.get(path)
     assert response.status_code == 404
     assert "not found" in response.text.lower()
+
+
+@pytest.mark.parametrize("path", ["/v1/models", "/models"])
+def test_get_models_reports_real_provider_per_model(client, auth_as, monkeypatch, path):
+    """Regression: `owned_by` must reflect each model's actual provider.
+
+    GET /v1/models previously hardcoded `provider="openai"` at its callsite for
+    every model, unlike GET /v1/models/{model_id} which already resolved the
+    real provider from the deployment. This exercises the real router +
+    provider-resolution stack (no mocking of create_model_info_response or
+    litellm.get_llm_provider), so it fails if the listing callsite regresses
+    to a hardcoded provider.
+    """
+    from litellm import Router
+    from litellm.proxy import utils as proxy_utils
+
+    router = Router(
+        model_list=[
+            {"model_name": "gpt-4", "litellm_params": {"model": "gpt-4"}},
+            {
+                "model_name": "claude-sonnet",
+                "litellm_params": {"model": "anthropic/claude-3-5-sonnet-latest"},
+            },
+        ]
+    )
+
+    monkeypatch.setattr(proxy_server, "llm_router", router)
+    monkeypatch.setattr(proxy_server, "prisma_client", MagicMock())
+
+    async def _fake_get_available_models_for_user(**kwargs):
+        return ["gpt-4", "claude-sonnet"]
+
+    monkeypatch.setattr(
+        proxy_utils,
+        "get_available_models_for_user",
+        _fake_get_available_models_for_user,
+    )
+
+    with auth_as():
+        response = client.get(path)
+
+    assert response.status_code == 200
+    owned_by = {m["id"]: m["owned_by"] for m in response.json()["data"]}
+    assert owned_by == {"gpt-4": "openai", "claude-sonnet": "anthropic"}

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -604,6 +604,75 @@ def test_create_model_info_response_no_router_keeps_base_fields():
         "created": response["created"],
         "owned_by": "openai",
     }
+
+
+def test_create_model_info_response_uses_created_when_given():
+    # Regression: `created` must come from the caller's resolved timestamp when
+    # provided, not always fall back to the fixed DEFAULT_MODEL_CREATED_AT_TIME.
+    response = create_model_info_response(
+        model_id="some-model", provider="openai", llm_router=None, created=12345
+    )
+    assert response["created"] == 12345
+
+
+def test_create_model_info_response_defaults_created_when_none():
+    from litellm.constants import DEFAULT_MODEL_CREATED_AT_TIME
+
+    response = create_model_info_response(
+        model_id="some-model", provider="openai", llm_router=None, created=None
+    )
+    assert response["created"] == DEFAULT_MODEL_CREATED_AT_TIME
+
+
+from litellm.proxy.utils import resolve_model_provider_and_created_at
+
+
+def test_resolve_model_provider_and_created_at_reads_deployment():
+    # Regression: /v1/models previously hardcoded owned_by="openai" for every
+    # model regardless of the deployment's real provider.
+    deployment = MagicMock()
+    deployment.litellm_params.model = "anthropic/claude-3-5-sonnet-latest"
+    deployment.model_info.created_at = real_datetime.datetime(2024, 1, 1, tzinfo=real_datetime.timezone.utc)
+    router = MagicMock()
+    router.get_deployment_by_model_group_name = MagicMock(return_value=deployment)
+
+    provider, created = resolve_model_provider_and_created_at(router, "claude-sonnet")
+
+    router.get_deployment_by_model_group_name.assert_called_once_with("claude-sonnet")
+    assert provider == "anthropic"
+    assert created == int(deployment.model_info.created_at.timestamp())
+
+
+def test_resolve_model_provider_and_created_at_no_deployment_defaults_openai():
+    # Wildcard routes / access groups have no backing deployment.
+    router = MagicMock()
+    router.get_deployment_by_model_group_name = MagicMock(return_value=None)
+
+    provider, created = resolve_model_provider_and_created_at(router, "openai/*")
+
+    assert provider == "openai"
+    assert created is None
+
+
+def test_resolve_model_provider_and_created_at_no_router_defaults_openai():
+    provider, created = resolve_model_provider_and_created_at(None, "some-model")
+    assert provider == "openai"
+    assert created is None
+
+
+def test_resolve_model_provider_and_created_at_no_created_at_returns_none():
+    deployment = MagicMock()
+    deployment.litellm_params.model = "gpt-4"
+    deployment.model_info.created_at = None
+    router = MagicMock()
+    router.get_deployment_by_model_group_name = MagicMock(return_value=deployment)
+
+    provider, created = resolve_model_provider_and_created_at(router, "gpt-4")
+
+    assert provider == "openai"
+    assert created is None
+
+
 class TestPostCallFailureHookLLMExceptionAlerting:
     """The llm_exceptions alert is for infra / LLM-API failures, not user
     errors (https://github.com/BerriAI/litellm/issues/3395). Already-normalized


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`GET /v1/models` hardcoded `provider="openai"` at its callsite for every model, so any Anthropic, Bedrock, Vertex AI, or Azure AI deployment came back reporting `owned_by: "openai"`. Verified against a live proxy (`python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml`) running `dev_config.yaml`, whose model_list spans Anthropic, Bedrock, Vertex AI, Azure AI, and OpenAI models.

Before the fix, commit `a4199d3c09` (base of this branch's parent history):

```
$ curl -s http://localhost:4001/v1/models -H "Authorization: Bearer $LITELLM_MASTER_KEY" | python3 -m json.tool | grep -E '"id"|"owned_by"'
            "id": "anthropic-haiku-4-5",
            "owned_by": "openai",
            "id": "bedrock-invoke-haiku-4-5",
            "owned_by": "openai",
            "id": "vertex-haiku-4-5",
            "owned_by": "openai",
            "id": "azure-haiku-4-5",
            "owned_by": "openai",
            "id": "gpt-4o-mini",
            "owned_by": "openai",
```

Every model, regardless of real provider, reports `owned_by: "openai"`.

After the fix, commit `2c7db2d1f8` (this branch's tip):

```
$ curl -s http://localhost:4000/v1/models -H "Authorization: Bearer $LITELLM_MASTER_KEY" | python3 -m json.tool
{
    "data": [
        {
            "id": "anthropic-haiku-4-5",
            "object": "model",
            "created": 1677610602,
            "owned_by": "anthropic",
            "max_input_tokens": 200000,
            "max_output_tokens": 64000
        },
        {
            "id": "bedrock-invoke-haiku-4-5",
            "object": "model",
            "created": 1677610602,
            "owned_by": "bedrock",
            "max_input_tokens": 200000,
            "max_output_tokens": 64000
        },
        {
            "id": "vertex-haiku-4-5",
            "object": "model",
            "created": 1677610602,
            "owned_by": "vertex_ai",
            "max_input_tokens": 200000,
            "max_output_tokens": 8192
        },
        {
            "id": "azure-haiku-4-5",
            "object": "model",
            "created": 1677610602,
            "owned_by": "azure_ai",
            "max_input_tokens": 200000,
            "max_output_tokens": 64000
        },
        {
            "id": "gpt-4o-mini",
            "object": "model",
            "created": 1677610602,
            "owned_by": "openai",
            "max_input_tokens": 128000,
            "max_output_tokens": 16384
        }
    ],
    "object": "list"
}
```

`owned_by` now reflects each model's actual provider. `created` still falls back to the fixed `DEFAULT_MODEL_CREATED_AT_TIME` here because these are config-defined models with no DB creation timestamp; for DB-added models on Enterprise, the endpoint now surfaces the real `LiteLLM_ProxyModelTable.created_at` instead of the fixed default.

No LLM completion call is involved in listing models, so this proof doesn't hit provider APIs; it's a pure metadata endpoint.

## Type

🐛 Bug Fix
✅ Test

## Changes

`GET /v1/models` and `GET /models` (`model_list()` in `litellm/proxy/proxy_server.py`) hardcoded `provider="openai"` at both of their `create_model_info_response()` callsites, regardless of the model's actual backend. The sibling `GET /v1/models/{model_id}` endpoint already resolved the real provider from the deployment, so this brings the plural endpoint in line and extracts the shared logic into `resolve_model_provider_and_created_at()` in `litellm/proxy/utils.py`, used by all three callsites. The same helper also resolves `created` from the model's real DB timestamp (`deployment.model_info.created_at`) when one exists, instead of every model reporting the endpoint's fixed 2023 default. Added unit tests for the new helper and `create_model_info_response()`'s `created` override in `tests/test_litellm/proxy/test_proxy_utils.py`, plus a route-level regression test in `tests/test_litellm/proxy/proxy_server/test_routes_models.py` that exercises the real router and provider-resolution stack (no mocked `create_model_info_response` or `litellm.get_llm_provider`) and fails against the old hardcoded behavior.