### PR TITLE
fix: skip post-call redis writes in v3 rate limiter for unconfigured keys

### DIFF
--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -2085,6 +2085,9 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
 
                     verbose_proxy_logger.debug(f"TPM tokens reserved: {estimated_tokens} for model {requested_model}")
 
+        else:
+            data.setdefault("metadata", {})["_no_rate_limits"] = True
+
         # Defense-in-depth: scrub any stash key that escaped onto data
         # top-level (stale cache hit, router pass, test fixture) before the
         # body is forwarded to the provider.
@@ -2433,6 +2436,9 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         the emitter; this helper just lists the candidate scopes so callers
         can split reserved-vs-unreserved.
         """
+        _lp_meta = kwargs.get("litellm_params", {}).get("metadata", {}) or {}
+        if _lp_meta.get("_no_rate_limits"):
+            return []
         user_api_key = standard_logging_metadata.get("user_api_key_hash")
         user_api_key_user_id = standard_logging_metadata.get("user_api_key_user_id")
         user_api_key_team_id = standard_logging_metadata.get("user_api_key_team_id")
@@ -2632,6 +2638,10 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         try:
             verbose_proxy_logger.debug("INSIDE parallel request limiter ASYNC SUCCESS LOGGING")
 
+            _lp_meta = kwargs.get("litellm_params", {}).get("metadata", {}) or {}
+            if _lp_meta.get("_no_rate_limits"):
+                return
+
             pipeline_operations = self._build_success_event_pipeline_operations(
                 kwargs=kwargs,
                 response_obj=response_obj,
@@ -2662,6 +2672,9 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
             litellm_parent_otel_span: Union[Span, None] = _get_parent_otel_span_from_kwargs(kwargs)
             standard_logging_object = kwargs.get("standard_logging_object") or {}
             standard_logging_metadata = standard_logging_object.get("metadata") or {}
+            _lp_meta = kwargs.get("litellm_params", {}).get("metadata", {}) or {}
+            if _lp_meta.get("_no_rate_limits"):
+                return
             user_api_key = standard_logging_metadata.get("user_api_key_hash")
 
             pipeline_operations: List[RedisPipelineIncrementOperation] = []

--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -239,6 +239,7 @@ TPM_RESERVED_SCOPES_KEY = "_litellm_tpm_reserved_scopes"
 # does not double-refund.
 TPM_RESERVATION_RELEASED_KEY = "_litellm_tpm_reservation_released"
 RATE_LIMIT_DESCRIPTORS_KEY = "_litellm_rate_limit_descriptors"
+NO_RATE_LIMITS_KEY = "_no_rate_limits"
 # Stash keys live ONLY in metadata channels — never at the top level of the
 # request body. Top-level keys are forwarded as body params to upstream
 # providers, which reject unknown fields with 400/429 errors.
@@ -248,6 +249,7 @@ _LITELLM_STASH_KEYS: Tuple[str, ...] = (
     TPM_RESERVED_SCOPES_KEY,
     TPM_RESERVATION_RELEASED_KEY,
     RATE_LIMIT_DESCRIPTORS_KEY,
+    NO_RATE_LIMITS_KEY,
 )
 
 
@@ -2086,7 +2088,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                     verbose_proxy_logger.debug(f"TPM tokens reserved: {estimated_tokens} for model {requested_model}")
 
         else:
-            data.setdefault("metadata", {})["_no_rate_limits"] = True
+            data.setdefault("metadata", {})[NO_RATE_LIMITS_KEY] = True
 
         # Defense-in-depth: scrub any stash key that escaped onto data
         # top-level (stale cache hit, router pass, test fixture) before the
@@ -2437,7 +2439,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         can split reserved-vs-unreserved.
         """
         _lp_meta = kwargs.get("litellm_params", {}).get("metadata", {}) or {}
-        if _lp_meta.get("_no_rate_limits"):
+        if _lp_meta.get(NO_RATE_LIMITS_KEY):
             return []
         user_api_key = standard_logging_metadata.get("user_api_key_hash")
         user_api_key_user_id = standard_logging_metadata.get("user_api_key_user_id")
