### PR TITLE
fix(auto_router): filter embedding models in complexity tab dropdowns, require all tiers, inline validation

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
@@ -4,9 +4,10 @@ import { vi } from "vitest";
 import ComplexityRouterConfig, { ComplexityRouterConfigValue } from "./ComplexityRouterConfig";
 
 const mockModelInfo = [
-  { model_group: "gpt-4" },
-  { model_group: "gpt-3.5-turbo" },
-  { model_group: "claude-3-opus" },
+  { model_group: "gpt-4", mode: "chat" },
+  { model_group: "gpt-3.5-turbo", mode: "chat" },
+  { model_group: "claude-3-opus", mode: "chat" },
+  { model_group: "text-embedding-3-small", mode: "embedding" },
 ] as any[];
 
 const defaultValue: ComplexityRouterConfigValue = {
@@ -206,5 +207,33 @@ describe("ComplexityRouterConfig", () => {
     );
     await user.click(screen.getByRole("switch"));
     expect(onSemanticMatchingEnabledChange).toHaveBeenCalledWith(true, expect.anything());
+  });
+
+  it("excludes embedding-mode models from the tier and classifier dropdowns", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ComplexityRouterConfig {...baseProps} />);
+
+    const simpleTierSection = screen.getByText("Simple Tier").closest(".mb-4") as HTMLElement;
+    const combobox = within(simpleTierSection).getByRole("combobox");
+    await user.click(combobox);
+
+    expect((await screen.findAllByText("gpt-3.5-turbo")).length).toBeGreaterThan(0);
+    expect(screen.queryAllByText("text-embedding-3-small")).toHaveLength(0);
+  });
+
+  it("does not show tier validation errors by default", () => {
+    renderWithProviders(<ComplexityRouterConfig {...baseProps} />);
+    expect(screen.queryByText("This tier is required")).not.toBeInTheDocument();
+  });
+
+  it("shows a validation error only under unfilled tiers when showValidationErrors is true", () => {
+    renderWithProviders(
+      <ComplexityRouterConfig
+        {...baseProps}
+        value={{ ...defaultValue, tiers: { ...defaultValue.tiers, REASONING: "" } }}
+        showValidationErrors={true}
+      />,
+    );
+    expect(screen.getAllByText("This tier is required")).toHaveLength(1);
   });
 });

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
@@ -226,6 +226,28 @@ describe("ComplexityRouterConfig", () => {
     expect(screen.queryByText("This tier is required")).not.toBeInTheDocument();
   });
 
+  it("shows an inline error on the classifier model select when llm is selected without a model", () => {
+    const llmValue: ComplexityRouterConfigValue = {
+      ...defaultValue,
+      classifier_type: "llm",
+      classifier_llm_config: { model: "", timeout_ms: 3000 },
+    };
+    renderWithProviders(<ComplexityRouterConfig {...baseProps} value={llmValue} showValidationErrors={true} />);
+    fireEvent.click(screen.getByText("Advanced: Classification Method"));
+    expect(screen.getByText("A classifier model is required")).toBeInTheDocument();
+  });
+
+  it("does not show the classifier model error once a classifier model is set", () => {
+    const llmValue: ComplexityRouterConfigValue = {
+      ...defaultValue,
+      classifier_type: "llm",
+      classifier_llm_config: { model: "gpt-3.5-turbo", timeout_ms: 3000 },
+    };
+    renderWithProviders(<ComplexityRouterConfig {...baseProps} value={llmValue} showValidationErrors={true} />);
+    fireEvent.click(screen.getByText("Advanced: Classification Method"));
+    expect(screen.queryByText("A classifier model is required")).not.toBeInTheDocument();
+  });
+
   it("shows a validation error only under unfilled tiers when showValidationErrors is true", () => {
     renderWithProviders(
       <ComplexityRouterConfig

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
@@ -95,6 +95,9 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
       label: model.model_group,
     }));
 
