### PR TITLE
fix(mcp): strip scheme default port from get_request_base_url netloc

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/oauth_utils.py
+++ b/litellm/proxy/_experimental/mcp_server/oauth_utils.py
@@ -129,7 +129,7 @@ def get_request_base_url(request: Request) -> str:
         if x_forwarded_port and ":" not in netloc:
             netloc = f"{netloc}:{x_forwarded_port}"
 
-    return urlunparse((scheme, netloc, parsed.path, "", "", ""))
+    return urlunparse((scheme, _strip_default_port(scheme, netloc), parsed.path, "", "", ""))
 
 
 def validate_loopback_redirect_uri(redirect_uri: str) -> None:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -1848,6 +1848,41 @@ async def test_token_endpoint_respects_x_forwarded_host():
             None,
             "https://external.com",
         ),
+        (
+            "http://localhost:4000/",
+            "https",
+            "proxy.example.com",
+            "443",
+            "https://proxy.example.com",
+        ),
+        (
+            "http://localhost:4000/",
+            "http",
+            "proxy.example.com",
+            "80",
+            "http://proxy.example.com",
+        ),
+        (
+            "http://internal.local/",
+            "https",
+            None,
+            "443",
+            "https://internal.local",
+        ),
+        (
+            "http://localhost:4000/",
+            "https",
+            "proxy.example.com",
+            "8443",
+            "https://proxy.example.com:8443",
+        ),
+        (
+            "http://localhost:4000/",
+            "https",
+            "proxy.example.com:443",
+            None,
+            "https://proxy.example.com",
+        ),
     ],
 )
 def test_get_request_base_url_comprehensive(


### PR DESCRIPTION
## Relevant issues

Supersedes #31771

## Linear ticket

Resolves LIT-4126

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

CI note: 126 checks pass; the single red job is `ci/circleci: batches_testing`, which currently fails identically on every open PR against `litellm_internal_staging` (checked 8 open PRs), so it is unrelated to this change

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Rig: local proxy on port 4126 with `general_settings.use_x_forwarded_for: true` and `mcp_trusted_proxy_ranges: ["127.0.0.0/8"]`, one `oauth2` / `authorization_code` MCP server whose `authorization_url` / `token_url` / `registration_url` point at a stub IdP on `127.0.0.1:9310`, `PROXY_BASE_URL` unset so the header reconstruction path is exercised. The load balancer is simulated by sending `X-Forwarded-Proto: https`, `X-Forwarded-Host: litellm.example.com`, `X-Forwarded-Port: 443` from a trusted range; ingresses set that port header on every TLS request, which is exactly the customer topology that breaks

Before, on this branch's base (`litellm_internal_staging` 80c5217ddc), the port leaks into every emitted URL:

```
$ curl -s http://localhost:4126/.well-known/oauth-authorization-server \
    -H "X-Forwarded-Proto: https" -H "X-Forwarded-Host: litellm.example.com" -H "X-Forwarded-Port: 443" \
    | python3 -m json.tool | head -5
{
    "issuer": "https://litellm.example.com:443",
    "authorization_endpoint": "https://litellm.example.com:443/v1/mcp/oauth/authorize",
    "token_endpoint": "https://litellm.example.com:443/v1/mcp/oauth/token",

$ curl -s -D - -o /dev/null "http://localhost:4126/stubidp/authorize?client_id=stub-client&redirect_uri=http://127.0.0.1:6274/callback&state=xyz&response_type=code&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256" \
    -H "X-Forwarded-Proto: https" -H "X-Forwarded-Host: litellm.example.com" -H "X-Forwarded-Port: 443" | grep -i ^location
location: http://127.0.0.1:9310/authorize?client_id=stub-client&redirect_uri=https%3A%2F%2Flitellm.example.com%3A443%2Fcallback&state=lCQVxUntM1Y_4Ay6d-NYFjBjNnxdkI54YtwpnCfUylk&response_type=code&scope=openid+mcp&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256

$ curl -s -X POST http://localhost:4126/stubidp/register -H "Content-Type: application/json" \
    -H "X-Forwarded-Proto: https" -H "X-Forwarded-Host: litellm.example.com" -H "X-Forwarded-Port: 443" \
    -d '{"redirect_uris":["http://127.0.0.1:6274/callback"],"client_name":"test-client"}' | python3 -m json.tool | grep -A2 redirect_uris
    "redirect_uris": [
        "https://litellm.example.com:443/callback"
    ]
```

The second command is the customer visible failure: the `redirect_uri` handed to the upstream IdP is `https://litellm.example.com:443/callback`, and providers that store the registered URI canonically and compare per RFC 6749 3.1.2.3 simple string comparison reject the flow with an invalid client or mismatched redirect_uri error

After, with this PR's commit, the same curls emit canonical URLs:

```
issuer                "https://litellm.example.com"
authorize Location    ...redirect_uri=https%3A%2F%2Flitellm.example.com%2Fcallback&...
DCR redirect_uris     ["https://litellm.example.com/callback"]
```

Edge cases on the fixed proxy: `X-Forwarded-Port: 8443` stays `https://litellm.example.com:8443`; `X-Forwarded-Proto: http` with port 80 becomes `http://litellm.example.com`; a port embedded directly in `X-Forwarded-Host: litellm.example.com:443` is also stripped; with no forwarding headers the local base `http://localhost:4126` is returned unchanged

## Type

Bug Fix

## Changes

`get_request_base_url` in `oauth_utils.py` rebuilds the public base URL from `X-Forwarded-*` headers sent by a trusted load balancer and appends `X-Forwarded-Port` to the netloc without eliding the scheme default port, so `X-Forwarded-Port: 443` (which ingresses send routinely) yields `https://host:443`. RFC 3986 6.2.3 treats an explicit default port as equivalent to none, and producers should omit it per 3.2.3. The module already has `_strip_default_port` and already applies it on the comparison side (`validate_trusted_redirect_uri` normalizes both netlocs before the same origin check), so validation tolerated `:443` while emission leaked it; this change applies the same helper to the returned netloc, making emission consistent with validation. Every emitter funnels through this function (authorize `redirect_uri`, token exchange `redirect_uri`, DCR `redirect_uris`, protected resource and authorization server metadata, WWW-Authenticate challenge URLs, the MCP registry), so the single call site covers them all

Five cases added to `test_get_request_base_url_comprehensive`: `:443` with `X-Forwarded-Host` stripped, `:80` with http stripped, `:443` on a portless base without `X-Forwarded-Host` stripped, non default `:8443` preserved, and `:443` embedded directly in `X-Forwarded-Host` stripped. On the unfixed base the four stripping cases fail and the preservation case passes; with the fix the full mapped file is 135 passed

Supersedes #31771, which contains the same one line fix; reopened here to land it under an internal branch with the live proof of fix attached and one extra regression case (`X-Forwarded-Host` carrying the port itself). Operators who cannot upgrade can set `PROXY_BASE_URL` to their canonical origin as a workaround; it takes priority over header reconstruction
