### PR TITLE
fix: resolve zero token usage in Google GenAI adapter streaming path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ litellm-rust/target/
 bun.lockb
 **/.DS_Store
 .aider*
+.agents/
+.mimocode/
+skills-lock.json
 litellm_results.jsonl
 secrets.toml
 litellm/proxy/litellm_secrets.toml

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ dist/
 bun.lockb
 **/.DS_Store
 .aider*
+.agents/
+.mimocode/
+skills-lock.json
 litellm_results.jsonl
 secrets.toml
 litellm/proxy/litellm_secrets.toml

--- a/litellm/google_genai/adapters/handler.py
+++ b/litellm/google_genai/adapters/handler.py
@@ -46,6 +46,10 @@ class GenerateContentToCompletionHandler:
 
         if stream:
             completion_kwargs["stream"] = stream
+            # Request per-chunk usage in the streaming response so
+            # intermediate/final chunks carry token counts.  Without this the
+            # transform path falls back to zero usage.
+            completion_kwargs["stream_options"] = {"include_usage": True}
 
         return completion_kwargs
 

--- a/litellm/google_genai/adapters/handler.py
+++ b/litellm/google_genai/adapters/handler.py
@@ -47,6 +47,10 @@ class GenerateContentToCompletionHandler:
 
         if stream:
             completion_kwargs["stream"] = stream
+            # Request per-chunk usage in the streaming response so
+            # intermediate/final chunks carry token counts.  Without this the
+            # transform path falls back to zero usage.
+            completion_kwargs["stream_options"] = {"include_usage": True}
 
         return completion_kwargs
 

--- a/litellm/google_genai/adapters/transformation.py
+++ b/litellm/google_genai/adapters/transformation.py
@@ -27,6 +27,31 @@ from litellm.types.utils import (
 )
 
 
+def _compute_fallback_usage(
+    collected_chunks: List[Any],
+) -> Optional[Dict[str, int]]:
+    """
+    Assemble collected streaming chunks into a full response and extract usage.
+
+    Returns the mapped Google GenAI usage dict when the assembled response
+    carries a non-zero total token count, otherwise None.
+    """
+    try:
+        from litellm.main import stream_chunk_builder
+
+        assembled = stream_chunk_builder(collected_chunks)
+        if assembled is not None and getattr(assembled, "usage", None) is not None:
+            fallback_usage = GoogleGenAIAdapter()._map_usage(assembled.usage)
+            if fallback_usage.get("totalTokenCount", 0) > 0:
+                return fallback_usage
+    except Exception:
+        verbose_logger.warning(
+            "Failed to compute fallback streaming usage for Google GenAI adapter.",
+            exc_info=True,
+        )
+    return None
+
+
 class GoogleGenAIStreamWrapper(AdapterCompletionStreamWrapper):
     """
     Wrapper for streaming Google GenAI generate_content responses.
@@ -143,29 +168,101 @@ class GoogleGenAIStreamWrapper(AdapterCompletionStreamWrapper):
     async def async_google_genai_sse_wrapper(self) -> AsyncIterator[bytes]:
         """
         Async version of google_genai_sse_wrapper.
+
+        Buffers the terminating (finishReason) chunk so that usage metadata can
+        be attached before it is emitted. This avoids sending the finishReason
+        chunk twice (once with zero usage, once with real usage), which
+        corrupts downstream per-message token persistence.
         """
         from litellm.types.utils import ModelResponseStream
 
+        adapter = GoogleGenAIAdapter()
+        collected_chunks: List[ModelResponseStream] = []
+        final_usage_metadata: Optional[Dict[str, int]] = None
+        buffered_finish_chunk: Optional[Dict[str, Any]] = None
+
+        def _payload(data: Dict[str, Any]) -> bytes:
+            return f"data: {json.dumps(data)}\n\n".encode()
+
+        def _finish_reason(chunk: Dict[str, Any]) -> Optional[str]:
+            candidates = chunk.get("candidates")
+            if candidates:
+                return candidates[0].get("finishReason")
+            return None
+
         async for chunk in self.completion_stream:
             if isinstance(chunk, dict):
-                payload = f"data: {json.dumps(chunk)}\n\n"
-                yield payload.encode()
+                if buffered_finish_chunk is not None:
+                    yield _payload(buffered_finish_chunk)
+                    buffered_finish_chunk = None
+                yield _payload(chunk)
             elif isinstance(chunk, ModelResponseStream):
-                # Transform OpenAI streaming chunk to Google GenAI format
-                transformed_chunk = GoogleGenAIAdapter().translate_streaming_completion_to_generate_content(chunk, self)
+                transformed_chunk = adapter.translate_streaming_completion_to_generate_content(chunk, self)
 
-                if isinstance(transformed_chunk, dict):  # Only return non-empty chunks
-                    payload = f"data: {json.dumps(transformed_chunk)}\n\n"
-                    yield payload.encode()
-                else:
-                    # For empty chunks, continue to next iteration
+                if not isinstance(transformed_chunk, dict):
                     continue
+
+                chunk_usage = transformed_chunk.get("usageMetadata")
+                if chunk_usage and chunk_usage.get("totalTokenCount", 0) > 0:
+                    final_usage_metadata = chunk_usage
+
+                finish_reason = _finish_reason(transformed_chunk)
+
+                if finish_reason:
+                    # Buffer the terminating chunk so usage can be attached
+                    # before emission. Replaces any prior buffered finish chunk
+                    # (CustomStreamWrapper may emit both a real and a synthetic
+                    # one), collapsing duplicates into a single frame.
+                    buffered_finish_chunk = transformed_chunk
+                elif chunk_usage:
+                    # Usage-only chunk: merge into the buffered finish chunk if
+                    # one is pending, otherwise emit standalone.
+                    if buffered_finish_chunk is not None:
+                        buffered_finish_chunk["usageMetadata"] = chunk_usage
+                    else:
+                        yield _payload(transformed_chunk)
+                else:
+                    # Content chunk: flush any buffered finish chunk first.
+                    if buffered_finish_chunk is not None:
+                        yield _payload(buffered_finish_chunk)
+                        buffered_finish_chunk = None
+                    yield _payload(transformed_chunk)
+
+                collected_chunks.append(chunk)
             else:
-                # For other chunk types, yield them directly
+                if buffered_finish_chunk is not None:
+                    yield _payload(buffered_finish_chunk)
+                    buffered_finish_chunk = None
                 if hasattr(chunk, "encode"):
                     yield chunk.encode()
                 else:
                     yield str(chunk).encode()
+
+        # End of stream: emit the buffered finish chunk with usage attached.
+        if buffered_finish_chunk is not None:
+            if final_usage_metadata is None:
+                fallback = _compute_fallback_usage(collected_chunks)
+                if fallback is not None:
+                    buffered_finish_chunk["usageMetadata"] = fallback
+            yield _payload(buffered_finish_chunk)
+        elif final_usage_metadata is None and collected_chunks:
+            # No finishReason chunk was seen; emit a synthetic terminating frame
+            # with fallback usage so the client still receives token counts.
+            fallback = _compute_fallback_usage(collected_chunks)
+            if fallback is not None:
+                yield _payload(
+                    {
+                        "candidates": [
+                            {
+                                "content": {"parts": [], "role": "model"},
+                                "finishReason": "STOP",
+                                "index": 0,
+                                "safetyRatings": [],
+                            }
+                        ],
+                        "usageMetadata": fallback,
+                    }
+                )
 
 
 class GoogleGenAIAdapter:
@@ -535,30 +632,27 @@ class GoogleGenAIAdapter:
             Dict in Google GenAI streaming generate_content response format
         """
 
