### PR TITLE
refactor(ui): use TanStack Pacer debounce for the team keys search

### DIFF
--- a/ui/litellm-dashboard/src/components/team/TeamVirtualKeysTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamVirtualKeysTable.test.tsx
@@ -24,6 +24,11 @@ vi.mock("../templates/key_info_view", () => ({
   )),
 }));
 
+// Resolve the debounced search synchronously so typed input lands in the useKeys query within the test tick.
+vi.mock("@tanstack/react-pacer/debouncer", () => ({
+  useDebouncedValue: (value: unknown) => [value, { cancel: vi.fn(), flush: vi.fn() }],
+}));
+
 const mockUseKeys = useKeys as MockedFunction<typeof useKeys>;
 
 const createMockKey = (overrides: Partial<KeyResponse> = {}): KeyResponse =>
@@ -286,10 +291,8 @@ describe("TeamVirtualKeysTable", () => {
 
     await user.type(await screen.findByTestId("datatable-search"), "check-002");
 
-    await waitFor(
-      () =>
-        expect(mockUseKeys).toHaveBeenLastCalledWith(1, 50, expect.objectContaining({ selectedKeyAlias: "check-002" })),
-      { timeout: 2000 },
+    await waitFor(() =>
+      expect(mockUseKeys).toHaveBeenLastCalledWith(1, 50, expect.objectContaining({ selectedKeyAlias: "check-002" })),
     );
   });
 

--- a/ui/litellm-dashboard/src/components/team/TeamVirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamVirtualKeysTable.tsx
@@ -10,10 +10,10 @@ import {
 } from "@/components/shared/DataTable";
 import { Input } from "@/components/ui/input";
 import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/outline";
+import { useDebouncedValue } from "@tanstack/react-pacer/debouncer";
 import { ColumnDef, ColumnFiltersState, OnChangeFn, PaginationState, SortingState } from "@tanstack/react-table";
 import { Badge, Icon, Text } from "@tremor/react";
 import { Popover, Tooltip, Typography } from "antd";
-import debounce from "lodash/debounce";
 import DefaultProxyAdminTag from "../common_components/DefaultProxyAdminTag";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { getModelDisplayName } from "../key_team_helpers/fetch_available_models_team_key";
@@ -43,24 +43,12 @@ export function TeamVirtualKeysTable({ teamId, teamAlias, organization }: TeamVi
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [searchInput, setSearchInput] = useState("");
-  const [searchQuery, setSearchQuery] = useState("");
+  const [searchQuery] = useDebouncedValue(searchInput, { wait: 300 });
 
-  const debouncedSetSearch = useMemo(
-    () =>
-      debounce((value: string) => {
-        setSearchQuery(value);
-        setTablePagination((prev) => ({ ...prev, pageIndex: 0 }));
-      }, 300),
-    [],
-  );
-  useEffect(() => () => debouncedSetSearch.cancel(), [debouncedSetSearch]);
-  const handleSearchChange = useCallback(
-    (value: string) => {
-      setSearchInput(value);
-      debouncedSetSearch(value);
-    },
-    [debouncedSetSearch],
-  );
+  const handleSearchChange = useCallback((value: string) => {
+    setSearchInput(value);
+    setTablePagination((prev) => ({ ...prev, pageIndex: 0 }));
+  }, []);
 
   const getFilterValue = useCallback(
     (columnId: string): string | undefined => {


### PR DESCRIPTION
## Relevant issues

Follow-up to review feedback on #32856: use the TanStack Pacer dependency we already ship instead of `lodash/debounce`

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a behavior-preserving refactor, so there is no visual change; the key-alias search still debounces to the same server query. To confirm the debounce still works through Pacer:

1. Start the proxy (`python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload`) and the UI dev server (`npm run dev` in `ui/litellm-dashboard`)
2. Open a team that has several keys, e.g. http://localhost:3000 then Teams -> pick a team -> Virtual Keys tab
3. Open the browser DevTools Network panel and filter to `key/list`
4. Type a partial alias into the "Search by key alias…" box
5. Confirm a single `GET /key/list?...&key_alias=<text>` fires roughly 300ms after you stop typing rather than one request per keystroke, and the table narrows to matching keys

## Type

🧹 Refactoring

## Changes

`TeamVirtualKeysTable` was the only key table still debouncing its search with `lodash/debounce`; the sibling `VirtualKeysTable` and `PaginatedKeyAliasSelect` already use `useDebouncedValue` from `@tanstack/react-pacer`, which is an existing dependency. This swaps the hand-wired `useMemo(debounce(...))` plus its cleanup effect for the same `useDebouncedValue(searchInput, { wait: 300 })` idiom, so the search-debounce pattern is consistent across the key tables and there is one fewer lodash entry point

Page reset on a new search now happens on the input change (like `VirtualKeysTable.handleFilterChange`) rather than inside the debounced callback, which is equivalent from the user's point of view since the debounced value only gates the query

The existing "maps the search box to a server-side key-alias query" regression test still covers the behavior; it now mocks `@tanstack/react-pacer/debouncer` to resolve synchronously, mirroring `VirtualKeysTable.test.tsx`
