### PR TITLE
feat(proxy): add filters to exclude health-check logs

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -5,7 +5,9 @@ import sys
 from datetime import datetime
 from logging import Formatter
 from typing import Any, Dict, Optional
+from urllib.parse import urlparse
 
+from litellm.constants import DEFAULT_EXCLUDED_UVICORN_ACCESS_PATHS
 from litellm.litellm_core_utils.secret_redaction import redact_string
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.litellm_core_utils.safe_json_loads import safe_json_loads
@@ -75,6 +77,55 @@ class SecretRedactionFilter(logging.Filter):
 
 
 _secret_filter = SecretRedactionFilter()
+
+
+class UvicornAccessPathFilter(logging.Filter):
+    # Marker so apply_log_filters can find and remove its own previously-installed
+    # filter instances without touching any other filter a user/library attached.
+    _litellm_managed = True
+
+    def __init__(self, excluded_paths: frozenset) -> None:
+        """Store the set of request paths whose access-log records should be dropped."""
+        super().__init__()
+        self.excluded_paths = excluded_paths
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Drop uvicorn.access records whose request path is in excluded_paths; pass everything else through unchanged."""
+        if record.name != "uvicorn.access" or not record.args or len(record.args) < 3:
+            return True
+        path = urlparse(str(record.args[2])).path
+        return path not in self.excluded_paths
+
+
+def apply_log_filters(
+    *,
+    excluded_uvicorn_access_paths: frozenset[str],
+    exclude_health_check_paths: bool = True,
+) -> None:
+    """
+    Configure which request paths are dropped from the uvicorn access log.
+
+    ``exclude_health_check_paths`` toggles DEFAULT_EXCLUDED_UVICORN_ACCESS_PATHS
+    (health-check probes) as a bundle. ``excluded_uvicorn_access_paths`` is an
+    independent, always-applied set of paths — it extends whatever the toggle
+    produces rather than being gated by it, so a path can still be excluded via
+    ``excluded_uvicorn_access_paths`` even when ``exclude_health_check_paths`` is
+    False. Safe to call repeatedly (e.g. on proxy config reload) — a stale
+    filter from a previous call is removed before the new one is attached.
+    """
+    access_logger = logging.getLogger("uvicorn.access")
+    # logging.getLogger returns the same logger instance on every call, so without this
+    # cleanup step, calling apply_log_filters again (config hot-reload, repeated
+    # load_config) would stack a new filter on top of the old one instead of replacing
+    # it -- and since every filter on a logger must pass for a record to be logged, the
+    # stale filter's excluded paths would keep applying even after the config changed.
+    for existing_filter in list(access_logger.filters):
+        if getattr(existing_filter, "_litellm_managed", False):
+            access_logger.removeFilter(existing_filter)
+
+    default_paths = DEFAULT_EXCLUDED_UVICORN_ACCESS_PATHS if exclude_health_check_paths else frozenset()
+    all_excluded_paths = default_paths | excluded_uvicorn_access_paths
+    access_logger.addFilter(UvicornAccessPathFilter(all_excluded_paths))
 
 
 json_logs = bool(os.getenv("JSON_LOGS", False))

--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -125,7 +125,8 @@ def apply_log_filters(
 
     default_paths = DEFAULT_EXCLUDED_UVICORN_ACCESS_PATHS if exclude_health_check_paths else frozenset()
     all_excluded_paths = default_paths | excluded_uvicorn_access_paths
-    access_logger.addFilter(UvicornAccessPathFilter(all_excluded_paths))
+    if all_excluded_paths:
+        access_logger.addFilter(UvicornAccessPathFilter(all_excluded_paths))
 
 
 json_logs = bool(os.getenv("JSON_LOGS", False))

--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -6,8 +6,10 @@ import sys
 from datetime import datetime
 from logging import Formatter
 from typing import Any, Final
+from urllib.parse import urlparse
 
 import litellm
+from litellm.constants import DEFAULT_EXCLUDED_UVICORN_ACCESS_PATHS
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.litellm_core_utils.safe_json_loads import safe_json_loads
 from litellm.litellm_core_utils.secret_redaction import redact_string
@@ -130,6 +132,56 @@ class CorrelationContextFilter(logging.Filter):
 
 
 _correlation_filter: Final = CorrelationContextFilter()
+
+
+class UvicornAccessPathFilter(logging.Filter):
+    # Marker so apply_log_filters can find and remove its own previously-installed
+    # filter instances without touching any other filter a user/library attached.
+    _litellm_managed = True
+
+    def __init__(self, excluded_paths: frozenset) -> None:
+        """Store the set of request paths whose access-log records should be dropped."""
+        super().__init__()
+        self.excluded_paths = excluded_paths
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Drop uvicorn.access records whose request path is in excluded_paths; pass everything else through unchanged."""
+        if record.name != "uvicorn.access" or not record.args or len(record.args) < 3:
+            return True
+        path = urlparse(str(record.args[2])).path
+        return path not in self.excluded_paths
+
+
+def apply_log_filters(
+    *,
+    excluded_uvicorn_access_paths: frozenset[str],
+    exclude_health_check_paths: bool = True,
+) -> None:
+    """
+    Configure which request paths are dropped from the uvicorn access log.
+
+    ``exclude_health_check_paths`` toggles DEFAULT_EXCLUDED_UVICORN_ACCESS_PATHS
+    (health-check probes) as a bundle. ``excluded_uvicorn_access_paths`` is an
+    independent, always-applied set of paths — it extends whatever the toggle
+    produces rather than being gated by it, so a path can still be excluded via
+    ``excluded_uvicorn_access_paths`` even when ``exclude_health_check_paths`` is
+    False. Safe to call repeatedly (e.g. on proxy config reload) — a stale
+    filter from a previous call is removed before the new one is attached.
+    """
+    access_logger = logging.getLogger("uvicorn.access")
+    # logging.getLogger returns the same logger instance on every call, so without this
+    # cleanup step, calling apply_log_filters again (config hot-reload, repeated
+    # load_config) would stack a new filter on top of the old one instead of replacing
+    # it -- and since every filter on a logger must pass for a record to be logged, the
+    # stale filter's excluded paths would keep applying even after the config changed.
+    for existing_filter in tuple(access_logger.filters):
+        if getattr(existing_filter, "_litellm_managed", False):
+            access_logger.removeFilter(existing_filter)
+
+    default_paths = DEFAULT_EXCLUDED_UVICORN_ACCESS_PATHS if exclude_health_check_paths else frozenset()
+    all_excluded_paths = default_paths | excluded_uvicorn_access_paths
+    if all_excluded_paths:
+        access_logger.addFilter(UvicornAccessPathFilter(all_excluded_paths))
 
 
 json_logs = bool(os.getenv("JSON_LOGS", False))

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1340,6 +1340,13 @@ BATCH_STATUS_POLL_INTERVAL_SECONDS = int(os.getenv("BATCH_STATUS_POLL_INTERVAL_S
 BATCH_STATUS_POLL_MAX_ATTEMPTS = int(os.getenv("BATCH_STATUS_POLL_MAX_ATTEMPTS", 24))  # for 24 hours
 
 HEALTH_CHECK_TIMEOUT_SECONDS = int(os.getenv("HEALTH_CHECK_TIMEOUT_SECONDS", 60))  # 60 seconds
+DEFAULT_EXCLUDED_UVICORN_ACCESS_PATHS: frozenset[str] = frozenset(
+    {
+        "/health/liveliness",
+        "/health/liveness",
+        "/health/readiness",
+    }
+)
 _background_health_check_max_tokens_env = os.getenv("BACKGROUND_HEALTH_CHECK_MAX_TOKENS")
 try:
     _raw_background_health_check_max_tokens = (

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1386,6 +1386,13 @@ BATCH_STATUS_POLL_INTERVAL_SECONDS: Final = int(os.getenv("BATCH_STATUS_POLL_INT
 BATCH_STATUS_POLL_MAX_ATTEMPTS: Final = int(os.getenv("BATCH_STATUS_POLL_MAX_ATTEMPTS", 24))  # for 24 hours
 
 HEALTH_CHECK_TIMEOUT_SECONDS: Final = int(os.getenv("HEALTH_CHECK_TIMEOUT_SECONDS", 60))  # 60 seconds
+DEFAULT_EXCLUDED_UVICORN_ACCESS_PATHS: Final[frozenset[str]] = frozenset(
+    {
+        "/health/liveliness",
+        "/health/liveness",
+        "/health/readiness",
+    }
+)
 _background_health_check_max_tokens_env: Final = os.getenv("BACKGROUND_HEALTH_CHECK_MAX_TOKENS")
 try:
     _raw_background_health_check_max_tokens: Final = (

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1959,6 +1959,17 @@ class TeamDefaultSettings(LiteLLMPydanticObjectBase):
     )  # allow params not defined here, these fall in litellm.completion(**kwargs)
 
 
+class LogFiltersConfig(LiteLLMPydanticObjectBase):
+    excluded_uvicorn_access_paths: List[str] = Field(
+        default_factory=list,
+        description="Additional request paths to drop from the uvicorn access log, on top of the built-in health-check paths (unless exclude_health_check_paths is set to False).",
+    )
+    exclude_health_check_paths: bool = Field(
+        default=True,
+        description="Whether to drop the built-in health-check paths (/health/readiness, /health/liveliness, /health/liveness) from the uvicorn access log. Set to False to see them logged again.",
+    )
+
+
 class DynamoDBArgs(LiteLLMPydanticObjectBase):
     billing_mode: Literal["PROVISIONED_THROUGHPUT", "PAY_PER_REQUEST"]
     read_capacity_units: Optional[int] = None

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2082,6 +2082,17 @@ class TeamDefaultSettings(LiteLLMPydanticObjectBase):
     )  # allow params not defined here, these fall in litellm.completion(**kwargs)
 
 
+class LogFiltersConfig(LiteLLMPydanticObjectBase):
+    excluded_uvicorn_access_paths: list[str] = Field(
+        default_factory=list,
+        description="Additional request paths to drop from the uvicorn access log, on top of the built-in health-check paths (unless exclude_health_check_paths is set to False).",
+    )
+    exclude_health_check_paths: bool = Field(
+        default=True,
+        description="Whether to drop the built-in health-check paths (/health/readiness, /health/liveliness, /health/liveness) from the uvicorn access log. Set to False to see them logged again.",
+    )
+
+
 class DynamoDBArgs(LiteLLMPydanticObjectBase):
     billing_mode: Literal["PROVISIONED_THROUGHPUT", "PAY_PER_REQUEST"]
     read_capacity_units: int | None = None

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -213,7 +213,7 @@ from functools import lru_cache
 
 import litellm
 from litellm import Router
-from litellm._logging import verbose_proxy_logger, verbose_router_logger
+from litellm._logging import apply_log_filters, verbose_proxy_logger, verbose_router_logger
 from litellm.caching.caching import DualCache, RedisCache
 from litellm.caching.redis_cluster_cache import RedisClusterCache
 from litellm.constants import (
@@ -4047,6 +4047,11 @@ class ProxyConfig:
         litellm_settings = config.get("litellm_settings", None)
         if litellm_settings is None:
             litellm_settings = {}
+
+        # Drop health-check probe noise from the uvicorn access log by default when the
+        # proxy starts; litellm_settings.log_filters below extends/overrides this.
+        apply_log_filters(excluded_uvicorn_access_paths=frozenset())
+
         if litellm_settings:
             # ANSI escape code for blue text
             blue_color_code = "\033[94m"
@@ -4322,6 +4327,14 @@ class ProxyConfig:
                     litellm.json_logs = True
                     litellm._turn_on_json()
                     verbose_proxy_logger.debug(f"{blue_color_code} Enabled JSON logging via config{reset_color_code}")
+                elif key == "log_filters" and value is not None:
+                    if not isinstance(value, dict):
+                        raise Exception(f"Invalid value set for log_filters - value={value}")
+                    log_filters_config = LogFiltersConfig(**value)
+                    apply_log_filters(
+                        excluded_uvicorn_access_paths=frozenset(log_filters_config.excluded_uvicorn_access_paths),
+                        exclude_health_check_paths=log_filters_config.exclude_health_check_paths,
+                    )
                 else:
                     verbose_proxy_logger.debug(
                         f"{blue_color_code} setting litellm.{key}={_redact_general_setting_value(key, value, is_full_admin=False)}{reset_color_code}"

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4048,9 +4048,7 @@ class ProxyConfig:
         if litellm_settings is None:
             litellm_settings = {}
 
-        # Drop health-check probe noise from the uvicorn access log by default when the
-        # proxy starts; litellm_settings.log_filters below extends/overrides this.
-        apply_log_filters(excluded_uvicorn_access_paths=frozenset())
+        log_filters_config: Optional[LogFiltersConfig] = None
 
         if litellm_settings:
             # ANSI escape code for blue text
@@ -4331,10 +4329,6 @@ class ProxyConfig:
                     if not isinstance(value, dict):
                         raise Exception(f"Invalid value set for log_filters - value={value}")
                     log_filters_config = LogFiltersConfig(**value)
-                    apply_log_filters(
-                        excluded_uvicorn_access_paths=frozenset(log_filters_config.excluded_uvicorn_access_paths),
-                        exclude_health_check_paths=log_filters_config.exclude_health_check_paths,
-                    )
                 else:
                     verbose_proxy_logger.debug(
                         f"{blue_color_code} setting litellm.{key}={_redact_general_setting_value(key, value, is_full_admin=False)}{reset_color_code}"
@@ -4353,6 +4347,15 @@ class ProxyConfig:
 
                         reset_audit_log_callback_cache()
                         _in_memory_loggers[:] = [cb for cb in _in_memory_loggers if not isinstance(cb, S3V2Logger)]
+
+        # Drop health-check probe noise from the uvicorn access log by default when the
+        # proxy starts; litellm_settings.log_filters (parsed above, if present) extends/overrides this.
+        apply_log_filters(
+            excluded_uvicorn_access_paths=frozenset(
+                log_filters_config.excluded_uvicorn_access_paths if log_filters_config else []
+            ),
+            exclude_health_check_paths=(log_filters_config.exclude_health_check_paths if log_filters_config else True),
+        )
 
         ## GENERAL SERVER SETTINGS (e.g. master key,..) # do this after initializing litellm, to ensure sentry logging works for proxylogging
         general_settings = config.get("general_settings", {})

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -222,7 +222,7 @@ from functools import lru_cache
 import litellm
 import litellm._redis
 from litellm import Router
-from litellm._logging import verbose_proxy_logger, verbose_router_logger
+from litellm._logging import apply_log_filters, verbose_proxy_logger, verbose_router_logger
 from litellm.caching.caching import DualCache, RedisCache
 from litellm.caching.redis_cluster_cache import RedisClusterCache
 from litellm.constants import (
@@ -4668,6 +4668,9 @@ class ProxyConfig:
         litellm_settings = config.get("litellm_settings", None)
         if litellm_settings is None:
             litellm_settings = {}
+
+        log_filters_config: LogFiltersConfig | None = None
+
         if litellm_settings:
             # ANSI escape code for blue text
             blue_color_code: Final = "\033[94m"
@@ -4984,6 +4987,10 @@ class ProxyConfig:
 
                     parse_budget_reset_time(value)
                     setattr(litellm, key, value)
+                elif key == "log_filters" and value is not None:
+                    if not isinstance(value, dict):
+                        raise Exception(f"Invalid value set for log_filters - value={value}")
+                    log_filters_config = LogFiltersConfig(**value)
                 else:
                     verbose_proxy_logger.debug(
                         "%s setting litellm.%s=%s%s",
@@ -5006,6 +5013,15 @@ class ProxyConfig:
 
                         reset_audit_log_callback_cache()
                         _in_memory_loggers[:] = [cb for cb in _in_memory_loggers if not isinstance(cb, S3V2Logger)]
+
+        # Drop health-check probe noise from the uvicorn access log by default when the
+        # proxy starts; litellm_settings.log_filters (parsed above, if present) extends/overrides this.
+        apply_log_filters(
+            excluded_uvicorn_access_paths=frozenset(
+                log_filters_config.excluded_uvicorn_access_paths if log_filters_config else ()
+            ),
+            exclude_health_check_paths=(log_filters_config.exclude_health_check_paths if log_filters_config else True),
+        )
 
         ## GENERAL SERVER SETTINGS (e.g. master key,..) # do this after initializing litellm, to ensure sentry logging works for proxylogging
         general_settings = config.get("general_settings", {})

--- a/tests/proxy_unit_tests/test_proxy_config_unit_test.py
+++ b/tests/proxy_unit_tests/test_proxy_config_unit_test.py
@@ -316,3 +316,182 @@ async def test_json_logs_calls_turn_on_json():
         # Cleanup
         os.unlink(temp_file_path)
         litellm.json_logs = False
+
+
+@pytest.mark.asyncio
+async def test_log_filters_calls_apply_log_filters():
+    """
+    Test that litellm_settings.log_filters.excluded_uvicorn_access_paths in the
+    config file reaches litellm._logging.apply_log_filters.
+    """
+    import tempfile
+
+    import yaml
+
+    config_content = {
+        "model_list": [
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "openai/gpt-4", "api_key": "test-key"},
+            }
+        ],
+        "litellm_settings": {
+            "log_filters": {"excluded_uvicorn_access_paths": ["/custom/noisy"]}
+        },
+    }
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as temp_file:
+        yaml.dump(config_content, temp_file)
+        temp_file_path = temp_file.name
+
+    try:
+        proxy_config = ProxyConfig()
+
+        with mock.patch(
+            "litellm.proxy.proxy_server.apply_log_filters"
+        ) as mock_apply_log_filters:
+            await proxy_config.load_config(
+                router=None,
+                config_file_path=temp_file_path,
+            )
+
+            # load_config always applies the defaults once unconditionally (so a proxy
+            # with no log_filters config still gets health-check suppression out of the
+            # box), then re-applies with the parsed config -- so the config-derived call
+            # is the *last* call, not the only one.
+            assert mock_apply_log_filters.call_count == 2
+            mock_apply_log_filters.assert_called_with(
+                excluded_uvicorn_access_paths=frozenset({"/custom/noisy"}),
+                exclude_health_check_paths=True,
+            )
+    finally:
+        os.unlink(temp_file_path)
+
+
+@pytest.mark.asyncio
+async def test_log_filters_exclude_health_check_paths_false_reaches_apply_log_filters():
+    """
+    Test that litellm_settings.log_filters.exclude_health_check_paths: false in the
+    config file reaches litellm._logging.apply_log_filters as exclude_health_check_paths=False.
+    """
+    import tempfile
+
+    import yaml
+
+    config_content = {
+        "model_list": [
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "openai/gpt-4", "api_key": "test-key"},
+            }
+        ],
+        "litellm_settings": {
+            "log_filters": {"exclude_health_check_paths": False}
+        },
+    }
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as temp_file:
+        yaml.dump(config_content, temp_file)
+        temp_file_path = temp_file.name
+
+    try:
+        proxy_config = ProxyConfig()
+
+        with mock.patch(
+            "litellm.proxy.proxy_server.apply_log_filters"
+        ) as mock_apply_log_filters:
+            await proxy_config.load_config(
+                router=None,
+                config_file_path=temp_file_path,
+            )
+
+            assert mock_apply_log_filters.call_count == 2
+            mock_apply_log_filters.assert_called_with(
+                excluded_uvicorn_access_paths=frozenset(),
+                exclude_health_check_paths=False,
+            )
+    finally:
+        os.unlink(temp_file_path)
+
+
+@pytest.mark.asyncio
+async def test_log_filters_invalid_value_raises():
+    """
+    Test that litellm_settings.log_filters set to a non-dict value raises a
+    clear error instead of failing deep inside LogFiltersConfig(**value).
+    """
+    import tempfile
+
+    import yaml
+
+    config_content = {
+        "model_list": [
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "openai/gpt-4", "api_key": "test-key"},
+            }
+        ],
+        "litellm_settings": {"log_filters": "not-a-dict"},
+    }
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as temp_file:
+        yaml.dump(config_content, temp_file)
+        temp_file_path = temp_file.name
+
+    try:
+        proxy_config = ProxyConfig()
+
+        with pytest.raises(Exception, match="Invalid value set for log_filters"):
+            await proxy_config.load_config(
+                router=None,
+                config_file_path=temp_file_path,
+            )
+    finally:
+        os.unlink(temp_file_path)
+
+
+@pytest.mark.asyncio
+async def test_log_filters_invalid_field_type_raises():
+    """
+    Test that litellm_settings.log_filters with a dict value that fails
+    LogFiltersConfig validation (excluded_uvicorn_access_paths is not a list)
+    still raises instead of silently swallowing the bad config.
+    """
+    import tempfile
+
+    import yaml
+
+    config_content = {
+        "model_list": [
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "openai/gpt-4", "api_key": "test-key"},
+            }
+        ],
+        "litellm_settings": {
+            "log_filters": {"excluded_uvicorn_access_paths": "not-a-list"}
+        },
+    }
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as temp_file:
+        yaml.dump(config_content, temp_file)
+        temp_file_path = temp_file.name
+
+    try:
+        proxy_config = ProxyConfig()
+
+        with pytest.raises(Exception):
+            await proxy_config.load_config(
+                router=None,
+                config_file_path=temp_file_path,
+            )
+    finally:
+        os.unlink(temp_file_path)

--- a/tests/proxy_unit_tests/test_proxy_config_unit_test.py
+++ b/tests/proxy_unit_tests/test_proxy_config_unit_test.py
@@ -319,6 +319,51 @@ async def test_json_logs_calls_turn_on_json():
 
 
 @pytest.mark.asyncio
+async def test_log_filters_absent_still_applies_defaults():
+    """
+    Test that load_config calls apply_log_filters exactly once with the
+    default (empty) args when litellm_settings.log_filters isn't set at all,
+    so health-check paths are still suppressed out of the box.
+    """
+    import tempfile
+
+    import yaml
+
+    config_content = {
+        "model_list": [
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "openai/gpt-4", "api_key": "test-key"},
+            }
+        ],
+    }
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as temp_file:
+        yaml.dump(config_content, temp_file)
+        temp_file_path = temp_file.name
+
+    try:
+        proxy_config = ProxyConfig()
+
+        with mock.patch(
+            "litellm.proxy.proxy_server.apply_log_filters"
+        ) as mock_apply_log_filters:
+            await proxy_config.load_config(
+                router=None,
+                config_file_path=temp_file_path,
+            )
+
+            mock_apply_log_filters.assert_called_once_with(
+                excluded_uvicorn_access_paths=frozenset(),
+                exclude_health_check_paths=True,
+            )
+    finally:
+        os.unlink(temp_file_path)
+
+
+@pytest.mark.asyncio
 async def test_log_filters_calls_apply_log_filters():
     """
     Test that litellm_settings.log_filters.excluded_uvicorn_access_paths in the
@@ -357,12 +402,7 @@ async def test_log_filters_calls_apply_log_filters():
                 config_file_path=temp_file_path,
             )
 
-            # load_config always applies the defaults once unconditionally (so a proxy
-            # with no log_filters config still gets health-check suppression out of the
-            # box), then re-applies with the parsed config -- so the config-derived call
-            # is the *last* call, not the only one.
-            assert mock_apply_log_filters.call_count == 2
-            mock_apply_log_filters.assert_called_with(
+            mock_apply_log_filters.assert_called_once_with(
                 excluded_uvicorn_access_paths=frozenset({"/custom/noisy"}),
                 exclude_health_check_paths=True,
             )
@@ -409,8 +449,7 @@ async def test_log_filters_exclude_health_check_paths_false_reaches_apply_log_fi
                 config_file_path=temp_file_path,
             )
 
-            assert mock_apply_log_filters.call_count == 2
-            mock_apply_log_filters.assert_called_with(
+            mock_apply_log_filters.assert_called_once_with(
                 excluded_uvicorn_access_paths=frozenset(),
                 exclude_health_check_paths=False,
             )

--- a/tests/proxy_unit_tests/test_proxy_config_unit_test.py
+++ b/tests/proxy_unit_tests/test_proxy_config_unit_test.py
@@ -356,3 +356,221 @@ class TestYamlStorePromptsDbOverride:
         """_yaml_general_settings_keys should be empty on init."""
         proxy_config = ProxyConfig()
         assert proxy_config._yaml_general_settings_keys == set()
+
+
+@pytest.mark.asyncio
+async def test_log_filters_absent_still_applies_defaults():
+    """
+    Test that load_config calls apply_log_filters exactly once with the
+    default (empty) args when litellm_settings.log_filters isn't set at all,
+    so health-check paths are still suppressed out of the box.
+    """
+    import tempfile
+
+    import yaml
+
+    config_content = {
+        "model_list": [
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "openai/gpt-4", "api_key": "test-key"},
+            }
+        ],
+    }
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as temp_file:
+        yaml.dump(config_content, temp_file)
+        temp_file_path = temp_file.name
+
+    try:
+        proxy_config = ProxyConfig()
+
+        with mock.patch(
+            "litellm.proxy.proxy_server.apply_log_filters"
+        ) as mock_apply_log_filters:
+            await proxy_config.load_config(
+                router=None,
+                config_file_path=temp_file_path,
+            )
+
+            mock_apply_log_filters.assert_called_once_with(
+                excluded_uvicorn_access_paths=frozenset(),
+                exclude_health_check_paths=True,
+            )
+    finally:
+        os.unlink(temp_file_path)
+
+
+@pytest.mark.asyncio
+async def test_log_filters_calls_apply_log_filters():
+    """
+    Test that litellm_settings.log_filters.excluded_uvicorn_access_paths in the
+    config file reaches litellm._logging.apply_log_filters.
+    """
+    import tempfile
+
+    import yaml
+
+    config_content = {
+        "model_list": [
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "openai/gpt-4", "api_key": "test-key"},
+            }
+        ],
+        "litellm_settings": {
+            "log_filters": {"excluded_uvicorn_access_paths": ["/custom/noisy"]}
+        },
+    }
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as temp_file:
+        yaml.dump(config_content, temp_file)
+        temp_file_path = temp_file.name
+
+    try:
+        proxy_config = ProxyConfig()
+
+        with mock.patch(
+            "litellm.proxy.proxy_server.apply_log_filters"
+        ) as mock_apply_log_filters:
+            await proxy_config.load_config(
+                router=None,
+                config_file_path=temp_file_path,
+            )
+
+            mock_apply_log_filters.assert_called_once_with(
+                excluded_uvicorn_access_paths=frozenset({"/custom/noisy"}),
+                exclude_health_check_paths=True,
+            )
+    finally:
+        os.unlink(temp_file_path)
+
+
+@pytest.mark.asyncio
+async def test_log_filters_exclude_health_check_paths_false_reaches_apply_log_filters():
+    """
+    Test that litellm_settings.log_filters.exclude_health_check_paths: false in the
+    config file reaches litellm._logging.apply_log_filters as exclude_health_check_paths=False.
+    """
+    import tempfile
+
+    import yaml
+
+    config_content = {
+        "model_list": [
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "openai/gpt-4", "api_key": "test-key"},
+            }
+        ],
+        "litellm_settings": {
+            "log_filters": {"exclude_health_check_paths": False}
+        },
+    }
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as temp_file:
+        yaml.dump(config_content, temp_file)
+        temp_file_path = temp_file.name
+
+    try:
+        proxy_config = ProxyConfig()
+
+        with mock.patch(
+            "litellm.proxy.proxy_server.apply_log_filters"
+        ) as mock_apply_log_filters:
+            await proxy_config.load_config(
+                router=None,
+                config_file_path=temp_file_path,
+            )
+
+            mock_apply_log_filters.assert_called_once_with(
+                excluded_uvicorn_access_paths=frozenset(),
+                exclude_health_check_paths=False,
+            )
+    finally:
+        os.unlink(temp_file_path)
+
+
+@pytest.mark.asyncio
+async def test_log_filters_invalid_value_raises():
+    """
+    Test that litellm_settings.log_filters set to a non-dict value raises a
+    clear error instead of failing deep inside LogFiltersConfig(**value).
+    """
+    import tempfile
+
+    import yaml
+
+    config_content = {
+        "model_list": [
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "openai/gpt-4", "api_key": "test-key"},
+            }
+        ],
+        "litellm_settings": {"log_filters": "not-a-dict"},
+    }
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as temp_file:
+        yaml.dump(config_content, temp_file)
+        temp_file_path = temp_file.name
+
+    try:
+        proxy_config = ProxyConfig()
+
+        with pytest.raises(Exception, match="Invalid value set for log_filters"):
+            await proxy_config.load_config(
+                router=None,
+                config_file_path=temp_file_path,
+            )
+    finally:
+        os.unlink(temp_file_path)
+
+
+@pytest.mark.asyncio
+async def test_log_filters_invalid_field_type_raises():
+    """
+    Test that litellm_settings.log_filters with a dict value that fails
+    LogFiltersConfig validation (excluded_uvicorn_access_paths is not a list)
+    still raises instead of silently swallowing the bad config.
+    """
+    import tempfile
+
+    import yaml
+
+    config_content = {
+        "model_list": [
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "openai/gpt-4", "api_key": "test-key"},
+            }
+        ],
+        "litellm_settings": {
+            "log_filters": {"excluded_uvicorn_access_paths": "not-a-list"}
+        },
+    }
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yaml", delete=False
+    ) as temp_file:
+        yaml.dump(config_content, temp_file)
+        temp_file_path = temp_file.name
+
+    try:
+        proxy_config = ProxyConfig()
+
+        with pytest.raises(Exception):
+            await proxy_config.load_config(
+                router=None,
+                config_file_path=temp_file_path,
+            )
+    finally:
+        os.unlink(temp_file_path)

--- a/tests/test_litellm/proxy/test_proxy_types.py
+++ b/tests/test_litellm/proxy/test_proxy_types.py
@@ -20,6 +20,14 @@ sys.path.insert(
 )  # Adds the parent directory to the system-path
 
 
+def test_log_filters_config_defaults():
+    from litellm.proxy._types import LogFiltersConfig
+
+    config = LogFiltersConfig()
+    assert config.excluded_uvicorn_access_paths == []
+    assert config.exclude_health_check_paths is True
+
+
 def test_audit_log_masking():
     from datetime import datetime
 

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -369,6 +369,24 @@ def test_apply_log_filters_explicit_path_wins_over_disabled_defaults():
     assert access_logger.filter(_uvicorn_access_record("/health/liveliness"))
 
 
+def test_apply_log_filters_noop_installs_no_filter():
+    apply_log_filters(excluded_uvicorn_access_paths=frozenset(), exclude_health_check_paths=False)
+    access_logger = logging.getLogger("uvicorn.access")
+
+    managed_filters = [f for f in access_logger.filters if getattr(f, "_litellm_managed", False)]
+    assert managed_filters == []
+
+
+def test_apply_log_filters_noop_removes_stale_filter():
+    apply_log_filters(excluded_uvicorn_access_paths=frozenset({"/a"}))
+    apply_log_filters(excluded_uvicorn_access_paths=frozenset(), exclude_health_check_paths=False)
+    access_logger = logging.getLogger("uvicorn.access")
+
+    managed_filters = [f for f in access_logger.filters if getattr(f, "_litellm_managed", False)]
+    assert managed_filters == []
+    assert access_logger.filter(_uvicorn_access_record("/a"))
+
+
 @pytest.mark.asyncio
 async def test_cache_hit_includes_custom_llm_provider():
     """

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -16,14 +16,37 @@ import litellm
 from litellm._logging import (
     ALL_LOGGERS,
     JsonFormatter,
+    UvicornAccessPathFilter,
     _initialize_loggers_with_handler,
     _turn_on_json,
+    apply_log_filters,
     verbose_logger,
     verbose_proxy_logger,
     verbose_router_logger,
 )
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.types.utils import StandardLoggingPayload
+
+
+def _uvicorn_access_record(path: str) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg='%s - "%s %s HTTP/1.1" %d',
+        args=("127.0.0.1:12345", "GET", path, "HTTP/1.1", 200),
+        exc_info=None,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_uvicorn_access_filters():
+    yield
+    access_logger = logging.getLogger("uvicorn.access")
+    for f in list(access_logger.filters):
+        if getattr(f, "_litellm_managed", False):
+            access_logger.removeFilter(f)
 
 
 class CacheHitCustomLogger(CustomLogger):