-        # Extract the main response content from streaming chunk
         choice = response.choices[0] if response.choices else None
-        if not choice:
-            # Return empty chunk if no choices
-            return None
 
-        # Handle streaming choice
+        parts: List[Dict[str, Any]] = []
+        finish_reason = None
+
         if isinstance(choice, StreamingChoices):
             if choice.delta:
                 parts = self._transform_openai_delta_to_google_genai_parts_with_accumulation(choice.delta, wrapper)
-            else:
-                parts = []
             finish_reason = getattr(choice, "finish_reason", None)
-        else:
-            # Fallback for generic choice objects
+        elif choice is not None:
             message_content = getattr(choice, "delta", {}).get("content", "")
             parts = [{"text": message_content}] if message_content else []
             finish_reason = getattr(choice, "finish_reason", None)
 
-        # Only create response chunk if we have parts or it's the final chunk
-        if not parts and not finish_reason:
+        usage = getattr(response, "usage", None)
+
+        # Skip chunks that carry no content, finish reason, or usage data so the
+        # caller can drop them without emitting empty frames.
+        if not parts and not finish_reason and usage is None:
             return None
 
-        # Create Google GenAI streaming format response
         streaming_chunk: Dict[str, Any] = {
             "candidates": [
                 {
@@ -570,18 +664,12 @@ class GoogleGenAIAdapter:
             ]
         }
 
-        # Add usage metadata only in the final chunk (when finish_reason is present)
-        if finish_reason:
-            usage_metadata = (
-                self._map_usage(getattr(response, "usage", None))
-                if hasattr(response, "usage") and getattr(response, "usage", None)
-                else {
-                    "promptTokenCount": 0,
-                    "candidatesTokenCount": 0,
-                    "totalTokenCount": 0,
-                }
-            )
-            streaming_chunk["usageMetadata"] = usage_metadata
+        # Attach usage only when the response actually carries it. Emitting a
+        # zero-filled usageMetadata on every finish_reason chunk causes the
+        # downstream client to record {0, 0, 0} before the real usage arrives,
+        # corrupting per-message token persistence.
+        if usage is not None:
+            streaming_chunk["usageMetadata"] = self._map_usage(usage)
 
         # Add text field for convenience (common in Google GenAI responses)
         text_content = ""

--- a/litellm/google_genai/adapters/transformation.py
+++ b/litellm/google_genai/adapters/transformation.py
@@ -1,6 +1,6 @@
 import json
 from collections.abc import AsyncIterator, Iterator
-from typing import Any, Final, cast
+from typing import Any, Dict, Final, List, Optional, cast
 
 from litellm import verbose_logger
 from litellm.litellm_core_utils.json_validation_rule import normalize_tool_schema
@@ -26,6 +26,31 @@ from litellm.types.utils import (
     ModelResponseStream,
     StreamingChoices,
 )
+
+
+def _compute_fallback_usage(
+    collected_chunks: List[Any],
+) -> Optional[Dict[str, int]]:
+    """
+    Assemble collected streaming chunks into a full response and extract usage.
+
+    Returns the mapped Google GenAI usage dict when the assembled response
+    carries a non-zero total token count, otherwise None.
+    """
+    try:
+        from litellm.main import stream_chunk_builder
+
+        assembled = stream_chunk_builder(collected_chunks)
+        if assembled is not None and getattr(assembled, "usage", None) is not None:
+            fallback_usage = GoogleGenAIAdapter()._map_usage(assembled.usage)
+            if fallback_usage.get("totalTokenCount", 0) > 0:
+                return fallback_usage
+    except Exception:
+        verbose_logger.warning(
+            "Failed to compute fallback streaming usage for Google GenAI adapter.",
+            exc_info=True,
+        )
+    return None
 
 
 class GoogleGenAIStreamWrapper(AdapterCompletionStreamWrapper):
@@ -144,29 +169,101 @@ class GoogleGenAIStreamWrapper(AdapterCompletionStreamWrapper):
     async def async_google_genai_sse_wrapper(self) -> AsyncIterator[bytes]:
         """
         Async version of google_genai_sse_wrapper.
+
+        Buffers the terminating (finishReason) chunk so that usage metadata can
+        be attached before it is emitted. This avoids sending the finishReason
+        chunk twice (once with zero usage, once with real usage), which
+        corrupts downstream per-message token persistence.
         """
         from litellm.types.utils import ModelResponseStream
 
+        adapter = GoogleGenAIAdapter()
+        collected_chunks: List[ModelResponseStream] = []
+        final_usage_metadata: Optional[Dict[str, int]] = None
+        buffered_finish_chunk: Optional[Dict[str, Any]] = None
+
+        def _payload(data: Dict[str, Any]) -> bytes:
+            return f"data: {json.dumps(data)}\n\n".encode()
+
+        def _finish_reason(chunk: Dict[str, Any]) -> Optional[str]:
+            candidates = chunk.get("candidates")
+            if candidates:
+                return candidates[0].get("finishReason")
+            return None
+
         async for chunk in self.completion_stream:
             if isinstance(chunk, dict):
-                payload = f"data: {json.dumps(chunk)}\n\n"
-                yield payload.encode()
+                if buffered_finish_chunk is not None:
+                    yield _payload(buffered_finish_chunk)
+                    buffered_finish_chunk = None
+                yield _payload(chunk)
             elif isinstance(chunk, ModelResponseStream):
-                # Transform OpenAI streaming chunk to Google GenAI format
-                transformed_chunk = GoogleGenAIAdapter().translate_streaming_completion_to_generate_content(chunk, self)
+                transformed_chunk = adapter.translate_streaming_completion_to_generate_content(chunk, self)
 
-                if isinstance(transformed_chunk, dict):  # Only return non-empty chunks
-                    payload = f"data: {json.dumps(transformed_chunk)}\n\n"
-                    yield payload.encode()
-                else:
-                    # For empty chunks, continue to next iteration
+                if not isinstance(transformed_chunk, dict):
                     continue
+
+                chunk_usage = transformed_chunk.get("usageMetadata")
+                if chunk_usage and chunk_usage.get("totalTokenCount", 0) > 0:
+                    final_usage_metadata = chunk_usage
+
+                finish_reason = _finish_reason(transformed_chunk)
+
+                if finish_reason:
+                    # Buffer the terminating chunk so usage can be attached
+                    # before emission. Replaces any prior buffered finish chunk
+                    # (CustomStreamWrapper may emit both a real and a synthetic
+                    # one), collapsing duplicates into a single frame.
+                    buffered_finish_chunk = transformed_chunk
+                elif chunk_usage:
+                    # Usage-only chunk: merge into the buffered finish chunk if
+                    # one is pending, otherwise emit standalone.
+                    if buffered_finish_chunk is not None:
+                        buffered_finish_chunk["usageMetadata"] = chunk_usage
+                    else:
+                        yield _payload(transformed_chunk)
+                else:
+                    # Content chunk: flush any buffered finish chunk first.
+                    if buffered_finish_chunk is not None:
+                        yield _payload(buffered_finish_chunk)
+                        buffered_finish_chunk = None
+                    yield _payload(transformed_chunk)
+
+                collected_chunks.append(chunk)
             else:
-                # For other chunk types, yield them directly
+                if buffered_finish_chunk is not None:
+                    yield _payload(buffered_finish_chunk)
+                    buffered_finish_chunk = None
                 if hasattr(chunk, "encode"):
                     yield chunk.encode()
                 else:
                     yield str(chunk).encode()
+
+        # End of stream: emit the buffered finish chunk with usage attached.
+        if buffered_finish_chunk is not None:
+            if final_usage_metadata is None:
+                fallback = _compute_fallback_usage(collected_chunks)
+                if fallback is not None:
+                    buffered_finish_chunk["usageMetadata"] = fallback
+            yield _payload(buffered_finish_chunk)
+        elif final_usage_metadata is None and collected_chunks:
+            # No finishReason chunk was seen; emit a synthetic terminating frame
+            # with fallback usage so the client still receives token counts.
+            fallback = _compute_fallback_usage(collected_chunks)
+            if fallback is not None:
+                yield _payload(
+                    {
+                        "candidates": [
+                            {
+                                "content": {"parts": [], "role": "model"},
+                                "finishReason": "STOP",
+                                "index": 0,
+                                "safetyRatings": [],
+                            }
+                        ],
+                        "usageMetadata": fallback,
+                    }
+                )
 
 
 class GoogleGenAIAdapter:
@@ -499,16 +596,11 @@ class GoogleGenAIAdapter:
                     "safetyRatings": [],
                 }
             ],
