### PR TITLE
fix(actions): pricing auto update action

### DIFF
--- a/.github/workflows/auto_update_price_and_context_window.yml
+++ b/.github/workflows/auto_update_price_and_context_window.yml
@@ -27,6 +27,8 @@ jobs:
           uv run --frozen --with 'aiohttp==3.13.3' python ".github/workflows/auto_update_price_and_context_window_file.py"
       - name: Create Pull Request
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add model_prices_and_context_window.json 
           git commit -m "Update model_prices_and_context_window.json file: $(date +'%Y-%m-%d')" 
           gh pr create --title "Update model_prices_and_context_window.json file" \

--- a/.github/workflows/auto_update_price_and_context_window.yml
+++ b/.github/workflows/auto_update_price_and_context_window.yml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "0 0 * * 0" # Run every Sundays at midnight
     #- cron: "0 0 * * *" # Run daily at midnight
-  workflow_dispatch:
 
 permissions:
   contents: write
@@ -12,7 +11,7 @@ permissions:
 
 jobs:
   auto_update_price_and_context_window:
-    # if: github.repository == 'BerriAI/litellm'
+    if: github.repository == 'BerriAI/litellm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/.github/workflows/auto_update_price_and_context_window.yml
+++ b/.github/workflows/auto_update_price_and_context_window.yml
@@ -17,28 +17,34 @@ jobs:
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          ref: litellm_internal_staging
+          fetch-depth: 0
           persist-credentials: false
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "0.10.9"
-      - name: Update JSON Data
-        run: |
-          uv run --frozen --with 'aiohttp==3.13.3' python ".github/workflows/auto_update_price_and_context_window_file.py"
-      - name: Create Pull Request
+      - name: Create and push updated branch
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # for git push url
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # for gh pr create
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+
+          BRANCH_NAME="auto-update-price-and-context-window-$(date +'%Y-%m-%d')"
+          echo "Creating branch: ${BRANCH_NAME}"
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          BRANCH_NAME="auto-update-price-and-context-window-$(date +'%Y-%m-%d')"
-          git checkout -b "${BRANCH_NAME}"
+
+          git fetch origin main "${BRANCH_NAME}" || true
+
+          if git show-ref --verify --quiet "refs/remotes/origin/${BRANCH_NAME}"; then
+            echo "Branch ${BRANCH_NAME} already exists. Skipping creation."
+            exit 0
+          fi
+
+          git checkout -b "${BRANCH_NAME}" origin/main
+          uv run --frozen --with 'aiohttp==3.13.3' python ".github/workflows/auto_update_price_and_context_window_file.py"
           git add model_prices_and_context_window.json
           git commit -m "Update model_prices_and_context_window.json file: $(date +'%Y-%m-%d')"
           git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${BRANCH_NAME}"
-          gh pr create --title "Update model_prices_and_context_window.json file" \
-            --body "Automated update for model_prices_and_context_window.json" \
-            --head "${BRANCH_NAME}" \
-            --base litellm_internal_staging
+          echo "Successfully created and pushed branch: ${BRANCH_NAME}"

--- a/.github/workflows/auto_update_price_and_context_window.yml
+++ b/.github/workflows/auto_update_price_and_context_window.yml
@@ -39,9 +39,17 @@ jobs:
           fi
           uv run --frozen --with 'aiohttp==3.13.3' python ".github/workflows/auto_update_price_and_context_window_file.py"
           git add model_prices_and_context_window.json
-          git commit -m "Update model_prices_and_context_window.json file: $(date +'%Y-%m-%d')"
-          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${BRANCH_NAME}"
-          gh pr create --title "Update model_prices_and_context_window.json file" \
-            --body "Automated update for model_prices_and_context_window.json" \
-            --head "${BRANCH_NAME}" \
-            --base "${BASE_BRANCH}"
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "Update model_prices_and_context_window.json file: $(date +'%Y-%m-%d')"
+            git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${BRANCH_NAME}"
+          fi
+          if gh pr view "${BRANCH_NAME}" >/dev/null 2>&1; then
+            echo "PR already exists for ${BRANCH_NAME}."
+          else
+            gh pr create --title "Update model_prices_and_context_window.json file" \
+              --body "Automated update for model_prices_and_context_window.json" \
+              --head "${BRANCH_NAME}" \
+              --base "${BASE_BRANCH}"
+          fi

