### PR TITLE
feat(team): bulk update team members

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -600,6 +600,7 @@ class LiteLLMRoutes(enum.Enum):
             "/team/permissions_list",
             "/team/permissions_update",
             "/team/permissions_bulk_update",
+            "/team/member/bulk_update",
             "/team/daily/activity",
             # model
             "/model/new",
@@ -3702,6 +3703,48 @@ class TeamMemberUpdateResponse(MemberUpdateResponse):
     rpm_limit: Optional[int] = None
     budget_duration: Optional[str] = None
     allowed_models: Optional[List[str]] = None
+
+
+class TeamMemberBulkUpdateFields(LiteLLMPydanticObjectBase):
+    max_budget_in_team: Optional[float] = None
+    role: Optional[Literal["admin", "user"]] = None
+    tpm_limit: Optional[int] = None
+    rpm_limit: Optional[int] = None
+    budget_duration: Optional[str] = None
+    allowed_models: Optional[List[str]] = None
+
+    @model_validator(mode="after")
+    def require_at_least_one_field(self):
+        if not self.model_fields_set:
+            raise ValueError("update_fields must specify at least one field to update")
+        return self
+
+
+class BulkTeamMemberUpdateRequest(LiteLLMPydanticObjectBase):
+    team_id: str
+    user_ids: Optional[List[str]] = None
+    all_members_in_team: bool = False
+    update_fields: TeamMemberBulkUpdateFields
+
+    @model_validator(mode="after")
+    def validate_selection(self):
+        has_user_ids = self.user_ids is not None and len(self.user_ids) > 0
+        if has_user_ids and self.all_members_in_team:
+            raise ValueError("Provide either user_ids or all_members_in_team=True, not both")
+        if not has_user_ids and not self.all_members_in_team:
+            raise ValueError("Must provide either user_ids (non-empty) or all_members_in_team=True")
+        return self
+
+
+class FailedTeamMemberUpdate(MemberUpdateResponse):
+    failed_reason: str
+
+
+class BulkTeamMemberUpdateResponse(LiteLLMPydanticObjectBase):
+    team_id: str
+    total_requested: int
+    successful_updates: List[TeamMemberUpdateResponse]
+    failed_updates: List[FailedTeamMemberUpdate]
 
 
 class TeamModelAddRequest(BaseModel):

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -33,6 +33,7 @@ _PROXY_ADMIN_VIEW_ONLY_BLOCKED_ROUTES = frozenset(
         "/team/unblock",
         "/team/permissions_update",
         "/team/permissions_bulk_update",
+        "/team/member/bulk_update",
         # model
         "/model/new",
         "/model/update",
@@ -734,6 +735,7 @@ class RouteChecks:
             "/team/new",
             "/team/update",
             "/team/delete",
+            "/team/member/bulk_update",
             "/model/new",
             "/model/update",
             "/model/delete",

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -3072,6 +3072,9 @@ async def bulk_update_team_members(
             successful_updates.append(response)
         except HTTPException as exc:
             failed_updates.append(FailedTeamMemberUpdate(user_id=user_id, failed_reason=str(exc.detail)))
+        except Exception as exc:
+            verbose_proxy_logger.exception("Failed to bulk update team member %s in team %s", user_id, data.team_id)
+            failed_updates.append(FailedTeamMemberUpdate(user_id=user_id, failed_reason=str(exc)))
 
     return BulkTeamMemberUpdateResponse(
         team_id=data.team_id,

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -28,8 +28,11 @@ from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.proxy._types import (
     UI_TEAM_ID,
     BlockTeamRequest,
+    BulkTeamMemberUpdateRequest,
+    BulkTeamMemberUpdateResponse,
     CommonProxyErrors,
     DeleteTeamRequest,
+    FailedTeamMemberUpdate,
     LiteLLM_AuditLogs,
     LiteLLM_DeletedTeamTable,
     LiteLLM_ManagementEndpoint_MetadataFields,
@@ -2999,6 +3002,82 @@ async def team_member_update(
         rpm_limit=data.rpm_limit,
         budget_duration=data.budget_duration,
         allowed_models=data.allowed_models,
+    )
+
+
+@router.post(
+    "/team/member/bulk_update",
+    tags=["team management"],
+    dependencies=[Depends(user_api_key_auth)],
+    response_model=BulkTeamMemberUpdateResponse,
+)
+@management_endpoint_wrapper
+async def bulk_update_team_members(
+    data: BulkTeamMemberUpdateRequest,
+    http_request: Request,
+    user_api_key_dict: Annotated[UserAPIKeyAuth, Depends(user_api_key_auth)],
+):
+    from litellm.proxy.proxy_server import prisma_client
+
+    if prisma_client is None:
+        raise HTTPException(status_code=500, detail={"error": "No db connected"})
+
+    existing_team_row = await TeamRepository(prisma_client).table.find_unique(where={"team_id": data.team_id})
+    if existing_team_row is None:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "Team id={} does not exist in db".format(data.team_id)},
+        )
+    existing_team = LiteLLM_TeamTable(**existing_team_row.model_dump())
+    if (
+        user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN.value
+        and not _is_user_team_admin(user_api_key_dict=user_api_key_dict, team_obj=existing_team)
+        and not await _is_user_org_admin_for_team(user_api_key_dict=user_api_key_dict, team_obj=existing_team)
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error": "Call not allowed. User not proxy admin OR team admin. route={}, team_id={}".format(
+                    "/team/member/bulk_update", data.team_id
+                )
+            },
+        )
+
+    if data.all_members_in_team:
+        user_ids = [member.user_id for member in existing_team.members_with_roles if member.user_id is not None]
+    else:
+        user_ids = list(dict.fromkeys(data.user_ids or []))
+
+    max_batch_size = 500
+    if len(user_ids) > max_batch_size:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "Maximum {} team members can be updated at once. Found {} user_ids.".format(
+                    max_batch_size, len(user_ids)
+                )
+            },
+        )
+
+    update_fields = data.update_fields.model_dump(exclude_unset=True)
+    successful_updates: List[TeamMemberUpdateResponse] = []
+    failed_updates: List[FailedTeamMemberUpdate] = []
+    for user_id in user_ids:
+        try:
+            response = await team_member_update(
+                data=TeamMemberUpdateRequest(team_id=data.team_id, user_id=user_id, **update_fields),
+                http_request=http_request,
+                user_api_key_dict=user_api_key_dict,
+            )
+            successful_updates.append(response)
+        except HTTPException as exc:
+            failed_updates.append(FailedTeamMemberUpdate(user_id=user_id, failed_reason=str(exc.detail)))
+
+    return BulkTeamMemberUpdateResponse(
+        team_id=data.team_id,
+        total_requested=len(user_ids),
+        successful_updates=successful_updates,
+        failed_updates=failed_updates,
     )
 
 

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -131,6 +131,7 @@ def test_proxy_admin_viewer_config_update_route_rejected():
         "/team/unblock",
         "/team/permissions_update",
         "/team/permissions_bulk_update",
+        "/team/member/bulk_update",
         # JWT key mapping write routes
         "/jwt/key/mapping/new",
         "/jwt/key/mapping/update",

--- a/tests/test_litellm/proxy/test_team_member_update.py
+++ b/tests/test_litellm/proxy/test_team_member_update.py
@@ -86,9 +86,7 @@ def happy_path_upsert(monkeypatch):
         AsyncMock(
             return_value={
                 "team_info": team_row,
-                "team_memberships": [
-                    types.SimpleNamespace(user_id="user-1", budget_id="bud-1")
-                ],
+                "team_memberships": [types.SimpleNamespace(user_id="user-1", budget_id="bud-1")],
             }
         ),
     )
@@ -98,9 +96,7 @@ def happy_path_upsert(monkeypatch):
 
 
 def _member_update_request(**overrides):
-    data = TeamMemberUpdateRequest(
-        team_id="team-1234", user_id="user-1", role="user", **overrides
-    )
+    data = TeamMemberUpdateRequest(team_id="team-1234", user_id="user-1", role="user", **overrides)
     request = Request({"type": "http", "method": "POST", "path": "/team/member_update"})
     auth = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN.value, user_id="admin")
     return data, request, auth
@@ -110,9 +106,7 @@ def _member_update_request(**overrides):
 async def test_team_member_update_sends_provided_fields_as_patch(happy_path_upsert):
     """Fields the request sets must reach _upsert_budget_and_membership as a
     budget patch, otherwise the member budget is never written/reset."""
-    data, request, auth = _member_update_request(
-        max_budget_in_team=10.0, budget_duration="30d"
-    )
+    data, request, auth = _member_update_request(max_budget_in_team=10.0, budget_duration="30d")
 
     response = await team_member_update(data, request, auth)
 
@@ -132,9 +126,7 @@ async def test_team_member_update_explicit_null_clears_field(happy_path_upsert):
 
     await team_member_update(data, request, auth)
 
-    assert happy_path_upsert.await_args.kwargs["budget_patch"] == {
-        "budget_duration": None
-    }
+    assert happy_path_upsert.await_args.kwargs["budget_patch"] == {"budget_duration": None}
 
 
 @pytest.mark.asyncio
@@ -158,9 +150,7 @@ async def test_team_member_update_omits_unset_fields_from_patch(happy_path_upser
     ],
 )
 @pytest.mark.asyncio
-async def test_team_member_update_rejects_invalid_budget_duration(
-    monkeypatch, bad_duration
-):
+async def test_team_member_update_rejects_invalid_budget_duration(monkeypatch, bad_duration):
     """An invalid budget_duration must be rejected with a 400 before any DB
     write, so it can never be persisted and later break the budget reset job."""
     monkeypatch.setattr(proxy_server, "prisma_client", object())
@@ -221,6 +211,35 @@ async def test_bulk_team_member_update_applies_patch_and_returns_member_failures
         "user_id": "user-1",
         "tpm_limit": 42,
     }
+
+
+@pytest.mark.asyncio
+async def test_bulk_team_member_update_returns_unexpected_member_failure(monkeypatch):
+    team_row = LiteLLM_TeamTable(
+        team_id="team-1234",
+        members_with_roles=[Member(user_id="user-1", role="user")],
+    )
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=team_row)
+    monkeypatch.setattr(proxy_server, "prisma_client", prisma_client)
+    monkeypatch.setattr(
+        team_endpoints, "team_member_update", AsyncMock(side_effect=RuntimeError("database unavailable"))
+    )
+
+    response = await bulk_update_team_members(
+        data=BulkTeamMemberUpdateRequest(
+            team_id="team-1234",
+            user_ids=["user-1"],
+            update_fields=TeamMemberBulkUpdateFields(tpm_limit=42),
+        ),
+        http_request=Request({"type": "http", "method": "POST", "path": "/team/member/bulk_update"}),
+        user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN.value, user_id="admin"),
+    )
+
+    assert response.successful_updates == []
+    assert response.failed_updates == [
+        team_endpoints.FailedTeamMemberUpdate(user_id="user-1", failed_reason="database unavailable")
+    ]
 
 
 def test_bulk_team_member_update_requires_exactly_one_member_selector():

--- a/tests/test_litellm/proxy/test_team_member_update.py
+++ b/tests/test_litellm/proxy/test_team_member_update.py
@@ -8,13 +8,18 @@ from starlette.requests import Request
 import litellm.proxy.proxy_server as proxy_server
 import litellm.proxy.management_endpoints.team_endpoints as team_endpoints
 from litellm.proxy._types import (
+    BulkTeamMemberUpdateRequest,
     LiteLLM_TeamTable,
     LitellmUserRoles,
     Member,
+    TeamMemberBulkUpdateFields,
     TeamMemberUpdateRequest,
     UserAPIKeyAuth,
 )
-from litellm.proxy.management_endpoints.team_endpoints import team_member_update
+from litellm.proxy.management_endpoints.team_endpoints import (
+    bulk_update_team_members,
+    team_member_update,
+)
 
 
 @pytest.mark.asyncio
@@ -178,3 +183,51 @@ async def test_team_member_update_rejects_invalid_budget_duration(
     assert exc_info.value.status_code == 400
     assert "budget_duration" in str(exc_info.value.detail)
     upsert_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bulk_team_member_update_applies_patch_and_returns_member_failures(monkeypatch):
+    team_row = LiteLLM_TeamTable(
+        team_id="team-1234",
+        members_with_roles=[Member(user_id="user-1", role="user")],
+    )
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=team_row)
+    monkeypatch.setattr(proxy_server, "prisma_client", prisma_client)
+    update_mock = AsyncMock(
+        side_effect=[
+            team_endpoints.TeamMemberUpdateResponse(team_id="team-1234", user_id="user-1", tpm_limit=42),
+            HTTPException(status_code=404, detail={"error": "User is not a team member"}),
+        ]
+    )
+    monkeypatch.setattr(team_endpoints, "team_member_update", update_mock)
+
+    response = await bulk_update_team_members(
+        data=BulkTeamMemberUpdateRequest(
+            team_id="team-1234",
+            user_ids=["user-1", "user-2", "user-1"],
+            update_fields=TeamMemberBulkUpdateFields(tpm_limit=42),
+        ),
+        http_request=Request({"type": "http", "method": "POST", "path": "/team/member/bulk_update"}),
+        user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN.value, user_id="admin"),
+    )
+
+    assert response.total_requested == 2
+    assert [member.user_id for member in response.successful_updates] == ["user-1"]
+    assert response.failed_updates[0].user_id == "user-2"
+    assert "not a team member" in response.failed_updates[0].failed_reason
+    assert update_mock.await_args_list[0].kwargs["data"].model_dump(exclude_unset=True) == {
+        "team_id": "team-1234",
+        "user_id": "user-1",
+        "tpm_limit": 42,
+    }
+
+
+def test_bulk_team_member_update_requires_exactly_one_member_selector():
+    with pytest.raises(ValueError, match="either user_ids or all_members_in_team"):
+        BulkTeamMemberUpdateRequest(
+            team_id="team-1234",
+            user_ids=["user-1"],
+            all_members_in_team=True,
+            update_fields=TeamMemberBulkUpdateFields(tpm_limit=42),
+        )