@@ -255,6 +278,95 @@ def test_initialize_loggers_with_handler_sets_propagate_false():
         assert (
             logger.propagate is False
         ), f"Logger {logger.name} has propagate set to {logger.propagate}, expected False"
+
+
+def test_uvicorn_access_path_filter_drops_excluded_path():
+    record = _uvicorn_access_record("/health/readiness")
+    filter = UvicornAccessPathFilter(frozenset({"/health/readiness"}))
+    assert filter.filter(record) is False
+
+
+def test_uvicorn_access_path_filter_keeps_other_paths():
+    record = _uvicorn_access_record("/chat/completions")
+    filter = UvicornAccessPathFilter(frozenset({"/health/readiness"}))
+    assert filter.filter(record) is True
+
+
+def test_uvicorn_access_path_filter_ignores_non_access_records():
+    record = logging.LogRecord(
+        name="uvicorn.error",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="boom",
+        args=("127.0.0.1:12345", "GET", "/health/readiness", "HTTP/1.1", 200),
+        exc_info=None,
+    )
+    filter = UvicornAccessPathFilter(frozenset({"/health/readiness"}))
+    assert filter.filter(record) is True
+
+
+def test_uvicorn_access_path_filter_ignores_malformed_args():
+    record = logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="malformed",
+        args=("127.0.0.1:12345", "GET"),
+        exc_info=None,
+    )
+    filter = UvicornAccessPathFilter(frozenset({"/health/readiness"}))
+    assert filter.filter(record) is True
+
+
+def test_apply_log_filters_defaults_drop_health_check_paths():
+    apply_log_filters(excluded_uvicorn_access_paths=frozenset())
+    access_logger = logging.getLogger("uvicorn.access")
+
+    for path in ("/health/readiness", "/health/liveliness", "/health/liveness"):
+        record = _uvicorn_access_record(path)
+        assert access_logger.filter(record) is False, f"expected {path} to be dropped by default"
+
+    record = _uvicorn_access_record("/chat/completions")
+    assert access_logger.filter(record)
+
+
+def test_apply_log_filters_merges_user_paths_with_defaults():
+    apply_log_filters(excluded_uvicorn_access_paths=frozenset({"/custom/noisy"}))
+    access_logger = logging.getLogger("uvicorn.access")
+
+    assert access_logger.filter(_uvicorn_access_record("/custom/noisy")) is False
+    assert access_logger.filter(_uvicorn_access_record("/health/readiness")) is False
+    assert access_logger.filter(_uvicorn_access_record("/chat/completions"))
+
+
+def test_apply_log_filters_reapply_replaces_previous_filter():
+    apply_log_filters(excluded_uvicorn_access_paths=frozenset({"/a"}))
+    apply_log_filters(excluded_uvicorn_access_paths=frozenset({"/b"}))
+    access_logger = logging.getLogger("uvicorn.access")
+
+    managed_filters = [f for f in access_logger.filters if getattr(f, "_litellm_managed", False)]
+    assert len(managed_filters) == 1
+
+    assert access_logger.filter(_uvicorn_access_record("/b")) is False
+    assert access_logger.filter(_uvicorn_access_record("/a"))
+
+
+def test_apply_log_filters_exclude_health_check_paths_false_disables_defaults():
+    apply_log_filters(excluded_uvicorn_access_paths=frozenset(), exclude_health_check_paths=False)
+    access_logger = logging.getLogger("uvicorn.access")
+
+    for path in ("/health/readiness", "/health/liveliness", "/health/liveness"):
+        assert access_logger.filter(_uvicorn_access_record(path)), f"expected {path} to be logged"
+
+
+def test_apply_log_filters_explicit_path_wins_over_disabled_defaults():
+    apply_log_filters(excluded_uvicorn_access_paths=frozenset({"/health/readiness"}), exclude_health_check_paths=False)
+    access_logger = logging.getLogger("uvicorn.access")
+
+    assert access_logger.filter(_uvicorn_access_record("/health/readiness")) is False
+    assert access_logger.filter(_uvicorn_access_record("/health/liveliness"))
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -20,8 +20,10 @@ from litellm._logging import (
     CorrelationContextFilter,
     CorrelationPlainFormatter,
     JsonFormatter,
+    UvicornAccessPathFilter,
     _initialize_loggers_with_handler,
     _turn_on_json,
+    apply_log_filters,
     session_id_var,
     set_session_id,
     set_trace_id,
@@ -32,6 +34,27 @@ from litellm._logging import (
 )
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.types.utils import StandardLoggingPayload
+
+
+def _uvicorn_access_record(path: str) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg='%s - "%s %s HTTP/1.1" %d',
+        args=("127.0.0.1:12345", "GET", path, "HTTP/1.1", 200),
+        exc_info=None,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_uvicorn_access_filters():
+    yield
+    access_logger = logging.getLogger("uvicorn.access")
+    for f in list(access_logger.filters):
+        if getattr(f, "_litellm_managed", False):
+            access_logger.removeFilter(f)
 
 
 class CacheHitCustomLogger(CustomLogger):
@@ -263,6 +286,113 @@ def test_initialize_loggers_with_handler_sets_propagate_false():
         assert (
             logger.propagate is False
         ), f"Logger {logger.name} has propagate set to {logger.propagate}, expected False"
+
+
+def test_uvicorn_access_path_filter_drops_excluded_path():
+    record = _uvicorn_access_record("/health/readiness")
+    filter = UvicornAccessPathFilter(frozenset({"/health/readiness"}))
+    assert filter.filter(record) is False
+
+
+def test_uvicorn_access_path_filter_keeps_other_paths():
+    record = _uvicorn_access_record("/chat/completions")
+    filter = UvicornAccessPathFilter(frozenset({"/health/readiness"}))
+    assert filter.filter(record) is True
+
+
+def test_uvicorn_access_path_filter_ignores_non_access_records():
+    record = logging.LogRecord(
+        name="uvicorn.error",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="boom",
+        args=("127.0.0.1:12345", "GET", "/health/readiness", "HTTP/1.1", 200),
+        exc_info=None,
+    )
+    filter = UvicornAccessPathFilter(frozenset({"/health/readiness"}))
+    assert filter.filter(record) is True
+
+
+def test_uvicorn_access_path_filter_ignores_malformed_args():
+    record = logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="malformed",
+        args=("127.0.0.1:12345", "GET"),
+        exc_info=None,
+    )
+    filter = UvicornAccessPathFilter(frozenset({"/health/readiness"}))
+    assert filter.filter(record) is True
+
+
+def test_apply_log_filters_defaults_drop_health_check_paths():
+    apply_log_filters(excluded_uvicorn_access_paths=frozenset())
+    access_logger = logging.getLogger("uvicorn.access")
+
+    for path in ("/health/readiness", "/health/liveliness", "/health/liveness"):
+        record = _uvicorn_access_record(path)
+        assert access_logger.filter(record) is False, f"expected {path} to be dropped by default"
+
+    record = _uvicorn_access_record("/chat/completions")
+    assert access_logger.filter(record)
+
+
+def test_apply_log_filters_merges_user_paths_with_defaults():
+    apply_log_filters(excluded_uvicorn_access_paths=frozenset({"/custom/noisy"}))
+    access_logger = logging.getLogger("uvicorn.access")
+
+    assert access_logger.filter(_uvicorn_access_record("/custom/noisy")) is False
+    assert access_logger.filter(_uvicorn_access_record("/health/readiness")) is False
+    assert access_logger.filter(_uvicorn_access_record("/chat/completions"))
+
+
+def test_apply_log_filters_reapply_replaces_previous_filter():
+    apply_log_filters(excluded_uvicorn_access_paths=frozenset({"/a"}))
+    apply_log_filters(excluded_uvicorn_access_paths=frozenset({"/b"}))
+    access_logger = logging.getLogger("uvicorn.access")
+
+    managed_filters = [f for f in access_logger.filters if getattr(f, "_litellm_managed", False)]
+    assert len(managed_filters) == 1
+
+    assert access_logger.filter(_uvicorn_access_record("/b")) is False
+    assert access_logger.filter(_uvicorn_access_record("/a"))
+
+
+def test_apply_log_filters_exclude_health_check_paths_false_disables_defaults():
+    apply_log_filters(excluded_uvicorn_access_paths=frozenset(), exclude_health_check_paths=False)
+    access_logger = logging.getLogger("uvicorn.access")
+
+    for path in ("/health/readiness", "/health/liveliness", "/health/liveness"):
+        assert access_logger.filter(_uvicorn_access_record(path)), f"expected {path} to be logged"
+
+
+def test_apply_log_filters_explicit_path_wins_over_disabled_defaults():
+    apply_log_filters(excluded_uvicorn_access_paths=frozenset({"/health/readiness"}), exclude_health_check_paths=False)
+    access_logger = logging.getLogger("uvicorn.access")
+
+    assert access_logger.filter(_uvicorn_access_record("/health/readiness")) is False
+    assert access_logger.filter(_uvicorn_access_record("/health/liveliness"))
+
+
+def test_apply_log_filters_noop_installs_no_filter():
+    apply_log_filters(excluded_uvicorn_access_paths=frozenset(), exclude_health_check_paths=False)
+    access_logger = logging.getLogger("uvicorn.access")
+
+    managed_filters = [f for f in access_logger.filters if getattr(f, "_litellm_managed", False)]
+    assert managed_filters == []
+
+
+def test_apply_log_filters_noop_removes_stale_filter():
+    apply_log_filters(excluded_uvicorn_access_paths=frozenset({"/a"}))
+    apply_log_filters(excluded_uvicorn_access_paths=frozenset(), exclude_health_check_paths=False)
+    access_logger = logging.getLogger("uvicorn.access")
+
+    managed_filters = [f for f in access_logger.filters if getattr(f, "_litellm_managed", False)]
+    assert managed_filters == []
+    assert access_logger.filter(_uvicorn_access_record("/a"))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Health-check probes (/health/readiness, /health/liveliness, /health/liveness) are excluded from the uvicorn access log by default. Users can extend the exclusion list via litellm_settings.log_filters.excluded_uvicorn_access_paths, or set exclude_health_check_paths: false to see the default paths logged again.

