### PR TITLE
feat(ui): working Test Connection for the complexity auto router

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Card, Form, Button, Tooltip, Typography, Select as AntdSelect, Radio, Badge, Space } from "antd";
+import { Card, Form, Button, Tooltip, Typography, Select as AntdSelect, Radio, Badge, Space, Modal } from "antd";
 import type { FormInstance } from "antd";
 import { ThunderboltOutlined, BranchesOutlined } from "@ant-design/icons";
 import { Text, TextInput } from "@tremor/react";
@@ -12,6 +12,8 @@ import ComplexityRouterConfig, { ComplexityRouterConfigValue } from "./Complexit
 import { KeywordTierRule } from "./KeywordTierRules";
 import { DEFAULT_MATCH_THRESHOLD } from "./SemanticKeywordMatching";
 import { buildComplexityRouterConfig, getSemanticConfigError } from "./build_complexity_router_config";
+import { buildAutoRouterTestTargets, AutoRouterTestTarget } from "./build_auto_router_test_targets";
+import AutoRouterConnectionTest from "./auto_router_connection_test";
 import NotificationManager from "../molecules/notifications_manager";
 
 interface AddAutoRouterTabProps {
@@ -44,6 +46,11 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({ form, handleOk, acc
 
   // Semantic router config (existing)
   const [routerConfig, setRouterConfig] = useState<any>(null);
+
+  const [isTestModalVisible, setIsTestModalVisible] = useState<boolean>(false);
+  const [isTestingConnection, setIsTestingConnection] = useState<boolean>(false);
+  const [connectionTestId, setConnectionTestId] = useState<number>(0);
+  const [testTargets, setTestTargets] = useState<AutoRouterTestTarget[]>([]);
 
   useEffect(() => {
     const fetchModelAccessGroups = async () => {
@@ -192,6 +199,24 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({ form, handleOk, acc
     } else {
       submitSemanticRouter(name);
     }
+  };
+
+  const handleTestConnection = () => {
+    const targets = buildAutoRouterTestTargets({
+      tiers: complexityRouterConfig.tiers,
+      semanticMatchingEnabled,
+      embeddingModel,
+    });
+
+    if (targets.length === 0) {
+      NotificationManager.fromBackend("Please select at least one model for a complexity tier");
+      return;
+    }
+
+    setTestTargets(targets);
+    setConnectionTestId((id) => id + 1);
+    setIsTestingConnection(true);
+    setIsTestModalVisible(true);
   };
 
   return (
@@ -355,10 +380,15 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({ form, handleOk, acc
               <Typography.Link href="https://github.com/BerriAI/litellm/issues">Need Help?</Typography.Link>
             </Tooltip>
             <div className="space-x-2">
-              {/* TODO: add back a Test Connection or JSON preview action here. Test Connection was removed
-                  because prepareModelAddRequest can't build a valid pre-save payload for an auto router
-                  (tiers are model-group references, not litellm_params); a JSON preview of the
-                  complexity_router_config would be a good alternative. */}
+              {routerType === "recommended" && (
+                <Button
+                  data-testid="auto-router-test-connect-btn"
+                  onClick={handleTestConnection}
+                  loading={isTestingConnection}
+                >
+                  Test Connection
+                </Button>
+              )}
               <Button
                 type="primary"
                 onClick={() => {
@@ -371,6 +401,36 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({ form, handleOk, acc
           </div>
         </Form>
       </Card>
+
+      <Modal
+        title="Connection Test Results"
+        open={isTestModalVisible}
+        onCancel={() => {
+          setIsTestModalVisible(false);
+          setIsTestingConnection(false);
+        }}
+        footer={[
+          <Button
+            key="close"
+            onClick={() => {
+              setIsTestModalVisible(false);
+              setIsTestingConnection(false);
+            }}
+          >
+            Close
+          </Button>,
+        ]}
+        width={700}
+      >
+        {isTestModalVisible && (
+          <AutoRouterConnectionTest
+            key={connectionTestId}
+            accessToken={accessToken}
+            targets={testTargets}
+            onTestComplete={() => setIsTestingConnection(false)}
+          />
+        )}
+      </Modal>
     </>
   );
 };

--- a/ui/litellm-dashboard/src/components/add_model/auto_router_connection_test.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/auto_router_connection_test.test.tsx
@@ -7,11 +7,11 @@ vi.mock("../networking", async () => {
   const actual = await vi.importActual("../networking");
   return {
     ...actual,
-    testConnectionRequest: vi.fn(),
+    testModelGroupConnection: vi.fn(),
   };
 });
 
-const getMock = async () => vi.mocked((await import("../networking")).testConnectionRequest);
+const getMock = async () => vi.mocked((await import("../networking")).testModelGroupConnection);
 
 const targets: AutoRouterTestTarget[] = [
   { labels: ["SIMPLE"], modelGroup: "gpt-4o-mini", mode: "chat" },
@@ -32,12 +32,12 @@ describe("AutoRouterConnectionTest", () => {
 
     await waitFor(() => expect(mock).toHaveBeenCalledTimes(3));
 
-    expect(mock).toHaveBeenCalledWith("sk-test", { model: "gpt-4o-mini" }, {}, "chat");
-    expect(mock).toHaveBeenCalledWith("sk-test", { model: "claude-sonnet-4" }, {}, "chat");
-    expect(mock).toHaveBeenCalledWith("sk-test", { model: "voyage-3-5" }, {}, "embedding");
+    expect(mock).toHaveBeenCalledWith("sk-test", "gpt-4o-mini", "chat");
+    expect(mock).toHaveBeenCalledWith("sk-test", "claude-sonnet-4", "chat");
+    expect(mock).toHaveBeenCalledWith("sk-test", "voyage-3-5", "embedding");
   });
 
-  it("shows a success indicator per target when the health check passes", async () => {
+  it("shows a success indicator per target when the routing probe passes", async () => {
     const mock = await getMock();
     mock.mockResolvedValue({ status: "success" });
 
@@ -48,12 +48,14 @@ describe("AutoRouterConnectionTest", () => {
     expect(screen.getByText("MEDIUM, COMPLEX")).toBeInTheDocument();
   });
 
-  it("renders the provider error message for a failing target while others pass", async () => {
+  it("renders the provider error message (litellm prefix stripped) for a failing target while others pass", async () => {
     const mock = await getMock();
-    mock.mockImplementation((_token, litellmParams) =>
-      litellmParams.model === "claude-sonnet-4"
-        ? Promise.resolve({ status: "error", result: { error: "litellm.AuthenticationError: invalid api key" } })
-        : Promise.resolve({ status: "success" }),
+    mock.mockImplementation((_token, modelGroup) =>
+      Promise.resolve(
+        modelGroup === "claude-sonnet-4"
+          ? { status: "error", error: "litellm.AuthenticationError: invalid api key" }
+          : { status: "success" },
+      ),
     );
 
     renderWithProviders(<AutoRouterConnectionTest accessToken="sk-test" targets={targets} />);
@@ -64,9 +66,9 @@ describe("AutoRouterConnectionTest", () => {
     expect(screen.getAllByTestId("test-status-success")).toHaveLength(2);
   });
 
-  it("surfaces a thrown network error as a failing row", async () => {
+  it("renders a non-litellm error string verbatim", async () => {
     const mock = await getMock();
-    mock.mockRejectedValue(new Error("Network request failed"));
+    mock.mockResolvedValue({ status: "error", error: "Connection test failed: 404 Not Found" });
 
     renderWithProviders(
       <AutoRouterConnectionTest
@@ -75,6 +77,8 @@ describe("AutoRouterConnectionTest", () => {
       />,
     );
 
-    await waitFor(() => expect(screen.getByTestId("test-error-message")).toHaveTextContent("Network request failed"));
+    await waitFor(() =>
+      expect(screen.getByTestId("test-error-message")).toHaveTextContent("Connection test failed: 404 Not Found"),
+    );
   });
 });

--- a/ui/litellm-dashboard/src/components/add_model/auto_router_connection_test.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/auto_router_connection_test.test.tsx
@@ -1,0 +1,80 @@
+import { renderWithProviders, screen, waitFor } from "../../../tests/test-utils";
+import { vi } from "vitest";
+import AutoRouterConnectionTest from "./auto_router_connection_test";
+import { AutoRouterTestTarget } from "./build_auto_router_test_targets";
+
+vi.mock("../networking", async () => {
+  const actual = await vi.importActual("../networking");
+  return {
+    ...actual,
+    testConnectionRequest: vi.fn(),
+  };
+});
+
+const getMock = async () => vi.mocked((await import("../networking")).testConnectionRequest);
+
+const targets: AutoRouterTestTarget[] = [
+  { labels: ["SIMPLE"], modelGroup: "gpt-4o-mini", mode: "chat" },
+  { labels: ["MEDIUM", "COMPLEX"], modelGroup: "claude-sonnet-4", mode: "chat" },
+  { labels: ["Embedding"], modelGroup: "voyage-3-5", mode: "embedding" },
+];
+
+describe("AutoRouterConnectionTest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("probes each target once with the right model and mode (chat for tiers, embedding for the embedding model)", async () => {
+    const mock = await getMock();
+    mock.mockResolvedValue({ status: "success" });
+
+    renderWithProviders(<AutoRouterConnectionTest accessToken="sk-test" targets={targets} />);
+
+    await waitFor(() => expect(mock).toHaveBeenCalledTimes(3));
+
+    expect(mock).toHaveBeenCalledWith("sk-test", { model: "gpt-4o-mini" }, {}, "chat");
+    expect(mock).toHaveBeenCalledWith("sk-test", { model: "claude-sonnet-4" }, {}, "chat");
+    expect(mock).toHaveBeenCalledWith("sk-test", { model: "voyage-3-5" }, {}, "embedding");
+  });
+
+  it("shows a success indicator per target when the health check passes", async () => {
+    const mock = await getMock();
+    mock.mockResolvedValue({ status: "success" });
+
+    renderWithProviders(<AutoRouterConnectionTest accessToken="sk-test" targets={targets} />);
+
+    await waitFor(() => expect(screen.getAllByTestId("test-status-success")).toHaveLength(3));
+    expect(screen.queryByTestId("test-status-error")).toBeNull();
+    expect(screen.getByText("MEDIUM, COMPLEX")).toBeInTheDocument();
+  });
+
+  it("renders the provider error message for a failing target while others pass", async () => {
+    const mock = await getMock();
+    mock.mockImplementation((_token, litellmParams) =>
+      litellmParams.model === "claude-sonnet-4"
+        ? Promise.resolve({ status: "error", result: { error: "litellm.AuthenticationError: invalid api key" } })
+        : Promise.resolve({ status: "success" }),
+    );
+
+    renderWithProviders(<AutoRouterConnectionTest accessToken="sk-test" targets={targets} />);
+
+    await waitFor(() => expect(screen.getByTestId("test-error-message")).toBeInTheDocument());
+    expect(screen.getByTestId("test-error-message")).toHaveTextContent("invalid api key");
+    expect(screen.getByTestId("test-error-message")).not.toHaveTextContent("litellm.AuthenticationError");
+    expect(screen.getAllByTestId("test-status-success")).toHaveLength(2);
+  });
+
+  it("surfaces a thrown network error as a failing row", async () => {
+    const mock = await getMock();
+    mock.mockRejectedValue(new Error("Network request failed"));
+
+    renderWithProviders(
+      <AutoRouterConnectionTest
+        accessToken="sk-test"
+        targets={[{ labels: ["SIMPLE"], modelGroup: "gpt-4o-mini", mode: "chat" }]}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("test-error-message")).toHaveTextContent("Network request failed"));
+  });
+});

--- a/ui/litellm-dashboard/src/components/add_model/auto_router_connection_test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/auto_router_connection_test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Typography } from "antd";
 import { CheckCircleTwoTone, CloseCircleTwoTone, LoadingOutlined } from "@ant-design/icons";
-import { testConnectionRequest } from "../networking";
+import { testModelGroupConnection, ModelGroupConnectionResult } from "../networking";
 import { AutoRouterTestTarget } from "./build_auto_router_test_targets";
 
 const { Text } = Typography;
@@ -12,43 +12,11 @@ interface AutoRouterConnectionTestProps {
   onTestComplete?: () => void;
 }
 
-type TargetResult = { status: "pending" } | { status: "success" } | { status: "error"; error: string };
-
-interface NormalizedResponse {
-  ok: boolean;
-  error?: string;
-}
-
-const normalizeTestConnectionResponse = (response: unknown): NormalizedResponse => {
-  if (typeof response !== "object" || response === null) {
-    return { ok: false, error: "Unexpected response from connection test" };
-  }
-  const record = response as Record<string, unknown>;
-  if (record.status === "success") {
-    return { ok: true };
-  }
-  const result =
-    typeof record.result === "object" && record.result !== null ? (record.result as Record<string, unknown>) : {};
-  const resultError = typeof result.error === "string" ? result.error : undefined;
-  const recordMessage = typeof record.message === "string" ? record.message : undefined;
-  return { ok: false, error: resultError ?? recordMessage ?? "Unknown error" };
-};
+type TargetResult = { status: "pending" } | ModelGroupConnectionResult;
 
 const cleanErrorMessage = (error: string): string => {
   const mainError = error.split("stack trace:")[0].trim();
   return mainError.replace(/^litellm\.(.*?)Error: /, "");
-};
-
-const runTarget = async (accessToken: string, target: AutoRouterTestTarget): Promise<TargetResult> => {
-  try {
-    const response = await testConnectionRequest(accessToken, { model: target.modelGroup }, {}, target.mode);
-    const normalized = normalizeTestConnectionResponse(response);
-    return normalized.ok
-      ? { status: "success" }
-      : { status: "error", error: cleanErrorMessage(normalized.error ?? "Unknown error") };
-  } catch (error) {
-    return { status: "error", error: cleanErrorMessage(error instanceof Error ? error.message : String(error)) };
-  }
 };
 
 const AutoRouterConnectionTest: React.FC<AutoRouterConnectionTestProps> = ({
@@ -61,16 +29,22 @@ const AutoRouterConnectionTest: React.FC<AutoRouterConnectionTestProps> = ({
   React.useEffect(() => {
     let cancelled = false;
     const run = async () => {
-      const settled = await Promise.all(targets.map((target) => runTarget(accessToken, target)));
-      if (cancelled) return;
-      setResults(settled);
-      if (onTestComplete) onTestComplete();
+      await Promise.all(
+        targets.map(async (target, index) => {
+          const result = await testModelGroupConnection(accessToken, target.modelGroup, target.mode);
+          if (cancelled) return;
+          const cleaned: TargetResult =
+            result.status === "error" ? { status: "error", error: cleanErrorMessage(result.error) } : result;
+          setResults((prev) => prev.map((r, i) => (i === index ? cleaned : r)));
+        }),
+      );
+      if (!cancelled && onTestComplete) onTestComplete();
     };
     run();
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- probes run once per mount; the parent remounts via `key` to start a fresh test, and re-running on prop identity changes would refire paid health checks
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- probes run once per mount; the parent remounts via `key` to start a fresh test, and re-running on prop identity changes would refire paid requests
   }, []);
 
   if (targets.length === 0) {
@@ -80,7 +54,8 @@ const AutoRouterConnectionTest: React.FC<AutoRouterConnectionTestProps> = ({
   return (
     <div className="space-y-3">
       <Text type="secondary" style={{ display: "block", marginBottom: 8 }}>
-        Each configured tier routes to a saved model group. Test Connection runs a live health check against each one.
+        Each configured tier routes to a saved model group. Test Connection sends a minimal request through the proxy to
+        each one, exactly as the auto router would.
       </Text>
       {targets.map((target, index) => {
         const result = results[index] ?? { status: "pending" };

--- a/ui/litellm-dashboard/src/components/add_model/auto_router_connection_test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/auto_router_connection_test.tsx
@@ -1,0 +1,132 @@
+import React from "react";
+import { Typography } from "antd";
+import { CheckCircleTwoTone, CloseCircleTwoTone, LoadingOutlined } from "@ant-design/icons";
+import { testConnectionRequest } from "../networking";
+import { AutoRouterTestTarget } from "./build_auto_router_test_targets";
+
+const { Text } = Typography;
+
+interface AutoRouterConnectionTestProps {
+  accessToken: string;
+  targets: AutoRouterTestTarget[];
+  onTestComplete?: () => void;
+}
+
+type TargetResult = { status: "pending" } | { status: "success" } | { status: "error"; error: string };
+
+interface NormalizedResponse {
+  ok: boolean;
+  error?: string;
+}
+
+const normalizeTestConnectionResponse = (response: unknown): NormalizedResponse => {
+  if (typeof response !== "object" || response === null) {
+    return { ok: false, error: "Unexpected response from connection test" };
+  }
+  const record = response as Record<string, unknown>;
+  if (record.status === "success") {
+    return { ok: true };
+  }
+  const result =
+    typeof record.result === "object" && record.result !== null ? (record.result as Record<string, unknown>) : {};
+  const resultError = typeof result.error === "string" ? result.error : undefined;
+  const recordMessage = typeof record.message === "string" ? record.message : undefined;
+  return { ok: false, error: resultError ?? recordMessage ?? "Unknown error" };
+};
+
+const cleanErrorMessage = (error: string): string => {
+  const mainError = error.split("stack trace:")[0].trim();
+  return mainError.replace(/^litellm\.(.*?)Error: /, "");
+};
+
+const runTarget = async (accessToken: string, target: AutoRouterTestTarget): Promise<TargetResult> => {
+  try {
+    const response = await testConnectionRequest(accessToken, { model: target.modelGroup }, {}, target.mode);
+    const normalized = normalizeTestConnectionResponse(response);
+    return normalized.ok
+      ? { status: "success" }
+      : { status: "error", error: cleanErrorMessage(normalized.error ?? "Unknown error") };
+  } catch (error) {
+    return { status: "error", error: cleanErrorMessage(error instanceof Error ? error.message : String(error)) };
+  }
+};
+
+const AutoRouterConnectionTest: React.FC<AutoRouterConnectionTestProps> = ({
+  accessToken,
+  targets,
+  onTestComplete,
+}) => {
+  const [results, setResults] = React.useState<TargetResult[]>(() => targets.map(() => ({ status: "pending" })));
+
+  React.useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      const settled = await Promise.all(targets.map((target) => runTarget(accessToken, target)));
+      if (cancelled) return;
+      setResults(settled);
+      if (onTestComplete) onTestComplete();
+    };
+    run();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- probes run once per mount; the parent remounts via `key` to start a fresh test, and re-running on prop identity changes would refire paid health checks
+  }, []);
+
+  if (targets.length === 0) {
+    return <Text type="secondary">No complexity tiers are configured yet, so there is nothing to test.</Text>;
+  }
+
+  return (
+    <div className="space-y-3">
+      <Text type="secondary" style={{ display: "block", marginBottom: 8 }}>
+        Each configured tier routes to a saved model group. Test Connection runs a live health check against each one.
+      </Text>
+      {targets.map((target, index) => {
+        const result = results[index] ?? { status: "pending" };
+        return (
+          <div
+            key={`${target.modelGroup}-${target.mode}`}
+            data-testid="auto-router-test-row"
+            style={{
+              border: "1px solid #e5e7eb",
+              borderRadius: 8,
+              padding: "12px 16px",
+              display: "flex",
+              alignItems: "flex-start",
+              gap: 12,
+            }}
+          >
+            <div style={{ fontSize: 18, lineHeight: "24px" }}>
+              {result.status === "pending" && <LoadingOutlined data-testid="test-status-pending" />}
+              {result.status === "success" && (
+                <CheckCircleTwoTone twoToneColor="#52c41a" data-testid="test-status-success" />
+              )}
+              {result.status === "error" && (
+                <CloseCircleTwoTone twoToneColor="#ff4d4f" data-testid="test-status-error" />
+              )}
+            </div>
+            <div style={{ flex: 1 }}>
+              <Text strong>{target.labels.join(", ")}</Text>{" "}
+              <Text type="secondary">
+                {"->"} {target.modelGroup}
+                {target.mode === "embedding" ? " (embedding)" : ""}
+              </Text>
+              {result.status === "error" && (
+                <Text
+                  type="danger"
+                  data-testid="test-error-message"
+                  style={{ display: "block", marginTop: 4, fontSize: 13 }}
+                >
+                  {result.error}
+                </Text>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default AutoRouterConnectionTest;

--- a/ui/litellm-dashboard/src/components/add_model/build_auto_router_test_targets.test.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_auto_router_test_targets.test.ts
@@ -1,0 +1,68 @@
+import { buildAutoRouterTestTargets } from "./build_auto_router_test_targets";
+
+const tiers = {
+  SIMPLE: "gpt-4o-mini",
+  MEDIUM: "claude-sonnet-4",
+  COMPLEX: "claude-sonnet-4",
+  REASONING: "o3",
+};
+
+describe("buildAutoRouterTestTargets", () => {
+  it("dedups tiers that share a model group into one chat target carrying both labels", () => {
+    const targets = buildAutoRouterTestTargets({ tiers, semanticMatchingEnabled: false, embeddingModel: undefined });
+    expect(targets).toEqual([
+      { labels: ["SIMPLE"], modelGroup: "gpt-4o-mini", mode: "chat" },
+      { labels: ["MEDIUM", "COMPLEX"], modelGroup: "claude-sonnet-4", mode: "chat" },
+      { labels: ["REASONING"], modelGroup: "o3", mode: "chat" },
+    ]);
+  });
+
+  it("drops empty/whitespace tiers", () => {
+    const targets = buildAutoRouterTestTargets({
+      tiers: { SIMPLE: "gpt-4o-mini", MEDIUM: "", COMPLEX: "   ", REASONING: "" },
+      semanticMatchingEnabled: false,
+      embeddingModel: undefined,
+    });
+    expect(targets).toEqual([{ labels: ["SIMPLE"], modelGroup: "gpt-4o-mini", mode: "chat" }]);
+  });
+
+  it("returns [] when no tier is configured", () => {
+    expect(
+      buildAutoRouterTestTargets({
+        tiers: { SIMPLE: "", MEDIUM: "", COMPLEX: "", REASONING: "" },
+        semanticMatchingEnabled: false,
+        embeddingModel: undefined,
+      }),
+    ).toEqual([]);
+  });
+
+  it("appends an embedding target only when semantic matching is on and a model is set", () => {
+    const targets = buildAutoRouterTestTargets({
+      tiers: { SIMPLE: "gpt-4o-mini", MEDIUM: "", COMPLEX: "", REASONING: "" },
+      semanticMatchingEnabled: true,
+      embeddingModel: "voyage-3-5",
+    });
+    expect(targets).toEqual([
+      { labels: ["SIMPLE"], modelGroup: "gpt-4o-mini", mode: "chat" },
+      { labels: ["Embedding"], modelGroup: "voyage-3-5", mode: "embedding" },
+    ]);
+  });
+
+  it("omits the embedding target when semantic matching is on but no model is chosen", () => {
+    const targets = buildAutoRouterTestTargets({
+      tiers: { SIMPLE: "gpt-4o-mini", MEDIUM: "", COMPLEX: "", REASONING: "" },
+      semanticMatchingEnabled: true,
+      embeddingModel: undefined,
+    });
+    expect(targets).toEqual([{ labels: ["SIMPLE"], modelGroup: "gpt-4o-mini", mode: "chat" }]);
+  });
+
+  it("omits the embedding target when a model is set but semantic matching is off", () => {
+    const targets = buildAutoRouterTestTargets({
+      tiers: { SIMPLE: "gpt-4o-mini", MEDIUM: "", COMPLEX: "", REASONING: "" },
+      semanticMatchingEnabled: false,
+      embeddingModel: "voyage-3-5",
+    });
+    expect(targets).toEqual([{ labels: ["SIMPLE"], modelGroup: "gpt-4o-mini", mode: "chat" }]);
+  });
+});

--- a/ui/litellm-dashboard/src/components/add_model/build_auto_router_test_targets.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_auto_router_test_targets.ts
@@ -14,7 +14,14 @@ export interface BuildAutoRouterTestTargetsParams {
   embeddingModel: string | undefined;
 }
 
-const TIER_ORDER: (keyof ComplexityTiers)[] = ["SIMPLE", "MEDIUM", "COMPLEX", "REASONING"];
+// Keys drive iteration order; `satisfies Record<keyof ComplexityTiers, null>` makes it a
+// compile error to add a tier to ComplexityTiers without listing it here (and vice versa).
+const TIER_ORDER = Object.keys({
+  SIMPLE: null,
+  MEDIUM: null,
+  COMPLEX: null,
+  REASONING: null,
+} satisfies Record<keyof ComplexityTiers, null>) as (keyof ComplexityTiers)[];
 
 export const buildAutoRouterTestTargets = ({
   tiers,

--- a/ui/litellm-dashboard/src/components/add_model/build_auto_router_test_targets.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_auto_router_test_targets.ts
@@ -1,0 +1,42 @@
+import { ComplexityTiers } from "./ComplexityRouterConfig";
+
+export type AutoRouterTestMode = "chat" | "embedding";
+
+export interface AutoRouterTestTarget {
+  labels: string[];
+  modelGroup: string;
+  mode: AutoRouterTestMode;
+}
+
+export interface BuildAutoRouterTestTargetsParams {
+  tiers: ComplexityTiers;
+  semanticMatchingEnabled: boolean;
+  embeddingModel: string | undefined;
+}
+
+const TIER_ORDER: (keyof ComplexityTiers)[] = ["SIMPLE", "MEDIUM", "COMPLEX", "REASONING"];
+
+export const buildAutoRouterTestTargets = ({
+  tiers,
+  semanticMatchingEnabled,
+  embeddingModel,
+}: BuildAutoRouterTestTargetsParams): AutoRouterTestTarget[] => {
+  const groupedByModel = TIER_ORDER.reduce<Record<string, string[]>>((acc, tier) => {
+    const modelGroup = tiers[tier]?.trim();
+    if (!modelGroup) return acc;
+    return { ...acc, [modelGroup]: [...(acc[modelGroup] ?? []), tier] };
+  }, {});
+
+  const tierTargets: AutoRouterTestTarget[] = Object.entries(groupedByModel).map(([modelGroup, labels]) => ({
+    labels,
+    modelGroup,
+    mode: "chat" as const,
+  }));
+
+  const embeddingTarget: AutoRouterTestTarget[] =
+    semanticMatchingEnabled && embeddingModel?.trim()
+      ? [{ labels: ["Embedding"], modelGroup: embeddingModel.trim(), mode: "embedding" as const }]
+      : [];
+
+  return [...tierTargets, ...embeddingTarget];
+};

--- a/ui/litellm-dashboard/src/components/networking.test.ts
+++ b/ui/litellm-dashboard/src/components/networking.test.ts
@@ -514,3 +514,19 @@ describe("sessionSpendLogsCall", () => {
     expect(parsed.searchParams.get("page_size")).toBe("100");
   });
 });
+
+describe("buildModelGroupTestRequest", () => {
+  it("builds a chat completion request with NO max_tokens (reasoning models 400 on a tiny cap)", () => {
+    const { path, body } = Networking.buildModelGroupTestRequest("o3", "chat");
+    expect(path).toBe("/v1/chat/completions");
+    expect(body).toEqual({ model: "o3", messages: [{ role: "user", content: "test from litellm" }] });
+    expect(body).not.toHaveProperty("max_tokens");
+    expect(body).not.toHaveProperty("max_completion_tokens");
+  });
+
+  it("builds an embeddings request for embedding mode", () => {
+    const { path, body } = Networking.buildModelGroupTestRequest("text-embedding-3-small", "embedding");
+    expect(path).toBe("/v1/embeddings");
+    expect(body).toEqual({ model: "text-embedding-3-small", input: "test from litellm" });
+  });
+});

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -2324,17 +2324,29 @@ export type ModelGroupConnectionResult = { status: "success" } | { status: "erro
  * resolves the group, credentials, and provider. Used by the auto-router Test
  * Connection to probe each tier's model group and the embedding model.
  */
+/**
+ * Build the minimal request that probes a model group by public name. No
+ * max_tokens: reasoning models (o1/o3/...) reject a tiny cap with "max_tokens
+ * reached" because reasoning tokens count against it, which would show a false
+ * failure for a reachable tier.
+ */
+export const buildModelGroupTestRequest = (
+  modelGroup: string,
+  mode: "chat" | "embedding",
+): { path: string; body: Record<string, unknown> } =>
+  mode === "embedding"
+    ? { path: "/v1/embeddings", body: { model: modelGroup, input: "test from litellm" } }
+    : {
+        path: "/v1/chat/completions",
+        body: { model: modelGroup, messages: [{ role: "user", content: "test from litellm" }] },
+      };
+
 export const testModelGroupConnection = async (
   accessToken: string,
   modelGroup: string,
   mode: "chat" | "embedding",
 ): Promise<ModelGroupConnectionResult> => {
-  const path = mode === "embedding" ? "/v1/embeddings" : "/v1/chat/completions";
-  const body =
-    mode === "embedding"
-      ? { model: modelGroup, input: "test from litellm" }
-      : { model: modelGroup, messages: [{ role: "user", content: "test from litellm" }], max_tokens: 1 };
-
+  const { path, body } = buildModelGroupTestRequest(modelGroup, mode);
   try {
     await apiClient.post(path, { accessToken, body });
     return { status: "success" };

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -2315,6 +2315,34 @@ export const testConnectionRequest = async (
   }
 };
 
+export type ModelGroupConnectionResult = { status: "success" } | { status: "error"; error: string };
+
+/**
+ * Test an existing model group by routing a minimal request through the proxy
+ * exactly as production would (by public model_group name). Unlike
+ * /health/test_connection, this needs no litellm_params resolution: the router
+ * resolves the group, credentials, and provider. Used by the auto-router Test
+ * Connection to probe each tier's model group and the embedding model.
+ */
+export const testModelGroupConnection = async (
+  accessToken: string,
+  modelGroup: string,
+  mode: "chat" | "embedding",
+): Promise<ModelGroupConnectionResult> => {
+  const path = mode === "embedding" ? "/v1/embeddings" : "/v1/chat/completions";
+  const body =
+    mode === "embedding"
+      ? { model: modelGroup, input: "test from litellm" }
+      : { model: modelGroup, messages: [{ role: "user", content: "test from litellm" }], max_tokens: 1 };
+
+  try {
+    await apiClient.post(path, { accessToken, body });
+    return { status: "success" };
+  } catch (error) {
+    return { status: "error", error: error instanceof Error ? error.message : String(error) };
+  }
+};
+
 // ... existing code ...
 export const keyInfoV1Call = async (accessToken: string, key: string) => {
   try {


### PR DESCRIPTION
## Relevant issues

Fixes #31590

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

<img width="1667" height="1191" alt="Screenshot 2026-07-11 at 5 34 44 PM" src="https://github.com/user-attachments/assets/93802e1f-4d9c-4631-919e-b25bc786325c" />

<img width="1900" height="1210" alt="Screenshot 2026-07-11 at 5 35 45 PM" src="https://github.com/user-attachments/assets/4323f915-6ff7-45a9-b8a0-c1ef6af84049" />

Captured at commit ddc13b331a

Context: when we consolidated the auto-router UI in #32859 the Test Connection button was removed, because the shared `prepareModelAddRequest` helper returns an empty array for an auto router (it has no `model_mappings`) and the caller crashed destructuring `result[0].litellmParamsObj`. That is the crash reported in #31590 and the open PR #31794.

Two approaches were considered. #31794, and my first cut, routed the test through `/health/test_connection`. That does not actually work for an auto router: the endpoint merges `{...configParams, ...requestParams}`, so passing the public `model_group` name as the request model overrides the resolved provider model and every tier fails with \"LLM Provider NOT provided\". The frontend only has the public group name, not the underlying `litellm_params`, so it cannot build the request that endpoint needs.

So this tests each model group the way production actually routes it: a minimal request to `/v1/chat/completions` (or `/v1/embeddings` for the embedding model) by public group name, through the shared `apiClient`. The router resolves the group, credentials, and provider itself, so a green row means the tier is genuinely reachable and a red row shows the real provider error.

Verified live against real APIs at commit ddc13b331a:

```
# embedding tier -> 200 (real Voyage call)
curl -s -X POST http://localhost:4000/v1/embeddings \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"voyage-4-large","input":"test from litellm"}'
# -> {"data":[{"embedding":[... 1024 dims ...]}], ...}

# chat tier -> real provider error surfaces per-row (here an expired key)
curl -s -X POST http://localhost:4000/v1/chat/completions \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"anthropic-sonnet-4-5","messages":[{"role":"user","content":"test from litellm"}],"max_tokens":1}'
# -> {"error":{"message":"litellm.AuthenticationError: ..."}}
```

UI flow (screenshots to follow): http://localhost:3000 -> Models & Endpoints -> Add Model -> Auto Router tab -> keep \"Auto-Router v2\" selected, set a name, assign a model group to each complexity tier, optionally enable Semantic Keyword Matching with an embedding model, then click \"Test Connection\". The result modal shows one row per distinct tier model group (tiers sharing a group collapse into one) plus an Embedding row, each green on success or red with the provider error, updating progressively as each probe returns.

## Type

🆕 New Feature
🐛 Bug Fix

## Changes

New pure helper `build_auto_router_test_targets.ts` turns the configured tiers plus the optional embedding model into a deduped list of probe targets, so tiers sharing a model group cost one call instead of several; a `satisfies Record<keyof ComplexityTiers, null>` guard makes adding a tier without listing it a compile error. New `testModelGroupConnection` in `networking.tsx` sends the minimal chat/embedding request through the shared `apiClient`. New `auto_router_connection_test.tsx` runs one probe per target and renders per-target status, updating each row as it settles. `add_auto_router_tab.tsx` gets the Test Connection button (recommended router only) and a results modal that remounts per run via a `key`. Backend is unchanged.

Tests cover the target builder (dedup, empty-tier dropping, embedding gating) and the component (one request per target with the right mode, success and provider-error rendering, litellm-prefix stripping). The component never calls `prepareModelAddRequest`, which is the guard against the #31590 regression.

Supersedes #31794