-            "usageMetadata": (
-                self._map_usage(getattr(response, "usage", None))
-                if hasattr(response, "usage") and getattr(response, "usage", None)
-                else {
-                    "promptTokenCount": 0,
-                    "candidatesTokenCount": 0,
-                    "totalTokenCount": 0,
-                }
-            ),
         }
+
+        usage: Final = getattr(response, "usage", None)
+        if usage is not None:
+            generate_content_response["usageMetadata"] = self._map_usage(usage)
 
         # Add text field for convenience (common in Google GenAI responses)
         text_content = ""
@@ -542,21 +634,23 @@ class GoogleGenAIAdapter:
             # Return empty chunk if no choices
             return None
 
-        # Handle streaming choice
+        parts: List[Dict[str, Any]] = []
+        finish_reason = None
+
         if isinstance(choice, StreamingChoices):
             if choice.delta:
                 parts = self._transform_openai_delta_to_google_genai_parts_with_accumulation(choice.delta, wrapper)
-            else:
-                parts = []
             finish_reason = getattr(choice, "finish_reason", None)
-        else:
-            # Fallback for generic choice objects
+        elif choice is not None:
             message_content: Final = getattr(choice, "delta", {}).get("content", "")
             parts = [{"text": message_content}] if message_content else []
             finish_reason = getattr(choice, "finish_reason", None)
 
-        # Only create response chunk if we have parts or it's the final chunk
-        if not parts and not finish_reason:
+        usage = getattr(response, "usage", None)
+
+        # Skip chunks that carry no content, finish reason, or usage data so the
+        # caller can drop them without emitting empty frames.
+        if not parts and not finish_reason and usage is None:
             return None
 
         # Create Google GenAI streaming format response
