### PR TITLE
feat(guardrails): add pre_mcp_call support to Content Filter

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
@@ -32,6 +32,7 @@ from litellm._logging import verbose_proxy_logger
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.utils import (
+    CallTypes,
     GenericGuardrailAPIInputs,
     GuardrailStatus,
     GuardrailTracingDetail,
@@ -1690,38 +1691,49 @@ class ContentFilterGuardrail(CustomGuardrail):
             return raw_name
         return None
 
-    @staticmethod
-    def _parse_masked_mcp_arguments(masked_arguments: str, tool_name: str) -> Dict[str, object]:
-        try:
-            parsed: object = json.loads(masked_arguments)
-        except json.JSONDecodeError:
-            parsed = None
-        if not isinstance(parsed, dict):
+    def _assert_mcp_argument_label_clean(self, text: str, detections: List[ContentFilterDetection]) -> None:
+        if self._filter_single_text(text, detections=detections) != text:
             raise HTTPException(
                 status_code=400,
-                detail={
-                    "error": "Content blocked: masking MCP tool call arguments produced invalid JSON",
-                    "mcp_tool_name": tool_name,
-                },
+                detail={"error": "Content blocked: MCP tool call argument matched a masking rule on a non-rewritable field"},
             )
-        return parsed
 
-    def _scan_mcp_tool_call_arguments(self, request_data: dict, detections: List[ContentFilterDetection]) -> None:
+    def _filter_mcp_argument_value(self, value: object, detections: List[ContentFilterDetection]) -> object:
+        if isinstance(value, str):
+            return self._filter_single_text(value, detections=detections)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            self._assert_mcp_argument_label_clean(str(value), detections)
+            return value
+        if isinstance(value, dict):
+            for key in value:
+                if isinstance(key, str):
+                    self._assert_mcp_argument_label_clean(key, detections)
+            return {key: self._filter_mcp_argument_value(item, detections) for key, item in value.items()}
+        if isinstance(value, list):
+            return [self._filter_mcp_argument_value(item, detections) for item in value]
+        return value
+
+    def _scan_mcp_tool_call_arguments(
+        self,
+        request_data: dict,
+        detections: List[ContentFilterDetection],
+        logging_obj: Optional["LiteLLMLoggingObj"] = None,
+    ) -> None:
         if not self._event_hook_is_event_type(GuardrailEventHooks.pre_mcp_call):
             return
-        tool_name = self._get_mcp_tool_name(request_data)
-        if tool_name is None:
+        call_type: object = getattr(logging_obj, "call_type", None)
+        if logging_obj is not None and call_type != CallTypes.call_mcp_tool.value:
+            return
+        if self._get_mcp_tool_name(request_data) is None:
             return
         raw_arguments: object = request_data.get("mcp_arguments")
         if not isinstance(raw_arguments, dict) or not raw_arguments:
             return
-        serialized_arguments = json.dumps(raw_arguments, ensure_ascii=False)
-        filtered_arguments = self._filter_single_text(serialized_arguments, detections=detections)
-        if filtered_arguments == serialized_arguments:
+        filtered_arguments = self._filter_mcp_argument_value(raw_arguments, detections)
+        if filtered_arguments == raw_arguments:
             return
-        masked_arguments = self._parse_masked_mcp_arguments(filtered_arguments, tool_name)
-        request_data["mcp_arguments"] = masked_arguments
-        request_data["modified_arguments"] = masked_arguments
+        request_data["mcp_arguments"] = filtered_arguments
+        request_data["modified_arguments"] = filtered_arguments
 
     async def apply_guardrail(
         self,
@@ -1778,7 +1790,9 @@ class ContentFilterGuardrail(CustomGuardrail):
             inputs["texts"] = processed_texts
 
             if input_type == "request":
-                self._scan_mcp_tool_call_arguments(request_data=request_data, detections=detections)
+                self._scan_mcp_tool_call_arguments(
+                    request_data=request_data, detections=detections, logging_obj=logging_obj
+                )
 
             # Count masked entities by type
             self._count_masked_entities(detections, masked_entity_count)

--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
@@ -1686,13 +1686,13 @@ class ContentFilterGuardrail(CustomGuardrail):
         )
 
     @staticmethod
-    def _get_mcp_tool_name(request_data: dict) -> Optional[str]:
+    def _get_mcp_tool_name(request_data: dict) -> str | None:
         raw_name: object = request_data.get("mcp_tool_name")
         if isinstance(raw_name, str) and raw_name:
             return raw_name
         return None
 
-    def _assert_mcp_argument_label_clean(self, text: str, detections: List[ContentFilterDetection]) -> None:
+    def _assert_mcp_argument_label_clean(self, text: str, detections: list[ContentFilterDetection]) -> None:
         if self._filter_single_text(text, detections=detections) != text:
             raise HTTPException(
                 status_code=400,
@@ -1702,7 +1702,7 @@ class ContentFilterGuardrail(CustomGuardrail):
             )
 
     def _filter_mcp_argument_value(
-        self, value: object, detections: List[ContentFilterDetection], depth: int = 0
+        self, value: object, detections: list[ContentFilterDetection], depth: int = 0
     ) -> object:
         if depth > DEFAULT_MAX_RECURSE_DEPTH:
             raise HTTPException(
@@ -1726,7 +1726,7 @@ class ContentFilterGuardrail(CustomGuardrail):
     def _scan_mcp_tool_call_arguments(
         self,
         request_data: dict,
-        detections: List[ContentFilterDetection],
+        detections: list[ContentFilterDetection],
         logging_obj: Optional["LiteLLMLoggingObj"] = None,
     ) -> None:
         if not self._event_hook_is_event_type(GuardrailEventHooks.pre_mcp_call):

--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
@@ -1683,6 +1683,46 @@ class ContentFilterGuardrail(CustomGuardrail):
             tracing_detail=GuardrailTracingDetail(**tracing_kw),  # type: ignore[typeddict-item]
         )
 
+    @staticmethod
+    def _get_mcp_tool_name(request_data: dict) -> Optional[str]:
+        raw_name: object = request_data.get("mcp_tool_name")
+        if isinstance(raw_name, str) and raw_name:
+            return raw_name
+        return None
+
+    @staticmethod
+    def _parse_masked_mcp_arguments(masked_arguments: str, tool_name: str) -> Dict[str, object]:
+        try:
+            parsed: object = json.loads(masked_arguments)
+        except json.JSONDecodeError:
+            parsed = None
+        if not isinstance(parsed, dict):
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": "Content blocked: masking MCP tool call arguments produced invalid JSON",
+                    "mcp_tool_name": tool_name,
+                },
+            )
+        return parsed
+
+    def _scan_mcp_tool_call_arguments(self, request_data: dict, detections: List[ContentFilterDetection]) -> None:
+        if not self._event_hook_is_event_type(GuardrailEventHooks.pre_mcp_call):
+            return
+        tool_name = self._get_mcp_tool_name(request_data)
+        if tool_name is None:
+            return
+        raw_arguments: object = request_data.get("mcp_arguments")
+        if not isinstance(raw_arguments, dict) or not raw_arguments:
+            return
+        serialized_arguments = json.dumps(raw_arguments, ensure_ascii=False)
+        filtered_arguments = self._filter_single_text(serialized_arguments, detections=detections)
+        if filtered_arguments == serialized_arguments:
+            return
+        masked_arguments = self._parse_masked_mcp_arguments(filtered_arguments, tool_name)
+        request_data["mcp_arguments"] = masked_arguments
+        request_data["modified_arguments"] = masked_arguments
+
     async def apply_guardrail(
         self,
         inputs: "GenericGuardrailAPIInputs",
@@ -1736,6 +1776,9 @@ class ContentFilterGuardrail(CustomGuardrail):
 
             verbose_proxy_logger.debug("ContentFilterGuardrail: Guardrail applied successfully")
             inputs["texts"] = processed_texts
+
+            if input_type == "request":
+                self._scan_mcp_tool_call_arguments(request_data=request_data, detections=detections)
 
             # Count masked entities by type
             self._count_masked_entities(detections, masked_entity_count)
@@ -1903,4 +1946,5 @@ class ContentFilterGuardrail(CustomGuardrail):
             GuardrailEventHooks.post_call,
             GuardrailEventHooks.during_call,
             GuardrailEventHooks.realtime_input_transcription,
+            GuardrailEventHooks.pre_mcp_call,
         ]

