### PR TITLE
fix(proxy): ban aws_profile_name from request bodies

### DIFF
--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -251,6 +251,7 @@ _BANNED_REQUEST_BODY_PARAMS: Tuple[str, ...] = (
     "aws_sts_endpoint",
     "aws_web_identity_token",
     "aws_role_name",
+    "aws_profile_name",
     "vertex_credentials",
     # Azure managed-identity / federated-auth token. The Azure provider
     # transformer reads ``azure_ad_token`` (top-level or via

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -1749,6 +1749,47 @@ class TestIsRequestBodySafeBlocksBedrockProjectOverride:
         )
 
 
+class TestIsRequestBodySafeBlocksAwsProfileOverride:
+    def test_aws_profile_name_in_request_body_is_rejected(self):
+        with pytest.raises(ValueError, match="aws_profile_name"):
+            is_request_body_safe(
+                request_body={
+                    "model": "bedrock/anthropic.claude-v2",
+                    "aws_profile_name": "any-profile-on-the-proxy-host",
+                },
+                general_settings={},
+                llm_router=None,
+                model="bedrock/anthropic.claude-v2",
+            )
+
+    def test_aws_profile_name_with_api_key_still_rejected(self):
+        with pytest.raises(ValueError, match="aws_profile_name"):
+            is_request_body_safe(
+                request_body={
+                    "model": "bedrock/anthropic.claude-v2",
+                    "api_key": "sk-anything",
+                    "aws_profile_name": "any-profile-on-the-proxy-host",
+                },
+                general_settings={},
+                llm_router=None,
+                model="bedrock/anthropic.claude-v2",
+            )
+
+    def test_admin_opt_in_proxy_wide_allows_aws_profile_name(self):
+        assert (
+            is_request_body_safe(
+                request_body={
+                    "model": "bedrock/anthropic.claude-v2",
+                    "aws_profile_name": "byok-profile",
+                },
+                general_settings={"allow_client_side_credentials": True},
+                llm_router=None,
+                model="bedrock/anthropic.claude-v2",
+            )
+            is True
+        )
+
+
 class TestIsRequestBodySafeBlocksNVCFFunctionOverride:
     """``nvcf_function_id`` is rejected as a request-body param unless the
     admin opted in proxy-wide or per-deployment."""

--- a/tests/test_litellm/proxy/auth/test_banned_params_extra_body.py
+++ b/tests/test_litellm/proxy/auth/test_banned_params_extra_body.py
@@ -23,6 +23,7 @@ from litellm.proxy.auth.auth_utils import is_request_body_safe  # noqa: E402
         "aws_web_identity_token",
         "aws_sts_endpoint",
         "aws_role_name",
+        "aws_profile_name",
         "api_base",
         "base_url",
         "vertex_credentials",


### PR DESCRIPTION
## Relevant issues

Security finding from our internal PR-review bot on #32956: client-controlled AWS profiles are used for signing

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`aws_profile_name` was missing from the proxy's request-body ban list, so an authenticated caller could put it in the body and make the proxy sign the outbound Bedrock request with any named AWS profile installed on the proxy host, instead of the deployment's configured identity (`BaseAWSLLM.get_credentials` -> `boto3.Session(profile_name=...)`). Same class as the already-banned `aws_role_name` / `aws_web_identity_token` / `aws_sts_endpoint`

Live proxy with a single `bedrock_mantle/openai.gpt-5.5` deployment that carries no AWS credentials of its own, so the only way a request can be signed is with a credential source the caller names. The proxy host has one named profile (`hostprofile`) available via `AWS_SHARED_CREDENTIALS_FILE`; the process env is scrubbed of every other AWS credential (`AWS_CONFIG_FILE=/dev/null`, no `AWS_ACCESS_KEY_ID` / `AWS_SESSION_TOKEN` / `AWS_BEARER_TOKEN_BEDROCK`, `AWS_EC2_METADATA_DISABLED=true`). Requests go to `/v1/responses` since that path already forwards `aws_profile_name` from the body today

```yaml
model_list:
  - model_name: mantle-gpt-5.5
    litellm_params:
      model: bedrock_mantle/openai.gpt-5.5
      api_base: https://bedrock-mantle.us-east-2.api.aws/v1
      aws_region_name: us-east-2

general_settings:
  master_key: sk-1234
```

