### PR TITLE
feat(guardrails): forward metadata through apply_guardrail endpoint

### DIFF
--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -2232,7 +2232,11 @@ async def apply_guardrail(
         if litellm_logging_obj is not None:
             _patch_logging_obj_for_guardrail(litellm_logging_obj, request)
 
-        request_data: dict = {"messages": request.messages} if request.messages else {}
+        request_data: dict = {}
+        if request.messages:
+            request_data["messages"] = request.messages
+        if request.metadata is not None:
+            request_data["metadata"] = request.metadata
         _input_type = _resolve_guardrail_input_type(active_guardrail, request.input_type)
         guardrailed_inputs = await active_guardrail.apply_guardrail(
             inputs={"texts": [request.text]},

--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -2200,7 +2200,10 @@ async def apply_guardrail(
         "guardrail_name": request.guardrail_name,
         "input": [request.text],
         "messages": request.messages or [],
-        "metadata": {"route": "/apply_guardrail"},
+        "metadata": {
+            **(request.metadata or {}),
+            "route": "/apply_guardrail",
+        },
     }
     litellm_logging_obj = None
     start_time = datetime.now(timezone.utc)
@@ -2232,11 +2235,10 @@ async def apply_guardrail(
         if litellm_logging_obj is not None:
             _patch_logging_obj_for_guardrail(litellm_logging_obj, request)
 
-        request_data: dict = {}
-        if request.messages:
-            request_data["messages"] = request.messages
-        if request.metadata is not None:
-            request_data["metadata"] = request.metadata
+        request_data: dict = {
+            **({"messages": request.messages} if request.messages is not None else {}),
+            **({"metadata": data["metadata"]} if request.metadata is not None else {}),
+        }
         _input_type = _resolve_guardrail_input_type(active_guardrail, request.input_type)
         guardrailed_inputs = await active_guardrail.apply_guardrail(
             inputs={"texts": [request.text]},

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -924,6 +924,7 @@ class ApplyGuardrailRequest(BaseModel):
     entities: Optional[List[PiiEntityType]] = None
     input_type: str = "request"
     messages: Optional[List[Dict[str, Any]]] = None
+    metadata: Optional[Dict[str, Any]] = None
 
 
 class ApplyGuardrailResponse(BaseModel):

--- a/tests/enterprise/litellm_enterprise/proxy/guardrails/test_apply_guardrail_endpoint.py
+++ b/tests/enterprise/litellm_enterprise/proxy/guardrails/test_apply_guardrail_endpoint.py
@@ -206,8 +206,75 @@ async def test_apply_guardrail_endpoint_without_optional_params(mock_proxy_loggi
 
 
 @pytest.mark.asyncio
-async def test_apply_guardrail_endpoint_forwards_metadata(mock_proxy_logging_ctx):
-    """Test that apply_guardrail forwards metadata to the guardrail implementation."""
+async def test_apply_guardrail_endpoint_forwards_processed_metadata(
+    mock_proxy_logging_ctx,
+):
+    """Test that apply_guardrail forwards server-processed metadata."""
+    from litellm.proxy.guardrails.guardrail_endpoints import apply_guardrail
+
+    with (
+        patch(
+            "litellm.proxy.guardrails.guardrail_endpoints.GUARDRAIL_REGISTRY"
+        ) as mock_registry,
+        mock_proxy_logging_ctx(),
+    ):
+        from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
+
+        mock_processor = ProxyBaseLLMRequestProcessing.return_value
+        logging_obj = mock_processor.common_processing_pre_call_logic.return_value[1]
+        processed_metadata = {
+            "forbidden_topics": ["taxes"],
+            "route": "/apply_guardrail",
+            "user_api_key_user_id": "authenticated-user",
+        }
+        mock_processor.common_processing_pre_call_logic.return_value = (
+            {"metadata": processed_metadata},
+            logging_obj,
+        )
+        mock_guardrail = Mock(spec=CustomGuardrail)
+        mock_guardrail.apply_guardrail = AsyncMock(return_value={"texts": ["ok"]})
+        mock_registry.get_initialized_guardrail_callback.return_value = mock_guardrail
+
+        request = ApplyGuardrailRequest(
+            guardrail_name="topic-guardrail",
+            text="What are tax loopholes?",
+            metadata={
+                "forbidden_topics": ["taxes"],
+                "route": "/spoofed-route",
+                "user_api_key_user_id": "spoofed-user",
+            },
+        )
+        user_api_key_dict = UserAPIKeyAuth(api_key="test-key")
+
+        response = await apply_guardrail(
+            fastapi_request=Mock(),
+            request=request,
+            user_api_key_dict=user_api_key_dict,
+        )
+
+        assert response.response_text == "ok"
+        ProxyBaseLLMRequestProcessing.assert_called_once_with(
+            data={
+                "guardrail_name": "topic-guardrail",
+                "input": ["What are tax loopholes?"],
+                "messages": [],
+                "metadata": {
+                    "forbidden_topics": ["taxes"],
+                    "route": "/apply_guardrail",
+                    "user_api_key_user_id": "spoofed-user",
+                },
+            }
+        )
+        mock_guardrail.apply_guardrail.assert_called_once_with(
+            inputs={"texts": ["What are tax loopholes?"]},
+            request_data={"metadata": processed_metadata},
+            input_type="request",
+        )
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_endpoint_preserves_empty_messages(mock_proxy_logging_ctx):
+    """Test that apply_guardrail preserves an explicitly empty messages list."""
     from litellm.proxy.guardrails.guardrail_endpoints import apply_guardrail
 
     with (
@@ -220,22 +287,19 @@ async def test_apply_guardrail_endpoint_forwards_metadata(mock_proxy_logging_ctx
         mock_guardrail.apply_guardrail = AsyncMock(return_value={"texts": ["ok"]})
         mock_registry.get_initialized_guardrail_callback.return_value = mock_guardrail
 
-        request = ApplyGuardrailRequest(
-            guardrail_name="topic-guardrail",
-            text="What are tax loopholes?",
-            metadata={"forbidden_topics": ["taxes"]},
-        )
-        user_api_key_dict = UserAPIKeyAuth(api_key="test-key")
-
         response = await apply_guardrail(
             fastapi_request=Mock(),
-            request=request,
-            user_api_key_dict=user_api_key_dict,
+            request=ApplyGuardrailRequest(
+                guardrail_name="test-guardrail",
+                text="Test text",
+                messages=[],
+            ),
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
         )
 
         assert response.response_text == "ok"
         mock_guardrail.apply_guardrail.assert_called_once_with(
-            inputs={"texts": ["What are tax loopholes?"]},
-            request_data={"metadata": {"forbidden_topics": ["taxes"]}},
+            inputs={"texts": ["Test text"]},
+            request_data={"messages": []},
             input_type="request",
         )

--- a/tests/enterprise/litellm_enterprise/proxy/guardrails/test_apply_guardrail_endpoint.py
+++ b/tests/enterprise/litellm_enterprise/proxy/guardrails/test_apply_guardrail_endpoint.py
@@ -203,3 +203,39 @@ async def test_apply_guardrail_endpoint_without_optional_params(mock_proxy_loggi
         mock_guardrail.apply_guardrail.assert_called_once_with(
             inputs={"texts": ["Test text"]}, request_data={}, input_type="request"
         )
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_endpoint_forwards_metadata(mock_proxy_logging_ctx):
+    """Test that apply_guardrail forwards metadata to the guardrail implementation."""
+    from litellm.proxy.guardrails.guardrail_endpoints import apply_guardrail
+
+    with (
+        patch(
+            "litellm.proxy.guardrails.guardrail_endpoints.GUARDRAIL_REGISTRY"
+        ) as mock_registry,
+        mock_proxy_logging_ctx(),
+    ):
+        mock_guardrail = Mock(spec=CustomGuardrail)
+        mock_guardrail.apply_guardrail = AsyncMock(return_value={"texts": ["ok"]})
+        mock_registry.get_initialized_guardrail_callback.return_value = mock_guardrail
+
+        request = ApplyGuardrailRequest(
+            guardrail_name="topic-guardrail",
+            text="What are tax loopholes?",
+            metadata={"forbidden_topics": ["taxes"]},
+        )
+        user_api_key_dict = UserAPIKeyAuth(api_key="test-key")
+
+        response = await apply_guardrail(
+            fastapi_request=Mock(),
+            request=request,
+            user_api_key_dict=user_api_key_dict,
+        )
+
+        assert response.response_text == "ok"
+        mock_guardrail.apply_guardrail.assert_called_once_with(
+            inputs={"texts": ["What are tax loopholes?"]},
+            request_data={"metadata": {"forbidden_topics": ["taxes"]}},
+            input_type="request",
+        )


### PR DESCRIPTION
## Title

Support parameterized guardrails on POST /guardrails/apply_guardrail via optional metadata

## Relevant issues

Fixes #33059

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] I have added a screenshot of my new test passing locally:
<img width="771" height="471" alt="image" src="https://github.com/user-attachments/assets/0bd223ba-e043-4fde-a27d-aa133e46c7e4" />

- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

Parameterized custom guardrails need per-request configuration when invoked through `POST /guardrails/apply_guardrail`, outside the normal LLM call path. The endpoint previously had no request field for guardrail-specific parameters, and Pydantic drops unknown JSON fields

This PR adds optional `metadata` to `ApplyGuardrailRequest`. Caller metadata enters the existing common request-processing pipeline before reaching the guardrail, which strips untrusted `user_api_key_*` values and adds authenticated identity fields. The endpoint only includes metadata in `request_data` when the client provided it, preserving the previous behavior when omitted. Explicitly empty `messages` lists are also preserved

The endpoint tests verify metadata forwarding after server processing, authenticated metadata precedence, backward-compatible omission, and empty-message preservation

Example request:

```json
{
  "guardrail_name": "my-topic-guardrail",
  "text": "What are tax loopholes?",
  "metadata": {
    "forbidden_topics": ["taxes", "finance"]
  }
}
```

Custom guardrail implementations that override `apply_guardrail` are responsible for reading `request_data["metadata"]`