### PR TITLE
fix(anthropic): upgrade legacy thinking to adaptive on chat completions & Bedrock Converse for 4.6+ models

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1241,6 +1241,35 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             return thinking
         return AnthropicThinkingParam(type=thinking.get("type", "enabled"), budget_tokens=max_tokens - 1)
 
+    @staticmethod
+    def _translate_legacy_thinking_for_adaptive_model(
+        model: str, optional_params: Dict, custom_llm_provider: str
+    ) -> None:
+        if not AnthropicConfig._is_adaptive_thinking_model(model, custom_llm_provider):
+            return
+        thinking = optional_params.get("thinking")
+        if not isinstance(thinking, dict) or thinking.get("type") != "enabled":
+            return
+
+        budget = int(thinking.get("budget_tokens") or 0)
+        if budget >= DEFAULT_REASONING_EFFORT_XHIGH_THINKING_BUDGET and AnthropicConfig._supports_effort_level(
+            model, "xhigh", custom_llm_provider
+        ):
+            effort = "xhigh"
+        elif budget >= DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET:
+            effort = "high"
+        elif budget >= DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET:
+            effort = "medium"
+        else:
+            effort = "low"
+
+        optional_params["thinking"] = {"type": "adaptive"}
+        output_config = optional_params.get("output_config")
+        if not isinstance(output_config, dict):
+            output_config = {}
+        output_config.setdefault("effort", effort)
+        optional_params["output_config"] = output_config
+
     def _extract_json_schema_from_response_format(self, value: Optional[dict]) -> Optional[dict]:
         if value is None:
             return None
@@ -1484,6 +1513,12 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             ):
                 optional_params["metadata"] = {"user_id": value}
             elif param == "thinking":
+                optional_params["thinking"] = value
+                AnthropicConfig._translate_legacy_thinking_for_adaptive_model(
+                    model=model,
+                    optional_params=optional_params,
+                    custom_llm_provider=self._resolved_provider,
+                )
                 if (
                     isinstance(value, dict)
                     and value.get("type") == "adaptive"
@@ -1514,8 +1549,6 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                             model,
                         )
                         optional_params.pop("thinking", None)
-                else:
-                    optional_params["thinking"] = value
             elif param == "reasoning_effort":
                 # Accept both string ("low") and dict ({"effort": "low",
                 # "summary": "concise"}). The Responses->Chat parser keeps the

--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -2,13 +2,9 @@ from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
 
 import httpx
 
-from litellm.constants import (
-    DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
-    DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
-    DEFAULT_REASONING_EFFORT_XHIGH_THINKING_BUDGET,
-)
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.litellm_core_utils.litellm_logging import verbose_logger
+from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 from litellm.llms.base_llm.anthropic_messages.transformation import (
     BaseAnthropicMessagesConfig,
 )
@@ -240,40 +236,6 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
             optional_params["output_config"] = existing_output_config
 
     @staticmethod
-    def _translate_legacy_thinking_for_adaptive_model(
-        model: str, optional_params: Dict, custom_llm_provider: str
-    ) -> None:
-        """Translate legacy ``thinking.type=enabled`` to adaptive for 4.6/4.7.
-        Caller-provided ``output_config.effort`` is never overridden.
-        """
-        from litellm.llms.anthropic.chat.transformation import AnthropicConfig
-
-        if not AnthropicModelInfo._is_adaptive_thinking_model(model, custom_llm_provider):
-            return
-        thinking = optional_params.get("thinking")
-        if not isinstance(thinking, dict) or thinking.get("type") != "enabled":
-            return
-
-        budget = int(thinking.get("budget_tokens") or 0)
-        if budget >= DEFAULT_REASONING_EFFORT_XHIGH_THINKING_BUDGET and (
-            AnthropicConfig._supports_effort_level(model, "xhigh", custom_llm_provider)
-        ):
-            effort = "xhigh"
-        elif budget >= DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET:
-            effort = "high"
-        elif budget >= DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET:
-            effort = "medium"
-        else:
-            effort = "low"
-
-        optional_params["thinking"] = {"type": "adaptive"}
-        existing_output_config = optional_params.get("output_config")
-        if not isinstance(existing_output_config, dict):
-            existing_output_config = {}
-        existing_output_config.setdefault("effort", effort)
-        optional_params["output_config"] = existing_output_config
-
-    @staticmethod
     def _translate_adaptive_effort_for_non_adaptive_model(
         model: str, optional_params: Dict, max_tokens: Optional[int], custom_llm_provider: str
     ) -> None:
