### PR TITLE
fix(logging): reuse cached GenericAPILogger instead of leaking flush …

### DIFF
--- a/litellm/integrations/generic_api/generic_api_callback.py
+++ b/litellm/integrations/generic_api/generic_api_callback.py
@@ -202,7 +202,12 @@ class GenericAPILogger(CustomBatchLogger):
         except asyncio.CancelledError:
             try:
                 await self.flush_queue()
+            except asyncio.CancelledError:
+                # A second cancellation during the final flush is still a
+                # cancellation; propagate it instead of swallowing it below.
+                raise
             except Exception:
+                # Best-effort: never let a final-flush error mask the cancellation.
                 pass
             raise
 

--- a/litellm/integrations/generic_api/generic_api_callback.py
+++ b/litellm/integrations/generic_api/generic_api_callback.py
@@ -157,6 +157,12 @@ class GenericAPILogger(CustomBatchLogger):
                 "endpoint not set for GenericAPILogger, GENERIC_LOGGER_ENDPOINT not found in environment variables"
             )
 
+        # Preserve the raw config headers for cache-identity comparison in
+        # LoggingCallbackManager._add_custom_callback_generic_api_str. self.headers below
+        # is post-processed by _get_headers (it injects a Content-Type header and merges
+        # env/global headers), so comparing it against the raw config headers would never
+        # match and would recreate the logger on every re-resolution.
+        self.source_headers = dict(headers) if isinstance(headers, dict) else headers
         self.headers: Dict = self._get_headers(headers)
         self.endpoint: str = endpoint
         self.event_types: Optional[List[API_EVENT_TYPES]] = event_types
@@ -184,8 +190,27 @@ class GenericAPILogger(CustomBatchLogger):
         #########################################################
         self.flush_lock = asyncio.Lock()
         super().__init__(**kwargs, flush_lock=self.flush_lock)
-        asyncio.create_task(self.periodic_flush())
+        self._flush_task = asyncio.create_task(self._run_periodic_flush())
         self.log_queue: List[Union[Dict, StandardLoggingPayload]] = []
+
+    async def _run_periodic_flush(self) -> None:
+        """Run the periodic flush loop; on cancellation, make a best-effort final
+        flush of any buffered logs before exiting. Prevents dropping the last batch
+        when this logger is evicted from the cache and cancelled via shutdown()."""
+        try:
+            await self.periodic_flush()
+        except asyncio.CancelledError:
+            try:
+                await self.flush_queue()
+            except Exception:
+                pass
+            raise
+
+    def shutdown(self) -> None:
+        """Cancel the background flush task. Called by LoggingCallbackManager when this
+        logger is evicted from the cache so its periodic_flush task does not leak."""
+        if not self._flush_task.done():
+            self._flush_task.cancel()
 
     def _get_headers(self, headers: Optional[dict] = None):
         """

--- a/litellm/integrations/generic_api/generic_api_callback.py
+++ b/litellm/integrations/generic_api/generic_api_callback.py
@@ -7,6 +7,7 @@ Callback to log events to a Generic API Endpoint
 """
 
 import asyncio
+import contextlib
 import json
 import os
 import re
@@ -158,7 +159,7 @@ class GenericAPILogger(CustomBatchLogger):
                 "endpoint not set for GenericAPILogger, GENERIC_LOGGER_ENDPOINT not found in environment variables"
             )
 
-        self.headers: dict[str, str] = self._get_headers(headers)
+        self.headers: dict[str, str] = self.resolve_headers(headers)
         self.endpoint: str = endpoint
         self.event_types: list[API_EVENT_TYPES] | None = event_types
         self.callback_name: str | None = callback_name
@@ -190,10 +191,30 @@ class GenericAPILogger(CustomBatchLogger):
         #########################################################
         self.flush_lock = asyncio.Lock()
         super().__init__(**kwargs, flush_lock=self.flush_lock)
