### PR TITLE
docs(pr-template): gate Final Attestation on presence of a QA runbook

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -44,7 +44,7 @@ If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slac
 
 ## QA runbook
 
-<!-- Only needed when your PR edits tests/e2e; delete this section otherwise
+<!-- This QA runbook and the Final Attestation below are only needed when your PR edits tests/e2e; delete both sections otherwise
 
 For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples
 
@@ -63,5 +63,7 @@ Example checklists:
 -->
 
 ### Final Attestation
+
+<!-- Part of the QA runbook above; keep this only if you kept that section (your PR edits tests/e2e), otherwise delete this Final Attestation too -->
 
 - [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Template-only change, so the proof is the rendered section itself. The QA runbook is already deleted whenever a PR does not touch tests/e2e; the Final Attestation was a sibling section that stayed behind, so contributors on non-e2e PRs were left attesting that "the tests check the right things" when there was no runbook and often no test to speak of. This ties the two together

Before, a non-e2e PR that deletes the QA runbook is still left with a dangling attestation:

```markdown
## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise
...
-->

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
```

After, the runbook comment names the Final Attestation as part of the same deletable unit, and the attestation carries its own note pointing back at the runbook, so deleting one deletes the other:

```markdown
## QA runbook

<!-- This QA runbook and the Final Attestation below are only needed when your PR edits tests/e2e; delete both sections otherwise
...
-->

### Final Attestation

<!-- Part of the QA runbook above; keep this only if you kept that section (your PR edits tests/e2e), otherwise delete this Final Attestation too -->

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
```

This PR itself dogfoods the rule: it edits no tests/e2e, so both the QA runbook and the Final Attestation are omitted below

## Type

📖 Documentation

## Changes

Groups the Final Attestation with the QA runbook so it is only present when a PR actually has a QA runbook (i.e., edits tests/e2e). The runbook's opening comment now says to delete both sections together when they do not apply, and the Final Attestation gets a comment marking it as part of the runbook. No behavior changes; nothing consumes these sections programmatically (no CI check or script references "Final Attestation" or "QA runbook"), so this is purely contributor-facing guidance