**Before**, captured at 3e9e52042a (the commit this branch is based on). With no profile named in the body the request cannot be signed (the deployment has no credentials), but injecting `aws_profile_name` in the body makes the proxy sign with the host profile and return a real completion from live us-east-2 Bedrock Mantle (real tokens billed, no mocks). That is the escalation: a caller chose which host identity signs the request

```bash
# control: no aws_profile_name -> unsigned, no credentials
curl -sS http://localhost:4021/v1/responses \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"mantle-gpt-5.5","input":"Reply with exactly: hi"}'
```
```json
{"error":{"message":"litellm.APIConnectionError: Bedrock Mantle auth failed: no Bearer token and no usable AWS credentials. ...botocore.exceptions.NoCredentialsError: Unable to locate credentials ...","code":"500"}}
```
```bash
# exploit: client injects a host profile name -> proxy signs with it
curl -sS http://localhost:4021/v1/responses \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"mantle-gpt-5.5","input":"Reply with exactly: profile hijack works","aws_profile_name":"hostprofile"}'
```
```json
{"id":"resp_...","model":"mantle-gpt-5.5","object":"response","output":[{"type":"reasoning",...},{"content":[{"text":"profile hijack works","type":"output_text"}],"role":"assistant",...}]}
```

**After**, captured at fe9722777e (branch head). The same injected body is rejected at the auth boundary before any signing happens, top-level and nested under `extra_body`:

```bash
curl -sS -w 'HTTP %{http_code}\n' http://localhost:4021/v1/responses \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"mantle-gpt-5.5","input":"Reply with exactly: profile hijack works","aws_profile_name":"hostprofile"}'
```
```
HTTP 401
{"error":{"message":"Authentication Error, Rejected Request: aws_profile_name is not allowed in request body. Clientside passthrough requires explicit admin opt-in via either `general_settings.allow_client_side_credentials = true` (proxy-wide) or `configurable_clientside_auth_params` on the deployment in your proxy config.yaml. ...","type":"auth_error","code":"401"}}
```
```bash
# same field nested under extra_body is blocked too
curl -sS -w 'HTTP %{http_code}\n' http://localhost:4021/v1/responses \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"mantle-gpt-5.5","input":"hi","extra_body":{"aws_profile_name":"hostprofile"}}'
```
```
HTTP 401
{"error":{"message":"Authentication Error, Rejected Request: aws_profile_name is not allowed in request body. ...","type":"auth_error","code":"401"}}
```

It is a gate, not a wall: the ban is the same admin-gated blocklist as the other credential fields, so an operator who deliberately wants client-side profiles turns it back on. With `general_settings.allow_client_side_credentials: true`, the same request signs and completes again (real Bedrock Mantle response):

```json
{"id":"resp_...","model":"mantle-gpt-5.5","object":"response","output":[{"content":[{"text":"opt-in path works",...}],"role":"assistant",...}]}
```

## Type

🐛 Bug Fix

## Changes

Adds `aws_profile_name` to `_BANNED_REQUEST_BODY_PARAMS` in `litellm/proxy/auth/auth_utils.py`. `aws_profile_name` flows into `BaseAWSLLM.get_credentials`, which passes it to `boto3.Session(profile_name=...)`, so a caller-supplied value selects which named profile on the proxy host signs the outbound Bedrock/SageMaker request. The blocklist already banned the other caller-controllable Bedrock auth fields (`aws_role_name`, `aws_web_identity_token`, `aws_sts_endpoint`); `aws_profile_name` is the same primitive and belongs with them. It inherits the existing admin opt-ins, so proxy-wide `allow_client_side_credentials` or a per-deployment `configurable_clientside_auth_params` still permits it when an operator wants client-side profile selection. Config-file `litellm_params` are unaffected; they never pass through this request-body check

The gap predates the credential-forwarding change in #32956; a Bedrock converse model has always read `aws_profile_name` off the request body, and #32956 additionally exposes it on the chat -> Responses bridge. Banning it at the proxy edge covers every path at once, so this ships as its own fix rather than riding on that PR

Regression tests in `tests/test_litellm/proxy/auth/`: `TestIsRequestBodySafeBlocksAwsProfileOverride` in `test_auth_utils.py` asserts a top-level `aws_profile_name` is rejected, that an accompanying `api_key` does not bypass the gate, and that `allow_client_side_credentials` still permits it; the `test_banned_params_extra_body.py` parametrization adds the `extra_body`-nested case. Both fail without the one-line ban and pass with it (verified by removing the entry)
