### PR TITLE
fix(anthropic): honor use_bearer_for_custom_base on /v1/messages passthrough

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -158,7 +158,17 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         headers, api_key = optionally_handle_anthropic_oauth(headers=headers, api_key=api_key)
 
         if "x-api-key" not in headers and "authorization" not in headers:
-            auth_header = AnthropicModelInfo.get_auth_header(api_key)
+            resolved_api_base = api_base
+            if resolved_api_base is None and isinstance(litellm_params, dict):
+                resolved_api_base = litellm_params.get("api_base")
+            use_bearer_for_custom_base: bool = bool(
+                isinstance(litellm_params, dict) and litellm_params.get("use_bearer_for_custom_base", False)
+            )
+            auth_header = AnthropicModelInfo.get_auth_header(
+                api_key,
+                api_base=resolved_api_base,
+                use_bearer_for_custom_base=use_bearer_for_custom_base,
+            )
             if auth_header is not None:
                 headers.update(auth_header)
         if "anthropic-version" not in headers:

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -387,6 +387,77 @@ class TestPassthroughOAuth:
         assert "authorization" not in updated_headers
 
 
+FAKE_CUSTOM_BASE_KEY = "custom-gateway-token-for-testing-123"
+CUSTOM_ANTHROPIC_BASE = "https://api.cloudflare.com/client/v4/accounts/acct/ai"
+
+
+class TestPassthroughBearerForCustomBase:
+    """Tests that the /v1/messages passthrough honors use_bearer_for_custom_base."""
+
+    def test_passthrough_custom_base_uses_bearer(self):
+        from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+            AnthropicMessagesConfig,
+        )
+
+        config = AnthropicMessagesConfig()
+
+        updated_headers, _ = config.validate_anthropic_messages_environment(
+            headers={},
+            model="claude-sonnet-4-5-20250929",
+            messages=[{"role": "user", "content": "Hello"}],
+            optional_params={},
+            litellm_params={"use_bearer_for_custom_base": True},
+            api_key=FAKE_CUSTOM_BASE_KEY,
+            api_base=CUSTOM_ANTHROPIC_BASE,
+        )
+
+        assert updated_headers["authorization"] == f"Bearer {FAKE_CUSTOM_BASE_KEY}"
+        assert "x-api-key" not in updated_headers
+
+    def test_passthrough_custom_base_via_litellm_params(self):
+        from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+            AnthropicMessagesConfig,
+        )
+
+        config = AnthropicMessagesConfig()
+
+        updated_headers, _ = config.validate_anthropic_messages_environment(
+            headers={},
+            model="claude-sonnet-4-5-20250929",
+            messages=[{"role": "user", "content": "Hello"}],
+            optional_params={},
+            litellm_params={
+                "api_base": CUSTOM_ANTHROPIC_BASE,
+                "use_bearer_for_custom_base": True,
+            },
+            api_key=FAKE_CUSTOM_BASE_KEY,
+            api_base=None,
+        )
+
+        assert updated_headers["authorization"] == f"Bearer {FAKE_CUSTOM_BASE_KEY}"
+        assert "x-api-key" not in updated_headers
+
+    def test_passthrough_custom_base_without_flag_uses_x_api_key(self):
+        from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+            AnthropicMessagesConfig,
+        )
+
+        config = AnthropicMessagesConfig()
+
+        updated_headers, _ = config.validate_anthropic_messages_environment(
+            headers={},
+            model="claude-sonnet-4-5-20250929",
+            messages=[{"role": "user", "content": "Hello"}],
+            optional_params={},
+            litellm_params={},
+            api_key=FAKE_CUSTOM_BASE_KEY,
+            api_base=CUSTOM_ANTHROPIC_BASE,
+        )
+
+        assert updated_headers["x-api-key"] == FAKE_CUSTOM_BASE_KEY
+        assert "authorization" not in updated_headers
+
+
 class TestIsAnthropicOAuthKey:
     """Tests for is_anthropic_oauth_key helper function."""
 


### PR DESCRIPTION
## Relevant issues

Fixes #33055

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This is an auth-header bug, so the observable difference is the header sent to the custom upstream. For a model with a custom Anthropic-compatible `api_base` and `use_bearer_for_custom_base: true`, the `/v1/messages` passthrough sent `x-api-key` before this change and sends `Authorization: Bearer <token>` after it

Reproduction from the issue (a custom Anthropic-compatible gateway such as Cloudflare AI Gateway, which rejects `x-api-key`):

```yaml
model_list:
  - model_name: claude-fable-5
    litellm_params:
      model: anthropic/anthropic/claude-fable-5
      api_base: https://gateway.example.com/v1
      api_key: os.environ/CUSTOM_GATEWAY_TOKEN
      use_bearer_for_custom_base: true
```

```bash
curl http://localhost:4000/v1/messages \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Bearer sk-litellm-...' \
  -d '{"model":"claude-fable-5","max_tokens":64,"messages":[{"role":"user","content":"ping"}]}'
```

Before the fix the upstream returns a 401 Authentication error because it receives `x-api-key`; after the fix it authenticates because it receives `Authorization: Bearer`

I was not able to run a full live e2e against a custom gateway from my environment since it needs a real Anthropic-compatible base that expects bearer auth. The behavior is pinned deterministically by the added regression tests, which fail on the current code and pass with the fix (the two bearer cases fail before the change and the backward-compatible `x-api-key` case passes both ways, so the mutation is killed). If you have a Cloudflare AI Gateway or similar endpoint handy, the curl above is the exact end-user reproduction

## Type

🐛 Bug Fix

## Changes

The chat path already reads `api_base` and `use_bearer_for_custom_base` from `litellm_params` and forwards them to `get_auth_header`, but the Anthropic `/v1/messages` passthrough did not. `AnthropicMessagesConfig.validate_anthropic_messages_environment` called `AnthropicModelInfo.get_auth_header(api_key)` with only the key, so `_make_api_key_auth_header` never saw a custom base or the bearer flag and always returned `x-api-key`

This change resolves `api_base` (from the argument, falling back to `litellm_params`) and `use_bearer_for_custom_base` the same way `validate_environment` does on the chat path, then passes both into `get_auth_header`. The resolution is local to the auth-header decision, so the value returned by the function is unchanged and routing is untouched. The existing default stays `x-api-key`, so behavior only changes when a caller opts in with `use_bearer_for_custom_base` on a non-Anthropic base

## QA runbook

The regression tests live in `tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py::TestPassthroughBearerForCustomBase` and cover the api_base-as-argument path, the api_base-from-litellm_params path, and the backward-compatible default that still uses `x-api-key` when the flag is absent

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
