### PR TITLE
cookbook: add complexity-based routing example (CustomRoutingStrategyBase)

### DIFF
--- a/cookbook/complexity_based_routing/README.md
+++ b/cookbook/complexity_based_routing/README.md
@@ -1,0 +1,170 @@
+# Complexity-based routing: send simple tasks local, complex tasks up-tier
+
+If you're running a hybrid stack (local models + cloud fallback) and want most
+traffic to stay on the cheap/local tier, escalating only when a task genuinely
+needs it, LiteLLM's built-in routing strategies (`latency-based-routing`,
+`cost-based-routing`, `usage-based-routing`, etc.) don't quite cover this: they
+route based on deployment health/cost, not on what the *request itself* needs.
+
+This recipe uses LiteLLM's `CustomRoutingStrategyBase` extension point to add a
+fourth axis: **task complexity**. One `model_name` (`task/auto`) fronts a tier
+ladder; a cheap classifier picks which underlying deployment actually serves
+each request.
+
+Built and validated on a real local+cloud hybrid stack (a 9B model on a
+consumer GPU as the "standard" tier, a 4B model on a second GPU as the "simple"
+tier, cloud as last resort) — not just a toy example. Two real findings worth
+calling out are below.
+
+## The tier ladder
+
+```
+task/auto
+  ├─ simple    -> small/fast local model      (lookups, formatting, status checks)
+  ├─ standard  -> primary local model         (default -- everyday agentic work)
+  ├─ deep      -> primary local model, again  (same model, reasoning/thinking mode ON)
+  └─ cloud     -> cheap cloud model           (only for things local genuinely can't do)
+```
+
+The `deep` tier is the one easy to miss: if your primary local model supports a
+toggleable reasoning/thinking mode (Qwen3, DeepSeek-R1-distills, etc.), register
+it as **two separate `model_name` entries** pointing at the same underlying
+model/deployment — one with thinking off (fast, default), one with thinking on
+(slow, free). That gives you a "local deep reasoning" rung between "fast local"
+and "cloud," and in our testing it covered a lot of ground that looked like it
+needed cloud but actually just needed more thinking time:
+
+```yaml
+model_list:
+  - model_name: primary-model
+    litellm_params:
+      model: ollama_chat/your-model
+      api_base: http://localhost:11434
+      think: false        # fast, default tier
+
+  - model_name: primary-model-deep
+    litellm_params:
+      model: ollama_chat/your-model   # same model
+      api_base: http://localhost:11434 # same deployment
+      think: true          # reasoning on -- still $0, just slower
+      timeout: 600          # give it room; reasoning can take tens of seconds
+```
+
+## The classifier
+
+Kept deliberately cheap: a heuristic gate first (keyword/length signals, near
+zero cost), falling back to one small-model classification call only for the
+ambiguous middle. Classify once per task and cache the decision — re-scoring
+every turn of a conversation risks flip-flopping models mid-thread, which is
+worse than picking one tier and staying with it.
+
+```python
+from litellm.router import CustomRoutingStrategyBase
+
+TIER_MODEL_NAMES = {
+    "simple": "small-model",
+    "standard": "primary-model",
+    "deep": "primary-model-deep",
+    "cloud": "cloud-model",
+}
+
+class ComplexityRoutingStrategy(CustomRoutingStrategyBase):
+    def __init__(self, router, default_sync, default_async):
+        self.router = router
+        self._default_sync = default_sync
+        self._default_async = default_async
+
+    async def async_get_available_deployment(self, model, messages=None, **kw):
+        if model != "task/auto":
+            # not our model group -- delegate to the router's normal behavior
+            return await self._default_async(model=model, messages=messages, **kw)
+
+        tier = await classify(messages)  # heuristic, then LLM fallback -- your logic
+        target = TIER_MODEL_NAMES[tier]
+        for deployment in self.router.model_list:
+            if deployment.get("model_name") == target:
+                return deployment
+        return None  # or fall back to a safe default tier
+```
+
+See `complexity_router.py` in this folder for the full version (heuristic
+gate, classifier prompt, per-task caching, fallback-on-error).
+
+## Two things that will cost you real debugging time if you don't know them going in
+
+**1. `set_custom_routing_strategy` only intercepts what you tell it to.** It's
+a plain `setattr` swap of `get_available_deployment` /
+`async_get_available_deployment` on the router instance — it does not filter by
+`model` for you. If your strategy doesn't explicitly pass through every
+`model` name that *isn't* your custom group to the router's original method
+(captured *before* you call `set_custom_routing_strategy`), every other model
+in your config silently starts going through your custom logic too, including
+ones with multiple load-balanced deployments that expect the built-in
+strategy's behavior.
+
+**2. `LITELLM_WORKER_STARTUP_HOOKS` fires before `llm_router` exists, and if
+your hook function is a blocking `async def` that the proxy awaits directly,
+it can hang your entire startup.** In our testing, the hook ran early enough
+that `litellm.proxy.proxy_server.llm_router` was still `None`, and awaiting a
+retry-loop inside the hook itself blocked the proxy from ever reaching
+"Application startup complete" — a self-deadlock, since router construction
+happens *after* the startup-hooks step completes. Fix: make the hook function
+itself synchronous and fire-and-forget the actual wait/registration logic via
+`asyncio.create_task(...)`, so the hook returns immediately and the polling
+runs once the event loop is free (which, in practice, was ~0 seconds after
+startup actually finished):
+
+```python
+def register():
+    import asyncio
+    asyncio.create_task(_wait_and_register())  # don't await this directly
+
+async def _wait_and_register():
+    import litellm.proxy.proxy_server as proxy_server
+    for _ in range(180):
+        if proxy_server.llm_router is not None:
+            break
+        await asyncio.sleep(1)
+    else:
+        return
+    router = proxy_server.llm_router
+    strategy = ComplexityRoutingStrategy(
+        router, router.get_available_deployment, router.async_get_available_deployment
+    )
+    router.set_custom_routing_strategy(strategy)
+```
+
+Wire it up with:
+
+```yaml
+# model_list needs a placeholder entry for the group name to be recognized:
+model_list:
+  - model_name: task/auto
+    litellm_params:
+      model: ollama_chat/your-model   # never actually used at request time --
+      api_base: http://localhost:11434 # the strategy always overrides the deployment
+```
+
+```bash
+LITELLM_WORKER_STARTUP_HOOKS=complexity_router:register
+```
+
+(mount `complexity_router.py` into the container alongside your `config.yaml`)
+
+## Validated results
+
+Two real A/B findings from our stack that motivated the `deep` tier
+specifically:
+
+- A 4B model asked a multi-source comparison question returned a coherent
+  answer with **every citation as a literal placeholder string instead of a
+  real reference** -- a reproducible failure, not a one-off. The same question
+  against the 9B model (still fully local) returned 46 real, correctly
+  numbered citations with working URLs, in less time.
+- A trivial one-word-answer prompt took 38-98 seconds against our primary
+  model with no other config change -- turned out to be unsuppressed
+  reasoning/thinking output on a model that supports toggling it, not routing
+  overhead. Once we split that into two tiers (`think: false` fast lane by
+  default, `think: true` as its own explicit tier), the fast lane dropped to
+  ~0.4s and the reasoning tier became a deliberate, cheap escalation step
+  instead of an accidental one.

