### PR TITLE
fix(anthropic): translate raw adaptive thinking for pre-4.6 models on chat completions and Bedrock Converse

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -227,6 +227,10 @@ DROP_UNSUPPORTED_OUTPUT_CONFIG_WARNING = (
     "Sonnet 4.6+, and Mythos Preview."
 )
 
+DROP_UNSUPPORTED_ADAPTIVE_THINKING_WARNING = (
+    "Dropping adaptive `thinking` for model=%s: max_tokens is too small to fit the minimum thinking budget."
+)
+
 DROP_UNSUPPORTED_SPEED_WARNING = (
     "Dropping unsupported `speed` for model=%s (drop_params=True). Fast mode is only supported on select Opus models."
 )
@@ -1220,6 +1224,23 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 llm_provider=llm_provider,
             )
 
+    @staticmethod
+    def _cap_thinking_budget_to_max_tokens(
+        thinking: AnthropicThinkingParam, max_tokens: Optional[int]
+    ) -> Optional[AnthropicThinkingParam]:
+        """Cap a legacy ``thinking.budget_tokens`` below ``max_tokens`` (Anthropic
+        requires ``max_tokens > budget_tokens``). Returns the (possibly capped)
+        thinking dict, or ``None`` when ``max_tokens`` is too small to fit even the
+        minimum thinking budget and thinking should be dropped."""
+        budget = thinking.get("budget_tokens")
+        if max_tokens is None or not isinstance(budget, int):
+            return thinking
+        if max_tokens <= ANTHROPIC_MIN_THINKING_BUDGET_TOKENS:
+            return None
+        if budget < max_tokens:
+            return thinking
+        return AnthropicThinkingParam(type=thinking.get("type", "enabled"), budget_tokens=max_tokens - 1)
+
     def _extract_json_schema_from_response_format(self, value: Optional[dict]) -> Optional[dict]:
         if value is None:
             return None
@@ -1463,7 +1484,37 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             ):
                 optional_params["metadata"] = {"user_id": value}
             elif param == "thinking":
-                optional_params["thinking"] = value
+                if (
+                    isinstance(value, dict)
+                    and value.get("type") == "adaptive"
+                    and not AnthropicConfig._is_adaptive_thinking_model(model)
+                ):
+                    # Callers (e.g. Claude Code) send adaptive thinking
+                    # unconditionally; translate it down to the legacy
+                    # `thinking={type: enabled, budget_tokens}` interface a
+                    # pre-4.6 model actually supports instead of forwarding a
+                    # shape the model will reject.
+                    max_tokens = non_default_params.get("max_completion_tokens") or non_default_params.get("max_tokens")
+                    legacy_thinking = AnthropicConfig._map_reasoning_effort(
+                        reasoning_effort="medium",
+                        model=model,
+                        llm_provider=self.custom_llm_provider or "anthropic",
+                    )
+                    capped_thinking = (
+                        AnthropicConfig._cap_thinking_budget_to_max_tokens(legacy_thinking, max_tokens)
+                        if legacy_thinking is not None
+                        else None
+                    )
+                    if capped_thinking is not None:
+                        optional_params["thinking"] = capped_thinking
+                    else:
+                        litellm.verbose_logger.warning(
+                            DROP_UNSUPPORTED_ADAPTIVE_THINKING_WARNING,
+                            model,
+                        )
+                        optional_params.pop("thinking", None)
+                else:
+                    optional_params["thinking"] = value
             elif param == "reasoning_effort":
                 # Accept both string ("low") and dict ({"effort": "low",
                 # "summary": "concise"}). The Responses->Chat parser keeps the

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1487,7 +1487,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 if (
                     isinstance(value, dict)
                     and value.get("type") == "adaptive"
-                    and not AnthropicConfig._is_adaptive_thinking_model(model)
+                    and not AnthropicConfig._is_adaptive_thinking_model(model, self._resolved_provider)
                 ):
                     # Callers (e.g. Claude Code) send adaptive thinking
                     # unconditionally; translate it down to the legacy
