### PR TITLE
fix(proxy): enforce budget and cost tracking for Dashscope tiered pricing

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -760,7 +760,11 @@ def _select_model_name_for_cost_calc(
     if custom_pricing is True:
         if router_model_id is not None and router_model_id in litellm.model_cost:
             entry = litellm.model_cost[router_model_id]
-            if entry.get("input_cost_per_token") is not None or entry.get("input_cost_per_second") is not None:
+            if (
+                entry.get("input_cost_per_token") is not None
+                or entry.get("input_cost_per_second") is not None
+                or entry.get("tiered_pricing") is not None
+            ):
                 return_model = router_model_id
             else:
                 return_model = model

--- a/litellm/litellm_core_utils/llm_cost_calc/tiered_pricing.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/tiered_pricing.py
@@ -1,0 +1,99 @@
+"""
+Provider-neutral graduated tiered pricing calculation.
+
+Shared by provider cost calculators (e.g. Dashscope) and the proxy budget
+reservation logic so neither has to depend on the other.
+"""
+
+from typing import List, Optional, Union
+
+
+def _coerce_cost_per_token(value: Union[float, int, str, None]) -> float:
+    """
+    Coerce a per-token cost into a float.
+
+    Model cost values loaded from YAML config may arrive as strings (e.g.
+    scientific notation like "4e-07"), which would break arithmetic.
+    """
+    if value is None:
+        return 0.0
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return 0.0
+    return float(value)
+
+
+def calculate_tiered_cost(
+    tokens: int,
+    tiered_pricing: List[dict],
+    cost_key: str,
+    fallback_cost_key: Optional[str] = None,
+) -> float:
+    """
+    Calculate cost for a given number of tokens based on a true tiered pricing structure.
+
+    This function iterates through sorted pricing tiers, calculates the cost for the
+    number of tokens that fall into each tier's range, and sums them up to get the total cost.
+
+    Args:
+        tokens (int): The total number of tokens to calculate the cost for.
+        tiered_pricing (List[dict]): A list of dictionaries, where each dictionary
+            represents a pricing tier.
+        cost_key (str): The key in the tier dictionary that holds the per-token cost
+            (e.g., 'input_cost_per_token').
+        fallback_cost_key (Optional[str], optional): A fallback key to use if the
+            primary `cost_key` is not found in a tier. Defaults to None.
+
+    Returns:
+        float: The total calculated cost for the given tokens.
+
+    Example:
+        >>> tiered_pricing = [
+        ...     {"range": [0, 100000], "input_cost_per_token": 0.0001},
+        ...     {"range": [100000, 500000], "input_cost_per_token": 0.00005},
+        ... ]
+
+        Calculating cost for 150,000 tokens:
+        (100,000 * 0.0001) + (50,000 * 0.00005) = $12.5
+    """
+    if not tiered_pricing or tokens <= 0:
+        return 0.0
+
+    total_cost = 0.0
+    tokens_processed = 0
+
+    sorted_tiers = sorted(tiered_pricing, key=lambda x: x.get("range", [0, 0])[0])
+
+    for tier in sorted_tiers:
+        if tokens_processed >= tokens:
+            break
+
+        tier_range = tier.get("range", [])
+        if len(tier_range) != 2:
+            continue
+
+        range_start, range_end = tier_range
+
+        if tokens <= range_start:
+            continue
+
+        tier_start = max(range_start, tokens_processed)
+        tier_end = min(range_end, tokens)
+
+        if tier_end > tier_start:
+            tokens_in_tier = tier_end - tier_start
+            cost_per_token = tier.get(cost_key) or tier.get(fallback_cost_key, 0)
+            total_cost += tokens_in_tier * _coerce_cost_per_token(cost_per_token)
+            tokens_processed = tier_end
+
+    # After loop, check if any tokens remain (i.e., tokens > highest tier's end range)
+    # and charge them at the last tier's rate.
+    if tokens_processed < tokens and sorted_tiers:
+        last_tier = sorted_tiers[-1]
+        remaining_tokens = tokens - tokens_processed
+        cost_per_token = last_tier.get(cost_key) or last_tier.get(fallback_cost_key, 0)
+        total_cost += remaining_tokens * _coerce_cost_per_token(cost_per_token)
+
+    return total_cost

--- a/litellm/litellm_core_utils/llm_cost_calc/tiered_pricing.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/tiered_pricing.py
@@ -97,3 +97,43 @@ def calculate_tiered_cost(
         total_cost += remaining_tokens * _coerce_cost_per_token(cost_per_token)
 
     return total_cost
+
+
+def select_tier_for_input(
+    tiered_pricing: List[dict],
+    input_tokens: int,
+) -> Optional[dict]:
+    """
+    Select the pricing tier for a request based on its total input token count.
+
+    Alibaba Model Studio (Dashscope) tiered pricing is all-or-nothing: the tier is
+    chosen by the total input tokens of a single request and every token in the
+    request (input and output) is billed at that one tier's rate, rather than
+    graduated income-tax-style slicing. A tier matches when
+    ``range_start < input_tokens <= range_end`` (so a request of exactly
+    ``range_end`` tokens stays in the lower tier, matching the official
+    ``0 < Token <= 32K`` phrasing). Requests above the highest declared range fall
+    back to the last (most expensive) tier.
+    """
+    if not tiered_pricing or input_tokens <= 0:
+        return None
+
+    sorted_tiers = sorted(tiered_pricing, key=lambda t: t.get("range", [0, 0])[0])
+    valid_tiers = [tier for tier in sorted_tiers if len(tier.get("range", [])) == 2]
+    if not valid_tiers:
+        return None
+
+    matching = [tier for tier in valid_tiers if tier["range"][0] < input_tokens <= tier["range"][1]]
+    if matching:
+        return matching[0]
+    return valid_tiers[-1]
+
+
+def tier_rate(
+    tier: dict,
+    cost_key: str,
+    fallback_cost_key: Optional[str] = None,
+) -> float:
+    """Read a per-token rate from a tier, coercing YAML string costs to float."""
+    raw = tier.get(cost_key) or tier.get(fallback_cost_key, 0)
+    return _coerce_cost_per_token(raw)

--- a/litellm/llms/dashscope/cost_calculator.py
+++ b/litellm/llms/dashscope/cost_calculator.py
@@ -7,6 +7,7 @@ Handles tiered pricing and prompt caching scenarios.
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
+from litellm.litellm_core_utils.llm_cost_calc.tiered_pricing import calculate_tiered_cost
 from litellm.types.utils import ModelInfo, Usage
 from litellm.utils import get_model_info
 
@@ -42,80 +43,6 @@ def _extract_token_breakdown(usage: Usage) -> TokenBreakdown:
     return TokenBreakdown(text_tokens, cached_tokens, completion_tokens, reasoning_tokens)
 
 
-def _calculate_tiered_cost(
-    tokens: int,
-    tiered_pricing: List[dict],
-    cost_key: str,
-    fallback_cost_key: Optional[str] = None,
-) -> float:
-    """
-    Calculate cost for a given number of tokens based on a true tiered pricing structure.
-
-    This function iterates through sorted pricing tiers, calculates the cost for the
-    number of tokens that fall into each tier's range, and sums them up to get the total cost.
-
-    Args:
-        tokens (int): The total number of tokens to calculate the cost for.
-        tiered_pricing (List[dict]): A list of dictionaries, where each dictionary
-            represents a pricing tier.
-        cost_key (str): The key in the tier dictionary that holds the per-token cost
-            (e.g., 'input_cost_per_token').
-        fallback_cost_key (Optional[str], optional): A fallback key to use if the
-            primary `cost_key` is not found in a tier. Defaults to None.
-
-    Returns:
-        float: The total calculated cost for the given tokens.
-
-    Example:
-        >>> tiered_pricing = [
-        ...     {"range": [0, 100000], "input_cost_per_token": 0.0001},
-        ...     {"range": [100000, 500000], "input_cost_per_token": 0.00005},
-        ... ]
-
-        Calculating cost for 150,000 tokens:
-        (100,000 * 0.0001) + (50,000 * 0.00005) = $12.5
-    """
-    if not tiered_pricing or tokens <= 0:
-        return 0.0
-
-    total_cost = 0.0
-    tokens_processed = 0
-
-    sorted_tiers = sorted(tiered_pricing, key=lambda x: x.get("range", [0, 0])[0])
-
-    for tier in sorted_tiers:
-        if tokens_processed >= tokens:
-            break
-
-        tier_range = tier.get("range", [])
-        if len(tier_range) != 2:
-            continue
-
-        range_start, range_end = tier_range
-
-        if tokens <= range_start:
-            continue
-
-        tier_start = max(range_start, tokens_processed)
-        tier_end = min(range_end, tokens)
-
-        if tier_end > tier_start:
-            tokens_in_tier = tier_end - tier_start
-            cost_per_token = tier.get(cost_key) or tier.get(fallback_cost_key, 0)
-            total_cost += tokens_in_tier * cost_per_token
-            tokens_processed = tier_end
-
-    # After loop, check if any tokens remain (i.e., tokens > highest tier's end range)
-    # and charge them at the last tier's rate.
-    if tokens_processed < tokens and sorted_tiers:
-        last_tier = sorted_tiers[-1]
-        remaining_tokens = tokens - tokens_processed
-        cost_per_token = last_tier.get(cost_key) or last_tier.get(fallback_cost_key, 0)
-        total_cost += remaining_tokens * cost_per_token
-
-    return total_cost
-
-
 def _calculate_prompt_cost(
     breakdown: TokenBreakdown,
     model_info: ModelInfo,
@@ -123,12 +50,12 @@ def _calculate_prompt_cost(
 ) -> float:
     """Calculate total prompt cost including cached tokens."""
     if tiered_pricing:
-        text_cost = _calculate_tiered_cost(
+        text_cost = calculate_tiered_cost(
             tokens=breakdown.text_tokens,
             tiered_pricing=tiered_pricing,
             cost_key="input_cost_per_token",
         )
-        cache_cost = _calculate_tiered_cost(
+        cache_cost = calculate_tiered_cost(
             tokens=breakdown.cached_tokens,
             tiered_pricing=tiered_pricing,
             cost_key="cache_read_input_token_cost",
@@ -155,12 +82,12 @@ def _calculate_completion_cost(
 ) -> float:
     """Calculate total completion cost including reasoning tokens."""
     if tiered_pricing:
-        completion_cost = _calculate_tiered_cost(
+        completion_cost = calculate_tiered_cost(
             tokens=breakdown.completion_tokens,
             tiered_pricing=tiered_pricing,
             cost_key="output_cost_per_token",
         )
-        reasoning_cost = _calculate_tiered_cost(
+        reasoning_cost = calculate_tiered_cost(
             tokens=breakdown.reasoning_tokens,
             tiered_pricing=tiered_pricing,
             cost_key="output_cost_per_reasoning_token",

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -10,7 +10,7 @@ import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.caching import DualCache
 from litellm.litellm_core_utils.duration_parser import duration_in_seconds
-from litellm.llms.dashscope.cost_calculator import _calculate_tiered_cost
+from litellm.litellm_core_utils.llm_cost_calc.tiered_pricing import calculate_tiered_cost
 from litellm.proxy._types import (
     LiteLLM_TeamMembership,
     LiteLLM_TeamTable,
@@ -938,7 +938,7 @@ def _estimate_request_input_cost_for_model(
         return None
     tiered_pricing = model_info.get("tiered_pricing")
     if isinstance(tiered_pricing, list) and tiered_pricing:
-        return _calculate_tiered_cost(
+        return calculate_tiered_cost(
             tokens=input_tokens,
             tiered_pricing=tiered_pricing,
             cost_key="input_cost_per_token",
@@ -985,11 +985,11 @@ def _estimate_request_max_cost_for_model(
     output_multiplier = _get_output_multiplier(request_body=request_body)
     tiered_pricing = model_info.get("tiered_pricing")
     if isinstance(tiered_pricing, list) and tiered_pricing:
-        return _calculate_tiered_cost(
+        return calculate_tiered_cost(
             tokens=input_tokens,
             tiered_pricing=tiered_pricing,
             cost_key="input_cost_per_token",
-        ) + _calculate_tiered_cost(
+        ) + calculate_tiered_cost(
             tokens=output_tokens * output_multiplier,
             tiered_pricing=tiered_pricing,
             cost_key="output_cost_per_token",
@@ -1056,6 +1056,13 @@ def _get_model_cost_info(
             model_group_info = llm_router.get_model_group_info(model_group=model)
             if model_group_info is not None:
                 model_group_cost_info = model_group_info.model_dump()
+                # Reservation runs before routing, so the concrete deployment is
+                # unknown here. We assume deployments in a group share pricing and
+                # use the first tiered table we find as the estimate. This is a
+                # best-effort admission gate; post-request billing is exact against
+                # the deployment that actually served the request. Mixing tiered and
+                # flat deployments in one group can therefore over- or under-estimate
+                # at reservation time only.
                 deployments = llm_router.get_model_list(model_name=model) or []
                 for deployment in deployments:
                     model_id = deployment.get("model_info", {}).get("id")

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -10,7 +10,7 @@ import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.caching import DualCache
 from litellm.litellm_core_utils.duration_parser import duration_in_seconds
-from litellm.litellm_core_utils.llm_cost_calc.tiered_pricing import calculate_tiered_cost
+from litellm.litellm_core_utils.llm_cost_calc.tiered_pricing import select_tier_for_input, tier_rate
 from litellm.proxy._types import (
     LiteLLM_TeamMembership,
     LiteLLM_TeamTable,
@@ -925,9 +925,25 @@ def _estimate_request_input_cost_for_model(
     model: str,
     llm_router: Router | None,
 ) -> float | None:
-    model_info = _get_model_cost_info(model=model, llm_router=llm_router)
-    if model_info is None:
-        return None
+    estimates = [
+        _input_cost_for_cost_info(
+            request_body=request_body,
+            route=route,
+            model=model,
+            model_info=model_info,
+        )
+        for model_info in _get_model_cost_infos(model=model, llm_router=llm_router)
+    ]
+    valid_estimates = [estimate for estimate in estimates if estimate is not None]
+    return max(valid_estimates) if valid_estimates else None
+
+
+def _input_cost_for_cost_info(
+    request_body: dict,
+    route: str,
+    model: str,
+    model_info: Dict[str, Any],
+) -> Optional[float]:
     input_tokens = _estimate_input_tokens(
         request_body=request_body,
         route=route,
@@ -938,11 +954,9 @@ def _estimate_request_input_cost_for_model(
         return None
     tiered_pricing = model_info.get("tiered_pricing")
     if isinstance(tiered_pricing, list) and tiered_pricing:
-        return calculate_tiered_cost(
-            tokens=input_tokens,
-            tiered_pricing=tiered_pricing,
-            cost_key="input_cost_per_token",
-        )
+        tier = select_tier_for_input(tiered_pricing=tiered_pricing, input_tokens=input_tokens)
+        if tier is not None:
+            return input_tokens * tier_rate(tier, "input_cost_per_token")
     input_cost_per_token = _to_float(model_info.get("input_cost_per_token"))
     if input_cost_per_token is None:
         return None
@@ -955,10 +969,25 @@ def _estimate_request_max_cost_for_model(
     model: str,
     llm_router: Optional[Router],
 ) -> Optional[float]:
-    model_info = _get_model_cost_info(model=model, llm_router=llm_router)
-    if model_info is None:
-        return None
+    estimates = [
+        _max_cost_for_cost_info(
+            request_body=request_body,
+            route=route,
+            model=model,
+            model_info=model_info,
+        )
+        for model_info in _get_model_cost_infos(model=model, llm_router=llm_router)
+    ]
+    valid_estimates = [estimate for estimate in estimates if estimate is not None]
+    return max(valid_estimates) if valid_estimates else None
 
+
+def _max_cost_for_cost_info(
+    request_body: dict,
+    route: str,
+    model: str,
+    model_info: Dict[str, Any],
+) -> Optional[float]:
     image_cost = _estimate_image_generation_cost(
         request_body=request_body,
         model_info=model_info,
@@ -966,8 +995,6 @@ def _estimate_request_max_cost_for_model(
     if image_cost is not None:
         return image_cost
 
-    input_cost_per_token = _to_float(model_info.get("input_cost_per_token"))
-    output_cost_per_token = _to_float(model_info.get("output_cost_per_token"))
     input_tokens = _estimate_input_tokens(
         request_body=request_body,
         route=route,
@@ -985,16 +1012,14 @@ def _estimate_request_max_cost_for_model(
     output_multiplier = _get_output_multiplier(request_body=request_body)
     tiered_pricing = model_info.get("tiered_pricing")
     if isinstance(tiered_pricing, list) and tiered_pricing:
-        return calculate_tiered_cost(
-            tokens=input_tokens,
-            tiered_pricing=tiered_pricing,
-            cost_key="input_cost_per_token",
-        ) + calculate_tiered_cost(
-            tokens=output_tokens * output_multiplier,
-            tiered_pricing=tiered_pricing,
-            cost_key="output_cost_per_token",
-        )
+        tier = select_tier_for_input(tiered_pricing=tiered_pricing, input_tokens=input_tokens)
+        if tier is not None:
+            return (input_tokens * tier_rate(tier, "input_cost_per_token")) + (
+                output_tokens * output_multiplier * tier_rate(tier, "output_cost_per_token")
+            )
 
+    input_cost_per_token = _to_float(model_info.get("input_cost_per_token"))
+    output_cost_per_token = _to_float(model_info.get("output_cost_per_token"))
     cost = 0.0
     if input_cost_per_token is not None:
         cost += input_tokens * input_cost_per_token
@@ -1052,46 +1077,69 @@ def _get_model_cost_info(
     llm_router: Optional[Router],
 ) -> Optional[Dict[str, Any]]:
     if llm_router is not None:
-        try:
-            model_group_info = llm_router.get_model_group_info(model_group=model)
-            if model_group_info is not None:
-                model_group_cost_info = model_group_info.model_dump()
-                # Reservation runs before routing, so the concrete deployment is
-                # unknown here. We assume deployments in a group share pricing and
-                # use the first tiered table we find as the estimate. This is a
-                # best-effort admission gate; post-request billing is exact against
-                # the deployment that actually served the request. Mixing tiered and
-                # flat deployments in one group can therefore over- or under-estimate
-                # at reservation time only.
-                deployments = llm_router.get_model_list(model_name=model) or []
-                for deployment in deployments:
-                    model_id = deployment.get("model_info", {}).get("id")
-                    backend_model = deployment.get("litellm_params", {}).get("model")
-                    if not isinstance(model_id, str) or not isinstance(backend_model, str):
-                        continue
-                    deployment_model_info = llm_router.get_deployment_model_info(
-                        model_id=model_id,
-                        model_name=backend_model,
-                    )
-                    if deployment_model_info is None:
-                        continue
-                    tiered_pricing = deployment_model_info.get("tiered_pricing")
-                    if isinstance(tiered_pricing, list) and tiered_pricing:
-                        return {
-                            **model_group_cost_info,
-                            "tiered_pricing": tiered_pricing,
-                        }
-                return model_group_cost_info
-        except Exception:
-            verbose_proxy_logger.debug(
-                "Unable to load router model group info for budget reservation",
-                exc_info=True,
-            )
+        model_group_info = llm_router.get_model_group_info(model_group=model)
+        if model_group_info is not None:
+            return model_group_info.model_dump()
+    return dict(litellm.get_model_info(model=model))
 
+
+def _get_model_cost_infos(
+    model: str,
+    llm_router: Optional[Router],
+) -> List[Dict[str, Any]]:
+    """Cost-info candidates to estimate a request against for one model group.
+
+    Reservation runs before routing, so the deployment that will serve the request
+    is unknown. Rather than guess, we estimate the cost against every eligible
+    pricing shape in the group (the group's flat rates plus each deployment's
+    tiered table) and let the caller reserve the maximum, so a cheaper sibling
+    deployment can never leave the request under-reserved.
+    """
     try:
-        return dict(litellm.get_model_info(model=model))
+        base = _get_model_cost_info(model=model, llm_router=llm_router)
+        if base is None:
+            return []
+        tiered_tables = _get_deployment_tiered_pricing_tables(model=model, llm_router=llm_router)
     except Exception:
+        verbose_proxy_logger.debug(
+            "Unable to load model cost info for budget reservation",
+            exc_info=True,
+        )
+        return []
+    if not tiered_tables:
+        return [base]
+    return [base, *({**base, "tiered_pricing": table} for table in tiered_tables)]
+
+
+def _deployment_tiered_pricing_table(
+    deployment: Dict[str, Any],
+    llm_router: Router,
+) -> Optional[List[dict]]:
+    model_id = deployment.get("model_info", {}).get("id")
+    backend_model = deployment.get("litellm_params", {}).get("model")
+    if not isinstance(model_id, str) or not isinstance(backend_model, str):
         return None
+    deployment_model_info = llm_router.get_deployment_model_info(model_id=model_id, model_name=backend_model)
+    if deployment_model_info is None:
+        return None
+    tiered_pricing = deployment_model_info.get("tiered_pricing")
+    if isinstance(tiered_pricing, list) and tiered_pricing:
+        return tiered_pricing
+    return None
+
+
+def _get_deployment_tiered_pricing_tables(
+    model: str,
+    llm_router: Optional[Router],
+) -> List[List[dict]]:
+    if llm_router is None:
+        return []
+    deployments = llm_router.get_model_list(model_name=model) or []
+    return [
+        table
+        for deployment in deployments
+        if (table := _deployment_tiered_pricing_table(deployment, llm_router)) is not None
+    ]
 
 
 def _estimate_input_tokens(

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -10,6 +10,7 @@ import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.caching import DualCache
 from litellm.litellm_core_utils.duration_parser import duration_in_seconds
+from litellm.llms.dashscope.cost_calculator import _calculate_tiered_cost
 from litellm.proxy._types import (
     LiteLLM_TeamMembership,
     LiteLLM_TeamTable,
@@ -927,9 +928,6 @@ def _estimate_request_input_cost_for_model(
     model_info = _get_model_cost_info(model=model, llm_router=llm_router)
     if model_info is None:
         return None
-    input_cost_per_token = _to_float(model_info.get("input_cost_per_token"))
-    if input_cost_per_token is None:
-        return None
     input_tokens = _estimate_input_tokens(
         request_body=request_body,
         route=route,
@@ -937,6 +935,16 @@ def _estimate_request_input_cost_for_model(
         model_info=model_info,
     )
     if input_tokens is None:
+        return None
+    tiered_pricing = model_info.get("tiered_pricing")
+    if isinstance(tiered_pricing, list) and tiered_pricing:
+        return _calculate_tiered_cost(
+            tokens=input_tokens,
+            tiered_pricing=tiered_pricing,
+            cost_key="input_cost_per_token",
+        )
+    input_cost_per_token = _to_float(model_info.get("input_cost_per_token"))
+    if input_cost_per_token is None:
         return None
     return input_tokens * input_cost_per_token
 
@@ -974,13 +982,25 @@ def _estimate_request_max_cost_for_model(
     if input_tokens is None or output_tokens is None:
         return None
 
+    output_multiplier = _get_output_multiplier(request_body=request_body)
+    tiered_pricing = model_info.get("tiered_pricing")
+    if isinstance(tiered_pricing, list) and tiered_pricing:
+        return _calculate_tiered_cost(
+            tokens=input_tokens,
+            tiered_pricing=tiered_pricing,
+            cost_key="input_cost_per_token",
+        ) + _calculate_tiered_cost(
+            tokens=output_tokens * output_multiplier,
+            tiered_pricing=tiered_pricing,
+            cost_key="output_cost_per_token",
+        )
+
     cost = 0.0
     if input_cost_per_token is not None:
         cost += input_tokens * input_cost_per_token
     elif input_tokens > 0:
         return None
 
-    output_multiplier = _get_output_multiplier(request_body=request_body)
     if output_cost_per_token is not None:
         cost += output_tokens * output_multiplier * output_cost_per_token
     elif output_tokens > 0:
@@ -1035,7 +1055,26 @@ def _get_model_cost_info(
         try:
             model_group_info = llm_router.get_model_group_info(model_group=model)
             if model_group_info is not None:
-                return model_group_info.model_dump()
+                model_group_cost_info = model_group_info.model_dump()
+                deployments = llm_router.get_model_list(model_name=model) or []
+                for deployment in deployments:
+                    model_id = deployment.get("model_info", {}).get("id")
+                    backend_model = deployment.get("litellm_params", {}).get("model")
+                    if not isinstance(model_id, str) or not isinstance(backend_model, str):
+                        continue
+                    deployment_model_info = llm_router.get_deployment_model_info(
+                        model_id=model_id,
+                        model_name=backend_model,
+                    )
+                    if deployment_model_info is None:
+                        continue
+                    tiered_pricing = deployment_model_info.get("tiered_pricing")
+                    if isinstance(tiered_pricing, list) and tiered_pricing:
+                        return {
+                            **model_group_cost_info,
+                            "tiered_pricing": tiered_pricing,
+                        }
+                return model_group_cost_info
         except Exception:
             verbose_proxy_logger.debug(
                 "Unable to load router model group info for budget reservation",

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -1014,20 +1014,29 @@ def _max_cost_for_cost_info(
     if isinstance(tiered_pricing, list) and tiered_pricing:
         tier = select_tier_for_input(tiered_pricing=tiered_pricing, input_tokens=input_tokens)
         if tier is not None:
+            output_rate = max(
+                tier_rate(tier, "output_cost_per_token"),
+                tier_rate(tier, "output_cost_per_reasoning_token"),
+            )
             return (input_tokens * tier_rate(tier, "input_cost_per_token")) + (
-                output_tokens * output_multiplier * tier_rate(tier, "output_cost_per_token")
+                output_tokens * output_multiplier * output_rate
             )
 
     input_cost_per_token = _to_float(model_info.get("input_cost_per_token"))
     output_cost_per_token = _to_float(model_info.get("output_cost_per_token"))
+    output_cost_per_reasoning_token = _to_float(model_info.get("output_cost_per_reasoning_token"))
     cost = 0.0
     if input_cost_per_token is not None:
         cost += input_tokens * input_cost_per_token
     elif input_tokens > 0:
         return None
 
-    if output_cost_per_token is not None:
-        cost += output_tokens * output_multiplier * output_cost_per_token
+    # The reasoning-token share is unknown before the request runs, so reserve every
+    # output token at the higher of the standard and reasoning rates to avoid
+    # under-reserving reasoning-heavy requests.
+    output_rate = max(output_cost_per_token or 0.0, output_cost_per_reasoning_token or 0.0)
+    if output_cost_per_token is not None or output_cost_per_reasoning_token is not None:
+        cost += output_tokens * output_multiplier * output_rate
     elif output_tokens > 0:
         return None
 

--- a/tests/test_litellm/llms/dashscope/test_dashscope_cost_calculator.py
+++ b/tests/test_litellm/llms/dashscope/test_dashscope_cost_calculator.py
@@ -131,6 +131,71 @@ class TestDashscopeCostCalculator:
 
         assert math.isclose(prompt_cost, expected_total_prompt_cost, rel_tol=1e-10)
 
+    def _register_string_valued_tiered_model(self, model_key: str) -> None:
+        """Register a model whose tier costs are strings, mimicking YAML config parsing."""
+        litellm.model_cost[model_key] = {
+            "litellm_provider": "dashscope",
+            "mode": "chat",
+            "tiered_pricing": [
+                {
+                    "range": [0, 1000],
+                    "input_cost_per_token": "4e-07",
+                    "output_cost_per_token": "1.6e-06",
+                },
+                {
+                    "range": [1000, 2000],
+                    "input_cost_per_token": "8e-07",
+                    "output_cost_per_token": "3.2e-06",
+                },
+            ],
+        }
+
+    def test_dashscope_tiered_pricing_string_costs_within_tier(self):
+        """
+        Regression: YAML-parsed tier costs can be strings (e.g. "4e-07"). Costs that
+        fall entirely within a single tier must still be computed as floats.
+        """
+        self._register_string_valued_tiered_model("dashscope/qwen-str-tier-test")
+
+        usage = Usage(prompt_tokens=500, completion_tokens=200)
+        prompt_cost, completion_cost = dashscope_cost_per_token(
+            model="qwen-str-tier-test", usage=usage
+        )
+
+        expected_prompt_cost = 500 * float("4e-07")
+        expected_completion_cost = 200 * float("1.6e-06")
+
+        assert prompt_cost > 0
+        assert completion_cost > 0
+        assert math.isclose(prompt_cost, expected_prompt_cost, rel_tol=1e-10)
+        assert math.isclose(completion_cost, expected_completion_cost, rel_tol=1e-10)
+
+    def test_dashscope_tiered_pricing_string_costs_exceeding_highest_tier(self):
+        """
+        Regression: string-valued tier costs must also be coerced in the
+        remaining-tokens path that charges tokens above the highest tier.
+        """
+        self._register_string_valued_tiered_model("dashscope/qwen-str-tier-test")
+
+        usage = Usage(prompt_tokens=2500, completion_tokens=3000)
+        prompt_cost, completion_cost = dashscope_cost_per_token(
+            model="qwen-str-tier-test", usage=usage
+        )
+
+        # prompt: 1000 @ tier1 + 1000 @ tier2 + 500 remaining @ tier2 rate
+        expected_prompt_cost = (
+            (1000 * float("4e-07")) + (1000 * float("8e-07")) + (500 * float("8e-07"))
+        )
+        # completion: 1000 @ tier1 + 1000 @ tier2 + 1000 remaining @ tier2 rate
+        expected_completion_cost = (
+            (1000 * float("1.6e-06")) + (1000 * float("3.2e-06")) + (1000 * float("3.2e-06"))
+        )
+
+        assert prompt_cost > 0
+        assert completion_cost > 0
+        assert math.isclose(prompt_cost, expected_prompt_cost, rel_tol=1e-10)
+        assert math.isclose(completion_cost, expected_completion_cost, rel_tol=1e-10)
+
     def test_dashscope_tiered_pricing_exceeding_highest_tier(self):
         """
         Tests tiered pricing when token count exceeds the highest defined tier range.

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -868,6 +868,87 @@ def test_tiered_reservation_is_all_or_nothing_with_output_tier_from_input_length
     assert estimated > graduated_under_reserve
 
 
+def test_tiered_reservation_uses_higher_reasoning_output_rate():
+    """Some tiered models price reasoning output above standard output. The
+    reasoning-token share is unknown before the request runs, so reservation must
+    charge every output token at the higher of the two rates to avoid under-reserving
+    reasoning-heavy requests."""
+    tiered_pricing = [
+        {
+            "range": [0, 32000],
+            "input_cost_per_token": 1e-06,
+            "output_cost_per_token": 1.2e-06,
+            "output_cost_per_reasoning_token": 4e-06,
+        }
+    ]
+    input_tokens = 1000
+    output_tokens = 500
+
+    with (
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation._get_model_cost_info",
+            return_value={"tiered_pricing": tiered_pricing, "max_output_tokens": 200000},
+        ),
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation._estimate_input_tokens",
+            return_value=input_tokens,
+        ),
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation._estimate_output_tokens",
+            return_value=output_tokens,
+        ),
+    ):
+        estimated = estimate_request_max_cost(
+            request_body=_request_body(),
+            route="/chat/completions",
+            llm_router=None,
+        )
+
+    expected = (input_tokens * 1e-06) + (output_tokens * 4e-06)
+    assert estimated == pytest.approx(expected)
+
+    # Reserving output at the plain rate would under-reserve reasoning-heavy calls.
+    under_reserve = (input_tokens * 1e-06) + (output_tokens * 1.2e-06)
+    assert estimated > under_reserve
+
+
+def test_flat_reservation_uses_higher_reasoning_output_rate():
+    """The same reasoning under-reservation gap exists for flat-rate models that
+    declare output_cost_per_reasoning_token above output_cost_per_token."""
+    input_tokens = 1000
+    output_tokens = 500
+
+    with (
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation._get_model_cost_info",
+            return_value={
+                "input_cost_per_token": 1e-06,
+                "output_cost_per_token": 1.2e-06,
+                "output_cost_per_reasoning_token": 4e-06,
+                "max_output_tokens": 200000,
+            },
+        ),
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation._estimate_input_tokens",
+            return_value=input_tokens,
+        ),
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation._estimate_output_tokens",
+            return_value=output_tokens,
+        ),
+    ):
+        estimated = estimate_request_max_cost(
+            request_body=_request_body(),
+            route="/chat/completions",
+            llm_router=None,
+        )
+
+    expected = (input_tokens * 1e-06) + (output_tokens * 4e-06)
+    assert estimated == pytest.approx(expected)
+    under_reserve = (input_tokens * 1e-06) + (output_tokens * 1.2e-06)
+    assert estimated > under_reserve
+
+
 def test_reservation_uses_most_expensive_deployment_in_group():
     """When a model group mixes deployments with different tiered rates, reservation
     must estimate against the most expensive one. Reserving the cheaper sibling would

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -824,6 +824,90 @@ async def test_should_reserve_tiered_pricing_cost(spend_counter_state):
     await release_budget_reservation(reservation)
 
 
+def test_tiered_reservation_is_all_or_nothing_with_output_tier_from_input_length():
+    """Dashscope tiered pricing is all-or-nothing: the tier is chosen by the total
+    input tokens and every token (input and output) is billed at that tier's rate.
+
+    A long-context request with a large output allowance must reserve the output at
+    the input-selected tier, not at the cheapest tier picked from the output volume.
+    The earlier graduated calculation under-reserved such requests, letting a caller
+    slip past a depleted budget."""
+    tiered_pricing = [
+        {"range": [0, 32000], "input_cost_per_token": 1e-06, "output_cost_per_token": 2e-06},
+        {"range": [32000, 128000], "input_cost_per_token": 4e-06, "output_cost_per_token": 8e-06},
+    ]
+    input_tokens = 100000  # falls entirely in the second tier
+    output_tokens = 1000
+
+    with (
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation._get_model_cost_info",
+            return_value={"tiered_pricing": tiered_pricing, "max_output_tokens": 200000},
+        ),
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation._estimate_input_tokens",
+            return_value=input_tokens,
+        ),
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation._estimate_output_tokens",
+            return_value=output_tokens,
+        ),
+    ):
+        estimated = estimate_request_max_cost(
+            request_body=_request_body(),
+            route="/chat/completions",
+            llm_router=None,
+        )
+
+    expected = (input_tokens * 4e-06) + (output_tokens * 8e-06)
+    assert estimated == pytest.approx(expected)
+
+    # What the old graduated math (with the output tier taken from output volume)
+    # would have reserved. The all-or-nothing estimate must be strictly larger.
+    graduated_under_reserve = (32000 * 1e-06) + (68000 * 4e-06) + (output_tokens * 2e-06)
+    assert estimated > graduated_under_reserve
+
+
+def test_reservation_uses_most_expensive_deployment_in_group():
+    """When a model group mixes deployments with different tiered rates, reservation
+    must estimate against the most expensive one. Reserving the cheaper sibling would
+    let a caller repeatedly hit the alias and exceed the budget once routed to the
+    costlier deployment."""
+    cheap = [{"range": [0, 32000], "input_cost_per_token": 1e-06, "output_cost_per_token": 2e-06}]
+    expensive = [{"range": [0, 32000], "input_cost_per_token": 5e-06, "output_cost_per_token": 1e-05}]
+    input_tokens = 1000
+    output_tokens = 10
+
+    with (
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation._get_model_cost_info",
+            return_value={"max_output_tokens": 200000},
+        ),
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation._get_deployment_tiered_pricing_tables",
+            return_value=[cheap, expensive],
+        ),
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation._estimate_input_tokens",
+            return_value=input_tokens,
+        ),
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation._estimate_output_tokens",
+            return_value=output_tokens,
+        ),
+    ):
+        estimated = estimate_request_max_cost(
+            request_body=_request_body(),
+            route="/chat/completions",
+            llm_router=None,
+        )
+
+    expected_expensive = (input_tokens * 5e-06) + (output_tokens * 1e-05)
+    expected_cheap = (input_tokens * 1e-06) + (output_tokens * 2e-06)
+    assert expected_expensive > expected_cheap
+    assert estimated == pytest.approx(expected_expensive)
+
+
 @pytest.mark.asyncio
 async def test_should_clamp_reservation_to_model_ceiling_when_caller_overrequests(
     spend_counter_state,

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -26,6 +26,7 @@ from litellm.proxy.spend_tracking.budget_reservation import (
     reserve_budget_for_request,
 )
 from litellm.proxy.utils import ProxyLogging
+from litellm.router import Router
 
 
 @pytest.fixture()
@@ -741,6 +742,85 @@ async def test_should_clamp_reservation_to_default_when_output_cap_missing(
 
     assert reservation is not None
     assert reservation["reserved_cost"] == pytest.approx(expected_cost)
+    await release_budget_reservation(reservation)
+
+
+@pytest.mark.asyncio
+async def test_should_reserve_tiered_pricing_cost(spend_counter_state):
+    _, key_cache = spend_counter_state
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=key_cache)
+    router = Router(
+        model_list=[
+            {
+                "model_name": "dashscope/qwen3-max",
+                "litellm_params": {
+                    "model": "dashscope/qwen3-max",
+                    "api_key": "sk-fake",
+                },
+                "model_info": {
+                    "max_input_tokens": 258048,
+                    "max_output_tokens": 65536,
+                    "tiered_pricing": [
+                        {
+                            "input_cost_per_token": 1.2e-06,
+                            "output_cost_per_token": 6e-06,
+                            "range": [0, 32000],
+                        },
+                        {
+                            "input_cost_per_token": 2.4e-06,
+                            "output_cost_per_token": 1.2e-05,
+                            "range": [32000, 128000],
+                        },
+                    ],
+                },
+            }
+        ]
+    )
+    request_body = {
+        "model": "dashscope/qwen3-max",
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_tokens": 10,
+    }
+
+    estimated_cost = estimate_request_max_cost(
+        request_body=request_body,
+        route="/chat/completions",
+        llm_router=router,
+    )
+    assert estimated_cost is not None
+    assert estimated_cost > 0
+
+    valid_token = UserAPIKeyAuth(
+        token="key-tiered-pricing",
+        spend=0.0,
+        max_budget=estimated_cost,
+    )
+    reservation = await reserve_budget_for_request(
+        request_body=request_body,
+        route="/chat/completions",
+        llm_router=router,
+        valid_token=valid_token,
+        team_object=None,
+        user_object=None,
+        prisma_client=None,
+        user_api_key_cache=key_cache,
+        proxy_logging_obj=proxy_logging_obj,
+    )
+
+    assert reservation is not None
+    assert reservation["reserved_cost"] == pytest.approx(estimated_cost)
+    with pytest.raises(litellm.BudgetExceededError):
+        await reserve_budget_for_request(
+            request_body=request_body,
+            route="/chat/completions",
+            llm_router=router,
+            valid_token=valid_token,
+            team_object=None,
+            user_object=None,
+            prisma_client=None,
+            user_api_key_cache=key_cache,
+            proxy_logging_obj=proxy_logging_obj,
+        )
     await release_budget_reservation(reservation)
 
 

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -1000,6 +1000,110 @@ def test_per_request_custom_pricing_with_router():
     assert "gpt-3.5-turbo" in selected
 
 
+def test_tiered_pricing_only_deployment_selects_router_model_id():
+    """A deployment priced solely via ``tiered_pricing`` (no flat
+    input/output cost) must resolve cost against its ``router_model_id``
+    entry, which holds the tiered table, instead of the shared backend alias
+    that has custom pricing fields stripped. Regression for tier-only models
+    (e.g. dashscope/qwen3.7-plus) being billed as free.
+    """
+    from litellm import Router
+    from litellm.cost_calculator import _select_model_name_for_cost_calc
+
+    router = Router(
+        model_list=[
+            {
+                "model_name": "qwen-3.7-plus",
+                "litellm_params": {
+                    "model": "dashscope/qwen3.7-plus",
+                    "api_key": "sk-fake",
+                },
+                "model_info": {
+                    "tiered_pricing": [
+                        {
+                            "input_cost_per_token": 4e-07,
+                            "output_cost_per_token": 1.6e-06,
+                            "range": [0, 256000],
+                        },
+                    ],
+                },
+            },
+        ]
+    )
+    router_model_id = router.model_list[0]["model_info"]["id"]
+
+    entry = litellm.model_cost[router_model_id]
+    assert entry.get("input_cost_per_token") is None
+    assert entry.get("tiered_pricing") is not None
+    # The stripped shared alias must not carry tiered pricing.
+    assert litellm.model_cost["dashscope/qwen3.7-plus"].get("tiered_pricing") is None
+
+    selected = _select_model_name_for_cost_calc(
+        model="dashscope/qwen3.7-plus",
+        completion_response=None,
+        custom_pricing=True,
+        custom_llm_provider="dashscope",
+        router_model_id=router_model_id,
+    )
+    assert selected is not None
+    assert router_model_id in selected
+
+
+def test_tiered_pricing_only_deployment_completion_cost_is_nonzero():
+    """End-to-end: a tier-only deployment must produce the tiered cost, not
+    $0. Mirrors the reported dashscope/qwen3.7-plus trace (12 prompt + 377
+    completion tokens).
+    """
+    from litellm import Router
+    from litellm.types.utils import Choices, Message
+
+    router = Router(
+        model_list=[
+            {
+                "model_name": "qwen-3.7-plus",
+                "litellm_params": {
+                    "model": "dashscope/qwen3.7-plus",
+                    "api_key": "sk-fake",
+                },
+                "model_info": {
+                    "tiered_pricing": [
+                        {
+                            "input_cost_per_token": 4e-07,
+                            "output_cost_per_token": 1.6e-06,
+                            "range": [0, 256000],
+                        },
+                        {
+                            "input_cost_per_token": 1.2e-06,
+                            "output_cost_per_token": 4.8e-06,
+                            "range": [256000, 1000000],
+                        },
+                    ],
+                },
+            },
+        ]
+    )
+    router_model_id = router.model_list[0]["model_info"]["id"]
+
+    response = ModelResponse(
+        model="dashscope/qwen3.7-plus",
+        choices=[Choices(index=0, message=Message(role="assistant", content="hi"))],
+        usage=Usage(prompt_tokens=12, completion_tokens=377, total_tokens=389),
+    )
+    response._hidden_params = {"custom_llm_provider": "dashscope", "model_id": router_model_id}
+
+    cost = completion_cost(
+        completion_response=response,
+        model="dashscope/qwen3.7-plus",
+        custom_llm_provider="dashscope",
+        custom_pricing=True,
+        router_model_id=router_model_id,
+    )
+
+    expected = 12 * 4e-07 + 377 * 1.6e-06
+    assert cost == pytest.approx(expected)
+    assert cost > 0
+
+
 def test_azure_realtime_cost_calculator():
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")


### PR DESCRIPTION
Resolves: LIT-4374 LIT-4373
#30738 #21249

Issue
Dashscope Qwen models that declare only tiered_pricing (per input-length brackets) and no global input_cost_per_token / output_cost_per_token broke budget enforcement and cost tracking end to end. A key that exceeded its budget kept serving requests, spend was recorded as $0, config costs written in scientific notation crashed the calculator, and even after reservation worked the estimate could be dodged by long-context requests or by aliases with a cheap deployment listed first

Cause
Several independent gaps along the tiered-pricing path. Pre-request reservation only understood flat per-token costs, so tier-only deployments estimated to zero. Post-request billing fell back to the generic model name (whose tiered_pricing is stripped at router registration) because _select_model_name_for_cost_calc didn't treat a tiered table as "priced". The tiered-cost helper used YAML values directly, so a string like 4e-07 raised TypeError: unsupported operand type(s) for +=: 'float' and 'str'. The reservation math used graduated slicing and picked the output tier from the output-token count, which under-reserves long-context requests, and it read pricing from only the first deployment in a group. Separately, the tiered helper lived inside the Dashscope module, so generic proxy code imported a provider-specific private function

Fix
Reservation now resolves each deployment's tiered table and prices requests all-or-nothing (tier chosen by total input tokens, that tier's input and output rates applied to every token), matching Alibaba Model Studio's official billing, and it estimates against every eligible deployment in a group and reserves the maximum so a cheaper sibling can't leave a request under-reserved. Post-request billing treats a tiered_pricing entry as priced, so tier-only deployments resolve to their deployment-specific id and bill the correct amount. The tiered-cost helper coerces per-token costs to float in both the in-range and remaining-tokens paths, and it moved to a provider-neutral home at litellm/litellm_core_utils/llm_cost_calc/tiered_pricing.py that both Dashscope and the reservation path import from. Regression tests cover tier-only selection and non-zero billing, string scientific-notation costs (in-range and above the highest tier), all-or-nothing reservation with the output tier taken from input length, and reserving the most expensive deployment in a group

One caveat worth keeping in the description or a comment: the post-request Dashscope calculator still uses graduated slicing (that's the scope of the separate PR #28047), so this PR aligns reservation to all-or-nothing but does not change post-request billing math.

Before:
<img width="885" height="816" alt="Screenshot 2026-07-11 at 2 28 23 PM" src="https://github.com/user-attachments/assets/c83e19c3-0d30-4ca8-b2db-ed9b6eaa53c7" />

After:
<img width="876" height="803" alt="Screenshot 2026-07-11 at 2 28 44 PM" src="https://github.com/user-attachments/assets/15d648fe-c71f-4be6-a5a3-99ef4dd0f2b9" />
