### PR TITLE
fix(streaming): preserve unsigned thinking blocks in stream_chunk_builder

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -382,14 +382,20 @@ class ChunkProcessor:
 
         def _flush_thinking_block() -> None:
             nonlocal current_thinking_text_parts, current_signature
-            if len(current_thinking_text_parts) > 0 and current_signature:
-                thinking_blocks.append(
-                    ChatCompletionThinkingBlock(
-                        type="thinking",
-                        thinking="".join(current_thinking_text_parts),
-                        signature=current_signature,
-                    )
+            if len(current_thinking_text_parts) > 0:
+                # Preserve the reasoning text even when no signature arrived (e.g. a
+                # stream truncated mid-thinking by max_tokens/cancellation, or a
+                # provider that emits thinking text without per-block signatures).
+                # `signature` is optional on ChatCompletionThinkingBlock, and the
+                # send-side prompt transforms already drop unsignable blocks before
+                # replaying them, so keeping the text here avoids losing it.
+                thinking_block = ChatCompletionThinkingBlock(
+                    type="thinking",
+                    thinking="".join(current_thinking_text_parts),
                 )
+                if current_signature:
+                    thinking_block["signature"] = current_signature
+                thinking_blocks.append(thinking_block)
             current_thinking_text_parts = []
             current_signature = None
 

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -238,6 +238,46 @@ def test_get_combined_thinking_content_preserves_interleaved_blocks():
     assert result[2]["signature"] == "sig_block2"
 
 
+def test_get_combined_thinking_content_preserves_unsigned_block():
+    """
+    Regression: a thinking block whose signature never arrives (stream truncated
+    mid-thinking by max_tokens/cancellation, or a provider that emits thinking
+    text without per-block signatures) must keep its reasoning text. Previously
+    the terminal flush required a signature and silently dropped the accumulated
+    text, so thinking_blocks came back as None.
+    """
+    base_chunk = {
+        "id": "chatcmpl-123",
+        "object": "chat.completion.chunk",
+        "created": 1234567890,
+        "model": "claude-sonnet-4-20250514",
+    }
+
+    def make_chunk(**delta_kwargs):
+        return ModelResponseStream(
+            **base_chunk,
+            choices=[StreamingChoices(index=0, delta=Delta(**delta_kwargs), finish_reason=None)],
+        )
+
+    chunks = [
+        make_chunk(role="assistant", content=None),
+        make_chunk(thinking_blocks=[{"type": "thinking", "thinking": "Let me reason "}]),
+        make_chunk(thinking_blocks=[{"type": "thinking", "thinking": "about this."}]),
+    ]
+    thinking_chunks = [
+        chunk for chunk in chunks if chunk["choices"][0]["delta"].get("thinking_blocks")
+    ]
+    processor = ChunkProcessor(chunks=chunks)
+    result = processor.get_combined_thinking_content(thinking_chunks)
+
+    assert result is not None, "unsigned thinking text must not be dropped"
+    assert len(result) == 1
+    assert result[0]["type"] == "thinking"
+    assert result[0]["thinking"] == "Let me reason about this."
+    # signature is optional and simply absent (or None) when none arrived
+    assert not result[0].get("signature")
+
+
 def test_cache_read_input_tokens_retained():
     chunk1 = ModelResponseStream(
         id="chatcmpl-95aabb85-c39f-443d-ae96-0370c404d70c",


### PR DESCRIPTION
## Relevant issues

Fixes #33034

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes lint / format / unit tests locally
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

Reasoning-content data loss during streamed-response assembly, reproducible offline (no keys/network).

**Before** (base `3d63eda`) — unsigned thinking text is dropped:

```
thinking_blocks (unsigned stream): None
```

**After** (this PR) — text preserved; signed/redacted paths unchanged:

```
UNSIGNED: [{'type': 'thinking', 'thinking': 'Let me reason about this.'}]
SIGNED  : [{'type': 'thinking', 'thinking': 'reasoning', 'signature': 'sig123'}]
REDACTED: [{'type': 'redacted_thinking', 'data': 'abc'}]
```

New regression test (fails on base, passes here) + existing thinking tests still green:

```
tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py  17 passed
  (incl. test_get_combined_thinking_content_preserves_unsigned_block)
```

## Type

🐛 Bug Fix

## Changes

`ChunkProcessor.get_combined_thinking_content` required both accumulated text and a signature to emit a thinking block, so a block whose signature never arrived (truncated stream, or a provider without per-block signatures) lost all its reasoning text. Emit the block whenever text exists and attach the signature only when present. `signature` is `Optional` on `ChatCompletionThinkingBlock`, and the send-side prompt transforms already drop unsignable blocks before replaying them, so this does not risk invalid replay. Signed and redacted paths are unchanged.

---

cc @ishaan-jaff @krrish-berri-2 — isolated data-loss fix in stream assembly with a regression test. Thanks!
