### PR TITLE
fix(bedrock_mantle): route xai.grok-4.3 via /openai/v1 frontier path

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -43574,6 +43574,7 @@
         "supports_vision": true
     },
     "bedrock_mantle/xai.grok-4.3": {
+        "use_openai_responses_path": true,
         "input_cost_per_token": 1.25e-06,
         "output_cost_per_token": 2.5e-06,
         "cache_read_input_token_cost": 2e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -43806,6 +43806,7 @@
         "supports_vision": true
     },
     "bedrock_mantle/xai.grok-4.3": {
+        "use_openai_responses_path": true,
         "input_cost_per_token": 1.25e-06,
         "output_cost_per_token": 2.5e-06,
         "cache_read_input_token_cost": 2e-07,

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
@@ -460,7 +460,12 @@ class TestBedrockMantleResponsesRegistry:
             model="xai.grok-4.3",
         )
         assert isinstance(cfg, BedrockMantleResponsesAPIConfig)
-        assert cfg.use_openai_path is False
+        # grok-4.3 is a third-party frontier model on Bedrock Mantle, served on the
+        # /openai/v1 base (like gpt-5.x / gemma-4), not the standard /v1 path used by
+        # open-weights models such as gpt-oss. The standard /v1 base returns
+        # "Berm is not enabled for this account", so the price-map entry carries
+        # use_openai_responses_path=true.
+        assert cfg.use_openai_path is True
 
     def test_unmapped_frontier_model_falls_through_to_none(self, restore_model_cost):
         # The gate is data-driven, not name-based: an unseen model not yet in the


### PR DESCRIPTION
## Relevant issues

Follow-up fix to #31916, which added `bedrock_mantle/xai.grok-4.3` but routed it on the standard `/v1` base. Original SigV4 issue: #31196.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

`bedrock_mantle` routing is data-driven from the price map: `mantle_base_segment()` returns `openai/v1` only when the model's entry has `use_openai_responses_path: true`, else `v1`. #31916 added grok-4.3 **without** the flag (by analogy to `gpt-oss`), so it routed to the standard `/v1` base.

But xAI Grok is a third-party **frontier** model on Bedrock Mantle and is served on the `/openai/v1` base (like gpt-5.x and gemma-4), not the `/v1` path used by open-weights models such as gpt-oss. Live behavior against `bedrock-mantle.<region>.api.aws` (real SigV4 calls, no mocks):

- **Before** (grok on `/v1/chat/completions`): `{"error":{"code":"access_denied","message":"Berm is not enabled for this account","type":"permission_denied_error"}}`
- **After** (this change — grok on `/openai/v1`): `200 OK`, normal completion (`finish_reason` present, reasoning + output tokens billed).

AWS docs confirm the `/openai/v1` prefix is required for these frontier models; omitting it returns a 404/validation error.

## Type

🐛 Bug Fix

## Changes

- Add `"use_openai_responses_path": true` to the `bedrock_mantle/xai.grok-4.3` entry in `model_prices_and_context_window.json` and its backup, so `mantle_base_segment()` returns `openai/v1`.
- Update `test_registry_returns_native_config_for_xai_grok` to assert `use_openai_path is True` (with a comment explaining grok is a frontier model on `/openai/v1`).
