### PR TITLE
test: remove live OpenAI fine-tuning job-creation test blocked by platform wind-down

### DIFF
--- a/tests/batches_tests/test_fine_tuning_api.py
+++ b/tests/batches_tests/test_fine_tuning_api.py
@@ -13,13 +13,10 @@ import litellm
 
 litellm.num_retries = 0
 import asyncio
-import logging
 from typing import Optional
-import openai
 from test_openai_batches_and_files import load_vertex_ai_credentials
 
 from litellm import create_fine_tuning_job
-from litellm._logging import verbose_logger
 from litellm.llms.vertex_ai.fine_tuning.handler import (
     FineTuningJobCreate,
     VertexFineTuningAPI,
@@ -45,115 +42,6 @@ class TestCustomLogger(CustomLogger):
             response_obj,
         )
         self.standard_logging_object = kwargs["standard_logging_object"]
-
-
-async def _acreate_fine_tuning_job_with_propagation_retry(
-    *, max_attempts: int = 12, initial_delay: float = 1.0, **kwargs
-):
-    """
-    Wrap litellm.acreate_fine_tuning_job and retry on the eventual-consistency
-    400 OpenAI returns when a freshly-uploaded training file isn't yet visible
-    to the fine-tuning endpoint (`'file-... does not exist'`).
-
-    Polling the files-retrieve endpoint or `FileObject.status` doesn't help —
-    OpenAI's `status` field is deprecated, and the retrieve and fine-tuning
-    endpoints don't share a consistency model. Retrying the operation itself
-    is the only reliable signal that propagation has finished.
-
-    Total budget with defaults: ~70s across 12 attempts (exp backoff capped at
-    8s).
-    """
-    delay = initial_delay
-    last_error: Optional[openai.BadRequestError] = None
-    for _ in range(max_attempts):
-        try:
-            return await litellm.acreate_fine_tuning_job(**kwargs)
-        except openai.BadRequestError as e:
-            if "does not exist" not in str(e):
-                raise
-            last_error = e
-        await asyncio.sleep(delay)
-        delay = min(delay * 1.5, 8.0)
-    assert last_error is not None
-    raise last_error
-
-
-@pytest.mark.asyncio
-async def test_create_fine_tune_jobs_async():
-    try:
-        custom_logger = TestCustomLogger()
-        litellm.callbacks = ["datadog", custom_logger]
-        verbose_logger.setLevel(logging.DEBUG)
-        file_name = "openai_batch_completions.jsonl"
-        _current_dir = os.path.dirname(os.path.abspath(__file__))
-        file_path = os.path.join(_current_dir, file_name)
-
-        file_obj = await litellm.acreate_file(
-            file=open(file_path, "rb"),
-            purpose="fine-tune",
-            custom_llm_provider="openai",
-        )
-        print("Response from creating file=", file_obj)
-
-        create_fine_tuning_response = (
-            await _acreate_fine_tuning_job_with_propagation_retry(
-                model="gpt-4o-mini-2024-07-18",
-                training_file=file_obj.id,
-            )
-        )
-
-        print(
-            "response from litellm.create_fine_tuning_job=", create_fine_tuning_response
-        )
-
-        assert create_fine_tuning_response.id is not None
-        assert create_fine_tuning_response.model == "gpt-4o-mini-2024-07-18"
-
-        await asyncio.sleep(2)
-        _logged_standard_logging_object = custom_logger.standard_logging_object
-        assert _logged_standard_logging_object is not None
-        print(
-            "custom_logger.standard_logging_object=",
-            json.dumps(_logged_standard_logging_object, indent=4),
-        )
-        assert _logged_standard_logging_object["model"] == "gpt-4o-mini-2024-07-18"
-        assert _logged_standard_logging_object["id"] == create_fine_tuning_response.id
-
-        # list fine tuning jobs
-        print("listing ft jobs")
-        ft_jobs = await litellm.alist_fine_tuning_jobs(limit=2)
-        print("response from litellm.list_fine_tuning_jobs=", ft_jobs)
-        assert len(list(ft_jobs)) > 0
-
-        # retrieve fine tuning job
-        response = await litellm.aretrieve_fine_tuning_job(
-            fine_tuning_job_id=create_fine_tuning_response.id,
-        )
-        print("response from litellm.retrieve_fine_tuning_job=", response)
-
-        # delete file
-
-        await litellm.afile_delete(
-            file_id=file_obj.id,
-        )
-
-        # cancel ft job
-        response = await litellm.acancel_fine_tuning_job(
-            fine_tuning_job_id=create_fine_tuning_response.id,
-        )
-
-        print("response from litellm.cancel_fine_tuning_job=", response)
-
-        assert response.status == "cancelled"
-        assert response.id == create_fine_tuning_response.id
-    except openai.RateLimitError:
-        pass
-    except Exception as e:
-        if "Job has already completed" in str(e):
-            return
-        else:
-            pytest.fail(f"Error occurred: {e}")
-    pass
 
 
 @pytest.mark.asyncio()
