### PR TITLE
fix(xecguard): use StandardLoggingGuardrailInformation in logging hook

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/xecguard/xecguard.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/xecguard/xecguard.py
@@ -49,7 +49,11 @@ from litellm.llms.custom_httpx.http_handler import (
     httpxSpecialProvider,
 )
 from litellm.types.guardrails import GuardrailEventHooks
-from litellm.types.utils import GenericGuardrailAPIInputs, GuardrailStatus
+from litellm.types.utils import (
+    GenericGuardrailAPIInputs,
+    GuardrailStatus,
+    StandardLoggingGuardrailInformation,
+)
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import (
@@ -246,16 +250,21 @@ class XecGuardGuardrail(CustomGuardrail):
                 "guardrail_intervened" if scan_result.get("decision") == "UNSAFE" else "success"
             )
             end_time = datetime.now()
-            kwargs["standard_logging_object"]["guardrail_information"] = {
-                "duration": (end_time - start_time).total_seconds(),
-                "end_time": end_time.timestamp(),
-                "guardrail_mode": "logging_only",
-                "guardrail_name": "xecguard",
-                "guardrail_response": scan_result,
-                "guardrail_status": guardrail_status,
-                "masked_entity_count": None,
-                "start_time": start_time.timestamp(),
-            }
+            slg = StandardLoggingGuardrailInformation(
+                guardrail_name=self.guardrail_name or "xecguard",
+                guardrail_mode=GuardrailEventHooks.logging_only,
+                guardrail_response=scan_result,
+                guardrail_status=guardrail_status,
+                start_time=start_time.timestamp(),
+                end_time=end_time.timestamp(),
+                duration=(end_time - start_time).total_seconds(),
+                masked_entity_count=None,
+            )
+            existing = kwargs["standard_logging_object"].get("guardrail_information")
+            if isinstance(existing, list):
+                existing.append(slg)
+            else:
+                kwargs["standard_logging_object"]["guardrail_information"] = [slg]
 
         except Exception as exc:
             verbose_proxy_logger.debug(

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_xecguard.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_xecguard.py
@@ -1644,11 +1644,36 @@ class TestXecGuardLoggingHook:
             )
             assert out_kwargs is kwargs
             assert out_result is result
-        info = kwargs["standard_logging_object"]["guardrail_information"]
+        info_list = kwargs["standard_logging_object"]["guardrail_information"]
+        assert isinstance(info_list, list), "guardrail_information must be a list"
+        assert len(info_list) == 1
+        info = info_list[0]
         assert info["guardrail_mode"] == "logging_only"
-        assert info["guardrail_name"] == "xecguard"
+        assert info["guardrail_name"] == "test-xecguard"
         assert info["guardrail_status"] == "success"
         assert info["guardrail_response"]["trace_id"] == "lg-1"
+
+    @pytest.mark.asyncio
+    async def test_async_logging_hook_appends_to_existing_guardrail_info(
+        self, xecguard_guardrail, mock_request_data
+    ):
+        resp = _make_response({"decision": "SAFE", "trace_id": "lg-4"})
+        prior_entry = {"guardrail_name": "other-guardrail"}
+        with patch.object(xecguard_guardrail.async_handler, "post", return_value=resp):
+            kwargs = {
+                **mock_request_data,
+                "standard_logging_object": {"guardrail_information": [prior_entry]},
+            }
+            await xecguard_guardrail.async_logging_hook(
+                kwargs=kwargs,
+                result=_build_model_response("some answer"),
+                call_type="acompletion",
+            )
+        info_list = kwargs["standard_logging_object"]["guardrail_information"]
+        assert len(info_list) == 2
+        assert info_list[0] is prior_entry
+        assert info_list[1]["guardrail_name"] == "test-xecguard"
+        assert info_list[1]["guardrail_response"]["trace_id"] == "lg-4"
 
     @pytest.mark.asyncio
     async def test_async_logging_hook_without_response_records_info(
@@ -1680,7 +1705,9 @@ class TestXecGuardLoggingHook:
                 result=_build_model_response("x"),
                 call_type="acompletion",
             )
