### PR TITLE
fix(datadog): harden LLM Obs re-queue path

### DIFF
--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -148,7 +148,7 @@ class DataDogLLMObsLogger(CustomBatchLogger):
             self.log_queue.append(payload)
 
             if len(self.log_queue) >= self.batch_size:
-                await self.async_send_batch()
+                await self.flush_queue()
         except Exception as e:
             verbose_logger.exception(f"DataDogLLMObs: Error logging success event - {str(e)}")
 
@@ -160,7 +160,7 @@ class DataDogLLMObsLogger(CustomBatchLogger):
             self.log_queue.append(payload)
 
             if len(self.log_queue) >= self.batch_size:
-                await self.async_send_batch()
+                await self.flush_queue()
         except Exception as e:
             verbose_logger.exception(f"DataDogLLMObs: Error logging failure event - {str(e)}")
 
@@ -186,6 +186,14 @@ class DataDogLLMObsLogger(CustomBatchLogger):
             undelivered = await self._send_with_413_split(batch_to_send)
             if undelivered:
                 self.log_queue = undelivered + self.log_queue
+                overflow = len(self.log_queue) - self.max_queue_size
+                if overflow > 0:
+                    del self.log_queue[:overflow]
+                    verbose_logger.warning(
+                        "DataDogLLMObs: log queue exceeded max_queue_size=%s; dropped %s oldest spans",
+                        self.max_queue_size,
+                        overflow,
+                    )
 
             if self.is_mock_mode:
                 verbose_logger.debug(f"[DATADOG MOCK] Batch of {len(batch_to_send)} events successfully mocked")
@@ -253,7 +261,7 @@ class DataDogLLMObsLogger(CustomBatchLogger):
                 pending.append(chunk[:mid])
                 continue
 
-            if response.status_code != 202:
+            if response.status_code >= 300:
                 verbose_logger.error(
                     "DataDogLLMObs: unexpected response status_code=%s, text=%s",
                     response.status_code,

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
@@ -1427,3 +1427,76 @@ class TestDataDogLLMObsBatchSplit:
 
         assert delivered == ["0", "1"]
         assert [s["span_id"] for s in logger.log_queue] == ["2", "3"]
+
+    @pytest.mark.asyncio
+    async def test_requeue_drops_oldest_beyond_max_queue_size(self):
+        """Re-queued spans must respect max_queue_size, dropping oldest first."""
+        logger = self._make_logger()
+        logger.max_queue_size = 2
+        logger.log_queue = [self._make_span(span_id=str(i)) for i in range(3)]
+
+        async def _mock_post_spans(spans):
+            raise Exception("Connection refused")
+
+        with patch.object(logger, "_post_spans", side_effect=_mock_post_spans):
+            await logger.async_send_batch()
+
+        assert [s["span_id"] for s in logger.log_queue] == ["1", "2"]
+
+    @pytest.mark.asyncio
+    async def test_returned_non_2xx_response_requeues(self):
+        """A client that returns a non-2xx response instead of raising must
+        also re-queue the undelivered spans."""
+        logger = self._make_logger()
+        logger.log_queue = [self._make_span(span_id=str(i)) for i in range(2)]
+
+        async def _mock_post_spans(spans):
+            resp = MagicMock()
+            resp.status_code = 500
+            resp.text = "Internal Server Error"
+            return resp
+
+        with patch.object(logger, "_post_spans", side_effect=_mock_post_spans):
+            await logger.async_send_batch()
+
+        assert [s["span_id"] for s in logger.log_queue] == ["0", "1"]
+
+    @pytest.mark.asyncio
+    async def test_returned_2xx_non_202_counts_as_delivered(self):
+        """A 2xx response other than 202 is a delivery, never a re-queue."""
+        logger = self._make_logger()
+        logger.log_queue = [self._make_span(span_id=str(i)) for i in range(2)]
+
+        async def _mock_post_spans(spans):
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.text = "OK"
+            return resp
+
+        with patch.object(logger, "_post_spans", side_effect=_mock_post_spans):
+            await logger.async_send_batch()
+
+        assert logger.log_queue == []
+
+    @pytest.mark.asyncio
+    async def test_batch_size_trigger_flushes_under_lock(self):
+        """The batch-size trigger goes through flush_queue so it takes the
+        flush lock and updates last_flush_time on a full drain."""
+        logger = self._make_logger()
+        logger.batch_size = 2
+        logger.last_flush_time = 0.0
+
+        async def _mock_post_spans(spans):
+            resp = MagicMock()
+            resp.status_code = 202
+            resp.text = "OK"
+            return resp
+
+        with patch.object(logger, "_post_spans", side_effect=_mock_post_spans), patch.object(
+            logger, "create_llm_obs_payload", side_effect=lambda *a, **k: self._make_span()
+        ):
+            await logger.async_log_success_event({}, None, None, None)
+            await logger.async_log_success_event({}, None, None, None)
+
+        assert logger.log_queue == []
+        assert logger.last_flush_time > 0.0


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4370

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

These are defensive failure-path changes with no reachable user-visible flow on a healthy intake, so the proof is the regression tests plus a mutation check: all three distinguishing tests fail on the parent branch's code and pass here

```
$ uv run pytest tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py -q
30 passed

on the parent branch (LIT-4358 fix only):
3 failed (test_requeue_drops_oldest_beyond_max_queue_size,
          test_returned_2xx_non_202_counts_as_delivered,
          test_batch_size_trigger_flushes_under_lock)
```

The shared happy path (proactive split and delivery against the real `api.us5.datadoghq.com` intake with real OpenAI traffic) was verified live in #32910

## Type

🐛 Bug Fix

## Changes

Stacked on #32910 (base is its branch; retargets to `litellm_internal_staging` automatically once it merges). Three hardening changes to the re-queue path the parent PR introduced

The transient-error re-queue is now capped at `max_queue_size`, dropping oldest spans first with a warning log. The base class documents this guard for exactly this retry scenario, but it only runs in `CustomBatchLogger.flush_queue`'s except branch, which never fires here because `async_send_batch` swallows its own errors; without the cap a persistently failing intake grows the queue without bound

A 2xx response other than 202 now counts as delivered instead of being treated as an unexpected response. Re-queueing accepted spans would duplicate them on every subsequent flush if the intake ever returned 200 or 201

The batch-size trigger in the success and failure hooks routes through `flush_queue` instead of calling `async_send_batch` directly, taking the flush lock like the periodic path does and keeping `last_flush_time` accurate, matching the log-intake logger

The same hardening for the log-intake `DataDogLogger` is tracked in LIT-4363
