### PR TITLE
fix(fallback-generalizations): anchor bedrock-claude-ids and restrict routing rules to bare ids

### DIFF
--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -475,8 +475,10 @@ def get_llm_provider(
 
         # Last resort for an otherwise-unknown model: a declarative
         # fallback-generalization routing rule (e.g. routes future claude-* to anthropic).
-        # Exact provider matches above always win; this only runs on a miss.
-        if not custom_llm_provider:
+        # Exact provider matches above always win; this only runs on a miss, and only
+        # for bare ids: a slash means an explicit provider prefix that failed every
+        # lookup above, which must keep raising rather than being guessed from a rule.
+        if not custom_llm_provider and "/" not in model:
             custom_llm_provider = match_routing_generalization(model)
 
         if not custom_llm_provider:

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -45051,8 +45051,8 @@
         "rules": [
             {
                 "name": "bedrock-claude-ids",
-                "pattern": "anthropic\\.claude-",
-                "description": "Any Bedrock-syntax Claude id: the dotted anthropic.claude- segment appears in bare (anthropic.claude-...), region-prefixed (us./eu./au./jp./apac.) and global.-prefixed ids, for every version. Routes these to bedrock before the bare-id Anthropic rule is consulted.",
+                "pattern": "^(?:[a-z-]+\\.)?anthropic\\.claude-",
+                "description": "Any Bedrock-syntax Claude id: anthropic.claude- at the start of the name, optionally behind a single dotted prefix segment covering region-prefixed (us./eu./au./jp./apac./us-gov.) and global.-prefixed ids, for every version. Anchored to the start so ids under a foreign namespace like someprovider/anthropic.claude-... never match; an unanchored substring match let keys scoped to bedrock/* pass the model access check for such ids. Routes these to bedrock before the bare-id Anthropic rule is consulted.",
                 "model_info": {
                     "litellm_provider": "bedrock"
                 }

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -45284,8 +45284,8 @@
         "rules": [
             {
                 "name": "bedrock-claude-ids",
-                "pattern": "anthropic\\.claude-",
-                "description": "Any Bedrock-syntax Claude id: the dotted anthropic.claude- segment appears in bare (anthropic.claude-...), region-prefixed (us./eu./au./jp./apac.) and global.-prefixed ids, for every version. Routes these to bedrock before the bare-id Anthropic rule is consulted.",
+                "pattern": "^(?:[a-z-]+\\.)?anthropic\\.claude-",
+                "description": "Any Bedrock-syntax Claude id: anthropic.claude- at the start of the name, optionally behind a single dotted prefix segment covering region-prefixed (us./eu./au./jp./apac./us-gov.) and global.-prefixed ids, for every version. Anchored to the start so ids under a foreign namespace like someprovider/anthropic.claude-... never match; an unanchored substring match let keys scoped to bedrock/* pass the model access check for such ids. Routes these to bedrock before the bare-id Anthropic rule is consulted.",
                 "model_info": {
                     "litellm_provider": "bedrock"
                 }

--- a/tests/test_litellm/litellm_core_utils/test_fallback_generalizations.py
+++ b/tests/test_litellm/litellm_core_utils/test_fallback_generalizations.py
@@ -261,6 +261,14 @@ def test_unknown_model_routes_via_routing_rule(restore_generalizations):
     assert provider == "openai"
 
 
+def test_slash_prefixed_unknown_provider_raises_despite_matching_rule(restore_generalizations):
+    """Routing rules are for bare-id inference only; an id under an unknown
+    provider namespace must keep raising even when a rule matches inside it."""
+    restore_generalizations([{"name": "myco", "pattern": r"myco-", "model_info": {"litellm_provider": "openai"}}])
+    with pytest.raises(litellm.BadRequestError):
+        litellm.get_llm_provider(model="mycoz/myco-fast-1")
+
+
 def test_capability_info_backfills_requested_provider(restore_generalizations):
     restore_generalizations(
         [
@@ -341,6 +349,16 @@ def test_shipped_bedrock_syntax_claude_id_routes_to_bedrock(shipped_cost_map):
         assert model not in litellm.model_cost
         _, provider, _, _ = litellm.get_llm_provider(model=model)
         assert provider == "bedrock", model
+
+
+def test_shipped_bedrock_rule_ignores_foreign_provider_prefixes(shipped_cost_map):
+    """Regression: the unanchored bedrock-claude-ids pattern substring-matched
+    bedrockz/anthropic.claude-..., so get_llm_provider inferred bedrock and keys
+    scoped to bedrock/* passed the model access check for that id."""
+    model = "bedrockz/anthropic.claude-3-5-sonnet-20240620"
+    assert match_routing_generalization(model) is None
+    with pytest.raises(litellm.BadRequestError):
+        litellm.get_llm_provider(model=model)
 
 
 def test_shipped_rules_resolve_unmapped_bedrock_claude_with_bedrock_provider(shipped_cost_map):


### PR DESCRIPTION
## Relevant issues

Every PR's "Unit Tests: Proxy Legacy Tests / auth-and-jwt" job started failing at 2026-07-12 00:43 UTC on two model-access deny params (`bedrockz/anthropic.claude-3-5-sonnet-20240620` against key/team models `['bedrock/*']`), for example https://github.com/BerriAI/litellm/actions/runs/29174424786/job/86600954535. The failures show up on branches whose diffs cannot affect auth, which is what pointed to shared state rather than any PR's changes

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on this branch, default cost-map behavior (no `LITELLM_LOCAL_MODEL_COST_MAP`, so the proxy fetched the current, still unanchored map from main at boot; the deny below is the new bare-id guard in `get_llm_provider` behaving exactly as an upgraded customer proxy would). Config is a `bedrock/*` wildcard deployment, the deployment shape this regression affects

```yaml
model_list:
  - model_name: bedrock/*
    litellm_params:
      model: bedrock/*
      aws_region_name: us-east-1

general_settings:
  master_key: sk-1234
```

```bash
docker run -d --name litellm_db -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=litellm -p 5434:5432 postgres:16
DATABASE_URL="postgresql://postgres:postgres@localhost:5434/litellm" prisma db push --schema litellm/proxy/schema.prisma --skip-generate
DATABASE_URL="postgresql://postgres:postgres@localhost:5434/litellm" python litellm/proxy/proxy_cli.py --config bedrock_wildcard_config.yaml --port 4020 --use_v2_migration_resolver

curl -s http://localhost:4020/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"models": ["bedrock/*"]}'
```

A key scoped to `bedrock/*` must not reach `bedrockz/...` (this returned a completion-path error before the fix because auth let it through; it now fails auth)

```bash
curl -s -w "\nHTTP %{http_code}\n" http://localhost:4020/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model": "bedrockz/anthropic.claude-3-5-sonnet-20240620", "messages": [{"role": "user", "content": "hi"}]}'
```

```
{"error":{"message":"key not allowed to access model. This key can only access models=['bedrock/*']. Tried to access bedrockz/anthropic.claude-3-5-sonnet-20240620","type":"key_model_access_denied","param":"model","code":"403"}}
HTTP 403
```

The same key still reaches real Bedrock through the wildcard (live AWS call, not mocked)

```bash
curl -s -w "\nHTTP %{http_code}\n" http://localhost:4020/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model": "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0", "messages": [{"role": "user", "content": "Reply with exactly: wildcard access works"}]}'
```

```
{"id":"chatcmpl-b18ba0b1-50c4-4326-9ff3-76ef2ede7c55","created":1783832717,"model":"bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"wildcard access works","role":"assistant"}}],"usage":{"completion_tokens":7,"prompt_tokens":15,"total_tokens":22}}
HTTP 200
```

## Type

🐛 Bug Fix

## Changes

The `fallback_generalizations` block introduced in #32873 ships a routing rule named `bedrock-claude-ids` with the unanchored pattern `anthropic\.claude-`. Rules match with `re.search`, so the rule also fires inside ids under a foreign provider namespace such as `bedrockz/anthropic.claude-3-5-sonnet-20240620`. `get_llm_provider` then resolves that id to provider `bedrock`, and `_model_custom_llm_provider_matches_wildcard_pattern` in `auth_checks.py` rewrites it as `bedrock/anthropic.claude-3-5-sonnet-20240620`, so keys and teams scoped to `bedrock/*` passed the model access check for ids they should never reach. The staging sync #32884 (merged 2026-07-12 00:42:56 UTC) published the rule to main's `model_prices_and_context_window.json`, which every proxy and CI job without `LITELLM_LOCAL_MODEL_COST_MAP` fetches at import; that is why auth-and-jwt went red on every PR at 00:43 with no related diff anywhere

The fix has two layers. The rule's pattern is now anchored as `^(?:[a-z-]+\.)?anthropic\.claude-`, which still covers bare, region-prefixed (us./eu./au./jp./apac./us-gov.) and global.-prefixed Bedrock ids but no longer matches slash-namespaced ids; this is the layer that heals released proxies, which fetch main's copy remotely and have no code from this PR. Separately, `get_llm_provider` now consults routing generalizations only for bare ids: a slash means an explicit provider prefix that already failed every provider lookup, and that keeps raising `BadRequestError` exactly as it did before the rules feature landed. The guard is why this PR's own CI is green immediately, and why every other PR heals on the next rebase or merge-queue run once this lands, even while main's JSON copy stays unanchored until the next staging sync

Both layers are pinned by new tests in `tests/test_litellm/litellm_core_utils/test_fallback_generalizations.py`: one asserts the shipped rule no longer matches `bedrockz/anthropic.claude-...` and that `get_llm_provider` raises for it, the other asserts a slash-prefixed unknown provider raises even when a rule matches inside the id. Each test was verified to fail with its half of the fix reverted. The previously failing params in `tests/proxy_unit_tests/test_auth_checks.py` pass again both with the bundled map and against the current remote map