-        asyncio.create_task(self.periodic_flush())
+        self._flush_task = asyncio.create_task(self._run_periodic_flush())
         self.log_queue: list[dict | StandardLoggingPayload] = []
 
-    def _get_headers(self, headers: dict | None = None):
+    async def _run_periodic_flush(self) -> None:
+        """Run the periodic flush loop; on cancellation, make a best-effort final
+        flush of any buffered logs before exiting. Prevents dropping the last batch
+        when this logger is evicted from the cache and cancelled via shutdown()."""
+        try:
+            await self.periodic_flush()
+        except asyncio.CancelledError:
+            # suppress(Exception) leaves a nested CancelledError (a BaseException) free to
+            # propagate, so a second cancellation during the final flush is still honored.
+            with contextlib.suppress(Exception):
+                await self.flush_queue()
+            raise
+
+    def shutdown(self) -> None:
+        """Cancel the background flush task. Called by LoggingCallbackManager when this
+        logger is evicted from the cache so its periodic_flush task does not leak."""
+        if not self._flush_task.done():
+            self._flush_task.cancel()
+
+    @staticmethod
+    def resolve_headers(headers: dict | None = None) -> dict[str, str]:  # mutable-ok: caller owns the returned headers
         """
         Get headers for the Generic API Logger
 

--- a/litellm/integrations/generic_api/generic_api_callback.py
+++ b/litellm/integrations/generic_api/generic_api_callback.py
@@ -158,12 +158,6 @@ class GenericAPILogger(CustomBatchLogger):
                 "endpoint not set for GenericAPILogger, GENERIC_LOGGER_ENDPOINT not found in environment variables"
             )
 
-        # Preserve the raw config headers for cache-identity comparison in
-        # LoggingCallbackManager._add_custom_callback_generic_api_str. self.headers below
-        # is post-processed by _get_headers (it injects a Content-Type header and merges
-        # env/global headers), so comparing it against the raw config headers would never
-        # match and would recreate the logger on every re-resolution.
-        self.source_headers = dict(headers) if isinstance(headers, dict) else headers
         self.headers: Dict = self._get_headers(headers)
         self.endpoint: str = endpoint
         self.event_types: Optional[List[API_EVENT_TYPES]] = event_types

--- a/litellm/integrations/generic_api/generic_api_callback.py
+++ b/litellm/integrations/generic_api/generic_api_callback.py
@@ -7,6 +7,7 @@ Callback to log events to a Generic API Endpoint
 """
 
 import asyncio
+import contextlib
 import json
 import os
 import re
@@ -200,15 +201,10 @@ class GenericAPILogger(CustomBatchLogger):
         try:
             await self.periodic_flush()
         except asyncio.CancelledError:
-            try:
+            # suppress(Exception) leaves a nested CancelledError (a BaseException) free to
+            # propagate, so a second cancellation during the final flush is still honored.
+            with contextlib.suppress(Exception):
                 await self.flush_queue()
-            except asyncio.CancelledError:
-                # A second cancellation during the final flush is still a
-                # cancellation; propagate it instead of swallowing it below.
-                raise
-            except Exception:
-                # Best-effort: never let a final-flush error mask the cancellation.
-                pass
             raise
 
     def shutdown(self) -> None:

--- a/litellm/litellm_core_utils/logging_callback_manager.py
+++ b/litellm/litellm_core_utils/logging_callback_manager.py
@@ -198,15 +198,19 @@ class LoggingCallbackManager:
             if (
                 isinstance(cached_logger, GenericAPILogger)
                 and cached_logger.endpoint == endpoint
-                and cached_logger.headers == headers
+                and cached_logger.source_headers == headers
                 and cached_logger.event_types == event_types
-                and cached_logger.log_format == log_format
+                and cached_logger.log_format == (log_format if log_format is not None else "json_array")
                 and cached_logger.max_retries == max_retries
                 and cached_logger.retry_delay == retry_delay
                 and cached_logger.timeout == timeout
             ):
                 return cached_logger
 
