### PR TITLE
chore(makefile): remove duplicate and stale targets and reconcile .PHONY

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,11 +187,6 @@ make lint
 make test-unit
 ```
 
-For exact CI compatibility (pins OpenAI version like CI):
-```bash
-make install-dev-ci     # Installs exact CI dependencies
-```
-
 ## Available Make Commands
 
 Run `make help` to see all available commands:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@
 .PHONY: help test test-unit test-unit-llms test-unit-proxy-guardrails test-unit-proxy-core test-unit-proxy-misc \
 	test-unit-integrations test-unit-core-utils test-unit-other test-unit-root \
 	test-proxy-unit-a test-proxy-unit-b test-integration test-unit-helm \
-	info lint lint-dev lint-checks format \
+	test-llm-translation test-llm-translation-single test-llm-translation-flush-vcr-cache \
+	lint lint-dev lint-checks format format-check \
+	lint-ruff lint-format-check-changed lint-format-changed lint-ruff-dev lint-ruff-FULL-dev \
 	lint-basedpyright lint-e2e-basedpyright lint-basedpyright-budget-update lint-type-discipline lint-type-discipline-budget-update \
 	lint-ruff-budget lint-ruff-budget-update lint-budget-update lint-gate \
 	install-dev install-proxy-dev install-test-deps install-hooks \
@@ -16,8 +18,6 @@ help:
 	@echo "Available commands:"
 	@echo "  make install-dev        - Install development dependencies"
 	@echo "  make install-proxy-dev  - Install proxy development dependencies"
-	@echo "  make install-dev-ci     - Install dev dependencies (CI-compatible, pins OpenAI)"
-	@echo "  make install-proxy-dev-ci - Install proxy dev dependencies (CI-compatible)"
 	@echo "  make install-test-deps  - Install the full local test environment"
 	@echo "  make install-helm-unittest - Install helm unittest plugin"
 	@echo "  make install-hooks      - Install git hooks (Conventional Commits + Branches)"
@@ -29,7 +29,6 @@ help:
 	@echo "  make lint-basedpyright  - Run basedpyright strict, gated by per-rule error counts"
 	@echo "  make lint-e2e-basedpyright - Run basedpyright over tests/e2e (zero errors allowed)"
 	@echo "  make lint-basedpyright-budget-update - Ratchet basedpyright limits down by what this branch fixed"
-	@echo "  make lint-format        - Check ruff format formatting (matches CI)"
 	@echo "  make lint-ruff-budget - Gate the codebase total of each strict ruff rule against its limit"
 	@echo "  make lint-gate        - Strict ruff gate in CI-parity mode (fetches staging, simulates the merge)"
 	@echo "  make lint-ruff-budget-update - Ratchet ruff-strict-budget.json limits down by what this branch fixed"
@@ -60,10 +59,6 @@ LINT_DEP_BASE ?= lint-fetch-base
 LINT_JOBS := $(shell sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 4)
 LINT_OUTPUT_SYNC := $(if $(filter output-sync,$(.FEATURES)),--output-sync=target,)
 
-# Show info
-info:
-	@echo "UV: $(UV)"
-
 # Installation targets
 # --inexact: sync the locked deps without pruning anything already installed, so running
 # a lint/format target doesn't tear the proxy extras (prisma, websockets, ...) out from
@@ -74,16 +69,9 @@ install-dev:
 install-proxy-dev:
 	$(UV) sync --frozen --group proxy-dev --extra proxy
 
-# CI-compatible installations (matches GitHub workflows exactly)
-install-dev-ci:
-	$(UV) sync --frozen
-
-install-proxy-dev-ci:
-	$(UV) sync --frozen --group proxy-dev --extra proxy
-
-install-test-deps: install-proxy-dev
+install-test-deps:
 	$(UV) sync --frozen --all-groups --all-extras
-	$(UV_RUN) prisma generate --schema litellm/proxy/schema.prisma
+	$(UV_RUN) python scripts/prisma_generate_if_needed.py
 
 install-helm-unittest:
 	helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.4.4 || echo "ignore error if plugin exists"
@@ -178,8 +166,6 @@ lint-type-discipline: $(LINT_DEP_INSTALL) $(LINT_DEP_BASE)
 # it needs the base ref fetched to resolve the merge-base.
 lint-basedpyright-budget-update: install-dev lint-fetch-base
 	($(UV_RUN) basedpyright --outputjson || true) | $(UV_RUN) python scripts/type_check_gate.py --update
-
-lint-format: format-check
 
 lint-ruff-budget: install-dev
 	$(UV_RUN) python scripts/ruff_strict_gate.py


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before (at c136797805): the "-ci" install targets are duplicates of the non-ci ones, and nothing in CI invokes make at all

```
$ make -n install-proxy-dev install-proxy-dev-ci
uv sync --frozen --group proxy-dev --extra proxy
uv sync --frozen --group proxy-dev --extra proxy
$ make -n install-dev install-dev-ci
uv sync --inexact --frozen
uv sync --frozen
$ grep -rl "make " .github/workflows/ | wc -l
0
```

After (at cddafc87ae), on a brand-new worktree with no `.venv`: the reworked `install-test-deps` provisions the full test environment in one go, and a second run skips the Prisma generate

```
$ make install-test-deps
uv sync --frozen --all-groups --all-extras
...
✔ Generated Prisma Client Python (v0.11.0) to ./.venv/lib/python3.12/site-packages/prisma in 265ms
$ make install-test-deps
uv run --no-sync python scripts/prisma_generate_if_needed.py
Prisma client already generated for litellm/proxy/schema.prisma (prisma 0.11.0); skipping prisma generate
```

and the removed targets are gone while `make help` still renders

```
$ make install-dev-ci
make: *** No rule to make target `install-dev-ci'.  Stop.
$ make lint-format
make: *** No rule to make target `lint-format'.  Stop.
$ make info
make: *** No rule to make target `info'.  Stop.
```

## Type

🧹 Refactoring

## Changes

Nothing in CI invokes make (no workflow contains a make call), so the "CI-compatible" install targets were dead weight: `install-proxy-dev-ci` was byte-for-byte identical to `install-proxy-dev`, and `install-dev-ci` was `install-dev` minus `--inexact`, with a help line claiming it "pins OpenAI", which it never did. Both are removed, along with the CONTRIBUTING.md paragraph recommending `install-dev-ci`. `lint-format` goes with them since it was a bare alias of `format-check` that `make help` listed as a second entry

`install-test-deps` drops its `install-proxy-dev` prerequisite, whose sync is a strict subset of the `--all-groups --all-extras` sync it runs anyway, and now generates the Prisma client through `scripts/prisma_generate_if_needed.py` like `lint-install` already does, so repeat runs skip the generate when the schema and prisma version are unchanged

The `info` target (echoing a hardcoded "UV: uv") is deleted, and `.PHONY` is reconciled with the real target list: `help`, `format-check`, the lint dev variants, and the `test-llm-translation` targets were missing, and the deleted targets are dropped
