### PR TITLE
fix(get_llm_provider): normalize openai/chat_completions/ model prefix

### DIFF
--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -163,6 +163,17 @@ def get_llm_provider(
                 api_key = litellm_params.api_key
 
         dynamic_api_key = None
+
+        # openai/chat_completions/<name> is an opt-in alias for the OpenAI chat completions
+        # API (mirrors the responses-path handling of the same prefix). Normalize it to
+        # openai/<name> so the bare model id reaches the provider; without this the literal
+        # "chat_completions/<name>" is forwarded and OpenAI rejects it. See #32489.
+        _openai_cc_prefix = "openai/chat_completions/"
+        if model.startswith(_openai_cc_prefix):
+            remainder = model[len(_openai_cc_prefix) :]
+            if remainder:
+                model = f"openai/{remainder}"
+
         # check if llm provider provided
         # AZURE AI-Studio Logic - Azure AI Studio supports AZURE/Cohere
         # If User passes azure/command-r-plus -> we should send it to cohere_chat/command-r-plus

--- a/tests/test_litellm/litellm_core_utils/test_get_llm_provider_logic.py
+++ b/tests/test_litellm/litellm_core_utils/test_get_llm_provider_logic.py
@@ -1,0 +1,36 @@
+from litellm import get_llm_provider
+
+
+def test_openai_chat_completions_prefix_is_normalized():
+    """Regression for #32489: `openai/chat_completions/<name>` must resolve to the
+    OpenAI provider with the bare model id. Without normalization the literal
+    `chat_completions/<name>` is forwarded to OpenAI, which rejects it as an
+    invalid model id on the /chat/completions path."""
+    model, provider, _, _ = get_llm_provider(model="openai/chat_completions/gpt-5.2")
+
+    assert provider == "openai"
+    assert model == "gpt-5.2"
+
+
+def test_openai_chat_completions_prefix_with_nested_path_is_normalized():
+    """The remainder after the prefix is preserved verbatim, including further slashes."""
+    model, provider, _, _ = get_llm_provider(model="openai/chat_completions/ft:gpt-4o:acme")
+
+    assert provider == "openai"
+    assert model == "ft:gpt-4o:acme"
+
+
+def test_openai_chat_completions_prefix_with_empty_remainder_is_left_untouched():
+    """A bare prefix with no model name is not a valid alias and must not be rewritten."""
+    model, provider, _, _ = get_llm_provider(model="openai/chat_completions/")
+
+    assert provider == "openai"
+    assert model == "chat_completions/"
+
+
+def test_plain_openai_model_is_unaffected():
+    """Models without the alias prefix must resolve exactly as before."""
+    model, provider, _, _ = get_llm_provider(model="openai/gpt-4o")
+
+    assert provider == "openai"
+    assert model == "gpt-4o"


### PR DESCRIPTION
## Relevant issues

Fixes #32489

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Reproduced at unit level against the `get_llm_provider` resolver. Before the fix the `chat_completions/` segment is forwarded as part of the model id; after, it is stripped:

```
# before fix
>>> get_llm_provider(model="openai/chat_completions/gpt-5.2")
('chat_completions/gpt-5.2', 'openai', None, None)   # -> OpenAI rejects "chat_completions/gpt-5.2"

# with fix
>>> get_llm_provider(model="openai/chat_completions/gpt-5.2")
('gpt-5.2', 'openai', None, None)
```

The two new regression tests `test_openai_chat_completions_prefix_is_normalized` and `test_openai_chat_completions_prefix_with_nested_path_is_normalized` fail on the base commit and pass with this change; `test_plain_openai_model_is_unaffected` guards against regressing normal openai model resolution.

I don't have an OpenAI-compatible proxy with a GPT-5.2 backend wired up to show the live 400, so the regression tests reproduce the exact resolution the /chat/completions path performs on the reported model id.

## Type

🐛 Bug Fix

## Changes

The `openai/chat_completions/<name>` model prefix is an opt-in alias for the OpenAI chat completions API (the mirror of the `responses/` prefix). It was only handled on the responses path, in `_normalize_openai_chat_completions_responses_model` inside `litellm/responses/main.py`. On the `/chat/completions` path the prefix was never stripped, so after the `openai/` provider segment was consumed the literal `chat_completions/<name>` remained as the model id and OpenAI rejected it with an invalid-model error (reported in #32489).

`get_llm_provider` now normalizes `openai/chat_completions/<name>` to `openai/<name>` early, before provider resolution, so the bare model id reaches the provider on every entrypoint that routes through it. The normalization is a no-op for any model id that does not carry the prefix, and a bare prefix with an empty remainder is left untouched. This keeps the change to the one reported problem; the `use_chat_completions_api` flag and the GPT-5 auto-route-to-responses behaviour mentioned in the issue are out of scope here.

A regression test file is added at `tests/test_litellm/litellm_core_utils/test_get_llm_provider_logic.py`.
