### PR TITLE
fix: redact provider_specific_fields and async streaming responses in message redaction

### DIFF
--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -42,13 +42,19 @@ def redact_message_input_output_from_custom_logger(
     return result
 
 
-def _redact_provider_specific_fields(fields: dict | None, redacted_str: str):
-    """Redact sensitive message-like fields within provider_specific_fields."""
+def _redact_provider_specific_fields(fields: dict | None, redacted_str: str) -> None:
+    """Redact generated reasoning nested in provider_specific_fields.
+
+    Providers mirror model reasoning here under their own names: Anthropic uses
+    thinking_blocks, Bedrock uses reasoningContent / reasoningContentBlocks."""
     if not isinstance(fields, dict):
         return
     for key in ("content", "reasoning", "reasoning_content"):
-        if key in fields and fields[key] is not None:
+        if fields.get(key) is not None:
             fields[key] = redacted_str
+    for key in ("thinking_blocks", "reasoningContent", "reasoningContentBlocks"):
+        if fields.get(key) is not None:
+            fields[key] = None
 
 
 def _redact_choice_content(choice):
@@ -179,9 +185,9 @@ def perform_redaction(model_call_details: dict, result):
     redact_vertex_ai_metadata_from_litellm_params(model_call_details)
 
     # Redact streaming response
-    for _streaming_key in ("complete_streaming_response", "async_complete_streaming_response"):
-        if model_call_details.get("stream", False) is True and _streaming_key in model_call_details:
-            _streaming_response = model_call_details[_streaming_key]
+    if model_call_details.get("stream", False) is True:
+        for _streaming_key in ("complete_streaming_response", "async_complete_streaming_response"):
+            _streaming_response = model_call_details.get(_streaming_key)
             if _streaming_response is None:
                 continue
             if hasattr(_streaming_response, "choices"):

--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -42,6 +42,15 @@ def redact_message_input_output_from_custom_logger(
     return result
 
 
+def _redact_provider_specific_fields(fields: dict | None, redacted_str: str):
+    """Redact sensitive message-like fields within provider_specific_fields."""
+    if not isinstance(fields, dict):
+        return
+    for key in ("content", "reasoning", "reasoning_content"):
+        if key in fields and fields[key] is not None:
+            fields[key] = redacted_str
+
+
 def _redact_choice_content(choice):
     """Helper to redact content in a choice (message or delta)."""
     if isinstance(choice, litellm.Choices):
@@ -50,12 +59,16 @@ def _redact_choice_content(choice):
             choice.message.reasoning_content = "redacted-by-litellm"
         if hasattr(choice.message, "thinking_blocks"):
             choice.message.thinking_blocks = None
+        if hasattr(choice.message, "provider_specific_fields") and choice.message.provider_specific_fields:
+            _redact_provider_specific_fields(choice.message.provider_specific_fields, "redacted-by-litellm")
     elif isinstance(choice, litellm.utils.StreamingChoices):
         choice.delta.content = "redacted-by-litellm"
         if hasattr(choice.delta, "reasoning_content"):
             choice.delta.reasoning_content = "redacted-by-litellm"
         if hasattr(choice.delta, "thinking_blocks"):
             choice.delta.thinking_blocks = None
+        if hasattr(choice.delta, "provider_specific_fields") and choice.delta.provider_specific_fields:
+            _redact_provider_specific_fields(choice.delta.provider_specific_fields, "redacted-by-litellm")
 
 
 def _redact_responses_api_output(output_items):
@@ -138,6 +151,8 @@ def _redact_model_response_dict_choices(choices, redacted_str: str):
                     choice["message"]["thinking_blocks"] = None
                 if "audio" in choice["message"]:
                     choice["message"]["audio"] = None
+                if "provider_specific_fields" in choice["message"]:
+                    _redact_provider_specific_fields(choice["message"]["provider_specific_fields"], redacted_str)
             elif "delta" in choice and isinstance(choice["delta"], dict):
                 choice["delta"]["content"] = redacted_str
                 if "reasoning_content" in choice["delta"]:
@@ -146,6 +161,8 @@ def _redact_model_response_dict_choices(choices, redacted_str: str):
                     choice["delta"]["thinking_blocks"] = None
                 if "audio" in choice["delta"]:
                     choice["delta"]["audio"] = None
+                if "provider_specific_fields" in choice["delta"]:
+                    _redact_provider_specific_fields(choice["delta"]["provider_specific_fields"], redacted_str)
         else:
             _redact_choice_content(choice)
 
@@ -162,17 +179,20 @@ def perform_redaction(model_call_details: dict, result):
     redact_vertex_ai_metadata_from_litellm_params(model_call_details)
 
     # Redact streaming response
-    if model_call_details.get("stream", False) is True and "complete_streaming_response" in model_call_details:
-        _streaming_response = model_call_details["complete_streaming_response"]
-        if hasattr(_streaming_response, "choices"):
-            for choice in _streaming_response.choices:
-                _redact_choice_content(choice)
-            redact_vertex_ai_metadata_from_logged_object(_streaming_response)
-        elif hasattr(_streaming_response, "output"):
-            _redact_responses_api_output(_streaming_response.output)
-            # Redact reasoning field in ResponsesAPIResponse
-            if hasattr(_streaming_response, "reasoning") and _streaming_response.reasoning is not None:
-                _streaming_response.reasoning = None
+    for _streaming_key in ("complete_streaming_response", "async_complete_streaming_response"):
+        if model_call_details.get("stream", False) is True and _streaming_key in model_call_details:
+            _streaming_response = model_call_details[_streaming_key]
+            if _streaming_response is None:
+                continue
+            if hasattr(_streaming_response, "choices"):
+                for choice in _streaming_response.choices:
+                    _redact_choice_content(choice)
+                redact_vertex_ai_metadata_from_logged_object(_streaming_response)
+            elif hasattr(_streaming_response, "output"):
+                _redact_responses_api_output(_streaming_response.output)
+                # Redact reasoning field in ResponsesAPIResponse
+                if hasattr(_streaming_response, "reasoning") and _streaming_response.reasoning is not None:
+                    _streaming_response.reasoning = None
 
     # Redact result
     if result is not None:

--- a/tests/test_litellm/litellm_core_utils/test_redact_messages.py
+++ b/tests/test_litellm/litellm_core_utils/test_redact_messages.py
@@ -525,7 +525,7 @@ class TestPerformRedaction:
         assert redacted_response.choices[0].message.content == "redacted-by-litellm"
 
     def test_redact_provider_specific_fields(self):
-        """Test that reasoning_content in provider_specific_fields is properly redacted."""
+        """The reasoning key inside provider_specific_fields is replaced with the redacted string."""
         result = {
             "choices": [
                 litellm.Choices(
@@ -543,3 +543,34 @@ class TestPerformRedaction:
 
         choice = redacted["choices"][0]
         assert choice.message.provider_specific_fields["reasoning"] == "redacted-by-litellm"
+
+    def test_redact_provider_specific_fields_nested_reasoning_keys(self):
+        """Regression: Anthropic (thinking_blocks) and Bedrock (reasoningContent,
+        reasoningContentBlocks) nest generated reasoning inside provider_specific_fields;
+        leaving them intact leaks reasoning to logging callbacks despite turn_off_message_logging."""
+        result = {
+            "choices": [
+                {
+                    "message": {
+                        "content": "message content",
+                        "role": "assistant",
+                        "provider_specific_fields": {
+                            "thinking_blocks": [
+                                {"type": "thinking", "thinking": "secret chain of thought"}
+                            ],
+                            "reasoningContent": {"reasoningText": {"text": "secret bedrock reasoning"}},
+                            "reasoningContentBlocks": [
+                                {"reasoningText": {"text": "secret bedrock reasoning"}}
+                            ],
+                        },
+                    }
+                }
+            ]
+        }
+
+        redacted = perform_redaction({}, result)
+
+        psf = redacted["choices"][0]["message"]["provider_specific_fields"]
+        assert psf["thinking_blocks"] is None
+        assert psf["reasoningContent"] is None
+        assert psf["reasoningContentBlocks"] is None

--- a/tests/test_litellm/litellm_core_utils/test_redact_messages.py
+++ b/tests/test_litellm/litellm_core_utils/test_redact_messages.py
@@ -269,6 +269,7 @@ class TestPerformRedaction:
                                 "reasoning_content": "message reasoning",
                                 "thinking_blocks": ["thinking"],
                                 "audio": {"data": "audio"},
+                                "provider_specific_fields": {"reasoning": "message reasoning"},
                             }
                         },
                         {
@@ -277,6 +278,7 @@ class TestPerformRedaction:
                                 "reasoning_content": "delta reasoning",
                                 "thinking_blocks": ["delta thinking"],
                                 "audio": {"data": "audio"},
+                                "provider_specific_fields": {"reasoning": "delta reasoning"},
                             }
                         },
                     ]
@@ -292,12 +294,14 @@ class TestPerformRedaction:
         assert message["reasoning_content"] == "redacted-by-litellm"
         assert message["thinking_blocks"] is None
         assert message["audio"] is None
+        assert message["provider_specific_fields"]["reasoning"] == "redacted-by-litellm"
 
         delta = choices[1]["delta"]
         assert delta["content"] == "redacted-by-litellm"
         assert delta["reasoning_content"] == "redacted-by-litellm"
         assert delta["thinking_blocks"] is None
         assert delta["audio"] is None
+        assert delta["provider_specific_fields"]["reasoning"] == "redacted-by-litellm"
 
     def test_redacts_object_choices_inside_model_response_dict(self):
         result = {
@@ -317,6 +321,37 @@ class TestPerformRedaction:
         choice = redacted["choices"][0]
         assert choice.message.content == "redacted-by-litellm"
         assert choice.message.reasoning_content == "redacted-by-litellm"
+
+    def test_redacts_streaming_choices_provider_specific_fields(self):
+        result = {
+            "choices": [
+                litellm.utils.StreamingChoices(
+                    delta=litellm.utils.Delta(
+                        content="delta content",
+                        provider_specific_fields={"reasoning": "delta reasoning"},
+                    )
+                )
+            ]
+        }
+
+        redacted = perform_redaction({}, result)
+
+        delta = redacted["choices"][0].delta
+        assert delta.content == "redacted-by-litellm"
+        assert delta.provider_specific_fields["reasoning"] == "redacted-by-litellm"
+
+    def test_redacts_streaming_responses_api_output_and_skips_none(self):
+        response = mock_responses_api_response("sensitive output")
+        model_call_details = {
+            "stream": True,
+            "complete_streaming_response": None,
+            "async_complete_streaming_response": response,
+        }
+
+        perform_redaction(model_call_details, result=None)
+
+        redacted = model_call_details["async_complete_streaming_response"]
+        assert redacted.output[0].content[0].text == "redacted-by-litellm"
 
     def test_redacts_response_output_objects_with_top_level_text(self):
         output_items = [
@@ -442,3 +477,69 @@ class TestPerformRedaction:
         assert "vertex_ai_url_context_metadata" not in hidden_params
         assert "vertex_ai_safety_ratings" not in hidden_params
         assert "vertex_ai_citation_metadata" not in hidden_params
+
+    def test_redact_async_complete_streaming_response(self):
+        """Test that async_complete_streaming_response is properly redacted."""
+        response_obj = litellm.ModelResponse(
+            choices=[
+                litellm.Choices(
+                    message=litellm.Message(content="secret content", role="assistant")
+                )
+            ]
+        )
+
+        model_call_details = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "prompt": "hi",
+            "input": "hi",
+            "stream": True,
+            "async_complete_streaming_response": response_obj,
+        }
+
+        perform_redaction(model_call_details, result=None)
+
+        redacted_response = model_call_details["async_complete_streaming_response"]
+        assert redacted_response.choices[0].message.content == "redacted-by-litellm"
+
+    def test_redact_complete_streaming_response(self):
+        """Test that complete_streaming_response is properly redacted."""
+        response_obj = litellm.ModelResponse(
+            choices=[
+                litellm.Choices(
+                    message=litellm.Message(content="secret content", role="assistant")
+                )
+            ]
+        )
+
+        model_call_details = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "prompt": "hi",
+            "input": "hi",
+            "stream": True,
+            "complete_streaming_response": response_obj,
+        }
+
+        perform_redaction(model_call_details, result=None)
+
+        redacted_response = model_call_details["complete_streaming_response"]
+        assert redacted_response.choices[0].message.content == "redacted-by-litellm"
+
+    def test_redact_provider_specific_fields(self):
+        """Test that reasoning_content in provider_specific_fields is properly redacted."""
+        result = {
+            "choices": [
+                litellm.Choices(
+                    message=litellm.Message(
+                        content="message content",
+                        role="assistant",
+                        reasoning_content="message reasoning",
+                        provider_specific_fields={"reasoning": "message reasoning"}
+                    )
+                )
+            ]
+        }
+
+        redacted = perform_redaction({}, result)
+
+        choice = redacted["choices"][0]
+        assert choice.message.provider_specific_fields["reasoning"] == "redacted-by-litellm"


### PR DESCRIPTION
## Relevant issues

N/A

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

When message redaction is enabled, `perform_redaction` scrubbed `content`, `reasoning_content`, and `thinking_blocks` at the top level but left `provider_specific_fields` untouched, so providers that mirror the model's reasoning into `provider_specific_fields` still leaked the raw text into logging callbacks such as Langfuse and S3. Anthropic nests it under `thinking_blocks`, and Bedrock under `reasoningContent` / `reasoningContentBlocks`, so a flat allowlist of `content` / `reasoning` / `reasoning_content` was not enough. It also only redacted `complete_streaming_response` and skipped `async_complete_streaming_response`, so async streaming calls leaked as well

To verify against a live proxy, enable redaction (`litellm_settings: turn_off_message_logging: true`) and send a streaming request to a reasoning-capable Anthropic or Bedrock model, then inspect the payload in your logging callback: the nested `provider_specific_fields` reasoning (`thinking_blocks`, `reasoningContent`, `reasoningContentBlocks`) and the async streaming message content now show `redacted-by-litellm` (or `null` for the block-shaped fields) instead of the original text

## Type

🐛 Bug Fix

## Changes

`perform_redaction` now redacts `provider_specific_fields` in both the object path (`_redact_choice_content` for `Choices` and `StreamingChoices`) and the dict path (`_redact_model_response_dict_choices`) through a small `_redact_provider_specific_fields` helper. The helper scrubs the text keys `content`, `reasoning`, and `reasoning_content`, and also nulls the block-shaped reasoning that Anthropic and Bedrock mirror into `provider_specific_fields`: `thinking_blocks` (Anthropic) and `reasoningContent` / `reasoningContentBlocks` (Bedrock), which would otherwise still leak. The streaming-redaction block now iterates over both `complete_streaming_response` and `async_complete_streaming_response` with a `None` guard, closing the async streaming gap

Added regression tests in `tests/test_litellm/litellm_core_utils/test_redact_messages.py` covering async and sync `complete_streaming_response` redaction, `provider_specific_fields` redaction, and the nested Anthropic/Bedrock reasoning keys
