### PR TITLE
feat(ui): adopt openapi-react-query ($api) and convert useCustomers

### DIFF
--- a/ui/litellm-dashboard/package-lock.json
+++ b/ui/litellm-dashboard/package-lock.json
@@ -29,6 +29,7 @@
         "next": "16.2.6",
         "openai": "4.104.0",
         "openapi-fetch": "^0.17.0",
+        "openapi-react-query": "^0.5.4",
         "papaparse": "5.5.3",
         "react": "18.3.1",
         "react-copy-to-clipboard": "5.1.1",
@@ -10542,6 +10543,19 @@
       "license": "MIT",
       "dependencies": {
         "openapi-typescript-helpers": "^0.1.0"
+      }
+    },
+    "node_modules/openapi-react-query": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/openapi-react-query/-/openapi-react-query-0.5.4.tgz",
+      "integrity": "sha512-V9lRiozjHot19/BYSgXYoyznDxDJQhEBSdi26+SJ0UqjMANLQhkni4XG+Z7e3Ag7X46ZLMrL9VxYkghU3QvbWg==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.80.0",
+        "openapi-fetch": "^0.17.0"
       }
     },
     "node_modules/openapi-typescript": {

--- a/ui/litellm-dashboard/package.json
+++ b/ui/litellm-dashboard/package.json
@@ -44,6 +44,7 @@
     "next": "16.2.6",
     "openai": "4.104.0",
     "openapi-fetch": "^0.17.0",
+    "openapi-react-query": "^0.5.4",
     "papaparse": "5.5.3",
     "react": "18.3.1",
     "react-copy-to-clipboard": "5.1.1",

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/customers/useCustomers.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/customers/useCustomers.test.ts
@@ -1,12 +1,10 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook, waitFor } from "@testing-library/react";
-import React, { ReactNode } from "react";
+import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useCustomers, type EndUser } from "./useCustomers";
 
-const mockGet = vi.fn();
+const useQueryMock = vi.fn();
 vi.mock("@/lib/http/api", () => ({
-  fetchClient: { GET: (...args: unknown[]) => mockGet(...args) },
+  $api: { useQuery: (...args: unknown[]) => useQueryMock(...args) },
 }));
 
 const mockUseAuthorized = vi.fn();
@@ -14,91 +12,52 @@ vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
   default: () => mockUseAuthorized(),
 }));
 
-const mockCustomers: EndUser[] = [
-  { user_id: "customer-1", alias: "Test Customer 1", spend: 150.5, blocked: false },
-  { user_id: "customer-2", alias: null, spend: 0, blocked: true },
-];
+const authorized = { accessToken: "test-access-token", userRole: "Admin" };
 
