### PR TITLE
feat(ui): extend topnav border across the sidebar header

### DIFF
--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -574,7 +574,7 @@ const Sidebar_: React.FC<SidebarProps> = ({
 
   return (
     <Sidebar collapsed={collapsed}>
-      <SidebarHeader>
+      <SidebarHeader className="h-14 border-b border-border group-data-[collapsed=true]/sidebar:h-auto">
         <div className="flex items-center justify-between gap-2 group-data-[collapsed=true]/sidebar:flex-col">
           <div className="flex min-w-0 items-center gap-2">
             <Link href={baseUrl || "/"} className="flex min-w-0 items-center" aria-label="LiteLLM home">


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

UI-only change; open the AI Gateway dashboard and look at the sidebar header (the logo and version row). Its bottom border now sits at the same 56px height as the dashboard top bar to its right, so the two line up and read as one continuous rule across the top, as if the top bar's bottom edge extends left across the sidebar. Collapsing the sidebar keeps the border while the header grows to fit the stacked logo and toggle

Before/after screenshots to follow

## Type

🆕 New Feature

## Changes

Pins the sidebar header to the same 56px height as the dashboard top bar and gives it a matching bottom border. Before this the header had no border and used its natural content height, so there was nothing tying the sidebar to the top bar; now both borders align into a single continuous line. When the rail is collapsed the header reverts to automatic height so the vertically stacked logo and toggle are not clipped, which mirrors the collapsed design

No test is included because this is a single styling class with no logic to exercise; a test asserting the class string would give no real signal

new: 
<img width="318" height="87" alt="image" src="https://github.com/user-attachments/assets/1e4a3b84-1fbd-423d-8ca2-5bc7ed1cfe2e" />

old:
<img width="401" height="93" alt="image" src="https://github.com/user-attachments/assets/ad82076b-e535-4d9c-a9c6-b6c07fbe67de" />