--- a/ui/litellm-dashboard/src/components/common_components/MemberTable.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/MemberTable.tsx
@@ -19,6 +19,7 @@ export interface MemberTableProps {
   showDeleteForMember?: (member: Member) => boolean;
   emptyText?: string;
   rowSelection?: React.ComponentProps<typeof Table<Member>>["rowSelection"];
+  extraActions?: React.ReactNode;
 }
 
 export default function MemberTable({
@@ -33,6 +34,7 @@ export default function MemberTable({
   showDeleteForMember,
   emptyText,
   rowSelection,
+  extraActions,
 }: MemberTableProps) {
   const baseColumns: ColumnsType<Member> = [
     {
@@ -115,10 +117,15 @@ export default function MemberTable({
         scroll={{ x: "max-content" }}
         locale={emptyText ? { emptyText } : undefined}
       />
-      {onAddMember && canEdit && (
-        <Button icon={<UserAddOutlined />} type="primary" onClick={onAddMember}>
-          Add Member
-        </Button>
+      {(onAddMember || extraActions) && canEdit && (
+        <Space>
+          {onAddMember && (
+            <Button icon={<UserAddOutlined />} type="primary" onClick={onAddMember}>
+              Add Member
+            </Button>
+          )}
+          {extraActions}
+        </Space>
       )}
     </Space>
   );

--- a/ui/litellm-dashboard/src/components/common_components/MemberTable.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/MemberTable.tsx
@@ -18,6 +18,7 @@ export interface MemberTableProps {
   extraColumns?: ColumnsType<Member>;
   showDeleteForMember?: (member: Member) => boolean;
   emptyText?: string;
+  rowSelection?: React.ComponentProps<typeof Table<Member>>["rowSelection"];
 }
 
 export default function MemberTable({
@@ -31,6 +32,7 @@ export default function MemberTable({
   extraColumns = [],
   showDeleteForMember,
   emptyText,
+  rowSelection,
 }: MemberTableProps) {
   const baseColumns: ColumnsType<Member> = [
     {
@@ -106,6 +108,7 @@ export default function MemberTable({
       <Table
         columns={baseColumns}
         dataSource={members}
+        rowSelection={rowSelection}
         rowKey={(record) => record.user_id ?? record.user_email ?? JSON.stringify(record)}
         pagination={false}
         size="small"

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -2732,6 +2732,32 @@ export interface Member {
   allowed_models?: string[] | null;
 }
 
+export interface TeamMemberBulkUpdateFields {
+  role?: "admin" | "user" | null;
+  max_budget_in_team?: number | null;
+  tpm_limit?: number | null;
+  rpm_limit?: number | null;
+  budget_duration?: string | null;
+  allowed_models?: string[] | null;
+}
+
+export const teamMemberBulkUpdateCall = async (
+  accessToken: string,
+  teamId: string,
+  userIds: string[],
+  allMembersInTeam: boolean,
+  updateFields: TeamMemberBulkUpdateFields,
+) => {
+  return apiClient.post(`/team/member/bulk_update`, {
+    accessToken,
+    body: {
+      team_id: teamId,
+      ...(allMembersInTeam ? { all_members_in_team: true } : { user_ids: userIds }),
+      update_fields: updateFields,
+    },
+  });
+};
+
 export const teamMemberAddCall = async (accessToken: string, teamId: string, formValues: Member) => {
   try {
     const url = proxyBaseUrl ? `${proxyBaseUrl}/team/member_add` : `/team/member_add`;

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -889,6 +889,12 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                 setSelectedEditMember={setSelectedEditMember}
                 setIsEditMemberModalVisible={setIsEditMemberModalVisible}
                 setIsAddMemberModalVisible={setIsAddMemberModalVisible}
+                onMembersUpdated={async () => {
+                  if (!accessToken) return;
+                  const updatedTeamData = await teamInfoCall(accessToken, teamId);
+                  setTeamData(updatedTeamData);
+                  onUpdate(updatedTeamData);
+                }}
               />
             ),
           },

--- a/ui/litellm-dashboard/src/components/team/TeamMemberTab.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamMemberTab.test.tsx
@@ -182,6 +182,25 @@ describe("TeamMembersComponent", () => {
     expect(screen.getByText("Add Member")).toBeInTheDocument();
   });
 
+  it("should show checkboxes after Select Members is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <TeamMembersComponent
+        teamData={createMockTeamData()}
+        canEditTeam={true}
+        handleMemberDelete={mockHandleMemberDelete}
+        setSelectedEditMember={mockSetSelectedEditMember}
+        setIsEditMemberModalVisible={mockSetIsEditMemberModalVisible}
+        setIsAddMemberModalVisible={mockSetIsAddMemberModalVisible}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Select Members" }));
+
+    expect(screen.getByRole("button", { name: "Bulk Edit (0 selected)" })).toBeDisabled();
+    expect(screen.getAllByRole("checkbox")).toHaveLength(3);
+  });
+
   it("should display dash when user email is null", () => {
     renderWithProviders(
       <TeamMembersComponent

--- a/ui/litellm-dashboard/src/components/team/TeamMemberTab.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamMemberTab.tsx
@@ -35,6 +35,8 @@ export default function TeamMemberTab({
 }: TeamMemberTabProps) {
   const [isBulkUpdateVisible, setIsBulkUpdateVisible] = useState(false);
   const [isBulkUpdating, setIsBulkUpdating] = useState(false);
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedMembers, setSelectedMembers] = useState<Member[]>([]);
   const [bulkUpdateForm] = Form.useForm();
   const formatNumber = (value: number | null): string => {
     if (value === null || value === undefined) return "0";
@@ -193,8 +195,6 @@ export default function TeamMemberTab({
   ];
 
   const handleBulkUpdate = async (values: {
-    all_members_in_team?: boolean;
-    user_ids?: string[];
     apply_role?: boolean;
     role?: "admin" | "user";
     apply_max_budget?: boolean;
@@ -209,6 +209,11 @@ export default function TeamMemberTab({
     allowed_models?: string[];
   }) => {
     if (!accessToken) return;
+    const userIds = selectedMembers.flatMap((member) => (member.user_id ? [member.user_id] : []));
+    if (userIds.length === 0) {
+      NotificationsManager.fromBackend("Select at least one team member");
+      return;
+    }
     const updateFields: TeamMemberBulkUpdateFields = {
       ...(values.apply_role ? { role: values.role } : {}),
       ...(values.apply_max_budget ? { max_budget_in_team: values.max_budget_in_team ?? null } : {}),
@@ -224,15 +229,11 @@ export default function TeamMemberTab({
 
     setIsBulkUpdating(true);
     try {
-      const response = await teamMemberBulkUpdateCall(
-        accessToken,
-        teamData.team_id,
-        values.user_ids ?? [],
-        values.all_members_in_team === true,
-        updateFields,
-      );
+      const response = await teamMemberBulkUpdateCall(accessToken, teamData.team_id, userIds, false, updateFields);
       await onMembersUpdated?.();
       setIsBulkUpdateVisible(false);
+      setSelectedMembers([]);
+      setSelectionMode(false);
       bulkUpdateForm.resetFields();
       NotificationsManager.success(
         `${response.successful_updates.length} team member${response.successful_updates.length === 1 ? "" : "s"} updated`,
@@ -250,9 +251,22 @@ export default function TeamMemberTab({
   return (
     <>
       {canEditTeam && (
-        <Button className="mb-3" onClick={() => setIsBulkUpdateVisible(true)}>
-          Bulk Update Members
-        </Button>
+        <Space className="mb-3">
+          <Button
+            onClick={() => {
+              setSelectionMode((current) => !current);
+              setSelectedMembers([]);
+            }}
+            type={selectionMode ? "primary" : "default"}
+          >
+            {selectionMode ? "Cancel Selection" : "Select Members"}
+          </Button>
+          {selectionMode && (
+            <Button type="primary" disabled={selectedMembers.length === 0} onClick={() => setIsBulkUpdateVisible(true)}>
+              Bulk Edit ({selectedMembers.length} selected)
+            </Button>
+          )}
+        </Space>
       )}
       <MemberTable
         members={teamData.team_info.members_with_roles}
@@ -275,12 +289,21 @@ export default function TeamMemberTab({
         roleColumnTitle="Team Role"
         roleTooltip="This role applies only to this team and is independent from the user's proxy-level role."
         extraColumns={extraColumns}
+        rowSelection={
+          selectionMode
+            ? {
+                selectedRowKeys: selectedMembers.flatMap((member) => (member.user_id ? [member.user_id] : [])),
+                onChange: (_selectedRowKeys, selectedRows) => setSelectedMembers(selectedRows),
+                getCheckboxProps: (member) => ({ disabled: member.user_id === null }),
+              }
+            : undefined
+        }
         showDeleteForMember={() =>
           isProxyAdmin || (canEditTeam && !isUserTeamAdmin) || (isUserTeamAdmin && !disableTeamAdminDeleteTeamUser)
         }
       />
       <Modal
-        title="Bulk Update Team Members"
+        title={`Bulk Edit ${selectedMembers.length} Team Member${selectedMembers.length === 1 ? "" : "s"}`}
         open={isBulkUpdateVisible}
         onCancel={() => setIsBulkUpdateVisible(false)}
         onOk={() => bulkUpdateForm.submit()}
@@ -288,31 +311,6 @@ export default function TeamMemberTab({
         confirmLoading={isBulkUpdating}
       >
         <Form form={bulkUpdateForm} layout="vertical" onFinish={handleBulkUpdate}>
-          <Form.Item name="all_members_in_team" valuePropName="checked">
-            <Checkbox>Update all {teamData.team_info.members_with_roles.length} members</Checkbox>
-          </Form.Item>
-          <Form.Item noStyle shouldUpdate>
-            {({ getFieldValue }) =>
-              !getFieldValue("all_members_in_team") && (
-                <Form.Item
-                  name="user_ids"
-                  label="Members"
-                  rules={[{ required: true, message: "Select at least one member" }]}
-                >
-                  <Select
-                    mode="multiple"
-                    placeholder="Select members"
-                    options={teamData.team_info.members_with_roles
-                      .filter((member) => member.user_id)
-                      .map((member) => ({
-                        label: member.user_email || member.user_id,
-                        value: member.user_id as string,
-                      }))}
-                  />
-                </Form.Item>
-              )
-            }
-          </Form.Item>
           <Typography.Text type="secondary">Choose the fields to apply to every selected member.</Typography.Text>
           <Form.Item name="apply_role" valuePropName="checked" className="mt-3 mb-1">
             <Checkbox>Team role</Checkbox>

--- a/ui/litellm-dashboard/src/components/team/TeamMemberTab.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamMemberTab.tsx
@@ -1,12 +1,16 @@
 import { useUISettings } from "@/app/(dashboard)/hooks/uiSettings/useUISettings";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
-import { Member } from "@/components/networking";
+import { Member, TeamMemberBulkUpdateFields, teamMemberBulkUpdateCall } from "@/components/networking";
+import BudgetDurationDropdown from "@/components/common_components/budget_duration_dropdown";
+import NotificationsManager from "@/components/molecules/notifications_manager";
+import NumericalInput from "@/components/shared/numerical_input";
 import { DateCell, MoneyCell } from "@/components/shared/table_cells";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
 import { isProxyAdminRole, isUserTeamAdminForSingleTeam } from "@/utils/roles";
 import { InfoCircleOutlined } from "@ant-design/icons";
-import { Space, Tooltip, Typography } from "antd";
+import { Button, Checkbox, Form, Modal, Select, Space, Tooltip, Typography } from "antd";
 import type { ColumnsType } from "antd/es/table";
+import { useState } from "react";
 import MemberTable from "@/components/common_components/MemberTable";
 import { TeamData } from "./TeamInfo";
 
@@ -17,6 +21,7 @@ interface TeamMemberTabProps {
   setSelectedEditMember: (member: Member) => void;
   setIsEditMemberModalVisible: (visible: boolean) => void;
   setIsAddMemberModalVisible: (visible: boolean) => void;
+  onMembersUpdated?: () => Promise<void>;
 }
 
 export default function TeamMemberTab({
@@ -26,7 +31,11 @@ export default function TeamMemberTab({
   setSelectedEditMember,
   setIsEditMemberModalVisible,
   setIsAddMemberModalVisible,
+  onMembersUpdated,
 }: TeamMemberTabProps) {
+  const [isBulkUpdateVisible, setIsBulkUpdateVisible] = useState(false);
+  const [isBulkUpdating, setIsBulkUpdating] = useState(false);
+  const [bulkUpdateForm] = Form.useForm();
   const formatNumber = (value: number | null): string => {
     if (value === null || value === undefined) return "0";
 
@@ -79,7 +88,7 @@ export default function TeamMemberTab({
   };
 
   const { data: uiSettingsData } = useUISettings();
-  const { userId, userRole } = useAuthorized();
+  const { accessToken, userId, userRole } = useAuthorized();
   const disableTeamAdminDeleteTeamUser = Boolean(uiSettingsData?.values?.disable_team_admin_delete_team_user);
   const isUserTeamAdmin = isUserTeamAdminForSingleTeam(teamData.team_info.members_with_roles, userId || "");
   const isProxyAdmin = isProxyAdminRole(userRole || "");
@@ -183,31 +192,217 @@ export default function TeamMemberTab({
     },
   ];
 
-  return (
-    <MemberTable
-      members={teamData.team_info.members_with_roles}
-      canEdit={canEditTeam}
-      onEdit={(record) => {
-        const membership = teamData.team_memberships.find((tm) => tm.user_id === record.user_id);
-        const enhancedMember = {
-          ...record,
-          max_budget_in_team: membership?.litellm_budget_table?.max_budget || null,
-          tpm_limit: membership?.litellm_budget_table?.tpm_limit || null,
-          rpm_limit: membership?.litellm_budget_table?.rpm_limit || null,
-          budget_duration: membership?.litellm_budget_table?.budget_duration || null,
-          allowed_models: membership?.litellm_budget_table?.allowed_models || [],
-        };
-        setSelectedEditMember(enhancedMember);
-        setIsEditMemberModalVisible(true);
-      }}
-      onDelete={handleMemberDelete}
-      onAddMember={() => setIsAddMemberModalVisible(true)}
-      roleColumnTitle="Team Role"
-      roleTooltip="This role applies only to this team and is independent from the user's proxy-level role."
-      extraColumns={extraColumns}
-      showDeleteForMember={() =>
-        isProxyAdmin || (canEditTeam && !isUserTeamAdmin) || (isUserTeamAdmin && !disableTeamAdminDeleteTeamUser)
+  const handleBulkUpdate = async (values: {
+    all_members_in_team?: boolean;
+    user_ids?: string[];
+    apply_role?: boolean;
+    role?: "admin" | "user";
+    apply_max_budget?: boolean;
+    max_budget_in_team?: number | null;
+    apply_budget_duration?: boolean;
+    budget_duration?: string | null;
+    apply_tpm_limit?: boolean;
+    tpm_limit?: number | null;
+    apply_rpm_limit?: boolean;
+    rpm_limit?: number | null;
+    apply_allowed_models?: boolean;
+    allowed_models?: string[];
+  }) => {
+    if (!accessToken) return;
+    const updateFields: TeamMemberBulkUpdateFields = {
+      ...(values.apply_role ? { role: values.role } : {}),
+      ...(values.apply_max_budget ? { max_budget_in_team: values.max_budget_in_team ?? null } : {}),
+      ...(values.apply_budget_duration ? { budget_duration: values.budget_duration ?? null } : {}),
+      ...(values.apply_tpm_limit ? { tpm_limit: values.tpm_limit ?? null } : {}),
+      ...(values.apply_rpm_limit ? { rpm_limit: values.rpm_limit ?? null } : {}),
+      ...(values.apply_allowed_models ? { allowed_models: values.allowed_models ?? [] } : {}),
+    };
+    if (Object.keys(updateFields).length === 0) {
+      NotificationsManager.fromBackend("Select at least one field to update");
+      return;
+    }
+
+    setIsBulkUpdating(true);
+    try {
+      const response = await teamMemberBulkUpdateCall(
+        accessToken,
+        teamData.team_id,
+        values.user_ids ?? [],
+        values.all_members_in_team === true,
+        updateFields,
+      );
+      await onMembersUpdated?.();
+      setIsBulkUpdateVisible(false);
+      bulkUpdateForm.resetFields();
+      NotificationsManager.success(
+        `${response.successful_updates.length} team member${response.successful_updates.length === 1 ? "" : "s"} updated`,
+      );
+      if (response.failed_updates.length > 0) {
+        NotificationsManager.fromBackend(`${response.failed_updates.length} team member updates failed`);
       }
-    />
+    } catch (error) {
+      NotificationsManager.fromBackend(error instanceof Error ? error.message : "Failed to bulk update team members");
+    } finally {
+      setIsBulkUpdating(false);
+    }
+  };
+
+  return (
+    <>
+      {canEditTeam && (
+        <Button className="mb-3" onClick={() => setIsBulkUpdateVisible(true)}>
+          Bulk Update Members
+        </Button>
+      )}
+      <MemberTable
+        members={teamData.team_info.members_with_roles}
+        canEdit={canEditTeam}
+        onEdit={(record) => {
+          const membership = teamData.team_memberships.find((tm) => tm.user_id === record.user_id);
+          const enhancedMember = {
+            ...record,
+            max_budget_in_team: membership?.litellm_budget_table?.max_budget || null,
+            tpm_limit: membership?.litellm_budget_table?.tpm_limit || null,
+            rpm_limit: membership?.litellm_budget_table?.rpm_limit || null,
+            budget_duration: membership?.litellm_budget_table?.budget_duration || null,
+            allowed_models: membership?.litellm_budget_table?.allowed_models || [],
+          };
+          setSelectedEditMember(enhancedMember);
+          setIsEditMemberModalVisible(true);
+        }}
+        onDelete={handleMemberDelete}
+        onAddMember={() => setIsAddMemberModalVisible(true)}
+        roleColumnTitle="Team Role"
+        roleTooltip="This role applies only to this team and is independent from the user's proxy-level role."
+        extraColumns={extraColumns}
+        showDeleteForMember={() =>
+          isProxyAdmin || (canEditTeam && !isUserTeamAdmin) || (isUserTeamAdmin && !disableTeamAdminDeleteTeamUser)
+        }
+      />
+      <Modal
+        title="Bulk Update Team Members"
+        open={isBulkUpdateVisible}
+        onCancel={() => setIsBulkUpdateVisible(false)}
+        onOk={() => bulkUpdateForm.submit()}
+        okText="Update Members"
+        confirmLoading={isBulkUpdating}
+      >
+        <Form form={bulkUpdateForm} layout="vertical" onFinish={handleBulkUpdate}>
+          <Form.Item name="all_members_in_team" valuePropName="checked">
+            <Checkbox>Update all {teamData.team_info.members_with_roles.length} members</Checkbox>
+          </Form.Item>
+          <Form.Item noStyle shouldUpdate>
+            {({ getFieldValue }) =>
+              !getFieldValue("all_members_in_team") && (
+                <Form.Item
+                  name="user_ids"
+                  label="Members"
+                  rules={[{ required: true, message: "Select at least one member" }]}
+                >
+                  <Select
+                    mode="multiple"
+                    placeholder="Select members"
+                    options={teamData.team_info.members_with_roles
+                      .filter((member) => member.user_id)
+                      .map((member) => ({
+                        label: member.user_email || member.user_id,
+                        value: member.user_id as string,
+                      }))}
+                  />
+                </Form.Item>
+              )
+            }
+          </Form.Item>
+          <Typography.Text type="secondary">Choose the fields to apply to every selected member.</Typography.Text>
+          <Form.Item name="apply_role" valuePropName="checked" className="mt-3 mb-1">
+            <Checkbox>Team role</Checkbox>
+          </Form.Item>
+          <Form.Item noStyle shouldUpdate>
+            {({ getFieldValue }) =>
+              getFieldValue("apply_role") && (
+                <Form.Item name="role" rules={[{ required: true, message: "Select a role" }]}>
+                  <Select
+                    placeholder="Select role"
+                    options={[
+                      { label: "Admin", value: "admin" },
+                      { label: "User", value: "user" },
+                    ]}
+                  />
+                </Form.Item>
+              )
+            }
+          </Form.Item>
+          <Form.Item name="apply_max_budget" valuePropName="checked" className="mb-1">
+            <Checkbox>Team member budget (USD)</Checkbox>
+          </Form.Item>
+          <Form.Item noStyle shouldUpdate>
+            {({ getFieldValue }) =>
+              getFieldValue("apply_max_budget") && (
+                <Form.Item name="max_budget_in_team">
+                  <NumericalInput
+                    min={0}
+                    step={0.01}
+                    placeholder="Leave blank to clear the budget"
+                    style={{ width: "100%" }}
+                  />
+                </Form.Item>
+              )
+            }
+          </Form.Item>
+          <Form.Item name="apply_budget_duration" valuePropName="checked" className="mb-1">
+            <Checkbox>Budget reset period</Checkbox>
+          </Form.Item>
+          <Form.Item noStyle shouldUpdate>
+            {({ getFieldValue }) =>
+              getFieldValue("apply_budget_duration") && (
+                <Form.Item name="budget_duration">
+                  <BudgetDurationDropdown />
+                </Form.Item>
+              )
+            }
+          </Form.Item>
+          <Form.Item name="apply_tpm_limit" valuePropName="checked" className="mb-1">
+            <Checkbox>TPM limit</Checkbox>
+          </Form.Item>
+          <Form.Item noStyle shouldUpdate>
+            {({ getFieldValue }) =>
+              getFieldValue("apply_tpm_limit") && (
+                <Form.Item name="tpm_limit">
+                  <NumericalInput min={0} placeholder="Leave blank to clear the TPM limit" style={{ width: "100%" }} />
+                </Form.Item>
+              )
+            }
+          </Form.Item>
+          <Form.Item name="apply_rpm_limit" valuePropName="checked" className="mb-1">
+            <Checkbox>RPM limit</Checkbox>
+          </Form.Item>
+          <Form.Item noStyle shouldUpdate>
+            {({ getFieldValue }) =>
+              getFieldValue("apply_rpm_limit") && (
+                <Form.Item name="rpm_limit">
+                  <NumericalInput min={0} placeholder="Leave blank to clear the RPM limit" style={{ width: "100%" }} />
+                </Form.Item>
+              )
+            }
+          </Form.Item>
+          <Form.Item name="apply_allowed_models" valuePropName="checked" className="mb-1">
+            <Checkbox>Allowed models</Checkbox>
+          </Form.Item>
+          <Form.Item noStyle shouldUpdate>
+            {({ getFieldValue }) =>
+              getFieldValue("apply_allowed_models") && (
+                <Form.Item name="allowed_models">
+                  <Select
+                    mode="multiple"
+                    placeholder="Leave empty to inherit team models"
+                    options={(teamData.team_info.models || []).map((model) => ({ label: model, value: model }))}
+                  />
+                </Form.Item>
+              )
+            }
+          </Form.Item>
+        </Form>
+      </Modal>
+    </>
   );
 }

--- a/ui/litellm-dashboard/src/components/team/TeamMemberTab.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamMemberTab.tsx
@@ -250,24 +250,6 @@ export default function TeamMemberTab({
 
   return (
     <>
-      {canEditTeam && (
-        <Space className="mb-3">
-          <Button
-            onClick={() => {
-              setSelectionMode((current) => !current);
-              setSelectedMembers([]);
-            }}
-            type={selectionMode ? "primary" : "default"}
-          >
-            {selectionMode ? "Cancel Selection" : "Select Members"}
-          </Button>
-          {selectionMode && (
-            <Button type="primary" disabled={selectedMembers.length === 0} onClick={() => setIsBulkUpdateVisible(true)}>
-              Bulk Edit ({selectedMembers.length} selected)
-            </Button>
-          )}
-        </Space>
-      )}
       <MemberTable
         members={teamData.team_info.members_with_roles}
         canEdit={canEditTeam}
@@ -286,6 +268,28 @@ export default function TeamMemberTab({
         }}
         onDelete={handleMemberDelete}
         onAddMember={() => setIsAddMemberModalVisible(true)}
+        extraActions={
+          <>
+            <Button
+              onClick={() => {
+                setSelectionMode((current) => !current);
+                setSelectedMembers([]);
+              }}
+              type={selectionMode ? "primary" : "default"}
+            >
+              {selectionMode ? "Cancel Selection" : "Select Members"}
+            </Button>
+            {selectionMode && (
+              <Button
+                type="primary"
+                disabled={selectedMembers.length === 0}
+                onClick={() => setIsBulkUpdateVisible(true)}
+              >
+                Bulk Edit ({selectedMembers.length} selected)
+              </Button>
+            )}
+          </>
+        }
         roleColumnTitle="Team Role"
         roleTooltip="This role applies only to this team and is independent from the user's proxy-level role."
         extraColumns={extraColumns}

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -436,26 +436,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/alerting/settings": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Alerting Settings
-         * @description Return the configurable alerting param, description, and current value
-         */
-        get: operations["alerting_settings_alerting_settings_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/anthropic/{endpoint}": {
         parameters: {
             query?: never;
@@ -1844,26 +1824,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/config/callback/delete": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Delete Callback
-         * @description Delete specific logging callback from configuration.
-         */
-        post: operations["delete_callback_config_callback_delete_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/config/cost_discount_config": {
         parameters: {
             query?: never;
@@ -1945,83 +1905,6 @@ export interface paths {
         patch: operations["update_cost_margin_config_config_cost_margin_config_patch"];
         trace?: never;
     };
-    "/config/field/delete": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Delete Config General Settings
-         * @description Delete the db value of this field in litellm general settings. Resets it to it's initial default value on litellm.
-         */
-        post: operations["delete_config_general_settings_config_field_delete_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/config/field/info": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Config General Settings */
-        get: operations["get_config_general_settings_config_field_info_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/config/field/update": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Update Config General Settings
-         * @description Update a specific field in litellm general settings
-         */
-        post: operations["update_config_general_settings_config_field_update_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/config/list": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Config List
-         * @description List the available fields + current values for a given type of setting (currently just 'general_settings'user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),)
-         */
-        get: operations["get_config_list_config_list_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/config/pass_through_endpoint": {
         parameters: {
             query?: never;
@@ -2090,64 +1973,6 @@ export interface paths {
          * @description Update a pass-through endpoint by ID.
          */
         post: operations["update_pass_through_endpoints_config_pass_through_endpoint__endpoint_id__post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/config/update": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Update Config
-         * @description For Admin UI - allows admin to update config via UI.
-         *
-         *     Writes only the sections present in the request body to LiteLLM_Config rows
-         *     (one row per top-level section). Sections the caller did not send are left
-         *     untouched — this endpoint never persists pre-existing YAML values to DB as
-         *     a side effect of an unrelated update.
-         */
-        post: operations["update_config_config_update_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/config/yaml": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Config Yaml Endpoint
-         * @description This is a mock endpoint, to show what you can set in config.yaml details in the Swagger UI.
-         *
-         *     Parameters:
-         *
-         *     The config.yaml object has the following attributes:
-         *     - **model_list**: *Optional[List[ModelParams]]* - A list of supported models on the server, along with model-specific configurations. ModelParams includes "model_name" (name of the model), "litellm_params" (litellm-specific parameters for the model), and "model_info" (additional info about the model such as id, mode, cost per token, etc).
-         *
-         *     - **litellm_settings**: *Optional[dict]*: Settings for the litellm module. You can specify multiple properties like "drop_params", "set_verbose", "api_base", "cache".
-         *
-         *     - **general_settings**: *Optional[ConfigGeneralSettings]*: General settings for the server like "completion_model" (default model for chat completion calls), "use_azure_key_vault" (option to load keys from azure key vault), "master_key" (key required for all calls to proxy), and others.
-         *
-         *     Please, refer to each class's description for a better understanding of the specific attributes within them.
-         *
-         *     Note: This is a mock endpoint primarily meant for demonstration purposes, and does not actually provide or change any configurations.
-         */
-        get: operations["config_yaml_endpoint_config_yaml_get"];
-        put?: never;
-        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -3100,120 +2925,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/debug/memory/details": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Memory Details
-         * @description Get detailed memory diagnostics for deep debugging.
-         *
-         *     Returns:
-         *     - worker_pid: Process ID
-         *     - process_memory: RAM usage, virtual memory, file handles, threads
-         *     - garbage_collector: GC thresholds, counts, collection history
-         *     - objects: Total tracked objects and top object types
-         *     - uncollectable: Objects that can't be garbage collected (potential leaks)
-         *     - cache_memory: Memory usage of user_api_key, router, and logging caches
-         *     - router_memory: Memory usage of router components (model_list, deployment_names, etc.)
-         *
-         *     Query Parameters:
-         *     - top_n: Number of top object types to return (default: 20)
-         *     - include_process_info: Include process-level memory info using psutil (default: true)
-         *
-         *     Example usage:
-         *     curl "http://localhost:4000/debug/memory/details?top_n=30" -H "Authorization: Bearer sk-1234"
-         *
-         *     All memory sizes are reported in both bytes and MB.
-         */
-        get: operations["get_memory_details_debug_memory_details_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/debug/memory/gc/configure": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Configure Gc Thresholds Endpoint
-         * @description Configure Python garbage collection thresholds.
-         *
-         *     Lower thresholds mean more frequent GC cycles (less memory, more CPU overhead).
-         *     Higher thresholds mean less frequent GC cycles (more memory, less CPU overhead).
-         *
-         *     Returns:
-         *     - message: Confirmation message
-         *     - previous_thresholds: Old threshold values
-         *     - new_thresholds: New threshold values
-         *     - objects_awaiting_collection: Current object count in gen-0
-         *     - tip: Hint about when next collection will occur
-         *
-         *     Query Parameters:
-         *     - generation_0: Number of allocations before gen-0 collection (default: 700)
-         *     - generation_1: Number of gen-0 collections before gen-1 collection (default: 10)
-         *     - generation_2: Number of gen-1 collections before gen-2 collection (default: 10)
-         *
-         *     Example for more aggressive collection:
-         *     curl -X POST "http://localhost:4000/debug/memory/gc/configure?generation_0=500" -H "Authorization: Bearer sk-1234"
-         *
-         *     Example for less aggressive collection:
-         *     curl -X POST "http://localhost:4000/debug/memory/gc/configure?generation_0=1000" -H "Authorization: Bearer sk-1234"
-         *
-         *     Monitor memory usage with GET /debug/memory/summary after changes.
-         */
-        post: operations["configure_gc_thresholds_endpoint_debug_memory_gc_configure_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/debug/memory/summary": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Memory Summary
-         * @description Get simplified memory usage summary for the proxy.
-         *
-         *     Returns:
-         *     - worker_pid: Process ID
-         *     - status: Overall health based on memory usage
-         *     - memory: Process memory usage and RAM info
-         *     - caches: Cache item counts and descriptions
-         *     - garbage_collector: GC status and pending object counts
-         *
-         *     Example usage:
-         *     curl http://localhost:4000/debug/memory/summary -H "Authorization: Bearer sk-1234"
-         *
-         *     For detailed analysis, call GET /debug/memory/details
-         *     For cache management, use the cache management endpoints
-         */
-        get: operations["get_memory_summary_debug_memory_summary_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/delete/allowed_ip": {
         parameters: {
             query?: never;
@@ -3299,312 +3010,6 @@ export interface paths {
          *     ```
          */
         post: operations["embeddings_embeddings_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/end_user/block": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Block User
-         * @description [BETA] Reject calls with this end-user id
-         *
-         *     Parameters:
-         *     - user_ids (List[str], required): The unique `user_id`s for the users to block
-         *
-         *         (any /chat/completion call with this user={end-user-id} param, will be rejected.)
-         *
-         *         ```
-         *         curl -X POST "http://0.0.0.0:8000/user/block"
-         *         -H "Authorization: Bearer sk-1234"
-         *         -d '{
-         *         "user_ids": [<user_id>, ...]
-         *         }'
-         *         ```
-         */
-        post: operations["block_user_end_user_block_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/end_user/daily/activity": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Customer Daily Activity
-         * @description Get daily activity for specific organizations or all accessible organizations.
-         */
-        get: operations["get_customer_daily_activity_end_user_daily_activity_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/end_user/delete": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Delete End User
-         * @description Delete multiple end-users.
-         *
-         *     Parameters:
-         *     - user_ids (List[str], required): The unique `user_id`s for the users to delete
-         *
-         *     Example curl:
-         *     ```
-         *     curl --location 'http://0.0.0.0:4000/customer/delete'         --header 'Authorization: Bearer sk-1234'         --header 'Content-Type: application/json'         --data '{
-         *             "user_ids" :["ishaan-jaff-5"]
-         *     }'
-         *
-         *     See below for all params
-         *     ```
-         */
-        post: operations["delete_end_user_end_user_delete_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/end_user/info": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * End User Info
-         * @description Get information about an end-user. An `end_user` is a customer (external user) of the proxy.
-         *
-         *     Parameters:
-         *     - end_user_id (str, required): The unique identifier for the end-user
-         *
-         *     Example curl:
-         *     ```
-         *     curl -X GET 'http://localhost:4000/customer/info?end_user_id=test-litellm-user-4'         -H 'Authorization: Bearer sk-1234'
-         *     ```
-         */
-        get: operations["end_user_info_end_user_info_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/end_user/list": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List End User
-         * @description [Admin-only] List all available customers
-         *
-         *     Example curl:
-         *     ```
-         *     curl --location --request GET 'http://0.0.0.0:4000/customer/list'         --header 'Authorization: Bearer sk-1234'
-         *     ```
-         */
-        get: operations["list_end_user_end_user_list_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/end_user/new": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * New End User
-         * @description Allow creating a new Customer
-         *
-         *
-         *     Parameters:
-         *     - user_id: str - The unique identifier for the user.
-         *     - alias: Optional[str] - A human-friendly alias for the user.
-         *     - blocked: bool - Flag to allow or disallow requests for this end-user. Default is False.
-         *     - max_budget: Optional[float] - The maximum budget allocated to the user. Either 'max_budget' or 'budget_id' should be provided, not both.
-         *     - budget_id: Optional[str] - The identifier for an existing budget allocated to the user. Either 'max_budget' or 'budget_id' should be provided, not both.
-         *     - allowed_model_region: Optional[Union[Literal["eu"], Literal["us"]]] - Require all user requests to use models in this specific region.
-         *     - default_model: Optional[str] - If no equivalent model in the allowed region, default all requests to this model.
-         *     - metadata: Optional[dict] = Metadata for customer, store information for customer. Example metadata = {"data_training_opt_out": True}
-         *     - budget_duration: Optional[str] - Budget is reset at the end of specified duration. If not set, budget is never reset. You can set duration as seconds ("30s"), minutes ("30m"), hours ("30h"), days ("30d").
-         *     - tpm_limit: Optional[int] - [Not Implemented Yet] Specify tpm limit for a given customer (Tokens per minute)
-         *     - rpm_limit: Optional[int] - [Not Implemented Yet] Specify rpm limit for a given customer (Requests per minute)
-         *     - model_max_budget: Optional[dict] - [Not Implemented Yet] Specify max budget for a given model. Example: {"openai/gpt-4o-mini": {"max_budget": 100.0, "budget_duration": "1d"}}
-         *     - max_parallel_requests: Optional[int] - [Not Implemented Yet] Specify max parallel requests for a given customer.
-         *     - soft_budget: Optional[float] - [Not Implemented Yet] Get alerts when customer crosses given budget, doesn't block requests.
-         *     - spend: Optional[float] - Specify initial spend for a given customer.
-         *     - budget_reset_at: Optional[str] - Specify the date and time when the budget should be reset.
-         *     - object_permission: Optional[LiteLLM_ObjectPermissionBase] - Customer-specific object permissions to control access to resources.
-         *         Supported fields:
-         *         * mcp_servers: List[str] - List of allowed MCP server IDs
-         *         * mcp_access_groups: List[str] - List of MCP access group names
-         *         * mcp_tool_permissions: Dict[str, List[str]] - Map of server ID to allowed tool names (e.g., {"server_1": ["tool_a", "tool_b"]})
-         *         * vector_stores: List[str] - List of allowed vector store IDs
-         *         * agents: List[str] - List of allowed agent IDs
-         *         * agent_access_groups: List[str] - List of agent access group names
-         *         Example: {"mcp_servers": ["server_1", "server_2"], "vector_stores": ["vector_store_1"], "agents": ["agent_1"]}
-         *         IF null or {} then no object-level restrictions apply.
-         *
-         *
-         *     - Allow specifying allowed regions
-         *     - Allow specifying default model
-         *
-         *     Example curl:
-         *     ```
-         *     curl --location 'http://0.0.0.0:4000/customer/new'         --header 'Authorization: Bearer sk-1234'         --header 'Content-Type: application/json'         --data '{
-         *             "user_id" : "ishaan-jaff-3",
-         *             "allowed_region": "eu",
-         *             "budget_id": "free_tier",
-         *             "default_model": "azure/gpt-3.5-turbo-eu"
-         *         }'
-         *
-         *     # With object permissions
-         *     curl -L -X POST 'http://localhost:4000/customer/new'         -H 'Authorization: Bearer sk-1234'         -H 'Content-Type: application/json'         -d '{
-         *             "user_id": "user_1",
-         *             "object_permission": {
-         *               "mcp_servers": ["server_1"],
-         *               "mcp_access_groups": ["public_group"],
-         *               "vector_stores": ["vector_store_1"]
-         *             }
-         *           }'
-         *
-         *         # return end-user object
-         *     ```
-         *
-         *     NOTE: This used to be called `/end_user/new`, we will still be maintaining compatibility for /end_user/XXX for these endpoints
-         */
-        post: operations["new_end_user_end_user_new_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/end_user/unblock": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Unblock User
-         * @description [BETA] Unblock calls with this user id
-         *
-         *     Example
-         *     ```
-         *     curl -X POST "http://0.0.0.0:8000/user/unblock"
-         *     -H "Authorization: Bearer sk-1234"
-         *     -d '{
-         *     "user_ids": [<user_id>, ...]
-         *     }'
-         *     ```
-         */
-        post: operations["unblock_user_end_user_unblock_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/end_user/update": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Update End User
-         * @description Example curl
-         *
-         *     Parameters:
-         *     - user_id: str
-         *     - alias: Optional[str] = None  # human-friendly alias
-         *     - blocked: bool = False  # allow/disallow requests for this end-user
-         *     - max_budget: Optional[float] = None
-         *     - budget_id: Optional[str] = None  # give either a budget_id or max_budget
-         *     - allowed_model_region: Optional[AllowedModelRegion] = (
-         *         None  # require all user requests to use models in this specific region
-         *     )
-         *     - default_model: Optional[str] = (
-         *         None  # if no equivalent model in allowed region - default all requests to this model
-         *     )
-         *     - object_permission: Optional[LiteLLM_ObjectPermissionBase] - Customer-specific object permissions to control access to resources.
-         *         Supported fields:
-         *         * mcp_servers: List[str] - List of allowed MCP server IDs
-         *         * mcp_access_groups: List[str] - List of MCP access group names
-         *         * mcp_tool_permissions: Dict[str, List[str]] - Map of server ID to allowed tool names
-         *         * vector_stores: List[str] - List of allowed vector store IDs
-         *         * agents: List[str] - List of allowed agent IDs
-         *         * agent_access_groups: List[str] - List of agent access group names
-         *         Example: {"mcp_servers": ["server_1"], "vector_stores": ["vector_store_1"]}
-         *         IF null or {} then no object-level restrictions apply.
-         *
-         *     Example curl:
-         *     ```
-         *     curl --location 'http://0.0.0.0:4000/customer/update'     --header 'Authorization: Bearer sk-1234'     --header 'Content-Type: application/json'     --data '{
-         *         "user_id": "test-litellm-user-4",
-         *         "budget_id": "paid_tier"
-         *     }'
-         *
-         *     # Updating object permissions
-         *     curl -L -X POST 'http://localhost:4000/customer/update'     --header 'Authorization: Bearer sk-1234'     --header 'Content-Type: application/json'     --data '{
-         *         "user_id": "user_1",
-         *         "object_permission": {
-         *           "mcp_servers": ["server_3"],
-         *           "vector_stores": ["vector_store_2", "vector_store_3"]
-         *         }
-         *       }'
-         *
-         *     See below for all params
-         *     ```
-         */
-        post: operations["update_end_user_end_user_update_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -4074,44 +3479,6 @@ export interface paths {
         patch: operations["gemini_proxy_route_gemini__endpoint__patch"];
         trace?: never;
     };
-    "/get/allowed_ips": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Allowed Ips */
-        get: operations["get_allowed_ips_get_allowed_ips_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/get/config/callbacks": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Config
-         * @description For Admin UI - allows admin to view config via UI
-         *     # return the callbacks and the env variables for the callback
-         */
-        get: operations["get_config_get_config_callbacks_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/get/default_team_settings": {
         parameters: {
             query?: never;
@@ -4309,440 +3676,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/global/activity": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Global Activity
-         * @description Get number of API Requests, total tokens through proxy
-         *
-         *     {
-         *         "daily_data": [
-         *                 const chartdata = [
-         *                 {
-         *                 date: 'Jan 22',
-         *                 api_requests: 10,
-         *                 total_tokens: 2000
-         *                 },
-         *                 {
-         *                 date: 'Jan 23',
-         *                 api_requests: 10,
-         *                 total_tokens: 12
-         *                 },
-         *         ],
-         *         "sum_api_requests": 20,
-         *         "sum_total_tokens": 2012
-         *     }
-         */
-        get: operations["get_global_activity_global_activity_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/activity/cache_hits": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Global Activity
-         * @description Get number of cache hits, vs misses
-         *
-         *     {
-         *         "daily_data": [
-         *                 const chartdata = [
-         *                 {
-         *                     date: 'Jan 22',
-         *                     cache_hits: 10,
-         *                     llm_api_calls: 2000
-         *                 },
-         *                 {
-         *                     date: 'Jan 23',
-         *                     cache_hits: 10,
-         *                     llm_api_calls: 12
-         *                 },
-         *         ],
-         *         "sum_cache_hits": 20,
-         *         "sum_llm_api_calls": 2012
-         *     }
-         */
-        get: operations["get_global_activity_global_activity_cache_hits_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/activity/exceptions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Global Activity Exceptions
-         * @description Get number of API Requests, total tokens through proxy
-         *
-         *     {
-         *         "daily_data": [
-         *                 const chartdata = [
-         *                 {
-         *                 date: 'Jan 22',
-         *                 num_rate_limit_exceptions: 10,
-         *                 },
-         *                 {
-         *                 date: 'Jan 23',
-         *                 num_rate_limit_exceptions: 10,
-         *                 },
-         *         ],
-         *         "sum_api_exceptions": 20,
-         *     }
-         */
-        get: operations["get_global_activity_exceptions_global_activity_exceptions_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/activity/exceptions/deployment": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Global Activity Exceptions Per Deployment
-         * @description Get number of 429 errors - Grouped by deployment
-         *
-         *     [
-         *         {
-         *             "deployment": "https://azure-us-east-1.openai.azure.com/",
-         *             "daily_data": [
-         *                     const chartdata = [
-         *                     {
-         *                     date: 'Jan 22',
-         *                     num_rate_limit_exceptions: 10
-         *                     },
-         *                     {
-         *                     date: 'Jan 23',
-         *                     num_rate_limit_exceptions: 12
-         *                     },
-         *             ],
-         *             "sum_num_rate_limit_exceptions": 20,
-         *
-         *         },
-         *         {
-         *             "deployment": "https://azure-us-east-1.openai.azure.com/",
-         *             "daily_data": [
-         *                     const chartdata = [
-         *                     {
-         *                     date: 'Jan 22',
-         *                     num_rate_limit_exceptions: 10,
-         *                     },
-         *                     {
-         *                     date: 'Jan 23',
-         *                     num_rate_limit_exceptions: 12
-         *                     },
-         *             ],
-         *             "sum_num_rate_limit_exceptions": 20,
-         *
-         *         },
-         *     ]
-         */
-        get: operations["get_global_activity_exceptions_per_deployment_global_activity_exceptions_deployment_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/activity/model": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Global Activity Model
-         * @description Get number of API Requests, total tokens through proxy - Grouped by MODEL
-         *
-         *     [
-         *         {
-         *             "model": "gpt-4",
-         *             "daily_data": [
-         *                     const chartdata = [
-         *                     {
-         *                     date: 'Jan 22',
-         *                     api_requests: 10,
-         *                     total_tokens: 2000
-         *                     },
-         *                     {
-         *                     date: 'Jan 23',
-         *                     api_requests: 10,
-         *                     total_tokens: 12
-         *                     },
-         *             ],
-         *             "sum_api_requests": 20,
-         *             "sum_total_tokens": 2012
-         *
-         *         },
-         *         {
-         *             "model": "azure/gpt-4-turbo",
-         *             "daily_data": [
-         *                     const chartdata = [
-         *                     {
-         *                     date: 'Jan 22',
-         *                     api_requests: 10,
-         *                     total_tokens: 2000
-         *                     },
-         *                     {
-         *                     date: 'Jan 23',
-         *                     api_requests: 10,
-         *                     total_tokens: 12
-         *                     },
-         *             ],
-         *             "sum_api_requests": 20,
-         *             "sum_total_tokens": 2012
-         *
-         *         },
-         *     ]
-         */
-        get: operations["get_global_activity_model_global_activity_model_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/all_end_users": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Global View All End Users
-         * @description [BETA] This is a beta endpoint. It will change.
-         *
-         *     Use this to just get all the unique `end_users`
-         */
-        get: operations["global_view_all_end_users_global_all_end_users_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/spend": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Global Spend
-         * @description [BETA] This is a beta endpoint. It will change.
-         *
-         *     View total spend across all proxy keys
-         */
-        get: operations["global_spend_global_spend_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/spend/all_tag_names": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Global Get All Tag Names */
-        get: operations["global_get_all_tag_names_global_spend_all_tag_names_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/spend/end_users": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Global Spend End Users
-         * @description [BETA] This is a beta endpoint. It will change.
-         *
-         *     Use this to get the top 'n' keys with the highest spend, ordered by spend.
-         */
-        post: operations["global_spend_end_users_global_spend_end_users_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/spend/keys": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Global Spend Keys
-         * @description [BETA] This is a beta endpoint. It will change.
-         *
-         *     Use this to get the top 'n' keys with the highest spend, ordered by spend.
-         */
-        get: operations["global_spend_keys_global_spend_keys_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/spend/logs": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Global Spend Logs
-         * @description [BETA] This is a beta endpoint. It will change.
-         *
-         *     Use this to get global spend (spend per day for last 30d). Admin-only endpoint
-         *
-         *     More efficient implementation of /spend/logs, by creating a view over the spend logs table.
-         */
-        get: operations["global_spend_logs_global_spend_logs_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/spend/models": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Global Spend Models
-         * @description [BETA] This is a beta endpoint. It will change.
-         *
-         *     Use this to get the top 'n' models with the highest spend, ordered by spend.
-         */
-        get: operations["global_spend_models_global_spend_models_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/spend/provider": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Global Spend Provider
-         * @description Get breakdown of spend per provider
-         *     [
-         *         {
-         *             "provider": "Azure OpenAI",
-         *             "spend": 20
-         *         },
-         *         {
-         *             "provider": "OpenAI",
-         *             "spend": 10
-         *         },
-         *         {
-         *             "provider": "VertexAI",
-         *             "spend": 30
-         *         }
-         *     ]
-         */
-        get: operations["get_global_spend_provider_global_spend_provider_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/spend/refresh": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Global Spend Refresh
-         * @description ADMIN ONLY / MASTER KEY Only Endpoint
-         *
-         *     Globally refresh spend MonthlyGlobalSpend view
-         */
-        post: operations["global_spend_refresh_global_spend_refresh_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/global/spend/report": {
         parameters: {
             query?: never;
@@ -4837,28 +3770,6 @@ export interface paths {
          *     ```
          */
         get: operations["global_view_spend_tags_global_spend_tags_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/global/spend/teams": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Global Spend Per Team
-         * @description [BETA] This is a beta endpoint. It will change.
-         *
-         *     Use this to get daily spend, grouped by `team_id` and `date`
-         */
-        get: operations["global_spend_per_team_global_spend_teams_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -6180,111 +5091,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/invitation/delete": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Invitation Delete
-         * @description Delete invitation link
-         *
-         *     ```
-         *     curl -X POST 'http://localhost:4000/invitation/delete'         -H 'Content-Type: application/json'         -d '{
-         *             "invitation_id": "1234" // 👈 id of invitation in 'LiteLLM_InvitationTable'
-         *         }'
-         *     ```
-         */
-        post: operations["invitation_delete_invitation_delete_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/invitation/info": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Invitation Info
-         * @description Allow admin to create invite links, to onboard new users to Admin UI.
-         *
-         *     ```
-         *     curl -X POST 'http://localhost:4000/invitation/new'         -H 'Content-Type: application/json'         -d '{
-         *             "user_id": "1234" // 👈 id of user in 'LiteLLM_UserTable'
-         *         }'
-         *     ```
-         */
-        get: operations["invitation_info_invitation_info_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/invitation/new": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * New Invitation
-         * @description Allow admin to create invite links, to onboard new users to Admin UI.
-         *
-         *     ```
-         *     curl -X POST 'http://localhost:4000/invitation/new'         -H 'Content-Type: application/json'         -d '{
-         *             "user_id": "1234" // 👈 id of user in 'LiteLLM_UserTable'
-         *         }'
-         *     ```
-         */
-        post: operations["new_invitation_invitation_new_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/invitation/update": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Invitation Update
-         * @description Update when invitation is accepted
-         *
-         *     ```
-         *     curl -X POST 'http://localhost:4000/invitation/update'         -H 'Content-Type: application/json'         -d '{
-         *             "invitation_id": "1234" // 👈 id of invitation in 'LiteLLM_InvitationTable'
-         *             "is_accepted": True // when invitation is accepted
-         *         }'
-         *     ```
-         */
-        post: operations["invitation_update_invitation_update_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/jwt/key/mapping/delete": {
         parameters: {
             query?: never;
@@ -7134,23 +5940,6 @@ export interface paths {
         patch: operations["langfuse_proxy_route_langfuse__endpoint__patch"];
         trace?: never;
     };
-    "/lazy/warm/{name}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Warm */
-        post: operations["warm_lazy_warm__name__post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/litellm/.well-known/litellm-ui-config": {
         parameters: {
             query?: never;
@@ -7162,23 +5951,6 @@ export interface paths {
         get: operations["get_ui_config_litellm__well_known_litellm_ui_config_get"];
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/login": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Login */
-        post: operations["login_login_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -7282,52 +6054,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/memory-usage-in-mem-cache": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Memory Usage In Mem Cache
-         * @description 1. user_api_key_cache
-         *     2. router_cache
-         *     3. proxy_logging_cache
-         *     4. internal_usage_cache
-         */
-        get: operations["memory_usage_in_mem_cache_memory_usage_in_mem_cache_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/memory-usage-in-mem-cache-items": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Memory Usage In Mem Cache Items
-         * @description 1. user_api_key_cache
-         *     2. router_cache
-         *     3. proxy_logging_cache
-         *     4. internal_usage_cache
-         */
-        get: operations["memory_usage_in_mem_cache_items_memory_usage_in_mem_cache_items_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/milvus/{endpoint}": {
         parameters: {
             query?: never;
@@ -7423,35 +6149,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/model/cost_map/source": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Model Cost Map Source
-         * @description ADMIN ONLY / MASTER KEY Only Endpoint
-         *
-         *     Returns information about where the current model cost/pricing data was loaded from.
-         *
-         *     Response fields:
-         *     - source: "local" (bundled backup) or "remote" (fetched from URL)
-         *     - url: the remote URL that was attempted (null when env-forced local)
-         *     - is_env_forced: true if LITELLM_LOCAL_MODEL_COST_MAP=True forced local usage
-         *     - fallback_reason: human-readable reason why remote failed (null on success)
-         *     - model_count: number of models in the currently loaded cost map
-         */
-        get: operations["get_model_cost_map_source_model_cost_map_source_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/model/delete": {
         parameters: {
             query?: never;
@@ -7526,66 +6223,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/model/metrics": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Model Metrics
-         * @description View number of requests & avg latency per model on config.yaml
-         */
-        get: operations["model_metrics_model_metrics_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/model/metrics/exceptions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Model Metrics Exceptions
-         * @description View number of failed requests per model on config.yaml
-         */
-        get: operations["model_metrics_exceptions_model_metrics_exceptions_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/model/metrics/slow_responses": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Model Metrics Slow Responses
-         * @description View number of hanging requests per model_group
-         */
-        get: operations["model_metrics_slow_responses_model_metrics_slow_responses_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/model/new": {
         parameters: {
             query?: never;
@@ -7600,46 +6237,6 @@ export interface paths {
          * @description Allows adding new models to the model list in the config.yaml
          */
         post: operations["add_new_model_model_new_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/model/settings": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Model Settings
-         * @description Returns provider name, description, and required parameters for each provider
-         */
-        get: operations["model_settings_model_settings_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/model/streaming_metrics": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Model Streaming Metrics
-         * @description View time to first token for models in spend logs
-         */
-        get: operations["model_streaming_metrics_model_streaming_metrics_get"];
-        put?: never;
-        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -9096,123 +7693,6 @@ export interface paths {
          * @description Update an organization
          */
         patch: operations["update_organization_organization_update_patch"];
-        trace?: never;
-    };
-    "/otel-spans": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Otel Spans */
-        get: operations["get_otel_spans_otel_spans_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/plugin-proxy/{plugin_name}/{path}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Plugin Proxy
-         * @description Authenticated reverse-proxy to a registered plugin backend.
-         *
-         *     Restricted to proxy_admin callers — the shared plugin_key must not be
-         *     usable as a confused-deputy credential by regular users.  Plugin UIs
-         *     talk to the plugin service directly via the iframe; this route is for
-         *     administrative and server-to-server access only.
-         *
-         *     The caller's litellm credential is stripped and replaced with the
-         *     plugin's own plugin_key so plugins never receive a live litellm API key.
-         */
-        get: operations["plugin_proxy_plugin_proxy__plugin_name___path__get"];
-        /**
-         * Plugin Proxy
-         * @description Authenticated reverse-proxy to a registered plugin backend.
-         *
-         *     Restricted to proxy_admin callers — the shared plugin_key must not be
-         *     usable as a confused-deputy credential by regular users.  Plugin UIs
-         *     talk to the plugin service directly via the iframe; this route is for
-         *     administrative and server-to-server access only.
-         *
-         *     The caller's litellm credential is stripped and replaced with the
-         *     plugin's own plugin_key so plugins never receive a live litellm API key.
-         */
-        put: operations["plugin_proxy_plugin_proxy__plugin_name___path__put"];
-        /**
-         * Plugin Proxy
-         * @description Authenticated reverse-proxy to a registered plugin backend.
-         *
-         *     Restricted to proxy_admin callers — the shared plugin_key must not be
-         *     usable as a confused-deputy credential by regular users.  Plugin UIs
-         *     talk to the plugin service directly via the iframe; this route is for
-         *     administrative and server-to-server access only.
-         *
-         *     The caller's litellm credential is stripped and replaced with the
-         *     plugin's own plugin_key so plugins never receive a live litellm API key.
-         */
-        post: operations["plugin_proxy_plugin_proxy__plugin_name___path__post"];
-        /**
-         * Plugin Proxy
-         * @description Authenticated reverse-proxy to a registered plugin backend.
-         *
-         *     Restricted to proxy_admin callers — the shared plugin_key must not be
-         *     usable as a confused-deputy credential by regular users.  Plugin UIs
-         *     talk to the plugin service directly via the iframe; this route is for
-         *     administrative and server-to-server access only.
-         *
-         *     The caller's litellm credential is stripped and replaced with the
-         *     plugin's own plugin_key so plugins never receive a live litellm API key.
-         */
-        delete: operations["plugin_proxy_plugin_proxy__plugin_name___path__delete"];
-        /**
-         * Plugin Proxy
-         * @description Authenticated reverse-proxy to a registered plugin backend.
-         *
-         *     Restricted to proxy_admin callers — the shared plugin_key must not be
-         *     usable as a confused-deputy credential by regular users.  Plugin UIs
-         *     talk to the plugin service directly via the iframe; this route is for
-         *     administrative and server-to-server access only.
-         *
-         *     The caller's litellm credential is stripped and replaced with the
-         *     plugin's own plugin_key so plugins never receive a live litellm API key.
-         */
-        options: operations["plugin_proxy_plugin_proxy__plugin_name___path__options"];
-        /**
-         * Plugin Proxy
-         * @description Authenticated reverse-proxy to a registered plugin backend.
-         *
-         *     Restricted to proxy_admin callers — the shared plugin_key must not be
-         *     usable as a confused-deputy credential by regular users.  Plugin UIs
-         *     talk to the plugin service directly via the iframe; this route is for
-         *     administrative and server-to-server access only.
-         *
-         *     The caller's litellm credential is stripped and replaced with the
-         *     plugin's own plugin_key so plugins never receive a live litellm API key.
-         */
-        head: operations["plugin_proxy_plugin_proxy__plugin_name___path__head"];
-        /**
-         * Plugin Proxy
-         * @description Authenticated reverse-proxy to a registered plugin backend.
-         *
-         *     Restricted to proxy_admin callers — the shared plugin_key must not be
-         *     usable as a confused-deputy credential by regular users.  Plugin UIs
-         *     talk to the plugin service directly via the iframe; this route is for
-         *     administrative and server-to-server access only.
-         *
-         *     The caller's litellm credential is stripped and replaced with the
-         *     plugin's own plugin_key so plugins never receive a live litellm API key.
-         */
-        patch: operations["plugin_proxy_plugin_proxy__plugin_name___path__patch"];
         trace?: never;
     };
     "/policies": {
@@ -10888,23 +9368,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/queue/chat/completions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Async Queue Request */
-        post: operations["async_queue_request_queue_chat_completions_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/rag/ingest": {
         parameters: {
             query?: never;
@@ -11071,52 +9534,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/reload/anthropic_beta_headers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Reload Anthropic Beta Headers
-         * @description ADMIN ONLY / MASTER KEY Only Endpoint
-         *
-         *     Manually reload the Anthropic beta headers configuration from the remote source.
-         *     This will fetch fresh configuration from the anthropic_beta_headers_config.json file.
-         */
-        post: operations["reload_anthropic_beta_headers_reload_anthropic_beta_headers_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/reload/model_cost_map": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Reload Model Cost Map
-         * @description ADMIN ONLY / MASTER KEY Only Endpoint
-         *
-         *     Manually reload the model cost map from the remote source.
-         *     This will fetch fresh pricing data from the model_prices_and_context_window.json file.
-         */
-        post: operations["reload_model_cost_map_reload_model_cost_map_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/rerank": {
         parameters: {
             query?: never;
@@ -11141,11 +9558,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /**
-         * WebSocket: responses_websocket_endpoint
-         * @description WebSocket connection endpoint
-         */
-        get: operations["websocket_responses_websocket_endpoint_get"];
+        get?: never;
         put?: never;
         /**
          * Responses Api
@@ -11398,108 +9811,6 @@ export interface paths {
          * @description Get a list of available routes in the FastAPI application.
          */
         get: operations["get_routes_routes_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/schedule/anthropic_beta_headers_reload": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Schedule Anthropic Beta Headers Reload
-         * @description ADMIN ONLY / MASTER KEY Only Endpoint
-         *
-         *     Schedule periodic reload of the Anthropic beta headers configuration.
-         *     This will create a background job that reloads the configuration every specified hours.
-         */
-        post: operations["schedule_anthropic_beta_headers_reload_schedule_anthropic_beta_headers_reload_post"];
-        /**
-         * Cancel Anthropic Beta Headers Reload
-         * @description ADMIN ONLY / MASTER KEY Only Endpoint
-         *
-         *     Cancel the scheduled periodic reload of the Anthropic beta headers configuration.
-         */
-        delete: operations["cancel_anthropic_beta_headers_reload_schedule_anthropic_beta_headers_reload_delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/schedule/anthropic_beta_headers_reload/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Anthropic Beta Headers Reload Status
-         * @description ADMIN ONLY / MASTER KEY Only Endpoint
-         *
-         *     Get the status of the scheduled Anthropic beta headers reload job.
-         */
-        get: operations["get_anthropic_beta_headers_reload_status_schedule_anthropic_beta_headers_reload_status_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/schedule/model_cost_map_reload": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Schedule Model Cost Map Reload
-         * @description ADMIN ONLY / MASTER KEY Only Endpoint
-         *
-         *     Schedule periodic reload of the model cost map.
-         *     This will create a background job that reloads the model cost map every specified hours.
-         */
-        post: operations["schedule_model_cost_map_reload_schedule_model_cost_map_reload_post"];
-        /**
-         * Cancel Model Cost Map Reload
-         * @description ADMIN ONLY / MASTER KEY Only Endpoint
-         *
-         *     Cancel the scheduled periodic reload of the model cost map.
-         */
-        delete: operations["cancel_model_cost_map_reload_schedule_model_cost_map_reload_delete"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/schedule/model_cost_map_reload/status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Model Cost Map Reload Status
-         * @description ADMIN ONLY / MASTER KEY Only Endpoint
-         *
-         *     Get the status of the scheduled model cost map reload job.
-         */
-        get: operations["get_model_cost_map_reload_status_schedule_model_cost_map_reload_status_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -12363,38 +10674,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/spend/keys": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Spend Key Fn
-         * @description View keys created, ordered by spend.
-         *
-         *     - Admin callers (PROXY_ADMIN / PROXY_ADMIN_VIEW_ONLY) see every key in
-         *       the database.
-         *     - All other callers (INTERNAL_USER / INTERNAL_USER_VIEW_ONLY, etc.) are
-         *       scoped to keys they own (``user_id == caller``). A caller with no
-         *       ``user_id`` has no scope and receives an empty list rather than the
-         *       full table.
-         *
-         *     Example Request:
-         *     ```
-         *     curl -X GET "http://0.0.0.0:8000/spend/keys" -H "Authorization: Bearer sk-1234"
-         *     ```
-         */
-        get: operations["spend_key_fn_spend_keys_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/spend/logs": {
         parameters: {
             query?: never;
@@ -12439,86 +10718,6 @@ export interface paths {
          *     ```
          */
         get: operations["view_spend_logs_spend_logs_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/spend/logs/session/ui": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Ui View Session Spend Logs
-         * @description Get paginated spend logs for a particular session.
-         *
-         *     Returns:
-         *         {
-         *             "data": List[LiteLLM_SpendLogs],
-         *             "total": int,
-         *             "page": int,
-         *             "page_size": int,
-         *             "total_pages": int,
-         *         }
-         */
-        get: operations["ui_view_session_spend_logs_spend_logs_session_ui_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/spend/logs/ui": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Ui View Spend Logs
-         * @description View spend logs with pagination support.
-         *     Available at both `/spend/logs/v2` (public API) and `/spend/logs/ui` (internal UI).
-         *
-         *     Returns paginated response with data, total, page, page_size, and total_pages.
-         *
-         *     Example:
-         *     ```
-         *     curl -X GET "http://0.0.0.0:8000/spend/logs/v2?start_date=2025-11-25%2000:00:00&end_date=2025-11-26%2023:59:59&page=1&page_size=50" -H "Authorization: Bearer sk-1234"
-         *     ```
-         */
-        get: operations["ui_view_spend_logs_spend_logs_ui_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/spend/logs/ui/{request_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Ui View Request Response For Request Id
-         * @description View request / response for a specific request_id
-         *
-         *     - goes through all callbacks, checks if any of them have a @property -> has_request_response_payload
-         *     - if so, it will return the request and response payload
-         */
-        get: operations["ui_view_request_response_for_request_id_spend_logs_ui__request_id__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -12577,208 +10776,6 @@ export interface paths {
          *     ```
          */
         get: operations["view_spend_tags_spend_tags_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/spend/users": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Spend User Fn
-         * @description View users created, ordered by spend.
-         *
-         *     - Admin callers (PROXY_ADMIN / PROXY_ADMIN_VIEW_ONLY) see every user, or
-         *       a specific user when ``user_id`` is supplied.
-         *     - All other callers may only read their own row. If they supply a
-         *       ``user_id`` query parameter that does not match their authenticated
-         *       ``user_id`` the request is rejected with HTTP 403; supplying their
-         *       own id (or none at all) returns just their row. A caller with no
-         *       ``user_id`` on their key has no scope and receives an empty list
-         *       rather than the full table.
-         *
-         *     Example Request:
-         *     ```
-         *     curl -X GET "http://0.0.0.0:8000/spend/users" -H "Authorization: Bearer sk-1234"
-         *     ```
-         *
-         *     View User Table row for user_id
-         *     ```
-         *     curl -X GET "http://0.0.0.0:8000/spend/users?user_id=1234" -H "Authorization: Bearer sk-1234"
-         *     ```
-         */
-        get: operations["spend_user_fn_spend_users_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/sso/callback": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Auth Callback
-         * @description Verify login
-         */
-        get: operations["auth_callback_sso_callback_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/sso/cli/complete/{login_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Cli Sso Complete */
-        post: operations["cli_sso_complete_sso_cli_complete__login_id__post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/sso/cli/poll/{key_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Cli Poll Key
-         * @description CLI polling endpoint - retrieves session from cache and generates JWT.
-         *
-         *     Flow:
-         *     1. First poll (no team_id): Returns teams list without generating JWT
-         *     2. Second poll (with team_id): Generates JWT with selected team and deletes session
-         *
-         *     Args:
-         *         key_id: The CLI login session ID
-         *         team_id: Optional team ID to assign to the JWT. If provided, must be one of user's teams.
-         */
-        get: operations["cli_poll_key_sso_cli_poll__key_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/sso/cli/start": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Cli Sso Start */
-        post: operations["cli_sso_start_sso_cli_start_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/sso/debug/callback": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Debug Sso Callback
-         * @description Returns the OpenID object returned by the SSO provider
-         */
-        get: operations["debug_sso_callback_sso_debug_callback_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/sso/debug/login": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Debug Sso Login
-         * @description Create Proxy API Keys using Google Workspace SSO. Requires setting PROXY_BASE_URL in .env
-         *     PROXY_BASE_URL should be the your deployed proxy endpoint, e.g. PROXY_BASE_URL="https://litellm-production-7002.up.railway.app/"
-         *     Example:
-         */
-        get: operations["debug_sso_login_sso_debug_login_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/sso/get/ui_settings": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Ui Settings */
-        get: operations["get_ui_settings_sso_get_ui_settings_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/sso/key/generate": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Google Login
-         * @description Create Proxy API Keys using Google Workspace SSO. Requires setting PROXY_BASE_URL in .env
-         *     PROXY_BASE_URL should be the your deployed proxy endpoint, e.g. PROXY_BASE_URL="https://litellm-production-7002.up.railway.app/"
-         *     Example:
-         */
-        get: operations["google_login_sso_key_generate_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -13325,36 +11322,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/team/filter/ui": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Ui View Teams
-         * @description [PROXY-ADMIN ONLY] Filter teams based on partial match of team_id or team_alias with pagination.
-         *
-         *     Args:
-         *         user_id (Optional[str]): Partial user ID to search for
-         *         user_email (Optional[str]): Partial email to search for
-         *         page (int): Page number for pagination (starts at 1)
-         *         page_size (int): Number of items per page (max 100)
-         *         user_api_key_dict (UserAPIKeyAuth): User authentication information
-         *
-         *     Returns:
-         *         List[LiteLLM_SpendLogs]: Paginated list of matching user records
-         */
-        get: operations["ui_view_teams_team_filter_ui_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/team/info": {
         parameters: {
             query?: never;
@@ -13428,6 +11395,23 @@ export interface paths {
         get: operations["list_team_team_list_get"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/team/member/bulk_update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Bulk Update Team Members */
+        post: operations["bulk_update_team_members_team_member_bulk_update_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -14376,32 +12360,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/user/available_roles": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Ui Get Available Role
-         * @description Endpoint used by Admin UI to show all available roles to assign a user
-         *     return {
-         *         "proxy_admin": {
-         *             "description": "Proxy Admin role",
-         *             "ui_label": "Admin"
-         *         }
-         *     }
-         */
-        get: operations["ui_get_available_role_user_available_roles_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/user/available_users": {
         parameters: {
             query?: never;
@@ -14565,36 +12523,6 @@ export interface paths {
          *     - user_ids: List[str] - The list of user id's to be deleted.
          */
         post: operations["delete_user_user_delete_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/user/filter/ui": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Ui View Users
-         * @description Filter users based on partial match of user_id or email with pagination.
-         *
-         *     Behaviour depends on the ``scope_user_search_to_org`` UI-setting flag
-         *     (stored in the ``litellm_uisettings`` table):
-         *
-         *     * **Flag OFF (default):** any authenticated user can search all users.
-         *     * **Flag ON:**
-         *       - Proxy admins see all users.
-         *       - Org admins see only users in their org(s).
-         *       - Team admins for an org-bound team see users in that org.
-         *       - Others receive a 403.
-         */
-        get: operations["ui_view_users_user_filter_ui_get"];
-        put?: never;
-        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -17219,11 +15147,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /**
-         * WebSocket: responses_websocket_endpoint
-         * @description WebSocket connection endpoint
-         */
-        get: operations["websocket_responses_websocket_endpoint_get_2"];
+        get?: never;
         put?: never;
         /**
          * Responses Api
@@ -18774,55 +16698,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v2/key/info": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Info Key Fn V2
-         * @description Retrieve information about a list of keys.
-         *
-         *     **New endpoint**. Currently admin only.
-         *     Parameters:
-         *         keys: Optional[list] = body parameter representing the key(s) in the request
-         *         user_api_key_dict: UserAPIKeyAuth = Dependency representing the user's API key
-         *     Returns:
-         *         Dict containing the key and its associated information
-         *
-         *     Example Curl:
-         *     ```
-         *     curl -X GET "http://0.0.0.0:4000/key/info"     -H "Authorization: Bearer sk-1234"     -d {"keys": ["sk-1", "sk-2", "sk-3"]}
-         *     ```
-         */
-        post: operations["info_key_fn_v2_v2_key_info_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v2/login": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Login V2 */
-        post: operations["login_v2_v2_login_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/v2/model/info": {
         parameters: {
             query?: never;
@@ -18971,40 +16846,6 @@ export interface paths {
         get: operations["user_info_v2_v2_user_info_get"];
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v3/login": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Login V3 */
-        post: operations["login_v3_v3_login_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v3/login/exchange": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Login V3 Exchange */
-        post: operations["login_v3_exchange_v3_login_exchange_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -19413,52 +17254,6 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
-        trace?: never;
-    };
-    "/vertex-ai/{endpoint}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Vertex Proxy Route
-         * @description Call LiteLLM proxy via Vertex AI SDK.
-         *
-         *     [Docs](https://docs.litellm.ai/docs/pass_through/vertex_ai)
-         */
-        get: operations["vertex_proxy_route_vertex_ai__endpoint__get_2"];
-        /**
-         * Vertex Proxy Route
-         * @description Call LiteLLM proxy via Vertex AI SDK.
-         *
-         *     [Docs](https://docs.litellm.ai/docs/pass_through/vertex_ai)
-         */
-        put: operations["vertex_proxy_route_vertex_ai__endpoint__put_2"];
-        /**
-         * Vertex Proxy Route
-         * @description Call LiteLLM proxy via Vertex AI SDK.
-         *
-         *     [Docs](https://docs.litellm.ai/docs/pass_through/vertex_ai)
-         */
-        post: operations["vertex_proxy_route_vertex_ai__endpoint__post_2"];
-        /**
-         * Vertex Proxy Route
-         * @description Call LiteLLM proxy via Vertex AI SDK.
-         *
-         *     [Docs](https://docs.litellm.ai/docs/pass_through/vertex_ai)
-         */
-        delete: operations["vertex_proxy_route_vertex_ai__endpoint__delete_2"];
-        options?: never;
-        head?: never;
-        /**
-         * Vertex Proxy Route
-         * @description Call LiteLLM proxy via Vertex AI SDK.
-         *
-         *     [Docs](https://docs.litellm.ai/docs/pass_through/vertex_ai)
-         */
-        patch: operations["vertex_proxy_route_vertex_ai__endpoint__patch_2"];
         trace?: never;
     };
     "/vertex_ai/discovery/{endpoint}": {
@@ -20628,12 +18423,6 @@ export interface components {
             /** Tags */
             tags?: string[];
         };
-        /**
-         * AlertType
-         * @description Enum for alert types and management event types
-         * @enum {string}
-         */
-        AlertType: "llm_exceptions" | "llm_too_slow" | "llm_requests_hanging" | "budget_alerts" | "spend_reports" | "failed_tracking_spend" | "db_exceptions" | "daily_reports" | "cooldown_deployment" | "new_model_added" | "outage_alerts" | "region_outage_alerts" | "fallback_reports" | "new_virtual_key_created" | "virtual_key_updated" | "virtual_key_deleted" | "new_team_created" | "team_updated" | "team_deleted" | "new_internal_user_created" | "internal_user_updated" | "internal_user_deleted";
         /** AllowedVectorStoreIndexItem */
         AllowedVectorStoreIndexItem: {
             /** Index Name */
@@ -21476,6 +19265,30 @@ export interface components {
                 [key: string]: unknown;
             } | null;
         };
+        /** BulkTeamMemberUpdateRequest */
+        BulkTeamMemberUpdateRequest: {
+            /**
+             * All Members In Team
+             * @default false
+             */
+            all_members_in_team: boolean;
+            /** Team Id */
+            team_id: string;
+            update_fields: components["schemas"]["TeamMemberBulkUpdateFields"];
+            /** User Ids */
+            user_ids?: string[] | null;
+        };
+        /** BulkTeamMemberUpdateResponse */
+        BulkTeamMemberUpdateResponse: {
+            /** Failed Updates */
+            failed_updates: components["schemas"]["FailedTeamMemberUpdate"][];
+            /** Successful Updates */
+            successful_updates: components["schemas"]["TeamMemberUpdateResponse"][];
+            /** Team Id */
+            team_id: string;
+            /** Total Requested */
+            total_requested: number;
+        };
         /**
          * BulkUpdateKeyRequest
          * @description Request for bulk key updates
@@ -21686,11 +19499,6 @@ export interface components {
          * @enum {string}
          */
         CallTypes: "embedding" | "aembedding" | "completion" | "acompletion" | "atext_completion" | "text_completion" | "image_generation" | "aimage_generation" | "image_edit" | "aimage_edit" | "moderation" | "amoderation" | "atranscription" | "transcription" | "aspeech" | "speech" | "rerank" | "arerank" | "search" | "asearch" | "_arealtime" | "_aresponses_websocket" | "create_batch" | "acreate_batch" | "aretrieve_batch" | "retrieve_batch" | "acancel_batch" | "cancel_batch" | "pass_through_endpoint" | "anthropic_messages" | "get_assistants" | "aget_assistants" | "create_assistants" | "acreate_assistants" | "delete_assistant" | "adelete_assistant" | "acreate_thread" | "create_thread" | "aget_thread" | "get_thread" | "a_add_message" | "add_message" | "aget_messages" | "get_messages" | "arun_thread" | "run_thread" | "arun_thread_stream" | "run_thread_stream" | "afile_retrieve" | "file_retrieve" | "afile_delete" | "file_delete" | "afile_list" | "file_list" | "acreate_file" | "create_file" | "afile_content" | "file_content" | "create_fine_tuning_job" | "acreate_fine_tuning_job" | "create_video" | "acreate_video" | "avideo_retrieve" | "video_retrieve" | "avideo_content" | "video_content" | "video_remix" | "avideo_remix" | "video_list" | "avideo_list" | "video_retrieve_job" | "avideo_retrieve_job" | "video_delete" | "avideo_delete" | "video_create_character" | "avideo_create_character" | "video_get_character" | "avideo_get_character" | "video_edit" | "avideo_edit" | "video_extension" | "avideo_extension" | "vector_store_file_create" | "avector_store_file_create" | "vector_store_file_list" | "avector_store_file_list" | "vector_store_file_retrieve" | "avector_store_file_retrieve" | "vector_store_file_content" | "avector_store_file_content" | "vector_store_file_update" | "avector_store_file_update" | "vector_store_file_delete" | "avector_store_file_delete" | "vector_store_create" | "avector_store_create" | "vector_store_search" | "avector_store_search" | "create_container" | "acreate_container" | "list_containers" | "alist_containers" | "retrieve_container" | "aretrieve_container" | "delete_container" | "adelete_container" | "list_container_files" | "alist_container_files" | "upload_container_file" | "aupload_container_file" | "create_sandbox" | "acreate_sandbox" | "delete_sandbox" | "adelete_sandbox" | "run_code" | "arun_code" | "code_interpreter_tool" | "acode_interpreter_tool" | "acancel_fine_tuning_job" | "cancel_fine_tuning_job" | "alist_fine_tuning_jobs" | "list_fine_tuning_jobs" | "aretrieve_fine_tuning_job" | "retrieve_fine_tuning_job" | "responses" | "aresponses" | "alist_input_items" | "llm_passthrough_route" | "allm_passthrough_route" | "generate_content" | "agenerate_content" | "generate_content_stream" | "agenerate_content_stream" | "ocr" | "aocr" | "call_mcp_tool" | "list_mcp_tools" | "asend_message" | "send_message" | "acreate_skill";
-        /** CallbackDelete */
-        CallbackDelete: {
-            /** Callback Name */
-            callback_name: string;
-        };
         /**
          * CallbackLogFailure
          * @description A record that failed to replay, identified by its index in the batch.
@@ -21844,6 +19652,7 @@ export interface components {
         /** ChatCompletionAudioObject */
         ChatCompletionAudioObject: {
             input_audio: components["schemas"]["InputAudio"];
+            prompt_cache_breakpoint?: components["schemas"]["PromptCacheBreakpoint"];
             /**
              * Type
              * @constant
@@ -22358,353 +20167,6 @@ export interface components {
             /** Regulation */
             regulation: string;
         };
-        /** ConfigFieldDelete */
-        ConfigFieldDelete: {
-            /**
-             * Config Type
-             * @constant
-             */
-            config_type: "general_settings";
-            /** Field Name */
-            field_name: string;
-        };
-        /** ConfigFieldInfo */
-        ConfigFieldInfo: {
-            /** Field Name */
-            field_name: string;
-            /** Field Value */
-            field_value: unknown;
-        };
-        /** ConfigFieldUpdate */
-        ConfigFieldUpdate: {
-            /**
-             * Config Type
-             * @constant
-             */
-            config_type: "general_settings";
-            /** Field Name */
-            field_name: string;
-            /** Field Value */
-            field_value: unknown;
-        };
-        /**
-         * ConfigGeneralSettings
-         * @description Documents all the fields supported by `general_settings` in config.yaml
-         */
-        ConfigGeneralSettings: {
-            /**
-             * Alert To Webhook Url
-             * @description Mapping of alert type to webhook url. e.g. `alert_to_webhook_url: {'budget_alerts': 'https://nothooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX'}`
-             */
-            alert_to_webhook_url?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Alert Types
-             * @description List of alerting types. By default it is all alerts
-             */
-            alert_types?: components["schemas"]["AlertType"][] | null;
-            /**
-             * Alerting
-             * @description List of alerting integrations. Today, just slack - `alerting: ['slack']`
-             */
-            alerting?: unknown[] | null;
-            /**
-             * Alerting Args
-             * @description Controllable params for slack alerting - e.g. ttl in cache.
-             */
-            alerting_args?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Alerting Threshold
-             * @description sends alerts if requests hang for 5min+
-             */
-            alerting_threshold?: number | null;
-            /**
-             * Allow Cli Sso Verification Uri Complete
-             * @description opt-in to RFC 8628 verification_uri_complete for the CLI SSO device flow, pre-filling the user_code in the browser. Off by default; intended for same-host clients where the device that starts the flow and the browser run on the same machine
-             */
-            allow_cli_sso_verification_uri_complete?: boolean | null;
-            /**
-             * Allowed Routes
-             * @description Proxy API Endpoints you want users to be able to access
-             */
-            allowed_routes?: unknown[] | null;
-            /**
-             * Background Health Checks
-             * @description run health checks in background
-             */
-            background_health_checks?: boolean | null;
-            /**
-             * Cancel On Disconnect
-             * @description cancel the in-flight upstream LLM request (non-streaming) when the client disconnects, freeing backend capacity (e.g. a vLLM GPU slot); the request is logged as a 499 failure
-             */
-            cancel_on_disconnect?: boolean | null;
-            /**
-             * Completion Model
-             * @description proxy level default model for all chat completion calls
-             */
-            completion_model?: string | null;
-            /** @description standalone Redis for cross-pod coordination (tpm/rpm rate limits, spend tracking, pod lock manager, shared health checks), configured independently of the response-cache backend; takes precedence over borrowing the `cache_params` Redis and over the REDIS_* env fallback */
-            coordination_redis?: components["schemas"]["CoordinationRedisParams"] | null;
-            /**
-             * Custom Auth
-             * @description override user_api_key_auth with your own auth script - https://docs.litellm.ai/docs/proxy/virtual_keys#custom-auth
-             */
-            custom_auth?: string | null;
-            /** @description custom args for instantiating dynamodb client - e.g. billing provision */
-            database_args?: components["schemas"]["DynamoDBArgs"] | null;
-            /**
-             * Database Connect Timeout
-             * @description Prisma `connect_timeout` URL param (seconds). Bounds how long the engine waits to establish a new connection before failing. Defaults to Prisma's built-in value when unset.
-             */
-            database_connect_timeout?: number | null;
-            /**
-             * Database Connection Pool Limit
-             * @description default connection pool for prisma client connecting to postgres db
-             * @default 10
-             */
-            database_connection_pool_limit: number | null;
-            /**
-             * Database Connection Timeout
-             * @description default timeout for a connection to the database
-             * @default 60
-             */
-            database_connection_timeout: number | null;
-            /**
-             * Database Disable Prepared Statements
-             * @description Disable server-side prepared statements by setting Prisma's `pgbouncer=true` URL param. Use this for pgbouncer transaction-pooling deployments, or to prevent the 'cached plan must not change result type' error that pooled connections hit during rolling schema migrations. An explicit `pgbouncer` in `database_extra_connection_params` takes precedence.
-             */
-            database_disable_prepared_statements?: boolean | null;
-            /**
-             * Database Extra Connection Params
-             * @description Escape hatch: extra key/value pairs appended verbatim to the Prisma DATABASE_URL / DIRECT_URL query string (e.g. `sslmode`, `pgbouncer`, `statement_cache_size`). Keys here override any default LiteLLM sets.
-             */
-            database_extra_connection_params?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Database Socket Timeout
-             * @description Prisma `socket_timeout` URL param (seconds). When set, an idle/slow connection that has not produced data within this window is closed. This is the main knob for capping idle DB connections from LiteLLM.
-             */
-            database_socket_timeout?: number | null;
-            /**
-             * Database Type
-             * @description to use dynamodb instead of postgres db
-             */
-            database_type?: "dynamo_db" | null;
-            /**
-             * Database Url
-             * @description connect to a postgres db - needed for generating temporary keys + tracking spend / key
-             */
-            database_url?: string | null;
-            /**
-             * Disable Budget Reservation
-             * @description If True, disables the optimistic per-request budget reservation introduced in v1.84.0. WARNING: This weakens hard budget enforcement. Without the reservation, a burst of concurrent requests from a single key can each pass the read-time spend check before any of them is charged, allowing a configured budget to be exceeded under high concurrency. Budgets are still evaluated on every request at read time, so an already-exhausted budget is still rejected. Enable only if your deployment is experiencing phantom BudgetExceededError responses caused by leaked reservations (see GitHub issue #27639). A proxy-level WARNING is logged on every request while this flag is active as a reminder that hard enforcement is relaxed.
-             */
-            disable_budget_reservation?: boolean | null;
-            /**
-             * Enable Public Model Hub
-             * @description Public model hub for users to see what models they have access to, supported openai params, etc.
-             * @default false
-             */
-            enable_public_model_hub: boolean;
-            /**
-             * Forward Client Headers To Llm Api
-             * @description If True, forwards client headers (e.g. Authorization) to the LLM API. Required for Claude Code with Max subscription.
-             */
-            forward_client_headers_to_llm_api?: boolean | null;
-            /**
-             * Global Max Parallel Requests
-             * @description global max parallel requests to allow for a proxy instance.
-             */
-            global_max_parallel_requests?: number | null;
-            /**
-             * Health Check Concurrency
-             * @description limit concurrent health checks per cycle; when unset, health checks run without a concurrency cap
-             */
-            health_check_concurrency?: number | null;
-            /**
-             * Health Check Interval
-             * @description background health check interval in seconds
-             * @default 300
-             */
-            health_check_interval: number;
-            /**
-             * Health Check Skip Disabled Background Models
-             * @description When true, deployments with model_info.disable_background_health_check are skipped for on-demand GET /health as well as the background health loop.
-             * @default false
-             */
-            health_check_skip_disabled_background_models: boolean;
-            /**
-             * Infer Model From Keys
-             * @description for `/models` endpoint, infers available model based on environment keys (e.g. OPENAI_API_KEY)
-             */
-            infer_model_from_keys?: boolean | null;
-            /** @description key manager to load keys from / decrypt keys with */
-            key_management_system?: components["schemas"]["KeyManagementSystem"] | null;
-            /**
-             * Master Key
-             * @description require a key for all calls to proxy
-             */
-            master_key?: string | null;
-            /**
-             * Max Parallel Requests
-             * @description maximum parallel requests for each api key
-             */
-            max_parallel_requests?: number | null;
-            /**
-             * Max Request Size Mb
-             * @description max request size in MB, if a request is larger than this size it will be rejected
-             */
-            max_request_size_mb?: number | null;
-            /**
-             * Max Response Size Mb
-             * @description max response size in MB, if a response is larger than this size it will be rejected
-             */
-            max_response_size_mb?: number | null;
-            /**
-             * Maximum Spend Logs Retention Period
-             * @description Maximum retention period for spend logs (e.g., '7d' for 7 days). Logs older than this will be deleted.
-             */
-            maximum_spend_logs_retention_period?: string | null;
-            /**
-             * Mcp Internal Ip Ranges
-             * @description Custom CIDR ranges that define internal/private networks for MCP access control. When set, only these ranges are treated as internal. Defaults to RFC 1918 private ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8).
-             */
-            mcp_internal_ip_ranges?: string[] | null;
-            /**
-             * Mcp Required Fields
-             * @description List of MCP server fields that must be filled in for a submission to pass standards checks (e.g. ['description', 'source_url', 'alias']).
-             */
-            mcp_required_fields?: string[] | null;
-            /**
-             * Mcp Trusted Proxy Ranges
-             * @description CIDR ranges of trusted reverse proxies. When set, X-Forwarded-For and X-Forwarded-* origin headers are only trusted from these IPs.
-             */
-            mcp_trusted_proxy_ranges?: string[] | null;
-            /**
-             * Mcp Xff Num Trusted Hops
-             * @description Number of trusted reverse proxies/load balancers in front of the gateway that append to X-Forwarded-For. When set (and mcp_trusted_proxy_ranges validates the direct peer), the client IP for MCP access control is read this many entries from the right of the chain instead of the spoofable leftmost value, defeating append-style X-Forwarded-For forgery.
-             */
-            mcp_xff_num_trusted_hops?: number | null;
-            /**
-             * Otel
-             * @description [BETA] OpenTelemetry support - this might change, use with caution.
-             */
-            otel?: boolean | null;
-            /**
-             * Pass Through Endpoints
-             * @description Set-up pass-through endpoints for provider-specific endpoints. Docs - https://docs.litellm.ai/docs/proxy/pass_through
-             */
-            pass_through_endpoints?: components["schemas"]["PassThroughGenericEndpoint"][] | null;
-            /**
-             * Pass Through Request Timeout
-             * @description Default upstream request timeout in seconds for native and custom pass-through endpoints that use pass_through_request. Defaults to 600 when unset.
-             */
-            pass_through_request_timeout?: number | null;
-            /**
-             * Plugins
-             * @description external services registered as embeddable UI plugins
-             */
-            plugins?: components["schemas"]["PluginConfig"][] | null;
-            /**
-             * Provider Url Destination Allowed Hosts
-             * @description Allowlist of hosts a request may redirect a provider call's destination URL to.
-             */
-            provider_url_destination_allowed_hosts?: string[] | null;
-            /**
-             * Reject Clientside Metadata Tags
-             * @description When set to True, rejects requests that contain client-side 'metadata.tags' to prevent users from influencing budgets by sending different tags. Tags can only be inherited from the API key metadata.
-             */
-            reject_clientside_metadata_tags?: boolean | null;
-            /**
-             * Store Model In Db
-             * @description If True, models and config are stored in and loaded from the database. Default is False.
-             */
-            store_model_in_db?: boolean | null;
-            /**
-             * Store Prompts In Spend Logs
-             * @description If True, stores request messages and responses in spend logs. Default is False.
-             */
-            store_prompts_in_spend_logs?: boolean | null;
-            /**
-             * Supported Db Objects
-             * @description Fine-grained control over which object types to load from the database when store_model_in_db is True. Available types: 'models', 'mcp', 'guardrails', 'vector_stores', 'pass_through_endpoints', 'prompts', 'model_cost_map', 'tools', 'config_overrides'. If not set, all objects are loaded (default behavior).
-             */
-            supported_db_objects?: components["schemas"]["SupportedDBObjectType"][] | null;
-            /**
-             * Trusted Proxy Ranges
-             * @description CIDR ranges of trusted reverse proxies allowed to provide identity headers for header-based auth paths such as enable_oauth2_proxy_auth and custom_ui_sso_sign_in_handler.
-             */
-            trusted_proxy_ranges?: string[] | null;
-            /**
-             * Ui Access Mode
-             * @description Control access to the Proxy UI
-             * @default all
-             */
-            ui_access_mode: ("admin_only" | "all") | null;
-            /**
-             * Use Azure Key Vault
-             * @description load keys from azure key vault
-             */
-            use_azure_key_vault?: boolean | null;
-            /**
-             * Use Google Kms
-             * @description decrypt keys with google kms
-             */
-            use_google_kms?: boolean | null;
-            /**
-             * Use Spend Logs Partitioning
-             * @description If True and LiteLLM_SpendLogs has been converted to a range-partitioned table (db_scripts/partition_spend_logs.sql), retention cleanup drops expired partitions instead of deleting rows, and pre-creates upcoming partitions. Default is False.
-             */
-            use_spend_logs_partitioning?: boolean | null;
-            /** User Header Mappings */
-            user_header_mappings?: components["schemas"]["UserHeaderMapping"][] | null;
-            /**
-             * User Header Name
-             * @description [DEPRECATED] Use 'user_header_mappings' instead. When set, the header value is treated as the end user id unless overridden by user_header_mappings.
-             */
-            user_header_name?: string | null;
-            /**
-             * User Mcp Management Mode
-             * @description Controls how non-admin users interact with MCP servers in the dashboard. 'restricted' shows only accessible servers, 'view_all' lists every server in read-only mode.
-             */
-            user_mcp_management_mode?: ("restricted" | "view_all") | null;
-            /**
-             * User Url Allowed Hosts
-             * @description SSRF allowlist for user-supplied URLs. Entries are `hostname` or `hostname:port` (bracketed for IPv6, e.g. `[::1]:8080`). Allowlisted hosts skip the blocked-network check in validate_url() but still resolve DNS. Use this to permit legitimate internal targets, e.g. an internal OpenAPI/MCP server.
-             */
-            user_url_allowed_hosts?: string[] | null;
-            /**
-             * User Url Validation
-             * @description Master switch for the SSRF guard applied to user-supplied URLs (image_url, file_url, MCP/OpenAPI spec URLs, etc). Defaults to True. Set to False to disable DNS/IP validation entirely (not recommended).
-             */
-            user_url_validation?: boolean | null;
-        };
-        /** ConfigList */
-        ConfigList: {
-            /** Field Default Value */
-            field_default_value: unknown;
-            /** Field Description */
-            field_description: string;
-            /** Field Name */
-            field_name: string;
-            /** Field Type */
-            field_type: string;
-            /** Field Value */
-            field_value: unknown;
-            /** Nested Fields */
-            nested_fields?: components["schemas"]["FieldDetail"][] | null;
-            /**
-             * Premium Field
-             * @default false
-             */
-            premium_field: boolean;
-            /** Stored In Db */
-            stored_in_db: boolean | null;
-        };
         /**
          * ConfigOverrideSettingsResponse
          * @description Response model for config override settings GET endpoints.
@@ -22729,34 +20191,6 @@ export interface components {
             values: {
                 [key: string]: unknown;
             };
-        };
-        /**
-         * ConfigYAML
-         * @description Documents all the fields supported by the config.yaml
-         */
-        ConfigYAML: {
-            /**
-             * Environment Variables
-             * @description Object to pass in additional environment variables via POST request
-             */
-            environment_variables?: {
-                [key: string]: unknown;
-            } | null;
-            general_settings?: components["schemas"]["ConfigGeneralSettings"] | null;
-            /**
-             * Litellm Settings
-             * @description litellm Module settings. See __init__.py for all, example litellm.drop_params=True, litellm.set_verbose=True, litellm.api_base, litellm.cache
-             */
-            litellm_settings?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * Model List
-             * @description List of supported models on the server, with model-specific configs
-             */
-            model_list?: components["schemas"]["ModelParams"][] | null;
-            /** @description litellm router object settings. See router.py __init__ for all, example router.num_retries=5, router.timeout=5, router.max_retries=5, router.retry_after=5 */
-            router_settings?: components["schemas"]["UpdateRouterConfig"] | null;
         };
         /** ConfigurableClientsideParamsCustomAuth */
         "ConfigurableClientsideParamsCustomAuth-Input": {
@@ -22845,82 +20279,6 @@ export interface components {
              * @enum {string}
              */
             pattern_type: "prebuilt" | "regex";
-        };
-        /**
-         * CoordinationRedisNode
-         * @description A single startup node of a cluster-mode Redis used for proxy coordination.
-         */
-        CoordinationRedisNode: {
-            /**
-             * Host
-             * @description hostname of the cluster node
-             */
-            host: string;
-            /**
-             * Port
-             * @description port of the cluster node
-             */
-            port: number;
-        };
-        /**
-         * CoordinationRedisParams
-         * @description Connection params for the proxy's coordination Redis (cross-pod tpm/rpm rate
-         *     limits, spend tracking, pod lock manager, shared health checks), configured
-         *     independently of the response-cache backend in `litellm_settings.cache_params`.
-         */
-        CoordinationRedisParams: {
-            /**
-             * Host
-             * @description Redis hostname
-             */
-            host?: string | null;
-            /**
-             * Password
-             * @description Redis password
-             */
-            password?: string | null;
-            /**
-             * Port
-             * @description Redis port
-             */
-            port?: number | null;
-            /**
-             * Sentinel Nodes
-             * @description sentinel [host, port] pairs; when set a sentinel-managed client is used
-             */
-            sentinel_nodes?: (string | number)[][] | null;
-            /**
-             * Sentinel Password
-             * @description password for the sentinel nodes
-             */
-            sentinel_password?: string | null;
-            /**
-             * Service Name
-             * @description sentinel service name
-             */
-            service_name?: string | null;
-            /**
-             * Ssl
-             * @description connect over TLS
-             */
-            ssl?: boolean | null;
-            /**
-             * Startup Nodes
-             * @description cluster-mode startup nodes; when set a cluster client is used
-             */
-            startup_nodes?: components["schemas"]["CoordinationRedisNode"][] | null;
-            /**
-             * Url
-             * @description full Redis connection url, e.g. redis://:pass@host:6379
-             */
-            url?: string | null;
-            /**
-             * Username
-             * @description Redis username
-             */
-            username?: string | null;
-        } & {
-            [key: string]: unknown;
         };
         /** CoordinationRedisSettingsField */
         CoordinationRedisSettingsField: {
@@ -23416,7 +20774,7 @@ export interface components {
         /** Deployment */
         Deployment: {
             litellm_params: components["schemas"]["LiteLLM_Params"];
-            model_info: components["schemas"]["litellm__types__router__ModelInfo"];
+            model_info: components["schemas"]["ModelInfo"];
             /** Model Name */
             model_name: string;
         } & {
@@ -23449,60 +20807,6 @@ export interface components {
              * @constant
              */
             type: "text";
-        };
-        /** DynamoDBArgs */
-        DynamoDBArgs: {
-            /** Assume Role Aws Role Name */
-            assume_role_aws_role_name?: string | null;
-            /** Assume Role Aws Session Name */
-            assume_role_aws_session_name?: string | null;
-            /** Aws Duration Seconds */
-            aws_duration_seconds?: number | null;
-            /** Aws Policy */
-            aws_policy?: string | null;
-            /** Aws Policy Arns */
-            aws_policy_arns?: string[] | null;
-            /** Aws Provider Id */
-            aws_provider_id?: string | null;
-            /** Aws Role Name */
-            aws_role_name?: string | null;
-            /** Aws Session Name */
-            aws_session_name?: string | null;
-            /** Aws Web Identity Token */
-            aws_web_identity_token?: string | null;
-            /**
-             * Billing Mode
-             * @enum {string}
-             */
-            billing_mode: "PROVISIONED_THROUGHPUT" | "PAY_PER_REQUEST";
-            /**
-             * Config Table Name
-             * @default LiteLLM_Config
-             */
-            config_table_name: string;
-            /**
-             * Key Table Name
-             * @default LiteLLM_VerificationToken
-             */
-            key_table_name: string;
-            /** Read Capacity Units */
-            read_capacity_units?: number | null;
-            /** Region Name */
-            region_name: string;
-            /**
-             * Spend Table Name
-             * @default LiteLLM_SpendLogs
-             */
-            spend_table_name: string;
-            /** Ssl Verify */
-            ssl_verify?: boolean | null;
-            /**
-             * User Table Name
-             * @default LiteLLM_UserTable
-             */
-            user_table_name: string;
-            /** Write Capacity Units */
-            write_capacity_units?: number | null;
         };
         /**
          * EmailEvent
@@ -23686,6 +20990,15 @@ export interface components {
                 [key: string]: unknown;
             } | null;
         };
+        /** FailedTeamMemberUpdate */
+        FailedTeamMemberUpdate: {
+            /** Failed Reason */
+            failed_reason: string;
+            /** User Email */
+            user_email?: string | null;
+            /** User Id */
+            user_id: string;
+        };
         /**
          * FallbackCreateRequest
          * @description Request model for creating/updating fallbacks
@@ -23776,19 +21089,6 @@ export interface components {
              * @description The model name
              */
             model: string;
-        };
-        /** FieldDetail */
-        FieldDetail: {
-            /** Field Default Value */
-            field_default_value?: unknown;
-            /** Field Description */
-            field_description: string;
-            /** Field Name */
-            field_name: string;
-            /** Field Type */
-            field_type: string;
-            /** Stored In Db */
-            stored_in_db: boolean | null;
         };
         /** FunctionCall */
         FunctionCall: {
@@ -24144,15 +21444,6 @@ export interface components {
              */
             team_member_permissions: string[] | null;
         };
-        /** GlobalEndUsersSpend */
-        GlobalEndUsersSpend: {
-            /** Api Key */
-            api_key?: string | null;
-            /** Endtime */
-            endTime?: string | null;
-            /** Starttime */
-            startTime?: string | null;
-        };
         /**
          * GraySwanGuardrailConfigModelOptionalParams
          * @description Optional parameters for the Gray Swan guardrail.
@@ -24465,53 +21756,6 @@ export interface components {
             /** User Id */
             user_id: string;
         };
-        /** InvitationDelete */
-        InvitationDelete: {
-            /** Invitation Id */
-            invitation_id: string;
-        };
-        /** InvitationModel */
-        InvitationModel: {
-            /** Accepted At */
-            accepted_at: string | null;
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /** Created By */
-            created_by: string;
-            /**
-             * Expires At
-             * Format: date-time
-             */
-            expires_at: string;
-            /** Id */
-            id: string;
-            /** Is Accepted */
-            is_accepted: boolean;
-            /**
-             * Updated At
-             * Format: date-time
-             */
-            updated_at: string;
-            /** Updated By */
-            updated_by: string;
-            /** User Id */
-            user_id: string;
-        };
-        /** InvitationNew */
-        InvitationNew: {
-            /** User Id */
-            user_id: string;
-        };
-        /** InvitationUpdate */
-        InvitationUpdate: {
-            /** Invitation Id */
-            invitation_id: string;
-            /** Is Accepted */
-            is_accepted: boolean;
-        };
         /** JWTKeyMappingResponse */
         JWTKeyMappingResponse: {
             /**
@@ -24565,11 +21809,6 @@ export interface components {
          * @enum {string}
          */
         KeyManagementRoutes: "/key/generate" | "/key/update" | "/key/delete" | "/key/regenerate" | "/key/service-account/generate" | "/key/{key_id}/regenerate" | "/key/block" | "/key/unblock" | "/key/bulk_update" | "/team/key/bulk_update" | "/key/{key_id}/reset_spend" | "/key/access_group_assignment" | "/key/info" | "/key/health" | "/key/list" | "/key/aliases" | "/team/daily/activity" | "/spend/logs" | "/spend/logs/v2";
-        /**
-         * KeyManagementSystem
-         * @enum {string}
-         */
-        KeyManagementSystem: "google_kms" | "azure_key_vault" | "aws_secret_manager" | "google_secret_manager" | "hashicorp_vault" | "cyberark" | "local" | "aws_kms" | "custom";
         /**
          * KeyMetadata
          * @description Metadata for a key
@@ -26255,13 +23494,6 @@ export interface components {
             /** User Role */
             user_role?: string | null;
         };
-        /** LiteLLM_UserTableFiltered */
-        LiteLLM_UserTableFiltered: {
-            /** User Email */
-            user_email?: string | null;
-            /** User Id */
-            user_id: string;
-        };
         /** LiteLLM_UserTableWithKeyCount */
         LiteLLM_UserTableWithKeyCount: {
             /**
@@ -27591,20 +24823,40 @@ export interface components {
             /** Tpm */
             tpm?: number | null;
         };
+        /** ModelInfo */
+        ModelInfo: {
+            /** Base Model */
+            base_model?: string | null;
+            /** Blocked */
+            blocked?: boolean | null;
+            /** Created At */
+            created_at?: string | null;
+            /** Created By */
+            created_by?: string | null;
+            /**
+             * Db Model
+             * @default false
+             */
+            db_model: boolean;
+            /** Id */
+            id: string | null;
+            /** Team Id */
+            team_id?: string | null;
+            /** Team Public Model Name */
+            team_public_model_name?: string | null;
+            /** Tier */
+            tier?: ("free" | "paid") | null;
+            /** Updated At */
+            updated_at?: string | null;
+            /** Updated By */
+            updated_by?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
         /** ModelInfoDelete */
         ModelInfoDelete: {
             /** Id */
             id: string;
-        };
-        /** ModelParams */
-        ModelParams: {
-            /** Litellm Params */
-            litellm_params: {
-                [key: string]: unknown;
-            };
-            model_info: components["schemas"]["litellm__proxy___types__ModelInfo"];
-            /** Model Name */
-            model_name: string;
         };
         /** ModelResponse */
         ModelResponse: {
@@ -28861,32 +26113,6 @@ export interface components {
             name: string;
         };
         /**
-         * PluginConfig
-         * @description A single external service registered as an embeddable UI plugin.
-         */
-        PluginConfig: {
-            /**
-             * Display Name
-             * @description human-readable label shown in the UI view switcher
-             */
-            display_name?: string | null;
-            /**
-             * Name
-             * @description unique plugin identifier (kebab-case)
-             */
-            name: string;
-            /**
-             * Plugin Key
-             * @description plugin's own credential, injected as Bearer auth only on /plugin-proxy/<name>/* reverse-proxy calls
-             */
-            plugin_key?: string | null;
-            /**
-             * Url
-             * @description base URL of the plugin service
-             */
-            url: string;
-        };
-        /**
          * PluginListItem
          * @description Plugin item in list responses.
          */
@@ -29557,6 +26783,19 @@ export interface components {
             /** Prompt Id */
             prompt_id: string;
             prompt_info?: components["schemas"]["PromptInfo"] | null;
+        };
+        /**
+         * PromptCacheBreakpoint
+         * @description Marks the exact end of a reusable prompt prefix.
+         *
+         *     The breakpoint inherits its TTL from the request's `prompt_cache_options.ttl`; the boundary is not rounded to a token block.
+         */
+        PromptCacheBreakpoint: {
+            /**
+             * Mode
+             * @constant
+             */
+            mode: "explicit";
         };
         /** PromptInfo */
         PromptInfo: {
@@ -30882,13 +28121,6 @@ export interface components {
             /** Model */
             model?: string | null;
         };
-        /**
-         * SupportedDBObjectType
-         * @description Supported database object types for fine-grained DB storage control.
-         *     Use in general_settings.supported_db_objects to specify which objects to load from DB.
-         * @enum {string}
-         */
-        SupportedDBObjectType: "models" | "mcp" | "guardrails" | "policies" | "vector_stores" | "pass_through_endpoints" | "prompts" | "model_cost_map" | "tools" | "config_overrides";
         /** SupportedEndpoint */
         SupportedEndpoint: {
             /** Endpoint */
@@ -31332,6 +28564,21 @@ export interface components {
             user_email?: string | null;
             /** User Id */
             user_id?: string | null;
+        };
+        /** TeamMemberBulkUpdateFields */
+        TeamMemberBulkUpdateFields: {
+            /** Allowed Models */
+            allowed_models?: string[] | null;
+            /** Budget Duration */
+            budget_duration?: string | null;
+            /** Max Budget In Team */
+            max_budget_in_team?: number | null;
+            /** Role */
+            role?: ("admin" | "user") | null;
+            /** Rpm Limit */
+            rpm_limit?: number | null;
+            /** Tpm Limit */
+            tpm_limit?: number | null;
         };
         /** TeamMemberDeleteRequest */
         TeamMemberDeleteRequest: {
@@ -32985,19 +30232,6 @@ export interface components {
             /** User Tpm Limit */
             user_tpm_limit?: number | null;
         };
-        /**
-         * UserHeaderMapping
-         * @description Map an incoming HTTP header to a LiteLLM user role.
-         */
-        UserHeaderMapping: {
-            /** Header Name */
-            header_name: string;
-            /**
-             * Litellm User Role
-             * @enum {string}
-             */
-            litellm_user_role: "internal_user" | "customer";
-        };
         /** UserInfoResponse */
         UserInfoResponse: {
             /** Keys */
@@ -33322,68 +30556,12 @@ export interface components {
             /** Status */
             status?: ("pending" | "running" | "paused" | "completed" | "failed") | null;
         };
-        /** ModelInfo */
-        litellm__proxy___types__ModelInfo: {
-            /** Base Model */
-            base_model: ("gpt-4-1106-preview" | "gpt-4-32k" | "gpt-4" | "gpt-3.5-turbo-16k" | "gpt-3.5-turbo" | "text-embedding-ada-002") | null;
-            /** Id */
-            id: string | null;
-            /**
-             * Input Cost Per Token
-             * @default 0
-             */
-            input_cost_per_token: number | null;
-            /**
-             * Max Tokens
-             * @default 2048
-             */
-            max_tokens: number | null;
-            /** Mode */
-            mode: ("embedding" | "chat" | "completion") | null;
-            /**
-             * Output Cost Per Token
-             * @default 0
-             */
-            output_cost_per_token: number | null;
-        } & {
-            [key: string]: unknown;
-        };
-        /** ModelInfo */
-        litellm__types__router__ModelInfo: {
-            /** Base Model */
-            base_model?: string | null;
-            /** Blocked */
-            blocked?: boolean | null;
-            /** Created At */
-            created_at?: string | null;
-            /** Created By */
-            created_by?: string | null;
-            /**
-             * Db Model
-             * @default false
-             */
-            db_model: boolean;
-            /** Id */
-            id: string | null;
-            /** Team Id */
-            team_id?: string | null;
-            /** Team Public Model Name */
-            team_public_model_name?: string | null;
-            /** Tier */
-            tier?: ("free" | "paid") | null;
-            /** Updated At */
-            updated_at?: string | null;
-            /** Updated By */
-            updated_by?: string | null;
-        } & {
-            [key: string]: unknown;
-        };
         /** updateDeployment */
         updateDeployment: {
             /** Blocked */
             blocked?: boolean | null;
             litellm_params?: components["schemas"]["updateLiteLLMParams"] | null;
-            model_info?: components["schemas"]["litellm__types__router__ModelInfo"] | null;
+            model_info?: components["schemas"]["ModelInfo"] | null;
             /** Model Name */
             model_name?: string | null;
         };
@@ -34103,26 +31281,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    alerting_settings_alerting_settings_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
                 };
             };
         };
@@ -36588,39 +33746,6 @@ export interface operations {
             };
         };
     };
-    delete_callback_config_callback_delete_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CallbackDelete"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     get_cost_discount_config_config_cost_discount_config_get: {
         parameters: {
             query?: never;
@@ -36720,134 +33845,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_config_general_settings_config_field_delete_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ConfigFieldDelete"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_config_general_settings_config_field_info_get: {
-        parameters: {
-            query: {
-                field_name: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ConfigFieldInfo"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_config_general_settings_config_field_update_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ConfigFieldUpdate"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_config_list_config_list_get: {
-        parameters: {
-            query: {
-                config_type: "general_settings";
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ConfigList"][];
                 };
             };
             /** @description Validation Error */
@@ -37002,72 +33999,6 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["PassThroughGenericEndpoint"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_config_config_update_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ConfigYAML"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    config_yaml_endpoint_config_yaml_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ConfigYAML"];
             };
         };
         responses: {
@@ -38255,102 +35186,6 @@ export interface operations {
             };
         };
     };
-    get_memory_details_debug_memory_details_get: {
-        parameters: {
-            query?: {
-                /** @description Number of top object types to return */
-                top_n?: number;
-                /** @description Include process memory info */
-                include_process_info?: boolean;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    configure_gc_thresholds_endpoint_debug_memory_gc_configure_post: {
-        parameters: {
-            query?: {
-                /** @description Generation 0 threshold (default: 700) */
-                generation_0?: number;
-                /** @description Generation 1 threshold (default: 10) */
-                generation_1?: number;
-                /** @description Generation 2 threshold (default: 10) */
-                generation_2?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_memory_summary_debug_memory_summary_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-        };
-    };
     delete_allowed_ip_delete_allowed_ip_post: {
         parameters: {
             query?: never;
@@ -38544,261 +35379,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    block_user_end_user_block_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["BlockUsers"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_customer_daily_activity_end_user_daily_activity_get: {
-        parameters: {
-            query?: {
-                end_user_ids?: string | null;
-                start_date?: string | null;
-                end_date?: string | null;
-                model?: string | null;
-                api_key?: string | null;
-                page?: number;
-                page_size?: number;
-                exclude_end_user_ids?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    delete_end_user_end_user_delete_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["DeleteCustomerRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DeleteCustomersResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    end_user_info_end_user_info_get: {
-        parameters: {
-            query: {
-                /** @description End User ID in the request parameters */
-                end_user_id: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CustomerResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_end_user_end_user_list_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CustomerResponse"][];
-                };
-            };
-        };
-    };
-    new_end_user_end_user_new_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["NewCustomerRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CustomerResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    unblock_user_end_user_unblock_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["BlockUsers"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_end_user_end_user_update_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateCustomerRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CustomerResponse"];
                 };
             };
             /** @description Validation Error */
@@ -39874,46 +36454,6 @@ export interface operations {
             };
         };
     };
-    get_allowed_ips_get_allowed_ips_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    get_config_get_config_callbacks_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
     get_default_team_settings_get_default_team_settings_get: {
         parameters: {
             query?: never;
@@ -40094,423 +36634,6 @@ export interface operations {
             };
         };
     };
-    get_global_activity_global_activity_get: {
-        parameters: {
-            query?: {
-                /** @description Time from which to start viewing spend */
-                start_date?: string | null;
-                /** @description Time till which to view spend */
-                end_date?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_global_activity_global_activity_cache_hits_get: {
-        parameters: {
-            query?: {
-                /** @description Time from which to start viewing spend */
-                start_date?: string | null;
-                /** @description Time till which to view spend */
-                end_date?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_global_activity_exceptions_global_activity_exceptions_get: {
-        parameters: {
-            query: {
-                /** @description Filter by model group */
-                model_group: string;
-                /** @description Time from which to start viewing spend */
-                start_date?: string | null;
-                /** @description Time till which to view spend */
-                end_date?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_global_activity_exceptions_per_deployment_global_activity_exceptions_deployment_get: {
-        parameters: {
-            query: {
-                /** @description Filter by model group */
-                model_group: string;
-                /** @description Time from which to start viewing spend */
-                start_date?: string | null;
-                /** @description Time till which to view spend */
-                end_date?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_global_activity_model_global_activity_model_get: {
-        parameters: {
-            query?: {
-                /** @description Time from which to start viewing spend */
-                start_date?: string | null;
-                /** @description Time till which to view spend */
-                end_date?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    global_view_all_end_users_global_all_end_users_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    global_spend_global_spend_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    global_get_all_tag_names_global_spend_all_tag_names_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-        };
-    };
-    global_spend_end_users_global_spend_end_users_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["GlobalEndUsersSpend"] | null;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    global_spend_keys_global_spend_keys_get: {
-        parameters: {
-            query?: {
-                /** @description Number of keys to get. Will return Top 'n' keys. */
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    global_spend_logs_global_spend_logs_get: {
-        parameters: {
-            query?: {
-                /** @description API Key to get global spend (spend per day for last 30d). Admin-only endpoint */
-                api_key?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    global_spend_models_global_spend_models_get: {
-        parameters: {
-            query?: {
-                /** @description Number of models to get. Will return Top 'n' models. */
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_global_spend_provider_global_spend_provider_get: {
-        parameters: {
-            query?: {
-                /** @description Time from which to start viewing spend */
-                start_date?: string | null;
-                /** @description Time till which to view spend */
-                end_date?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    global_spend_refresh_global_spend_refresh_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
     get_global_spend_report_global_spend_report_get: {
         parameters: {
             query?: {
@@ -40607,26 +36730,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    global_spend_per_team_global_spend_teams_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
                 };
             };
         };
@@ -41859,136 +37962,6 @@ export interface operations {
             };
         };
     };
-    invitation_delete_invitation_delete_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["InvitationDelete"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["InvitationModel"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    invitation_info_invitation_info_get: {
-        parameters: {
-            query: {
-                invitation_id: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["InvitationModel"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    new_invitation_invitation_new_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["InvitationNew"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["InvitationModel"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    invitation_update_invitation_update_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["InvitationUpdate"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["InvitationModel"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     delete_jwt_key_mapping_jwt_key_mapping_delete_post: {
         parameters: {
             query?: never;
@@ -42834,37 +38807,6 @@ export interface operations {
             };
         };
     };
-    warm_lazy_warm__name__post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                name: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     get_ui_config_litellm__well_known_litellm_ui_config_get: {
         parameters: {
             query?: never;
@@ -42881,26 +38823,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["UiDiscoveryEndpoints"];
-                };
-            };
-        };
-    };
-    login_login_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
                 };
             };
         };
@@ -43021,46 +38943,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    memory_usage_in_mem_cache_memory_usage_in_mem_cache_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    memory_usage_in_mem_cache_items_memory_usage_in_mem_cache_items_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
                 };
             };
         };
@@ -43411,26 +39293,6 @@ export interface operations {
             };
         };
     };
-    get_model_cost_map_source_model_cost_map_source_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
     delete_model_model_delete_post: {
         parameters: {
             query?: never;
@@ -43499,111 +39361,6 @@ export interface operations {
             };
         };
     };
-    model_metrics_model_metrics_get: {
-        parameters: {
-            query?: {
-                _selected_model_group?: string | null;
-                startTime?: string | null;
-                endTime?: string | null;
-                api_key?: string | null;
-                customer?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    model_metrics_exceptions_model_metrics_exceptions_get: {
-        parameters: {
-            query?: {
-                _selected_model_group?: string | null;
-                startTime?: string | null;
-                endTime?: string | null;
-                api_key?: string | null;
-                customer?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    model_metrics_slow_responses_model_metrics_slow_responses_get: {
-        parameters: {
-            query?: {
-                _selected_model_group?: string | null;
-                startTime?: string | null;
-                endTime?: string | null;
-                api_key?: string | null;
-                customer?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     add_new_model_model_new_post: {
         parameters: {
             query?: never;
@@ -43616,59 +39373,6 @@ export interface operations {
                 "application/json": components["schemas"]["Deployment"];
             };
         };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    model_settings_model_settings_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    model_streaming_metrics_model_streaming_metrics_get: {
-        parameters: {
-            query?: {
-                _selected_model_group?: string | null;
-                startTime?: string | null;
-                endTime?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {
@@ -45495,250 +41199,6 @@ export interface operations {
             };
         };
     };
-    get_otel_spans_otel_spans_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__put: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__options: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__head: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    plugin_proxy_plugin_proxy__plugin_name___path__patch: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                plugin_name: string;
-                path: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     create_policy_policies_post: {
         parameters: {
             query?: never;
@@ -47310,37 +42770,6 @@ export interface operations {
             };
         };
     };
-    async_queue_request_queue_chat_completions_post: {
-        parameters: {
-            query?: {
-                model?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     rag_ingest_rag_ingest_post: {
         parameters: {
             query?: never;
@@ -47439,46 +42868,6 @@ export interface operations {
             };
         };
     };
-    reload_anthropic_beta_headers_reload_anthropic_beta_headers_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    reload_model_cost_map_reload_model_cost_map_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
     rerank_rerank_post: {
         parameters: {
             query?: never;
@@ -47496,24 +42885,6 @@ export interface operations {
                 content: {
                     "application/json": unknown;
                 };
-            };
-        };
-    };
-    websocket_responses_websocket_endpoint_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description WebSocket Protocol Switched */
-            101: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
             };
         };
     };
@@ -47742,148 +43113,6 @@ export interface operations {
         };
     };
     get_routes_routes_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    schedule_anthropic_beta_headers_reload_schedule_anthropic_beta_headers_reload_post: {
-        parameters: {
-            query: {
-                hours: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    cancel_anthropic_beta_headers_reload_schedule_anthropic_beta_headers_reload_delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    get_anthropic_beta_headers_reload_status_schedule_anthropic_beta_headers_reload_status_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    schedule_model_cost_map_reload_schedule_model_cost_map_reload_post: {
-        parameters: {
-            query: {
-                hours: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    cancel_model_cost_map_reload_schedule_model_cost_map_reload_delete: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    get_model_cost_map_reload_status_schedule_model_cost_map_reload_status_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -48851,26 +44080,6 @@ export interface operations {
             };
         };
     };
-    spend_key_fn_spend_keys_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
     view_spend_logs_spend_logs_get: {
         parameters: {
             query?: {
@@ -48900,150 +44109,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    ui_view_session_spend_logs_spend_logs_session_ui_get: {
-        parameters: {
-            query: {
-                /** @description Get all spend logs for a particular session */
-                session_id: string;
-                /** @description Page number for pagination */
-                page?: number;
-                /** @description Number of items per page */
-                page_size?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    ui_view_spend_logs_spend_logs_ui_get: {
-        parameters: {
-            query?: {
-                /** @description Get spend logs based on api key */
-                api_key?: string | null;
-                /** @description Get spend logs based on user_id */
-                user_id?: string | null;
-                /** @description request_id to get spend logs for specific request_id */
-                request_id?: string | null;
-                /** @description Filter spend logs by session_id (partial string match) */
-                session_id?: string | null;
-                /** @description Filter spend logs by team_id */
-                team_id?: string | null;
-                /** @description Filter logs with spend greater than or equal to this value */
-                min_spend?: number | null;
-                /** @description Filter logs with spend less than or equal to this value */
-                max_spend?: number | null;
-                /** @description Time from which to start viewing key spend */
-                start_date?: string | null;
-                /** @description Time till which to view key spend */
-                end_date?: string | null;
-                /** @description Page number for pagination */
-                page?: number;
-                /** @description Number of items per page */
-                page_size?: number;
-                /** @description Filter logs by status (e.g., success, failure) */
-                status_filter?: string | null;
-                /** @description Filter logs by model */
-                model?: string | null;
-                /** @description Filter logs by model ID (litellm model deployment id) */
-                model_id?: string | null;
-                /** @description Filter logs by model group */
-                model_group?: string | null;
-                /** @description Filter logs by key alias */
-                key_alias?: string | null;
-                /** @description Filter logs by end user */
-                end_user?: string | null;
-                /** @description Filter logs by error code (e.g., '404', '500') */
-                error_code?: string | null;
-                /** @description Filter logs by error message (partial string match) */
-                error_message?: string | null;
-                /** @description Sort logs by field: spend, total_tokens, startTime, endTime, request_duration_ms, model, or ttft_ms */
-                sort_by?: string;
-                /** @description Sort order: asc or desc */
-                sort_order?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    ui_view_request_response_for_request_id_spend_logs_ui__request_id__get: {
-        parameters: {
-            query?: {
-                /** @description Time from which to start viewing key spend */
-                start_date?: string | null;
-                /** @description Time till which to view key spend */
-                end_date?: string | null;
-            };
-            header?: never;
-            path: {
-                request_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */
@@ -49152,250 +44217,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["LiteLLM_SpendLogs"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    spend_user_fn_spend_users_get: {
-        parameters: {
-            query?: {
-                /** @description Get User Table row for user_id */
-                user_id?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    auth_callback_sso_callback_get: {
-        parameters: {
-            query?: {
-                state?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    cli_sso_complete_sso_cli_complete__login_id__post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                login_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    cli_poll_key_sso_cli_poll__key_id__get: {
-        parameters: {
-            query?: {
-                team_id?: string | null;
-            };
-            header?: {
-                "x-litellm-cli-poll-secret"?: string | null;
-            };
-            path: {
-                key_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    cli_sso_start_sso_cli_start_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    debug_sso_callback_sso_debug_callback_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    debug_sso_login_sso_debug_login_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    get_ui_settings_sso_get_ui_settings_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    google_login_sso_key_generate_get: {
-        parameters: {
-            query?: {
-                source?: string | null;
-                key?: string | null;
-                existing_key?: string | null;
-                return_to?: string | null;
-                user_code?: string | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */
@@ -50001,44 +44822,6 @@ export interface operations {
             };
         };
     };
-    ui_view_teams_team_filter_ui_get: {
-        parameters: {
-            query?: {
-                /** @description Team ID in the request parameters */
-                team_id?: string | null;
-                /** @description Team alias in the request parameters */
-                team_alias?: string | null;
-                /** @description Page number for pagination */
-                page?: number;
-                /** @description Number of items per page */
-                page_size?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_TeamTable"][];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     team_info_team_info_get: {
         parameters: {
             query?: {
@@ -50129,6 +44912,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    bulk_update_team_members_team_member_bulk_update_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BulkTeamMemberUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BulkTeamMemberUpdateResponse"];
                 };
             };
             /** @description Validation Error */
@@ -51325,26 +46141,6 @@ export interface operations {
             };
         };
     };
-    ui_get_available_role_user_available_roles_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
     available_enterprise_users_user_available_users_get: {
         parameters: {
             query?: never;
@@ -51512,46 +46308,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    ui_view_users_user_filter_ui_get: {
-        parameters: {
-            query?: {
-                /** @description User ID in the request parameters */
-                user_id?: string | null;
-                /** @description User email in the request parameters */
-                user_email?: string | null;
-                /** @description Team ID — used when a team admin searches for users to add to their team */
-                team_id?: string | null;
-                /** @description Page number for pagination */
-                page?: number;
-                /** @description Number of items per page */
-                page_size?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["LiteLLM_UserTableFiltered"][];
                 };
             };
             /** @description Validation Error */
@@ -55266,24 +50022,6 @@ export interface operations {
             };
         };
     };
-    websocket_responses_websocket_endpoint_get_2: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description WebSocket Protocol Switched */
-            101: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
     responses_api_v1_responses_post: {
         parameters: {
             query?: never;
@@ -57348,59 +52086,6 @@ export interface operations {
             };
         };
     };
-    info_key_fn_v2_v2_key_info_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["KeyRequest"] | null;
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    login_v2_v2_login_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
     model_info_v2_v2_model_info_get: {
         parameters: {
             query?: {
@@ -57550,46 +52235,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    login_v3_v3_login_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-        };
-    };
-    login_v3_exchange_v3_login_exchange_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
                 };
             };
         };
@@ -58273,161 +52918,6 @@ export interface operations {
             header?: never;
             path: {
                 vector_store_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    vertex_proxy_route_vertex_ai__endpoint__get_2: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                endpoint: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    vertex_proxy_route_vertex_ai__endpoint__put_2: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                endpoint: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    vertex_proxy_route_vertex_ai__endpoint__post_2: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                endpoint: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    vertex_proxy_route_vertex_ai__endpoint__delete_2: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                endpoint: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    vertex_proxy_route_vertex_ai__endpoint__patch_2: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                endpoint: string;
             };
             cookie?: never;
         };


### PR DESCRIPTION
## Relevant issues


## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Ran the proxy locally at `http://localhost:4000` and the dashboard locally at `http://localhost:3000`. Dashboard production build passed with `npm run build`.

`make pre-commit` now passes end to end. `schema.d.ts` was regenerated against an environment with the full proxy dependency set (the earlier regeneration silently dropped routes whose imports failed), so its diff against the base branch is additive only: the new `/team/member/bulk_update` route and its models. The bulk update API call moved out of `networking.tsx` into `team/teamMemberBulkUpdate.ts` to clear the eslint max-params baseline, and the new pydantic models use modern typing syntax to stay within the ruff strict budget

## Type

🆕 New Feature

## Changes

Adds `POST /team/member/bulk_update` for applying the existing team-member update fields to selected members or every member in a team. The Team Members tab now provides a bulk-update modal for role, budget, budget duration, TPM, RPM, and allowed-model changes. Per-member failures are returned without rolling back successful updates.