-        info = kwargs["standard_logging_object"]["guardrail_information"]
+        info_list = kwargs["standard_logging_object"]["guardrail_information"]
+        assert isinstance(info_list, list), "guardrail_information must be a list"
+        info = info_list[0]
         assert info["guardrail_status"] == "guardrail_intervened"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4335

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Full live e2e suite against a proxy on localhost:4001 backed by a real Postgres, with real OpenAI API traffic, exercising streaming and non-streaming completions, SAFE and UNSAFE scan decisions, multiple guardrails appending to the same request, and the guardrail usage endpoints. The only substituted component is the XecGuard vendor endpoint itself (no XecGuard service token is available in this environment), replaced by a local HTTP server on 127.0.0.1:9410 that returns a realistic scan payload and decides UNSAFE when a marker string appears in the messages; everything else is live

```yaml
model_list:
  - model_name: gpt-4.1-mini
    litellm_params:
      model: openai/gpt-4.1-mini
      api_key: os.environ/OPENAI_API_KEY
guardrails:
  - guardrail_name: xecguard-logging
    litellm_params:
      guardrail: xecguard
      mode: logging_only
      api_base: http://127.0.0.1:9410
      api_key: xgs_local_stub
      default_on: true
  - guardrail_name: xecguard-logging-secondary
    litellm_params:
      guardrail: xecguard
      mode: logging_only
      api_base: http://127.0.0.1:9410
      api_key: xgs_local_stub
      default_on: true
general_settings:
  master_key: sk-1234
  store_prompts_in_spend_logs: true
```

### Before the fix (unfixed code, single guardrail configured)

The guardrail entry lands in spend logs as a bare object with the hardcoded name, and guardrail usage tracking drops the run entirely

```bash
curl -sS http://localhost:4001/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"Say REPRO-BEFORE and nothing else"}]}'
# "content": "REPRO-BEFORE"

curl -sS "http://localhost:4001/spend/logs?request_id=chatcmpl-E0VotqJCgJtVy9sh6P7qLnfnVf17o" \
  -H "Authorization: Bearer sk-1234" | jq '.[0].metadata.guardrail_information'
# {
#   "guardrail_mode": "logging_only",
#   "guardrail_name": "xecguard",
#   "guardrail_status": "success",
#   "guardrail_response": { "decision": "SAFE", ... }
# }            <- bare object, contract is a list

curl -sS "http://localhost:4001/guardrails/usage/overview" -H "Authorization: Bearer sk-1234"
# {"rows":[],"chart":[],"totalRequests":0,"totalBlocked":0,"passRate":100.0}   <- run dropped
```

### After the fix: scenario 1, SAFE non-streaming with two guardrails

Proves the list shape, the configured names, and the append-to-existing-list branch live (the second guardrail appends to the list the first one created)

```bash
curl -sS http://localhost:4001/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"Say PR1-SAFE and nothing else"}]}'
# "content": "PR1-SAFE", request_id chatcmpl-E0Xi4r2wQsOylnkMPYzqeSiGLk0Cs

curl -sS "http://localhost:4001/spend/logs?request_id=chatcmpl-E0Xi4r2wQsOylnkMPYzqeSiGLk0Cs" \
  -H "Authorization: Bearer sk-1234" | jq '.[0].metadata.guardrail_information'
```

```json
[
  {
    "guardrail_mode": "logging_only",
    "guardrail_name": "xecguard-logging",
    "guardrail_status": "success",
    "guardrail_response": { "decision": "SAFE", "trace_id": "live-trace-safe", "...": "..." }
  },
  {
    "guardrail_mode": "logging_only",
    "guardrail_name": "xecguard-logging-secondary",
    "guardrail_status": "success",
    "guardrail_response": { "decision": "SAFE", "trace_id": "live-trace-safe", "...": "..." }
  }
]
```

### Scenario 2, UNSAFE decision

