### PR TITLE
fix(fireworks_ai): honor cache_read_input_token_cost when billing cached prompt tokens

### DIFF
--- a/litellm/llms/fireworks_ai/cost_calculator.py
+++ b/litellm/llms/fireworks_ai/cost_calculator.py
@@ -10,6 +10,7 @@ from litellm.constants import (
     FIREWORKS_AI_56_B_MOE,
     FIREWORKS_AI_176_B_MOE,
 )
+from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
 from litellm.types.utils import Usage
 from litellm.utils import get_model_info
 
@@ -65,22 +66,10 @@ def cost_per_token(model: str, usage: Usage) -> Tuple[float, float]:
     Returns:
         Tuple[float, float] - prompt_cost_in_usd, completion_cost_in_usd
     """
-    ## check if model mapped, else use default pricing
     try:
-        model_info = get_model_info(model=model, custom_llm_provider="fireworks_ai")
+        get_model_info(model=model, custom_llm_provider="fireworks_ai")
+        resolved_model = model
     except Exception:
-        base_model = get_base_model_for_pricing(model_name=model)
+        resolved_model = get_base_model_for_pricing(model_name=model)
 
-        ## GET MODEL INFO
-        model_info = get_model_info(
-            model=base_model, custom_llm_provider="fireworks_ai"
-        )
-
-    ## CALCULATE INPUT COST
-
-    prompt_cost: float = usage["prompt_tokens"] * model_info["input_cost_per_token"]
-
-    ## CALCULATE OUTPUT COST
-    completion_cost = usage["completion_tokens"] * model_info["output_cost_per_token"]
-
-    return prompt_cost, completion_cost
+    return generic_cost_per_token(model=resolved_model, usage=usage, custom_llm_provider="fireworks_ai")

--- a/litellm/llms/fireworks_ai/cost_calculator.py
+++ b/litellm/llms/fireworks_ai/cost_calculator.py
@@ -12,7 +12,6 @@ from litellm.constants import (
 )
 from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
 from litellm.types.utils import Usage
-from litellm.utils import get_model_info
 
 
 # Extract the number of billion parameters from the model name
@@ -67,9 +66,10 @@ def cost_per_token(model: str, usage: Usage) -> Tuple[float, float]:
         Tuple[float, float] - prompt_cost_in_usd, completion_cost_in_usd
     """
     try:
-        get_model_info(model=model, custom_llm_provider="fireworks_ai")
-        resolved_model = model
+        return generic_cost_per_token(model=model, usage=usage, custom_llm_provider="fireworks_ai")
     except Exception:
-        resolved_model = get_base_model_for_pricing(model_name=model)
-
-    return generic_cost_per_token(model=resolved_model, usage=usage, custom_llm_provider="fireworks_ai")
+        return generic_cost_per_token(
+            model=get_base_model_for_pricing(model_name=model),
+            usage=usage,
+            custom_llm_provider="fireworks_ai",
+        )

