### PR TITLE
refactor(ui): standardize debounce waits behind shared DEBOUNCE_WAIT_MS constant

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.tsx
@@ -8,6 +8,7 @@
 
 import { DownOutlined, ExportOutlined, InfoCircleOutlined, LoadingOutlined, RightOutlined } from "@ant-design/icons";
 import { useDebouncedState } from "@tanstack/react-pacer/debouncer";
+import { DEBOUNCE_WAIT_MS } from "@/utils/debounceConstants";
 import {
   Card,
   Col,
@@ -94,7 +95,7 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
   // Debounced search for user selector
   const [userSearchInput, setUserSearchInput] = useState("");
   const [debouncedUserSearch, setDebouncedUserSearch] = useDebouncedState("", {
-    wait: 300,
+    wait: DEBOUNCE_WAIT_MS,
   });
 
   const {

--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users.tsx
@@ -16,6 +16,7 @@ import {
 import OnboardingModal, { InvitationLink } from "@/components/onboarding_link";
 
 import { updateExistingKeys } from "@/utils/dataUtils";
+import { DEBOUNCE_WAIT_MS } from "@/utils/debounceConstants";
 import { isAdminRole, isProxyAdminRole } from "@/utils/roles";
 import { useDebouncedState } from "@tanstack/react-pacer/debouncer";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -86,7 +87,7 @@ const ViewUserDashboard: React.FC<ViewUserDashboardProps> = ({
   const [userToDelete, setUserToDelete] = useState<UserInfo | null>(null);
   const [activeTab, setActiveTab] = useState("users");
   const [filters, setFilters] = useState<FilterState>(initialFilters);
-  const [debouncedFilters, setDebouncedFilters, debouncer] = useDebouncedState(filters, { wait: 300 });
+  const [debouncedFilters, setDebouncedFilters, debouncer] = useDebouncedState(filters, { wait: DEBOUNCE_WAIT_MS });
   const [isInvitationLinkModalVisible, setIsInvitationLinkModalVisible] = useState(false);
   const [invitationLinkData, setInvitationLinkData] = useState<InvitationLink | null>(null);
   const [baseUrl, setBaseUrl] = useState<string | null>(null);

--- a/ui/litellm-dashboard/src/components/KeyAliasSelect/PaginatedKeyAliasSelect/PaginatedKeyAliasSelect.tsx
+++ b/ui/litellm-dashboard/src/components/KeyAliasSelect/PaginatedKeyAliasSelect/PaginatedKeyAliasSelect.tsx
@@ -1,4 +1,5 @@
 import { useInfiniteKeyAliases } from "@/app/(dashboard)/hooks/keys/useKeyAliases";
+import { DEBOUNCE_WAIT_MS } from "@/utils/debounceConstants";
 import { LoadingOutlined } from "@ant-design/icons";
 import { useDebouncedState } from "@tanstack/react-pacer/debouncer";
 import { Select } from "antd";
@@ -16,7 +17,6 @@ export interface PaginatedKeyAliasSelectProps {
 }
 
 const SCROLL_THRESHOLD = 0.8;
-const DEBOUNCE_MS = 300;
 
 export const PaginatedKeyAliasSelect = ({
   value,
@@ -30,7 +30,7 @@ export const PaginatedKeyAliasSelect = ({
 }: PaginatedKeyAliasSelectProps) => {
   const [searchInput, setSearchInput] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useDebouncedState("", {
-    wait: DEBOUNCE_MS,
+    wait: DEBOUNCE_WAIT_MS,
   });
 
   const teamId = allFilters?.["Team ID"] || undefined;

--- a/ui/litellm-dashboard/src/components/ModelSelect/PaginatedModelSelect/PaginatedModelSelect.tsx
+++ b/ui/litellm-dashboard/src/components/ModelSelect/PaginatedModelSelect/PaginatedModelSelect.tsx
@@ -1,4 +1,5 @@
 import { useInfiniteModelInfo } from "@/app/(dashboard)/hooks/models/useModels";
+import { DEBOUNCE_WAIT_MS } from "@/utils/debounceConstants";
 import { LoadingOutlined } from "@ant-design/icons";
 import { useDebouncedState } from "@tanstack/react-pacer/debouncer";
 import { Select, Space, Typography } from "antd";
@@ -17,7 +18,6 @@ export interface PaginatedModelSelectProps {
 }
 
 const SCROLL_THRESHOLD = 0.8;
-const DEBOUNCE_MS = 300;
 
 export const PaginatedModelSelect = ({
   value,
@@ -30,7 +30,7 @@ export const PaginatedModelSelect = ({
 }: PaginatedModelSelectProps) => {
   const [searchInput, setSearchInput] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useDebouncedState("", {
-    wait: DEBOUNCE_MS,
+    wait: DEBOUNCE_WAIT_MS,
   });
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteModelInfo(

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
@@ -4,6 +4,7 @@ import { useOrganizations } from "@/app/(dashboard)/hooks/organizations/useOrgan
 import { useAllTeams } from "@/app/(dashboard)/hooks/teams/useTeams";
 import { useDebouncedValue } from "@tanstack/react-pacer/debouncer";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
+import { DEBOUNCE_WAIT_MS } from "@/utils/debounceConstants";
 import { ChevronDownIcon, ChevronRightIcon, ChevronUpIcon, SwitchVerticalIcon } from "@heroicons/react/outline";
 import {
   ColumnDef,
@@ -64,7 +65,7 @@ export function VirtualKeysTable() {
     pageSize: 50,
   });
   const [filters, setFilters] = useState<KeyFilterState>(DEFAULT_KEY_FILTERS);
-  const [debouncedFilters] = useDebouncedValue(filters, { wait: 300 });
+  const [debouncedFilters] = useDebouncedValue(filters, { wait: DEBOUNCE_WAIT_MS });
 
   const sortBy = sorting.length > 0 ? sorting[0].id : null;
   const sortOrder = sorting.length > 0 ? (sorting[0].desc ? "desc" : "asc") : null;

--- a/ui/litellm-dashboard/src/components/common_components/team_dropdown.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/team_dropdown.tsx
@@ -3,6 +3,7 @@ import { Select, Typography } from "antd";
 import { LoadingOutlined } from "@ant-design/icons";
 import { useDebouncedState } from "@tanstack/react-pacer/debouncer";
 import { useInfiniteTeams } from "@/app/(dashboard)/hooks/teams/useTeams";
+import { DEBOUNCE_WAIT_MS } from "@/utils/debounceConstants";
 import { Team } from "../key_team_helpers/key_list";
 
 const { Text } = Typography;
@@ -19,7 +20,6 @@ interface TeamDropdownProps {
 }
 
 const SCROLL_THRESHOLD = 0.8;
-const DEBOUNCE_MS = 300;
 
 const TeamDropdown: React.FC<TeamDropdownProps> = ({
   value,
@@ -31,7 +31,7 @@ const TeamDropdown: React.FC<TeamDropdownProps> = ({
 }) => {
   const [searchInput, setSearchInput] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useDebouncedState("", {
-    wait: DEBOUNCE_MS,
+    wait: DEBOUNCE_WAIT_MS,
   });
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteTeams(

--- a/ui/litellm-dashboard/src/components/common_components/team_multi_select.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/team_multi_select.tsx
@@ -3,6 +3,7 @@ import { Select, Typography } from "antd";
 import { LoadingOutlined } from "@ant-design/icons";
 import { useDebouncedState } from "@tanstack/react-pacer/debouncer";
 import { useInfiniteTeams } from "@/app/(dashboard)/hooks/teams/useTeams";
+import { DEBOUNCE_WAIT_MS } from "@/utils/debounceConstants";
 import { Team } from "../key_team_helpers/key_list";
 
 const { Text } = Typography;
@@ -17,7 +18,6 @@ interface TeamMultiSelectProps {
 }
 
 const SCROLL_THRESHOLD = 0.8;
-const DEBOUNCE_MS = 300;
 
 const TeamMultiSelect: React.FC<TeamMultiSelectProps> = ({
   value = [],
@@ -29,7 +29,7 @@ const TeamMultiSelect: React.FC<TeamMultiSelectProps> = ({
 }) => {
   const [searchInput, setSearchInput] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useDebouncedState("", {
-    wait: DEBOUNCE_MS,
+    wait: DEBOUNCE_WAIT_MS,
   });
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteTeams(

--- a/ui/litellm-dashboard/src/components/team/TeamVirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamVirtualKeysTable.tsx
@@ -9,6 +9,7 @@ import {
   DataTableToolbar,
 } from "@/components/shared/DataTable";
 import { Input } from "@/components/ui/input";
+import { DEBOUNCE_WAIT_MS } from "@/utils/debounceConstants";
 import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/outline";
 import { useDebouncedValue } from "@tanstack/react-pacer/debouncer";
 import { ColumnDef, ColumnFiltersState, OnChangeFn, PaginationState, SortingState } from "@tanstack/react-table";
@@ -43,7 +44,7 @@ export function TeamVirtualKeysTable({ teamId, teamAlias, organization }: TeamVi
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [searchInput, setSearchInput] = useState("");
-  const [searchQuery] = useDebouncedValue(searchInput, { wait: 300 });
+  const [searchQuery] = useDebouncedValue(searchInput, { wait: DEBOUNCE_WAIT_MS });
 
   const handleSearchChange = useCallback((value: string) => {
     setSearchInput(value);

--- a/ui/litellm-dashboard/src/utils/debounceConstants.ts
+++ b/ui/litellm-dashboard/src/utils/debounceConstants.ts
@@ -1,0 +1,1 @@
+export const DEBOUNCE_WAIT_MS = 300;


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

No behavior change: every touched site already waited 300ms, this PR only moves the number behind one shared constant. Smoke check at commit 87b0f50d2c, screenshots to follow:

1. Run the proxy with the admin UI and open http://localhost:4000/ui/?page=api-keys
2. Type a few characters into the Key Alias search with the browser Network tab open
3. Confirm exactly one keys list request fires about 300ms after typing stops, not one per keystroke

## Type

🧹 Refactoring

## Changes

First PR of a 5 PR stack consolidating the dashboard's debouncing onto `@tanstack/react-pacer`. Adds `src/utils/debounceConstants.ts` exporting `DEBOUNCE_WAIT_MS = 300` and switches the eight existing react-pacer call sites (VirtualKeysTable, TeamVirtualKeysTable, view_users, UsagePageView, PaginatedKeyAliasSelect, PaginatedModelSelect, team_dropdown, team_multi_select) to it, deleting their per-file `DEBOUNCE_MS` copies and inline `300` literals

No tests added because no behavior changes; the 98 existing tests covering the touched components all pass. Later PRs in the stack migrate the hand-rolled debounce sites and use this constant instead of magic numbers; deliberate exceptions (e.g. 500ms selects) keep their own named constants