@@ -1498,8 +1498,8 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                     legacy_thinking = AnthropicConfig._map_reasoning_effort(
                         reasoning_effort="medium",
                         model=model,
-                        custom_llm_provider=self.custom_llm_provider or "anthropic",
-                        llm_provider=self.custom_llm_provider or "anthropic",
+                        custom_llm_provider=self._resolved_provider,
+                        llm_provider=self._resolved_provider,
                     )
                     capped_thinking = (
                         AnthropicConfig._cap_thinking_budget_to_max_tokens(legacy_thinking, max_tokens)

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1498,6 +1498,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                     legacy_thinking = AnthropicConfig._map_reasoning_effort(
                         reasoning_effort="medium",
                         model=model,
+                        custom_llm_provider=self.custom_llm_provider or "anthropic",
                         llm_provider=self.custom_llm_provider or "anthropic",
                     )
                     capped_thinking = (

--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -3,7 +3,6 @@ from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
 import httpx
 
 from litellm.constants import (
-    ANTHROPIC_MIN_THINKING_BUDGET_TOKENS,
     DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
     DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
     DEFAULT_REASONING_EFFORT_XHIGH_THINKING_BUDGET,
@@ -353,7 +352,7 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         except _BadRequestError as e:
             raise AnthropicError(message=str(e.message), status_code=400)
         capped_thinking = (
-            AnthropicMessagesConfig._cap_thinking_budget_to_max_tokens(legacy_thinking, max_tokens)
+            AnthropicConfig._cap_thinking_budget_to_max_tokens(legacy_thinking, max_tokens)
             if legacy_thinking is not None
             else None
         )
@@ -370,21 +369,6 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
                 optional_params["output_config"] = residual
             else:
                 optional_params.pop("output_config", None)
-
-    @staticmethod
-    def _cap_thinking_budget_to_max_tokens(thinking: Dict, max_tokens: Optional[int]) -> Optional[Dict]:
-        """Cap a legacy ``thinking.budget_tokens`` below ``max_tokens`` (Anthropic
-        requires ``max_tokens > budget_tokens``). Returns the (possibly capped)
-        thinking dict, or ``None`` when ``max_tokens`` is too small to fit even the
-        minimum thinking budget and thinking should be dropped."""
-        budget = thinking.get("budget_tokens")
-        if max_tokens is None or not isinstance(budget, int):
-            return thinking
-        if max_tokens <= ANTHROPIC_MIN_THINKING_BUDGET_TOKENS:
-            return None
-        if budget < max_tokens:
-            return thinking
-        return {**thinking, "budget_tokens": max_tokens - 1}
 
     def transform_anthropic_messages_request(
         self,

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -33,6 +33,7 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
     make_valid_bedrock_tool_name,
 )
 from litellm.llms.anthropic.chat.transformation import (
+    DROP_UNSUPPORTED_ADAPTIVE_THINKING_WARNING,
     DROP_UNSUPPORTED_OUTPUT_CONFIG_WARNING,
     REASONING_EFFORT_TO_OUTPUT_CONFIG_EFFORT,
     AnthropicConfig,
@@ -899,7 +900,28 @@ class AmazonConverseConfig(BaseConfig):
                     "tool_choice": {"disable_parallel_tool_use": disable_parallel}
                 }
             if param == "thinking":
-                optional_params["thinking"] = value
+                if (
+                    isinstance(value, dict)
+                    and value.get("type") == "adaptive"
+                    and not AnthropicConfig._is_adaptive_thinking_model(model, "bedrock")
+                ):
+                    max_tokens = non_default_params.get("max_completion_tokens") or non_default_params.get("max_tokens")
+                    legacy_thinking = AnthropicConfig._map_reasoning_effort(
+                        reasoning_effort="medium",
+                        model=model,
+                        custom_llm_provider="bedrock",
+                    )
+                    capped = (
+                        AnthropicConfig._cap_thinking_budget_to_max_tokens(legacy_thinking, max_tokens)
+                        if legacy_thinking is not None
+                        else None
+                    )
+                    if capped is not None:
+                        optional_params["thinking"] = capped
+                    else:
+                        litellm.verbose_logger.warning(DROP_UNSUPPORTED_ADAPTIVE_THINKING_WARNING, model)
+                else:
+                    optional_params["thinking"] = value
             elif param == "reasoning_effort" and isinstance(value, str):
                 self._handle_reasoning_effort_parameter(
                     model=model, reasoning_effort=value, optional_params=optional_params

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import litellm
 from litellm.constants import (
+    ANTHROPIC_MIN_THINKING_BUDGET_TOKENS,
     DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
     DEFAULT_REASONING_EFFORT_LOW_THINKING_BUDGET,
     DEFAULT_REASONING_EFFORT_MAX_THINKING_BUDGET,
@@ -2441,6 +2442,78 @@ def test_reasoning_effort_maps_to_adaptive_thinking_for_claude_4_6_models():
                 "output_config" in result
             ), f"output_config missing for {model} with effort={effort}"
             assert result["output_config"]["effort"] == effort_map[effort]
+
+
+def test_raw_adaptive_thinking_translates_to_legacy_for_pre_46_model():
+    """Clients like Claude Code send ``thinking={"type": "adaptive"}`` directly
+    (not via ``reasoning_effort``) on every request, regardless of which model
+    the request routes to. For a pre-4.6 model that doesn't understand
+    adaptive thinking, this must be translated to the legacy
+    ``thinking={type: enabled, budget_tokens}`` interface instead of being
+    forwarded raw, which Anthropic would reject."""
+    config = AnthropicConfig()
+
+    result = config.map_openai_params(
+        non_default_params={"thinking": {"type": "adaptive"}, "max_tokens": 8192},
+        optional_params={},
+        model="claude-haiku-4-5-20251001",
+        drop_params=False,
+    )
+
+    assert result["thinking"]["type"] == "enabled"
+    assert result["thinking"]["budget_tokens"] == DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET
+
+
+def test_raw_adaptive_thinking_budget_capped_below_max_tokens():
+    """Anthropic requires ``max_tokens > thinking.budget_tokens``. When the
+    default medium budget wouldn't fit, it must be capped below max_tokens
+    rather than forwarded as an invalid combination."""
+    config = AnthropicConfig()
+
+    max_tokens = DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET - 100
+    result = config.map_openai_params(
+        non_default_params={"thinking": {"type": "adaptive"}, "max_tokens": max_tokens},
+        optional_params={},
+        model="claude-haiku-4-5-20251001",
+        drop_params=False,
+    )
+
+    assert result["thinking"]["type"] == "enabled"
+    assert result["thinking"]["budget_tokens"] == max_tokens - 1
+
+
+def test_raw_adaptive_thinking_dropped_when_max_tokens_too_small():
+    """When max_tokens can't fit even the minimum thinking budget, thinking
+    must be dropped entirely so the request still succeeds, matching how the
+    native /v1/messages passthrough already handles this."""
+    config = AnthropicConfig()
+
+    result = config.map_openai_params(
+        non_default_params={
+            "thinking": {"type": "adaptive"},
+            "max_tokens": ANTHROPIC_MIN_THINKING_BUDGET_TOKENS,
+        },
+        optional_params={},
+        model="claude-haiku-4-5-20251001",
+        drop_params=False,
+    )
+
+    assert "thinking" not in result
+
+
+def test_raw_adaptive_thinking_untouched_for_46_plus_model():
+    """Adaptive-thinking models understand ``thinking={"type": "adaptive"}``
+    natively, so it must pass through unmodified."""
+    config = AnthropicConfig()
+
+    result = config.map_openai_params(
+        non_default_params={"thinking": {"type": "adaptive"}, "max_tokens": 8192},
+        optional_params={},
+        model="claude-sonnet-4-6-20260219",
+        drop_params=False,
+    )
+
+    assert result["thinking"] == {"type": "adaptive"}
 
 
 @pytest.fixture

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -5767,3 +5767,52 @@ def test_message_level_cache_control_drops_ttl_for_unsupported_model(ttl_target)
     cache_points = _collect_cache_points(result)
     assert len(cache_points) == 1
     assert "ttl" not in cache_points[0]
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "bedrock/converse/us.anthropic.claude-haiku-4-5",
+        "bedrock/converse/us.anthropic.claude-sonnet-4-5",
+    ],
+)
+def test_adaptive_thinking_translated_to_legacy_on_pre_46_converse(model):
+    """Raw thinking={type: adaptive} from callers like Claude Code must be
+    translated to legacy thinking={type: enabled, budget_tokens} for pre-4.6
+    models on Bedrock Converse rather than forwarded as-is and rejected."""
+    config = AmazonConverseConfig()
+
+    optional_params = config.map_openai_params(
+        non_default_params={"thinking": {"type": "adaptive"}, "max_tokens": 8192},
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+
+    thinking = optional_params.get("thinking")
+    assert thinking is not None
+    assert thinking["type"] == "enabled"
+    assert isinstance(thinking.get("budget_tokens"), int)
+    assert thinking["budget_tokens"] < 8192
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "bedrock/converse/us.anthropic.claude-opus-4-7",
+        "bedrock/converse/us.anthropic.claude-sonnet-4-6",
+    ],
+)
+def test_adaptive_thinking_passes_through_on_46_plus_converse(model):
+    """thinking={type: adaptive} must be forwarded unchanged for 4.6+ models
+    that natively support adaptive thinking."""
+    config = AmazonConverseConfig()
+
+    optional_params = config.map_openai_params(
+        non_default_params={"thinking": {"type": "adaptive"}, "max_tokens": 8192},
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+
+    assert optional_params.get("thinking") == {"type": "adaptive"}

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -5816,3 +5816,24 @@ def test_adaptive_thinking_passes_through_on_46_plus_converse(model):
     )
 
     assert optional_params.get("thinking") == {"type": "adaptive"}
+
+
+def test_adaptive_thinking_dropped_when_max_tokens_too_small_converse():
+    """When max_tokens can't fit even the minimum thinking budget, the raw
+    adaptive block must be dropped entirely rather than translated, so the
+    Bedrock Converse request still succeeds."""
+    from litellm.constants import ANTHROPIC_MIN_THINKING_BUDGET_TOKENS
+
+    config = AmazonConverseConfig()
+
+    optional_params = config.map_openai_params(
+        non_default_params={
+            "thinking": {"type": "adaptive"},
+            "max_tokens": ANTHROPIC_MIN_THINKING_BUDGET_TOKENS,
+        },
+        optional_params={},
+        model="bedrock/converse/us.anthropic.claude-sonnet-4-5",
+        drop_params=False,
+    )
+
+    assert "thinking" not in optional_params


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live against a proxy hitting the real Anthropic API, model `anthropic/claude-sonnet-4-5` (a pre-4.6 model that rejects adaptive thinking). Before is staging `92dfbdbb21`; after is this branch

Before, adaptive thinking on `/chat/completions` to a pre-4.6 model is forwarded unchanged and the model rejects it

```bash
curl -sS $GW/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{
  "model": "anthropic-sonnet-4-5", "max_tokens": 8192,
  "thinking": {"type": "adaptive"},
  "messages": [{"role": "user", "content": "In one sentence, why is the sky blue?"}]}'
# staging -> HTTP 400 (adaptive thinking is not supported on this model)
# this branch -> HTTP 200
```

The translation is visible in the proxy debug log: the client's `{'type': 'adaptive'}` becomes `{'type': 'enabled', 'budget_tokens': 2048}` before the upstream call

Example: 

```
# --- chat/completions: adaptive thinking on a PRE-4.6 model ---
for PORT in 4000 4001; do echo "=== :$PORT chat/completions ==="; curl -sS -o /dev/null -w "HTTP %{http_code}\n" \
  http://localhost:$PORT/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{
    "model": "anthropic-sonnet-4-5", "max_tokens": 8192,
    "thinking": {"type": "adaptive"},
    "messages": [{"role": "user", "content": "In one sentence, why is the sky blue?"}]}'; done

# --- Bedrock Converse: adaptive thinking on a PRE-4.6 converse model ---
for PORT in 4000 4001; do echo "=== :$PORT bedrock converse ==="; curl -sS -o /dev/null -w "HTTP %{http_code}\n" \
  http://localhost:$PORT/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{
    "model": "bedrock-converse-sonnet-4-5", "max_tokens": 8192,
    "thinking": {"type": "adaptive"},
    "messages": [{"role": "user", "content": "In one sentence, why is the sky blue?"}]}'; done
```

Output: 
<img width="828" height="87" alt="Screenshot 2026-07-11 at 7 49 49 PM" src="https://github.com/user-attachments/assets/8c8c3edf-5862-4080-9ad9-d2fc2986a4b7" />


## Type

🐛 Bug Fix

## Changes

Follow-up to #32867, which translated the 4.6+ adaptive-thinking interface down to what pre-4.6 Anthropic models accept on the native `/v1/messages` passthrough. Two paths still forwarded a raw `thinking={type: "adaptive"}` block straight to pre-4.6 models that reject it

The first commit handles the `/chat/completions` path in `AnthropicConfig.map_openai_params`: when a caller (e.g. Claude Code, which sends adaptive thinking unconditionally) passes `thinking={type: "adaptive"}` and the target is not an adaptive-thinking model, it is translated to legacy `thinking={type: enabled, budget_tokens}`, capped below `max_tokens`, and dropped with a warning when `max_tokens` cannot fit even the minimum budget

The second commit extends the same translation to the Bedrock Converse path (`AmazonConverseConfig.map_openai_params`), which previously assigned the adaptive block through unchanged and let Bedrock reject it downstream

Also fixes a latent bug in the `/chat/completions` translation surfaced during review: the call to `AnthropicConfig._is_adaptive_thinking_model` / `_map_reasoning_effort` was missing the resolved `custom_llm_provider`, so it raised at runtime after the rebase; both now pass `self._resolved_provider`

The reverse direction (upgrading legacy `thinking={type:enabled}` to adaptive for 4.6+ models) is tracked separately in #32973 to keep this PR to one problem
