### PR TITLE
fix(fireworks): set finish_reason=tool_calls for content-embedded tool calls

### DIFF
--- a/litellm/llms/fireworks_ai/chat/transformation.py
+++ b/litellm/llms/fireworks_ai/chat/transformation.py
@@ -530,10 +530,22 @@ class FireworksAIConfig(OpenAIGPTConfig):
 
         ## FIREWORKS AI sends tool calls in the content field instead of tool_calls
         for choice in response.choices:
-            cast(Choices, choice).message = self._handle_message_content_with_tool_calls(
-                message=cast(Choices, choice).message,
+            typed_choice = cast(Choices, choice)
+            typed_choice.message = self._handle_message_content_with_tool_calls(
+                message=typed_choice.message,
                 tool_calls=optional_params.get("tools", None),
             )
+            # Fireworks keeps finish_reason="stop" even when the content held a
+            # tool call, and transform_response builds the ModelResponse directly
+            # (bypassing convert_to_model_response_object). Align with the
+            # OpenAI-style contract and the shared converter so agent loops that
+            # branch on finish_reason == "tool_calls" execute the tool.
+            if (
+                typed_choice.finish_reason == "stop"
+                and typed_choice.message.tool_calls
+                and len(typed_choice.message.tool_calls) > 0
+            ):
+                typed_choice.finish_reason = "tool_calls"
 
         response._hidden_params = {
             "additional_headers": additional_headers,

--- a/litellm/llms/fireworks_ai/chat/transformation.py
+++ b/litellm/llms/fireworks_ai/chat/transformation.py
@@ -540,11 +540,7 @@ class FireworksAIConfig(OpenAIGPTConfig):
             # (bypassing convert_to_model_response_object). Align with the
             # OpenAI-style contract and the shared converter so agent loops that
             # branch on finish_reason == "tool_calls" execute the tool.
-            if (
-                typed_choice.finish_reason == "stop"
-                and typed_choice.message.tool_calls
-                and len(typed_choice.message.tool_calls) > 0
-            ):
+            if typed_choice.finish_reason == "stop" and typed_choice.message.tool_calls:
                 typed_choice.finish_reason = "tool_calls"
 
         response._hidden_params = {

--- a/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
@@ -1098,3 +1098,102 @@ def test_streaming_surfaces_fireworks_response_fields():
     assert surfaced["fireworks_raw_outputs"] == [raw_output]
     assert surfaced["fireworks_perf_metrics"] == {"prompt-tokens": 5}
     assert surfaced["fireworks_prompt_token_ids"] == [1, 2, 3]
+
+
+def test_transform_response_sets_finish_reason_tool_calls_for_content_tool_call():
+    """
+    Fireworks returns tool calls as a JSON string in message.content with
+    finish_reason="stop". After the content is converted into message.tool_calls,
+    finish_reason must become "tool_calls" (matching the shared response converter
+    and providers like Ollama/xAI) so OpenAI-style agent loops execute the tool
+    instead of treating the turn as finished.
+    """
+    config = FireworksAIConfig()
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    body = {
+        "id": "resp-test",
+        "object": "chat.completion",
+        "created": 1234567890,
+        "model": "llama-v3-70b-instruct",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": json.dumps({"name": "get_weather", "arguments": {"city": "SF"}}),
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+    result = config.transform_response(
+        model="llama-v3-70b-instruct",
+        raw_response=_make_fireworks_raw_response(body),
+        model_response=ModelResponse(),
+        logging_obj=MagicMock(),
+        request_data={},
+        messages=[{"role": "user", "content": "weather in SF?"}],
+        optional_params={"tools": tools},
+        litellm_params={},
+        encoding=None,
+        api_key="test-key",
+    )
+
+    choice = result.choices[0]
+    assert choice.message.tool_calls is not None
+    assert choice.message.tool_calls[0].function.name == "get_weather"
+    assert choice.finish_reason == "tool_calls"
+
+
+def test_transform_response_keeps_stop_for_plain_text():
+    """A normal text answer (no tool call in content) must keep finish_reason='stop'."""
+    config = FireworksAIConfig()
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "get_weather", "parameters": {"type": "object", "properties": {}}},
+        }
+    ]
+    body = {
+        "id": "resp-test",
+        "object": "chat.completion",
+        "created": 1234567890,
+        "model": "llama-v3-70b-instruct",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "It is sunny in SF."},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+
+    result = config.transform_response(
+        model="llama-v3-70b-instruct",
+        raw_response=_make_fireworks_raw_response(body),
+        model_response=ModelResponse(),
+        logging_obj=MagicMock(),
+        request_data={},
+        messages=[{"role": "user", "content": "weather in SF?"}],
+        optional_params={"tools": tools},
+        litellm_params={},
+        encoding=None,
+        api_key="test-key",
+    )
+
+    choice = result.choices[0]
+    assert choice.message.content == "It is sunny in SF."
+    assert not choice.message.tool_calls
+    assert choice.finish_reason == "stop"


### PR DESCRIPTION
## Relevant issues

Fixes #33036

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes lint / format / unit tests locally
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

Reproducible offline (no keys/network).

**Before** (base `3d63eda`) — tool call present but finish_reason wrong:

```
TOOL-CALL : tool_calls=['get_weather'] | finish_reason='stop'
```

**After** (this PR):

```
TOOL-CALL : tool_calls=['get_weather'] | finish_reason='tool_calls'
PLAIN-TEXT: content='Just a normal text answer.' | finish_reason='stop'   # unaffected
```

New regression tests (the tool-call one fails on base, passes here) + full Fireworks file green:

```
tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py  50 passed
  (incl. test_transform_response_sets_finish_reason_tool_calls_for_content_tool_call
         test_transform_response_keeps_stop_for_plain_text)
```

## Type

🐛 Bug Fix

## Changes

`transform_response` builds the `ModelResponse` directly (bypassing `convert_to_model_response_object`) and converts Fireworks' content-embedded tool call into `message.tool_calls` without updating `finish_reason`. Set `finish_reason="tool_calls"` after the conversion when a tool call is present and `finish_reason` is still `"stop"` — matching the shared response converter and providers like Ollama/xAI. Plain-text responses are unaffected.

---

cc @ishaan-jaff @krrish-berri-2 — isolated Fireworks tool-calling fix with regression tests. Thanks!
