### PR TITLE
feat: add Huawei Cloud MaaS as OpenAI-compatible provider

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -183,5 +183,11 @@
       "max_completion_tokens": "max_tokens"
     },
     "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/embeddings"]
+  },
+  "huawei_maas": {
+    "base_url": "https://api-ap-southeast-1.modelarts-maas.com/openai/v1",
+    "api_key_env": "HUAWEI_MAAS_API_KEY",
+    "api_base_env": "HUAWEI_MAAS_API_BASE",
+    "supported_endpoints": ["/v1/chat/completions", "/v1/embeddings"]
   }
 }

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -45620,5 +45620,87 @@
                 }
             }
         ]
+    },
+    "huawei_maas/deepseek-v3.1": {
+        "input_cost_per_token": 5.39e-07,
+        "litellm_provider": "huawei_maas",
+        "mode": "chat",
+        "output_cost_per_token": 1.617e-06,
+        "source": "https://support.huaweicloud.com/intl/en-us/price-maas/price-maas-0002.html",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true
+    },
+    "huawei_maas/deepseek-v4-pro": {
+        "input_cost_per_token": 1.617e-06,
+        "litellm_provider": "huawei_maas",
+        "mode": "chat",
+        "output_cost_per_token": 3.235e-06,
+        "source": "https://support.huaweicloud.com/intl/en-us/price-maas/price-maas-0002.html",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true
+    },
+    "huawei_maas/glm-5": {
+        "input_cost_per_token": 5.39e-07,
+        "litellm_provider": "huawei_maas",
+        "max_input_tokens": 196608,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "mode": "chat",
+        "output_cost_per_token": 2.426e-06,
+        "source": "https://support.huaweicloud.com/intl/en-us/price-maas/price-maas-0002.html",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
+    "huawei_maas/glm-5.1": {
+        "input_cost_per_token": 8.09e-07,
+        "litellm_provider": "huawei_maas",
+        "max_input_tokens": 196608,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 3.235e-06,
+        "source": "https://support.huaweicloud.com/intl/en-us/price-maas/price-maas-0002.html",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
+    "huawei_maas/glm-5.2": {
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "huawei_maas",
+        "max_input_tokens": 196608,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://support.huaweicloud.com/intl/en-us/price-maas/price-maas-0002.html",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
     }
 }

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -2941,6 +2941,23 @@
         "rerank": false,
         "a2a": false
       }
+    },
+    "huawei_maas": {
+      "display_name": "Huawei Cloud MaaS (`huawei_maas`)",
+      "url": "https://docs.litellm.ai/docs/providers/huawei_maas",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": true,
+        "responses": true,
+        "embeddings": true,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "files": true,
+        "rerank": false
+      }
     }
   },
   "endpoints": {


### PR DESCRIPTION
## What does this PR do?

Adds Huawei Cloud ModelArts MaaS (Model-as-a-Service) as a native OpenAI-compatible provider.

MaaS provides OpenAI-compatible inference endpoints for models like GLM-5.2, GLM-5.1, GLM-5, DeepSeek-V4-Pro, and DeepSeek-V3.1. The endpoint is:

```
https://api-ap-southeast-1.modelarts-maas.com/openai/v1
```

## Changes

1. **`litellm/llms/openai_like/providers.json`** — Add `huawei_maas` provider entry with `base_url`, `api_key_env`, `api_base_env`, and supported endpoints (`/v1/chat/completions`, `/v1/embeddings`)

2. **`model_prices_and_context_window.json`** — Add pricing and context window info for 5 models:

| Model | Max Input | Max Output | Input Cost (per token) | Output Cost (per token) |
|-------|-----------|------------|------------------------|------------------------|
| GLM-5.2 | 196,608 | 131,072 | $1.4/1M | $4.4/1M |
| GLM-5.1 | 196,608 | 131,072 | $0.809/1M | $3.235/1M |
| GLM-5 | 196,608 | 65,536 | $0.539/1M | $2.426/1M |
| DeepSeek-V4-Pro | — | — | $1.617/1M | $3.235/1M |
| DeepSeek-V3.1 | — | — | $0.539/1M | $1.617/1M |

Pricing source: https://support.huaweicloud.com/intl/en-us/price-maas/price-maas-0002.html

## Usage

```python
import litellm, os

os.environ['HUAWEI_MAAS_API_KEY'] = 'your-maas-api-key'

response = litellm.completion(
    model='huawei_maas/glm-5.2',
    messages=[{'role': 'user', 'content': 'Hello!'}],
)
print(response.choices[0].message.content)
```

## Type of change

- [x] New feature (non-breaking change that adds a new provider)

## Notes

- Huawei Cloud MaaS is fully OpenAI-compatible, so no custom Python transformation class is needed — the JSON provider entry is sufficient.
- The `api_base_env` field allows users to override the base URL for different MaaS regions (e.g., cn-north-4, cn-hong-kong).
- This follows the same pattern as other Chinese provider entries like `dashscope` (Alibaba), `tencent` (Tencent), and `volcano` (ByteDance).