### PR TITLE
fix(mcp): pass user auth to resource listing

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -2692,6 +2692,7 @@ class MCPServerManager:
         extra_headers: Optional[dict[str, str]] = None,
         add_prefix: bool = True,
         raw_headers: Optional[dict[str, str]] = None,
+        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
     ) -> list[Resource]:
         """Fetch available resources from a single MCP server."""
 
@@ -2715,6 +2716,7 @@ class MCPServerManager:
                 extra_headers=extra_headers,
                 stdio_env=stdio_env,
                 subject_token=subject_token,
+                user_api_key_auth=user_api_key_auth,
             )
 
             resources = await client.list_resources()
@@ -2734,6 +2736,7 @@ class MCPServerManager:
         extra_headers: Optional[dict[str, str]] = None,
         add_prefix: bool = True,
         raw_headers: Optional[dict[str, str]] = None,
+        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
     ) -> list[ResourceTemplate]:
         """Fetch available resource templates from a single MCP server."""
 
@@ -2757,6 +2760,7 @@ class MCPServerManager:
                 extra_headers=extra_headers,
                 stdio_env=stdio_env,
                 subject_token=subject_token,
+                user_api_key_auth=user_api_key_auth,
             )
 
             resource_templates = await client.list_resource_templates()

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2104,6 +2104,7 @@ if MCP_AVAILABLE:
                     extra_headers=extra_headers,
                     add_prefix=True,  # Always add server prefix
                     raw_headers=raw_headers,
+                    user_api_key_auth=user_api_key_auth,
                 )
                 all_resources.extend(resources)
 
@@ -2155,6 +2156,7 @@ if MCP_AVAILABLE:
                     extra_headers=extra_headers,
                     add_prefix=True,  # Always add server prefix
                     raw_headers=raw_headers,
+                    user_api_key_auth=user_api_key_auth,
                 )
                 all_resource_templates.extend(resource_templates)
                 verbose_logger.debug(

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -712,9 +712,12 @@ async def test_get_resource_templates_from_mcp_servers_success():
 
 @pytest.mark.asyncio
 async def test_resource_listing_passes_user_auth_to_oauth_resolver():
-    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
-        MCPServerManager,
-    )
+    try:
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            MCPServerManager,
+        )
+    except ImportError:
+        pytest.skip("MCP server not available")
 
     manager = MCPServerManager()
     user_api_key_auth = UserAPIKeyAuth(api_key="test_key", user_id="user")

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -644,6 +644,10 @@ async def test_get_resources_from_mcp_servers_success():
     mock_allowed.assert_awaited_once()
     assert mock_headers.call_count == 2
     assert mock_manager.get_resources_from_server.await_count == 2
+    assert all(
+        call.kwargs["user_api_key_auth"] is user_api_key_auth
+        for call in mock_manager.get_resources_from_server.await_args_list
+    )
     assert {resource.name for resource in resources} == {
         "resource_a",
         "resource_b",
@@ -702,7 +706,36 @@ async def test_get_resource_templates_from_mcp_servers_success():
     mock_allowed.assert_awaited_once()
     mock_headers.assert_called_once()
     mock_manager.get_resource_templates_from_server.assert_awaited_once()
+    assert mock_manager.get_resource_templates_from_server.await_args.kwargs["user_api_key_auth"] is user_api_key_auth
     assert [template.name for template in templates] == ["template"]
+
+
+@pytest.mark.asyncio
+async def test_resource_listing_passes_user_auth_to_oauth_resolver():
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        MCPServerManager,
+    )
+
+    manager = MCPServerManager()
+    user_api_key_auth = UserAPIKeyAuth(api_key="test_key", user_id="user")
+    server = MCPServer(
+        server_id="oauth-server",
+        name="oauth-server",
+        transport=MCPTransport.http,
+        url="https://example.com/mcp",
+        auth_type=MCPAuth.oauth2,
+    )
+    client = MagicMock()
+    client.list_resources = AsyncMock(return_value=[])
+    client.list_resource_templates = AsyncMock(return_value=[])
+
+    with patch.object(manager, "_create_mcp_client", AsyncMock(return_value=client)) as create_client:
+        await manager.get_resources_from_server(server, user_api_key_auth=user_api_key_auth)
+        assert create_client.await_args.kwargs["user_api_key_auth"] is user_api_key_auth
+
+        create_client.reset_mock()
+        await manager.get_resource_templates_from_server(server, user_api_key_auth=user_api_key_auth)
+        assert create_client.await_args.kwargs["user_api_key_auth"] is user_api_key_auth
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -1807,6 +1807,7 @@ class TestMCPServerManager:
             extra_headers=None,
             stdio_env=None,
             subject_token=None,
+            user_api_key_auth=None,
         )
         mock_client.list_resource_templates.assert_awaited_once()
         mock_prefix.assert_called_once_with(mock_templates, server, add_prefix=False)


### PR DESCRIPTION
## Relevant issues

Refs https://github.com/BerriAI/litellm/issues/33072

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks run locally
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Both runs used a live LiteLLM proxy on `127.0.0.1:4000`, a live PostgreSQL database, and an OAuth-protected FastMCP upstream on `127.0.0.1:8765`

The stored credential was reset to an expired access token with a valid refresh token before each run, and the upstream MCP server rejected any bearer token that had not been issued by its real `/token` refresh endpoint

Before, at commit `3d63edaa6d`, the MCP SDK client completed a real session but both protected resource collections disappeared

```bash
git rev-parse --short HEAD
E2E_VIRTUAL_KEY=<redacted> uv run python /tmp/litellm_mcp_resources_client.py
```

```text
3d63edaa6d
{"resource_templates": [], "resources": []}
```

The proxy logged the upstream authorization failures while returning empty collections

```text
Failed to get resources from server oauth_e2e: 401: Unauthorized
Failed to get resource templates from server oauth_e2e: 401: Unauthorized
```

The persisted credential remained unchanged

```text
{'access_token_refreshed': False, 'refresh_token_rotated': False}
```

After, at commit `f57414d16d`, the same MCP SDK client triggered the refresh grant and received both protected collections

```bash
git rev-parse --short HEAD
E2E_VIRTUAL_KEY=<redacted> uv run python /tmp/litellm_mcp_resources_client.py
```

```text
f57414d16d
{"resource_templates": ["oauth_e2e-oauth-item"], "resources": ["oauth_e2e-oauth-status"]}
```

The persisted credential shows the access token refresh, refresh token rotation, and updated expiry

```text
{'access_token_refreshed': True, 'refresh_token_rotated': True, 'expires_at_updated': True}
```

## Type

Bug Fix

## Changes

Resource and resource-template listing now pass the current `UserAPIKeyAuth` into `MCPServerManager`, allowing the v2 `authorization_code` resolver to load and refresh the correct per-user credential before opening the upstream MCP session

Focused regression coverage verifies the auth context is preserved across both listing paths and reaches the OAuth client creation boundary

## Validation

```text
uv run pytest -q tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py tests/mcp_tests/test_per_user_oauth_cache.py\n473 passed, 3 warnings in 175.42s

make pre-commit
All checks passed!
```