@@ -455,6 +343,9 @@ async def test_mock_openai_create_fine_tune_job():
     from openai import AsyncOpenAI
     from openai.types.fine_tuning.fine_tuning_job import FineTuningJob, Hyperparameters
 
+    custom_logger = TestCustomLogger()
+    previous_callbacks = litellm.callbacks
+    litellm.callbacks = [custom_logger]
     client = AsyncOpenAI(api_key="fake-api-key")
 
     with patch.object(client.fine_tuning.jobs, "create") as mock_create:
@@ -499,6 +390,19 @@ async def test_mock_openai_create_fine_tune_job():
             response.fine_tuned_model
             == "ft:gpt-4o-mini-2024-07-18:org:custom_suffix:id"
         )
+
+    try:
+        for _ in range(20):
+            if custom_logger.standard_logging_object is not None:
+                break
+            await asyncio.sleep(0.25)
+        logged = custom_logger.standard_logging_object
+        assert logged is not None
+        assert logged["model"] == "gpt-4o-mini-2024-07-18"
+        assert logged["id"] == response.id
+        assert logged["call_type"] == "acreate_fine_tuning_job"
+    finally:
+        litellm.callbacks = previous_callbacks
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before (base `f604034c17`, where the live test still exists): `batches_testing` fails on every run since 2026-07-11 with an OpenAI-side error on fine-tuning job creation, and rerunning never clears it ([run 1](https://circleci.com/gh/BerriAI/litellm/2057303), [rerun 2](https://circleci.com/gh/BerriAI/litellm/2057677), [rerun 3](https://circleci.com/gh/BerriAI/litellm/2058307), all `FAILED tests/batches_tests/test_fine_tuning_api.py::test_create_fine_tune_jobs_async ... Error code: 500 ... server_error`). Every `batches_testing` run before 2026-07-11 17:18 UTC passed, so this is the platform change landing, not a flake

Root cause, reproduced directly against OpenAI with no litellm in the path (same file and model the test uses):

```
$ FILE_ID=$(curl -s https://api.openai.com/v1/files -H "Authorization: Bearer $OPENAI_API_KEY" \
    -F purpose=fine-tune -F file=@tests/batches_tests/openai_batch_completions.jsonl | jq -r .id)
$ curl -s -w '\nHTTP %{http_code}\n' https://api.openai.com/v1/fine_tuning/jobs \
    -H "Authorization: Bearer $OPENAI_API_KEY" -H 'Content-Type: application/json' \
    -d "{\"training_file\": \"$FILE_ID\", \"model\": \"gpt-4o-mini-2024-07-18\"}"
{
  "error": {
    "message": "OpenAI is winding down the fine-tuning platform and your organization is no longer able to create new fine-tuning training jobs. Learn more https://developers.openai.com/api/docs/deprecations#update-to-openais-self-serve-fine-tuning",
    "type": "invalid_request_error",
    "param": null,
    "code": "training_not_available"
  }
}
HTTP 403
```

Per that deprecations page, organizations without fine-tuned-model inference in the past 60 days lost fine-tuning job creation on July 2, 2026, and all remaining organizations lose it on January 6, 2027, so this capability is not coming back for CI

After (`a67b3ca348`): the proof is this PR's own `batches_testing` check going green, with the remaining 10 tests in the file passing

## Type

✅ Test

## Changes

`test_create_fine_tune_jobs_async` was the one test that created a real OpenAI fine-tuning job, and OpenAI has permanently revoked that capability for the org (403 `training_not_available`, surfaced as a 500 through the SDK path CI uses), so it now fails every `batches_testing` run on every PR. Since the block is permanent, this deletes the test instead of skipping it

The request contract it exercised stays covered by the existing mocked tests in the same file (`test_mock_openai_create_fine_tune_job`, `test_mock_openai_list_fine_tune_jobs`, `test_mock_openai_cancel_fine_tune_job`, `test_mock_openai_retrieve_fine_tune_job`). Its one unique assertion, that a success callback receives a `standard_logging_object` with the right `model` and `id`, is folded into `test_mock_openai_create_fine_tune_job`, which now registers a callback logger, polls for the logged payload, and asserts `model`, `id`, and `call_type`. The `_acreate_fine_tuning_job_with_propagation_retry` helper and the imports only the deleted test used are removed with it