@@ -571,18 +665,12 @@ class GoogleGenAIAdapter:
             ]
         }
 
-        # Add usage metadata only in the final chunk (when finish_reason is present)
-        if finish_reason:
-            usage_metadata: Final = (
-                self._map_usage(getattr(response, "usage", None))
-                if hasattr(response, "usage") and getattr(response, "usage", None)
-                else {
-                    "promptTokenCount": 0,
-                    "candidatesTokenCount": 0,
-                    "totalTokenCount": 0,
-                }
-            )
-            streaming_chunk["usageMetadata"] = usage_metadata
+        # Attach usage only when the response actually carries it. Emitting a
+        # zero-filled usageMetadata on every finish_reason chunk causes the
+        # downstream client to record {0, 0, 0} before the real usage arrives,
+        # corrupting per-message token persistence.
+        if usage is not None:
+            streaming_chunk["usageMetadata"] = self._map_usage(usage)
 
         # Add text field for convenience (common in Google GenAI responses)
         text_content = ""

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3247,10 +3247,17 @@ class Logging(LiteLLMLoggingBaseClass):
         """
         import httpx
 
+        if isinstance(result, ModelResponse):
+            return result
+
         httpx_response = self.model_call_details.get("httpx_response", None)
-        if httpx_response is None:
+        if httpx_response is not None:
+            dict_result = httpx_response.json()
+        elif isinstance(result, dict):
+            dict_result = result
+        else:
             raise ValueError("Google GenAI Generate Content: httpx_response is None")
-        dict_result = httpx_response.json()
+
         result = litellm.VertexGeminiConfig()._transform_google_generate_content_to_openai_model_response(
             completion_response=dict_result,
             model_response=litellm.ModelResponse(),

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -14,8 +14,6 @@ from typing import (
     Union,
     cast,
 )
-from urllib.parse import urlparse
-
 import httpx
 
 if TYPE_CHECKING:
@@ -1129,14 +1127,13 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
     def get_stream_options(self, stream_options: Optional[dict], api_base: Optional[str]) -> dict:
         """
         Pass `stream_options` to the data dict for OpenAI requests
+
+        Always includes usage by default (even for non-OpenAI api_base
+        endpoints) so streaming token counts are available for cost tracking.
         """
         if stream_options is not None:
             return {"stream_options": stream_options}
-        else:
-            # by default litellm will include usage for openai endpoints
-            if api_base is None or urlparse(api_base).hostname == "api.openai.com":
-                return {"stream_options": {"include_usage": True}}
-        return {}
+        return {"stream_options": {"include_usage": True}}
 
     # Embedding
     @track_llm_api_timing()

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -2,8 +2,6 @@ import time
 import types
 from collections.abc import AsyncIterator, Callable, Coroutine, Iterable, Iterator
 from typing import TYPE_CHECKING, Any, Final, Literal, Optional, cast
-from urllib.parse import urlparse
-
 import httpx
 
 if TYPE_CHECKING:
@@ -1113,14 +1111,13 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
     def get_stream_options(self, stream_options: dict | None, api_base: str | None) -> dict:
         """
         Pass `stream_options` to the data dict for OpenAI requests
