### PR TITLE
docs(github): add QA runbook section to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -44,4 +44,18 @@ If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slac
 
 ## QA runbook
 
-<!-- For PRs that change behavior (features, fixes, tests): list the manual steps a reviewer can follow to QA each change by hand against a live proxy, mapping 1:1 to what the automated proof asserts. One "- [ ]" checklist per test or behavior, each item a concrete action (route, request body, expected response). Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for examples. Delete this section if there is nothing to QA by hand -->
+<!-- Only needed when your PR edits tests/e2e; delete this section otherwise
+
+For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one "- [ ]" checklist per test, each item a concrete action (route, request body, expected response). Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples
+
+Example checklists:
+
+### test_key_rpm_limit_blocks_third_request
+- [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
+- [ ] Send three /v1/chat/completions requests with that key inside one minute
+- [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
+
+### test_model_create_appears_in_ui
+- [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
+- [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -46,7 +46,7 @@ If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slac
 
 <!-- Only needed when your PR edits tests/e2e; delete this section otherwise
 
-For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response). Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples
+For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples
 
 Example checklists:
 
@@ -54,8 +54,14 @@ Example checklists:
   - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
   - [ ] Send three /v1/chat/completions requests with that key inside one minute
   - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
+  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
 
 - tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
   - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
   - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
+  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
 -->
+
+### Final Attestation
+
+- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -46,16 +46,16 @@ If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slac
 
 <!-- Only needed when your PR edits tests/e2e; delete this section otherwise
 
-For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one "- [ ]" checklist per test, each item a concrete action (route, request body, expected response). Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples
+For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response). Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples
 
 Example checklists:
 
-### test_key_rpm_limit_blocks_third_request
-- [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
-- [ ] Send three /v1/chat/completions requests with that key inside one minute
-- [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
+- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
+  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
+  - [ ] Send three /v1/chat/completions requests with that key inside one minute
+  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
 
-### test_model_create_appears_in_ui
-- [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
-- [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
+- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
+  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
+  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -41,3 +41,7 @@ If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slac
 ✅ Test
 
 ## Changes
+
+## QA runbook
+
+<!-- For PRs that change behavior (features, fixes, tests): list the manual steps a reviewer can follow to QA each change by hand against a live proxy, mapping 1:1 to what the automated proof asserts. One "- [ ]" checklist per test or behavior, each item a concrete action (route, request body, expected response). Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for examples. Delete this section if there is nothing to QA by hand -->


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This PR only touches `.github/pull_request_template.md`, so there is no runtime surface to exercise and nothing to run against a live proxy. The proof is the rendered template section itself, pasted verbatim below as captured at commit 0008d96af4d969cc497d829f1a635f7cd3a7df5c

```markdown
## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
```

## Type

📖 Documentation

## Changes

PRs #32914 and #32963 introduced a "QA runbook" section in their descriptions: a hand-runnable checklist that maps 1:1 to what the automated proof asserts, so a reviewer can QA each change manually against a live proxy. This makes that section a standard part of the PR template so authors are prompted for it, with an HTML comment spelling out what to include and pointing at those two PRs as examples

The guidance comment scopes the section to PRs that edit tests/e2e and carries two short example checklists matching the shape those runbooks use, a top-level bullet with the test's pytest node id and what it proves in plain words followed by nested concrete steps. Each example checklist ends with a sanity-check step asking whether the test is worth adding and asserts something specific rather than hand-wavey or flaky, and a rendered Final Attestation subsection has the author check that the tests cover the right things, including edge cases, so regressions in the respective real-world customer use-cases are not possible after the PR. PRs outside that scope delete the section, the same way the template's other guidance comments are removed once filled in
