### PR TITLE
fix(makefile): diff dev lint targets against litellm_internal_staging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,7 @@ make lint
 
 Individual linting commands:
 ```bash
-make format-check       # Check Black formatting
+make format-check       # Check ruff format formatting
 make lint-ruff          # Run Ruff linting
 make lint-basedpyright  # Run basedpyright type checking
 make check-circular-imports    # Check for circular imports
@@ -164,14 +164,14 @@ Apply formatting (auto-fixes issues):
 make format
 ```
 
-> **Black formatting is enforced in CI.** All PRs must pass the Black formatting check.
+> **ruff format is enforced in CI.** All PRs must pass the ruff format check.
 >
-> - **AI coding agents** (Claude Code, Copilot, Cursor, etc.): `AGENTS.md` and `CLAUDE.md` instruct agents to run `poetry run black .` before committing.
-> - **VS Code users**: Install the [Black Formatter extension](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter) and enable format-on-save:
+> - **AI coding agents** (Claude Code, Copilot, Cursor, etc.): `AGENTS.md` and `CLAUDE.md` instruct agents to run `make pre-commit` before committing, which format-checks the staged files.
+> - **VS Code users**: Install the [Ruff extension](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff) and enable format-on-save:
 >   ```json
 >   {
 >     "[python]": {
->       "editor.defaultFormatter": "ms-python.black-formatter",
+>       "editor.defaultFormatter": "charliermarsh.ruff",
 >       "editor.formatOnSave": true
 >     }
 >   }
@@ -201,8 +201,8 @@ make help                       # Show all available commands
 make install-dev               # Install development dependencies
 make install-proxy-dev         # Install proxy development dependencies
 make install-test-deps         # Install the full local test environment
-make format                    # Apply Black code formatting
-make format-check              # Check Black formatting (matches CI)
+make format                    # Apply ruff format code formatting
+make format-check              # Check ruff format formatting (matches CI)
 make lint                      # Run all linting checks
 make test-unit                 # Run unit tests
 make test-integration          # Run integration tests
@@ -214,7 +214,7 @@ make test-unit-helm            # Run Helm unit tests
 LiteLLM follows the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html).
 
 Our automated quality checks include:
-- **Black** for consistent code formatting
+- **ruff format** for consistent code formatting
 - **Ruff** for linting and code quality
 - **basedpyright** for static type checking
 - **Circular import detection**

--- a/Makefile
+++ b/Makefile
@@ -135,8 +135,8 @@ lint-ruff: $(LINT_DEP_INSTALL)
 # inspiration from:
 # https://github.com/astral-sh/ruff/discussions/10977
 # https://github.com/astral-sh/ruff/discussions/4049
-lint-format-changed: install-dev
-	@git diff origin/main --unified=0 --no-color -- '*.py' | \
+lint-format-changed: install-dev lint-fetch-base
+	@git diff origin/litellm_internal_staging --unified=0 --no-color -- '*.py' | \
 	perl -ne '\
 		if (/^diff --git a\/(.*) b\//) { $$file = $$1; } \
 		if (/^@@ .* \+(\d+)(?:,(\d+))? @@/) { \
@@ -150,16 +150,16 @@ lint-format-changed: install-dev
 			$(UV_RUN) ruff format --range "$$lines" "$$file"; \
 		done
 
-lint-ruff-dev: install-dev
+lint-ruff-dev: install-dev lint-fetch-base
 	@tmpfile=$$(mktemp /tmp/ruff-dev.XXXXXX) && \
 	cd litellm && \
 	($(UV_RUN) ruff check . --output-format=pylint || true) > "$$tmpfile" && \
-	$(UV_RUN) diff-quality --violations=pylint "$$tmpfile" --compare-branch=origin/main && \
+	$(UV_RUN) diff-quality --violations=pylint "$$tmpfile" --compare-branch=origin/litellm_internal_staging && \
 	cd .. ; \
 	rm -f "$$tmpfile"
 
-lint-ruff-FULL-dev: install-dev
-	@files=$$(git diff --name-only origin/main -- '*.py'); \
+lint-ruff-FULL-dev: install-dev lint-fetch-base
+	@files=$$(git diff --name-only origin/litellm_internal_staging -- '*.py'); \
 	if [ -n "$$files" ]; then echo "$$files" | xargs $(UV_RUN) ruff check; \
 	else echo "No changed .py files to check."; fi
 

--- a/README.md
+++ b/README.md
@@ -633,9 +633,9 @@ For detailed contributing guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
 LiteLLM follows the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html).
 
 Our automated checks include:
-- **Black** for code formatting
+- **ruff format** for code formatting
 - **Ruff** for linting and code quality
-- **MyPy** for type checking
+- **basedpyright** for type checking
 - **Circular import detection**
 - **Import safety checks**
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All runs on a brand-new, completely clean worktree of litellm_internal_staging with zero local changes

Before (at c136797805): `lint-ruff-FULL-dev` diffs against origin/main, which had diverged from staging by 8 main-only and 23 staging-only commits at the time of writing, so a clean checkout fails with 43 ruff errors from 13 files the developer never touched

```
$ make lint-ruff-FULL-dev
...
help: Remove assignment to unused variable `response`

Found 43 errors.
[*] 28 fixable with the `--fix` option (15 hidden fixes can be enabled with the `--unsafe-fixes` option).
make: *** [lint-ruff-FULL-dev] Error 1
```

After (at 1ea8a62261): the same targets fetch the actual PR base and correctly report a clean tree

```
$ make lint-ruff-FULL-dev
git fetch origin litellm_internal_staging
No changed .py files to check.
$ make lint-ruff-dev
Diff Quality
Quality Report: pylint
Diff: origin/litellm_internal_staging...HEAD, staged and unstaged changes
-------------
No lines with quality information in this diff.
```

`lint-format-changed` likewise exits 0 with nothing to reformat on the same clean tree. The docs commit (1b6dcf6f08) is text-only

## Type

🐛 Bug Fix
📖 Documentation

## Changes

The convenience dev lint targets (`lint-format-changed`, `lint-ruff-dev`, `lint-ruff-FULL-dev`, and `lint-dev`, which chains the first) still diffed against origin/main, a leftover from before the repo's PR base moved to litellm_internal_staging. main and staging diverge constantly, so on a clean checkout these targets flagged, or in `lint-format-changed`'s case reformatted, files the developer never touched; they also used whatever stale origin/main the local clone happened to have, since nothing fetched it first. They now diff against origin/litellm_internal_staging and depend on the existing `lint-fetch-base` target so the base is fresh, matching how every other delta-scoped gate in the Makefile resolves its base

The second commit sweeps the matching doc drift: CONTRIBUTING.md still said Black formatting is enforced in CI, told AI agents to run `poetry run black .`, recommended the Black VS Code extension, and labelled `make format`/`make format-check` as Black commands, while README.md's code-quality list claimed Black and MyPy. The stack has been ruff format plus basedpyright for a while (agents are instructed via CLAUDE.md to run `make pre-commit`, which format-checks staged files), so the docs now say that