+            # Cache miss (config changed or first creation). Build the replacement
+            # first, so that an invalid config raising in the constructor cannot leave
+            # the still-cached logger cancelled. Only after a successful build do we
+            # retire the evicted logger's background flush task.
             new_logger = GenericAPILogger(
                 endpoint=endpoint,
                 headers=headers,
@@ -216,6 +220,8 @@ class LoggingCallbackManager:
                 retry_delay=retry_delay,
                 timeout=timeout,
             )
+            if isinstance(cached_logger, GenericAPILogger):
+                cached_logger.shutdown()
             _generic_api_logger_cache[callback] = new_logger
             return new_logger
 

--- a/litellm/litellm_core_utils/logging_callback_manager.py
+++ b/litellm/litellm_core_utils/logging_callback_manager.py
@@ -204,15 +204,19 @@ class LoggingCallbackManager:
             if (
                 isinstance(cached_logger, GenericAPILogger)
                 and cached_logger.endpoint == endpoint
-                and cached_logger.headers == headers
+                and cached_logger.headers == GenericAPILogger.resolve_headers(headers)
                 and cached_logger.event_types == event_types
-                and cached_logger.log_format == log_format
+                and cached_logger.log_format == (log_format if log_format is not None else "json_array")
                 and cached_logger.max_retries == max_retries
                 and cached_logger.retry_delay == retry_delay
                 and cached_logger.timeout == timeout
             ):
                 return cached_logger
 
+            # Cache miss (config changed or first creation). Build the replacement
+            # first, so that an invalid config raising in the constructor cannot leave
+            # the still-cached logger cancelled. Only after a successful build do we
+            # retire the evicted logger's background flush task.
             new_logger = GenericAPILogger(
                 endpoint=endpoint,
                 headers=headers,
@@ -222,6 +226,8 @@ class LoggingCallbackManager:
                 retry_delay=retry_delay,
                 timeout=timeout,
             )
+            if isinstance(cached_logger, GenericAPILogger):
+                cached_logger.shutdown()
             _generic_api_logger_cache[callback] = new_logger
             return new_logger
 

