### PR TITLE
feat(complexity_router): log the cause of each routing decision

### DIFF
--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -708,8 +708,10 @@ class ComplexityRouter(CustomLogger):
         override_tier = await self._resolve_keyword_tier_override(user_message, request_kwargs)
         if override_tier is not None:
             routed_model = self.get_model_for_tier(override_tier)
+            cause = "semantic_keyword_match" if self.config.semantic_keyword_matching else "literal_keyword_match"
             verbose_router_logger.info(
-                f"ComplexityRouter: keyword rule fired, tier={override_tier.value}, routed_model={routed_model}"
+                f"ComplexityRouter: routing decision cause={cause}, "
+                f"tier={override_tier.value}, routed_model={routed_model}"
             )
             return PreRoutingHookResponse(
                 model=routed_model,
@@ -720,7 +722,8 @@ class ComplexityRouter(CustomLogger):
         routed_model = self.get_model_for_tier(tier)
 
         verbose_router_logger.info(
-            f"ComplexityRouter: tier={tier.value}, score={score:.3f}, signals={signals}, routed_model={routed_model}"
+            f"ComplexityRouter: routing decision cause=complexity_scorer, tier={tier.value}, "
+            f"score={score:.3f}, signals={signals}, routed_model={routed_model}"
         )
 
         return PreRoutingHookResponse(

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -5,6 +5,7 @@ Tests the rule-based complexity scoring and tier assignment logic.
 """
 
 import asyncio
+import logging
 import os
 import sys
 from typing import Dict, List
@@ -19,6 +20,7 @@ sys.path.insert(
 
 import litellm
 from litellm import Router
+from litellm._logging import verbose_router_logger
 from litellm.router_strategy.complexity_router.complexity_router import (
     ComplexityRouter,
     DimensionScore,
@@ -2019,3 +2021,88 @@ class TestSubCallMetadataSanitization:
         assert sanitized_auth.team_id == "team-1"
         assert sanitized_auth.api_key == auth.api_key
         assert auth.budget_reservation == {"reserved_cost": 1.0}
+
+
+class TestRoutingDecisionCauseLogging:
+    """The info log must name what drove each routing decision so an operator can tell a
+    literal keyword match, a semantic keyword match, and the complexity scorer apart.
+    """
+
+    @pytest.fixture
+    def router_log_capture(self, caplog):
+        # verbose_router_logger sets propagate=False, so caplog's root handler never sees
+        # its records; attach the capture handler directly for the duration of the test.
+        caplog.set_level(logging.INFO, logger="LiteLLM Router")
+        verbose_router_logger.addHandler(caplog.handler)
+        try:
+            yield caplog
+        finally:
+            verbose_router_logger.removeHandler(caplog.handler)
+
+    @pytest.mark.asyncio
+    async def test_literal_keyword_match_logs_its_cause(
+        self, mock_router_instance, basic_config, router_log_capture
+    ):
+        config = {
+            **basic_config,
+            "keyword_tier_rules": [{"keywords": ["deploy to k8s"], "tier": "REASONING"}],
+        }
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config=config,
+        )
+        await router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=[{"role": "user", "content": "please deploy to k8s now"}],
+        )
+        assert "routing decision cause=literal_keyword_match" in router_log_capture.text
+        assert "tier=REASONING" in router_log_capture.text
+        # A literal match must not be mislabelled as semantic.
+        assert "cause=semantic_keyword_match" not in router_log_capture.text
+
+    @pytest.mark.asyncio
+    async def test_semantic_keyword_match_logs_its_cause(self, basic_config, router_log_capture):
+        fake_router = FakeEmbeddingRouter()
+        config = {
+            **basic_config,
+            "keyword_tier_rules": [{"keywords": ["kubernetes deployment"], "tier": "REASONING"}],
+            "semantic_keyword_matching": True,
+            "embedding_model": "fake-embed",
+            "match_threshold": 0.5,
+        }
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=fake_router,
+            complexity_router_config=config,
+        )
+        await router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=[{"role": "user", "content": "help me roll out my k8s cluster today"}],
+        )
+        assert "routing decision cause=semantic_keyword_match" in router_log_capture.text
+        assert "tier=REASONING" in router_log_capture.text
+        # A semantic match must not be mislabelled as literal.
+        assert "cause=literal_keyword_match" not in router_log_capture.text
+
+    @pytest.mark.asyncio
+    async def test_complexity_scorer_logs_its_cause(
+        self, mock_router_instance, basic_config, router_log_capture
+    ):
+        # No keyword rules -> the scorer decides, and its line must be tagged as such.
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config=basic_config,
+        )
+        await router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=[{"role": "user", "content": "What is the boiling point of water at sea level?"}],
+        )
+        assert "routing decision cause=complexity_scorer" in router_log_capture.text
+        assert "score=" in router_log_capture.text
+        assert "cause=literal_keyword_match" not in router_log_capture.text
+        assert "cause=semantic_keyword_match" not in router_log_capture.text


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Tested at commit `3385a32` against a live proxy (`python litellm/proxy/proxy_cli.py --config litellm/proxy/complexity_router_proof.yaml --detailed_debug --port 4001`) with two requests.

**Before** (venv-installed litellm, old format):

```
# curl -s ... -d '{"model":"auto-router","messages":[{"role":"user","content":"What is the capital of France?"}]}'
LiteLLM Router:INFO: complexity_router.py:722 - ComplexityRouter: tier=SIMPLE, score=-0.150, signals=['short (7 tokens)', 'simple (what is)'], routed_model=simple-model

# curl -s ... -d '{"model":"auto-router","messages":[{"role":"user","content":"Help me deploy to kubernetes please."}]}'
LiteLLM Router:INFO: complexity_router.py:711 - ComplexityRouter: keyword rule fired, tier=REASONING, routed_model=reasoning-model
```

No way to tell from the log whether the keyword match was literal or semantic, and the scorer line has no consistent `cause=` marker.

**After** (this branch, commit `3385a32`):

```
# curl -s ... -d '{"model":"auto-router","messages":[{"role":"user","content":"What is the capital of France?"}]}'
LiteLLM Router:INFO: complexity_router.py:724 - ComplexityRouter: routing decision cause=complexity_scorer, tier=SIMPLE, score=-0.150, signals=['short (7 tokens)', 'simple (what is)'], routed_model=simple-model

# curl -s ... -d '{"model":"auto-router","messages":[{"role":"user","content":"Help me deploy to kubernetes please."}]}'
LiteLLM Router:INFO: complexity_router.py:712 - ComplexityRouter: routing decision cause=literal_keyword_match, tier=REASONING, routed_model=reasoning-model
```

Both lines now carry `cause=` and are greppable by decision type.

## Type

🆕 New Feature

## Changes

The complexity router's info log didn't say what drove a routing decision. Literal and semantic keyword matches logged an identical "keyword rule fired" line with no way to tell which mechanism fired, and the scorer's line carried no consistent marker tying it to the same decision framework.

This emits one greppable line per decision naming the cause: `literal_keyword_match`, `semantic_keyword_match`, or `complexity_scorer`. The hook already knows which path ran (the config's `semantic_keyword_matching` flag distinguishes lexical from semantic; the override-vs-scorer branch distinguishes keyword match from scorer), so this is label-only: no behavior change, no new types, no added latency.

Adds three regression tests asserting each decision path logs its cause; they fail if a label is swapped or the `cause=` marker is dropped.