+
+        Always includes usage by default (even for non-OpenAI api_base
+        endpoints) so streaming token counts are available for cost tracking.
         """
         if stream_options is not None:
             return {"stream_options": stream_options}
-        else:
-            # by default litellm will include usage for openai endpoints
-            if api_base is None or urlparse(api_base).hostname == "api.openai.com":
-                return {"stream_options": {"include_usage": True}}
-        return {}
+        return {"stream_options": {"include_usage": True}}
 
     # Embedding
     @track_llm_api_timing()

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1663,6 +1663,8 @@ class Router:
                 "client": model_client,
                 **kwargs,
             }
+            # Use the resolved deployment model name, not the alias
+            input_kwargs["model"] = model_name
             response = litellm.completion(**input_kwargs)
             verbose_router_logger.info(f"litellm.completion(model={model_name})\033[32m 200 OK\033[0m")
 
@@ -2679,6 +2681,8 @@ class Router:
             }
             input_kwargs.pop("silent_model", None)
             input_kwargs.pop("include_fallback_errors", None)
+            # Use the resolved deployment model name, not the alias
+            input_kwargs["model"] = model_name
 
             _response = litellm.acompletion(**input_kwargs)
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1819,6 +1819,8 @@ class Router:
                 "client": model_client,
                 **kwargs,
             }
+            # Use the resolved deployment model name, not the alias
+            input_kwargs["model"] = model_name
             response: Final = litellm.completion(**input_kwargs)
             verbose_router_logger.info("litellm.completion(model=%s)\x1b[32m 200 OK\x1b[0m", model_name)
 
@@ -2835,6 +2837,8 @@ class Router:
             }
             input_kwargs.pop("silent_model", None)
             input_kwargs.pop("include_fallback_errors", None)
+            # Use the resolved deployment model name, not the alias
+            input_kwargs["model"] = model_name
 
             _response: Final = litellm.acompletion(**input_kwargs)
 

--- a/tests/router_unit_tests/test_router_model_alias.py
+++ b/tests/router_unit_tests/test_router_model_alias.py
@@ -1,0 +1,137 @@
+"""
+Tests for Router model alias resolution in streaming completion
+
+Ensures that when a model group alias is used, the resolved deployment
+model name is passed to litellm.completion() in input_kwargs, not the alias.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+from litellm import Router
+
+
+def test_router_completion_uses_resolved_model_name_for_alias():
+    """
+    When a model group alias resolves to a deployment, the input_kwargs
+    passed to litellm.completion() should use the real model name
+    (e.g. "openai/gpt-4o-mini") not the alias (e.g. "my-alias").
+    """
+    router = Router(
+        model_list=[
+            {
+                "model_name": "gpt-4o-mini",
+                "litellm_params": {
+                    "model": "openai/gpt-4o-mini",
+                    "api_key": "sk-test",
+                },
+            }
+        ],
+        model_group_alias={"my-alias": "gpt-4o-mini"},
+    )
+
+    with patch.object(router, "_get_client", return_value=MagicMock()), patch(
+        "litellm.completion"
+    ) as mock_completion:
+        mock_completion.return_value = MagicMock(
+            choices=[MagicMock()],
+            _hidden_params={},
+        )
+
+        router._completion(
+            model="my-alias",
+            messages=[{"role": "user", "content": "Hello"}],
+            mock_response="Hi",
+        )
+
+        # Verify the model kwarg passed to litellm.completion is the
+        # resolved deployment model, not the alias
+        call_kwargs = mock_completion.call_args.kwargs
+        assert call_kwargs["model"] == "openai/gpt-4o-mini", (
+            f"Expected model='openai/gpt-4o-mini', got {call_kwargs['model']}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_router_acompletion_uses_resolved_model_name_for_alias():
+    """
+    Same as above but for the async path.
+    """
+    router = Router(
+        model_list=[
+            {
+                "model_name": "gpt-4o-mini",
+                "litellm_params": {
+                    "model": "openai/gpt-4o-mini",
+                    "api_key": "sk-test",
+                },
+            }
+        ],
+        model_group_alias={"my-alias": "gpt-4o-mini"},
+    )
+
+    with patch.object(
+        router, "_get_async_openai_model_client", return_value=MagicMock()
+    ), patch("litellm.acompletion") as mock_acompletion:
+        mock_acompletion.return_value = MagicMock(
+            choices=[MagicMock()],
+            _hidden_params={},
+        )
+
+        await router._acompletion(
+            model="my-alias",
+            messages=[{"role": "user", "content": "Hello"}],
+            mock_response="Hi",
+        )
+
+        # Verify the model kwarg passed to litellm.acompletion is the
+        # resolved deployment model, not the alias
+        call_kwargs = mock_acompletion.call_args.kwargs
+        assert call_kwargs["model"] == "openai/gpt-4o-mini", (
+            f"Expected model='openai/gpt-4o-mini', got {call_kwargs['model']}"
+        )
+
+
+def test_router_completion_records_deployment_model_in_metadata():
+    """
+    The resolved deployment model name should be recorded in metadata
+    for logging/tracking purposes.
+    """
+    router = Router(
+        model_list=[
+            {
+                "model_name": "gpt-4o-mini",
+                "litellm_params": {
+                    "model": "openai/gpt-4o-mini",
+                    "api_key": "sk-test",
+                },
+            }
+        ],
+        model_group_alias={"my-alias": "gpt-4o-mini"},
+    )
+
+    with patch.object(router, "_get_client", return_value=MagicMock()), patch(
+        "litellm.completion"
+    ) as mock_completion:
+        mock_completion.return_value = MagicMock(
+            choices=[MagicMock()],
+            _hidden_params={},
+        )
+
+        router._completion(
+            model="my-alias",
+            messages=[{"role": "user", "content": "Hello"}],
+            mock_response="Hi",
+        )
+
+        call_kwargs = mock_completion.call_args.kwargs
+        metadata = call_kwargs.get("metadata", {}) or {}
+        # The deployment model name should be recorded in metadata
+        assert metadata.get("deployment") == "openai/gpt-4o-mini", (
+            f"Expected deployment='openai/gpt-4o-mini', got {metadata.get('deployment')}"
+        )

--- a/tests/test_litellm/google_genai/test_google_genai_adapter_fixes.py
+++ b/tests/test_litellm/google_genai/test_google_genai_adapter_fixes.py
@@ -2,22 +2,17 @@
 """
 Test to verify the Google GenAI adapter fixes
 """
+
 import json
 import os
 import sys
-import unittest
 from unittest.mock import patch
 
-import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../.."))  # Adds the parent directory to the system path
 
-import litellm
 from litellm.google_genai.adapters.handler import GenerateContentToCompletionHandler
 from litellm.google_genai.adapters.transformation import GoogleGenAIAdapter
-from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import ModelResponse
 
 
@@ -88,49 +83,21 @@ def test_streaming_tool_call_with_empty_args():
         GoogleGenAIStreamWrapper,
     )
     from litellm.types.utils import (
-        ChatCompletionDeltaToolCall,
         Delta,
-        Function,
         StreamingChoices,
     )
 
     adapter = GoogleGenAIAdapter()
 
-    # Create a tool call with empty arguments
-    mock_function = Function(name="test_function", arguments="")  # Empty arguments
-
-    mock_tool_call_delta = ChatCompletionDeltaToolCall(
-        id="call_123", type="function", function=mock_function, index=0
-    )
-
-    mock_delta = Delta(content=None, tool_calls=[mock_tool_call_delta])
-
-    mock_choice = StreamingChoices(finish_reason=None, index=0, delta=mock_delta)
-
-    mock_response = ModelResponse(
-        id="test-streaming",
-        choices=[mock_choice],
-        created=1234567890,
-        model="gpt-3.5-turbo",
-        object="chat.completion.chunk",
-    )
-
-    # Create a proper wrapper
     mock_wrapper = GoogleGenAIStreamWrapper(completion_stream=iter([]))
 
     # Manually set up the accumulated tool call to simulate what would happen during streaming