--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
@@ -29,6 +29,7 @@ from fastapi import HTTPException
 
 from litellm import Router
 from litellm._logging import verbose_proxy_logger
+from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.utils import (
@@ -1695,10 +1696,19 @@ class ContentFilterGuardrail(CustomGuardrail):
         if self._filter_single_text(text, detections=detections) != text:
             raise HTTPException(
                 status_code=400,
-                detail={"error": "Content blocked: MCP tool call argument matched a masking rule on a non-rewritable field"},
+                detail={
+                    "error": "Content blocked: MCP tool call argument matched a masking rule on a non-rewritable field"
+                },
             )
 
-    def _filter_mcp_argument_value(self, value: object, detections: List[ContentFilterDetection]) -> object:
+    def _filter_mcp_argument_value(
+        self, value: object, detections: List[ContentFilterDetection], depth: int = 0
+    ) -> object:
+        if depth > DEFAULT_MAX_RECURSE_DEPTH:
+            raise HTTPException(
+                status_code=400,
+                detail={"error": "Content blocked: MCP tool call arguments exceed the maximum nesting depth"},
+            )
         if isinstance(value, str):
             return self._filter_single_text(value, detections=detections)
         if isinstance(value, (int, float)) and not isinstance(value, bool):
@@ -1708,9 +1718,9 @@ class ContentFilterGuardrail(CustomGuardrail):
             for key in value:
                 if isinstance(key, str):
                     self._assert_mcp_argument_label_clean(key, detections)
-            return {key: self._filter_mcp_argument_value(item, detections) for key, item in value.items()}
+            return {key: self._filter_mcp_argument_value(item, detections, depth + 1) for key, item in value.items()}
         if isinstance(value, list):
-            return [self._filter_mcp_argument_value(item, detections) for item in value]
+            return [self._filter_mcp_argument_value(item, detections, depth + 1) for item in value]
         return value
 
     def _scan_mcp_tool_call_arguments(

--- a/tests/code_coverage_tests/recursive_detector.py
+++ b/tests/code_coverage_tests/recursive_detector.py
@@ -54,6 +54,7 @@ IGNORE_FUNCTIONS = [
     "sanitize_oci_schema",  # OCI: bounded by JSON-schema tree depth.
     "_freeze_for_dedupe",  # OTEL: max depth set (default 16, _FREEZE_MAX_DEPTH); fails closed by returning repr(value) at the cap.
     "apply_json_merge_patch",  # max depth set (_MAX_MERGE_DEPTH=64); fails closed by raising ValueError at the cap.
+    "_filter_mcp_argument_value",  # max depth set (DEFAULT_MAX_RECURSE_DEPTH); fails closed by blocking the MCP call at the cap.
 ]
 
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
@@ -2500,38 +2500,183 @@ class TestContentFilterMCPPreCall:
         assert "modified_arguments" not in request_data
 
     @pytest.mark.asyncio
-    async def test_apply_guardrail_mcp_mask_breaking_json_blocks(self):
+    async def test_apply_guardrail_mcp_anchored_regex_matches_argument_value(self):
         """
-        Masking that corrupts the JSON structure of arguments blocks instead of corrupting the call
+        Anchored custom regexes apply to each argument value, not to a serialized JSON document
         """
         patterns = [
             ContentFilterPattern(
                 pattern_type="regex",
-                pattern="secret..",
-                name="json_breaker",
+                pattern="^secret$",
+                name="anchored_secret",
+                action=ContentFilterAction.BLOCK,
+            ),
+        ]
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-mcp-anchored",
+            event_hook=GuardrailEventHooks.pre_mcp_call,
+            patterns=patterns,
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.apply_guardrail(
+                inputs={},
+                request_data={"mcp_tool_name": "save_note", "mcp_arguments": {"note": "secret"}},
+                input_type="request",
+            )
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_apply_guardrail_mcp_mask_preserves_nested_structure(self):
+        """
+        Masking rewrites string values inside nested dicts and lists without corrupting the structure
+        """
+        patterns = [
+            ContentFilterPattern(
+                pattern_type="prebuilt",
+                pattern_name="email",
                 action=ContentFilterAction.MASK,
             ),
         ]
         guardrail = ContentFilterGuardrail(
-            guardrail_name="test-mcp-broken-mask",
+            guardrail_name="test-mcp-nested-mask",
             event_hook=GuardrailEventHooks.pre_mcp_call,
             patterns=patterns,
         )
 
         request_data = {
-            "mcp_tool_name": "save_note",
-            "mcp_arguments": {"note": "secret"},
+            "mcp_tool_name": "send_email",
+            "mcp_arguments": {
+                "recipients": ["team", "cc jane.doe@example.com"],
+                "meta": {"note": "from bob@example.com", "count": 2},
+            },
         }
+
+        await guardrail.apply_guardrail(inputs={}, request_data=request_data, input_type="request")
+
+        modified = request_data["modified_arguments"]
+        assert modified["recipients"][0] == "team"
+        assert "[EMAIL_REDACTED]" in modified["recipients"][1]
+        assert "jane.doe@example.com" not in modified["recipients"][1]
+        assert "[EMAIL_REDACTED]" in modified["meta"]["note"]
+        assert modified["meta"]["count"] == 2
+        assert request_data["mcp_arguments"] == modified
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mcp_arguments",
+        [
+            {"this is confidential data": "x"},
+            {"a": {"contains confidential stuff": "x"}},
+        ],
+    )
+    async def test_apply_guardrail_mcp_argument_keys_scanned(self, mcp_arguments):
+        """
+        Blocked content smuggled in argument keys (top-level or nested) is detected, not just values
+        """
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-mcp-key-smuggling",
+            event_hook=GuardrailEventHooks.pre_mcp_call,
+            blocked_words=[BlockedWord(keyword="confidential", action=ContentFilterAction.BLOCK)],
+        )
 
         with pytest.raises(HTTPException) as exc_info:
             await guardrail.apply_guardrail(
                 inputs={},
-                request_data=request_data,
+                request_data={"mcp_tool_name": "send_email", "mcp_arguments": mcp_arguments},
                 input_type="request",
             )
 
         assert exc_info.value.status_code == 400
