### PR TITLE
feat(router): random-pick multi-model complexity tiers

### DIFF
--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -14,6 +14,7 @@ Inspired by ClawRouter: https://github.com/BlockRunAI/ClawRouter
 """
 
 import asyncio
+import random
 import re
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union, cast
 
@@ -437,21 +438,25 @@ class ComplexityRouter(CustomLogger):
         """
         tier_key = tier.value if isinstance(tier, ComplexityTier) else tier
 
-        # Check config tiers mapping
-        model = self.config.tiers.get(tier_key)
-        if model:
-            return model
+        if tier_key in self.config.tiers:
+            return self._pick_from_tier_value(self.config.tiers[tier_key], tier_key)
 
-        # Fallback to default model if configured
         if self.config.default_model:
             return self.config.default_model
 
-        # Last resort: return MEDIUM tier model or error
-        medium_model = self.config.tiers.get(ComplexityTier.MEDIUM.value)
-        if medium_model:
-            return medium_model
+        medium_key = ComplexityTier.MEDIUM.value
+        if medium_key in self.config.tiers:
+            return self._pick_from_tier_value(self.config.tiers[medium_key], medium_key)
 
         raise ValueError(f"No model configured for tier {tier_key} and no default_model set")
+
+    @staticmethod
+    def _pick_from_tier_value(model: Union[str, List[str]], tier_key: str) -> str:
+        if isinstance(model, str):
+            return model
+        if not model:
+            raise ValueError(f"Empty model pool for tier {tier_key}")
+        return random.choice(model)
 
     def _lexical_tier_override(self, user_message: str) -> Optional[ComplexityTier]:
         """When keyword_tier_rules match literally, the most-severe matched tier wins.

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -451,7 +451,7 @@ class ComplexityRouter(CustomLogger):
         raise ValueError(f"No model configured for tier {tier_key} and no default_model set")
 
     @staticmethod
-    def _pick_from_tier_value(model: Union[str, List[str]], tier_key: str) -> str:
+    def _pick_from_tier_value(model: str | list[str], tier_key: str) -> str:
         if isinstance(model, str):
             return model
         if not model:

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -248,8 +248,7 @@ class ComplexityRouterConfig(BaseModel):
     tiers: Dict[str, Union[str, List[str]]] = Field(
         default_factory=lambda: DEFAULT_TIER_MODELS.copy(),
         description=(
-            "Mapping of complexity tiers to a model or model pool. "
-            "A list is randomly picked from for that tier"
+            "Mapping of complexity tiers to a model or model pool. A list is randomly picked from for that tier"
         ),
     )
 

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -6,7 +6,7 @@ All values are configurable via proxy config.yaml.
 """
 
 from enum import Enum
-from typing import Dict, List, Literal, Optional, Union
+from typing import Dict, List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -245,7 +245,7 @@ class ComplexityRouterConfig(BaseModel):
     """Configuration for the ComplexityRouter."""
 
     # string = pin; list = random pick from the tier pool
