### PR TITLE
build(dev-env): add make bootstrap and unprovisioned-checkout preflight to pre-commit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Don't hesitate to use values in .env to get needed API keys and other secrets, a
 
 Python max line length is 120, not 88
 
-On a fresh worktree or clone, run `make bootstrap` before anything else. It provisions everything tests, `make pre-commit`, and a local proxy need: the uv env with proxy extras, the Prisma client, and the dashboard's node_modules; on worktrees it also copies `.env` from the main checkout (it never overwrites an existing `.env`)
+On a fresh worktree or clone, run `make bootstrap` before anything else. It provisions everything tests, `make pre-commit`, and a local proxy need
 
 Run tests before you commit. Also, run `make pre-commit` right before each commit, which generates types (as needed) and formats/lints your code. Any errors found must be fixed. It only runs when there are staged frontend and/or backend changes and calculates violations, generates types, etc. based on the worktree, so stage what you need or stash/delete unwanted files in litellm/ or ui/ (where backend and frontend lint run, respectively) before running it. If it fails because dashboard api types are stale, it already regenerated them for you. You just need to stage the schema.d.ts, re-run `make pre-commit` to confirm it passes, and commit
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,8 @@ Don't hesitate to use values in .env to get needed API keys and other secrets, a
 
 Python max line length is 120, not 88
 
+On a fresh worktree or clone, run `make bootstrap` before anything else. It provisions everything tests, `make pre-commit`, and a local proxy need: the uv env with proxy extras, the Prisma client, and the dashboard's node_modules; on worktrees it also copies `.env` from the main checkout (it never overwrites an existing `.env`)
+
 Run tests before you commit. Also, run `make pre-commit` right before each commit, which generates types (as needed) and formats/lints your code. Any errors found must be fixed. It only runs when there are staged frontend and/or backend changes and calculates violations, generates types, etc. based on the worktree, so stage what you need or stash/delete unwanted files in litellm/ or ui/ (where backend and frontend lint run, respectively) before running it. If it fails because dashboard api types are stale, it already regenerated them for you. You just need to stage the schema.d.ts, re-run `make pre-commit` to confirm it passes, and commit
 
 When you fix violations gated by `ruff-strict-budget.json`, `type-discipline-budget.json`, or `basedpyright-code-budget.json`, run `make lint-budget-update` and commit the lowered limits so the ceilings ratchet down instead of leaving stale headroom. It measures the working tree, so it must contain exactly the fixes you're committing

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,12 @@
 	lint-ruff-budget lint-ruff-budget-update lint-budget-update lint-gate \
 	install-dev install-proxy-dev install-test-deps install-hooks \
 	install-helm-unittest check-circular-imports check-import-safety pre-commit \
-	lint-install lint-fetch-base
+	lint-install lint-fetch-base bootstrap
 
 # Default target
 help:
 	@echo "Available commands:"
+	@echo "  make bootstrap          - Provision a fresh clone/worktree: Python env with proxy extras, Prisma client, dashboard node_modules; worktrees also copy .env from the main checkout"
 	@echo "  make install-dev        - Install development dependencies"
 	@echo "  make install-proxy-dev  - Install proxy development dependencies"
 	@echo "  make install-dev-ci     - Install dev dependencies (CI-compatible, pins OpenAI)"
@@ -70,6 +71,18 @@ info:
 # under a dev's venv (CI installs its own env per job, so it is unaffected by this).
 install-dev:
 	$(UV) sync --inexact --frozen
+
+bootstrap:
+	$(UV) sync --inexact --frozen --extra proxy --group proxy-dev --group e2e-dev
+	$(UV_RUN) python scripts/prisma_generate_if_needed.py
+	cd ui/litellm-dashboard && npm ci --no-audit --no-fund
+	@main_root=$$(git worktree list --porcelain | head -1 | sed 's/^worktree //'); \
+	if [ "$$main_root" != "$$(git rev-parse --show-toplevel)" ] && [ -f "$$main_root/.env" ] && [ ! -f .env ]; then \
+		cp "$$main_root/.env" .env && echo "bootstrap: copied .env from $$main_root"; \
+	else \
+		echo "bootstrap: .env left untouched"; \
+	fi
+	@echo "bootstrap: done"
 
 install-proxy-dev:
 	$(UV) sync --frozen --group proxy-dev --extra proxy

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 # Default target
 help:
 	@echo "Available commands:"
