### PR TITLE
fix(auth): deny wildcard model access for unrecognized provider prefixes

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -4384,12 +4384,21 @@ def _model_custom_llm_provider_matches_wildcard_pattern(model: str, allowed_mode
     - `allowed_model_pattern=anthropic/*`
     """
     try:
-        model, custom_llm_provider, _, _ = get_llm_provider(model=model)
+        resolved_model, custom_llm_provider, _, _ = get_llm_provider(model=model)
     except Exception:
         return False
 
+    # Only infer a provider for a bare model name (e.g. "gpt-4o" -> "openai/gpt-4o").
+    # When get_llm_provider cannot strip an explicit provider prefix (e.g. an
+    # unrecognized "bedrockz/...") it leaves the prefix on the resolved model while
+    # still guessing a provider ("bedrock"), so re-prefixing would build a bogus
+    # "bedrock/bedrockz/..." that spuriously matches "bedrock/*" and grant access to
+    # a model the key/team is not allowed to call.
+    if "/" in resolved_model:
+        return False
+
     return is_model_allowed_by_pattern(
-        model=f"{custom_llm_provider}/{model}",
+        model=f"{custom_llm_provider}/{resolved_model}",
         allowed_model_pattern=allowed_model_pattern,
     )
 

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -4413,3 +4413,41 @@ async def test_common_checks_personal_user_budget_blocks_in_gather():
                 request=MagicMock(spec=Request),
             )
     assert "User=u1" in str(over.value)
+
+
+@pytest.mark.parametrize(
+    "model, allowed_models, expected",
+    [
+        # bare model name resolves its provider and matches a provider wildcard
+        ("gpt-4", ["openai/*"], True),
+        # explicit, correct provider prefix matches
+        ("bedrock/anthropic.claude-3-5-sonnet-20240620", ["bedrock/*"], True),
+        # explicit but WRONG provider prefix must NOT match, even though
+        # get_llm_provider loosely resolves "bedrockz/..." to the "bedrock" provider
+        ("bedrockz/anthropic.claude-3-5-sonnet-20240620", ["bedrock/*"], False),
+        ("openaiz/gpt-4o-mini", ["openai/*"], False),
+        # sub-pattern precision is preserved
+        ("bedrock/claude-3-5-sonnet-20240620", ["bedrock/claude-*"], True),
+        ("bedrock/claude-3-6-sonnet-20240620", ["bedrock/claude-3-5-*"], False),
+    ],
+)
+def test_model_matches_any_wildcard_pattern_in_list_respects_provider_prefix(
+    model, allowed_models, expected
+):
+    """
+    A wildcard like "bedrock/*" must not grant access to a different, unrecognized
+    provider prefix such as "bedrockz/...". get_llm_provider loosely resolves
+    "bedrockz/..." to the "bedrock" provider without stripping the prefix, so the
+    provider-inference matcher must skip re-prefixing an already-prefixed model to
+    avoid a "bedrock/bedrockz/..." string that spuriously matches "bedrock/*".
+    """
+    from litellm.proxy.auth.auth_checks import (
+        _model_matches_any_wildcard_pattern_in_list,
+    )
+
+    assert (
+        _model_matches_any_wildcard_pattern_in_list(
+            model=model, allowed_model_list=allowed_models
+        )
+        is expected
+    )


### PR DESCRIPTION
## Relevant issues

Fixes #33030

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes lint / format / unit tests locally
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

Access-control bug in the proxy's wildcard model-access check, reproducible offline (no keys/network).

**Root cause:** `_model_custom_llm_provider_matches_wildcard_pattern` re-prefixes the model returned by `get_llm_provider` with the inferred provider. For a bare name (`gpt-4o` → `openai/gpt-4o`) that is correct, but `get_llm_provider("bedrockz/anthropic.claude-3-5-sonnet-20240620")` loosely resolves the provider to `bedrock` **without stripping** the `bedrockz/` prefix, so the re-check runs against `bedrock/bedrockz/anthropic...`, which matches `bedrock/*` and grants access.

**Before** (base `3d63eda`) — the repo's own regression tests fail:

```
FAILED tests/proxy_unit_tests/test_auth_checks.py::test_can_key_call_model_wildcard_access[key_models4-bedrockz/anthropic.claude-3-5-sonnet-20240620-False]
FAILED tests/proxy_unit_tests/test_auth_checks.py::test_can_team_access_model[bedrockz/anthropic.claude-3-5-sonnet-20240620-team_models5-False]
2 failed, 16 passed
```
(This is the `auth-and-jwt` job that is currently red on PRs against `litellm_oss_daily_2026_07_10`.)

**After** (this PR):

```
tests/proxy_unit_tests/test_auth_checks.py .. (test_can_key_call_model_wildcard_access + test_can_team_access_model)
18 passed
```

New focused, offline unit test (fails on base, passes here):

```
tests/test_litellm/proxy/auth/test_auth_checks.py::test_model_matches_any_wildcard_pattern_in_list_respects_provider_prefix[...]  6 passed
```

Matrix verified via the matcher directly:

| model | allowed | result |
|---|---|---|
| `openai/gpt-4o` | `openai/*` | ✅ allow |
| `bedrock/anthropic.claude-3-5-sonnet-20240620` | `bedrock/*` | ✅ allow |
| `bedrockz/anthropic.claude-3-5-sonnet-20240620` | `bedrock/*` | ⛔ deny (was wrongly allowed) |
| `openaiz/gpt-4o-mini` | `openai/*` | ⛔ deny |
| `gpt-4` (bare) | `openai/*` | ✅ allow (inference preserved) |
| `bedrock/claude-3-6-sonnet-20240620` | `bedrock/claude-3-5-*` | ⛔ deny |

## Type

🐛 Bug Fix

## Changes

Only infer a provider for a **bare** model name. If `get_llm_provider` returns a model that still contains `/` (an unrecognized prefix it could not strip), skip the re-prefix and return `False`, so a wildcard like `bedrock/*` no longer matches a different prefix such as `bedrockz/*`. Valid prefixes and bare-name provider inference are unchanged.

---

cc @ishaan-jaff @krrish-berri-2 — this also fixes the `auth-and-jwt` regression currently red on `litellm_oss_daily_*` (the two `bedrockz` access-check cases). Small and isolated; would appreciate a look. Thanks!
