### PR TITLE
chore: bump litellm-proxy-extras 0.4.75 -> 0.4.76

### DIFF
--- a/litellm-proxy-extras/pyproject.toml
+++ b/litellm-proxy-extras/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm-proxy-extras"
-version = "0.4.75"
+version = "0.4.76"
 description = "Additional files for the LiteLLM Proxy. Reduces the size of the main litellm package."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -26,7 +26,7 @@ required-version = ">=0.10.9"
 module-root = ""
 
 [tool.commitizen]
-version = "0.4.75"
+version = "0.4.76"
 version_files = [
     "pyproject.toml:^version",
     "../pyproject.toml:litellm-proxy-extras==",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ proxy = [
     "azure-identity>=1.25.2,<2.0",
     "azure-storage-blob>=12.28.0,<13.0",
     "mcp>=1.26.0,<2.0",
-    "litellm-proxy-extras==0.4.75",
+    "litellm-proxy-extras==0.4.76",
     "litellm-enterprise==0.1.49",
     "RestrictedPython>=8.1,<9.0",
     "rich>=13.9.4,<14.0",

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-08T17:10:15.525149Z"
+exclude-newer = "2026-07-08T23:20:11.959202Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3661,7 +3661,7 @@ source = { editable = "enterprise" }
 
 [[package]]
 name = "litellm-proxy-extras"
-version = "0.4.75"
+version = "0.4.76"
 source = { editable = "litellm-proxy-extras" }
 
 [[package]]


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Not applicable. A version bump has no runtime behavior to demonstrate; the change is limited to package version strings and the refreshed lock

## Type

🚄 Infrastructure

## Changes

Routine pre-release version bump ahead of promoting `litellm_internal_staging` into `main` for this week's release candidate. The `litellm-proxy-extras` folder changed since the last release while its version still matched `main`, so it gets a PATCH bump from 0.4.75 to 0.4.76. That updates `litellm-proxy-extras/pyproject.toml`, the `litellm-proxy-extras==` pin in the root `pyproject.toml`, and `uv.lock`

`enterprise` is unchanged from `main`, and the root `litellm` package stays on the 1.93.0 line (this promotion cuts that line's rc rather than opening a new minor line), so neither is bumped. The only extra line in the `uv.lock` diff is the rolling `exclude-newer` window moving forward, which is expected; `uv lock` reported `litellm-proxy-extras` as the sole updated package
