### PR TITLE
fix(guardrails): walk reasoning.summary_text and custom_tool_call_output in _content_utils

### DIFF
--- a/litellm/proxy/guardrails/_content_utils.py
+++ b/litellm/proxy/guardrails/_content_utils.py
@@ -146,6 +146,25 @@ def walk_user_text(data: Dict[str, Any], visit: Callable[[str], str]) -> int:
     """
     visited = 0
 
+    def _rewrite_summary(summary: List[Any]) -> List[Any]:
+        nonlocal visited
+        new_parts: List[Any] = []
+        for summary_part in summary:
+            if isinstance(summary_part, str) and summary_part:
+                visited += 1
+                new_parts.append(visit(summary_part))
+            elif (
+                isinstance(summary_part, dict)
+                and summary_part.get("type") in TEXT_PART_TYPES
+                and isinstance(summary_part.get("text"), str)
+                and summary_part["text"]
+            ):
+                visited += 1
+                new_parts.append({**summary_part, "text": visit(summary_part["text"])})
+            else:
+                new_parts.append(summary_part)
+        return new_parts
+
     def _rewrite_content(content: Any) -> Any:
         nonlocal visited
         if isinstance(content, str):
@@ -167,6 +186,10 @@ def walk_user_text(data: Dict[str, Any], visit: Callable[[str], str]) -> int:
                 ):
                     visited += 1
                     new_parts.append({**part, "text": visit(part["text"])})
+                elif (
+                    isinstance(part, dict) and part.get("type") == "reasoning" and isinstance(part.get("summary"), list)
+                ):
+                    new_parts.append({**part, "summary": _rewrite_summary(part["summary"])})
                 else:
                     new_parts.append(part)
             return new_parts

--- a/litellm/proxy/guardrails/_content_utils.py
+++ b/litellm/proxy/guardrails/_content_utils.py
@@ -32,12 +32,23 @@ def is_text_content_call_type(call_type: str) -> bool:
     return call_type in TEXT_CONTENT_CALL_TYPES
 
 
-TEXT_PART_TYPES: FrozenSet[str] = frozenset({"text", "input_text", "output_text"})
+TEXT_PART_TYPES: FrozenSet[str] = frozenset({"text", "input_text", "output_text", "summary_text"})
+
+# Responses-API item types whose ``output`` field carries user/tool text
+# that guardrails should inspect.  ``function_call_output`` is the
+# built-in shape; ``custom_tool_call_output`` is the custom-tool
+# counterpart (see ``ChatCompletionCustomToolCallOutput``).
+_OUTPUT_ITEM_TYPES: FrozenSet[str] = frozenset({"function_call_output", "custom_tool_call_output"})
 
 
 def _iter_text_parts_in_content(content: Any) -> Iterator[str]:
     """Yield text fragments from a ``message.content`` value (string or
-    multimodal list). Non-text parts (images, audio, …) are skipped."""
+    multimodal list). Non-text parts (images, audio, …) are skipped.
+
+    Also descends into ``reasoning`` items whose ``summary`` list may
+    contain ``summary_text`` parts carrying chain-of-thought text that
+    guardrails need to inspect/redact.
+    """
     if isinstance(content, str):
         if content:
             yield content
@@ -55,6 +66,12 @@ def _iter_text_parts_in_content(content: Any) -> Iterator[str]:
                 text = part.get("text")
                 if isinstance(text, str) and text:
                     yield text
+            elif part.get("type") == "reasoning":
+                # Reasoning items carry a ``summary`` list of
+                # ``{"type": "summary_text", "text": "..."}`` parts.
+                summary = part.get("summary")
+                if isinstance(summary, list):
+                    yield from _iter_text_parts_in_content(summary)
 
 
 def _coerce_input_to_messages(input_value: Any) -> List[Dict[str, Any]]:
@@ -72,8 +89,15 @@ def _coerce_input_to_messages(input_value: Any) -> List[Dict[str, Any]]:
                 messages.append({"role": item.get("role") or "user", "content": [item]})
             elif "content" in item:
                 messages.append({"role": item.get("role") or "user", "content": item["content"]})
-            elif item.get("type") == "function_call_output" and "output" in item:
+            elif item.get("type") in _OUTPUT_ITEM_TYPES and "output" in item:
                 messages.append({"role": item.get("role") or "tool", "content": item["output"]})