-        assert "invalid JSON" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_apply_guardrail_mcp_numeric_mask_match_blocks(self):
+        """
+        A MASK rule matching a numeric argument blocks the call, since a redaction tag cannot be
+        represented in a number
+        """
+        patterns = [
+            ContentFilterPattern(
+                pattern_type="prebuilt",
+                pattern_name="visa",
+                action=ContentFilterAction.MASK,
+            ),
+        ]
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-mcp-numeric-mask",
+            event_hook=GuardrailEventHooks.pre_mcp_call,
+            patterns=patterns,
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.apply_guardrail(
+                inputs={},
+                request_data={"mcp_tool_name": "charge_card", "mcp_arguments": {"card": 4111111111111111}},
+                input_type="request",
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "non-rewritable" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_apply_guardrail_mixed_mode_chat_call_not_scanned(self):
+        """
+        A mixed pre_call + pre_mcp_call guardrail must not run the MCP scan on a chat invocation,
+        identified by the proxy-owned logging object's call_type, even when MCP keys are planted
+        """
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-mixed-mode-chat",
+            event_hook=[GuardrailEventHooks.pre_call, GuardrailEventHooks.pre_mcp_call],
+            blocked_words=[BlockedWord(keyword="confidential", action=ContentFilterAction.BLOCK)],
+        )
+
+        chat_logging_obj = MagicMock()
+        chat_logging_obj.call_type = "acompletion"
+
+        request_data = {
+            "mcp_tool_name": "send_email",
+            "mcp_arguments": {"body": "this is confidential data"},
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+
+        await guardrail.apply_guardrail(
+            inputs={"texts": ["hello"]},
+            request_data=request_data,
+            input_type="request",
+            logging_obj=chat_logging_obj,
+        )
+
+        assert "modified_arguments" not in request_data
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("mcp_call_type", [None, "call_mcp_tool"])
+    async def test_apply_guardrail_mixed_mode_mcp_call_scanned(self, mcp_call_type):
+        """
+        The same mixed mode guardrail still scans genuine MCP invocations, whether the logging
+        object is absent (canonical synthetic payload) or carries the MCP call_type
+        """
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-mixed-mode-mcp",
+            event_hook=[GuardrailEventHooks.pre_call, GuardrailEventHooks.pre_mcp_call],
+            blocked_words=[BlockedWord(keyword="confidential", action=ContentFilterAction.BLOCK)],
+        )
+
+        logging_obj = None
+        if mcp_call_type is not None:
+            logging_obj = MagicMock()
+            logging_obj.call_type = mcp_call_type
+
+        with pytest.raises(HTTPException):
+            await guardrail.apply_guardrail(
+                inputs={},
+                request_data={
+                    "mcp_tool_name": "send_email",
+                    "mcp_arguments": {"body": "this is confidential data"},
+                },
+                input_type="request",
+                logging_obj=logging_obj,
+            )
 
     @pytest.mark.asyncio
     async def test_apply_guardrail_non_mcp_name_arguments_not_scanned(self):

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
@@ -2398,3 +2398,257 @@ class TestTracingFieldsE2E:
         # No detections, so these should be None
         assert slg.get("detection_method") is None
         assert slg.get("match_details") is None
