### PR TITLE
feat(proxy): expose uvicorn --limit-concurrency

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -801,6 +801,19 @@ class ProxyInitializationHelpers:
     envvar="MAX_REQUESTS_BEFORE_RESTART_JITTER",
 )
 @click.option(
+    "--limit_concurrency",
+    default=None,
+    type=click.IntRange(min=1),
+    help=(
+        "Set uvicorn's concurrency limit. Uvicorn counts both active tasks and "
+        "accepted connections and returns HTTP 503 after the limit is reached. "
+        "Idle connections can consume capacity, so use upstream connection/header "
+        "timeouts and per-client connection limits. Only applies to uvicorn "
+        "(ignored under --run_gunicorn / --run_hypercorn / --run_granian)."
+    ),
+    envvar="LIMIT_CONCURRENCY",
+)
+@click.option(
     "--enforce_prisma_migration_check",
     is_flag=True,
     default=False,
@@ -868,6 +881,7 @@ def run_server(
     timeout_worker_healthcheck,
     max_requests_before_restart,
     max_requests_before_restart_jitter: Optional[int],
+    limit_concurrency: Optional[int],
     enforce_prisma_migration_check: bool,
     use_v2_migration_resolver: bool,
     reload: bool,
@@ -1241,6 +1255,8 @@ def run_server(
         if max_requests_before_restart is not None:
             uvicorn_args["limit_max_requests"] = max_requests_before_restart
         if run_gunicorn is False and run_hypercorn is False and run_granian is False:
+            if limit_concurrency is not None:
+                uvicorn_args["limit_concurrency"] = limit_concurrency
             if max_requests_before_restart_jitter is not None:
                 ProxyInitializationHelpers._apply_uvicorn_max_requests_jitter(
                     uvicorn_args=uvicorn_args,

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -569,6 +569,79 @@ class TestProxyInitializationHelpers:
             ), f"exit_code={result.exit_code}, output={result.output}"
             mock_uvicorn_run.assert_called_once()
 
+    @patch("uvicorn.run")
+    @patch("atexit.register")
+    @patch("litellm.proxy.db.prisma_client.PrismaManager.setup_database")
+    @patch(
+        "litellm.proxy.db.prisma_client.should_update_prisma_schema", return_value=False
+    )
+    def test_limit_concurrency_passed_to_uvicorn(
+        self, mock_should_update, mock_setup_db, mock_atexit_register, mock_uvicorn_run
+    ):
+        """--limit_concurrency must reach uvicorn.run so uvicorn sheds load with 503
+        past the cap; omitted values stay absent and non-positive values are rejected."""
+        from click.testing import CliRunner
+
+        from litellm.proxy.proxy_cli import run_server
+
+        runner = CliRunner()
+        mock_proxy_module = MagicMock(
+            app=MagicMock(),
+            ProxyConfig=MagicMock(),
+            KeyManagementSettings=MagicMock(),
+            save_worker_config=MagicMock(),
+        )
+        clean_env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("DATABASE_URL", "DIRECT_URL")
+        }
+        with (
+            patch.dict(os.environ, clean_env, clear=True),
+            patch.dict(
+                "sys.modules",
+                {
+                    "proxy_server": mock_proxy_module,
+                    "litellm.proxy.proxy_server": mock_proxy_module,
+                },
+            ),
+            patch(
+                "litellm.proxy.proxy_cli.ProxyInitializationHelpers._get_default_unvicorn_init_args"
+            ) as mock_get_args,
+        ):
+            mock_get_args.side_effect = lambda *a, **k: {
+                "app": "litellm.proxy.proxy_server:app",
+                "host": "localhost",
+                "port": 8000,
+            }
+
+            result = runner.invoke(
+                run_server, ["--local", "--limit_concurrency", "250"]
+            )
+            assert (
+                result.exit_code == 0
+            ), f"exit_code={result.exit_code}, output={result.output}"
+            mock_uvicorn_run.assert_called_once()
+            assert mock_uvicorn_run.call_args.kwargs.get("limit_concurrency") == 250
+
+            mock_uvicorn_run.reset_mock()
+            result = runner.invoke(run_server, ["--local"])
+            assert (
+                result.exit_code == 0
+            ), f"exit_code={result.exit_code}, output={result.output}"
+            mock_uvicorn_run.assert_called_once()
+            assert "limit_concurrency" not in mock_uvicorn_run.call_args.kwargs
+
+            for invalid_value in ("0", "-1"):
+                mock_uvicorn_run.reset_mock()
+                result = runner.invoke(
+                    run_server,
+                    ["--local", "--limit_concurrency", invalid_value],
+                )
+                assert result.exit_code == 2
+                assert "Invalid value for '--limit_concurrency'" in result.output
+                mock_uvicorn_run.assert_not_called()
+
     @pytest.mark.parametrize(
         "timeout_config,expected_timeout",
         [


### PR DESCRIPTION
## Relevant issues

Proxy workers can grow memory without bound and OOM when a cache or rate-limit dependency (for example a Redis cluster) starts timing out. Accepted connections and active request tasks accumulate faster than they drain while uvicorn continues accepting work. LiteLLM currently has no CLI option for uvicorn's built-in concurrency limit.

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes the checks relevant to the changed files; any remaining OSV failure is also present on the current OSS daily base
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Reproduced against the official `litellm:v1.90.0` image with a Redis-compatible cluster and Postgres, a mock model (no provider cost), and fixed client concurrency. The cluster is paused mid-run (`docker pause`) so every cache/rate-limit operation times out, matching the production signature. Observed request coroutines are counted from live coroutines named `InFlightRequestsMiddleware.__call__`.

Without a concurrency limit, observed request coroutines and RSS grow without bound and the container is OOMKilled:

```
outage: inflight 442 -> 2,375 -> 6,845 -> 10,600+ (no ceiling)
outage: RSS 1.2GB -> 1.9GB, still rising at zero inbound traffic -> OOMKilled (exit 137)
```

With `--limit_concurrency 200`, uvicorn sheds load with HTTP 503 after its connection/task count reaches the configured limit. In this outage reproduction, observed request coroutines plateau and RSS stays flat through the outage and after load stops:

```
outage:   inflight = 200, 200, 201, 201 ... (capped)
outage:   RSS flat at ~1.14GB
no load:  RSS flat (no growth at zero traffic)
```

Repro steps (a single-node cluster stands in for a serverless cache; pausing it forces the same connection timeouts):

```bash
docker run -d --name cache --network oom valkey/valkey:8-alpine \
  valkey-server --cluster-enabled yes --cluster-announce-ip <ip> --cluster-require-full-coverage no
docker exec cache sh -c 'valkey-cli cluster addslots $(seq 0 16383)'

# proxy built from this branch
docker run -d --name proxy --network oom --memory 2g \
  -e LIMIT_CONCURRENCY=200 -e DATABASE_URL=... -e STORE_MODEL_IN_DB=True \
  -v $PWD/config.yaml:/config.yaml litellm-with-fix \
  --config /config.yaml --num_workers 1

# generate a virtual key, drive steady traffic to the mock model, then:
docker pause cache
docker stats proxy
```

An isolated A/B showed `--request_timeout` alone does not bound the observed growth (request coroutines still climbed past 11k). Uvicorn's concurrency limit is the setting that plateaued the observed coroutine count in this reproduction.

## Operational caveat

Uvicorn's `limit_concurrency` counts both active tasks and accepted TCP connections; it is not a request-only semaphore. Idle or slow clients can consume capacity. Deployments using this opt-in setting should enforce upstream connection/header timeouts and per-client connection limits.

## Type

🆕 New Feature

## Changes

Adds a `--limit_concurrency` CLI flag and `LIMIT_CONCURRENCY` environment variable that map directly to uvicorn's `limit_concurrency`. Values must be positive; zero and negative values are rejected by the CLI. Once uvicorn's connection/task count reaches the configured limit, uvicorn returns HTTP 503 instead of accepting more work.

The option sits next to the existing `--max_requests_before_restart` handling and applies only to the uvicorn path. It is ignored under `--run_gunicorn`, `--run_hypercorn`, and `--run_granian`.

Files changed:

- `litellm/proxy/proxy_cli.py`: adds the option, threads it into `run_server`, and applies it to the uvicorn arguments.
- `tests/test_litellm/proxy/test_proxy_cli.py`: verifies that the configured value reaches `uvicorn.run`, that the argument is absent when omitted, and that zero and negative values are rejected.

### Final Attestation

- [x] The tests cover configured, omitted, and invalid non-positive values, and the operational caveat documents uvicorn's accepted-connection semantics.