+            elif item.get("type") == "reasoning":
+                # Reasoning items carry chain-of-thought text in their
+                # ``summary`` list.  Synthesise a message so guardrails
+                # can inspect/redact that text.
+                summary = item.get("summary")
+                if isinstance(summary, list):
+                    messages.append({"role": "assistant", "content": summary})
     return messages
 
 
@@ -157,8 +181,12 @@ def walk_user_text(data: Dict[str, Any], visit: Callable[[str], str]) -> int:
                         input_value[idx] = {**item, "text": visit(item["text"])}
                 elif "content" in item:
                     item["content"] = _rewrite_content(item["content"])
-                elif item.get("type") == "function_call_output" and "output" in item:
+                elif item.get("type") in _OUTPUT_ITEM_TYPES and "output" in item:
                     item["output"] = _rewrite_content(item["output"])
+                elif item.get("type") == "reasoning":
+                    summary = item.get("summary")
+                    if isinstance(summary, list):
+                        item["summary"] = _rewrite_content(summary)
         return visited
 
     return visited

--- a/litellm/proxy/guardrails/_content_utils.py
+++ b/litellm/proxy/guardrails/_content_utils.py
@@ -41,6 +41,24 @@ TEXT_PART_TYPES: FrozenSet[str] = frozenset({"text", "input_text", "output_text"
 _OUTPUT_ITEM_TYPES: FrozenSet[str] = frozenset({"function_call_output", "custom_tool_call_output"})
 
 
+def _iter_summary_texts(summary: Any) -> Iterator[str]:
+    """Yield text fragments from a ``reasoning`` item's ``summary`` list —
+    ``summary_text`` parts and bare strings; anything else is skipped."""
+    if not isinstance(summary, list):
+        return
+    for summary_part in summary:
+        if isinstance(summary_part, str):
+            if summary_part:
+                yield summary_part
+            continue
+        if not isinstance(summary_part, dict):
+            continue
+        if summary_part.get("type") in TEXT_PART_TYPES:
+            summary_text = summary_part.get("text")
+            if isinstance(summary_text, str) and summary_text:
+                yield summary_text
+
+
 def _iter_text_parts_in_content(content: Any) -> Iterator[str]:
     """Yield text fragments from a ``message.content`` value (string or
     multimodal list). Non-text parts (images, audio, …) are skipped.
@@ -69,9 +87,7 @@ def _iter_text_parts_in_content(content: Any) -> Iterator[str]:
             elif part.get("type") == "reasoning":
                 # Reasoning items carry a ``summary`` list of
                 # ``{"type": "summary_text", "text": "..."}`` parts.
-                summary = part.get("summary")
-                if isinstance(summary, list):
-                    yield from _iter_text_parts_in_content(summary)
+                yield from _iter_summary_texts(part.get("summary"))
 
 
 def _coerce_input_to_messages(input_value: Any) -> List[Dict[str, Any]]:

--- a/tests/test_litellm/proxy/guardrails/test_content_utils.py
+++ b/tests/test_litellm/proxy/guardrails/test_content_utils.py
@@ -544,6 +544,31 @@ def test_iter_message_text_walks_reasoning_summary_text():
     assert "secret-in-cot" in texts
 
 
+def test_iter_message_text_reasoning_part_inside_message_content():
+    """A reasoning item nested inside a message's content list is walked
+    directly by ``_iter_text_parts_in_content``: summary_text parts and bare
+    strings in the summary yield their text, everything else is skipped."""
+    data = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "reasoning",
+                        "summary": [
+                            {"type": "summary_text", "text": "cot-secret"},
+                            "bare-summary-string",
+                            {"type": "image_url", "image_url": {"url": "..."}},
+                            42,
+                        ],
+                    },
+                ],
+            },
+        ]
+    }
+    assert list(iter_message_text(data)) == ["cot-secret", "bare-summary-string"]
+
+
 def test_walk_user_text_redacts_reasoning_summary_text():
     """walk_user_text should rewrite text inside reasoning.summary."""
     data = {

--- a/tests/test_litellm/proxy/guardrails/test_content_utils.py
+++ b/tests/test_litellm/proxy/guardrails/test_content_utils.py
@@ -583,6 +583,35 @@ def test_walk_user_text_redacts_reasoning_summary_text():
     assert data["input"][0]["summary"][0]["text"] == "[REDACTED]"
 
 
+def test_walk_user_text_redacts_reasoning_part_inside_message_content():
+    """Greptile P1: a reasoning item nested inside ``messages[i]["content"]``
+    was detected by ``iter_message_text`` but copied through unchanged by
+    ``walk_user_text``; read and write coverage must agree."""
+    data = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "reasoning",
+                        "summary": [
+                            {"type": "summary_text", "text": "SSN-123 in cot"},
+                            "bare SSN-123",
+                            {"type": "image_url", "image_url": {"url": "..."}},
+                        ],
+                    },
+                ],
+            },
+        ]
+    }
+    count = walk_user_text(data, lambda t: t.replace("SSN-123", "[REDACTED]"))
+    assert count == 2
+    summary = data["messages"][0]["content"][0]["summary"]
+    assert summary[0] == {"type": "summary_text", "text": "[REDACTED] in cot"}
+    assert summary[1] == "bare [REDACTED]"
+    assert summary[2] == {"type": "image_url", "image_url": {"url": "..."}}
+
+
 def test_build_inspection_messages_reasoning_summary():
     """build_inspection_messages should include reasoning summary text."""
     data = {

--- a/tests/test_litellm/proxy/guardrails/test_content_utils.py
+++ b/tests/test_litellm/proxy/guardrails/test_content_utils.py
@@ -524,3 +524,87 @@ def test_apply_redacted_messages_back_skips_input_when_not_string():
     data = {"input": [{"type": "text", "text": "leak"}]}
     apply_redacted_messages_back(data, [{"role": "user", "content": "[REDACTED]"}])
     assert data["input"] == [{"type": "text", "text": "leak"}]
+
+
+# -------------------------------------------------------------------
+# LIT-4303: reasoning.summary_text walking
+# -------------------------------------------------------------------
+
+def test_iter_message_text_walks_reasoning_summary_text():
+    """Reasoning items with summary_text parts should yield their text."""
+    data = {
+        "input": [
+            {"type": "reasoning", "summary": [
+                {"type": "summary_text", "text": "secret-in-cot"},
+            ]},
+        ]
+    }
+    from litellm.proxy.guardrails._content_utils import iter_message_text
+    texts = list(iter_message_text(data))
+    assert "secret-in-cot" in texts
+
+
+def test_walk_user_text_redacts_reasoning_summary_text():
+    """walk_user_text should rewrite text inside reasoning.summary."""
+    data = {
+        "input": [
+            {"type": "reasoning", "summary": [
+                {"type": "summary_text", "text": "SSN-123"},
+            ]},
+        ]
+    }
+    count = walk_user_text(data, lambda t: t.replace("SSN-123", "[REDACTED]"))
+    assert count >= 1
+    assert data["input"][0]["summary"][0]["text"] == "[REDACTED]"
+
+
+def test_build_inspection_messages_reasoning_summary():
+    """build_inspection_messages should include reasoning summary text."""
+    data = {
+        "input": [
+            {"type": "reasoning", "summary": [
+                {"type": "summary_text", "text": "chain-of-thought leak"},
+            ]},
+        ]
+    }
+    msgs = build_inspection_messages(data)
+    assert any("chain-of-thought leak" in m["content"] for m in msgs)
+
+
+# -------------------------------------------------------------------
+# LIT-4302: custom_tool_call_output walking
+# -------------------------------------------------------------------
+
+def test_iter_message_text_walks_custom_tool_call_output():
+    """custom_tool_call_output items should yield their output text."""
+    data = {
+        "input": [
+            {"type": "custom_tool_call_output", "output": "tool-secret"},
+        ]
+    }
+    from litellm.proxy.guardrails._content_utils import iter_message_text
+    texts = list(iter_message_text(data))
+    assert "tool-secret" in texts
+
+
+def test_walk_user_text_redacts_custom_tool_call_output():
+    """walk_user_text should rewrite text inside custom_tool_call_output."""
+    data = {
+        "input": [
+            {"type": "custom_tool_call_output", "output": "PII-data"},
+        ]
+    }
+    count = walk_user_text(data, lambda t: t.replace("PII-data", "[MASKED]"))
+    assert count >= 1
+    assert data["input"][0]["output"] == "[MASKED]"
+
+
+def test_build_inspection_messages_custom_tool_call_output():
+    """build_inspection_messages should include custom_tool_call_output text."""
+    data = {
+        "input": [
+            {"type": "custom_tool_call_output", "output": "custom-tool-leak"},
+        ]
+    }
+    msgs = build_inspection_messages(data)
+    assert any("custom-tool-leak" in m["content"] for m in msgs)


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4303
Resolves LIT-4302

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live proxy e2e against the real OpenAI API, no mocks. Proxy launched with the `hide-secrets` guardrail (which redacts via the shared `walk_user_text` this PR extends) in `pre_call` mode, `default_on: true`:

```bash
python litellm/proxy/proxy_cli.py --config e2e_config.yaml --port 4000 --detailed_debug
```

```yaml
model_list:
  - model_name: gpt-5.6
    litellm_params:
      model: openai/gpt-5.6
      api_key: os.environ/OPENAI_API_KEY

guardrails:
  - guardrail_name: hide-secrets
    litellm_params:
      guardrail: hide-secrets
      mode: pre_call
      default_on: true
```

LIT-4302, `custom_tool_call_output`: replay a custom tool round-trip whose output carries a fake AWS key, and ask the model to echo the tool output verbatim

```bash
curl -s http://localhost:4000/v1/responses \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' -d '{
  "model": "gpt-5.6",
  "input": [
    {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "The read_config tool returned one line of an ini file. Repeat that line back exactly as you received it, then stop."}]},
    {"type": "custom_tool_call", "call_id": "call_e2e43", "name": "read_config", "input": "{}"},
    {"type": "custom_tool_call_output", "call_id": "call_e2e43", "output": "aws_access_key_id = AKIAIOSFODNN7EXAMPLE"}
  ],
  "tools": [{"type": "custom", "name": "read_config", "description": "Reads one line from the app ini config"}]
}'
```

The model answered with the redacted text, which is what the guardrail rewrote before the request left the proxy:

```
MODEL SAID: aws_access_key_id = [REDACTED]
```

Before this PR the same request reaches OpenAI with the raw key because `custom_tool_call_output` items fell through every branch of `walk_user_text`

LIT-4303, `reasoning.summary_text`: replay an agent-synthesized reasoning item (ADK-bridge style) whose summary carries the same fake key

```bash
curl -s http://localhost:4000/v1/responses \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' -d '{
  "model": "gpt-5.6",
  "store": false,
  "input": [
    {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "What did you find in the config?"}]},
    {"type": "reasoning", "summary": [{"type": "summary_text", "text": "I inspected the config and found aws_access_key_id AKIAIOSFODNN7EXAMPLE. I will reuse it for the next call."}]},
    {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "I found the aws_access_key_id in the config."}]},
    {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Repeat your reasoning summary from the previous turn word for word, then stop."}]}
  ]
}'
```

OpenAI accepts the request (HTTP 200, `status: completed`); replayed summaries are not assistant-visible text so the redaction proof is the outgoing payload in the proxy's detailed debug log:

```
$ grep -c AKIAIOSFODNN7EXAMPLE litellm_e2e.log
0
$ grep -o "I inspected the config and found aws_access_key_id [^.]*\." litellm_e2e.log | sort | uniq -c
  16 I inspected the config and found aws_access_key_id [REDACTED].
$ grep "redacted secrets" litellm_e2e.log | tail -1
11:29:38 - LiteLLM Proxy:WARNING: secret_detection.py:484 - Detected and redacted secrets in message: ['AWS Access Key']
```

The raw key appears zero times in the entire debug log, which includes the full request payload sent to OpenAI; every occurrence of the summary sentence in the outgoing payload reads `[REDACTED]`

Full guardrails unit suite: `tests/test_litellm/proxy/guardrails/` passes, 2272 tests, including the 8 regression tests added here

## Type

🐛 Bug Fix

## Changes

LIT-4303: agents replaying Responses API output emit `reasoning` items with `summary_text` parts. Guardrails silently skipped these, leaving chain-of-thought PII and secrets unredacted.

LIT-4302: `custom_tool_call_output` items (the custom-tool counterpart of `function_call_output`) were also silently bypassed.

- Add `summary_text` to `TEXT_PART_TYPES`
- `_iter_text_parts_in_content` descends into `reasoning.summary` via a new `_iter_summary_texts` helper; the walk is iterative because the code-quality gate bans new recursive functions
- `_coerce_input_to_messages` synthesizes messages for both new types
- `walk_user_text` rewrites text inside both new types, including reasoning items nested inside a `messages[i]["content"]` list (`_rewrite_summary`), so read and write coverage agree
- New `_OUTPUT_ITEM_TYPES` frozenset for `function_call_output` and `custom_tool_call_output`