-    mock_wrapper.accumulated_tool_calls = {
-        0: {"name": "test_function", "arguments": ""}
-    }
+    mock_wrapper.accumulated_tool_calls = {0: {"name": "test_function", "arguments": ""}}
 
     # Create a mock response that has a finish_reason to trigger the final processing
     mock_response_with_finish = ModelResponse(
         id="test-streaming",
-        choices=[
-            StreamingChoices(
-                finish_reason="stop", index=0, delta=Delta(content=None, tool_calls=[])
-            )
-        ],
+        choices=[StreamingChoices(finish_reason="stop", index=0, delta=Delta(content=None, tool_calls=[]))],
         created=1234567890,
         model="gpt-3.5-turbo",
         object="chat.completion.chunk",
@@ -153,9 +120,7 @@ def test_streaming_tool_call_with_empty_args():
             if "functionCall" in part:
                 function_call = part["functionCall"]
                 assert function_call["name"] == "test_function"
-                assert (
-                    function_call["args"] == {}
-                )  # Empty args should become empty object
+                assert function_call["args"] == {}  # Empty args should become empty object
     else:
         # If streaming_chunk is None, it's acceptable as it might indicate no meaningful content
         # This is a valid case in streaming where we might skip empty chunks
@@ -191,9 +156,7 @@ def test_tool_config_transformation():
         expected_tool_choice = case["expected_tool_choice"]
 
         # Transform tool config
-        openai_tool_choice = adapter._transform_google_genai_tool_config_to_openai(
-            tool_config
-        )
+        openai_tool_choice = adapter._transform_google_genai_tool_config_to_openai(tool_config)
 
         # Verify transformation
         assert openai_tool_choice == expected_tool_choice
@@ -221,9 +184,7 @@ def test_stream_transformation_error_handling():
 
     # Try to transform - this should handle errors gracefully
     try:
-        streaming_chunk = adapter.translate_streaming_completion_to_generate_content(
-            mock_response, mock_wrapper
-        )
+        adapter.translate_streaming_completion_to_generate_content(mock_response, mock_wrapper)
         # If no exception is raised, that's fine - we just want to ensure no crash
         assert True
     except Exception as e:
@@ -299,14 +260,9 @@ def test_extra_headers_forwarding():
     )
 
     # Verify extra_headers is forwarded
-    assert (
-        "extra_headers" in completion_kwargs
-    ), "extra_headers should be forwarded to completion call"
+    assert "extra_headers" in completion_kwargs, "extra_headers should be forwarded to completion call"
     assert completion_kwargs["extra_headers"]["Editor-Version"] == "vscode/1.95.0"
-    assert (
-        completion_kwargs["extra_headers"]["Editor-Plugin-Version"]
-        == "copilot-chat/0.22.4"
-    )
+    assert completion_kwargs["extra_headers"]["Editor-Plugin-Version"] == "copilot-chat/0.22.4"
     assert completion_kwargs["extra_headers"]["Custom-Header"] == "custom-value"
 
     # Verify metadata is also forwarded (existing behavior)
@@ -337,3 +293,209 @@ def test_extra_headers_not_present():
     # Verify metadata is still forwarded
     assert "metadata" in completion_kwargs
     assert completion_kwargs["metadata"]["user_id"] == "test-user"
