### PR TITLE
refactor(ui): extract a shared CopyButton and fix the sidebar copy confirmation

### DIFF
--- a/ui/litellm-dashboard/src/components/SidebarAccountMenu/SidebarAccountMenu.test.tsx
+++ b/ui/litellm-dashboard/src/components/SidebarAccountMenu/SidebarAccountMenu.test.tsx
@@ -179,7 +179,7 @@ describe("SidebarAccountMenu", () => {
     expect(screen.queryByTitle("Thanks for using LiteLLM!")).not.toBeInTheDocument();
   });
 
-  it("should copy the email and show the confirmation checkmark on success", async () => {
+  it("wires the email row to the shared copy button", async () => {
     const user = userEvent.setup();
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
@@ -188,42 +188,10 @@ describe("SidebarAccountMenu", () => {
     await openMenu(user);
 
     const copyButton = screen.getByRole("button", { name: "Copy email" });
-    expect(copyButton.querySelector(".lucide-copy")).toBeInTheDocument();
-
     await user.click(copyButton);
 
     expect(writeText).toHaveBeenCalledWith("test@example.com");
     await waitFor(() => expect(copyButton.querySelector(".lucide-check")).toBeInTheDocument());
-  });
-
-  it("should not show the checkmark when the clipboard write is rejected", async () => {
-    const user = userEvent.setup();
-    const writeText = vi.fn().mockRejectedValue(new Error("permission denied"));
-    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
-
-    renderWithProviders(<SidebarAccountMenu onLogout={mockOnLogout} />);
-    await openMenu(user);
-
-    const copyButton = screen.getByRole("button", { name: "Copy email" });
-    await user.click(copyButton);
-
-    await waitFor(() => expect(writeText).toHaveBeenCalledWith("test@example.com"));
-    expect(copyButton.querySelector(".lucide-check")).not.toBeInTheDocument();
-    expect(copyButton.querySelector(".lucide-copy")).toBeInTheDocument();
-  });
-
-  it("should not show the checkmark when the clipboard API is unavailable", async () => {
-    const user = userEvent.setup();
-    Object.defineProperty(navigator, "clipboard", { value: undefined, configurable: true });
-
-    renderWithProviders(<SidebarAccountMenu onLogout={mockOnLogout} />);
-    await openMenu(user);
-
-    const copyButton = screen.getByRole("button", { name: "Copy email" });
-    await user.click(copyButton);
-
-    expect(copyButton.querySelector(".lucide-check")).not.toBeInTheDocument();
-    expect(copyButton.querySelector(".lucide-copy")).toBeInTheDocument();
   });
 
   it("should call onLogout when logout is clicked", async () => {

--- a/ui/litellm-dashboard/src/components/SidebarAccountMenu/SidebarAccountMenu.test.tsx
+++ b/ui/litellm-dashboard/src/components/SidebarAccountMenu/SidebarAccountMenu.test.tsx
@@ -179,7 +179,7 @@ describe("SidebarAccountMenu", () => {
     expect(screen.queryByTitle("Thanks for using LiteLLM!")).not.toBeInTheDocument();
   });
 
-  it("should copy the email to the clipboard", async () => {
+  it("should copy the email and show the confirmation checkmark on success", async () => {
     const user = userEvent.setup();
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
@@ -187,9 +187,43 @@ describe("SidebarAccountMenu", () => {
     renderWithProviders(<SidebarAccountMenu onLogout={mockOnLogout} />);
     await openMenu(user);
 
-    await user.click(screen.getByRole("button", { name: "Copy email" }));
+    const copyButton = screen.getByRole("button", { name: "Copy email" });
+    expect(copyButton.querySelector(".lucide-copy")).toBeInTheDocument();
+
+    await user.click(copyButton);
 
     expect(writeText).toHaveBeenCalledWith("test@example.com");
+    await waitFor(() => expect(copyButton.querySelector(".lucide-check")).toBeInTheDocument());
+  });
+
+  it("should not show the checkmark when the clipboard write is rejected", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockRejectedValue(new Error("permission denied"));
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+
+    renderWithProviders(<SidebarAccountMenu onLogout={mockOnLogout} />);
+    await openMenu(user);
+
+    const copyButton = screen.getByRole("button", { name: "Copy email" });
+    await user.click(copyButton);
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("test@example.com"));
+    expect(copyButton.querySelector(".lucide-check")).not.toBeInTheDocument();
+    expect(copyButton.querySelector(".lucide-copy")).toBeInTheDocument();
+  });
+
+  it("should not show the checkmark when the clipboard API is unavailable", async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(navigator, "clipboard", { value: undefined, configurable: true });
+
+    renderWithProviders(<SidebarAccountMenu onLogout={mockOnLogout} />);
+    await openMenu(user);
+
+    const copyButton = screen.getByRole("button", { name: "Copy email" });
+    await user.click(copyButton);
+
+    expect(copyButton.querySelector(".lucide-check")).not.toBeInTheDocument();
+    expect(copyButton.querySelector(".lucide-copy")).toBeInTheDocument();
   });
 
   it("should call onLogout when logout is clicked", async () => {

--- a/ui/litellm-dashboard/src/components/SidebarAccountMenu/SidebarAccountMenu.tsx
+++ b/ui/litellm-dashboard/src/components/SidebarAccountMenu/SidebarAccountMenu.tsx
@@ -68,9 +68,10 @@ const CopyButton: React.FC<{ value: string | null; label: string }> = ({ value, 
       type="button"
       variant="ghost"
       size="icon-xs"
-      onClick={() => {
+      onClick={async () => {
+        if (!navigator.clipboard) return;
         try {
-          navigator.clipboard?.writeText(value);
+          await navigator.clipboard.writeText(value);
           setCopied(true);
         } catch {
           setCopied(false);
@@ -218,7 +219,7 @@ const SidebarAccountMenu: React.FC<SidebarAccountMenuProps> = ({ onLogout, colla
               title="Thanks for using LiteLLM!"
               aria-hidden
             >
-              🌑
+              🌴
             </span>
           )}
           <span className="flex-1" />

--- a/ui/litellm-dashboard/src/components/SidebarAccountMenu/SidebarAccountMenu.tsx
+++ b/ui/litellm-dashboard/src/components/SidebarAccountMenu/SidebarAccountMenu.tsx
@@ -7,6 +7,7 @@ import { useDisableShowPrompts } from "@/app/(dashboard)/hooks/useDisableShowPro
 import { useDisableUsageIndicator } from "@/app/(dashboard)/hooks/useDisableUsageIndicator";
 import { emitLocalStorageChange, removeLocalStorageItem, setLocalStorageItem } from "@/utils/localStorageUtils";
 import { navAccountDisplayName } from "@/components/Navbar/navDisplayName";
+import CopyButton from "@/components/shared/CopyButton";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -14,8 +15,8 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/cva.config";
-import { Check, ChevronsUpDown, Copy, Crown, IdCard, LogOut, Mail, ShieldCheck } from "lucide-react";
-import React, { useEffect, useState } from "react";
+import { ChevronsUpDown, Crown, IdCard, LogOut, Mail, ShieldCheck } from "lucide-react";
+import React from "react";
 
 const RELEASE_NOTES_URL = "https://docs.litellm.ai/release_notes";
 
@@ -51,40 +52,6 @@ function initialsFromIdentity(email: string | null, userId: string | null): stri
   }
   return "?";
 }
-
-const CopyButton: React.FC<{ value: string | null; label: string }> = ({ value, label }) => {
-  const [copied, setCopied] = useState(false);
-
-  useEffect(() => {
-    if (!copied) return;
-    const timer = setTimeout(() => setCopied(false), 1200);
-    return () => clearTimeout(timer);
-  }, [copied]);
-
-  if (!value) return null;
-
-  return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon-xs"
-      onClick={async () => {
-        if (!navigator.clipboard) return;
-        try {
-          await navigator.clipboard.writeText(value);
-          setCopied(true);
-        } catch {
-          setCopied(false);
-        }
-      }}
-      aria-label={label}
-      title={label}
-      className="text-muted-foreground hover:text-primary"
-    >
-      {copied ? <Check className="size-[15px]" /> : <Copy className="size-[15px]" />}
-    </Button>
-  );
-};
 
 const InfoRow: React.FC<{ icon: React.ReactNode; label: string; children: React.ReactNode }> = ({
   icon,

--- a/ui/litellm-dashboard/src/components/shared/CopyButton.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/CopyButton.test.tsx
@@ -1,0 +1,55 @@
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen, waitFor } from "../../../tests/test-utils";
+import CopyButton from "./CopyButton";
+
+describe("CopyButton", () => {
+  it("renders nothing when there is no value", () => {
+    const { container } = renderWithProviders(<CopyButton value={null} label="Copy value" />);
+    expect(container.querySelector("button")).toBeNull();
+  });
+
+  it("shows the confirmation checkmark only after a successful write", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+
+    renderWithProviders(<CopyButton value="secret-value" label="Copy value" />);
+
+    const button = screen.getByRole("button", { name: "Copy value" });
+    expect(button.querySelector(".lucide-copy")).toBeInTheDocument();
+
+    await user.click(button);
+
+    expect(writeText).toHaveBeenCalledWith("secret-value");
+    await waitFor(() => expect(button.querySelector(".lucide-check")).toBeInTheDocument());
+  });
+
+  it("does not show the checkmark when the clipboard write is rejected", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockRejectedValue(new Error("permission denied"));
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+
+    renderWithProviders(<CopyButton value="secret-value" label="Copy value" />);
+
+    const button = screen.getByRole("button", { name: "Copy value" });
+    await user.click(button);
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("secret-value"));
+    expect(button.querySelector(".lucide-check")).not.toBeInTheDocument();
+    expect(button.querySelector(".lucide-copy")).toBeInTheDocument();
+  });
+
+  it("does not show the checkmark when the clipboard API is unavailable", async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(navigator, "clipboard", { value: undefined, configurable: true });
+
+    renderWithProviders(<CopyButton value="secret-value" label="Copy value" />);
+
+    const button = screen.getByRole("button", { name: "Copy value" });
+    await user.click(button);
+
+    expect(button.querySelector(".lucide-check")).not.toBeInTheDocument();
+    expect(button.querySelector(".lucide-copy")).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/shared/CopyButton.tsx
+++ b/ui/litellm-dashboard/src/components/shared/CopyButton.tsx
@@ -1,0 +1,49 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/cva.config";
+import { Check, Copy } from "lucide-react";
+import React, { useEffect, useState } from "react";
+
+interface CopyButtonProps {
+  value: string | null | undefined;
+  label: string;
+  className?: string;
+  iconClassName?: string;
+}
+
+const CopyButton: React.FC<CopyButtonProps> = ({ value, label, className, iconClassName = "size-[15px]" }) => {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = setTimeout(() => setCopied(false), 1200);
+    return () => clearTimeout(timer);
+  }, [copied]);
+
+  if (!value) return null;
+
+  const handleCopy = async () => {
+    if (!navigator.clipboard) return;
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-xs"
+      onClick={handleCopy}
+      aria-label={label}
+      title={label}
+      className={cn("text-muted-foreground hover:text-primary", className)}
+    >
+      {copied ? <Check className={iconClassName} /> : <Copy className={iconClassName} />}
+    </Button>
+  );
+};
+
+export default CopyButton;


### PR DESCRIPTION
## Relevant issues

Follow-up to #32931; addresses the Greptile P1 from that PR

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a UI-only change, so there is no LLM call or curl to show; here is how to see the before / after in the dashboard

1. Run the proxy and the dashboard dev server (`npm run dev` in `ui/litellm-dashboard`)
2. Open the dashboard and click the account control at the bottom of the left sidebar to open the account menu
3. Simulate a context where the clipboard is unavailable: open DevTools and run `Object.defineProperty(navigator, 'clipboard', { value: undefined, configurable: true })` in the console. A plain HTTP origin or a denied clipboard permission reproduces the same thing
4. Click the copy icon next to Email or User ID

Before (staging / #32931 at merge): the icon flips to a checkmark even though nothing was copied

After (this branch, 7d4fba569d): the icon stays as the copy glyph, so there is no false confirmation. In a normal secure context with the clipboard available, clicking still copies the value and shows the checkmark as before

Screenshots to follow

## Type

🧹 Refactoring

🐛 Bug Fix

## Changes

The sidebar account menu's copy button flipped to the checkmark synchronously, before the clipboard write settled. That meant it confirmed a copy that never happened when `navigator.clipboard` was undefined (non-secure origins, or blocked by browser policy) or when `writeText` rejected on a permission denial. The rejection was never caught because the promise was not awaited, so users saw a false "copied" signal on fields like email and user id

The dashboard had this copy-icon-to-checkmark pattern hand-rolled in several spots, and the sidebar's private copy button was the one carrying the bug. Rather than patch that one copy in place, this extracts a single canonical `CopyButton` into `components/shared`, built on the `Button` primitive with a guarded and awaited clipboard write so the checkmark shows only after a successful copy. `SidebarAccountMenu` now consumes it, and its private copy button is gone. There is no first-party shadcn copy primitive to import; a small owned component on top of `Button` is the idiomatic pattern, so this makes it reusable instead of per-file

Also swaps the header accent emoji in the menu header from the new-moon glyph to a palm tree, as requested

For tests, the shared `CopyButton` gets its own unit test covering the empty-value guard, the success path (checkmark appears), and both failure modes (rejected write and unavailable clipboard, where the checkmark must not appear). Both failure tests were confirmed to fail against the pre-fix synchronous handler and pass after. The sidebar test keeps one case asserting the email row is wired to the shared button

The other hand-rolled copies (chat messages, request/response log panel) are left for a follow-up so this stays scoped to the sidebar

<img width="267" height="37" alt="image" src="https://github.com/user-attachments/assets/4442e7ea-4ae0-4f85-98bc-6c12a5e96663" />