--- a/tests/test_litellm/llms/fireworks_ai/test_fireworks_ai_cost_calculator.py
+++ b/tests/test_litellm/llms/fireworks_ai/test_fireworks_ai_cost_calculator.py
@@ -1,0 +1,96 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+import litellm
+from litellm.litellm_core_utils.get_model_cost_map import get_model_cost_map
+from litellm.llms.fireworks_ai.cost_calculator import cost_per_token
+from litellm.types.utils import PromptTokensDetailsWrapper, Usage
+
+
+@pytest.fixture(autouse=True)
+def force_local_model_cost(monkeypatch):
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    litellm.model_cost = get_model_cost_map(url=litellm.model_cost_map_url)
+
+
+def test_cost_per_token_applies_cache_read_discount():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/25950.
+
+    Fireworks reports cached prompt tokens in
+    ``usage.prompt_tokens_details.cached_tokens`` and the price map defines
+    ``cache_read_input_token_cost`` for cache-capable models. The pre-fix
+    calculator multiplied every prompt token by ``input_cost_per_token`` and
+    silently dropped the cache discount, so users were overbilled on any
+    cache-hit turn.
+    """
+    model = "accounts/fireworks/models/kimi-k2p5"
+    model_info = litellm.model_cost[f"fireworks_ai/{model}"]
+    input_rate = model_info["input_cost_per_token"]
+    cache_read_rate = model_info["cache_read_input_token_cost"]
+    assert cache_read_rate < input_rate
+
+    prompt_tokens = 1000
+    cached_tokens = 800
+    completion_tokens = 50
+
+    usage = Usage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=cached_tokens,
+        ),
+    )
+
+    prompt_cost, completion_cost = cost_per_token(model=model, usage=usage)
+
+    fresh_tokens = prompt_tokens - cached_tokens
+    expected_prompt = fresh_tokens * input_rate + cached_tokens * cache_read_rate
+    expected_completion = completion_tokens * model_info["output_cost_per_token"]
+
+    assert prompt_cost == pytest.approx(expected_prompt, rel=1e-9)
+    assert completion_cost == pytest.approx(expected_completion, rel=1e-9)
+
+
+def test_cost_per_token_no_cache_matches_flat_rate():
+    """
+    Cache-free requests must keep charging every prompt token at the standard
+    input rate; this guards against a regression where the cache-aware path
+    accidentally re-classifies plain prompt tokens.
+    """
+    model = "accounts/fireworks/models/kimi-k2p5"
+    model_info = litellm.model_cost[f"fireworks_ai/{model}"]
+
+    prompt_tokens = 400
+    completion_tokens = 60
+    usage = Usage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+    )
+
+    prompt_cost, completion_cost = cost_per_token(model=model, usage=usage)
+
+    assert prompt_cost == pytest.approx(prompt_tokens * model_info["input_cost_per_token"], rel=1e-9)
+    assert completion_cost == pytest.approx(completion_tokens * model_info["output_cost_per_token"], rel=1e-9)
+
+
+def test_cost_per_token_unmapped_model_falls_back_to_size_tier():
+    """
+    Models that are not in the local price map must still be priced via the
+    parameter-size tier fallback (``get_base_model_for_pricing``) rather than
+    raising.
+    """
+    model = "some-brand-new-70b-model-that-is-not-mapped"
+    usage = Usage(prompt_tokens=100, completion_tokens=25, total_tokens=125)
+
+    prompt_cost, completion_cost = cost_per_token(model=model, usage=usage)
+
+    tier_info = litellm.model_cost["fireworks-ai-above-16b"]
+    assert prompt_cost == pytest.approx(100 * tier_info["input_cost_per_token"], rel=1e-9)
+    assert completion_cost == pytest.approx(25 * tier_info["output_cost_per_token"], rel=1e-9)


### PR DESCRIPTION
## Relevant issues

Fixes #25950

## Linear ticket

n/a

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on \`make test-unit\`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting \`@greptileai\` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Steps to reproduce with a live proxy against real Fireworks:

1. Configure the proxy against a cache-capable Fireworks model (e.g. \`kimi-k2p5\`, \`glm-4p7\`, \`glm-5p1\`). Example \`config.yaml\`:

\`\`\`yaml
model_list:
  - model_name: kimi-k2p5
    litellm_params:
      model: fireworks_ai/accounts/fireworks/models/kimi-k2p5
      api_key: os.environ/FIREWORKS_API_KEY
\`\`\`

2. Run the proxy: \`python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log\`

3. First call primes the cache, second call gets a cache hit:

\`\`\`bash
for i in 1 2; do
  curl -s http://localhost:4000/chat/completions \
    -H "Authorization: Bearer sk-1234" \
    -H "Content-Type: application/json" \
    -d '{
      "model": "kimi-k2p5",
      "messages": [
        {"role": "system", "content": "<a long system prompt of ~1000 tokens>"},
        {"role": "user", "content": "Say hi"}
      ]
    }' | jq '{usage, cost: .response_cost}'
done
\`\`\`

Before this patch, the second call reports cost identical to the first even though \`usage.prompt_tokens_details.cached_tokens\` is populated. After this patch, the second call's \`response_cost\` drops because cached tokens are billed at \`cache_read_input_token_cost\` (e.g. \`1e-07\` vs \`6e-07\` for \`kimi-k2p5\`, a 6x discount on the cached fraction).

Also verified against the local price map with the new unit tests:

- \`test_cost_per_token_applies_cache_read_discount\` reproduces #25950: with \`prompt_tokens=1000, cached_tokens=800\` on \`kimi-k2p5\`, the pre-fix code bills \`1000 * input_cost = 6e-4\`; the fixed code bills \`200 * input_cost + 800 * cache_read_cost = 2e-4\`.
- \`test_cost_per_token_no_cache_matches_flat_rate\` guards the non-cache path so this refactor doesn't silently re-classify plain prompt tokens.
- \`test_cost_per_token_unmapped_model_falls_back_to_size_tier\` guards the parameter-size tier fallback (\`get_base_model_for_pricing\`) for models not in the local price map.

## Type

🐛 Bug Fix

## Changes

\`litellm/llms/fireworks_ai/cost_calculator.py\` used a hand-rolled \`prompt_tokens * input_cost_per_token\` computation that ignored every extra Usage field: \`cached_tokens\`, \`cache_creation_tokens\`, \`audio_tokens\`, \`reasoning_tokens\`. DeepSeek, xAI, Perplexity, and other OpenAI-compatible providers delegate to \`generic_cost_per_token\`, which handles all of these against the fields already defined in the price map (\`cache_read_input_token_cost\`, \`cache_creation_input_token_cost\`, etc.). Fireworks was the outlier.

This change routes Fireworks through the same helper. The size-tier fallback (\`fireworks-ai-up-to-4b\`, \`fireworks-ai-4.1b-to-16b\`, \`fireworks-ai-above-16b\`, and the two MoE tiers) is preserved for models that are not in the local price map; it just resolves the model name before handing off to the shared calculator.

Adds \`tests/test_litellm/llms/fireworks_ai/test_fireworks_ai_cost_calculator.py\` with three regression tests that would have failed against the pre-fix code (verified locally by reverting the change and re-running).