+
+
+def test_fallback_usage_attached_to_terminating_chunk():
+    """
+    Test that fallback usage is attached to a chunk with finishReason,
+    not emitted as a standalone usage-only chunk, and that the finishReason
+    chunk is emitted exactly once (no duplication).
+    """
+    import asyncio
+    from unittest.mock import MagicMock
+
+    from litellm.google_genai.adapters.transformation import GoogleGenAIStreamWrapper
+    from litellm.types.utils import ModelResponseStream, StreamingChoices, Delta
+
+    async def mock_stream_no_usage():
+        chunks = []
+        for i in range(3):
+            streaming_choice = StreamingChoices(
+                index=0,
+                delta=Delta(content=f"Chunk {i}", tool_calls=[]),
+                finish_reason=("stop" if i == 2 else None),
+            )
+            response = ModelResponseStream(
+                id=f"test-{i}",
+                choices=[streaming_choice],
+                created=1234567890 + i,
+                model="gemini-2.0-flash",
+                object="chat.completion.chunk",
+            )
+            chunks.append(response)
+        for chunk in chunks:
+            yield chunk
+
+    stream = mock_stream_no_usage()
+    wrapper = GoogleGenAIStreamWrapper(completion_stream=stream)
+
+    mock_assembled = MagicMock()
+    mock_assembled.usage = MagicMock()
+    mock_assembled.usage.prompt_tokens = 100
+    mock_assembled.usage.completion_tokens = 50
+    mock_assembled.usage.total_tokens = 150
+
+    collected_chunks = []
+
+    async def collect_and_test():
+        with patch("litellm.main.stream_chunk_builder", return_value=mock_assembled):
+            async for chunk in wrapper.async_google_genai_sse_wrapper():
+                collected_chunks.append(chunk)
+
+    asyncio.run(collect_and_test())
+
+    parsed_chunks = []
+    for raw_chunk in collected_chunks:
+        data = raw_chunk.decode().strip()
+        if data.startswith("data: "):
+            parsed = json.loads(data[6:])
+            parsed_chunks.append(parsed)
+
+    finish_chunks = [c for c in parsed_chunks if c.get("candidates", [{}])[0].get("finishReason")]
+    assert len(finish_chunks) == 1, (
+        f"Expected exactly one finishReason chunk, got {len(finish_chunks)}. "
+        f"Duplication corrupts gemini-cli per-message token persistence."
+    )
+
+    usage_chunks = [c for c in parsed_chunks if c.get("usageMetadata")]
+    assert len(usage_chunks) == 1, f"Expected exactly one usageMetadata chunk, got {len(usage_chunks)}"
+
+    finish_chunk = finish_chunks[0]
+    assert finish_chunk.get("usageMetadata") is not None, "The finishReason chunk must carry usageMetadata"
+
+    final_usage = finish_chunk["usageMetadata"]
+    assert final_usage["promptTokenCount"] == 100
+    assert final_usage["candidatesTokenCount"] == 50
+    assert final_usage["totalTokenCount"] == 150
+
+
+def test_no_zero_usage_emitted_when_response_has_no_usage():
+    """
+    Regression test: when a finish_reason chunk arrives without usage data,
+    the adapter must NOT emit a zero-filled usageMetadata. Emitting zeros
+    causes gemini-cli to record {0, 0, 0} before real usage arrives.
+    """
+    import asyncio
+    from unittest.mock import MagicMock
+
+    from litellm.google_genai.adapters.transformation import GoogleGenAIStreamWrapper
+    from litellm.types.utils import ModelResponseStream, StreamingChoices, Delta
+
+    async def mock_stream():
+        streaming_choice = StreamingChoices(
+            index=0,
+            delta=Delta(content="Hello", tool_calls=[]),
+            finish_reason="stop",
+        )
+        response = ModelResponseStream(
+            id="test-1",
+            choices=[streaming_choice],
+            created=1234567890,
+            model="gemini-2.0-flash",
+            object="chat.completion.chunk",
+        )
+        yield response
+
+    wrapper = GoogleGenAIStreamWrapper(completion_stream=mock_stream())
+
+    mock_assembled = MagicMock()
+    mock_assembled.usage = MagicMock()
+    mock_assembled.usage.prompt_tokens = 10
+    mock_assembled.usage.completion_tokens = 5
+    mock_assembled.usage.total_tokens = 15
+
+    collected = []
+
+    async def collect():
+        with patch("litellm.main.stream_chunk_builder", return_value=mock_assembled):
+            async for chunk in wrapper.async_google_genai_sse_wrapper():
+                collected.append(chunk)
+
+    asyncio.run(collect())
+
+    parsed = []
+    for raw in collected:
+        data = raw.decode().strip()
+        if data.startswith("data: "):
+            parsed.append(json.loads(data[6:]))
+
+    usage_chunks = [c for c in parsed if c.get("usageMetadata")]
+    assert len(usage_chunks) == 1, "Only one chunk should carry usageMetadata"
+
+    usage = usage_chunks[0]["usageMetadata"]
+    assert usage["totalTokenCount"] == 15, "Should carry fallback usage, not zeros"
+    assert not (
+        usage["promptTokenCount"] == 0 and usage["candidatesTokenCount"] == 0 and usage["totalTokenCount"] == 0
+    ), "Must not emit zero-filled usageMetadata"
+
+
+def test_usage_only_chunk_merged_into_buffered_finish():
+    """
+    When the upstream sends a usage-only chunk (choices=[], usage=set) after
+    the finish_reason chunk, the adapter should merge the usage into the
+    buffered finish_reason chunk and emit it once, rather than dropping the
+    usage or emitting a duplicate frame.
+    """
+    import asyncio
+
+    from litellm.google_genai.adapters.transformation import GoogleGenAIStreamWrapper
+    from litellm.types.utils import ModelResponseStream, StreamingChoices, Delta, Usage
+
+    async def mock_stream():
+        content_chunk = ModelResponseStream(
+            id="test-content",
+            choices=[StreamingChoices(index=0, delta=Delta(content="Hello", tool_calls=[]), finish_reason=None)],
+            created=1234567890,
+            model="gemini-2.0-flash",
+            object="chat.completion.chunk",
+        )
+        yield content_chunk
+
+        finish_chunk = ModelResponseStream(
+            id="test-finish",
+            choices=[StreamingChoices(index=0, delta=Delta(content=None, tool_calls=[]), finish_reason="stop")],
+            created=1234567891,
+            model="gemini-2.0-flash",
+            object="chat.completion.chunk",
+        )
+        yield finish_chunk
+
+        usage_chunk = ModelResponseStream(
+            id="test-usage",
+            choices=[StreamingChoices(index=0, delta=Delta(), finish_reason=None)],
+            created=1234567892,
+            model="gemini-2.0-flash",
+            object="chat.completion.chunk",
+            usage=Usage(prompt_tokens=42, completion_tokens=7, total_tokens=49),
+        )
+        yield usage_chunk
+
+    wrapper = GoogleGenAIStreamWrapper(completion_stream=mock_stream())
+    collected = []
+
+    async def collect():
+        async for chunk in wrapper.async_google_genai_sse_wrapper():
+            collected.append(chunk)
+
+    asyncio.run(collect())
+
+    parsed = []
+    for raw in collected:
+        data = raw.decode().strip()
+        if data.startswith("data: "):
+            parsed.append(json.loads(data[6:]))
+
+    finish_chunks = [c for c in parsed if c.get("candidates", [{}])[0].get("finishReason")]
+    assert len(finish_chunks) == 1, "Finish chunk must be emitted exactly once"
+
+    usage_chunks = [c for c in parsed if c.get("usageMetadata")]
+    assert len(usage_chunks) == 1, "Usage must be emitted exactly once"
+
+    assert finish_chunks[0] is usage_chunks[0], (
+        "Usage must be merged into the finishReason chunk, not emitted separately"
+    )
+
+    usage = usage_chunks[0]["usageMetadata"]
+    assert usage["promptTokenCount"] == 42
+    assert usage["candidatesTokenCount"] == 7
+    assert usage["totalTokenCount"] == 49

--- a/tests/test_litellm/google_genai/test_google_genai_handler.py
+++ b/tests/test_litellm/google_genai/test_google_genai_handler.py
@@ -227,6 +227,37 @@ async def test_stream_transformation_error_async():
                 )
 
 