+
+
+class TestContentFilterMCPPreCall:
+    """Test pre_mcp_call support: MCP tool call argument scanning in apply_guardrail"""
+
+    def test_pre_mcp_call_is_supported_event_hook(self):
+        """
+        Constructing the guardrail with mode pre_mcp_call must succeed (LIT-4226)
+        """
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-mcp-mode",
+            event_hook=GuardrailEventHooks.pre_mcp_call,
+            blocked_words=[BlockedWord(keyword="confidential", action=ContentFilterAction.BLOCK)],
+        )
+
+        assert GuardrailEventHooks.pre_mcp_call in guardrail.supported_event_hooks
+
+    @pytest.mark.asyncio
+    async def test_apply_guardrail_blocks_mcp_tool_arguments(self):
+        """
+        Blocked word inside MCP tool call arguments raises HTTPException
+        """
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-mcp-block",
+            event_hook=GuardrailEventHooks.pre_mcp_call,
+            blocked_words=[BlockedWord(keyword="confidential", action=ContentFilterAction.BLOCK)],
+        )
+
+        request_data = {
+            "mcp_tool_name": "send_email",
+            "mcp_arguments": {"body": "this is confidential data"},
+        }
+
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.apply_guardrail(
+                inputs={},
+                request_data=request_data,
+                input_type="request",
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "confidential" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_apply_guardrail_masks_mcp_tool_arguments(self):
+        """
+        MASK pattern match inside MCP arguments writes masked args to modified_arguments
+        """
+        patterns = [
+            ContentFilterPattern(
+                pattern_type="prebuilt",
+                pattern_name="email",
+                action=ContentFilterAction.MASK,
+            ),
+        ]
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-mcp-mask",
+            event_hook=GuardrailEventHooks.pre_mcp_call,
+            patterns=patterns,
+        )
+
+        request_data = {
+            "mcp_tool_name": "send_email",
+            "mcp_arguments": {"contact": "reach me at test@example.com"},
+        }
+
+        await guardrail.apply_guardrail(
+            inputs={},
+            request_data=request_data,
+            input_type="request",
+        )
+
+        modified = request_data["modified_arguments"]
+        assert "[EMAIL_REDACTED]" in modified["contact"]
+        assert "test@example.com" not in modified["contact"]
+        assert request_data["mcp_arguments"] == modified
+
+    @pytest.mark.asyncio
+    async def test_apply_guardrail_mcp_arguments_clean_pass(self):
+        """
+        Clean MCP arguments pass through without modification
+        """
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-mcp-clean",
+            event_hook=GuardrailEventHooks.pre_mcp_call,
+            blocked_words=[BlockedWord(keyword="confidential", action=ContentFilterAction.BLOCK)],
+        )
+
+        request_data = {
+            "mcp_tool_name": "get_weather",
+            "mcp_arguments": {"city": "Paris"},
+        }
+
+        await guardrail.apply_guardrail(
+            inputs={},
+            request_data=request_data,
+            input_type="request",
+        )
+
+        assert "modified_arguments" not in request_data
+
+    @pytest.mark.asyncio
+    async def test_apply_guardrail_mcp_mask_breaking_json_blocks(self):
+        """
+        Masking that corrupts the JSON structure of arguments blocks instead of corrupting the call
+        """
+        patterns = [
+            ContentFilterPattern(
+                pattern_type="regex",
+                pattern="secret..",
+                name="json_breaker",
+                action=ContentFilterAction.MASK,
+            ),
+        ]
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-mcp-broken-mask",
+            event_hook=GuardrailEventHooks.pre_mcp_call,
+            patterns=patterns,
+        )
+
+        request_data = {
+            "mcp_tool_name": "save_note",
+            "mcp_arguments": {"note": "secret"},
+        }
+
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.apply_guardrail(
+                inputs={},
+                request_data=request_data,
+                input_type="request",
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "invalid JSON" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_apply_guardrail_non_mcp_name_arguments_not_scanned(self):
+        """
+        A raw body with top-level name + arguments (e.g. pass-through) is not treated as an MCP call;
+        only the canonical mcp_tool_name + mcp_arguments keys trigger the scan
+        """
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-non-mcp-shape",
+            event_hook=GuardrailEventHooks.pre_call,
+            blocked_words=[BlockedWord(keyword="confidential", action=ContentFilterAction.BLOCK)],
+        )
+
+        await guardrail.apply_guardrail(
+            inputs={"texts": ["hello"]},
+            request_data={"name": "send_email", "arguments": {"body": "confidential data"}},
+            input_type="request",
+        )
+
+    @pytest.mark.asyncio
+    async def test_apply_guardrail_mcp_response_side_not_scanned(self):
+        """
+        input_type response does not run the MCP argument scan
+        """
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-mcp-response-side",
+            event_hook=GuardrailEventHooks.pre_mcp_call,
+            blocked_words=[BlockedWord(keyword="confidential", action=ContentFilterAction.BLOCK)],
+        )
+
+        await guardrail.apply_guardrail(
+            inputs={"texts": ["clean response"]},
+            request_data={
+                "mcp_tool_name": "send_email",
+                "mcp_arguments": {"body": "this is confidential data"},
+            },
+            input_type="response",
+        )
+    @pytest.mark.asyncio
+    async def test_apply_guardrail_blocks_non_ascii_mcp_arguments(self):
+        """
+        Non-ASCII blocked words in MCP arguments must be detected (json.dumps must not escape them)
+        """
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-mcp-non-ascii",
+            event_hook=GuardrailEventHooks.pre_mcp_call,
+            blocked_words=[BlockedWord(keyword="\u673a\u5bc6", action=ContentFilterAction.BLOCK)],
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.apply_guardrail(
+                inputs={},
+                request_data={
+                    "mcp_tool_name": "send_email",
+                    "mcp_arguments": {"body": "this is \u673a\u5bc6 data"},
+                },
+                input_type="request",
+            )
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_apply_guardrail_mcp_mask_survives_chained_guardrails(self):
+        """
+        A second masking guardrail must scan the already-masked arguments, not resurrect the originals
+        """
+        email_guardrail = ContentFilterGuardrail(
+            guardrail_name="test-mcp-chain-email",
+            event_hook=GuardrailEventHooks.pre_mcp_call,
+            patterns=[
+                ContentFilterPattern(pattern_type="prebuilt", pattern_name="email", action=ContentFilterAction.MASK)
+            ],
+        )
+        phone_guardrail = ContentFilterGuardrail(
+            guardrail_name="test-mcp-chain-phone",
+            event_hook=GuardrailEventHooks.pre_mcp_call,
+            patterns=[
+                ContentFilterPattern(pattern_type="prebuilt", pattern_name="us_phone", action=ContentFilterAction.MASK)
+            ],
+        )
+
+        request_data = {
+            "mcp_tool_name": "send_email",
+            "mcp_arguments": {"contact": "email test@example.com phone 555-123-4567"},
+        }
+
+        await email_guardrail.apply_guardrail(inputs={}, request_data=request_data, input_type="request")
+        await phone_guardrail.apply_guardrail(inputs={}, request_data=request_data, input_type="request")
+
+        final = request_data["modified_arguments"]
+        assert "test@example.com" not in final["contact"]
+        assert "555-123-4567" not in final["contact"]
+        assert "[EMAIL_REDACTED]" in final["contact"]
+        assert "[US_PHONE_REDACTED]" in final["contact"]
+
+    @pytest.mark.asyncio
+    async def test_apply_guardrail_pre_call_mode_ignores_forged_mcp_keys(self):
+        """
+        A pre_call mode guardrail must not run the MCP scan even when a caller plants MCP keys in the body
+        """
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-forged-mcp-keys",
+            event_hook=GuardrailEventHooks.pre_call,
+            blocked_words=[BlockedWord(keyword="confidential", action=ContentFilterAction.BLOCK)],
+        )
+
+        request_data = {
+            "mcp_tool_name": "send_email",
+            "mcp_arguments": {"body": "this is confidential data"},
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+
+        await guardrail.apply_guardrail(
+            inputs={"texts": ["hello"]},
+            request_data=request_data,
+            input_type="request",
+        )
+
+        assert "modified_arguments" not in request_data
+        assert request_data["mcp_arguments"] == {"body": "this is confidential data"}

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
@@ -2652,3 +2652,29 @@ class TestContentFilterMCPPreCall:
 
         assert "modified_arguments" not in request_data
         assert request_data["mcp_arguments"] == {"body": "this is confidential data"}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "request_data",
+        [
+            {"name": "send_email", "arguments": {"body": "confidential data"}},
+            {"name": "send_email", "mcp_arguments": {"body": "confidential data"}},
+        ],
+    )
+    async def test_apply_guardrail_pre_mcp_mode_requires_canonical_keys(self, request_data):
+        """
+        Even in pre_mcp_call mode, only the canonical mcp_tool_name key identifies an MCP call;
+        a bare name key must not, regardless of which arguments key accompanies it
+        """
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-mcp-canonical-keys",
+            event_hook=GuardrailEventHooks.pre_mcp_call,
+            blocked_words=[BlockedWord(keyword="confidential", action=ContentFilterAction.BLOCK)],
+        )
+
+        await guardrail.apply_guardrail(
+            inputs={},
+            request_data=request_data,
+            input_type="request",
+        )
+        assert "modified_arguments" not in request_data

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_content_filter.py
@@ -2620,6 +2620,33 @@ class TestContentFilterMCPPreCall:
         assert "non-rewritable" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
