### PR TITLE
feat: add byesu as a JSON-configured OpenAI-compatible provider

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -759,6 +759,7 @@ openai_compatible_providers: List = [
     "nano-gpt",  # Nano-GPT - JSON-configured provider
     "poe",  # Poe - JSON-configured provider
     "chutes",  # Chutes - JSON-configured provider
+    "byesu",  # Byesu - JSON-configured provider
     "parasail",  # Parasail - JSON-configured provider
     "libertai",  # LibertAI - JSON-configured provider
     "featherless_ai",

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -58,6 +58,16 @@
       "max_completion_tokens": "max_tokens"
     }
   },
+  "byesu": {
+    "base_url": "https://byesu.com/v1",
+    "api_key_env": "BYESU_API_KEY",
+    "api_base_env": "BYESU_API_BASE",
+    "base_class": "openai_gpt",
+    "param_mappings": {
+      "max_completion_tokens": "max_tokens"
+    },
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
+  },
   "chutes": {
     "base_url": "https://llm.chutes.ai/v1/",
     "api_key_env": "CHUTES_API_KEY",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3392,6 +3392,7 @@ class LlmProviders(str, Enum):
     NANOGPT = "nano-gpt"
     POE = "poe"
     CHUTES = "chutes"
+    BYESU = "byesu"
     NEOSANTARA = "neosantara"
     PARASAIL = "parasail"
     XIAOMI_MIMO = "xiaomi_mimo"

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -2941,6 +2941,22 @@
         "rerank": false,
         "a2a": false
       }
+    },
+    "byesu": {
+      "display_name": "Byesu (`byesu`)",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": true,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
     }
   },
   "endpoints": {

--- a/tests/test_litellm/llms/openai_like/test_byesu_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_byesu_provider.py
@@ -1,0 +1,97 @@
+"""
+Tests for the `byesu` JSON-configured OpenAI-compatible provider.
+
+byesu is registered purely via litellm/llms/openai_like/providers.json, so these
+tests exercise the JSON registry, provider routing, and the dynamically generated
+config class. No network calls are made.
+"""
+
+import os
+import sys
+
+try:
+    import pytest  # noqa: F401
+except ImportError:
+    pytest = None  # allow standalone execution
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../..")))
+
+import litellm  # noqa: E402
+from litellm import get_llm_provider  # noqa: E402
+
+
+class TestByesuProvider:
+    def test_byesu_loaded_from_json(self):
+        """byesu is discovered by the JSON provider registry."""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        assert JSONProviderRegistry.exists("byesu")
+
+        cfg = JSONProviderRegistry.get("byesu")
+        assert cfg is not None
+        assert cfg.base_url == "https://byesu.com/v1"
+        assert cfg.api_key_env == "BYESU_API_KEY"
+        assert cfg.api_base_env == "BYESU_API_BASE"
+
+    def test_byesu_in_openai_compatible_providers(self):
+        """byesu is registered as an OpenAI-compatible provider."""
+        from litellm.constants import openai_compatible_providers
+
+        assert "byesu" in openai_compatible_providers
+
+    def test_byesu_get_llm_provider_routing(self):
+        """`byesu/<model>` resolves to custom_llm_provider == 'byesu'."""
+        model, custom_llm_provider, _, _ = get_llm_provider(model="byesu/gpt-4o-mini")
+        assert custom_llm_provider == "byesu"
+        assert model == "gpt-4o-mini"
+
+    def test_byesu_api_base_and_key_resolution(self):
+        """The dynamic config resolves the byesu base URL and honors overrides."""
+        from litellm.llms.openai_like.dynamic_config import create_config_class
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        config_class = create_config_class(JSONProviderRegistry.get("byesu"))
+        config = config_class()
+
+        # Defaults to the byesu base URL
+        api_base, _ = config._get_openai_compatible_provider_info(None, "test-key")
+        assert api_base == "https://byesu.com/v1"
+
+        # Explicit overrides win
+        api_base, api_key = config._get_openai_compatible_provider_info(
+            "https://custom.example.com/v1", "override-key"
+        )
+        assert api_base == "https://custom.example.com/v1"
+        assert api_key == "override-key"
+
+    def test_byesu_param_mapping(self):
+        """max_completion_tokens is mapped to max_tokens per providers.json."""
+        from litellm.llms.openai_like.dynamic_config import create_config_class
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        config_class = create_config_class(JSONProviderRegistry.get("byesu"))
+        config = config_class()
+
+        result = config.map_openai_params(
+            {"max_completion_tokens": 128},
+            {},
+            "gpt-4o-mini",
+            False,
+        )
+        assert result.get("max_tokens") == 128
+        assert "max_completion_tokens" not in result
+
+    def test_byesu_declares_responses_api(self):
+        """byesu declares /v1/responses support."""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        assert JSONProviderRegistry.supports_responses_api("byesu")
+
+
+if __name__ == "__main__":
+    t = TestByesuProvider()
+    for name in dir(t):
+        if name.startswith("test_"):
+            getattr(t, name)()
+            print(f"PASS {name}")
+    print("All byesu provider tests passed.")


### PR DESCRIPTION
## Register byesu as a JSON-configured OpenAI-compatible provider

Adds **byesu** ([byesu.com](https://byesu.com)) as a first-class provider prefix (`byesu/`) via the JSON provider registry, so users can call it without manually setting `api_base` each time.

byesu is an AI API gateway exposing a standard OpenAI-compatible endpoint (`https://byesu.com/v1`, Chat Completions + Responses). No custom Python handler is needed — it plugs into the existing `openai_like` JSON mechanism, same as publicai / tensormesh / cometapi.

### Changes
- `litellm/llms/openai_like/providers.json` — add the `byesu` block (`base_class: openai_gpt`, `max_completion_tokens → max_tokens` mapping, `/v1/chat/completions` + `/v1/responses`).
- `litellm/constants.py` — add `"byesu"` to `openai_compatible_providers`.
- `litellm/types/utils.py` — add `BYESU = "byesu"` to `LlmProviders`.
- `tests/test_litellm/llms/openai_like/test_byesu_provider.py` — new tests (JSON registry discovery, provider routing, dynamic-config base URL / key resolution, param mapping, `/responses` support). No network calls.

### Endpoint verification
`/v1/chat/completions` and `/v1/responses` return auth errors (not 404) on byesu, confirming the routes exist; a bogus path returns 404 for contrast.

### Honest note
I don't have a local Python/Poetry env set up for litellm on this machine, so I could **not** run `make format` / `make lint` / the unit test locally — the edits were made against the current source and validated for JSON/Python syntax + against the real `json_loader.py` / `dynamic_config.py` internals the test relies on. Please point out anything CI flags and I'll fix it right away.

Companion docs PR: BerriAI/litellm-docs#549