-const authorized = {
-  accessToken: "test-access-token",
-  userRole: "Admin",
-  userId: "test-user-id",
-  token: "test-token",
-  userEmail: "test@example.com",
-  premiumUser: false,
-  disabledPersonalKeyCreation: null,
-  showSSOBanner: false,
-};
+type QueryOptions = { enabled: boolean; select: (data: EndUser[] | undefined) => EndUser[] };
+
+const lastCallOptions = (): QueryOptions => useQueryMock.mock.calls[0][3] as QueryOptions;
 
 describe("useCustomers", () => {
-  let queryClient: QueryClient;
-
   beforeEach(() => {
-    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     vi.clearAllMocks();
+    useQueryMock.mockReturnValue({ data: [] });
     mockUseAuthorized.mockReturnValue(authorized);
   });
 
-  const wrapper = ({ children }: { children: ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: queryClient }, children);
-
-  it("fetches /customer/list and returns the typed list on success", async () => {
-    mockGet.mockResolvedValue({ data: mockCustomers });
-
-    const { result } = renderHook(() => useCustomers(), { wrapper });
-
-    expect(result.current.isLoading).toBe(true);
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
-    expect(result.current.data).toEqual(mockCustomers);
-    expect(mockGet).toHaveBeenCalledWith("/customer/list");
-    expect(mockGet).toHaveBeenCalledTimes(1);
+  it("queries GET /customer/list with a derived key (no hand-written queryKey)", () => {
+    renderHook(() => useCustomers());
+    expect(useQueryMock).toHaveBeenCalledWith("get", "/customer/list", {}, expect.any(Object));
   });
 
-  it("surfaces an error when the request rejects", async () => {
-    const testError = new Error("Failed to fetch customers");
-    mockGet.mockRejectedValue(testError);
-
-    const { result } = renderHook(() => useCustomers(), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.isError).toBe(true);
-    });
-
-    expect(result.current.error).toEqual(testError);
-    expect(result.current.data).toBeUndefined();
+  it("enables the query only for an admin holding an access token", () => {
+    renderHook(() => useCustomers());
+    expect(lastCallOptions().enabled).toBe(true);
   });
 
-  it("falls back to an empty list when the response has no body", async () => {
-    mockGet.mockResolvedValue({ data: undefined });
-
-    const { result } = renderHook(() => useCustomers(), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
-    expect(result.current.data).toEqual([]);
+  it("disables the query when the access token is missing", () => {
+    mockUseAuthorized.mockReturnValue({ ...authorized, accessToken: null });
+    renderHook(() => useCustomers());
+    expect(lastCallOptions().enabled).toBe(false);
   });
 
-  it("does not fetch when the access token is missing", () => {
-    mockUseAuthorized.mockReturnValue({ ...authorized, accessToken: null, token: null });
-
-    const { result } = renderHook(() => useCustomers(), { wrapper });
-
-    expect(result.current.isFetched).toBe(false);
-    expect(mockGet).not.toHaveBeenCalled();
-  });
-
-  it("does not fetch when the user is not an admin", () => {
+  it("disables the query for a non-admin role", () => {
     mockUseAuthorized.mockReturnValue({ ...authorized, userRole: "member" });
+    renderHook(() => useCustomers());
+    expect(lastCallOptions().enabled).toBe(false);
+  });
 
-    const { result } = renderHook(() => useCustomers(), { wrapper });
+  it("selects an empty list when the response body is missing", () => {
+    renderHook(() => useCustomers());
+    expect(lastCallOptions().select(undefined)).toEqual([]);
+  });
 
-    expect(result.current.isFetched).toBe(false);
-    expect(mockGet).not.toHaveBeenCalled();
+  it("selects the customer list through unchanged", () => {
+    const customers: EndUser[] = [
+      { user_id: "customer-1", alias: "Test Customer 1", spend: 150.5, blocked: false },
+      { user_id: "customer-2", alias: null, spend: 0, blocked: true },
+    ];
+    renderHook(() => useCustomers());
+    expect(lastCallOptions().select(customers)).toEqual(customers);
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/customers/useCustomers.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/customers/useCustomers.test.ts
@@ -16,7 +16,10 @@ const authorized = { accessToken: "test-access-token", userRole: "Admin" };
 
 type QueryOptions = { enabled: boolean; select: (data: EndUser[] | undefined) => EndUser[] };
 
-const lastCallOptions = (): QueryOptions => useQueryMock.mock.calls[0][3] as QueryOptions;
+const lastCallOptions = (): QueryOptions => {
+  const calls = useQueryMock.mock.calls;
+  return calls[calls.length - 1][3] as QueryOptions;
+};
 
 describe("useCustomers", () => {
   beforeEach(() => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/customers/useCustomers.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/customers/useCustomers.ts
@@ -1,19 +1,19 @@
-import { useQuery } from "@tanstack/react-query";
-import { createQueryKeys } from "../common/queryKeysFactory";
-import { fetchClient } from "@/lib/http/api";
+import { $api } from "@/lib/http/api";
 import { all_admin_roles } from "@/utils/roles";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import type { components } from "@/lib/http/schema";
 
 export type EndUser = components["schemas"]["CustomerResponse"];
 
-const customersKeys = createQueryKeys("customers");
-
 export const useCustomers = () => {
   const { accessToken, userRole } = useAuthorized();
-  return useQuery({
-    queryKey: customersKeys.list({}),
-    queryFn: async () => (await fetchClient.GET("/customer/list")).data ?? [],
-    enabled: Boolean(accessToken) && all_admin_roles.includes(userRole!),
-  });
+  return $api.useQuery(
+    "get",
+    "/customer/list",
+    {},
+    {
+      enabled: Boolean(accessToken) && all_admin_roles.includes(userRole!),
+      select: (data) => data ?? [],
+    },
+  );
 };

--- a/ui/litellm-dashboard/src/lib/http/api.ts
+++ b/ui/litellm-dashboard/src/lib/http/api.ts
@@ -1,4 +1,5 @@
 import createFetchClient, { type Middleware } from "openapi-fetch";
+import createQueryClient from "openapi-react-query";
 import type { paths } from "./schema";
 import { ApiError, deriveErrorMessage } from "./client";
 import { getAuthHeaderName, getAuthToken, getRequestBaseUrl, reportError } from "./runtime";
@@ -46,3 +47,11 @@ const middleware: Middleware = {
  */
 export const fetchClient = createFetchClient<paths>({ baseUrl: globalThis.location?.origin ?? "" });
 fetchClient.use(middleware);
+
+/**
+ * TanStack Query bound to the typed client. Callers write
+ * `$api.useQuery("get", "/path", init, options)`; the query key is derived from
+ * method + path + init (no hand-maintained key), the request signal is
+ * forwarded for cancellation, and the response type comes from schema.d.ts.
+ */
+export const $api = createQueryClient(fetchClient);


### PR DESCRIPTION
## Relevant issues

Follow-up to #29884 (the typed openapi-fetch foundation), which merged into `litellm_internal_staging`

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This is a refactor with no user-facing behavior change; the Customers selector on the Usage page reads through `useCustomers`, so it exercises the converted hook end to end. Captured at commit d3d399d136 with a proxy on localhost:4000 and the dashboard dev server on localhost:3000

1. Start the proxy: `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`
2. Start the dashboard: `cd ui/litellm-dashboard && npm run dev`
3. Log in, open `http://localhost:3000/?login=success&page=usage`, and open the customer / end-user selector
4. In the Network tab confirm the request goes to `http://localhost:4000/customer/list`, carries the bearer auth header, and returns 200 with the customer list rendering in the dropdown as before
5. Endpoint sanity check from the shell: `curl -sS -H "Authorization: Bearer $LITELLM_KEY" http://localhost:4000/customer/list | jq '.[0]'`

## Type

🆕 New Feature

## Changes

This builds on the merged foundation from #29884 by adopting `openapi-react-query` and converting the first caller onto it. `lib/http/api.ts` now exposes `$api = createQueryClient(fetchClient)` alongside the existing `fetchClient`, so callers write `$api.useQuery("get", "/path", init, options)` instead of hand-writing a TanStack Query `queryFn` around `fetchClient.GET`

`useCustomers` is converted to `$api.useQuery("get", "/customer/list", {}, { enabled, select })`. Three things fall out of this. The query key is now derived from method plus path plus init, so the hand-maintained `createQueryKeys("customers")` entry and the manual `queryKey` are deleted and can no longer drift from the endpoint they key. The request `AbortSignal` is forwarded automatically, so an unmounted or superseded query actually cancels rather than running to completion. And the response type still flows from `schema.d.ts` as `CustomerResponse[]`, with the empty-body fallback moved into `select`

The dependency is `openapi-react-query`, a small runtime wrapper over the `openapi-fetch` client already in the tree; it adds no codegen and no CI surface. The hook's test targets its actual contribution: the path it queries, the admin-and-token `enabled` gate on both arms, and the `select` empty-body fallback, so a regression in any of those fails the suite
