### PR TITLE
fix(utils): report missing ZAI_API_KEY in validate_environment for zai models

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -6090,6 +6090,11 @@ def validate_environment(
                 keys_in_environment = True
             else:
                 missing_keys.append("MOONSHOT_API_KEY")
+        elif custom_llm_provider == "zai":
+            if "ZAI_API_KEY" in os.environ:
+                keys_in_environment = True
+            else:
+                missing_keys.append("ZAI_API_KEY")
     else:
         ## openai - chatcompletion + text completion
         if (

--- a/tests/litellm_utils_tests/test_utils.py
+++ b/tests/litellm_utils_tests/test_utils.py
@@ -447,6 +447,20 @@ def test_validate_environment_ollama_failed():
         assert kv["missing_keys"] == ["OLLAMA_API_BASE"]
 
 
+@mock.patch.dict(os.environ, {}, clear=True)
+def test_validate_environment_zai_failed():
+    kv = validate_environment(model="zai/glm-5.1")
+    assert not kv["keys_in_environment"]
+    assert kv["missing_keys"] == ["ZAI_API_KEY"]
+
+
+@mock.patch.dict(os.environ, {"ZAI_API_KEY": "sk-my-test-key"}, clear=True)
+def test_validate_environment_zai():
+    kv = validate_environment(model="zai/glm-5.1")
+    assert kv["keys_in_environment"]
+    assert kv["missing_keys"] == []
+
+
 def test_function_to_dict():
     print("testing function to dict for get current weather")
 


### PR DESCRIPTION
## Relevant issues

Fixes #32962

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Same command before and after, with no `ZAI_API_KEY` in the environment:

```bash
env -u ZAI_API_KEY python -c 'import litellm; print(litellm.validate_environment(model="zai/glm-5.1"))'
```

Before (base `9e7ba6575`):

```
{'keys_in_environment': True, 'missing_keys': []}
```

After (this branch):

```
{'keys_in_environment': False, 'missing_keys': ['ZAI_API_KEY']}
```

And with `ZAI_API_KEY` set, this branch still reports `{'keys_in_environment': True, 'missing_keys': []}`

## Type

🐛 Bug Fix

## Changes

`validate_environment` resolves the provider and walks an explicit elif chain; `zai` was missing from it, and because `missing_keys` is only populated inside a matched branch, unlisted providers fall through to a false all-clear (`keys_in_environment: True`, empty `missing_keys`) instead of reporting the missing key. The sibling providers `deepseek`, `moonshot`, and `dashscope` are all handled, so this looks like an omission from when zai was added

This PR adds the `zai` branch expecting `ZAI_API_KEY` (the key the zai chat transformation reads), mirroring the `moonshot` pattern, and two regression tests next to the existing `validate_environment` tests: no key must yield `keys_in_environment: False` with `missing_keys == ['ZAI_API_KEY']`, and key set must yield `True` with no missing keys. The no-key test was run against the unfixed base and fails there (`assert not True`), so it locks this exact regression. The chain's general fail-open behavior for unlisted providers is left as is; that is a wider design question and this PR stays scoped to the zai omission

Built with my two-agent Claude workflow: Claude Code implemented against my written spec, verified by mutation-tested regression tests and automated review; the issue selection, scope decisions, and verification standards are mine