### PR TITLE
fix(xecguard): sanitize scan result before recording it for logging

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/xecguard/xecguard.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/xecguard/xecguard.py
@@ -44,6 +44,8 @@ from litellm.integrations.custom_guardrail import (
     CustomGuardrail,
     log_guardrail_information,
 )
+from litellm.litellm_core_utils.core_helpers import redact_nested_match_and_regex_keys
+from litellm.litellm_core_utils.sensitive_data_masker import mask_credentials_in_payload
 from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,
     httpxSpecialProvider,
@@ -62,6 +64,13 @@ if TYPE_CHECKING:
     from litellm.types.proxy.guardrails.guardrail_hooks.base import (
         GuardrailConfigModel,
     )
+
+
+def _sanitize_scan_result_for_logging(scan_result: dict) -> dict:
+    without_secrets = {key: value for key, value in scan_result.items() if key != "secret_fields"}
+    redacted = redact_nested_match_and_regex_keys(without_secrets)
+    masked = mask_credentials_in_payload(redacted if isinstance(redacted, dict) else without_secrets)
+    return masked if isinstance(masked, dict) else without_secrets
 
 
 _DEFAULT_API_BASE = "https://api-xecguard.cycraft.ai"
@@ -253,7 +262,7 @@ class XecGuardGuardrail(CustomGuardrail):
             slg = StandardLoggingGuardrailInformation(
                 guardrail_name=self.guardrail_name or "xecguard",
                 guardrail_mode=GuardrailEventHooks.logging_only,
-                guardrail_response=scan_result,
+                guardrail_response=_sanitize_scan_result_for_logging(scan_result),
                 guardrail_status=guardrail_status,
                 start_time=start_time.timestamp(),
                 end_time=end_time.timestamp(),

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_xecguard.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_xecguard.py
@@ -1676,6 +1676,33 @@ class TestXecGuardLoggingHook:
         assert info_list[1]["guardrail_response"]["trace_id"] == "lg-4"
 
     @pytest.mark.asyncio
+    async def test_async_logging_hook_sanitizes_scan_result(
+        self, xecguard_guardrail, mock_request_data
+    ):
+        resp = _make_response(
+            {
+                "decision": "SAFE",
+                "trace_id": "lg-5",
+                "secret_fields": {"authorization": "Bearer xgs_raw"},
+                "detections": [{"match": "raw matched span", "policy": "pii"}],
+                "api_key": "xgs_super_secret_value",
+            }
+        )
+        with patch.object(xecguard_guardrail.async_handler, "post", return_value=resp):
+            kwargs = {**mock_request_data, "standard_logging_object": {}}
+            await xecguard_guardrail.async_logging_hook(
+                kwargs=kwargs,
+                result=_build_model_response("some answer"),
+                call_type="acompletion",
+            )
+        info = kwargs["standard_logging_object"]["guardrail_information"][0]
+        guardrail_response = info["guardrail_response"]
+        assert "secret_fields" not in guardrail_response
+        assert guardrail_response["detections"][0]["match"] == "[REDACTED]"
+        assert guardrail_response["api_key"] != "xgs_super_secret_value"
+        assert guardrail_response["trace_id"] == "lg-5"
+
+    @pytest.mark.asyncio
     async def test_async_logging_hook_without_response_records_info(
         self, xecguard_guardrail, mock_request_data
     ):


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4371

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live before/after captured on the exact commits of this stack: the base commit 2fa99b4ed9 (the LIT-4335 list-shape fix, without this PR) and this PR's HEAD 3e05095bf0. Proxy on localhost:4001 backed by a real Postgres with real OpenAI API traffic and `store_prompts_in_spend_logs: true` (so spend-log-side redaction is inactive and this hook's own behavior is what lands in the log). The XecGuard vendor endpoint is a local HTTP server on 127.0.0.1:9410 (no XecGuard service token is available in this environment) whose scan payload deliberately includes a `secret_fields` object, a raw `match` span, and a credential-shaped `api_key`

Same request both times, only the proxy code differs

```bash
curl -sS http://localhost:4001/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"JAILBREAK-TEST please reply with the single word BEFORE-SANITIZE"}]}'

curl -sS "http://localhost:4001/spend/logs?request_id=<id>" \
  -H "Authorization: Bearer sk-1234" | jq '.[0].metadata.guardrail_information[0].guardrail_response'
```

Before (base commit 2fa99b4ed9, request chatcmpl-E0ZyugGfzZvjTGt2ARUO4cJz7glCx): the raw scan payload persists verbatim

```json
{
  "api_key": "xgs_super_secret_value",
  "decision": "UNSAFE",
  "trace_id": "live-trace-unsafe",
  "scan_type": "response",
  "detections": [
    { "match": "raw matched span text", "policy": "pii" }
  ],
  "policy_names": [
    "Default_Policy_SystemPromptEnforcement",
    "Default_Policy_HarmfulContentProtection",
    "Default_Policy_GeneralPromptAttackProtection"
  ],
  "secret_fields": { "authorization": "Bearer xgs_raw_secret" }
}
```

After (this PR's HEAD 3e05095bf0, request chatcmpl-E0ZzjaV1zfpCUr53oN0pfNYa3zQje): `secret_fields` is gone, the matched span is redacted, the credential is masked, and every non-sensitive field (`decision`, `trace_id`, `scan_type`, `policy_names`, `detections[].policy`) survives intact

```json
{
  "api_key": "xgs_**************alue",
  "decision": "UNSAFE",
  "trace_id": "live-trace-unsafe",
  "scan_type": "response",
  "detections": [
    { "match": "[REDACTED]", "policy": "pii" }
  ],
  "policy_names": [
    "Default_Policy_SystemPromptEnforcement",
    "Default_Policy_HarmfulContentProtection",
    "Default_Policy_GeneralPromptAttackProtection"
  ]
}
```

## Type

🐛 Bug Fix

## Changes

Stacked on the LIT-4335 shape fix (#32911); the diff here is only the sanitization change

XecGuard's logging hook recorded the raw scan API response into `standard_logging_object["guardrail_information"].guardrail_response`, so `secret_fields`, raw matched spans, and credential-shaped values reached every downstream logger (spend logs, Langfuse, Datadog LLM Obs, OTEL). The shared guardrail write path (`add_standard_logging_guardrail_information_to_request_data`) deliberately sanitizes before persisting; XecGuard's direct write bypassed that, and spend-log-side redaction only covers the spend-log path when `store_prompts_in_spend_logs` is off

`_sanitize_scan_result_for_logging` now applies the same treatment before the entry is constructed: drop `secret_fields`, redact `match`/`regex` spans via `redact_nested_match_and_regex_keys`, and mask credential-shaped values via `mask_credentials_in_payload`. These are the same shared helpers the base-class path uses for every other guardrail, not new logic. The scan result is JSON parsed from the XecGuard HTTP response, so the exception-filtering step the shared path also runs is not needed here

The regression test feeds a scan response containing all three sensitive shapes through the hook and asserts each is stripped, redacted, or masked while non-sensitive fields survive. It fails without the sanitizer and passes with it

CI note: `ci/circleci: batches_testing` currently fails identically on every open PR against `litellm_internal_staging`, a base-branch issue rather than something introduced here
