### PR TITLE
fix(completion): forward aws credential kwargs into litellm_params so the responses bridge keeps WIF auth

### DIFF
--- a/litellm/litellm_core_utils/get_litellm_params.py
+++ b/litellm/litellm_core_utils/get_litellm_params.py
@@ -2,26 +2,8 @@ from typing import Optional
 
 from litellm.llms.openai.data_residency import infer_openai_data_residency
 
-# Pre-define optional kwargs keys as frozenset for O(1) lookups
-# These are extracted from kwargs only if present, avoiding unnecessary .get() calls
-OPTIONAL_KWARGS_KEYS = frozenset(
+AWS_CREDENTIAL_KWARGS_KEYS = frozenset(
     {
-        "azure_ad_token",
-        "tenant_id",
-        "client_id",
-        "client_secret",
-        "azure_username",
-        "azure_password",
-        "azure_scope",
-        "timeout",
-        "gcs_bucket_name",
-        "bucket_name",
-        "vertex_credentials",
-        "vertex_project",
-        "vertex_location",
-        "vertex_ai_project",
-        "vertex_ai_location",
-        "vertex_ai_credentials",
         "aws_region_name",
         "aws_access_key_id",
         "aws_secret_access_key",
@@ -34,12 +16,38 @@ OPTIONAL_KWARGS_KEYS = frozenset(
         "aws_external_id",
         "aws_bedrock_runtime_endpoint",
         "aws_bedrock_project_id",
-        "tpm",
-        "rpm",
-        "itpm",
-        "otpm",
-        "use_xai_oauth",
     }
+)
+
+# Pre-define optional kwargs keys as frozenset for O(1) lookups
+# These are extracted from kwargs only if present, avoiding unnecessary .get() calls
+OPTIONAL_KWARGS_KEYS = (
+    frozenset(
+        {
+            "azure_ad_token",
+            "tenant_id",
+            "client_id",
+            "client_secret",
+            "azure_username",
+            "azure_password",
+            "azure_scope",
+            "timeout",
+            "gcs_bucket_name",
+            "bucket_name",
+            "vertex_credentials",
+            "vertex_project",
+            "vertex_location",
+            "vertex_ai_project",
+            "vertex_ai_location",
+            "vertex_ai_credentials",
+            "tpm",
+            "rpm",
+            "itpm",
+            "otpm",
+            "use_xai_oauth",
+        }
+    )
+    | AWS_CREDENTIAL_KWARGS_KEYS
 )
 
 # Backward-compatible alias for existing imports/tests.

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -877,6 +877,15 @@ class BaseAWSLLM:
                     "Resource": "*",
                     "Condition": {"Bool": {"aws:SecureTransport": "true"}},
                 },
+                {
+                    "Sid": "BedrockMantleLiteLLM",
+                    "Effect": "Allow",
+                    "Action": [
+                        "bedrock-mantle:CreateInference",
+                    ],
+                    "Resource": "*",
+                    "Condition": {"Bool": {"aws:SecureTransport": "true"}},
+                },
             ],
         }
         assume_role_params = {

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -92,7 +92,10 @@ from litellm.litellm_core_utils.completion_timeout import CompletionTimeout
 from litellm.litellm_core_utils.request_timeout_resolver import (
     get_configured_request_timeout,
 )
-from litellm.litellm_core_utils.get_litellm_params import OPTIONAL_KWARGS_KEYS
+from litellm.litellm_core_utils.get_litellm_params import (
+    AWS_CREDENTIAL_KWARGS_KEYS,
+    OPTIONAL_KWARGS_KEYS,
+)
 from litellm.litellm_core_utils.dd_tracing import tracer
 from litellm.litellm_core_utils.get_provider_specific_headers import (
     ProviderSpecificHeaderUtils,
@@ -5322,7 +5325,7 @@ def completion(  # type: ignore
             tpm=kwargs.get("tpm"),
             rpm=kwargs.get("rpm"),
             use_xai_oauth=kwargs.get("use_xai_oauth", False),
-            aws_bedrock_project_id=kwargs.get("aws_bedrock_project_id"),
+            **{key: kwargs[key] for key in AWS_CREDENTIAL_KWARGS_KEYS if key in kwargs},
         )
         cast(LiteLLMLoggingObj, logging).update_environment_variables(
             model=model,

--- a/tests/test_litellm/llms/bedrock/test_web_identity_session_policy.py
+++ b/tests/test_litellm/llms/bedrock/test_web_identity_session_policy.py
@@ -158,6 +158,54 @@ class TestClaudePlatformActionsCovered:
         )
 
 
+class TestBedrockMantleActionsCovered:
+    """LIT-3859: bedrock_mantle inference authorizes against the
+    ``bedrock-mantle`` action namespace, so the session-policy ceiling
+    must include it or every Mantle request via OIDC/WIF auth denies
+    with "no session policy allows the bedrock-mantle:CreateInference
+    action" even when the role's identity policy grants it."""
+
+    def test_bedrock_mantle_create_inference_present(self):
+        policy = _captured_policy()
+        all_actions: set = set()
+        for stmt in policy["Statement"]:
+            stmt_actions = stmt.get("Action")
+            if isinstance(stmt_actions, str):
+                all_actions.add(stmt_actions)
+            elif isinstance(stmt_actions, list):
+                all_actions.update(stmt_actions)
+        assert "bedrock-mantle:CreateInference" in all_actions, (
+            "bedrock-mantle:CreateInference missing from session policy — "
+            "bedrock_mantle/* requests will 403 on OIDC/WIF auth"
+        )
+
+    def test_bedrock_mantle_statement_allows(self):
+        policy = _captured_policy()
+        stmt = _statement_by_sid(policy, "BedrockMantleLiteLLM")
+        assert stmt["Effect"] == "Allow"
+        assert stmt["Resource"] == "*"
+
+    def test_no_bedrock_mantle_wildcard(self):
+        policy = _captured_policy()
+        stmt = _statement_by_sid(policy, "BedrockMantleLiteLLM")
+        actions = stmt["Action"]
+        if isinstance(actions, str):
+            actions = [actions]
+        assert "bedrock-mantle:*" not in actions, (
+            "session policy must not grant bedrock-mantle:* — "
+            "the ceiling should match the documented action set"
+        )
+
+    def test_bedrock_mantle_statement_carries_secure_transport_condition(self):
+        policy = _captured_policy()
+        stmt = _statement_by_sid(policy, "BedrockMantleLiteLLM")
+        cond = stmt.get("Condition") or {}
+        assert cond.get("Bool", {}).get("aws:SecureTransport") == "true", (
+            "BedrockMantleLiteLLM must require aws:SecureTransport=true "
+            "to keep parity with the bedrock statement"
+        )
+
+
 def _make_jwt(payload: dict) -> str:
     def _segment(data: dict) -> str:
         return base64.urlsafe_b64encode(json.dumps(data).encode()).rstrip(b"=").decode()

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -2084,8 +2084,24 @@ def test_stream_chunk_builder_text_completion_combines_text_and_usage():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "aws_credential_kwargs",
+    [
+        {
+            "aws_session_name": "litellm-gcp",
+            "aws_role_name": "arn:aws:iam::123456789012:role/litellm-bedrock-role",
+            "aws_web_identity_token": "oidc/google/108963886734710037768",
+        },
+        {
+            "aws_access_key_id": "AKIASTATICKEYFORTEST",
+            "aws_secret_access_key": "static-secret-key",
+            "aws_session_token": "static-session-token",
+        },
+    ],
+    ids=["web_identity", "static_keys"],
+)
 async def test_acompletion_forwards_aws_credentials_through_responses_bridge(
-    respx_mock: respx.MockRouter, monkeypatch
+    respx_mock: respx.MockRouter, monkeypatch, aws_credential_kwargs: dict
 ):
     from botocore.credentials import Credentials
 
@@ -2126,17 +2142,15 @@ async def test_acompletion_forwards_aws_credentials_through_responses_bridge(
             messages=[{"role": "user", "content": "hi"}],
             api_base="https://bedrock-mantle.us-east-2.api.aws/v1",
             aws_region_name="us-east-2",
-            aws_session_name="litellm-gcp",
-            aws_role_name="arn:aws:iam::123456789012:role/litellm-bedrock-role",
-            aws_web_identity_token="oidc/google/108963886734710037768",
             num_retries=0,
+            **aws_credential_kwargs,
         )
 
         assert response.choices[0].message.content == "ok"
         credential_kwargs = get_credentials_mock.call_args.kwargs
-        assert credential_kwargs["aws_role_name"] == "arn:aws:iam::123456789012:role/litellm-bedrock-role"
-        assert credential_kwargs["aws_web_identity_token"] == "oidc/google/108963886734710037768"
-        assert credential_kwargs["aws_session_name"] == "litellm-gcp"
+        assert credential_kwargs["aws_region_name"] == "us-east-2"
+        for key, value in aws_credential_kwargs.items():
+            assert credential_kwargs[key] == value
         authorization = respx_mock.calls.last.request.headers["Authorization"]
         assert authorization.startswith("AWS4-HMAC-SHA256")
         assert "fake-key" in authorization

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -2081,3 +2081,65 @@ def test_stream_chunk_builder_text_completion_combines_text_and_usage():
     assert response.usage.prompt_tokens > 0
     assert response.usage.completion_tokens > 0
     assert response.usage.total_tokens == response.usage.prompt_tokens + response.usage.completion_tokens
+
+
+@pytest.mark.asyncio
+async def test_acompletion_forwards_aws_credentials_through_responses_bridge(
+    respx_mock: respx.MockRouter, monkeypatch
+):
+    from botocore.credentials import Credentials
+
+    from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+
+    original_disable_aiohttp = litellm.disable_aiohttp_transport
+    try:
+        litellm.disable_aiohttp_transport = True
+        monkeypatch.setenv("DISABLE_AIOHTTP_TRANSPORT", "True")
+        litellm.in_memory_llm_clients_cache.flush_cache()
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        monkeypatch.delenv("BEDROCK_MANTLE_API_KEY", raising=False)
+
+        get_credentials_mock = MagicMock(return_value=Credentials("fake-key", "fake-secret"))
+        monkeypatch.setattr(BaseAWSLLM, "get_credentials", get_credentials_mock)
+
+        respx_mock.post("https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses").respond(
+            json={
+                "id": "resp_123",
+                "object": "response",
+                "created_at": 1760144904,
+                "status": "completed",
+                "model": "openai.gpt-5.4",
+                "output": [
+                    {
+                        "type": "message",
+                        "id": "msg_1",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [{"type": "output_text", "text": "ok", "annotations": []}],
+                    }
+                ],
+            }
+        )
+
+        response = await litellm.acompletion(
+            model="bedrock_mantle/openai.gpt-5.4",
+            messages=[{"role": "user", "content": "hi"}],
+            api_base="https://bedrock-mantle.us-east-2.api.aws/v1",
+            aws_region_name="us-east-2",
+            aws_session_name="litellm-gcp",
+            aws_role_name="arn:aws:iam::123456789012:role/litellm-bedrock-role",
+            aws_web_identity_token="oidc/google/108963886734710037768",
+            num_retries=0,
+        )
+
+        assert response.choices[0].message.content == "ok"
+        credential_kwargs = get_credentials_mock.call_args.kwargs
+        assert credential_kwargs["aws_role_name"] == "arn:aws:iam::123456789012:role/litellm-bedrock-role"
+        assert credential_kwargs["aws_web_identity_token"] == "oidc/google/108963886734710037768"
+        assert credential_kwargs["aws_session_name"] == "litellm-gcp"
+        authorization = respx_mock.calls.last.request.headers["Authorization"]
+        assert authorization.startswith("AWS4-HMAC-SHA256")
+        assert "fake-key" in authorization
+    finally:
+        litellm.disable_aiohttp_transport = original_disable_aiohttp
+        litellm.in_memory_llm_clients_cache.flush_cache()


### PR DESCRIPTION
## Relevant issues

Pylon #5084

## Linear ticket

Resolves LIT-3859

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy with two `bedrock_mantle/openai.gpt-5.5` deployments (a responses-only model, so `/v1/chat/completions` goes through the chat -> Responses API bridge). One deployment uses web identity federation like the reporting customer's config, backed by a real Google-issued OIDC token and a real IAM role (`accounts.google.com` OIDC provider + role in a dev account, trust policy locked to a single Google account); the other uses static keys. The proxy process is scrubbed of every ambient AWS credential source (no `AWS_ACCESS_KEY_ID`/`AWS_SESSION_TOKEN`/`AWS_BEARER_TOKEN_BEDROCK`/`BEDROCK_MANTLE_API_KEY` in env, `AWS_CONFIG_FILE=/dev/null`, `AWS_SHARED_CREDENTIALS_FILE=/dev/null`, `AWS_EC2_METADATA_DISABLED=true`), so the deployment `litellm_params` are the only possible credential source

```yaml
model_list:
  - model_name: mantle-gpt-5.5-wif
    litellm_params:
      model: bedrock_mantle/openai.gpt-5.5
      api_base: https://bedrock-mantle.us-east-2.api.aws/v1
      aws_region_name: us-east-2
      aws_session_name: litellm-gcp
      aws_role_name: arn:aws:iam::439158074652:role/litellm-wif-proof-role
      aws_web_identity_token: oidc/file//secrets/wif-creds/token
  - model_name: mantle-gpt-5.5-keys
    litellm_params:
      model: bedrock_mantle/openai.gpt-5.5
      api_base: https://bedrock-mantle.us-east-2.api.aws/v1
      aws_region_name: us-east-2
      aws_access_key_id: os.environ/MANTLE_AWS_ACCESS_KEY_ID
      aws_secret_access_key: os.environ/MANTLE_AWS_SECRET_ACCESS_KEY
      aws_session_token: os.environ/MANTLE_AWS_SESSION_TOKEN

general_settings:
  master_key: sk-1234
```

```bash
gcloud auth print-identity-token > /secrets/wif-creds/token
LITELLM_OIDC_ALLOWED_CREDENTIAL_DIRS=/secrets/wif-creds \
  python litellm/proxy/proxy_cli.py --config lit3859_proof.yaml --port 4020

curl -sS http://localhost:4020/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Bearer sk-1234' \
  -d '{"model": "mantle-gpt-5.5-wif", "messages": [{"role": "user", "content": "Reply with exactly: hello from bedrock mantle via wif"}]}'
```

**Before**, captured at f2fb6b8e73 (the commit this branch is based on), both deployments fail with the exact error from the ticket even though the credentials are sitting in the config:

```json
{
    "error": {
        "message": "litellm.APIConnectionError: Bedrock Mantle auth failed: no Bearer token and no usable AWS credentials. Set BEDROCK_MANTLE_API_KEY (or AWS_BEARER_TOKEN_BEDROCK) or pass api_key for Bearer auth, or provide AWS credentials (IAM role / access key / profile / web identity) for SigV4.\nTraceback (most recent call last):\n  File \".../litellm/llms/bedrock_mantle/common_utils.py\", line 86, in sign_request\n    return self._aws_signer._sign_request(\n  File \".../litellm/llms/bedrock/base_aws_llm.py\", line 1528, in _sign_request\n    sigv4.add_auth(request)\n  File \".../botocore/auth.py\", line 429, in add_auth\n    raise NoCredentialsError()\nbotocore.exceptions.NoCredentialsError: Unable to locate credentials\n...",
        "code": "500"
    }
}
```

**After the first fix**, captured at e0463a38ff, the static-keys deployment returns a real completion from the live us-east-2 Bedrock Mantle endpoint (real tokens billed, no mocks):

```json
{
    "id": "chatcmpl-585b4284-0f82-4bb1-9fd7-ab6b282d8cea",
    "created": 1783811850,
    "model": "mantle-gpt-5.5-keys",
    "object": "chat.completion",
    "choices": [
        {
            "finish_reason": "stop",
            "index": 0,
            "message": {
                "content": "hello from bedrock mantle",
                "role": "assistant"
            }
        }
    ],
    "usage": {
        "completion_tokens": 20,
        "prompt_tokens": 15,
        "total_tokens": 35
    }
}
```

but the WIF deployment, whose credentials now do reach STS (real `AssumeRoleWithWebIdentity` succeeds), surfaced a second bug at the same commit; the hardcoded session policy sent with the STS call does not cover the `bedrock-mantle` action namespace, so the request is denied regardless of what the role's identity policy grants:

```json
{
    "error": {
        "message": "litellm.APIConnectionError: Bedrock_mantleException - {\"error\":{\"code\":\"access_denied\",\"message\":\"User: arn:aws:sts::439158074652:assumed-role/litellm-wif-proof-role/litellm-gcp is not authorized to perform: bedrock-mantle:CreateInference on resource: arn:aws:bedrock-mantle:us-east-2:439158074652:project/default because no session policy allows the bedrock-mantle:CreateInference action\",\"param\":null,\"type\":\"permission_denied_error\"}}...",
        "code": "500"
    }
}
```

**After both fixes**, captured at 201730efe5, the WIF deployment completes the full chain for real (Google OIDC token from file -> STS `AssumeRoleWithWebIdentity` -> SigV4 -> live Mantle endpoint):

```json
{
    "id": "chatcmpl-dac3820f-55eb-411d-afed-48f9c0961f23",
    "created": 1783812806,
    "model": "mantle-gpt-5.5-wif",
    "object": "chat.completion",
    "choices": [
        {
            "finish_reason": "stop",
            "index": 0,
            "message": {
                "content": "hello from bedrock mantle via wif",
                "role": "assistant"
            }
        }
    ],
    "usage": {
        "completion_tokens": 23,
        "prompt_tokens": 18,
        "total_tokens": 41
    }
}
```

Streaming through the same WIF deployment also works:

```
data: {"id":"chatcmpl-41209fb1-951c-46a2-95b3-409d5113d78f","object":"chat.completion.chunk","created":1783812819,"model":"mantle-gpt-5.5-wif","choices":[{"index":0,"delta":{"role":"assistant","content":"stream"}}]}
data: {"id":"chatcmpl-d104dbf4-1093-4f60-9573-fe00c7aeaa8e","object":"chat.completion.chunk","created":1783812819,"model":"mantle-gpt-5.5-wif","choices":[{"index":0,"delta":{"content":"ed"}}]}
...
```

**Customer-identical rig**: the runs above fed the Google OIDC token via `oidc/file//`. To remove even that delta, the same before/after was repeated on a fresh GCE instance (Debian 12, service account attached), where the config uses the customer's exact token style (`oidc/google/<service-account-unique-id>`) so litellm fetches the identity token from the GCP metadata server itself; no token file, no AWS credentials anywhere on the box

```yaml
      aws_session_name: litellm-gcp
      aws_role_name: arn:aws:iam::439158074652:role/litellm-wif-proof-role
      aws_web_identity_token: oidc/google/116028322316888866787
```

Before, captured at f2fb6b8e73 on the instance, the identical customer error:

```
litellm.APIConnectionError: Bedrock Mantle auth failed: no Bearer token and no usable AWS credentials. Set BEDROCK_MANTLE_API_KEY (or AWS_BEARER_TOKEN_BEDROCK) or pass api_key for Bearer auth, or provide AWS credentials (IAM role / access key / profile / web identity) for SigV4.
```

After, captured at cc27528d4f (branch head) on the instance, a real completion over the full metadata-server -> STS -> SigV4 chain, streaming included:

```json
{"id":"chatcmpl-b44f6951-8574-4ba4-8c9d-ffc20897b82e","created":1783815213,"model":"mantle-gpt-5.5-wif","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"hello from bedrock mantle via wif","role":"assistant"}}],"usage":{"completion_tokens":24,"prompt_tokens":18,"total_tokens":42}}
```

## Type

🐛 Bug Fix

## Changes

Two bugs, both required for WIF (and any other `aws_*` credential style) to work on `bedrock_mantle` models reached via chat completions

First: chat completions requests to responses-only `bedrock_mantle` models (`mode: responses` in the price map, e.g. `openai.gpt-5.4`/`openai.gpt-5.5`) are routed through the chat -> Responses API bridge (`litellm/completion_extras/litellm_responses_transformation`). The bridge's internal `aresponses` call takes its credentials from `litellm_params`, which `completion()` builds via `get_litellm_params`; that call's explicit argument list forwarded `aws_bedrock_project_id` but none of the other `aws_*` credential kwargs (`aws_role_name`, `aws_web_identity_token`, `aws_session_name`, `aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `aws_profile_name`, `aws_external_id`, `aws_sts_endpoint`, ...). SigV4 signing then fell back to botocore's default chain and raised `NoCredentialsError` ("Bedrock Mantle auth failed: no Bearer token and no usable AWS credentials") even though the deployment config carried valid credentials. Direct `/v1/responses` requests never hit this path, which is why the same deployment worked there. The fix defines `AWS_CREDENTIAL_KWARGS_KEYS` in `litellm/litellm_core_utils/get_litellm_params.py` (folded into the existing `OPTIONAL_KWARGS_KEYS`) and has `completion()` spread exactly those keys from `kwargs` into its `get_litellm_params` call. A side effect is that `aws_bedrock_project_id` is now only present in `litellm_params` when the caller passed it, instead of always being present as `None`; all consumers read it with `.get()` or pydantic attribute access, so this is safe

Second: `_auth_with_web_identity_token` attaches an inline session policy to `AssumeRoleWithWebIdentity`, which acts as a permission ceiling on the resulting credentials. It covered `bedrock:*` invoke actions and the `aws-external-anthropic:*` namespace (added for claude_platform in #30200) but not `bedrock-mantle:*`, so once credentials were forwarded, every Mantle request over OIDC/WIF auth still failed with "no session policy allows the bedrock-mantle:CreateInference action" no matter how permissive the role's identity policy was. The fix adds a `BedrockMantleLiteLLM` statement allowing `bedrock-mantle:CreateInference` (the only action the provider's chat and responses surfaces need), with the same `aws:SecureTransport` condition as the existing statements. Static-credential and IRSA paths were unaffected since they do not attach this session policy

The ticket proposed switching `dict(litellm_params)` to `model_dump()` in `async_response_api_handler`; I tested that first and it does not address the bug, since pydantic >= 2.10 iteration already includes `__pydantic_extra__` and the params are dropped earlier, in `completion()`

Regression tests: `test_acompletion_forwards_aws_credentials_through_responses_bridge` in `tests/test_litellm/test_main.py` drives `acompletion` on a responses-only Mantle model, parametrized over both credential styles (role/web-identity/session and static key/secret/session-token), and asserts each kwarg reaches `get_credentials` and that the outgoing request is SigV4 signed; `TestBedrockMantleActionsCovered` in `tests/test_litellm/llms/bedrock/test_web_identity_session_policy.py` asserts the session policy grants `bedrock-mantle:CreateInference` with the hardening conditions intact. Each fails without its corresponding fix and passes with it (verified by mutating `AWS_CREDENTIAL_KWARGS_KEYS` and the session policy)