--- a/litellm/litellm_core_utils/logging_callback_manager.py
+++ b/litellm/litellm_core_utils/logging_callback_manager.py
@@ -198,7 +198,7 @@ class LoggingCallbackManager:
             if (
                 isinstance(cached_logger, GenericAPILogger)
                 and cached_logger.endpoint == endpoint
-                and cached_logger.source_headers == headers
+                and cached_logger.headers == cached_logger._get_headers(headers)
                 and cached_logger.event_types == event_types
                 and cached_logger.log_format == (log_format if log_format is not None else "json_array")
                 and cached_logger.max_retries == max_retries

--- a/tests/test_litellm/litellm_core_utils/test_logging_callback_manager.py
+++ b/tests/test_litellm/litellm_core_utils/test_logging_callback_manager.py
@@ -9,6 +9,7 @@ Covers:
 """
 
 import asyncio
+import contextlib
 
 import pytest
 
@@ -74,7 +75,6 @@ class TestGenericAPILoggerCaching:
             }
         }
         logger_a = LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
-        flush_task_a = logger_a._flush_task
 
         litellm.callback_settings["cb"]["endpoint"] = "http://127.0.0.1:9/b"
         logger_b = LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
@@ -82,8 +82,9 @@ class TestGenericAPILoggerCaching:
         try:
             assert logger_a is not logger_b
 
-            await asyncio.sleep(0)
-            assert flush_task_a.cancelled() is True
+            with contextlib.suppress(asyncio.CancelledError):
+                await logger_a._flush_task
+            assert logger_a._flush_task.cancelled()
         finally:
             logger_b.shutdown()
 
@@ -109,3 +110,25 @@ class TestGenericAPILoggerCaching:
             assert _generic_api_logger_cache["cb"] is logger_a
         finally:
             logger_a.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_final_flush_error_on_cancellation_is_swallowed(self):
+        litellm.callback_settings = {
+            "cb": {
+                "callback_type": "generic_api",
+                "endpoint": "http://127.0.0.1:9/a",
+                "headers": {"Authorization": "Bearer t"},
+            }
+        }
+        logger = LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
+
+        async def _raise_on_flush():
+            raise Exception("boom")
+
+        logger.flush_queue = _raise_on_flush
+
+        logger.shutdown()
+
+        with contextlib.suppress(asyncio.CancelledError):
+            await logger._flush_task
+        assert logger._flush_task.cancelled() is True

--- a/tests/test_litellm/litellm_core_utils/test_logging_callback_manager.py
+++ b/tests/test_litellm/litellm_core_utils/test_logging_callback_manager.py
@@ -1,0 +1,111 @@
+"""
+Tests for LoggingCallbackManager._add_custom_callback_generic_api_str — the GenericAPILogger
+cache-resolution path.
+
+Covers:
+  - Cache hit reuses the same logger instance across repeated resolutions
+  - Invalid empty log_format still raises ValueError
+  - Genuine config change recreates the logger and cancels the old flush task
+"""
+
+import asyncio
+
+import pytest
+
+import litellm
+from litellm.litellm_core_utils.logging_callback_manager import (
+    LoggingCallbackManager,
+    GenericAPILogger,
+    _generic_api_logger_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_generic_api_logger_state():
+    _generic_api_logger_cache.clear()
+    litellm.callback_settings = {}
+    yield
+    _generic_api_logger_cache.clear()
+    litellm.callback_settings = {}
+
+
+class TestGenericAPILoggerCaching:
+    @pytest.mark.asyncio
+    async def test_generic_api_logger_reused_on_repeated_resolution(self):
+        litellm.callback_settings = {
+            "cb": {
+                "callback_type": "generic_api",
+                "endpoint": "http://127.0.0.1:9/x",
+                "headers": {"Authorization": "Bearer t"},
+            }
+        }
+
+        resolved = [LoggingCallbackManager._add_custom_callback_generic_api_str("cb") for _ in range(5)]
+
+        try:
+            assert all(isinstance(logger, GenericAPILogger) for logger in resolved)
+            assert all(logger is resolved[0] for logger in resolved)
+        finally:
+            resolved[0].shutdown()
+
+    @pytest.mark.asyncio
+    async def test_generic_api_logger_empty_log_format_still_raises(self):
+        litellm.callback_settings = {
+            "cb": {
+                "callback_type": "generic_api",
+                "endpoint": "http://127.0.0.1:9/x",
+                "headers": {"Authorization": "Bearer t"},
+                "log_format": "",
+            }
+        }
+
+        with pytest.raises(ValueError):
+            LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
+
+    @pytest.mark.asyncio
+    async def test_generic_api_logger_recreated_and_old_task_cancelled_on_config_change(
+        self,
+    ):
+        litellm.callback_settings = {
+            "cb": {
+                "callback_type": "generic_api",
+                "endpoint": "http://127.0.0.1:9/a",
+                "headers": {"Authorization": "Bearer t"},
+            }
+        }
+        logger_a = LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
+        flush_task_a = logger_a._flush_task
+
+        litellm.callback_settings["cb"]["endpoint"] = "http://127.0.0.1:9/b"
+        logger_b = LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
+
+        try:
+            assert logger_a is not logger_b
+
+            await asyncio.sleep(0)
+            assert flush_task_a.cancelled() is True
+        finally:
+            logger_b.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_bad_replacement_config_does_not_evict_existing_logger(self):
+        litellm.callback_settings = {
+            "cb": {
+                "callback_type": "generic_api",
+                "endpoint": "http://127.0.0.1:9/a",
+                "headers": {"Authorization": "Bearer t"},
+            }
+        }
+        logger_a = LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
+        flush_task_a = logger_a._flush_task
+
+        litellm.callback_settings["cb"]["log_format"] = "bad_format"
+
+        try:
+            with pytest.raises(ValueError):
+                LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
+
+            assert flush_task_a.cancelled() is False
+            assert _generic_api_logger_cache["cb"] is logger_a
+        finally:
+            logger_a.shutdown()

--- a/tests/test_litellm/litellm_core_utils/test_logging_callback_manager.py
+++ b/tests/test_litellm/litellm_core_utils/test_logging_callback_manager.py
@@ -1,0 +1,171 @@
+"""
+Tests for the GenericAPILogger cache-resolution path in
+LoggingCallbackManager._add_custom_callback_generic_api_str.
+
+Covers:
+  - Cache hit reuses the same logger instance across repeated resolutions
+  - Invalid empty log_format still raises ValueError
+  - Genuine config change recreates the logger and cancels the old flush task
+  - Header rotation is compared on the effective headers, not the raw config ones
+"""
+
+import asyncio
+import contextlib
+
+import pytest
+
+import litellm
+from litellm.litellm_core_utils.logging_callback_manager import (
+    GenericAPILogger,
+    LoggingCallbackManager,
+    _generic_api_logger_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def callback_settings(monkeypatch):
+    settings = {}
+    monkeypatch.setattr(litellm, "callback_settings", settings)
+    _generic_api_logger_cache.clear()
+    yield settings
+    _generic_api_logger_cache.clear()
+
+
+class TestGenericAPILoggerCaching:
+    @pytest.mark.asyncio
+    async def test_generic_api_logger_reused_on_repeated_resolution(self, callback_settings):
+        callback_settings["cb"] = {
+            "callback_type": "generic_api",
+            "endpoint": "http://127.0.0.1:9/x",
+            "headers": {"Authorization": "Bearer t"},
+        }
+
+        resolved = [LoggingCallbackManager._add_custom_callback_generic_api_str("cb") for _ in range(5)]
+
+        try:
+            assert all(isinstance(logger, GenericAPILogger) for logger in resolved)
+            assert all(logger is resolved[0] for logger in resolved)
+        finally:
+            resolved[0].shutdown()
+
+    @pytest.mark.asyncio
+    async def test_generic_api_logger_empty_log_format_still_raises(self, callback_settings):
+        callback_settings["cb"] = {
+            "callback_type": "generic_api",
+            "endpoint": "http://127.0.0.1:9/x",
+            "headers": {"Authorization": "Bearer t"},
+            "log_format": "",
+        }
+
+        with pytest.raises(ValueError, match="Invalid log_format"):
+            LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
+
+    @pytest.mark.asyncio
+    async def test_generic_api_logger_recreated_and_old_task_cancelled_on_config_change(self, callback_settings):
+        callback_settings["cb"] = {
+            "callback_type": "generic_api",
+            "endpoint": "http://127.0.0.1:9/a",
+            "headers": {"Authorization": "Bearer t"},
+        }
+        logger_a = LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
+
+        callback_settings["cb"]["endpoint"] = "http://127.0.0.1:9/b"
+        logger_b = LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
+
+        try:
+            assert logger_a is not logger_b
+
+            with contextlib.suppress(asyncio.CancelledError):
+                await logger_a._flush_task
+            assert logger_a._flush_task.cancelled()
+        finally:
+            logger_b.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_bad_replacement_config_does_not_evict_existing_logger(self, callback_settings):
+        callback_settings["cb"] = {
+            "callback_type": "generic_api",
+            "endpoint": "http://127.0.0.1:9/a",
+            "headers": {"Authorization": "Bearer t"},
+        }
+        logger_a = LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
+        flush_task_a = logger_a._flush_task
+
+        callback_settings["cb"]["log_format"] = "bad_format"
+
+        try:
+            with pytest.raises(ValueError, match="Invalid log_format"):
+                LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
+
+            assert flush_task_a.cancelled() is False
+            assert _generic_api_logger_cache["cb"] is logger_a
+        finally:
+            logger_a.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_env_header_rotation_recreates_logger(self, callback_settings, monkeypatch):
+        monkeypatch.setenv("GENERIC_LOGGER_HEADERS", "Authorization=Bearer old")
+        callback_settings["cb"] = {
+            "callback_type": "generic_api",
+            "endpoint": "http://127.0.0.1:9/a",
+            "headers": {"X-Static": "s"},
+        }
+        logger_a = LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
+
+        monkeypatch.setenv("GENERIC_LOGGER_HEADERS", "Authorization=Bearer new")
+        logger_b = LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
+
+        try:
+            assert logger_a is not logger_b
+            assert logger_b.headers["Authorization"] == "Bearer new"
+
+            with contextlib.suppress(asyncio.CancelledError):
+                await logger_a._flush_task
+            assert logger_a._flush_task.cancelled()
+        finally:
+            logger_b.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_env_header_shadowed_by_config_reuses_logger(self, callback_settings, monkeypatch):
+        monkeypatch.setenv("GENERIC_LOGGER_HEADERS", "Authorization=Bearer old")
+        callback_settings["cb"] = {
+            "callback_type": "generic_api",
+            "endpoint": "http://127.0.0.1:9/a",
+            "headers": {"Authorization": "Bearer from-config"},
+        }
+        logger_a = LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
+
+        monkeypatch.setenv("GENERIC_LOGGER_HEADERS", "Authorization=Bearer new")
+        logger_b = LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
+
+        try:
+            assert logger_a is logger_b
+        finally:
+            logger_a.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_final_flush_error_on_cancellation_is_swallowed(self, callback_settings):
+        callback_settings["cb"] = {
+            "callback_type": "generic_api",
+            "endpoint": "http://127.0.0.1:9/a",
+            "headers": {"Authorization": "Bearer t"},
+        }
+        logger = LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
+
+        flushed = asyncio.Event()
+
+        async def _raise_on_flush():
+            flushed.set()
+            raise Exception("boom")
+
+        logger.flush_queue = _raise_on_flush
+        # Let the flush task reach its first await; cancelling a task that never started
+        # skips _run_periodic_flush entirely and the final-flush path goes untested.
+        await asyncio.sleep(0)
+
+        logger.shutdown()
+
+        with contextlib.suppress(asyncio.CancelledError):
+            await logger._flush_task
+        assert flushed.is_set()
+        assert logger._flush_task.cancelled() is True

--- a/tests/test_litellm/litellm_core_utils/test_logging_callback_manager.py
+++ b/tests/test_litellm/litellm_core_utils/test_logging_callback_manager.py
@@ -6,6 +6,7 @@ Covers:
   - Cache hit reuses the same logger instance across repeated resolutions
   - Invalid empty log_format still raises ValueError
   - Genuine config change recreates the logger and cancels the old flush task
+  - Header rotation is compared on the effective headers, not the raw config ones
 """
 
 import asyncio
@@ -108,6 +109,51 @@ class TestGenericAPILoggerCaching:
 
             assert flush_task_a.cancelled() is False
             assert _generic_api_logger_cache["cb"] is logger_a
+        finally:
+            logger_a.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_env_header_rotation_recreates_logger(self, monkeypatch):
+        monkeypatch.setenv("GENERIC_LOGGER_HEADERS", "Authorization=Bearer old")
+        litellm.callback_settings = {
+            "cb": {
+                "callback_type": "generic_api",
+                "endpoint": "http://127.0.0.1:9/a",
+                "headers": {"X-Static": "s"},
+            }
+        }
+        logger_a = LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
+
+        monkeypatch.setenv("GENERIC_LOGGER_HEADERS", "Authorization=Bearer new")
+        logger_b = LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
+
+        try:
+            assert logger_a is not logger_b
+            assert logger_b.headers["Authorization"] == "Bearer new"
+
+            with contextlib.suppress(asyncio.CancelledError):
+                await logger_a._flush_task
+            assert logger_a._flush_task.cancelled()
+        finally:
+            logger_b.shutdown()
+
+    @pytest.mark.asyncio
+    async def test_env_header_shadowed_by_config_reuses_logger(self, monkeypatch):
+        monkeypatch.setenv("GENERIC_LOGGER_HEADERS", "Authorization=Bearer old")
+        litellm.callback_settings = {
+            "cb": {
+                "callback_type": "generic_api",
+                "endpoint": "http://127.0.0.1:9/a",
+                "headers": {"Authorization": "Bearer from-config"},
+            }
+        }
+        logger_a = LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
+
+        monkeypatch.setenv("GENERIC_LOGGER_HEADERS", "Authorization=Bearer new")
+        logger_b = LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
+
+        try:
+            assert logger_a is logger_b
         finally:
             logger_a.shutdown()
 

--- a/tests/test_litellm/litellm_core_utils/test_logging_callback_manager.py
+++ b/tests/test_litellm/litellm_core_utils/test_logging_callback_manager.py
@@ -122,13 +122,20 @@ class TestGenericAPILoggerCaching:
         }
         logger = LoggingCallbackManager._add_custom_callback_generic_api_str("cb")
 