--- a/.github/workflows/auto_update_price_and_context_window.yml
+++ b/.github/workflows/auto_update_price_and_context_window.yml
@@ -36,4 +36,4 @@ jobs:
             --head auto-update-price-and-context-window-$(date +'%Y-%m-%d') \
             --base main
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/auto_update_price_and_context_window.yml
+++ b/.github/workflows/auto_update_price_and_context_window.yml
@@ -44,12 +44,12 @@ jobs:
           else
             git commit -m "Update model_prices_and_context_window.json file: $(date +'%Y-%m-%d')"
             git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${BRANCH_NAME}"
-          fi
-          if gh pr view "${BRANCH_NAME}" >/dev/null 2>&1; then
-            echo "PR already exists for ${BRANCH_NAME}."
-          else
-            gh pr create --title "Update model_prices_and_context_window.json file" \
-              --body "Automated update for model_prices_and_context_window.json" \
-              --head "${BRANCH_NAME}" \
-              --base "${BASE_BRANCH}"
+            if gh pr view "${BRANCH_NAME}" >/dev/null 2>&1; then
+              echo "PR already exists for ${BRANCH_NAME}."
+            else
+              gh pr create --title "Update model_prices_and_context_window.json file" \
+                --body "Automated update for model_prices_and_context_window.json" \
+                --head "${BRANCH_NAME}" \
+                --base "${BASE_BRANCH}"
+            fi
           fi

--- a/.github/workflows/auto_update_price_and_context_window.yml
+++ b/.github/workflows/auto_update_price_and_context_window.yml
@@ -26,14 +26,18 @@ jobs:
         run: |
           uv run --frozen --with 'aiohttp==3.13.3' python ".github/workflows/auto_update_price_and_context_window_file.py"
       - name: Create Pull Request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add model_prices_and_context_window.json 
-          git commit -m "Update model_prices_and_context_window.json file: $(date +'%Y-%m-%d')" 
+          BRANCH_NAME="auto-update-price-and-context-window-$(date +'%Y-%m-%d')"
+          git checkout -b "${BRANCH_NAME}"
+          git add model_prices_and_context_window.json
+          git commit -m "Update model_prices_and_context_window.json file: $(date +'%Y-%m-%d')"
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${BRANCH_NAME}"
           gh pr create --title "Update model_prices_and_context_window.json file" \
             --body "Automated update for model_prices_and_context_window.json" \
-            --head auto-update-price-and-context-window-$(date +'%Y-%m-%d') \
+            --head "${BRANCH_NAME}" \
             --base main
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto_update_price_and_context_window.yml
+++ b/.github/workflows/auto_update_price_and_context_window.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
+          ref: litellm_internal_staging
           persist-credentials: false
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
@@ -40,4 +41,4 @@ jobs:
           gh pr create --title "Update model_prices_and_context_window.json file" \
             --body "Automated update for model_prices_and_context_window.json" \
             --head "${BRANCH_NAME}" \
-            --base main
+            --base litellm_internal_staging

--- a/.github/workflows/auto_update_price_and_context_window.yml
+++ b/.github/workflows/auto_update_price_and_context_window.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch || github.ref_name }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/auto_update_price_and_context_window.yml
+++ b/.github/workflows/auto_update_price_and_context_window.yml
@@ -36,4 +36,4 @@ jobs:
             --head auto-update-price-and-context-window-$(date +'%Y-%m-%d') \
             --base main
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto_update_price_and_context_window.yml
+++ b/.github/workflows/auto_update_price_and_context_window.yml
@@ -26,11 +26,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           BRANCH_NAME="auto-update-price-and-context-window-$(date +'%Y-%m-%d')"
-          BASE_BRANCH="${{ github.event.repository.default_branch }}"
           git fetch origin "${BASE_BRANCH}" "${BRANCH_NAME}" || true
           if git show-ref --verify --quiet "refs/remotes/origin/${BRANCH_NAME}"; then
             git checkout -B "${BRANCH_NAME}" "origin/${BRANCH_NAME}"

--- a/.github/workflows/auto_update_price_and_context_window.yml
+++ b/.github/workflows/auto_update_price_and_context_window.yml
@@ -22,9 +22,6 @@ jobs:
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "0.10.9"
-      - name: Update JSON Data
-        run: |
-          uv run --frozen --with 'aiohttp==3.13.3' python ".github/workflows/auto_update_price_and_context_window_file.py"
       - name: Create Pull Request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -34,12 +31,13 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           BRANCH_NAME="auto-update-price-and-context-window-$(date +'%Y-%m-%d')"
           BASE_BRANCH="${{ github.event.repository.default_branch }}"
