### PR TITLE
fix(proxy-auth): stop unrecognized model namespaces slipping through provider wildcard keys

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -45051,8 +45051,8 @@
         "rules": [
             {
                 "name": "bedrock-claude-ids",
-                "pattern": "anthropic\\.claude-",
-                "description": "Any Bedrock-syntax Claude id: the dotted anthropic.claude- segment appears in bare (anthropic.claude-...), region-prefixed (us./eu./au./jp./apac.) and global.-prefixed ids, for every version. Routes these to bedrock before the bare-id Anthropic rule is consulted.",
+                "pattern": "^(?:[a-z-]+\\.)?anthropic\\.claude-",
+                "description": "A Bedrock-syntax Claude id, for every version: anthropic.claude- at the start of the name, optionally behind a single dotted geo segment (us./eu./au./jp./apac./global./us-gov.). Anchored to the start because routing rules see the raw request string and provider inference feeds the proxy's provider/* wildcard access checks: an id under an unrecognized namespace such as bedrockz/anthropic.claude-... must stay unroutable rather than resolve to bedrock and slip through a bedrock/* key. Routes to bedrock before the bare-id Anthropic rule is consulted.",
                 "model_info": {
                     "litellm_provider": "bedrock"
                 }

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -4383,14 +4383,23 @@ def _model_custom_llm_provider_matches_wildcard_pattern(model: str, allowed_mode
     or
     - `model=claude-3-5-sonnet-20240620`
     - `allowed_model_pattern=anthropic/*`
+
+    A model that already carries a namespace get_llm_provider did not consume
+    (e.g. `bedrockz/anthropic.claude-...`) is never granted here: its provider was
+    inferred from a fragment of the full string, so rebuilding
+    `{provider}/{model}` would produce `bedrock/bedrockz/...` and slip an
+    unrecognized namespace through a `bedrock/*` key.
     """
     try:
-        model, custom_llm_provider, _, _ = get_llm_provider(model=model)
+        stripped_model, custom_llm_provider, _, _ = get_llm_provider(model=model)
     except Exception:
         return False
 
+    if stripped_model == model and "/" in model:
+        return False
+
     return is_model_allowed_by_pattern(
-        model=f"{custom_llm_provider}/{model}",
+        model=f"{custom_llm_provider}/{stripped_model}",
         allowed_model_pattern=allowed_model_pattern,
     )
 

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -45284,8 +45284,8 @@
         "rules": [
             {
                 "name": "bedrock-claude-ids",
-                "pattern": "anthropic\\.claude-",
-                "description": "Any Bedrock-syntax Claude id: the dotted anthropic.claude- segment appears in bare (anthropic.claude-...), region-prefixed (us./eu./au./jp./apac.) and global.-prefixed ids, for every version. Routes these to bedrock before the bare-id Anthropic rule is consulted.",
+                "pattern": "^(?:[a-z-]+\\.)?anthropic\\.claude-",
+                "description": "A Bedrock-syntax Claude id, for every version: anthropic.claude- at the start of the name, optionally behind a single dotted geo segment (us./eu./au./jp./apac./global./us-gov.). Anchored to the start because routing rules see the raw request string and provider inference feeds the proxy's provider/* wildcard access checks: an id under an unrecognized namespace such as bedrockz/anthropic.claude-... must stay unroutable rather than resolve to bedrock and slip through a bedrock/* key. Routes to bedrock before the bare-id Anthropic rule is consulted.",
                 "model_info": {
                     "litellm_provider": "bedrock"
                 }

--- a/tests/proxy_unit_tests/test_auth_checks.py
+++ b/tests/proxy_unit_tests/test_auth_checks.py
@@ -236,6 +236,8 @@ async def test_can_team_call_model(model, expect_to_work):
         (["bedrock/*"], "bedrock/anthropic.claude-3-5-sonnet-20240620", True),
         (["bedrock/*"], "bedrockz/anthropic.claude-3-5-sonnet-20240620", False),
         (["bedrock/us.*"], "bedrock/us.amazon.nova-micro-v1:0", True),
+        (["openai/*"], "ft:gpt-4-0613", True),
+        (["openai/*"], "bedrockz/ft:gpt-4-0613", False),
     ],
 )
 @pytest.mark.asyncio

--- a/tests/test_litellm/litellm_core_utils/test_get_model_cost_map.py
+++ b/tests/test_litellm/litellm_core_utils/test_get_model_cost_map.py
@@ -138,6 +138,42 @@ def test_shipped_backup_carries_the_claude_routing_rules():
         set_fallback_generalizations(previous)
 
 
+def test_shipped_routing_rules_never_match_through_an_unrecognized_namespace():
+    """Routing rules decide ``litellm_provider`` for otherwise-unknown ids, and the
+    proxy's wildcard access check (``can_key_call_model`` with a ``bedrock/*`` key)
+    trusts that inference: it rebuilds ``{provider}/{model}`` and matches it against
+    the key's patterns. A routing pattern that matches as a substring lets
+    ``bedrockz/anthropic.claude-...`` resolve to bedrock and slip through a
+    ``bedrock/*`` key, so every shipped routing rule must anchor to the start of
+    the name and never match an id carrying an unrecognized namespace prefix."""
+    backup = GetModelCostMap.load_local_model_cost_map()
+    rules = backup[FALLBACK_GENERALIZATIONS_KEY]["rules"]
+
+    routing_rules = [r for r in rules if "litellm_provider" in r["model_info"]]
+    assert routing_rules
+    assert all(r["pattern"].startswith("^") for r in routing_rules)
+
+    previous = list(get_fallback_generalization_rules())
+    try:
+        set_fallback_generalizations(rules)
+        for bedrock_id in [
+            "anthropic.claude-3-5-sonnet-20240620-v1:0",
+            "anthropic.claude-v2:1",
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "us-gov.anthropic.claude-3-5-sonnet-20240620-v1:0",
+            "global.anthropic.claude-fable-5-20260120-v1:0",
+        ]:
+            assert match_routing_generalization(bedrock_id) == "bedrock", bedrock_id
+        for namespaced in [
+            "bedrockz/anthropic.claude-3-5-sonnet-20240620",
+            "bedrockz/us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+            "bedrockz/claude-3-5-sonnet-20240620",
+        ]:
+            assert match_routing_generalization(namespaced) is None, namespaced
+    finally:
+        set_fallback_generalizations(previous)
+
+
 def test_shipped_backup_marks_claude_4_6_plus_adaptive_not_4_0():
     """Adaptive thinking is data, not code. The bundled backup must carry
     supports_adaptive_thinking on genuine Claude >= 4.6 entries (every provider


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup: proxy on localhost:4055 with a `bedrock/*` wildcard deployment and a virtual key restricted to `models: ["bedrock/*"]`

```yaml
model_list:
  - model_name: bedrock/*
    litellm_params:
      model: bedrock/*

general_settings:
  master_key: sk-1234
```

```bash
python litellm/proxy/proxy_cli.py --config bedrock_wildcard_config.yaml --port 4055
KEY=$(curl -s -X POST http://localhost:4055/key/generate -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" -d '{"models": ["bedrock/*"]}' | jq -r .key)
```

Before (at 4baeb283f3): the `bedrockz/` model is waved through auth, reaches the Bedrock invoke path with the bogus model id, and dies on AWS's error response with a 500

```bash
curl -s -w '\nHTTP %{http_code}\n' -X POST http://localhost:4055/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model": "bedrockz/anthropic.claude-3-5-sonnet-20240620", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 10}'
```

```
{"error":{"message":"litellm.APIConnectionError: 'content'\nTraceback (most recent call last):\n  File \".../litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py\", line 404, in transform_response\n ... KeyError: 'content'\n. Received Model Group=bedrockz/anthropic.claude-3-5-sonnet-20240620\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"500"}}
HTTP 500
```

After (at d0d1c0e346): the same request is denied at auth

```
{"error":{"message":"key not allowed to access model. This key can only access models=['bedrock/*']. Tried to access bedrockz/anthropic.claude-3-5-sonnet-20240620","type":"key_model_access_denied","param":"model","code":"403"}}
HTTP 403
```

After (at d0d1c0e346): real Bedrock traffic through the same key still works, both prefixed and as a bare region-prefixed id that relies on the (still matching, now anchored) routing rule

```bash
curl -s -w '\nHTTP %{http_code}\n' -X POST http://localhost:4055/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model": "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0", "messages": [{"role": "user", "content": "Say hello in exactly three words"}], "max_tokens": 20}'
```

```
{"id":"chatcmpl-cb3a5fc2-2418-44cf-b9c6-2a1759657845", ... "message":{"content":"Hello, world friend.","role":"assistant"}}, ... }
HTTP 200
```

```bash
curl -s -w '\nHTTP %{http_code}\n' -X POST http://localhost:4055/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model": "us.anthropic.claude-haiku-4-5-20251001-v1:0", "messages": [{"role": "user", "content": "Say hello in exactly three words"}], "max_tokens": 20}'
```

```
{"id":"chatcmpl-c21e30f5-2cab-481f-831e-09758db9dbfd", ... "message":{"content":"Hello, world friend.","role":"assistant"}}, ... }
HTTP 200
```

## Type

🐛 Bug Fix

## Changes

The `bedrock-claude-ids` routing rule shipped in #32873 matches `anthropic\.claude-` as an unanchored substring. `get_llm_provider` consults routing rules with the full request string, so `bedrockz/anthropic.claude-3-5-sonnet-20240620` resolved to provider `bedrock`, and the proxy's wildcard access fallback rebuilt `bedrock/bedrockz/anthropic.claude-...`, which matches a `bedrock/*` key. A key restricted to `bedrock/*` could therefore call models under any unrecognized namespace that happens to contain a Bedrock-looking fragment. The hole predates #32873 for Claude 4.8+ ids (the old `bedrock-anthropic-claude-mid-conversation-system` rule was equally unanchored); #32873 widened it to every Claude version, which is what finally tripped the existing `bedrockz` denial test in `tests/proxy_unit_tests/test_auth_checks.py`

Two layers of fix. First, the rule's pattern is now `^(?:[a-z-]+\.)?anthropic\.claude-` in both `model_prices_and_context_window.json` and the bundled backup: anchored to the start of the name, with one optional dotted geo segment so bare (`anthropic.claude-...`), region-prefixed (`us.` / `eu.` / `au.` / `jp.` / `apac.` / `us-gov.`) and `global.`-prefixed ids all still route to bedrock, while a string carrying any `something/` namespace cannot match. Routing rules only ever see ids whose prefix failed the known-provider split, so anchoring on `bedrock/` (or the invoke/converse forms) would be wrong; those prefixed forms are resolved earlier and never reach the rules

Second, `_model_custom_llm_provider_matches_wildcard_pattern` in `litellm/proxy/auth/auth_checks.py` now refuses to grant when `get_llm_provider` inferred a provider without consuming a namespace the model carries. That inference fallback exists for bare ids like `gpt-4o` under an `openai/*` key; when the model already contains `/` and nothing was consumed, the provider came from a fragment of the full string and rebuilding `{provider}/{model}` smuggles the unrecognized namespace through. This closes the same class of bypass through every other substring-shaped inference (for example `"ft:gpt-4" in model` let `bedrockz/ft:gpt-4-0613` through an `openai/*` key; a new test covers it), and it keeps the auth invariant independent of whatever rule data the proxy fetched

On why #32873's CI stayed green even though the `auth-and-jwt` job did run `test_auth_checks.py`: the proxy tests import litellm, which fetches the model cost map from raw.githubusercontent.com main at import time (no CI job sets `LITELLM_LOCAL_MODEL_COST_MAP`), so the run exercised main's then-old rules rather than the PR's JSON. The new `test_shipped_routing_rules_never_match_through_an_unrecognized_namespace` in `tests/test_litellm/litellm_core_utils/test_get_model_cost_map.py` loads the checkout's own backup map, requires every shipped routing rule to be start-anchored, and asserts the namespace invariant directly, so a future unanchored routing rule fails on the PR that introduces it. Note that until this JSON reaches main, the remote map still carries the unanchored rule; the auth guard is what keeps `bedrockz/...` denied on live proxies in the meantime, and the mutation checks confirm each test kills its own fix being reverted