+        flushed = asyncio.Event()
+
         async def _raise_on_flush():
+            flushed.set()
             raise Exception("boom")
 
         logger.flush_queue = _raise_on_flush
+        # Let the flush task reach its first await; cancelling a task that never started
+        # skips _run_periodic_flush entirely and the final-flush path goes untested.
+        await asyncio.sleep(0)
 
         logger.shutdown()
 
         with contextlib.suppress(asyncio.CancelledError):
             await logger._flush_task
+        assert flushed.is_set()
         assert logger._flush_task.cancelled() is True


### PR DESCRIPTION
## TLDR

Problem this solves:

- the `generic_api` logger cache never hits, so every re-resolution rebuilds it
- each rebuild starts another flush loop that nothing ever cancels
- background tasks, CPU and memory grow with zero traffic

How it solves it:

- compare the cached logger on effective headers and normalized `log_format`
- keep the flush task handle and cancel it when a logger is evicted
- build the replacement first, so a bad config cannot cancel a live logger

## User Flow

Before: an operator running the proxy with a `generic_api` logging callback watches the process grow every time the callback config is re-applied, even while it serves nothing

1. They start the proxy with a `generic_api` callback pointed at their logging endpoint
2. Their deployment re-applies the same unchanged callback config
3. Every re-application leaves another live flush loop behind; after 50 of them the process holds 50 loggers and 50 loops
4. CPU and memory keep climbing on an idle gateway, and the only way out is a restart