-	@echo "  make bootstrap          - Provision a fresh clone/worktree: Python env with proxy extras, Prisma client, dashboard node_modules; worktrees also copy .env from the main checkout"
+	@echo "  make bootstrap          - Provision a fresh clone/worktree"
 	@echo "  make install-dev        - Install development dependencies"
 	@echo "  make install-proxy-dev  - Install proxy development dependencies"
 	@echo "  make install-dev-ci     - Install dev dependencies (CI-compatible, pins OpenAI)"

--- a/README.md
+++ b/README.md
@@ -552,17 +552,12 @@ The Terraform modules live at [`terraform/litellm/aws/`](./terraform/litellm/aws
 2. Run dependent services `docker-compose up db prometheus`
 
 #### Backend
-1. (In root) create virtual environment `python -m venv .venv`
-2. Activate virtual environment `source .venv/bin/activate`
-3. Install dependencies `uv sync --all-extras --group proxy-dev`
-4. `uv run prisma generate`
-5. `prisma generate`
-6. Start proxy backend `python litellm/proxy/proxy_cli.py`
+1. (In root) provision the checkout with `make bootstrap` (installs the Python env with proxy extras, generates the Prisma client, and installs the dashboard's node_modules)
+2. Start proxy backend `uv run python litellm/proxy/proxy_cli.py`
 
 #### Frontend
-1. Navigate to `ui/litellm-dashboard`
-2. Install dependencies `npm install`
-3. Run `npm run dev` to start the dashboard
+1. Navigate to `ui/litellm-dashboard` (dependencies were already installed by `make bootstrap`)
+2. Run `npm run dev` to start the dashboard
 
 ### Verify Docker Image Signatures
 

--- a/README.md
+++ b/README.md
@@ -552,12 +552,12 @@ The Terraform modules live at [`terraform/litellm/aws/`](./terraform/litellm/aws
 2. Run dependent services `docker-compose up db prometheus`
 
 #### Backend
-1. (In root) provision the checkout with `make bootstrap` (installs the Python env with proxy extras, generates the Prisma client, and installs the dashboard's node_modules)
-2. Start proxy backend `uv run python litellm/proxy/proxy_cli.py`
+1. Run `make bootstrap`
+2. Start proxy backend: `uv run python litellm/proxy/proxy_cli.py`
 
 #### Frontend
-1. Navigate to `ui/litellm-dashboard` (dependencies were already installed by `make bootstrap`)
-2. Run `npm run dev` to start the dashboard
+1. Navigate to `ui/litellm-dashboard` (dependencies were already installed w/ `make bootstrap`)
+2. Start dashboard: `npm run dev`
 
 ### Verify Docker Image Signatures
 

--- a/scripts/pre_commit_lint.sh
+++ b/scripts/pre_commit_lint.sh
@@ -89,6 +89,11 @@ EOF
 
 status=0
 
+bootstrap_hint() {
+    echo "  This checkout looks unprovisioned (fresh worktree or clone)." >&2
+    echo "  Fix: make bootstrap" >&2
+}
+
 if [ -n "$litellm_py_files" ]; then
     echo "pre-commit: linting Python (make lint)"
     make lint || { echo "✗ Python lint failed. Fix the reds above, then re-run make pre-commit." >&2; status=1; }
@@ -109,7 +114,13 @@ fi
 
 if [ -n "$ui_prettier_files" ] || [ -n "$ui_eslint_files" ]; then
     echo "pre-commit: linting dashboard (prettier + eslint + lint budgets)"
-    lint_dashboard || { echo "✗ Dashboard lint failed. See above; format with: (cd ui/litellm-dashboard && npm run format)." >&2; status=1; }
+    if [ ! -d ui/litellm-dashboard/node_modules ]; then
+        echo "✗ ui/litellm-dashboard/node_modules is missing; dashboard lint cannot run." >&2
+        bootstrap_hint
+        status=1
+    else
+        lint_dashboard || { echo "✗ Dashboard lint failed. See above; format with: (cd ui/litellm-dashboard && npm run format)." >&2; status=1; }
+    fi
 fi
 
 if [ -n "$spec_files" ]; then
@@ -118,7 +129,15 @@ if [ -n "$spec_files" ]; then
     # and an up-to-date Prisma client; check-ui-api-types.yml installs those and runs
     # prisma generate before gen:api, so mirror that here or a stale client can mask
     # drift that CI will still flag.
-    if ! uv run --no-sync python scripts/prisma_generate_if_needed.py; then
+    if [ ! -d ui/litellm-dashboard/node_modules ]; then
+        echo "✗ ui/litellm-dashboard/node_modules is missing; the gen:api sync check cannot run." >&2
+        bootstrap_hint
+        status=1
+    elif ! uv run --no-sync python -c "import orjson, prisma" 2>/dev/null; then
+        echo "✗ The Python env lacks the proxy deps (orjson/prisma) that gen:api needs." >&2
+        bootstrap_hint
+        status=1
+    elif ! uv run --no-sync python scripts/prisma_generate_if_needed.py; then
         echo "✗ Could not regenerate Prisma client (prisma generate failed)." >&2
         status=1
     elif ( cd ui/litellm-dashboard && LITELLM_PYTHON="uv run --no-sync python" npm run gen:api ); then


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All runs on a brand-new worktree with no `.venv`, no `node_modules`, and no `.env`

Before (at 5fc1a3c671): `make pre-commit` with a staged proxy file dies on a 20-line traceback that never names the actual problem

```
Traceback (most recent call last):
  File ".../scripts/prisma_generate_if_needed.py", line 50, in main
    version = importlib.metadata.version("prisma")
  ...
importlib.metadata.PackageNotFoundError: No package metadata was found for prisma
✗ Could not regenerate Prisma client (prisma generate failed).
make: *** [pre-commit] Error 1
```

(and once you fix that by hand it fails twice more, first on missing proxy extras inside gen:api, then on the missing `node_modules/.bin/openapi-typescript`, each as a raw node/python stack trace)

After (at c9beaf85ff): the same command fails fast and names the fix

```
pre-commit: checking dashboard API types are in sync (npm run gen:api)
✗ ui/litellm-dashboard/node_modules is missing; the gen:api sync check cannot run.
  This checkout looks unprovisioned (fresh worktree or clone).
  Fix: make bootstrap
make: *** [pre-commit] Error 1
```

Running the named fix provisions everything in one shot (uv env with proxy extras, Prisma client, dashboard node_modules, worktree `.env` copy)

```
$ make bootstrap
uv sync --inexact --frozen --extra proxy --group proxy-dev --group e2e-dev
uv run --no-sync python scripts/prisma_generate_if_needed.py
cd ui/litellm-dashboard && npm ci --no-audit --no-fund
added 831 packages in 9s
bootstrap: copied .env from /Users/mateo/Development/litellm_internal_staging
bootstrap: done
```

and the previously failing `make pre-commit` then passes end to end on the first try, including the gen:api schema sync check

```
pre-commit: checking dashboard API types are in sync (npm run gen:api)
✨ openapi-typescript 7.13.0
🚀 .../openapi.json -> .../src/lib/http/schema.d.ts [449.6ms]
```

On a normal clone (not a worktree) the `.env` step is a guarded no-op: the first `git worktree list` entry equals the checkout root, so bootstrap prints "bootstrap: .env left untouched" and never creates or overwrites secrets

## Type

🚄 Infrastructure

## Changes

Fresh worktrees and clones fail `make pre-commit` three consecutive times (bare uv env without the prisma package, missing proxy extras inside gen:api, missing dashboard node_modules), each as an opaque stack trace with no pointer to the fix. Agents and humans end up reverse-engineering the dev-env requirements one traceback at a time

This adds a `make bootstrap` target that provisions a checkout in one command: `uv sync --inexact --frozen --extra proxy --group proxy-dev --group e2e-dev` (the same set `pre_commit_lint.sh` and the lint jobs need), the Prisma client via the existing `prisma_generate_if_needed.py`, `npm ci` for the dashboard, and, only when the checkout is a linked worktree, a copy of the main checkout's `.env` (detected via the first `git worktree list --porcelain` entry; it never overwrites an existing `.env` and does nothing on regular clones)

`scripts/pre_commit_lint.sh` gains preflight checks in the two blocks that need the node/proxy toolchain: missing `node_modules` and a missing `orjson`/`prisma` import now fail fast with a message that names `make bootstrap`, instead of surfacing as node ENOENT or importlib stack traces. CLAUDE.md documents the target so agents run it before anything else on fresh checkouts, and the README's "Run in Developer Mode" section now points at `make bootstrap` in place of its stale manual steps (hand-made venv, a duplicated `prisma generate`, separate `npm install`)

No tests added: this is Makefile and shell build tooling with no runtime surface; the proof transcript above is the before/after verification
