### PR TITLE
perf(rust): enable LTO and codegen-units=1 for release profile

### DIFF
--- a/litellm-rust/Cargo.toml
+++ b/litellm-rust/Cargo.toml
@@ -6,6 +6,11 @@ members = [
 ]
 resolver = "2"
 
+[profile.release]
+lto = true
+codegen-units = 1
+strip = true
+
 [workspace.package]
 edition = "2021"
 license = "MIT"

--- a/litellm-rust/crates/core/tests/release_profile.rs
+++ b/litellm-rust/crates/core/tests/release_profile.rs
@@ -23,10 +23,20 @@ fn release_profile_block(manifest: &str) -> String {
         .split_once("[profile.release]")
         .map(|(_, rest)| rest)
         .expect("workspace Cargo.toml should declare [profile.release]");
-    match after_header.find("\n[") {
-        Some(next_section) => after_header[..next_section].to_string(),
-        None => after_header.to_string(),
-    }
+    let raw_block = match after_header.find("\n[") {
+        Some(next_section) => &after_header[..next_section],
+        None => after_header,
+    };
+
+    // Strip TOML comments (whole-line and trailing) so a commented-out
+    // breadcrumb like `# lto = true` can't satisfy the assertions below
+    // while the real setting has been weakened.
+    raw_block
+        .lines()
+        .map(|line| line.split('#').next().unwrap_or("").trim())
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 #[test]

--- a/litellm-rust/crates/core/tests/release_profile.rs
+++ b/litellm-rust/crates/core/tests/release_profile.rs
@@ -1,0 +1,52 @@
+//! Enforcement: the workspace release profile keeps LTO, single-codegen-unit,
+//! and symbol stripping enabled.
+//!
+//! These settings shrink and speed up the `litellm-ai-gateway` and
+//! `litellm-python-bridge` release artifacts (see #31352). This test fails if
+//! `[profile.release]` in the workspace `Cargo.toml` is removed or weakened,
+//! so a regression can't land silently.
+//!
+//! Std-only (no toml crate): same hand-rolled scan style as
+//! `workspace_crate_allowlist.rs`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn workspace_root() -> PathBuf {
+    Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/../.."))
+        .canonicalize()
+        .expect("workspace root should resolve")
+}
+
+fn release_profile_block(manifest: &str) -> String {
+    let after_header = manifest
+        .split_once("[profile.release]")
+        .map(|(_, rest)| rest)
+        .expect("workspace Cargo.toml should declare [profile.release]");
+    match after_header.find("\n[") {
+        Some(next_section) => after_header[..next_section].to_string(),
+        None => after_header.to_string(),
+    }
+}
+
+#[test]
+fn release_profile_enables_lto_codegen_units_and_strip() {
+    let root = workspace_root();
+    let manifest = fs::read_to_string(root.join("Cargo.toml"))
+        .expect("workspace Cargo.toml should be readable");
+
+    let profile = release_profile_block(&manifest);
+
+    assert!(
+        profile.contains("lto = true"),
+        "[profile.release] must keep `lto = true` (see #31352)"
+    );
+    assert!(
+        profile.contains("codegen-units = 1"),
+        "[profile.release] must keep `codegen-units = 1` (see #31352)"
+    );
+    assert!(
+        profile.contains("strip = true"),
+        "[profile.release] must keep `strip = true` (see #31352)"
+    );
+}


### PR DESCRIPTION
## Relevant issues

Closes #31352

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a Cargo release profile change, so the relevant proof is a clean release build before and after, not a proxy call. Measured on the same machine, same command, only the workspace Cargo.toml differing

Before (commit 3d63edaa6d, upstream default profile):
```
$ cargo clean
$ time cargo build --locked --release -p litellm-ai-gateway --features server
    Finished `release` profile [optimized] target(s) in 30.36s
real    0m30.413s

$ ls -lh target/release/litellm-ai-gateway
-rwxr-xr-x. 1 dmartel dmartel 8.2M target/release/litellm-ai-gateway
```

After (commit ad6d346ac9, this PR's profile):
```
$ cargo clean
$ time cargo build --locked --release -p litellm-ai-gateway --features server
    Finished `release` profile [optimized] target(s) in 24.72s
real    0m24.778s

$ ls -lh target/release/litellm-ai-gateway
-rwxr-xr-x. 1 dmartel dmartel 4.2M target/release/litellm-ai-gateway
```

`litellm-python-bridge` also builds cleanly in release with the new profile:
```
$ cargo build --locked --release -p litellm-python-bridge
    Finished `release` profile [optimized] target(s) in 38.92s
$ ls -lh target/release/*.so
-rwxr-xr-x. 1 dmartel dmartel 3.6M target/release/lib_native.so
```

`cargo fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo test --workspace --locked` all pass, including the new regression test

## Type

🚄 Infrastructure
✅ Test

## Changes

Adds a workspace-level `[profile.release]` to `litellm-rust/Cargo.toml`:

```toml
[profile.release]
lto = true
codegen-units = 1
strip = true
```

Since the profile is declared at the workspace level, it applies to every crate (the `litellm-ai-gateway` binary and the `litellm-python-bridge` cdylib) without per-crate duplication, and has no effect on the dev profile used for local iteration. Only affects release builds; CI's fmt/clippy/test job runs in the dev profile and is unaffected

Left out `panic = "abort"`, which is present in the ripgrep profile referenced in #31352 as a model. `litellm-python-bridge` is a PyO3 cdylib loaded inside the Python interpreter; with `panic = "abort"` a Rust panic would kill the whole Python process instead of being caught by PyO3 and surfaced as a Python exception, which conflicts with this workspace's rule that Rust code must avoid panicking on user/provider input and let the host map errors to exceptions

Also adds `litellm-rust/crates/core/tests/release_profile.rs`, a regression test that fails if `[profile.release]` in the workspace manifest is weakened or removed, following the same std-only manifest-scanning approach as the existing `workspace_crate_allowlist.rs` test