@@ -316,7 +278,6 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         subclasses to handle.
         """
         from litellm.exceptions import BadRequestError as _BadRequestError
-        from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 
         if AnthropicConfig._is_adaptive_thinking_model(model, custom_llm_provider):
             return
@@ -397,7 +358,7 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
             custom_llm_provider=self._resolved_provider,
         )
 
-        self._translate_legacy_thinking_for_adaptive_model(
+        AnthropicConfig._translate_legacy_thinking_for_adaptive_model(
             model=model,
             optional_params=anthropic_messages_optional_request_params,
             custom_llm_provider=self._resolved_provider,
@@ -421,8 +382,6 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         # Transform context_management from OpenAI format to Anthropic format if needed
         context_management_param = anthropic_messages_optional_request_params.get("context_management")
         if context_management_param is not None:
-            from litellm.llms.anthropic.chat.transformation import AnthropicConfig
-
             transformed_context_management = AnthropicConfig.map_openai_context_management_to_anthropic(
                 context_management_param
             )

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -900,6 +900,12 @@ class AmazonConverseConfig(BaseConfig):
                     "tool_choice": {"disable_parallel_tool_use": disable_parallel}
                 }
             if param == "thinking":
+                optional_params["thinking"] = value
+                AnthropicConfig._translate_legacy_thinking_for_adaptive_model(
+                    model=model,
+                    optional_params=optional_params,
+                    custom_llm_provider="bedrock",
+                )
                 if (
                     isinstance(value, dict)
                     and value.get("type") == "adaptive"
@@ -920,8 +926,7 @@ class AmazonConverseConfig(BaseConfig):
                         optional_params["thinking"] = capped
                     else:
                         litellm.verbose_logger.warning(DROP_UNSUPPORTED_ADAPTIVE_THINKING_WARNING, model)
-                else:
-                    optional_params["thinking"] = value
+                        optional_params.pop("thinking", None)
             elif param == "reasoning_effort" and isinstance(value, str):
                 self._handle_reasoning_effort_parameter(
                     model=model, reasoning_effort=value, optional_params=optional_params

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -22,6 +22,12 @@ from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
     AnthropicMessagesConfig,
 )
+from litellm.llms.bedrock.chat.invoke_transformations.anthropic_claude3_transformation import (
+    AmazonAnthropicClaudeConfig,
+)
+from litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.transformation import (
+    VertexAIAnthropicConfig,
+)
 from litellm.types.llms.anthropic import ANTHROPIC_BETA_HEADER_VALUES
 from litellm.types.utils import ServerToolUse
 
@@ -2514,6 +2520,35 @@ def test_raw_adaptive_thinking_untouched_for_46_plus_model():
     )
 
     assert result["thinking"] == {"type": "adaptive"}
+
+
+@pytest.mark.parametrize(
+    "config,model",
+    [
+        (AnthropicConfig(), "claude-opus-4-8"),
+        (
+            AmazonAnthropicClaudeConfig(),
+            "global.anthropic.claude-opus-4-8",
+        ),
+        (VertexAIAnthropicConfig(), "claude-opus-4-8"),
+    ],
+    ids=["anthropic", "bedrock-invoke", "vertex"],
+)
+def test_legacy_thinking_maps_to_adaptive_thinking_for_chat_routes(config, model):
+    result = config.map_openai_params(
+        non_default_params={
+            "thinking": {
+                "type": "enabled",
+                "budget_tokens": DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
+            }
+        },
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+
+    assert result["thinking"] == {"type": "adaptive"}
+    assert result["output_config"] == {"effort": "high"}
 
 
 @pytest.fixture

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -341,6 +341,25 @@ def test_reasoning_effort_sets_output_config_for_adaptive_models_converse(
     assert optional_params["output_config"] == {"effort": expected_effort}
 
 
+def test_legacy_thinking_maps_to_adaptive_thinking_for_converse():
+    config = AmazonConverseConfig()
+
+    optional_params = config.map_openai_params(
+        non_default_params={
+            "thinking": {
+                "type": "enabled",
+                "budget_tokens": 4096,
+            }
+        },
+        optional_params={"output_config": {"effort": "low"}},
+        model="bedrock/converse/global.anthropic.claude-opus-4-8",
+        drop_params=False,
+    )
+
+    assert optional_params["thinking"] == {"type": "adaptive"}
+    assert optional_params["output_config"] == {"effort": "low"}
+
+
 @pytest.mark.parametrize(
     "model",
     [


### PR DESCRIPTION
## Relevant issues

Fixes #32973

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The broken behavior is reproduced live in #32973: legacy `thinking={"type": "enabled", "budget_tokens": N}` sent to a 4.6+ model on `/chat/completions` returns a 400 (`"thinking.type.enabled" is not supported for this model`), while the same request on `/v1/messages` succeeds. With this change the `/chat/completions` and Bedrock Converse paths upgrade the legacy shape the same way the messages passthrough already does

```bash
curl -sS $GW/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{
  "model": "anthropic-opus-4-8", "max_tokens": 8192,
  "thinking": {"type": "enabled", "budget_tokens": 4096},
  "messages": [{"role": "user", "content": "In one sentence, why is the sky blue?"}]}'
# before this change -> HTTP 400
# with this change   -> HTTP 200 (upgraded to thinking={type: adaptive} + output_config.effort)
```

## Type

🐛 Bug Fix

## Changes

This is the reverse direction of #32944. That PR translates the 4.6+ adaptive interface down to legacy for pre-4.6 models. This one translates legacy `thinking={type: enabled, budget_tokens}` up to `thinking={type: adaptive}` + `output_config.effort` (budget mapped to effort tier) for 4.6+ models, which reject the legacy shape

The upgrade helper `_translate_legacy_thinking_for_adaptive_model` already existed on the `/v1/messages` passthrough. It is hoisted onto `AnthropicConfig` so the chat completions and Bedrock Converse paths share one implementation instead of duplicating it, and the messages passthrough now calls the shared helper

Stacked on #32944 (the downgrade PR), since the upgrade builds on the same restructured `thinking` handling. The base will retarget to `litellm_internal_staging` once #32944 merges

The implementation in this branch was authored by Devin AI; it originally landed on #32944 and was moved here to keep that PR scoped to the downgrade direction
