### PR TITLE
fix(guardrails): walk custom_tool_call_output items in _content_utils

### DIFF
--- a/litellm/proxy/guardrails/_content_utils.py
+++ b/litellm/proxy/guardrails/_content_utils.py
@@ -34,6 +34,12 @@ def is_text_content_call_type(call_type: str) -> bool:
 
 TEXT_PART_TYPES: FrozenSet[str] = frozenset({"text", "input_text", "output_text"})
 
+# Responses-API item types whose ``output`` field carries user/tool text
+# that guardrails should inspect.  ``function_call_output`` is the
+# built-in shape; ``custom_tool_call_output`` is the custom-tool
+# counterpart (see ``ChatCompletionCustomToolCallOutput``).
+_OUTPUT_ITEM_TYPES: frozenset[str] = frozenset({"function_call_output", "custom_tool_call_output"})
+
 
 def _iter_text_parts_in_content(content: Any) -> Iterator[str]:
     """Yield text fragments from a ``message.content`` value (string or
@@ -72,7 +78,7 @@ def _coerce_input_to_messages(input_value: Any) -> List[Dict[str, Any]]:
                 messages.append({"role": item.get("role") or "user", "content": [item]})
             elif "content" in item:
                 messages.append({"role": item.get("role") or "user", "content": item["content"]})
-            elif item.get("type") == "function_call_output" and "output" in item:
+            elif item.get("type") in _OUTPUT_ITEM_TYPES and "output" in item:
                 messages.append({"role": item.get("role") or "tool", "content": item["output"]})
     return messages
 
@@ -157,7 +163,7 @@ def walk_user_text(data: Dict[str, Any], visit: Callable[[str], str]) -> int:
                         input_value[idx] = {**item, "text": visit(item["text"])}
                 elif "content" in item:
                     item["content"] = _rewrite_content(item["content"])
-                elif item.get("type") == "function_call_output" and "output" in item:
+                elif item.get("type") in _OUTPUT_ITEM_TYPES and "output" in item:
                     item["output"] = _rewrite_content(item["output"])
         return visited
 

--- a/litellm/proxy/guardrails/_content_utils.py
+++ b/litellm/proxy/guardrails/_content_utils.py
@@ -38,7 +38,7 @@ TEXT_PART_TYPES: FrozenSet[str] = frozenset({"text", "input_text", "output_text"
 # that guardrails should inspect.  ``function_call_output`` is the
 # built-in shape; ``custom_tool_call_output`` is the custom-tool
 # counterpart (see ``ChatCompletionCustomToolCallOutput``).
-_OUTPUT_ITEM_TYPES: frozenset[str] = frozenset({"function_call_output", "custom_tool_call_output"})
+_OUTPUT_ITEM_TYPES: Frozenset[str] = frozenset({"function_call_output", "custom_tool_call_output"})
 
 
 def _iter_text_parts_in_content(content: Any) -> Iterator[str]:

--- a/litellm/proxy/guardrails/_content_utils.py
+++ b/litellm/proxy/guardrails/_content_utils.py
@@ -38,7 +38,7 @@ TEXT_PART_TYPES: FrozenSet[str] = frozenset({"text", "input_text", "output_text"
 # that guardrails should inspect.  ``function_call_output`` is the
 # built-in shape; ``custom_tool_call_output`` is the custom-tool
 # counterpart (see ``ChatCompletionCustomToolCallOutput``).
-_OUTPUT_ITEM_TYPES: Frozenset[str] = frozenset({"function_call_output", "custom_tool_call_output"})
+_OUTPUT_ITEM_TYPES: frozenset[str] = frozenset({"function_call_output", "custom_tool_call_output"})
 
 
 def _iter_text_parts_in_content(content: Any) -> Iterator[str]:

--- a/tests/test_litellm/proxy/guardrails/test_content_utils.py
+++ b/tests/test_litellm/proxy/guardrails/test_content_utils.py
@@ -524,3 +524,42 @@ def test_apply_redacted_messages_back_skips_input_when_not_string():
     data = {"input": [{"type": "text", "text": "leak"}]}
     apply_redacted_messages_back(data, [{"role": "user", "content": "[REDACTED]"}])
     assert data["input"] == [{"type": "text", "text": "leak"}]
+
+
+# -------------------------------------------------------------------
+# LIT-4302: custom_tool_call_output walking
+# -------------------------------------------------------------------
+
+def test_iter_message_text_walks_custom_tool_call_output():
+    """custom_tool_call_output items should yield their output text."""
+    data = {
+        "input": [
+            {"type": "custom_tool_call_output", "output": "tool-secret"},
+        ]
+    }
+    from litellm.proxy.guardrails._content_utils import iter_message_text
+    texts = list(iter_message_text(data))
+    assert "tool-secret" in texts
+
+
+def test_walk_user_text_redacts_custom_tool_call_output():
+    """walk_user_text should rewrite text inside custom_tool_call_output."""
+    data = {
+        "input": [
+            {"type": "custom_tool_call_output", "output": "PII-data"},
+        ]
+    }
+    count = walk_user_text(data, lambda t: t.replace("PII-data", "[MASKED]"))
+    assert count >= 1
+    assert data["input"][0]["output"] == "[MASKED]"
+
+
+def test_build_inspection_messages_custom_tool_call_output():
+    """build_inspection_messages should include custom_tool_call_output text."""
+    data = {
+        "input": [
+            {"type": "custom_tool_call_output", "output": "custom-tool-leak"},
+        ]
+    }
+    msgs = build_inspection_messages(data)
+    assert any("custom-tool-leak" in m["content"] for m in msgs)


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4302

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live proxy e2e against the real OpenAI API, no mocks. Proxy launched from this branch with the `hide-secrets` guardrail (which redacts via the shared `walk_user_text` this PR extends) in `pre_call` mode:

```yaml
model_list:
  - model_name: gpt-5.6
    litellm_params:
      model: openai/gpt-5.6
      api_key: os.environ/OPENAI_API_KEY

guardrails:
  - guardrail_name: hide-secrets
    litellm_params:
      guardrail: hide-secrets
      mode: pre_call
      default_on: true
```

Replay a custom tool round-trip whose output carries a fake AWS key, and ask the model to echo the tool output verbatim:

```bash
curl -s http://localhost:23773/v1/responses \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' -d '{
  "model": "gpt-5.6",
  "input": [
    {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "The read_config tool returned one line of an ini file. Repeat that line back exactly as you received it, then stop."}]},
    {"type": "custom_tool_call", "call_id": "call_e2e43", "name": "read_config", "input": "{}"},
    {"type": "custom_tool_call_output", "call_id": "call_e2e43", "output": "aws_access_key_id = AKIAIOSFODNN7EXAMPLE"}
  ],
  "tools": [{"type": "custom", "name": "read_config", "description": "Reads one line from the app ini config"}]
}'
```

The model answered with the redacted text, which is what the guardrail rewrote before the request left the proxy:

```
MODEL SAID: aws_access_key_id = [REDACTED]
```

The raw key appears zero times in the proxy's detailed debug log (which includes the full request payload sent to OpenAI), and the guardrail logged the rewrite:

```
$ grep -c AKIAIOSFODNN7EXAMPLE litellm_e2e.log
0
$ grep "redacted secrets" litellm_e2e.log | tail -1
17:36:13 - LiteLLM Proxy:WARNING: secret_detection.py:484 - Detected and redacted secrets in message: ['AWS Access Key']
```

Before this PR the same request reaches OpenAI with the raw key because `custom_tool_call_output` items fell through every branch of `walk_user_text`

## Type

🐛 Bug Fix

## Changes

Follow-up to LIT-4294. The shared guardrail helper walks `function_call_output` items, but the Responses API also emits `custom_tool_call_output` items with the same `output` shape (see `ChatCompletionCustomToolCallOutput`). Callers using OpenAI custom tools silently bypassed every text guardrail on those items.

- New `_OUTPUT_ITEM_TYPES` frozenset covering `function_call_output` and `custom_tool_call_output`
- `_coerce_input_to_messages` and `walk_user_text` match on the frozenset instead of the single `function_call_output` literal, so both item types are inspected and redacted identically
- 3 regression tests mirroring the existing `function_call_output` coverage

The `reasoning.summary_text` counterpart (LIT-4303) ships separately in its own PR