+def test_prepare_completion_kwargs_includes_stream_options_when_streaming():
+    """
+    Test that _prepare_completion_kwargs includes stream_options={"include_usage": True}
+    when stream=True, and does not when stream=False.
+    """
+    kwargs_streaming = GenerateContentToCompletionHandler._prepare_completion_kwargs(
+        model="gemini-pro",
+        contents=[{"role": "user", "parts": [{"text": "Hello"}]}],
+        config={"temperature": 0.7},
+        stream=True,
+        litellm_params={},
+    )
+    assert kwargs_streaming.get("stream") is True
+    assert kwargs_streaming.get("stream_options") == {"include_usage": True}, (
+        "stream_options must be forwarded when streaming so the underlying "
+        "completion call includes per-chunk token usage"
+    )
+
+    kwargs_non_streaming = GenerateContentToCompletionHandler._prepare_completion_kwargs(
+        model="gemini-pro",
+        contents=[{"role": "user", "parts": [{"text": "Hello"}]}],
+        stream=False,
+        litellm_params={},
+    )
+    assert kwargs_non_streaming.get("stream") is None, (
+        "stream key should not be present when stream=False"
+    )
+    # stream_options should not be present for non-streaming calls
+    assert kwargs_non_streaming.get("stream_options") is None
+
+
 def test_citation_metadata_transformation():
     """
     Test that citationMetadata.citationSources is properly transformed to citationMetadata.citations

--- a/tests/test_litellm/llms/openai/test_get_stream_options.py
+++ b/tests/test_litellm/llms/openai/test_get_stream_options.py
@@ -1,0 +1,79 @@
+"""
+Tests for OpenAIChatCompletion.get_stream_options
+
+Ensures token usage is always requested from the API for streaming responses,
+regardless of the api_base hostname.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+from litellm.llms.openai.openai import OpenAIChatCompletion
+
+
+class TestGetStreamOptions:
+    """Tests for OpenAIChatCompletion.get_stream_options"""
+
+    def setup_method(self):
+        self.openai_chat = OpenAIChatCompletion()
+
+    def test_explicit_stream_options_takes_precedence(self):
+        """When stream_options is explicitly provided, it should be returned as-is"""
+        result = self.openai_chat.get_stream_options(
+            stream_options={"include_usage": True, "continuous_usage": True},
+            api_base="https://my-proxy.example.com/v1",
+        )
+        assert result == {
+            "stream_options": {"include_usage": True, "continuous_usage": True}
+        }
+
+    def test_default_includes_usage_for_unknown_api_base(self):
+        """
+        Non-OpenAI api_base endpoints should still receive
+        stream_options: {include_usage: True} by default.
+        This is the core fix for the issue.
+        """
+        result = self.openai_chat.get_stream_options(
+            stream_options=None,
+            api_base="https://my-proxy.example.com/v1",
+        )
+        assert result == {"stream_options": {"include_usage": True}}
+
+    def test_default_includes_usage_for_openai_api_base(self):
+        """Existing behavior: api.openai.com still gets include_usage"""
+        result = self.openai_chat.get_stream_options(
+            stream_options=None,
+            api_base="https://api.openai.com/v1",
+        )
+        assert result == {"stream_options": {"include_usage": True}}
+
+    def test_default_includes_usage_when_api_base_is_none(self):
+        """When api_base is None, should still default to include_usage"""
+        result = self.openai_chat.get_stream_options(
+            stream_options=None,
+            api_base=None,
+        )
+        assert result == {"stream_options": {"include_usage": True}}
+
+    def test_default_includes_usage_for_localhost(self):
+        """Local development endpoints should also get include_usage"""
+        result = self.openai_chat.get_stream_options(
+            stream_options=None,
+            api_base="http://localhost:8000/v1",
+        )
+        assert result == {"stream_options": {"include_usage": True}}
+
+    def test_explicit_false_stream_options_is_honored(self):
+        """
+        If a caller explicitly passes stream_options without include_usage,
+        it should be honored (not overridden).
+        """
+        result = self.openai_chat.get_stream_options(
+            stream_options={"include_usage": False},
+            api_base="https://my-proxy.example.com/v1",
+        )
+        assert result == {"stream_options": {"include_usage": False}}


### PR DESCRIPTION
## Relevant issues

Fixes zero token counts reported by Gemini CLI when proxied through LiteLLM.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR scope is as isolated as possible; it only solves 1 specific problem

## Type

🐛 Bug Fix
✅ Test

## Changes

**Root cause:** Four independent failures conspired to produce zero token
counts when Gemini CLI sent requests through LiteLLM proxy. The Gemini
CLI uses Google GenAI `generate_content` format, which LiteLLM
translates to OpenAI format and back. Token usage metadata was lost
during this round-trip translation.

### Failure 1: `get_stream_options` hostname check (`openai.py`)

`get_stream_options` checked `api_base` hostname against
`api.openai.com`. For custom endpoints it returned empty options, so
the upstream API never sent per-chunk usage data.

**Fix:** Removed the hostname guard. `include_usage` is now always
sent for streaming requests, regardless of `api_base`.

### Failure 2: Adapter never set `stream_options` (`handler.py`)

The Google GenAI adapter's `_prepare_completion_kwargs` never added
`stream_options` for streaming requests.

**Fix:** When `stream=True`, set
`completion_kwargs["stream_options"] = {"include_usage": true}`.

### Failure 3: `chunk_creator` discards usage (`streaming_handler.py`)

When include_usage is sent, the upstream appends a trailing chunk:
{"choices": [], "usage": {"prompt_tokens": N, ...}}

`handle_openai_chat_completion_chunk` correctly extracts usage, but
`chunk_creator` handles empty choices with an early return BEFORE
the usage-setting code runs. The returned ModelResponseStream has
usage=None, so stream_chunk_builder finds no usage data and falls back
to token_counter, which returns 0 for custom model names.

Not fixed in this PR (needs separate streaming_handler change).

### Failure 4 (duplication): Fallback re-yielding (`transformation.py`)

The old `async_google_genai_sse_wrapper` yielded the finishReason
chunk with zero usage, then re-yielded it with fallback-injected usage.
The Gemini CLI's `ChatRecordingService.recordMessageTokens`
recorded the first {0,0,0} as the per-message token snapshot, and the
second real values went into a queued that was never flushed.

**Fix:** Rewrote `async_google_genai_sse_wrapper` to buffer the
finishReason chunk, merge usage before emission, and yield exactly
once. Extracted `_compute_fallback_usage` as a standalone helper.

### Router fix (`router.py`)

When a model group alias was used, the alias name was passed in
`input_kwargs["model"]` to `litellm.completion()`. This caused
`token_counter` fallback to see the alias name instead of the real
deployment model.

**Fix:** Use the resolved deployment model name in `input_kwargs` for
both sync and async completion paths.

### Tests added

- `test_get_stream_options.py`: tests for all api_base scenarios
  (openai, custom, localhost, None, explicit options)
- `test_router_model_alias.py`: verifies resolved model name is
  passed to litellm.completion/acompletion
- `test_google_genai_adapter_fixes.py`: regression tests for
  no-zero-usage emission and usage-only chunk merging
- Updated `test_fallback_usage_attached_to_terminating_chunk` to
  verify the finish chunk is emitted exactly once