+    async def test_apply_guardrail_mcp_arguments_exceeding_max_depth_block(self):
+        """
+        Arguments nested beyond DEFAULT_MAX_RECURSE_DEPTH block fail-closed instead of passing unscanned
+        """
+        from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
+
+        guardrail = ContentFilterGuardrail(
+            guardrail_name="test-mcp-depth-cap",
+            event_hook=GuardrailEventHooks.pre_mcp_call,
+            blocked_words=[BlockedWord(keyword="confidential", action=ContentFilterAction.BLOCK)],
+        )
+
+        deep: dict = {"leaf": "confidential data"}
+        for _ in range(DEFAULT_MAX_RECURSE_DEPTH + 1):
+            deep = {"level": deep}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.apply_guardrail(
+                inputs={},
+                request_data={"mcp_tool_name": "save_note", "mcp_arguments": deep},
+                input_type="request",
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "nesting depth" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
     async def test_apply_guardrail_mixed_mode_chat_call_not_scanned(self):
         """
         A mixed pre_call + pre_mcp_call guardrail must not run the MCP scan on a chat invocation,

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
@@ -2095,9 +2095,11 @@ async def test_get_guardrail_ui_settings_returns_per_provider_supported_modes():
 
     modes_by_provider = result.supported_modes_by_provider
 
-    # Guardrails from the bug report: neither accepts pre_mcp_call, and the
-    # settings endpoint must reflect that so the UI can hide it.
-    assert "pre_mcp_call" not in modes_by_provider["litellm_content_filter"]
+    # Content Filter now supports pre_mcp_call (LIT-4226 feature half) but not
+    # during_mcp_call; Tool Permission still supports neither, and the settings
+    # endpoint must reflect both so the UI shows exactly the savable modes.
+    assert "pre_mcp_call" in modes_by_provider["litellm_content_filter"]
+    assert "during_mcp_call" not in modes_by_provider["litellm_content_filter"]
     assert modes_by_provider["tool_permission"] == ["pre_call", "post_call"]
 
     # MCP-capable guardrails must still advertise the MCP hooks so users who
@@ -2139,10 +2141,12 @@ async def test_ui_settings_map_matches_runtime_supported_event_hooks():
         ], provider
 
 
-def test_content_filter_runtime_rejects_pre_mcp_call():
+def test_content_filter_runtime_rejects_unsupported_mcp_hook():
     """
     Locks the runtime side of the LIT-4226 contract: the ContentFilterGuardrail
-    validator must reject pre_mcp_call at construction. If someone widens the
+    validator must reject a hook missing from its supported list at
+    construction. pre_mcp_call is supported since the LIT-4226 feature half, so
+    during_mcp_call is the unsupported example now. If someone widens the
     UI classmethod but forgets to widen the runtime supported_event_hooks (or
     vice versa), the two-lists-must-agree test above catches the drift and this
     test catches the specific bug the ticket reported.
@@ -2155,7 +2159,7 @@ def test_content_filter_runtime_rejects_pre_mcp_call():
     with pytest.raises(ValueError, match="not in the supported event hooks"):
         ContentFilterGuardrail(
             guardrail_name="lit4226-runtime-check",
-            event_hook=GuardrailEventHooks.pre_mcp_call,
+            event_hook=GuardrailEventHooks.during_mcp_call,
         )
 
 
@@ -2197,14 +2201,14 @@ def test_strict_guardrail_modes_flag_controls_raise_vs_warn(monkeypatch, caplog)
     with pytest.raises(ValueError, match="not in the supported event hooks"):
         ContentFilterGuardrail(
             guardrail_name="lit4226-strict-default",
-            event_hook=GuardrailEventHooks.pre_mcp_call,
+            event_hook=GuardrailEventHooks.during_mcp_call,
         )
 
     monkeypatch.setenv("LITELLM_STRICT_GUARDRAIL_MODES", "false")
     with caplog.at_level(logging.WARNING):
         instance = ContentFilterGuardrail(
             guardrail_name="lit4226-strict-off",
-            event_hook=GuardrailEventHooks.pre_mcp_call,
+            event_hook=GuardrailEventHooks.during_mcp_call,
         )
     assert instance is not None
     assert any("not in the supported event hooks" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4226

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup: proxy on localhost:4226 with a real Postgres, one OpenAI model (`gpt-4.1-mini`, real API traffic), and a local streamable-http MCP server (`FastMCP`, disclosed: the MCP tool server is a two-tool local server since guardrail evaluation is fully local regex/keyword matching; the LLM side hits the real OpenAI API)

Before (base code), creating the guardrail with mode `pre_mcp_call` fails with the exact error from the ticket

```bash
curl -sS -X POST http://localhost:4226/guardrails -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{
  "guardrail": {
    "guardrail_name": "content-filter-mcp",
    "litellm_params": {
      "guardrail": "litellm_content_filter",
      "mode": "pre_mcp_call",
      "default_on": true,
      "blocked_words": [{"keyword": "confidential", "action": "BLOCK"}],
      "patterns": [{"pattern_type": "prebuilt", "pattern_name": "email", "action": "MASK"}]
    },
    "guardrail_info": {}
  }
}'
```

```
{"detail":"400: Guardrail configuration error: Event hook GuardrailEventHooks.pre_mcp_call is not in the supported event hooks [<GuardrailEventHooks.pre_call: 'pre_call'>, <GuardrailEventHooks.post_call: 'post_call'>, <GuardrailEventHooks.during_call: 'during_call'>, <GuardrailEventHooks.realtime_input_transcription: 'realtime_input_transcription'>]"}
```

After (this PR), the same request succeeds

```
{"guardrail_name":"content-filter-mcp", ..., "guardrail":"litellm_content_filter","mode":"pre_mcp_call"},"guardrail_info":{},"guardrail_id":"6a276af8-0835-4bef-a4f3-91ef8d45f0a2"}
```

Blocked keyword inside MCP tool call arguments blocks the call

```bash
curl -sS -X POST http://localhost:4226/mcp-rest/tools/call -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"server_id":"a110d0044e2e7fa61ab9df5482daf770","name":"send_email","arguments":{"to":"bob@corp.example","body":"here is the confidential roadmap"}}'
```

```
{"detail":{"error":"Content blocked: keyword 'confidential' detected","keyword":"confidential","description":null,"guardrail_name":"content-filter-mcp","guardrail_mode":"pre_mcp_call"}}
HTTP 400
```

Non-ASCII blocked word (`机密`) in arguments also blocks; before the `ensure_ascii=False` fix the serialized form was `\uXXXX` escaped and sailed through

```bash
curl -sS -X POST http://localhost:4226/mcp-rest/tools/call -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"server_id":"a110d0044e2e7fa61ab9df5482daf770","name":"send_email","arguments":{"to":"bob","body":"这是机密数据"}}'
```

```
{"detail":{"error":"Content blocked: keyword '机密' detected","keyword":"机密","description":null,"guardrail_name":"content-filter-mcp-cjk","guardrail_mode":"pre_mcp_call"}}
HTTP 400
```

Clean arguments pass through

```bash
curl -sS -X POST http://localhost:4226/mcp-rest/tools/call -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"server_id":"a110d0044e2e7fa61ab9df5482daf770","name":"get_weather","arguments":{"city":"Paris"}}'
```

```
{"_meta":null,"content":[{"type":"text","text":"weather in Paris: sunny","annotations":null,"_meta":null}],"structuredContent":{"result":"weather in Paris: sunny"},"isError":false}
HTTP 200
```

MASK pattern (email) redacts the argument value before it reaches the tool; the tool's echo proves the masked value is what was executed

```bash
curl -sS -X POST http://localhost:4226/mcp-rest/tools/call -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"server_id":"a110d0044e2e7fa61ab9df5482daf770","name":"send_email","arguments":{"to":"team","body":"forward this to jane.doe@example.com please"}}'
```

```
{"_meta":null,"content":[{"type":"text","text":"email sent to team: forward this to [EMAIL_REDACTED] please","annotations":null,"_meta":null}],"structuredContent":{"result":"email sent to team: forward this to [EMAIL_REDACTED] please"},"isError":false}
HTTP 200
```

Anchored custom regex `^secret$` (BLOCK) matches a whole argument value and respects its anchors; under the earlier whole-document serialization approach the first call would have passed

```bash
curl -sS -X POST http://localhost:4226/mcp-rest/tools/call -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"server_id":"a110d0044e2e7fa61ab9df5482daf770","name":"send_email","arguments":{"to":"bob","body":"secret"}}'
```

```
{"detail":{"error":"Content blocked: anchored_secret pattern detected","pattern":"anchored_secret","guardrail_name":"cf-mcp-anchored","guardrail_mode":"pre_mcp_call"}}
HTTP 400
```

```bash
curl -sS -X POST http://localhost:4226/mcp-rest/tools/call -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"server_id":"a110d0044e2e7fa61ab9df5482daf770","name":"send_email","arguments":{"to":"bob","body":"the secret garden"}}'
```

```
{"_meta":null,"content":[{"type":"text","text":"email sent to bob: the secret garden", ...}],"isError":false}
HTTP 200
```

Blocked content smuggled in an argument key blocks, and a MASK rule (prebuilt `visa`) matching a numeric argument blocks instead of corrupting the number

```bash
curl -sS -X POST http://localhost:4226/mcp-rest/tools/call -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"server_id":"a110d0044e2e7fa61ab9df5482daf770","name":"send_email","arguments":{"to":"bob","body":"hello","this is confidential data":"x"}}'
```

```
{"detail":{"error":"Content blocked: keyword 'confidential' detected","keyword":"confidential", ... "guardrail_mode":"pre_mcp_call"}}
HTTP 400
```

```bash
curl -sS -X POST http://localhost:4226/mcp-rest/tools/call -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"server_id":"a110d0044e2e7fa61ab9df5482daf770","name":"send_email","arguments":{"to":"bob","body":4111111111111111}}'
```

```
{"detail":{"error":"Content blocked: MCP tool call argument matched a masking rule on a non-rewritable field", ... "guardrail_mode":"pre_mcp_call"}}
HTTP 400
```

A mixed mode `["pre_call", "pre_mcp_call"]` guardrail enforces on genuine MCP calls and on real chat content, but ignores MCP keys planted in a chat body: the planted-keys request sailed past the guardrail and reached OpenAI (which rejected the unknown fields, pre-existing proxy behavior unrelated to guardrails), while the same keyword in an actual chat message is blocked

```bash
curl -sS -X POST http://localhost:4226/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"Reply with exactly: hi"}],"mcp_tool_name":"send_email","mcp_arguments":{"body":"contains topsecretword here"}}'
```

```
{"error":{"message":"litellm.BadRequestError: OpenAIException - Unrecognized request arguments supplied: mcp_arguments, mcp_tool_name. ...","code":"400"}}
```

```bash
curl -sS -X POST http://localhost:4226/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"tell me about topsecretword"}]}'
```

```
{"error":{"message":"Content blocked: keyword 'topsecretword' detected", ... "guardrail_name":"cf-mixed-mode","guardrail_mode":["pre_call","pre_mcp_call"]}}
HTTP 400
```

A regular chat completion is not affected by the `pre_mcp_call` guardrail; real OpenAI call with the blocked keyword passes through untouched

```bash
curl -sS -X POST http://localhost:4226/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"Reply with exactly: confidential ok"}]}'
```

```
{"id":"chatcmpl-E0XSp0TJL2eVZmwrp9sjA8xJ7nzFf", ... "message":{"content":"confidential ok","role":"assistant", ...}
```
<img width="1002" height="825" alt="Screenshot 2026-07-11 at 4 07 35 PM" src="https://github.com/user-attachments/assets/bd375409-d220-4229-9b61-ca51d13a05c9" />

## Type

🆕 New Feature

## Changes

LIT-4226 reported that the Admin UI offers `pre_mcp_call` as a guardrail mode but the proxy rejects it for the LiteLLM Content Filter guardrail. The UI-side fix (filtering the mode dropdown per provider) is PR #32712; this PR is the feature half for Content Filter: it makes `pre_mcp_call` an actually supported and enforced mode

`GuardrailEventHooks.pre_mcp_call` is added to `ContentFilterGuardrail`'s `supported_event_hooks`, which fixes the 400 at guardrail creation. Since the MCP guardrail translation handler delivers the tool call via `request_data` rather than `inputs["texts"]`, `apply_guardrail` gains a small request-side scan: when the guardrail's configured mode includes `pre_mcp_call` and the canonical MCP keys are present (`mcp_tool_name` plus a non-empty `mcp_arguments` dict, which `_convert_mcp_to_llm_format` always sets on both the MCP protocol path and the `/mcp-rest` path) it recursively walks the arguments and runs every string value through the existing `_filter_single_text` pipeline, so all existing detection features (blocked words, prebuilt and custom regex patterns, categories) work on MCP tool calls with no new configuration surface. Scanning per value rather than one JSON serialization of the whole dict means anchored custom regexes (`^secret$`) match argument values as users would expect, values containing quotes or newlines are scanned in raw form, and masking rewrites a value in place so it can never corrupt the argument structure. Argument keys are scanned too, since callers control keys as fully as values; a MASK rule matching a key blocks rather than renaming it (a renamed key would break the tool's schema). Numeric values are scanned as their string form; a MASK match on a number likewise blocks, since a redaction tag cannot be represented in a number

The scan is deliberately narrow. It does not fall back to bare `name`/`arguments` keys because the pass-through guardrail path hands `apply_guardrail` the raw upstream body as `request_data`, and a body that happens to carry those keys must not be treated as an MCP call. It is gated on the guardrail's own event hook, and additionally on the proxy-owned logging object's call type, so neither a `pre_call` mode Content Filter nor a mixed `["pre_call", "pre_mcp_call"]` one runs the MCP scan on a chat invocation, even if a caller plants `mcp_tool_name`/`mcp_arguments` in a chat body (the proxy writes `litellm_logging_obj` into the request data itself right before the hooks run, so that signal cannot be forged). Scope note: only the tool call arguments are scanned; the tool name itself is not (tool allow/deny is the Tool Permission guardrail's job), and a call with empty arguments is not scanned

BLOCK raises the same HTTPException contract as other hooks. MASK writes the masked arguments to both `request_data["mcp_arguments"]` and `request_data["modified_arguments"]`, the same dual-write the Cisco AI Defense guardrail does; `modified_arguments` is what `_convert_mcp_hook_response_to_kwargs` applies to the outbound tool call, and rewriting `mcp_arguments` means a later guardrail in the chain scans the sanitized arguments instead of resurrecting the originals (covered by a chained-guardrails regression test)

Backward compatibility: the change is additive. A Content Filter configured with `mode: pre_call` still does not run on MCP calls (no implicit mode aliasing was added), and a `mode: pre_mcp_call` guardrail does not run on chat completions (verified live above). The MCP scan only fires when the MCP request shape is present, so `/apply_guardrail`, UI test-guardrail, chat, and realtime paths are unaffected

Now that #32712 is merged, this branch is rebased on top of it: the added hook lives in Content Filter's `get_supported_event_hooks()` classmethod, so the Admin UI mode dropdown and the runtime validator pick it up from the same list. The #32712 regression tests are updated accordingly: the UI settings map now asserts `pre_mcp_call` present and `during_mcp_call` absent for `litellm_content_filter`, and the runtime-rejection and strict-mode tests use `during_mcp_call` as the unsupported example

Tests: `TestContentFilterMCPPreCall` in the mapped test file covers mode acceptance, block on blocked keyword in arguments, non-ASCII blocked word in arguments, anchored regex matching a whole argument value, blocked content smuggled in top-level and nested argument keys, a MASK rule matching a numeric argument escalating to block, mask with `mcp_arguments` plus `modified_arguments` write-back, mask preserving nested dict and list structure, mask surviving chained masking guardrails, clean pass-through, that a non-MCP body with top-level `name` and `arguments` is not scanned (in both pre_call and pre_mcp_call modes), that `pre_call` and mixed `["pre_call", "pre_mcp_call"]` guardrails ignore planted MCP keys on chat invocations while the mixed mode still scans genuine MCP invocations, and that the response side does not scan. All fail on base and pass with this change
