### PR TITLE
feat(pricing): add MiniMax M2.7 cost map entry

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -25696,6 +25696,20 @@
         "max_input_tokens": 1000000,
         "max_output_tokens": 8192
     },
+    "minimax/MiniMax-M2.7": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
+        "cache_read_input_token_cost": 6e-08,
+        "litellm_provider": "minimax",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "max_input_tokens": 204800,
+        "max_output_tokens": 196608
+    },
     "minimax/MiniMax-M2": {
         "input_cost_per_token": 3e-07,
         "output_cost_per_token": 1.2e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -25854,6 +25854,20 @@
         "max_input_tokens": 1000000,
         "max_output_tokens": 8192
     },
+    "minimax/MiniMax-M2.7": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
+        "cache_read_input_token_cost": 6e-08,
+        "litellm_provider": "minimax",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "max_input_tokens": 204800,
+        "max_output_tokens": 196608
+    },
     "minimax/MiniMax-M2": {
         "input_cost_per_token": 3e-07,
         "output_cost_per_token": 1.2e-06,

--- a/tests/test_litellm/litellm_core_utils/test_get_model_cost_map.py
+++ b/tests/test_litellm/litellm_core_utils/test_get_model_cost_map.py
@@ -4,8 +4,10 @@ count actual model entries, not reserved meta keys) and the extraction of the
 ``fallback_generalizations`` block out of the raw map.
 """
 
+import json
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -22,6 +24,35 @@ from litellm.litellm_core_utils.get_model_cost_map import (
     _count_model_entries,
     _finalize_model_cost_map,
 )
+
+
+def test_minimax_m27_native_model_cost_map_entry():
+    repo_root = Path(__file__).parents[3]
+    root_map = json.loads(
+        (repo_root / "model_prices_and_context_window.json").read_text()
+    )
+    backup_map = GetModelCostMap.load_local_model_cost_map()
+
+    expected = {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
+        "cache_read_input_token_cost": 6e-08,
+        "litellm_provider": "minimax",
+        "mode": "chat",
+        "supports_function_calling": True,
+        "supports_tool_choice": True,
+        "supports_prompt_caching": True,
+        "supports_reasoning": True,
+        "supports_system_messages": True,
+        "max_input_tokens": 204800,
+        "max_output_tokens": 196608,
+    }
+
+    for model_map in [root_map, backup_map]:
+        entry = model_map["minimax/MiniMax-M2.7"]
+        for key, value in expected.items():
+            assert entry[key] == value
+        assert "supports_vision" not in entry
 
 
 def _make_models(n: int) -> dict:


### PR DESCRIPTION
## Relevant issues

Closes #33058

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes the relevant local checks for this isolated pricing-map change
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This adds a static model-cost-map entry. The values are sourced from MiniMax official docs:

- Context window: MiniMax Model Invocation docs list `MiniMax-M2.7` with a `204,800` context window.
  https://platform.minimax.io/docs/guides/text-generation
- Pricing: MiniMax Pay-as-you-go docs list `MiniMax-M2.7` at `$0.3 / M` input, `$1.2 / M` output, and `$0.06 / M` prompt-cache read.
  https://platform.minimax.io/docs/guides/pricing-paygo
- Capability shape: MiniMax Messages API docs say M2.7/M2.5/M2.1/M2 support text and tool calls only, and do not accept image/video input.
  https://platform.minimax.io/docs/api-reference/text-chat-anthropic

Local verification:

```bash
python -m pytest tests/test_litellm/litellm_core_utils/test_get_model_cost_map.py -q
# 9 passed

python -m black --check tests/test_litellm/litellm_core_utils/test_get_model_cost_map.py
# 1 file would be left unchanged
```

## Type

? Test

## Changes

- Added native `minimax/MiniMax-M2.7` to `model_prices_and_context_window.json`.
- Added the matching backup entry in `litellm/model_prices_and_context_window_backup.json`.
- Added a regression test covering the native entry in both shipped maps, including pricing, context/output windows, prompt caching, tool support, reasoning support, and the absence of `supports_vision`.