+  const classifierModelMissing =
+    showValidationErrors && value.classifier_type === "llm" && !value.classifier_llm_config?.model;
+
   const handleTierChange = (tier: keyof ComplexityTiers, model: string) => {
     onChange({
       ...value,
@@ -233,7 +236,13 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
                         showSearch
                         style={{ width: "100%" }}
                         options={modelOptions}
+                        status={classifierModelMissing ? "error" : undefined}
                       />
+                      {classifierModelMissing && (
+                        <Text type="danger" style={{ fontSize: 12 }}>
+                          A classifier model is required
+                        </Text>
+                      )}
                     </div>
                     <div>
                       <Text strong style={{ display: "block", marginBottom: 4 }}>

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
@@ -45,6 +45,7 @@ interface ComplexityRouterConfigProps {
   onEmbeddingModelChange?: (model: string) => void;
   matchThreshold?: number;
   onMatchThresholdChange?: (threshold: number) => void;
+  showValidationErrors?: boolean;
 }
 
 const TIER_DESCRIPTIONS: Record<keyof ComplexityTiers, { label: string; description: string; examples: string }> = {
@@ -84,12 +85,15 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
   onEmbeddingModelChange = () => {},
   matchThreshold = 0.5,
   onMatchThresholdChange = () => {},
+  showValidationErrors = false,
 }) => {
-  // Prepare model options for dropdowns
-  const modelOptions = modelInfo.map((model) => ({
-    value: model.model_group,
-    label: model.model_group,
-  }));
+  // Embedding models can't serve a chat-completion role, so they're excluded here.
+  const modelOptions = modelInfo
+    .filter((model) => model.mode !== "embedding")
+    .map((model) => ({
+      value: model.model_group,
+      label: model.model_group,
+    }));
 
   const handleTierChange = (tier: keyof ComplexityTiers, model: string) => {
     onChange({
@@ -148,6 +152,7 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
       <Card>
         {(Object.keys(TIER_DESCRIPTIONS) as Array<keyof ComplexityTiers>).map((tier, index) => {
           const tierInfo = TIER_DESCRIPTIONS[tier];
+          const tierMissing = showValidationErrors && !value.tiers[tier];
           return (
             <div key={tier}>
               {index > 0 && <Divider style={{ margin: "16px 0" }} />}
@@ -170,7 +175,13 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
                   showSearch
                   style={{ width: "100%" }}
                   options={modelOptions}
+                  status={tierMissing ? "error" : undefined}
                 />
+                {tierMissing && (
+                  <Text type="danger" style={{ fontSize: 12 }}>
+                    This tier is required
+                  </Text>
+                )}
               </div>
             </div>
           );
@@ -323,6 +334,7 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
             matchThreshold={matchThreshold}
             onMatchThresholdChange={onMatchThresholdChange}
             modelInfo={modelInfo}
+            showValidationErrors={showValidationErrors}
           />
         </>
       )}

--- a/ui/litellm-dashboard/src/components/add_model/SemanticKeywordMatching.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/SemanticKeywordMatching.test.tsx
@@ -1,0 +1,53 @@
+import { renderWithProviders, screen } from "../../../tests/test-utils";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import SemanticKeywordMatching from "./SemanticKeywordMatching";
+
+const mockModelInfo = [
+  { model_group: "gpt-4", mode: "chat" },
+  { model_group: "text-embedding-3-small", mode: "embedding" },
+  { model_group: "voyage-3-5", mode: "embedding" },
+  { model_group: "legacy-model" },
+] as any[];
+
+const baseProps = {
+  enabled: true,
+  onEnabledChange: vi.fn(),
+  embeddingModel: undefined,
+  onEmbeddingModelChange: vi.fn(),
+  matchThreshold: 0.5,
+  onMatchThresholdChange: vi.fn(),
+  modelInfo: mockModelInfo,
+};
+
+describe("SemanticKeywordMatching", () => {
+  it("only lists embedding-mode models in the embedding model dropdown", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SemanticKeywordMatching {...baseProps} />);
+
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+
+    expect((await screen.findAllByText("text-embedding-3-small")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("voyage-3-5").length).toBeGreaterThan(0);
+    expect(screen.queryAllByText("gpt-4")).toHaveLength(0);
+    expect(screen.queryAllByText("legacy-model")).toHaveLength(0);
+  });
+
+  it("does not show a validation error by default", () => {
+    renderWithProviders(<SemanticKeywordMatching {...baseProps} showValidationErrors={false} />);
+    expect(screen.queryByText("An embedding model is required")).not.toBeInTheDocument();
+  });
+
+  it("shows a validation error when showValidationErrors is true and no embedding model is set", () => {
+    renderWithProviders(<SemanticKeywordMatching {...baseProps} showValidationErrors={true} />);
+    expect(screen.getByText("An embedding model is required")).toBeInTheDocument();
+  });
+
+  it("hides the validation error once an embedding model is set", () => {
+    renderWithProviders(
+      <SemanticKeywordMatching {...baseProps} showValidationErrors={true} embeddingModel="voyage-3-5" />,
+    );
+    expect(screen.queryByText("An embedding model is required")).not.toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/add_model/SemanticKeywordMatching.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/SemanticKeywordMatching.tsx
@@ -15,6 +15,7 @@ interface SemanticKeywordMatchingProps {
   matchThreshold: number;
   onMatchThresholdChange: (threshold: number) => void;
   modelInfo: ModelGroup[];
+  showValidationErrors?: boolean;
 }
 
 const SemanticKeywordMatching: React.FC<SemanticKeywordMatchingProps> = ({
@@ -25,11 +26,14 @@ const SemanticKeywordMatching: React.FC<SemanticKeywordMatchingProps> = ({
   matchThreshold,
   onMatchThresholdChange,
   modelInfo,
+  showValidationErrors = false,
 }) => {
-  const modelOptions = Array.from(new Set(modelInfo.map((model) => model.model_group))).map((model_group) => ({
+  const embeddingModels = modelInfo.filter((model) => model.mode === "embedding");
+  const modelOptions = Array.from(new Set(embeddingModels.map((model) => model.model_group))).map((model_group) => ({
     value: model_group,
     label: model_group,
   }));
+  const embeddingModelMissing = showValidationErrors && !embeddingModel;
 
   return (
     <Card className="mb-4">
@@ -60,7 +64,13 @@ const SemanticKeywordMatching: React.FC<SemanticKeywordMatchingProps> = ({
               showSearch
               style={{ width: "100%" }}
               options={modelOptions}
+              status={embeddingModelMissing ? "error" : undefined}
             />
+            {embeddingModelMissing && (
+              <Text type="danger" style={{ fontSize: 12 }}>
+                An embedding model is required
+              </Text>
+            )}
           </div>
           <div>
             <Text className="text-sm font-medium mb-1 block">Minimum match score</Text>

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -1,0 +1,40 @@
+import { renderWithProviders, screen } from "../../../tests/test-utils";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { Form } from "antd";
+import AddAutoRouterTab from "./add_auto_router_tab";
+import NotificationManager from "../molecules/notifications_manager";
+
+vi.mock("../networking", () => ({
+  modelAvailableCall: vi.fn().mockResolvedValue({ data: [] }),
+}));
+
+vi.mock("@/components/llm_calls/fetch_models", () => ({
+  fetchAvailableModels: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("./handle_add_auto_router_submit", () => ({
+  handleAddAutoRouterSubmit: vi.fn(),
+}));
+
+vi.mock("../molecules/notifications_manager", () => ({
+  default: { fromBackend: vi.fn() },
+}));
+
+const Harness = () => {
+  const [form] = Form.useForm();
+  return <AddAutoRouterTab form={form} handleOk={vi.fn()} accessToken="token" userRole="Admin" />;
+};
+
+describe("AddAutoRouterTab", () => {
+  it("flags every mandatory field when Add Auto Router is clicked with nothing filled", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Harness />);
+
+    await user.click(screen.getByRole("button", { name: /add auto router/i }));
+
+    expect(await screen.findByText("Auto router name is required")).toBeInTheDocument();
+    expect(screen.getAllByText("This tier is required")).toHaveLength(4);
+    expect(NotificationManager.fromBackend).toHaveBeenCalledWith("Please enter an Auto Router Name");
+  });
+});

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -11,7 +11,11 @@ import RouterConfigBuilder from "./RouterConfigBuilder";
 import ComplexityRouterConfig, { ComplexityRouterConfigValue } from "./ComplexityRouterConfig";
 import { KeywordTierRule } from "./KeywordTierRules";
 import { DEFAULT_MATCH_THRESHOLD } from "./SemanticKeywordMatching";
-import { buildComplexityRouterConfig, getSemanticConfigError } from "./build_complexity_router_config";
+import {
+  buildComplexityRouterConfig,
+  getMissingTiersError,
+  getSemanticConfigError,
+} from "./build_complexity_router_config";
 import { buildAutoRouterTestTargets, AutoRouterTestTarget } from "./build_auto_router_test_targets";
 import AutoRouterConnectionTest from "./auto_router_connection_test";
 import NotificationManager from "../molecules/notifications_manager";
@@ -43,6 +47,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({ form, handleOk, acc
   const [semanticMatchingEnabled, setSemanticMatchingEnabled] = useState<boolean>(false);
   const [embeddingModel, setEmbeddingModel] = useState<string | undefined>(undefined);
   const [matchThreshold, setMatchThreshold] = useState<number>(DEFAULT_MATCH_THRESHOLD);
+  const [showValidationErrors, setShowValidationErrors] = useState<boolean>(false);
 
   // Semantic router config (existing)
   const [routerConfig, setRouterConfig] = useState<any>(null);
@@ -86,19 +91,22 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({ form, handleOk, acc
       classifier_llm_config: classifierLlmConfig,
     } = complexityRouterConfig;
 
-    const filledTiers = Object.values(tiers).filter(Boolean);
-    if (filledTiers.length === 0) {
-      NotificationManager.fromBackend("Please select at least one model for a complexity tier");
+    const missingTiersError = getMissingTiersError(tiers);
+    if (missingTiersError) {
+      setShowValidationErrors(true);
+      NotificationManager.fromBackend(missingTiersError);
       return;
     }
 
     if (classifierType === "llm" && !classifierLlmConfig?.model) {
+      setShowValidationErrors(true);
       NotificationManager.fromBackend("Please select a classifier model, or switch back to Heuristic");
       return;
     }
 
     const semanticError = getSemanticConfigError({ semanticMatchingEnabled, embeddingModel, keywordTierRules });
     if (semanticError) {
+      setShowValidationErrors(true);
       NotificationManager.fromBackend(semanticError);
       return;
     }
@@ -296,6 +304,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({ form, handleOk, acc
                 onEmbeddingModelChange={setEmbeddingModel}
                 matchThreshold={matchThreshold}
                 onMatchThresholdChange={setMatchThreshold}
+                showValidationErrors={showValidationErrors}
               />
             </div>
           ) : (

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -198,6 +198,8 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({ form, handleOk, acc
   const handleAutoRouterSubmit = () => {
     const name = form.getFieldValue("auto_router_name");
     if (!name) {
+      setShowValidationErrors(true);
+      form.validateFields(["auto_router_name"]).catch(() => undefined);
       NotificationManager.fromBackend("Please enter an Auto Router Name");
       return;
     }

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -238,7 +238,14 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({ form, handleOk, acc
       <Card className="mb-4">
         <div className="mb-4">
           <Text className="text-sm font-medium mb-2 block">Router Type</Text>
-          <Radio.Group value={routerType} onChange={(e) => setRouterType(e.target.value)} className="w-full">
+          <Radio.Group
+            value={routerType}
+            onChange={(e) => {
+              setRouterType(e.target.value);
+              setShowValidationErrors(false);
+            }}
+            className="w-full"
+          >
             <Space direction="vertical" className="w-full">
               <Radio value="recommended" className="w-full">
                 <div className="flex items-center gap-2">

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
@@ -1,5 +1,6 @@
 import {
   buildComplexityRouterConfig,
+  getMissingTiersError,
   getSemanticConfigError,
   BuildComplexityRouterConfigParams,
 } from "./build_complexity_router_config";
@@ -121,6 +122,31 @@ describe("buildComplexityRouterConfig", () => {
     };
     const config = buildComplexityRouterConfig(params);
     expect(config.keyword_tier_rules).toBeUndefined();
+  });
+});
+
+describe("getMissingTiersError", () => {
+  it("returns null when all four tiers have a model", () => {
+    expect(getMissingTiersError(tiers)).toBeNull();
+  });
+
+  it("names the specific missing tier when only one is blank", () => {
+    expect(getMissingTiersError({ ...tiers, REASONING: "" })).toBe(
+      "Select a model for the following tier(s): REASONING",
+    );
+  });
+
+  it("names multiple missing tiers in SIMPLE/MEDIUM/COMPLEX/REASONING order", () => {
+    expect(getMissingTiersError({ ...tiers, SIMPLE: "", REASONING: "" })).toBe(
+      "Select a model for the following tier(s): SIMPLE, REASONING",
+    );
+  });
+
+  it("names all four tiers when none are filled", () => {
+    const noTiers = { SIMPLE: "", MEDIUM: "", COMPLEX: "", REASONING: "" };
+    expect(getMissingTiersError(noTiers)).toBe(
+      "Select a model for the following tier(s): SIMPLE, MEDIUM, COMPLEX, REASONING",
+    );
   });
 });
 

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
@@ -30,6 +30,14 @@ export interface ComplexityRouterConfigPayload {
   match_threshold?: number;
 }
 
+const TIER_KEYS: Array<keyof ComplexityTiers> = ["SIMPLE", "MEDIUM", "COMPLEX", "REASONING"];
+
+export const getMissingTiersError = (tiers: ComplexityTiers): string | null => {
+  const missing = TIER_KEYS.filter((tier) => !tiers[tier]);
+  if (missing.length === 0) return null;
+  return `Select a model for the following tier(s): ${missing.join(", ")}`;
+};
+
 export const getSemanticConfigError = ({
   semanticMatchingEnabled,
   embeddingModel,


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

UI change; verify against a live proxy.

1. Go to Models and End points click Add Model, then the Auto Router tab, then Auto-Router v2 (Recommended)
2. Enable semantic keyword matching and open the "Embedding model" dropdown; it lists only embedding-mode model groups (e.g. `voyage-3-5`), no chat models
3. Open each of the 4 tier dropdowns and the LLM Classifier model dropdown (under Advanced: Classification Method); the embedding model is absent from all of them
4. Leave one or more tiers blank and click "Add Auto Router"; a notification names exactly the missing tier(s), nothing is submitted, and each blank tier select gets a red outline with "This tier is required" below it
5. Clear the name field too and click "Add Auto Router" again; the name field and every blank tier are flagged together in one click
6. Pick a model for one of the blank tiers; its error clears immediately without clicking submit again
7. Fill all 4 tiers and the name, enable semantic matching without an embedding model, click "Add Auto Router"; the existing "Select an embedding model..." notification fires and the embedding model select shows the same red outline and helper text
8. Under Advanced: Classification Method, pick LLM Classifier without choosing a classifier model and click "Add Auto Router"; the classifier model select shows the same red outline with "A classifier model is required"
9. Fill everything in and submit; the router is created successfully

Screenshots to be posted below:
<img width="1583" height="664" alt="Screenshot 2026-07-11 at 7 15 48 PM" src="https://github.com/user-attachments/assets/4d0cd7ca-584a-4151-8a66-3f926ba272f8" />
<img width="1539" height="330" alt="Screenshot 2026-07-11 at 7 15 29 PM" src="https://github.com/user-attachments/assets/23e54a12-b796-4580-ac4b-9973a6232517" />
<img width="1639" height="293" alt="Screenshot 2026-07-11 at 7 15 22 PM" src="https://github.com/user-attachments/assets/7eb7e152-d63f-4a83-9f5c-4d3e682af3ce" />
<img width="1634" height="1035" alt="Screenshot 2026-07-11 at 7 15 02 PM" src="https://github.com/user-attachments/assets/2a227b93-dcea-4088-aa96-66c39f24bdf1" />

## Type

🐛 Bug Fix

## Changes

The Add Auto Router recommended (complexity) tab had three gaps. The "Embedding model" dropdown for semantic keyword matching listed every model group regardless of mode, so a chat model could be selected where an embedding endpoint is required. Conversely, the 4 complexity tier dropdowns and the LLM classifier model dropdown listed embedding-only models, which can't serve a chat-completion role. And submit-time validation only required at least one of the four tiers to be filled, so a router could be created with 3 of 4 tiers blank and requests classified into those tiers would fail at runtime

This PR filters the embedding dropdown to `mode === "embedding"` model groups (matching the existing pattern in `S3VectorsConfig.tsx` and cache settings), filters the tier and classifier dropdowns to exclude embedding models, and adds a `getMissingTiersError` validator that blocks submit until all four tiers have a model, naming the specific missing tiers in the error

It also adds inline validation: once a submit attempt fails any check, unfilled tier selects and the embedding model select get a red outline plus helper text, and each field's error clears live as soon as the user fills it in. Switching between router types resets the inline errors so a fresh form doesn't start out highlighted (raised by Greptile). Clicking Add Auto Router with the name empty previously returned early with only a toast, so blank tiers weren't flagged; now the name field and all unfilled tiers get their error state together on a single click. The LLM classifier model select gets the same inline treatment when the LLM classifier is selected without a model

Unit tests cover the new validator, both dropdown filters, and the inline error rendering in `build_complexity_router_config.test.ts`, `ComplexityRouterConfig.test.tsx`, and the new `SemanticKeywordMatching.test.tsx`



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only form validation and dropdown filtering for auto-router creation; no auth, API, or routing runtime changes.
> 
> **Overview**
> **Auto-Router v2 (Add Model)** now separates chat vs embedding models in dropdowns and blocks incomplete complexity-router configs with clearer inline feedback.
> 
> Tier and LLM classifier selects **exclude** `mode === "embedding"` groups; the semantic **embedding model** select **only** lists embedding-mode groups (legacy groups without `mode` no longer appear there). Submit validation replaces “at least one tier” with **`getMissingTiersError`**, which requires all four tiers and names any missing ones in the toast.
> 
> A **`showValidationErrors`** flag turns on after a failed submit (and clears when switching router type): blank tiers, missing classifier model when using LLM classification, and missing embedding model when semantic matching is enabled get red outlines and helper text that clear as soon as the field is filled. Empty auto-router name now triggers form validation in the same click so name and tier errors can show together. Unit tests cover the validator, filters, and inline UI in `ComplexityRouterConfig`, `SemanticKeywordMatching`, `add_auto_router_tab`, and `build_complexity_router_config`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e90f61e48a84ae8fd7610333032a40b22e6c928. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->