-          git fetch origin "${BRANCH_NAME}" || true
+          git fetch origin "${BASE_BRANCH}" "${BRANCH_NAME}" || true
           if git show-ref --verify --quiet "refs/remotes/origin/${BRANCH_NAME}"; then
             git checkout -B "${BRANCH_NAME}" "origin/${BRANCH_NAME}"
           else
-            git checkout -b "${BRANCH_NAME}"
+            git checkout -b "${BRANCH_NAME}" "origin/${BASE_BRANCH}"
           fi
+          uv run --frozen --with 'aiohttp==3.13.3' python ".github/workflows/auto_update_price_and_context_window_file.py"
           git add model_prices_and_context_window.json
           git commit -m "Update model_prices_and_context_window.json file: $(date +'%Y-%m-%d')"
           git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${BRANCH_NAME}"

--- a/.github/workflows/auto_update_price_and_context_window.yml
+++ b/.github/workflows/auto_update_price_and_context_window.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: "0 0 * * 0" # Run every Sundays at midnight
     #- cron: "0 0 * * *" # Run daily at midnight
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -11,7 +12,7 @@ permissions:
 
 jobs:
   auto_update_price_and_context_window:
-    if: github.repository == 'BerriAI/litellm'
+    # if: github.repository == 'BerriAI/litellm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/.github/workflows/auto_update_price_and_context_window.yml
+++ b/.github/workflows/auto_update_price_and_context_window.yml
@@ -27,8 +27,8 @@ jobs:
           uv run --frozen --with 'aiohttp==3.13.3' python ".github/workflows/auto_update_price_and_context_window_file.py"
       - name: Create Pull Request
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # for git push url
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # for gh pr create
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/auto_update_price_and_context_window.yml
+++ b/.github/workflows/auto_update_price_and_context_window.yml
@@ -17,34 +17,33 @@ jobs:
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          fetch-depth: 0
           persist-credentials: false
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "0.10.9"
-      - name: Create and push updated branch
+      - name: Update JSON Data
+        run: |
+          uv run --frozen --with 'aiohttp==3.13.3' python ".github/workflows/auto_update_price_and_context_window_file.py"
+      - name: Create Pull Request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -euo pipefail
-
-          BRANCH_NAME="auto-update-price-and-context-window-$(date +'%Y-%m-%d')"
-          echo "Creating branch: ${BRANCH_NAME}"
-
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          git fetch origin main "${BRANCH_NAME}" || true
-
+          BRANCH_NAME="auto-update-price-and-context-window-$(date +'%Y-%m-%d')"
+          BASE_BRANCH="${{ github.event.repository.default_branch }}"
+          git fetch origin "${BRANCH_NAME}" || true
           if git show-ref --verify --quiet "refs/remotes/origin/${BRANCH_NAME}"; then
-            echo "Branch ${BRANCH_NAME} already exists. Skipping creation."
-            exit 0
+            git checkout -B "${BRANCH_NAME}" "origin/${BRANCH_NAME}"
+          else
+            git checkout -b "${BRANCH_NAME}"
           fi
-
-          git checkout -b "${BRANCH_NAME}" origin/main
-          uv run --frozen --with 'aiohttp==3.13.3' python ".github/workflows/auto_update_price_and_context_window_file.py"
           git add model_prices_and_context_window.json
           git commit -m "Update model_prices_and_context_window.json file: $(date +'%Y-%m-%d')"
           git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${BRANCH_NAME}"
-          echo "Successfully created and pushed branch: ${BRANCH_NAME}"
+          gh pr create --title "Update model_prices_and_context_window.json file" \
+            --body "Automated update for model_prices_and_context_window.json" \
+            --head "${BRANCH_NAME}" \
+            --base "${BASE_BRANCH}"

--- a/.github/workflows/auto_update_price_and_context_window_file.py
+++ b/.github/workflows/auto_update_price_and_context_window_file.py
@@ -85,24 +85,31 @@ def transform_openrouter_data(data):
 def transform_vercel_ai_gateway_data(data):
     transformed = {}
     for row in data:
