### PR TITLE
fix(anthropic): honor bearer auth for messages custom base

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -171,8 +171,13 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         # Check for Anthropic OAuth token in Authorization header
         headers, api_key = optionally_handle_anthropic_oauth(headers=headers, api_key=api_key)
 
+        if api_base is None and isinstance(litellm_params, dict):
+            api_base = litellm_params.get("api_base")
+        use_bearer_for_custom_base = bool(
+            isinstance(litellm_params, dict) and litellm_params.get("use_bearer_for_custom_base", False)
+        )
         if "x-api-key" not in headers and "authorization" not in headers:
-            auth_header = AnthropicModelInfo.get_auth_header(api_key)
+            auth_header = AnthropicModelInfo.get_auth_header(api_key, api_base, use_bearer_for_custom_base)
             if auth_header is not None:
                 headers.update(auth_header)
         if "anthropic-version" not in headers:

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -386,6 +386,29 @@ class TestPassthroughOAuth:
         assert updated_headers["x-api-key"] == FAKE_REGULAR_KEY
         assert "authorization" not in updated_headers
 
+    def test_passthrough_custom_api_base_uses_bearer_when_configured(self):
+        from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+            AnthropicMessagesConfig,
+        )
+
+        config = AnthropicMessagesConfig()
+
+        updated_headers, _ = config.validate_anthropic_messages_environment(
+            headers={},
+            model="anthropic/claude-fable-5",
+            messages=[{"role": "user", "content": "Hello"}],
+            optional_params={},
+            litellm_params={
+                "api_base": "https://api.cloudflare.com/client/v4/accounts/test/ai",
+                "use_bearer_for_custom_base": True,
+            },
+            api_key="custom-api-key",
+            api_base=None,
+        )
+
+        assert updated_headers["authorization"] == "Bearer custom-api-key"
+        assert "x-api-key" not in updated_headers
+
 
 class TestIsAnthropicOAuthKey:
     """Tests for is_anthropic_oauth_key helper function."""

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -387,6 +387,7 @@ class TestPassthroughOAuth:
         assert "authorization" not in updated_headers
 
     def test_passthrough_custom_api_base_uses_bearer_when_configured(self):
+        """Passthrough messages endpoint uses Bearer auth for custom api_base when configured."""
         from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
             AnthropicMessagesConfig,
         )


### PR DESCRIPTION

## Relevant issues

Fixes  #33055

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Before this change, Anthropic `/v1/messages` ignored `use_bearer_for_custom_base: true` and sent custom gateway credentials as `x-api-key`, causing Cloudflare AI Gateway to return 401.

Repro config:

```yaml
model_list:
  - model_name: claude-fable-5
    litellm_params:
      model: anthropic/anthropic/claude-fable-5
      api_base: https://api.cloudflare.com/client/v4/accounts/<account-id>/ai
      api_key: os.environ/CLOUDFLARE_API_TOKEN
      use_bearer_for_custom_base: true
```

Observed failure before the fix:

```text
POST https://api.cloudflare.com/client/v4/accounts/<account-id>/ai/v1/messages
401 Unauthorized
{"result":null,"success":false,"errors":[{"code":10000,"message":"Authentication error"}],"messages":[]}
```

The same upstream request succeeds when sent directly with Bearer auth:

```bash
curl -X POST "https://api.cloudflare.com/client/v4/accounts/<account-id>/ai/v1/messages" \
  --header "Content-Type: application/json" \
  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
  --data '{
    "model": "anthropic/claude-fable-5",
    "max_tokens": 512,
    "messages": [
      {"role": "user", "content": "Hello"}
    ]
  }'
```


After the fix, the same LiteLLM proxy deployment succeeds against Cloudflare AI Gateway:

```bash
curl --location 'http://localhost:4000/v1/messages' \
  --header 'Content-Type: application/json' \
  --header 'Authorization: Bearer <LITELLM_PROXY_KEY>' \
  --data '{
    "model": "claude-fable-5",
    "max_tokens": 2048,
    "messages": [
      {
        "role": "user",
        "content": "壮壮数他家的鸡和兔,有头共16个，有脚共44只。问：壮壮家的鸡和兔分别有多少只？"
      }
    ]
  }'
```

Response:

```json
{
  "id": "msg_011CcyiYkbubqDKNjQEiVZHR",
  "type": "message",
  "role": "assistant",
  "content": [
    {
      "type": "text",
      "text": "...答案：鸡 10 只，兔 6 只..."
    }
  ],
  "model": "claude-fable-5",
  "stop_reason": "end_turn",
  "usage": {
    "input_tokens": 55,
    "output_tokens": 331
  },
  "gatewayMetadata": {
    "keySource": "Unified"
  }
}
```

This verifies that Anthropic `/v1/messages` custom base auth now reaches Cloudflare AI Gateway successfully instead of returning `401 Authentication error`.


## Type

🐛 Bug Fix
✅ Test

## Changes

Updates Anthropic Messages passthrough auth so `use_bearer_for_custom_base` is honored for custom API bases. This matches the existing Anthropic chat/completions behavior and fixes custom `/v1/messages` gateways that require `Authorization: Bearer`.

Adds a regression test covering `AnthropicMessagesConfig.validate_anthropic_messages_environment()` with a custom `api_base`, `api_key`, and `use_bearer_for_custom_base: true`, asserting that LiteLLM sends Bearer auth and does not send `x-api-key`.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
