### PR TITLE
fix(bedrock): apply empty-user-message substitution in converse string branch

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -4395,7 +4395,7 @@ class BedrockConverseMessagesProcessor:
                                 _parts.append(_cache_point_block)
                     user_content.extend(_parts)
                 elif message_block["content"] and isinstance(message_block["content"], str):
-                    _part = BedrockContentBlock(text=messages[msg_i]["content"])
+                    _part = BedrockContentBlock(text=message_block["content"])
                     _cache_point_block = litellm.AmazonConverseConfig()._get_cache_point_block(
                         message_block, block_type="content_block", model=model
                     )
@@ -4770,7 +4770,7 @@ def _bedrock_converse_messages_pt(
                             _parts.append(_cache_point_block)
                 user_content.extend(_parts)
             elif message_block["content"] and isinstance(message_block["content"], str):
-                _part = BedrockContentBlock(text=messages[msg_i]["content"])
+                _part = BedrockContentBlock(text=message_block["content"])
                 _cache_point_block = litellm.AmazonConverseConfig()._get_cache_point_block(
                     message_block, block_type="content_block", model=model
                 )

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -183,6 +183,62 @@ def test_bedrock_converse_assistant_with_empty_thinking_block_and_tool_calls():
 
 
 @pytest.mark.parametrize(
+    "empty_content",
+    ["", "   "],
+    ids=["empty", "spaces"],
+)
+def test_bedrock_converse_string_user_message_uses_continue_substitution(monkeypatch, empty_content):
+    """
+    Regression for the string-content branch of `_bedrock_converse_messages_pt`.
+
+    `get_user_message_block_or_continue_message()` replaces empty/whitespace-only
+    user content with a "continue" placeholder because Bedrock Converse rejects
+    blank-text ContentBlocks (issue #7169). The list-content branch honored that
+    substitution, but the string-content branch read the *original* message
+    content (`messages[msg_i]["content"]`) instead of the substituted block, so an
+    empty/whitespace string was forwarded to Bedrock unchanged and rejected with
+    "The text field in the ContentBlock object ... is blank."
+
+    Verify string content emits the substituted "Please continue." text, matching
+    the list-content branch.
+    """
+    monkeypatch.setattr(litellm, "modify_params", True)
+
+    result = _bedrock_converse_messages_pt(
+        messages=[{"role": "user", "content": empty_content}],
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        llm_provider="bedrock",
+    )
+
+    user_blocks = [m for m in result if m["role"] == "user"]
+    text_blocks = [b["text"] for m in user_blocks for b in m["content"] if "text" in b]
+    assert text_blocks == ["Please continue."], f"expected continue substitution, got {result!r}"
+    for text in text_blocks:
+        assert text.strip(), "Bedrock rejects blank-text ContentBlocks"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "empty_content",
+    ["", "   "],
+    ids=["empty", "spaces"],
+)
+async def test_bedrock_converse_string_user_message_uses_continue_substitution_async(monkeypatch, empty_content):
+    """Async counterpart of the string-content substitution regression (issue #7169)."""
+    monkeypatch.setattr(litellm, "modify_params", True)
+
+    result = await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
+        messages=[{"role": "user", "content": empty_content}],
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        llm_provider="bedrock",
+    )
+
+    user_blocks = [m for m in result if m["role"] == "user"]
+    text_blocks = [b["text"] for m in user_blocks for b in m["content"] if "text" in b]
+    assert text_blocks == ["Please continue."], f"expected continue substitution, got {result!r}"
+
+
+@pytest.mark.parametrize(
     "thinking_block",
     [
         {"type": "thinking", "thinking": "oss reasoning", "signature": None},


### PR DESCRIPTION
## Relevant issues

Fixes #33016

## Linear ticket

<!-- external contributor: none -->

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes lint / format / unit tests locally (`ruff format --check`, `ruff check`, `basedpyright` no new errors, targeted `pytest`)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 (Greptile scored this **5/5 — safe to merge**)

## Screenshots / Proof of Fix

This is a pure, offline message-transformation bug, so the deterministic proof is the transform output before vs. after. (A live Bedrock call would need AWS credentials / real spend, but the entire defect and fix live inside the message transform, so its output is the root-cause proof.)

**Before** — commit `3d63eda` (base, buggy). Whitespace/empty user content is forwarded blank, which Bedrock rejects with *"The text field in the ContentBlock object ... is blank."*:

```
SYNC  whitespace : [{'role': 'user', 'content': [{'text': '   '}]}]
SYNC  empty      : [{'role': 'user', 'content': [{'text': ''}]}]
```

**After** — commit `94ffd3e` (this PR). Substitution applied for both sync and async, matching the list-content branch:

```
SYNC  whitespace : [{'role': 'user', 'content': [{'text': 'Please continue.'}]}]
SYNC  empty      : [{'role': 'user', 'content': [{'text': 'Please continue.'}]}]
ASYNC whitespace : [{'role': 'user', 'content': [{'text': 'Please continue.'}]}]
ASYNC empty      : [{'role': 'user', 'content': [{'text': 'Please continue.'}]}]
```

New regression tests — fail on `3d63eda`, pass on `94ffd3e`:

```
tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py \
  ::test_bedrock_converse_string_user_message_uses_continue_substitution[empty]        PASSED
  ::test_bedrock_converse_string_user_message_uses_continue_substitution[spaces]       PASSED
  ::test_bedrock_converse_string_user_message_uses_continue_substitution_async[empty]  PASSED
  ::test_bedrock_converse_string_user_message_uses_continue_substitution_async[spaces] PASSED
4 passed
```

Full `test_litellm_core_utils_prompt_templates_factory.py` (84 passed) and the `tests/test_litellm/llms/bedrock/chat/` suite (324 passed) stay green.

## Type

🐛 Bug Fix

## Changes

`_bedrock_converse_messages_pt` / `_bedrock_converse_messages_pt_async` substitute an empty or whitespace-only user message with a `"Please continue."` placeholder (issue #7169) because Bedrock Converse rejects blank-text `ContentBlock`s. The substitution is returned as `message_block`; the list-content branch used it, but the string-content branch read the original `messages[msg_i]["content"]`, so the substitution was silently discarded for string content and the blank text was sent to Bedrock unchanged.

Both branches now read `message_block["content"]`, matching the list-content path and the adjacent `_get_cache_point_block(message_block, ...)` call. Regression tests cover empty and whitespace string content for the sync and async transforms.

---

cc @ishaan-jaff @krrish-berri-2 — small, isolated Bedrock Converse fix with regression tests; would appreciate a look when you get a chance. Thanks for maintaining LiteLLM!