After: the same flow holds one logger and one flush loop

1. They start the proxy with a `generic_api` callback pointed at their logging endpoint
2. Their deployment re-applies the same unchanged callback config
3. Every re-application returns the logger that is already running; after 50 of them the process holds 1 logger and 1 loop
4. An idle gateway stays flat, and a genuine config change swaps the logger instead of stacking one more

## Relevant issues

None; found while auditing proxy callback lifecycle

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Shared setup, `pr33065_config.yaml`:

```yaml
model_list:
  - model_name: haiku
    litellm_params:
      model: anthropic/claude-haiku-4-5-20251001
      api_key: os.environ/ANTHROPIC_API_KEY

callback_settings:
  sink_logger:
    callback_type: generic_api
    endpoint: http://127.0.0.1:9099/logs
    headers:
      Authorization: Bearer sk-sink

litellm_settings:
  success_callback: ["sink_logger"]

general_settings:
  master_key: sk-1234
```

Shared setup, `repro_leak.py`, which re-resolves one unchanged `generic_api` callback 50 times and counts what stayed alive:

```python
import asyncio

import litellm
from litellm.litellm_core_utils.logging_callback_manager import (
    LoggingCallbackManager,
    _generic_api_logger_cache,
)

RESOLUTIONS = 50


async def main():
    _generic_api_logger_cache.clear()
    litellm.callback_settings = {
        "cb": {
            "callback_type": "generic_api",
            "endpoint": "http://127.0.0.1:9099/logs",
            "headers": {"Authorization": "Bearer sk-test"},
        }
    }

    loggers = [LoggingCallbackManager._add_custom_callback_generic_api_str("cb") for _ in range(RESOLUTIONS)]
    await asyncio.sleep(0)

    live = [t for t in asyncio.all_tasks() if "periodic_flush" in repr(t.get_coro()) and not t.done()]

    print(f"re-resolutions            : {len(loggers)}")
    print(f"distinct logger instances : {len({id(logger) for logger in loggers})}")
    print(f"live background tasks     : {len(live)}")
    print(f"VERDICT                   : {'LEAK CONFIRMED' if len(live) > 1 else 'no leak'}")


asyncio.run(main())
```