-    tiers: Dict[str, Union[str, List[str]]] = Field(
+    tiers: dict[str, str | list[str]] = Field(
         default_factory=lambda: DEFAULT_TIER_MODELS.copy(),
         description=(
             "Mapping of complexity tiers to a model or model pool. A list is randomly picked from for that tier"

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -6,9 +6,9 @@ All values are configurable via proxy config.yaml.
 """
 
 from enum import Enum
-from typing import Dict, List, Literal, Optional
+from typing import Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class ComplexityTier(str, Enum):
@@ -244,10 +244,13 @@ class ClassifierLLMConfig(BaseModel):
 class ComplexityRouterConfig(BaseModel):
     """Configuration for the ComplexityRouter."""
 
-    # Tier to model mapping
-    tiers: Dict[str, str] = Field(
+    # string = pin; list = random pick from the tier pool
+    tiers: Dict[str, Union[str, List[str]]] = Field(
         default_factory=lambda: DEFAULT_TIER_MODELS.copy(),
-        description="Mapping of complexity tiers to model names",
+        description=(
+            "Mapping of complexity tiers to a model or model pool. "
+            "A list is randomly picked from for that tier"
+        ),
     )
 
     # Tier boundaries (normalized scores)
@@ -334,6 +337,21 @@ class ComplexityRouterConfig(BaseModel):
     )
 
     model_config = ConfigDict(extra="allow")  # Allow additional fields
+
+    @field_validator("tiers", mode="before")
+    @classmethod
+    def _coerce_tier_values(cls, value: object) -> object:
+        if not isinstance(value, dict):
+            return value
+        coerced: dict[str, object] = {}
+        for key, item in value.items():
+            if isinstance(item, str):
+                coerced[key] = item
+            elif isinstance(item, (list, tuple)):
+                coerced[key] = list(item)
+            else:
+                coerced[key] = item
+        return coerced
 
     @model_validator(mode="after")
     def _validate_llm_classifier_config(self) -> "ComplexityRouterConfig":

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -315,6 +315,36 @@ class TestModelSelection:
         model = router.get_model_for_tier(ComplexityTier.SIMPLE)
         assert model == "fallback-model"
 
+    def test_get_model_for_tier_list_random_choice(self, mock_router_instance):
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "tiers": {"SIMPLE": ["cheap", "premium"], "MEDIUM": "mid"},
+                "default_model": "mid",
+            },
+        )
+        pool = ["cheap", "premium"]
+        with patch(
+            "litellm.router_strategy.complexity_router.complexity_router.random.choice",
+            return_value="premium",
+        ) as choice:
+            assert router.get_model_for_tier(ComplexityTier.SIMPLE) == "premium"
+            choice.assert_called_once_with(pool)
+        assert router.get_model_for_tier(ComplexityTier.MEDIUM) == "mid"
+
+    def test_get_model_for_tier_empty_pool_raises(self, mock_router_instance):
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "tiers": {"SIMPLE": []},
+                "default_model": "mid",
+            },
+        )
+        with pytest.raises(ValueError, match="Empty model pool for tier SIMPLE"):
+            router.get_model_for_tier(ComplexityTier.SIMPLE)
+
 
 class TestPreRoutingHook:
     """Test the async_pre_routing_hook method."""


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured at `cbc2b8cb7b` against a ComplexityRouter configured with a SIMPLE pool of `["gpt-4o-mini", "claude-haiku-4-5"]` and pinned MEDIUM/COMPLEX models:

```bash
python - <<'PY'
from collections import Counter
from unittest.mock import MagicMock
from litellm.router_strategy.complexity_router.complexity_router import ComplexityRouter
from litellm.router_strategy.complexity_router.config import ComplexityTier

router = ComplexityRouter(
    model_name="complexity-router",
    litellm_router_instance=MagicMock(),
    complexity_router_config={
        "tiers": {
            "SIMPLE": ["gpt-4o-mini", "claude-haiku-4-5"],
            "MEDIUM": "gpt-4o",
            "COMPLEX": "claude-sonnet-4-5",
        },
        "default_model": "gpt-4o",
    },
)

counts = Counter(router.get_model_for_tier(ComplexityTier.SIMPLE) for _ in range(200))
print("SIMPLE pool picks over 200 draws:", dict(counts))
print("MEDIUM pin:", router.get_model_for_tier(ComplexityTier.MEDIUM))
print("COMPLEX pin:", router.get_model_for_tier(ComplexityTier.COMPLEX))
PY
```

```
SIMPLE pool picks over 200 draws: {'gpt-4o-mini': 99, 'claude-haiku-4-5': 101}
MEDIUM pin: gpt-4o
COMPLEX pin: claude-sonnet-4-5
```

## Type

🆕 New Feature
✅ Test

## Changes

Complexity router tiers can now be a string or a list of model names

When a tier is a list, `get_model_for_tier` randomly picks from that pool (same idea as simple-shuffle). A bare string still pins the tier to one model. Empty pools raise instead of silently falling through to `default_model`

This is independent of adaptive soft-floor mode; adaptive remains a separate PR