### PR TITLE
fix(streaming): stop clobbering prompt_tokens_details with None across chunks

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -615,10 +615,8 @@ class ChunkProcessor:
                         "web_search_requests",
                     )
 
-                prompt_tokens_details = cast(
-                    PromptTokensDetailsWrapper | None,
-                    usage_chunk_dict["prompt_tokens_details"],
-                )
+                if usage_chunk_dict["prompt_tokens_details"] is not None:
+                    prompt_tokens_details = usage_chunk_dict["prompt_tokens_details"]
 
                 cache_creation_token_details = self._capture_cache_creation_token_details(
                     prompt_tokens_details, cache_creation_token_details

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -597,6 +597,79 @@ def test_stream_chunk_builder_litellm_usage_chunks():
     assert usage.total_tokens == 77
 
 
+def test_streaming_preserves_prompt_tokens_details_from_earlier_chunk():
+    """
+    prompt_tokens_details is aggregated last-wins across usage-bearing chunks.
+    Some providers (e.g. Gemini via Vertex AI) send a chunk with the detailed
+    breakdown followed by a later chunk whose usage carries only the flat
+    prompt/completion/total counts with prompt_tokens_details=None. Without a
+    None-guard on the reassignment (unlike the analogous completion_tokens_details
+    handling just above it), that later chunk clobbers the real breakdown,
+    leaving prompt_tokens_details=None on the final usage object even though a
+    real breakdown was reported earlier in the stream.
+
+    This silently starves any consumer that assumes usage.prompt_tokens_details
+    is always populated once reported once — e.g. Sentry's openai_agents
+    integration crashes with AttributeError on 'NoneType' object has no
+    attribute 'cached_tokens' when this happens on the Responses API path.
+    """
+    chunk_with_details = ModelResponseStream(
+        id="chatcmpl-mocked-usage-2",
+        created=1745513206,
+        model="gemini/gemini-3-flash-preview",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(content=""),
+            )
+        ],
+        stream_options={"include_usage": True},
+        usage=Usage(
+            completion_tokens=0,
+            prompt_tokens=3,
+            total_tokens=3,
+            completion_tokens_details=None,
+            prompt_tokens_details=PromptTokensDetails(
+                audio_tokens=None, cached_tokens=0
+            ),
+        ),
+    )
+
+    chunk_without_details = ModelResponseStream(
+        id="chatcmpl-mocked-usage-2",
+        created=1745513207,
+        model="gemini/gemini-3-flash-preview",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(content=None),
+            )
+        ],
+        stream_options={"include_usage": True},
+        usage=Usage(
+            completion_tokens=50,
+            prompt_tokens=0,
+            total_tokens=53,
+            completion_tokens_details=None,
+            prompt_tokens_details=None,
+        ),
+    )
+
+    chunks = [chunk_with_details, chunk_without_details]
+    processor = ChunkProcessor(chunks=chunks)
+
+    usage = processor.calculate_usage(
+        chunks=chunks, model="gemini/gemini-3-flash-preview", completion_output=""
+    )
+
+    assert usage.prompt_tokens_details is not None
+    assert usage.prompt_tokens_details.cached_tokens == 0
+
+
 def test_get_model_from_chunks_azure_model_router():
     """
     Test that _get_model_from_chunks finds the actual model from Azure Model Router chunks.


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in `ChunkProcessor._calculate_usage_per_chunk` (streaming usage aggregation) where `prompt_tokens_details` gets silently reset to `None` if a later usage-bearing chunk in the same stream doesn't carry the breakdown, even when an earlier chunk in the same stream reported it correctly.

## Root cause

`_calculate_usage_per_chunk` loops over all chunks and aggregates usage fields. `completion_tokens_details` is only overwritten when the current chunk's value is not `None`:

```python
if usage_chunk_dict["completion_tokens_details"] is not None:
    completion_tokens_details = usage_chunk_dict["completion_tokens_details"]
```

`prompt_tokens_details` has no equivalent guard — it's unconditionally reassigned on every usage-bearing chunk:

```python
prompt_tokens_details = cast(
    Optional[PromptTokensDetailsWrapper],
    usage_chunk_dict["prompt_tokens_details"],
)
```

If a provider sends more than one chunk with a `usage` field, and a later chunk's `prompt_tokens_details` is `None` (e.g. a totals-only trailing chunk), it clobbers a real breakdown that was reported earlier in the same stream.

## How I found this

Traced a production crash: switching an agent from `OpenAIChatCompletionsModel` to `OpenAIResponsesModel` (OpenAI Agents SDK) started raising `AttributeError: 'NoneType' object has no attribute 'cached_tokens'` inside `sentry_sdk`'s `openai_agents` integration, but only for a Gemini-backed agent (`vertex_ai/gemini-3-flash-preview`), never for an OpenAI-backed one.

Reproduced end-to-end against a real LiteLLM proxy:
- Non-streaming `/v1/responses` call for the Gemini model: `input_tokens_details` is populated correctly (`{"cached_tokens": 0, ...}`).
- Streaming `/v1/responses` call for the same model: the final `response.completed` event's `usage` is missing `input_tokens_details` entirely.
- Streaming raw `/v1/chat/completions` for the same model *does* carry `prompt_tokens_details` on its usage chunk.

That pointed at the Responses-API-emulation-over-chat-completions layer's own usage reconstruction (`stream_chunk_builder` → `ChunkProcessor.calculate_usage` → `_calculate_usage_per_chunk`), where I found the missing guard above.

Confirmed directly against this function with two synthetic chunks (one with `prompt_tokens_details`, one without, in that order) — reproduces exactly:

```
details-chunk THEN no-details-chunk  -> prompt_tokens_details = None      (bug)
no-details-chunk THEN details-chunk  -> prompt_tokens_details = <populated>
```

## Fix

Add the same `is not None` guard already used for `completion_tokens_details`.

## Test plan

Added `test_streaming_preserves_prompt_tokens_details_from_earlier_chunk` in `tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py`, modeled on the existing Gemini-shaped usage-chunk tests in the same file.

- Verified the new test fails without the fix (reproduces the exact `None` clobbering) and passes with it.
- Ran the full `test_streaming_chunk_builder_utils.py` file: 17 passed, no existing tests broken by this change.