### PR TITLE
feat(ollama): update reasoning_effort to think mapping for latest Ollama docs

### DIFF
--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -46,6 +46,30 @@ else:
     LiteLLMLoggingObj = Any
 
 
+_OLLAMA_THINK_LEVELS: tuple[str, ...] = ("low", "medium", "high", "max")
+
+
+def _map_reasoning_effort_to_think(value: Any, model: str) -> Union[bool, str]:
+    if not isinstance(value, str):
+        return bool(value)
+
+    if model.startswith("gpt-oss"):
+        if value in _OLLAMA_THINK_LEVELS[:3]:
+            return value
+        return "high" if value in {"xhigh", "max"} else "low"
+
+    effort_to_think: dict[str, Union[bool, str]] = {
+        "none": False,
+        "minimal": False,
+        "low": "low",
+        "medium": "medium",
+        "high": "high",
+        "xhigh": "max",
+        "max": "max",
+    }
+    return effort_to_think.get(value, value in {"low", "medium", "high"})
+
+
 class OllamaChatConfig(BaseConfig):
     """
     Reference: https://github.com/ollama/ollama/blob/main/docs/api.md#parameters
@@ -178,10 +202,7 @@ class OllamaChatConfig(BaseConfig):
                 if value.get("json_schema") and value["json_schema"].get("schema"):
                     optional_params["format"] = value["json_schema"]["schema"]
             if param == "reasoning_effort" and value is not None:
-                if model.startswith("gpt-oss"):
-                    optional_params["think"] = value
-                else:
-                    optional_params["think"] = value in {"low", "medium", "high"}
+                optional_params["think"] = _map_reasoning_effort_to_think(value, model)
             ### FUNCTION CALLING LOGIC ###
             # Ollama 0.4+ supports native tool calling - pass tools directly
             # and let Ollama handle model capability detection

--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -28,6 +28,7 @@ from litellm.types.utils import (
 )
 
 from ..common_utils import OllamaError, OllamaModelInfo, _convert_image
+from ..chat.transformation import _map_reasoning_effort_to_think
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
@@ -177,10 +178,7 @@ class OllamaConfig(BaseConfig):
             elif param == "stop":
                 optional_params["stop"] = value
             elif param == "reasoning_effort" and value is not None:
-                if model.startswith("gpt-oss"):
-                    optional_params["think"] = value
-                else:
-                    optional_params["think"] = value in {"low", "medium", "high"}
+                optional_params["think"] = _map_reasoning_effort_to_think(value, model)
             elif param == "response_format" and isinstance(value, dict):
                 if value["type"] == "json_object":
                     optional_params["format"] = "json"

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -906,3 +906,81 @@ class TestOllamaToolCallTransformation:
         assert tool_msg["content"] == "Sunny, 72°F"
         assert "tool_call_id" in tool_msg, "tool_call_id must be forwarded to Ollama"
         assert tool_msg["tool_call_id"] == "call_abc123"
+
+
+class TestOllamaReasoningEffortToThinkMapping:
+    """Regression tests for reasoning_effort to ollama think parameter translation.
+
+    Ollama's think field accepts booleans or levels (low/medium/high/max).
+    See https://docs.ollama.com/capabilities/thinking.
+
+    GPT-OSS only accepts low/medium/high (no max, no boolean).
+    """
+
+    @pytest.mark.parametrize(
+        "effort,expected_think",
+        [
+            ("none", False),
+            ("minimal", False),
+            ("low", "low"),
+            ("medium", "medium"),
+            ("high", "high"),
+            ("xhigh", "max"),
+            ("max", "max"),
+        ],
+    )
+    def test_non_gpt_oss_effort_to_think_mapping(self, effort, expected_think):
+        """Each reasoning_effort level maps to the correct ollama think value."""
+        config = OllamaChatConfig()
+        optional_params = config.map_openai_params(
+            non_default_params={"reasoning_effort": effort},
+            optional_params={},
+            model="qwen3",
+            drop_params=False,
+        )
+        assert optional_params["think"] == expected_think
+
+    @pytest.mark.parametrize(
+        "effort,expected_think",
+        [
+            ("low", "low"),
+            ("medium", "medium"),
+            ("high", "high"),
+            ("xhigh", "high"),
+            ("max", "high"),
+            ("none", "low"),
+            ("minimal", "low"),
+        ],
+    )
+    def test_gpt_oss_effort_to_think_mapping(self, effort, expected_think):
+        """GPT-OSS only accepts low/medium/high; max/xhigh clamp to high, none/minimal to low."""
+        config = OllamaChatConfig()
+        optional_params = config.map_openai_params(
+            non_default_params={"reasoning_effort": effort},
+            optional_params={},
+            model="gpt-oss:120b",
+            drop_params=False,
+        )
+        assert optional_params["think"] == expected_think
+
+    def test_non_string_reasoning_effort_falls_back_to_bool(self):
+        """A non-string value (e.g. True) is coerced to a boolean."""
+        config = OllamaChatConfig()
+        optional_params = config.map_openai_params(
+            non_default_params={"reasoning_effort": True},
+            optional_params={},
+            model="qwen3",
+            drop_params=False,
+        )
+        assert optional_params["think"] is True
+
+    def test_reasoning_effort_none_value_does_not_set_think(self):
+        """When reasoning_effort is explicitly None, think is not set at all."""
+        config = OllamaChatConfig()
+        optional_params = config.map_openai_params(
+            non_default_params={"reasoning_effort": None},
+            optional_params={},
+            model="qwen3",
+            drop_params=False,
+        )
+        assert "think" not in optional_params


### PR DESCRIPTION
## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

The following image demonstrates making a completion request to the `glm-5.2:cloud` model with `reasoning_effort` set to `none`. The model performs standard completion and returns only the final message content. The `reasoning_content` field is completely omitted from the response payload.

<img width="1270" height="576" alt="image" src="https://github.com/user-attachments/assets/3efd6af1-d75b-4203-8155-93a41cc439f1" /></br>
The following image demonstrates making a completion request to the `glm-5.2:cloud` model with `reasoning_effort` set to `max`. The parameter maps successfully to Ollama's native think configuration, returning the `reasoning_content` field in the response payload.

<img width="1275" height="821" alt="image" src="https://github.com/user-attachments/assets/384b6713-bf8e-4921-b60f-1810a6b54c17" />


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature

## Changes

This pull request adds support for translating the OpenAI standard `reasoning_effort` parameter to Ollama's native `think` configuration, referencing the official Ollama documentation on enabling thinking in API calls at [Ollama Docs: Enable thinking in API calls](https://docs.ollama.com/capabilities/thinking#enable-thinking-in-api-calls). The mapping has been added to both Ollama chat and completion configurations to ensure uniform behavior.

A helper function handles mapping various reasoning effor levels to the specific string and boolean flags required by the Ollama API. For general Ollama models, effort levels are mapped to `low`, `medium`, `high`, or `max`. For `gpt-oss` models, the effort is mapped specifically to `low`, `medium`, or `high`, with `max` and `xhigh` being safely clamnped to `high`.

Unit tests verify that both the standard mapping and the specialized `gpt-oss` mapping behave correctly across all reasoning effort inputs.