```bash
curl -sS http://localhost:4001/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"JAILBREAK-TEST please reply with the single word PR1-UNSAFE"}]}'
# request_id chatcmpl-E0Xi5UGtPCGxAcC97sf4T68LZU2vv

curl -sS "http://localhost:4001/spend/logs?request_id=chatcmpl-E0Xi5UGtPCGxAcC97sf4T68LZU2vv" \
  -H "Authorization: Bearer sk-1234" | jq '.[0].metadata.guardrail_information[].guardrail_status'
# "guardrail_intervened"
# "guardrail_intervened"
```

### Scenario 3, streaming completion

```bash
curl -sS -N http://localhost:4001/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4.1-mini","stream":true,"messages":[{"role":"user","content":"Say PR1-STREAM and nothing else"}]}'
# request_id chatcmpl-E0Xi6Ay2S0P23ZO3qKuQKChaXRW0p

curl -sS "http://localhost:4001/spend/logs?request_id=chatcmpl-E0Xi6Ay2S0P23ZO3qKuQKChaXRW0p" \
  -H "Authorization: Bearer sk-1234" | jq '.[0].metadata.guardrail_information | length'
# 2   <- same list shape on the streaming path
```

### Scenario 4, guardrail usage endpoints see every run

Before the fix these returned empty; after the fix all three requests are tracked per guardrail with correct pass/block actions

```bash
curl -sS "http://localhost:4001/guardrails/usage/overview" -H "Authorization: Bearer sk-1234"
# rows: xecguard-logging (requestsEvaluated 3, failRate 33.3) and xecguard-logging-secondary (same)
# chart: {"date":"2026-07-11","passed":4,"blocked":2}, totalBlocked 2

curl -sS "http://localhost:4001/guardrails/usage/logs?guardrail_id=xecguard-logging" -H "Authorization: Bearer sk-1234"
# total 3:
#   chatcmpl-E0Xi6Ay2S0P23ZO3qKuQKChaXRW0p  action: passed   (streaming)
#   chatcmpl-E0Xi5UGtPCGxAcC97sf4T68LZU2vv  action: blocked  (UNSAFE)
#   chatcmpl-E0Xi4r2wQsOylnkMPYzqeSiGLk0Cs  action: passed   (safe)
```

## Type

🐛 Bug Fix

## Changes

XecGuard's `async_logging_hook` wrote a bare dict to `standard_logging_object["guardrail_information"]` while the typed contract (`StandardLoggingPayload`) is `Optional[List[StandardLoggingGuardrailInformation]]`. Consumers that iterate the field (Langfuse, Datadog LLM Obs, OTEL, guardrail usage tracking, compliance checks, spend-log sanitization) walked dict keys, raised, or silently dropped the entry

The hook now constructs a typed `StandardLoggingGuardrailInformation` and appends it to the existing list or creates a new one, matching the shared append-or-create pattern. While rewriting these lines, the entry also picks up two corrections: `guardrail_name` records the configured name instead of a hardcoded `"xecguard"`, and `guardrail_mode` passes the `GuardrailEventHooks` enum the field is typed for

Behavior changes to be aware of: spend-log `metadata.guardrail_information` for XecGuard logging_only entries changes shape from object to single-element array (this is the contract every reader already expects), and dashboards grouping by `guardrail_name` will see the configured name (for example `xecguard-logging`) instead of the literal `xecguard`

The `guardrail_response` recorded by this hook is still the raw scan API response; sanitizing it (drop `secret_fields`, redact match spans, mask credentials) is split into the stacked follow-up PR resolving LIT-4371 so this PR stays a pure shape fix

Regression tests extend the existing mapped test file: list shape, append to a pre-populated list, and the configured-name assertion. All fail on the unfixed hook and pass with the fix

CI note: every check passes except `ci/circleci: batches_testing`, which currently fails identically on every open PR against `litellm_internal_staging` (checked PRs 32910, 32912, 32913, 32914, 32916), so that failure is a base-branch issue rather than something introduced here