--- a/cookbook/complexity_based_routing/complexity_router.py
+++ b/cookbook/complexity_based_routing/complexity_router.py
@@ -1,0 +1,214 @@
+"""
+Complexity-based routing strategy for LiteLLM.
+
+Registers a custom routing strategy (LiteLLM's documented CustomRoutingStrategyBase
+extension point) that intercepts requests to the "task/auto" model group, classifies
+the request's complexity, and returns the appropriate underlying local/cloud
+deployment. Every other model group name passes through untouched to the router's
+original deployment-selection logic.
+
+Wire it up in your proxy config:
+
+    environment:
+      LITELLM_WORKER_STARTUP_HOOKS: complexity_router:register
+    volumes:
+      - ./config.yaml:/app/config.yaml
+      - ./complexity_router.py:/app/complexity_router.py
+
+and add a placeholder model_list entry for "task/auto" (see README.md) so the
+router recognizes the group name -- the strategy below always overrides which
+actual deployment gets used at request time.
+
+Adjust TIER_MODEL_NAMES, CLASSIFIER_URL/MODEL, and the heuristic regexes to match
+your own model_list entries and provider layout.
+"""
+import hashlib
+import re
+
+import httpx
+from litellm.router import CustomRoutingStrategyBase
+
+AUTO_MODEL_GROUP = "task/auto"
+
+# tier -> the model_name you've defined for it in config.yaml's model_list
+TIER_MODEL_NAMES = {
+    "simple": "small-model",       # fast, cheap, local
+    "standard": "primary-model",   # your everyday local model
+    "deep": "primary-model-deep",  # same model, reasoning/thinking mode on
+    "cloud": "cloud-model",        # last resort
+}
+DEFAULT_TIER = "standard"
+
+SIMPLE_HINTS = re.compile(
+    r"\b(look ?up|fetch|what is|status of|define|list|format|convert)\b", re.I
+)
+COMPLEX_HINTS = re.compile(
+    r"\b(compare|analy[sz]e|strategy|decide|design|architecture|trade-?off|"
+    r"evaluate|plan|prioriti[sz]e)\b",
+    re.I,
+)
+
+# Classify locally via a small/cheap model, called *directly* (not through this
+# same proxy) to avoid any risk of recursive routing.
+CLASSIFIER_URL = "http://localhost:11435/api/chat"
+CLASSIFIER_MODEL = "small-model"
+CLASSIFIER_TIMEOUT = 15.0
+
+# Coarse in-memory per-task cache, keyed on the opening user message. Classify
+# once at task-start and stick with it rather than re-scoring every turn --
+# re-scoring risks flip-flopping models mid-conversation. Not durable across
+# proxy restarts; that's an accepted limitation of this simple version.
+_cache: dict[str, str] = {}
+_CACHE_MAX = 500
+
+
+def _first_user_message(messages):
+    for m in messages or []:
+        if m.get("role") == "user":
+            return m.get("content") or ""
+    return ""
+
+
+def _cache_key(text):
+    return hashlib.sha256(text[:500].encode("utf-8")).hexdigest()
+
+
+def _heuristic_tier(text):
+    """Cheap, zero-latency gate. Returns a tier, or None if ambiguous."""
+    if COMPLEX_HINTS.search(text):
+        return "deep"
+    if len(text) < 200 and SIMPLE_HINTS.search(text):
+        return "simple"
+    if len(text) < 40:
+        return "simple"
+    return None
+
+
+async def _llm_classify(text):
+    """Ambiguous middle case: one cheap local call to score it."""
+    prompt = (
+        "Rate the complexity of fulfilling this request on a scale of 1-3.\n"
+        "1 = simple lookup, fact, or single-step task\n"
+        "2 = moderate reasoning, synthesis, or multi-step task\n"
+        "3 = complex, strategic, or judgment-heavy task requiring deep reasoning\n"
+        f"Request: {text[:2000]}\n"
+        "Respond with only the number."
+    )
+    try:
+        async with httpx.AsyncClient(timeout=CLASSIFIER_TIMEOUT) as client:
+            resp = await client.post(
+                CLASSIFIER_URL,
+                json={
+                    "model": CLASSIFIER_MODEL,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "stream": False,
+                    "think": False,
+                },
+            )
+            resp.raise_for_status()
+            content = resp.json()["message"]["content"].strip()
+            match = re.search(r"[123]", content)
+            score = int(match.group()) if match else 2
+            return {1: "simple", 2: "standard", 3: "deep"}[score]
+    except Exception:
+        return DEFAULT_TIER
+
+
+async def _classify(messages):
+    text = _first_user_message(messages)
+    if not text:
+        return DEFAULT_TIER
+
+    key = _cache_key(text)
+    if key in _cache:
+        return _cache[key]
+
+    tier = _heuristic_tier(text)
+    if tier is None:
+        tier = await _llm_classify(text)
+
+    if len(_cache) >= _CACHE_MAX:
+        _cache.clear()
+    _cache[key] = tier
+    return tier
+
+
+def _find_deployment(router, model_name):
+    for deployment in router.model_list:
+        if deployment.get("model_name") == model_name:
+            return deployment
+    return None
+
+
+class ComplexityRoutingStrategy(CustomRoutingStrategyBase):
+    def __init__(self, router, default_sync, default_async):
+        self.router = router
+        self._default_sync = default_sync
+        self._default_async = default_async
+
+    def get_available_deployment(
+        self, model, messages=None, input=None, specific_deployment=False,
+        request_kwargs=None,
+    ):
+        if model != AUTO_MODEL_GROUP:
+            return self._default_sync(
+                model=model, messages=messages, input=input,
+                specific_deployment=specific_deployment, request_kwargs=request_kwargs,
+            )
+        # Sync path: heuristic only (no blocking LLM call here).
+        text = _first_user_message(messages)
+        tier = _heuristic_tier(text) or DEFAULT_TIER
+        deployment = _find_deployment(self.router, TIER_MODEL_NAMES[tier])
+        return deployment or _find_deployment(self.router, TIER_MODEL_NAMES[DEFAULT_TIER])
+
+    async def async_get_available_deployment(
+        self, model, messages=None, input=None, specific_deployment=False,
+        request_kwargs=None,
+    ):
+        if model != AUTO_MODEL_GROUP:
+            return await self._default_async(
+                model=model, messages=messages, input=input,
+                specific_deployment=specific_deployment, request_kwargs=request_kwargs,
+            )
+        tier = await _classify(messages or [])
+        deployment = _find_deployment(self.router, TIER_MODEL_NAMES[tier])
+        if deployment is None:
+            deployment = _find_deployment(self.router, TIER_MODEL_NAMES[DEFAULT_TIER])
+        return deployment
+
+
+async def _wait_and_register():
+    import asyncio
+    import litellm.proxy.proxy_server as proxy_server
+
+    llm_router = None
+    for attempt in range(180):
+        llm_router = proxy_server.llm_router
+        if llm_router is not None:
+            break
+        await asyncio.sleep(1)
+
+    if llm_router is None:
+        print(f"[complexity-router] llm_router never became ready, giving up after 180s")
+        return
+
+    strategy = ComplexityRoutingStrategy(
+        router=llm_router,
+        default_sync=llm_router.get_available_deployment,
+        default_async=llm_router.async_get_available_deployment,
+    )
+    llm_router.set_custom_routing_strategy(strategy)
+    print(f"[complexity-router] registered after {attempt}s")
+
+
+def register():
+    """
+    Startup hook entrypoint. Must return immediately -- LITELLM_WORKER_STARTUP_HOOKS
+    fires before llm_router is constructed, and awaiting the wait loop directly here
+    would block the proxy's own startup indefinitely. Schedule it as a background
+    task instead.
+    """
+    import asyncio
+
+    asyncio.create_task(_wait_and_register())
+    print("[complexity-router] scheduled background registration task")