### Before (f005afa146)

#### Re-resolving an unchanged callback config

1. `python repro_leak.py`
2. Output:

```
re-resolutions            : 50
distinct logger instances : 50
live background tasks     : 50
VERDICT                   : LEAK CONFIRMED
```

#### Serving a live request with the callback configured

1. `python litellm/proxy/proxy_cli.py --config pr33065_config.yaml --port 4000 --detailed_debug`
2. `curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"haiku","messages":[{"role":"user","content":"reply with the single word: pong"}],"max_tokens":16}'`
3. Output: HTTP 200, `"content": "pong"`, 15 prompt and 5 completion tokens off a real Anthropic call
4. `grep "CustomLogger periodic flush" proxy.log | awk '{print $1}' | uniq -c` shows one tick per 5 seconds, the single loop a fresh proxy is supposed to have:

```
   1 10:38:08
   1 10:38:13
   1 10:38:18
   1 10:38:23
   1 10:38:28
```

### After (e2a632f8da)

#### Re-resolving an unchanged callback config

1. `python repro_leak.py`
2. Output:

```
re-resolutions            : 50
distinct logger instances : 1
live background tasks     : 1
VERDICT                   : no leak
```

#### Serving a live request with the callback configured

1. `python litellm/proxy/proxy_cli.py --config pr33065_config.yaml --port 4000 --detailed_debug`
2. `curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"haiku","messages":[{"role":"user","content":"reply with the single word: pong"}],"max_tokens":16}'`
3. Output: HTTP 200, `"content": "pong"`, 15 prompt and 5 completion tokens off a real Anthropic call
4. `grep "CustomLogger periodic flush" proxy.log | awk '{print $1}' | uniq -c` still shows one tick per 5 seconds, so the fix costs the normal path nothing:

```
   1 10:36:32
   1 10:36:37
   1 10:36:42
   1 10:36:47
   1 10:36:52
```

## Type

🐛 Bug Fix

## Changes

The cache comparison in `LoggingCallbackManager._add_custom_callback_generic_api_str` missed on two fields, so it never returned the cached logger. Headers were compared raw against the effective headers the constructor stores, which merge in `Content-Type`, `GENERIC_LOGGER_HEADERS` and `litellm.generic_logger_headers`; `log_format` was compared raw against the `"json_array"` default the constructor substitutes when the config omits it. Both sides are now compared the same way, and `_get_headers` becomes the public static `resolve_headers` so the manager can normalize without reaching into the instance.

`GenericAPILogger` now keeps its flush task handle and exposes `shutdown()`, which the manager calls on the evicted logger once the replacement is built. Building first matters: an invalid replacement config raises in the constructor, and the still-cached logger has to survive that. On cancellation the loop makes one best-effort final flush so an evicted logger does not drop its last batch, and a second cancellation during that flush is honored rather than swallowed.

## Caveats

- `code-quality` is red on the base branch itself, unrelated to this diff
- the leak never shows in a response body, only in background task growth

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