@@ -2639,7 +2641,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
             verbose_proxy_logger.debug("INSIDE parallel request limiter ASYNC SUCCESS LOGGING")
 
             _lp_meta = kwargs.get("litellm_params", {}).get("metadata", {}) or {}
-            if _lp_meta.get("_no_rate_limits"):
+            if _lp_meta.get(NO_RATE_LIMITS_KEY):
                 return
 
             pipeline_operations = self._build_success_event_pipeline_operations(
@@ -2673,7 +2675,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
             standard_logging_object = kwargs.get("standard_logging_object") or {}
             standard_logging_metadata = standard_logging_object.get("metadata") or {}
             _lp_meta = kwargs.get("litellm_params", {}).get("metadata", {}) or {}
-            if _lp_meta.get("_no_rate_limits"):
+            if _lp_meta.get(NO_RATE_LIMITS_KEY):
                 return
             user_api_key = standard_logging_metadata.get("user_api_key_hash")
 

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Unit Tests for the max parallel request limiter v3 for the proxy
 """
 
@@ -2853,6 +2853,7 @@ async def test_pre_call_hook_does_not_leak_internal_stash_to_request_body():
     from litellm.proxy.hooks.parallel_request_limiter_v3 import (
         _LITELLM_STASH_KEYS,
         RATE_LIMIT_DESCRIPTORS_KEY,
+        NO_RATE_LIMITS_KEY,
         TPM_RESERVED_TOKENS_KEY,
     )
 
@@ -2917,6 +2918,7 @@ async def test_pre_call_hook_rejects_caller_supplied_stash_values():
     from litellm.proxy.hooks.parallel_request_limiter_v3 import (
         _LITELLM_STASH_KEYS,
         RATE_LIMIT_DESCRIPTORS_KEY,
+        NO_RATE_LIMITS_KEY,
         TPM_RESERVED_TOKENS_KEY,
     )
 
@@ -2955,15 +2957,110 @@ async def test_pre_call_hook_rejects_caller_supplied_stash_values():
         call_type="completion",
     )
 
+    # NO_RATE_LIMITS_KEY is excluded from this leak check: this key has no
+    # configured tpm/rpm limits, so the server itself legitimately sets it
+    # in the `else` branch of `if descriptors:` -- unlike the other stash
+    # keys, its presence here is correct behavior, not a leak. The actual
+    # anti-forgery property for NO_RATE_LIMITS_KEY is covered separately by
+    # test_pre_call_hook_rejects_caller_supplied_no_rate_limits_marker,
+    # which uses a key WITH real limits configured (so the server's own
+    # `else` branch never fires) to prove a client-forged marker is
+    # stripped rather than trusted.
+    non_marker_stash_keys = [k for k in _LITELLM_STASH_KEYS if k != NO_RATE_LIMITS_KEY]
     for channel in (
         data,
         data.get("metadata") or {},
         data.get("litellm_metadata") or {},
     ):
-        leaked = [k for k in _LITELLM_STASH_KEYS if k in channel]
+        leaked = [k for k in non_marker_stash_keys if k in channel]
         assert not leaked, f"caller-supplied stash survived in {channel!r}: {leaked}"
 
+    # The marker's value should be the server's own True, not preserved
+    # unmodified from caller input (caller never set it in this test, but
+    # this guards against a future accidental pass-through of caller data).
+    metadata = data.get("metadata") or {}
+    assert metadata.get(NO_RATE_LIMITS_KEY) is True
 
+
+
+@pytest.mark.asyncio
+async def test_pre_call_hook_rejects_caller_supplied_no_rate_limits_marker():
+    """Client-supplied metadata: {"_no_rate_limits": true} must be stripped
+    before async_pre_call_hook processes the request. The server sets this
+    marker itself in the else branch when descriptors are empty -- a client
+    must not be able to forge it to bypass TPM accounting."""
+    from litellm.proxy.hooks.parallel_request_limiter_v3 import (
+        NO_RATE_LIMITS_KEY,
+        RATE_LIMIT_DESCRIPTORS_KEY,
+    )
+
+    _api_key = hash_token("sk-inject-no-rate-limits")
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key=_api_key,
+        tpm_limit=1000,
+        rpm_limit=5,
+    )
+    local_cache = DualCache()
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(local_cache),
+    )
+
+    async def mock_should_rate_limit(descriptors, **kwargs):
+        return {"overall_code": "OK", "statuses": []}
+
+    async def mock_reserve_tpm_tokens(descriptors, estimated_tokens, **kwargs):
+        return {
+            "overall_code": "OK",
+            "statuses": [
+                {
+                    "code": "OK",
+                    "current_limit": 1000,
+                    "limit_remaining": 1000 - estimated_tokens,
+                    "descriptor_key": d["key"],
+                    "descriptor_value": d["value"],
+                    "rate_limit_type": "tokens",
+                }
+                for d in descriptors
+            ],
+        }
+
+    handler.should_rate_limit = mock_should_rate_limit
+    handler.reserve_tpm_tokens = mock_reserve_tpm_tokens
+
+    # Client injects _no_rate_limits in metadata BEFORE the hook runs
+    data: Dict[str, Any] = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "hello"}],
+        "metadata": {"_no_rate_limits": True},
+    }
+
+    await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict,
+        cache=local_cache,
+        data=data,
+        call_type="completion",
+    )
+
+    metadata = data.get("metadata") or {}
+    assert NO_RATE_LIMITS_KEY not in metadata, (
+        "client-injected _no_rate_limits must be stripped by _strip_stash_keys_from_all_channels"
+    )
+    assert RATE_LIMIT_DESCRIPTORS_KEY in metadata, (
+        "real descriptors should still be reserved for a key with tpm_limit"
+    )
+
+    # TPM scope targets must NOT be empty -- accounting must not be skipped
+    standard_metadata = {
+        "user_api_key_hash": _api_key,
+        "user_api_key_team_id": None,
+        "user_api_key_user_id": None,
+    }
+    targets = handler._collect_tpm_scope_targets(
+        standard_logging_metadata=standard_metadata,
+        kwargs={"litellm_params": {"metadata": metadata}},
+        model_group="gpt-4o-mini",
+    )
+    assert len(targets) > 0, "TPM scope targets must not be empty when _no_rate_limits was stripped"
 # ----------------------- Per-MCP-server rate limiting (v3) -----------------------
 
 

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
@@ -3537,3 +3537,180 @@ async def test_pre_call_hook_skips_reservation_when_disabled(monkeypatch):
     )
 
     assert TPM_RESERVED_TOKENS_KEY not in (data.get("metadata") or {})
+
+
+@pytest.mark.asyncio
+async def test_no_rate_limits_marker_set_when_descriptors_empty():
+    """When no rate-limit descriptors are built for a request, async_pre_call_hook
+    sets _no_rate_limits=True in data['metadata'] so downstream callbacks can
+    skip Redis writes entirely."""
+    _api_key = hash_token("sk-no-limits")
+    local_cache = DualCache()
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(local_cache),
+    )
+
+    user_api_key_dict = UserAPIKeyAuth(api_key=_api_key)
+
+    should_rate_limit_called = False
+
+    async def mock_should_rate_limit(*args, **kwargs):
+        nonlocal should_rate_limit_called
+        should_rate_limit_called = True
+        return {"overall_code": "OK", "statuses": []}
+
+    handler.should_rate_limit = mock_should_rate_limit
+
+    data: Dict[str, Any] = {"model": "gpt-3.5-turbo"}
+    await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict,
+        cache=local_cache,
+        data=data,
+        call_type="completion",
+    )
+
+    assert not should_rate_limit_called, "should_rate_limit must not run when descriptors is empty"
+    assert data["metadata"]["_no_rate_limits"] is True
+
+
+@pytest.mark.asyncio
+async def test_no_rate_limits_skips_tpm_scope_targets():
+    """_collect_tpm_scope_targets returns [] when _no_rate_limits is set in
+    litellm_params metadata, preventing any TPM counter writes."""
+    local_cache = DualCache()
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(local_cache),
+    )
+
+    standard_metadata = {
+        "user_api_key_hash": hash_token("sk-test"),
+        "user_api_key_team_id": "team-1",
+    }
+
+    # Without _no_rate_limits: should return non-empty targets
+    kwargs_without = {"litellm_params": {"metadata": {}}}
+    targets = handler._collect_tpm_scope_targets(
+        standard_logging_metadata=standard_metadata,
+        kwargs=kwargs_without,
+        model_group="gpt-4",
+    )
+    assert len(targets) > 0, "should return targets when marker is absent"
+
+    # With _no_rate_limits: must return empty list
+    kwargs_with = {"litellm_params": {"metadata": {"_no_rate_limits": True}}}
+    targets = handler._collect_tpm_scope_targets(
+        standard_logging_metadata=standard_metadata,
+        kwargs=kwargs_with,
+        model_group="gpt-4",
+    )
+    assert targets == [], "must return [] when _no_rate_limits is set"
+
+
+@pytest.mark.asyncio
+async def test_no_rate_limits_skips_failure_event_writes():
+    """async_log_failure_event returns early without touching Redis when
+    _no_rate_limits is set in litellm_params metadata."""
+    _api_key = hash_token("sk-fail-no-limits")
+    local_cache = DualCache()
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(local_cache),
+    )
+
+    captured_ops: List[Any] = []
+
+    async def mock_pipeline(increment_list, **kwargs):
+        captured_ops.extend(increment_list)
+
+    handler.internal_usage_cache.dual_cache.async_increment_cache_pipeline = mock_pipeline
+
+    mock_kwargs = {
+        "standard_logging_object": {"metadata": {"user_api_key_hash": _api_key}},
+        "litellm_params": {"metadata": {"_no_rate_limits": True}},
+    }
+
+    await handler.async_log_failure_event(
+        kwargs=mock_kwargs, response_obj=None, start_time=None, end_time=None,
+    )
+
+    assert captured_ops == [], "no Redis writes should happen when _no_rate_limits is set"
+
+
+@pytest.mark.asyncio
+async def test_no_rate_limits_skips_success_event_writes():
+    """async_log_success_event returns early without touching Redis when
+    _no_rate_limits is set in litellm_params metadata."""
+    from unittest.mock import MagicMock
+
+    _api_key = hash_token("sk-success-no-limits")
+    local_cache = DualCache()
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(local_cache),
+    )
+
+    captured_ops: List[Any] = []
+
+    async def mock_pipeline(increment_list, **kwargs):
+        captured_ops.extend(increment_list)
+
+    handler.internal_usage_cache.dual_cache.async_increment_cache_pipeline = mock_pipeline
+
+    mock_response = MagicMock(spec=ModelResponse)
+    mock_response.usage = Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+
+    mock_kwargs = {
+        "standard_logging_object": {
+            "metadata": {"user_api_key_hash": _api_key}
+        },
+        "litellm_params": {"metadata": {"_no_rate_limits": True}},
+    }
+
+    await handler.async_log_success_event(
+        kwargs=mock_kwargs, response_obj=mock_response, start_time=None, end_time=None,
+    )
+
+    assert captured_ops == [], "no Redis writes should happen when _no_rate_limits is set"
+
+
+@pytest.mark.asyncio
+async def test_with_rate_limits_still_writes_redis():
+    """Regression guard: when descriptors ARE present (rate limits configured),
+    async_log_success_event and async_log_failure_event still write Redis as before."""
+    from unittest.mock import MagicMock
+
+    _api_key = hash_token("sk-with-limits")
+    local_cache = DualCache()
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(local_cache),
+    )
+
+    captured_ops: List[Any] = []
+
+    async def mock_pipeline(increment_list, **kwargs):
+        captured_ops.extend(increment_list)
+
+    handler.internal_usage_cache.dual_cache.async_increment_cache_pipeline = mock_pipeline
+
+    mock_kwargs = {
+        "standard_logging_object": {
+            "metadata": {"user_api_key_hash": _api_key}
+        },
+        "litellm_params": {"metadata": {}},
+    }
+
+    # --- success event ---
+    mock_response = MagicMock(spec=ModelResponse)
+    mock_response.usage = Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+
+    await handler.async_log_success_event(
+        kwargs=mock_kwargs, response_obj=mock_response, start_time=None, end_time=None,
+    )
+
+    assert len(captured_ops) > 0, "success event must write Redis ops when _no_rate_limits is absent"
+    captured_ops.clear()
+
+    # --- failure event ---
+    await handler.async_log_failure_event(
+        kwargs=mock_kwargs, response_obj=None, start_time=None, end_time=None,
+    )
+
+    assert len(captured_ops) > 0, "failure event must write Redis ops when _no_rate_limits is absent"


### PR DESCRIPTION
## Relevant issues
Fixes #31880 (v3 portion — companion to #32447 which fixed the legacy v1 limiter)

## Linear ticket


## Pre-Submission checklist
- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?
If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix
Verified via unit tests directly exercising each guard (see Testing
below). Traced the full metadata flow to confirm `data["metadata"]`
is never forwarded to LLM providers — provider `transform_request`
builds the HTTP body strictly from `model`, `messages`, and
`optional_params` (narrow, unrelated exception: Anthropic's handler
reads `user_id` from metadata, unaffected by this change).

## Type
🐛 Bug Fix

## Changes
This is the v3 (default) counterpart to #32447, based on the root-cause
analysis and implementation plan from @deepanshululla on #31880.

`_PROXY_MaxParallelRequestsHandler_v3`'s `async_pre_call_hook` already
correctly short-circuits all pre-call Redis work when no rate-limit
descriptors exist for a request (the `if descriptors:` guard) — no
`+1` is ever written for an unlimited key/user/team/org. However,
`async_log_success_event` and `async_log_failure_event` had no
equivalent awareness: both unconditionally built and wrote
`max_parallel_requests` decrements and TPM pipeline operations for
every completed request, regardless of whether any pre-call increment
occurred.

**How it works:**
- `async_pre_call_hook` now sets `data["metadata"]["_no_rate_limits"] = True`
  in the (previously empty) `else` branch of `if descriptors:`.
- `_collect_tpm_scope_targets`, `async_log_success_event` (before
  `_build_success_event_pipeline_operations` is called), and
  `async_log_failure_event` all check this marker as an early-return
  guard, skipping the Redis write entirely for unlimited entities.

**Security fix (added after initial review):** a client could send
`metadata: {"_no_rate_limits": true}` in their own request and have it
trusted, letting them forge the marker to skip real TPM accounting.
`NO_RATE_LIMITS_KEY` is now added to `_LITELLM_STASH_KEYS`, so the
existing `_strip_stash_keys_from_all_channels` call (which already
runs at the top of `async_pre_call_hook`, before the legitimate
server-side set) strips any client-supplied value first. Verified
with a negative-control test.

**Scope:**
- `litellm/proxy/hooks/parallel_request_limiter_v3.py` only.
- Does not touch the legacy v1 limiter (#32447) or the descriptor-
  building logic in `async_pre_call_hook` (only adds the `else` branch).

**Testing** — `tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py`:
- `test_no_rate_limits_marker_set_when_descriptors_empty`
- `test_no_rate_limits_skips_tpm_scope_targets`
- `test_no_rate_limits_skips_success_event_writes`
- `test_no_rate_limits_skips_failure_event_writes`
- `test_with_rate_limits_still_writes_redis` (regression guard)
- `test_pre_call_hook_rejects_caller_supplied_no_rate_limits_marker`
  (security regression guard)

All tests pass (77 passed, 1 pre-existing skip). Lint and format clean.

**Note:** two unrelated pre-existing failures on this base branch
(OSV Scan CVE in `uv.lock`; a wildcard-matching bug in
`test_auth_checks.py`) — confirmed neither is touched by this PR's
commits.