### PR DESCRIPTION
## Summary

Adds a cookbook example for complexity-based routing: a `CustomRoutingStrategyBase` that classifies each request's complexity (cheap heuristic gate, falling back to a small local model for ambiguous cases) and routes to a tiered set of deployments accordingly, rather than routing purely on deployment health/cost/latency.

Also demonstrates a pattern for models with a toggleable reasoning/thinking mode (Qwen3, DeepSeek-R1-distills, etc.): register the same underlying model as two separate `model_name` entries with different `think` params, giving a free "local deep reasoning" tier between "fast local" and "cloud" instead of needing a second physical model.

Built and validated against a real local+cloud hybrid stack, not a toy example -- the README includes two concrete before/after findings from that testing (a 4B model producing placeholder citations on multi-source questions vs. a 9B model producing 46 real ones; a model defaulting to 38-98s of unsuppressed reasoning output on a one-word-answer prompt, fixed by splitting fast/deep into explicit tiers).

## Two non-obvious pitfalls documented in the README

1. `set_custom_routing_strategy` is a plain `setattr` swap with no built-in filtering by `model` -- if a custom strategy doesn't explicitly pass through every non-target model group to the router's original method (captured before calling `set_custom_routing_strategy`), every other configured model silently starts going through the custom logic too.
2. `LITELLM_WORKER_STARTUP_HOOKS` fires before `llm_router` is constructed. A hook that blocks (e.g. an `async def` the proxy awaits directly, doing a retry-loop inside) can deadlock the proxy's own startup, since router construction happens after the startup-hooks step completes. Fix: make the hook itself synchronous and fire-and-forget the actual wait/registration via `asyncio.create_task`.

## What's included

- `cookbook/complexity_based_routing/README.md` -- concept, tier ladder, wiring instructions, both pitfalls above
- `cookbook/complexity_based_routing/complexity_router.py` -- generalized, runnable reference implementation (heuristic gate + LLM-classifier fallback + per-task caching + fire-and-forget registration)

## Test plan

- [x] Validated end-to-end against a real proxy instance: simple/standard/deep/cloud tiers all confirmed routing correctly via live requests
- [x] Confirmed the `LITELLM_WORKER_STARTUP_HOOKS` timing pitfall firsthand (hit the deadlock, fixed it, documented the fix)
- [x] `complexity_router.py` syntax-checked (`python3 -m py_compile`)