-        obj = {
-            "max_tokens": row["context_window"],
-            "input_cost_per_token": float(row["pricing"]["input"]),
-            "output_cost_per_token": float(row["pricing"]["output"]),
-            'max_output_tokens': row['max_tokens'],
-            'max_input_tokens': row["context_window"],
-        }
+        obj = {}
+
+        if "context_window" in row:
+            obj['max_tokens'] = row["context_window"]
+            obj['max_input_tokens'] = row["context_window"]
+
+        if "pricing" in row:
+            if "input" in row["pricing"] and row["pricing"]["input"] is not None:
+                obj['input_cost_per_token'] = float(row["pricing"]["input"])
+            if "output" in row["pricing"] and row["pricing"]["output"] is not None:
+                obj['output_cost_per_token'] = float(row["pricing"]["output"])
+
+        if "max_tokens" in row:
+            obj['max_output_tokens'] = row['max_tokens']
 
         # Handle cache pricing if available
         if "pricing" in row:
             if "input_cache_read" in row["pricing"] and row["pricing"]["input_cache_read"] is not None:
                 obj['cache_read_input_token_cost'] = float(f"{float(row['pricing']['input_cache_read']):e}")
-            
+
             if "input_cache_write" in row["pricing"] and row["pricing"]["input_cache_write"] is not None:
                 obj['cache_creation_input_token_cost'] = float(f"{float(row['pricing']['input_cache_write']):e}")
 
         mode = "embedding" if "embedding" in row["id"].lower() else "chat"
-        
+
         obj.update({"litellm_provider": "vercel_ai_gateway", "mode": mode})
 
         transformed[f'vercel_ai_gateway/{row["id"]}'] = obj
@@ -133,17 +140,17 @@ def main():
 
     # Load local data from file
     local_data = load_local_data(local_file_path)
-    
+
     # Fetch OpenRouter data
     openrouter_data = asyncio.run(fetch_data(openrouter_url))
     # Transform the fetched OpenRouter data
     openrouter_data = transform_openrouter_data(openrouter_data)
-    
+
     # Fetch Vercel AI Gateway data
     vercel_data = asyncio.run(fetch_data(vercel_ai_gateway_url))
     # Transform the fetched Vercel AI Gateway data
     vercel_data = transform_vercel_ai_gateway_data(vercel_data)
-    
+
     # Combine both datasets
     all_remote_data = {**openrouter_data, **vercel_data}
 


### PR DESCRIPTION
## Relevant issues

This PR brings back to life the automated refresh for Vercel AI gateway and OpenRouter gateway.

Fixes:
- https://github.com/BerriAI/litellm/issues/27325
- https://github.com/BerriAI/litellm/issues/33068
- and a couple more

## Context

This action refreshes models and their prices from OpenRouter and Vercel AI SDK: https://github.com/BerriAI/litellm/blob/litellm_internal_staging/.github/workflows/auto_update_price_and_context_window.yml

However, it was failing silently. Example of a failed run: https://github.com/BerriAI/litellm/actions/runs/29173737985/job/86599055076

I reproduced the error on my fork:
```
Traceback (most recent call last):
  File "/workspaces/litellm-contrib/.github/workflows/auto_update_price_and_context_window_file.py", line 159, in <module>
    main()
  File "/workspaces/litellm-contrib/.github/workflows/auto_update_price_and_context_window_file.py", line 145, in main
    vercel_data = transform_vercel_ai_gateway_data(vercel_data)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/litellm-contrib/.github/workflows/auto_update_price_and_context_window_file.py", line 91, in transform_vercel_ai_gateway_data
```

The reason is that it fails for models that have no output pricing. For example, alibaba/qwen3-embedding-0.6b only has input pricing. Missing pricing.output (embeddings, video models) makes float(row["pricing"]["output"]) throw.

Screenshot from Vercel AI gateway of a model that has no output pricing:
<img width="1552" height="334" alt="image" src="https://github.com/user-attachments/assets/3cad230e-7fed-41a4-bf3e-469af2f64f2c" />

Works on the fork: https://github.com/oskarkocol/litellm-contrib/actions/runs/29249385824/job/86813935404

**Note**: I followed the repo convention of using ${{ secrets.GITHUB_TOKEN }} If you see an error like “GitHub Actions is not permitted to create or approve pull requests (createPullRequest)” due to repo permissions, use a PAT stored as custom secret, like ${{ secrets.GH_TOKEN }}

## Follow-up PRs (stacked)

This PR fixes the workflow only. Provider additions are split out and stacked on this branch:

- Novita pricing source: BerriAI/litellm#XXXX (base: `fix/auto-update-action`). [Draft PR](https://github.com/oskarkocol/litellm-contrib/pull/3).
- Cerebras via Narev: BerriAI/litellm#YYYY (base: Novita PR branch). [Draft PR](https://github.com/oskarkocol/litellm-contrib/pull/4)

Please merge this PR first; the follow-ups will be retargeted to `litellm_internal_staging` after it lands.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix
✅ Test

## Changes

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