## Relevant issues

+ https://github.com/BerriAI/litellm/issues/28325
+ https://github.com/BerriAI/litellm/issues/18992

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->
<img width="1045" height="720" alt="Снимок экрана — 2026-07-12 в 18 53 34" src="https://github.com/user-attachments/assets/efe1d75e-59f2-4748-bc37-c931e5af942a" />
<img width="1056" height="723" alt="Снимок экрана — 2026-07-12 в 18 54 22" src="https://github.com/user-attachments/assets/6c497da9-5f3e-4792-afc7-2100122c6da2" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes
Adds `litellm_settings.log_filters` to the proxy config, giving operators a first-class way to drop noisy paths from the uvicorn access log without writing a custom Python logging filter or passing `--log_config`.

By default, health-check probes (`/health/readiness`, `/health/liveliness`, `/health/liveness`) are excluded from the access log, since these are typically polled by Kubernetes at a high frequency and produce most of the noise. `excluded_uvicorn_access_paths` lets users extend that list with their own paths, and `exclude_health_check_paths: false` turns the default exclusion off entirely if someone wants those probes logged again. A path listed explicitly in `excluded_uvicorn_access_paths` is always excluded, even when `exclude_health_check_paths` is false.

The filter is attached directly to the `uvicorn.access` logger via `logging.Filter`, after uvicorn's own logging setup runs but during normal proxy config parsing, so it survives config reloads and works the same whether or not JSON logging is enabled.

```yaml
litellm_settings:
  log_filters:
    # optional: extends the built-in health-check exclusion list, doesn't replace it
    excluded_uvicorn_access_paths:
      - /my/custom/noisy/endpoint
    # optional: defaults to true; set to false to see health-check probes logged again
    exclude_health_check_paths: false

```
⚠️
Note on CI: two unrelated test failures appear in this PR's CI run, `test_can_key_call_model_wildcard_access[key_models4-bedrockz/anthropic.claude-3-5-sonnet-20240620-False]` and `test_can_team_access_model[bedrockz/anthropic.claude-3-5-sonnet-20240620-team_models5-False]` in `tests/proxy_unit_tests/test_auth_checks.py`. Both are pre-existing on `litellm_oss_daily_2026_07_10` and reproduce in a clean worktree of that branch with none of this PR's changes applied, so they're unrelated to this change. `git diff` between this branch and the base branch touches nothing under `litellm/proxy/auth_checks.py` or `litellm/proxy/auth/`.

