### PR TITLE
feat(websearch_interception): responses API support via the shared agentic mechanism

### DIFF
--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -761,56 +761,6 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
         """
         return AgenticLoopPlan(run_agentic_loop=False)
 
-    async def async_should_run_responses_api_agentic_loop(
-        self,
-        response: Any,
-        model: str,
-        input: Any,
-        tools: Optional[List[Dict]],
-        stream: bool,
-        custom_llm_provider: str,
-        kwargs: Dict,
-        original_stream: Optional[bool] = None,
-    ) -> Tuple[bool, Dict]:
-        """
-        Hook to determine if the Responses-API agentic loop should be executed.
-
-        ``input`` is the OpenAI Responses-API ``input`` (string or list of items),
-        not the chat-style ``messages``.
-
-        ``stream`` is the post-conversion value seen by the underlying call;
-        ``original_stream`` is the pre-conversion value the caller requested
-        (callbacks earlier in the pipeline may have rewritten ``stream`` to
-        ``False`` so they could consume the response). Use ``original_stream``
-        when behavior should depend on what the client asked for, ``stream``
-        when it should depend on what the wire actually carried.
-        """
-        return False, {}
-
-    async def async_run_responses_api_agentic_loop(
-        self,
-        tools: Dict,
-        model: str,
-        input: Any,
-        response: Any,
-        response_api_optional_request_params: Dict,
-        litellm_params: Dict,
-        logging_obj: "LiteLLMLoggingObj",
-        stream: bool,
-        kwargs: Dict,
-        original_stream: Optional[bool] = None,
-    ) -> Any:
-        """
-        Hook to execute the Responses-API agentic loop.
-
-        Implementations should run any local tool execution (e.g. web search)
-        and return a ``ResponsesAPIResponse`` matching the original request shape.
-
-        See ``async_should_run_responses_api_agentic_loop`` for the
-        ``stream`` / ``original_stream`` distinction.
-        """
-        return response
-
     # Useful helpers for custom logger classes
 
     def truncate_standard_logging_payload_content(

--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -761,6 +761,56 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
         """
         return AgenticLoopPlan(run_agentic_loop=False)
 
+    async def async_should_run_responses_api_agentic_loop(
+        self,
+        response: Any,
+        model: str,
+        input: Any,
+        tools: Optional[List[Dict]],
+        stream: bool,
+        custom_llm_provider: str,
+        kwargs: Dict,
+        original_stream: Optional[bool] = None,
+    ) -> Tuple[bool, Dict]:
+        """
+        Hook to determine if the Responses-API agentic loop should be executed.
+
+        ``input`` is the OpenAI Responses-API ``input`` (string or list of items),
+        not the chat-style ``messages``.
+
+        ``stream`` is the post-conversion value seen by the underlying call;
+        ``original_stream`` is the pre-conversion value the caller requested
+        (callbacks earlier in the pipeline may have rewritten ``stream`` to
+        ``False`` so they could consume the response). Use ``original_stream``
+        when behavior should depend on what the client asked for, ``stream``
+        when it should depend on what the wire actually carried.
+        """
+        return False, {}
+
+    async def async_run_responses_api_agentic_loop(
+        self,
+        tools: Dict,
+        model: str,
+        input: Any,
+        response: Any,
+        response_api_optional_request_params: Dict,
+        litellm_params: Dict,
+        logging_obj: "LiteLLMLoggingObj",
+        stream: bool,
+        kwargs: Dict,
+        original_stream: Optional[bool] = None,
+    ) -> Any:
+        """
+        Hook to execute the Responses-API agentic loop.
+
+        Implementations should run any local tool execution (e.g. web search)
+        and return a ``ResponsesAPIResponse`` matching the original request shape.
+
+        See ``async_should_run_responses_api_agentic_loop`` for the
+        ``stream`` / ``original_stream`` distinction.
+        """
+        return response
+
     # Useful helpers for custom logger classes
 
     def truncate_standard_logging_payload_content(

--- a/litellm/integrations/websearch_interception/ARCHITECTURE.md
+++ b/litellm/integrations/websearch_interception/ARCHITECTURE.md
@@ -37,9 +37,29 @@ The interception system automatically detects and handles:
 | **LiteLLM Standard** | `name="litellm_web_search"` | Any | Direct name match | N/A |
 | **Anthropic Native** | `type="web_search_20250305"` | Bedrock, Claude API | Type prefix: `startswith("web_search_")` | ✅ Yes (web_search_2026, etc.) |
 | **Claude Code CLI** | `name="web_search"`, `type="web_search_20250305"` | Claude Code | Name + type check | ✅ Yes (version-agnostic) |
+| **Responses API (server-hosted)** | `type="web_search"` / `type="web_search_preview"` | Bedrock Mantle, OpenAI (Codex CLI) | `is_web_search_tool_responses_api` | ✅ Yes |
 | **Legacy** | `name="WebSearch"` | Custom | Name match | N/A (backwards compat) |
 
 **Future Compatibility**: The `startswith("web_search_")` check in `tools.py` automatically supports future Anthropic web search versions.
+
+### Surfaces
+
+Interception runs on three request surfaces, each gated by the
+`_agentic_loop_api_surface` marker so a single set of shared hooks
+(`async_should_run_agentic_loop` / `async_build_agentic_loop_plan`) can serve
+all of them:
+
+| Surface | Marker | Client API | Response parser |
+|---------|--------|-----------|-----------------|
+| **Anthropic Messages** | (unset) | `/v1/messages` | `content[].tool_use` |
+| **Chat Completions** | `chat_completions` | `/v1/chat/completions` | `choices[].tool_calls` |
+| **Responses** | `responses` | `/v1/responses` | `output[].function_call` |
+
+On the Responses surface the server-hosted `web_search` tool (rejected by
+Bedrock Mantle) is rewritten to a flat `litellm_web_search` function tool in the
+pre-call deployment hook, then the shared mechanism runs the search and re-runs
+the model with `function_call_output` items patched into `input` — see
+`_build_responses_agentic_loop_plan` and `_execute_responses_agentic_plan`.
 
 ### Claude Code CLI Integration
 
@@ -159,8 +179,8 @@ sequenceDiagram
 | **Tool Name Constant** | `constants.py` | `LITELLM_WEB_SEARCH_TOOL_NAME = "litellm_web_search"` |
 | **Tool Conversion** | `anthropic/.../ handler.py` | Converts native tools to LiteLLM standard before API call |
 | **Transformation Logic** | `transformation.py` | Detect tool_use, build tool_result messages, format search responses |
-| **Agentic Loop Hooks** | `integrations/custom_logger.py` | Base hooks: `async_should_run_agentic_loop()`, `async_run_agentic_loop()` |
-| **Hook Orchestration** | `llms/custom_httpx/llm_http_handler.py` | `_call_agentic_completion_hooks()` - calls hooks after response |
+| **Agentic Loop Hooks** | `integrations/custom_logger.py` | Base hooks: `async_should_run_agentic_loop()`, `async_run_agentic_loop()`, `async_build_agentic_loop_plan()` |
+| **Hook Orchestration** | `llms/custom_httpx/llm_http_handler.py` | `_call_agentic_completion_hooks()` - runs hooks after response; `_execute_responses_agentic_plan()` re-runs the Responses call from a plan |
 | **Router Search Tools** | `proxy/proxy_server.py` | `llm_router.search_tools` - configured search providers |
 | **Search Endpoints** | `proxy/search_endpoints/endpoints.py` | Router logic for selecting search provider |
 

--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -7,7 +7,6 @@ server-side using litellm router's search tools.
 """
 
 import asyncio
-import json
 import math
 import uuid
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
@@ -35,6 +34,7 @@ from litellm.types.integrations.websearch_interception import (
 )
 from litellm.types.integrations.custom_logger import (
     CHAT_COMPLETION_AGENTIC_SURFACE,
+    RESPONSES_AGENTIC_SURFACE,
     AgenticLoopPlan,
     AgenticLoopRequestPatch,
 )
@@ -263,7 +263,7 @@ class WebSearchInterceptionLogger(CustomLogger):
             call_type_str = ""
         else:
             call_type_str = getattr(call_type, "value", None) or str(call_type)
-        is_responses_api_call = call_type_str == "aresponses"
+        is_responses_api_call = call_type_str in ("aresponses", "responses")
 
         if is_responses_api_call:
             tool_predicate = is_web_search_tool_responses_api
@@ -483,6 +483,14 @@ class WebSearchInterceptionLogger(CustomLogger):
                 kwargs=kwargs,
             )
 
+        if kwargs.get("_agentic_loop_api_surface") == RESPONSES_AGENTIC_SURFACE:
+            return await self._should_run_responses_agentic_loop(
+                response=response,
+                tools=tools,
+                stream=stream,
+                custom_llm_provider=custom_llm_provider,
+            )
+
         verbose_logger.debug(f"WebSearchInterception: Hook called! provider={custom_llm_provider}, stream={stream}")
         verbose_logger.debug(f"WebSearchInterception: Response type: {type(response)}")
 
@@ -677,6 +685,15 @@ class WebSearchInterceptionLogger(CustomLogger):
                 kwargs=kwargs,
             )
 
+        if kwargs.get("_agentic_loop_api_surface") == RESPONSES_AGENTIC_SURFACE:
+            return await self._build_responses_agentic_loop_plan(
+                tools=tools,
+                model=model,
+                messages=messages,
+                response=response,
+                kwargs=kwargs,
+            )
+
         tool_calls = tools["tool_calls"]
         thinking_blocks = tools.get("thinking_blocks", [])
         request_patch, structured_results = await self._build_anthropic_request_patch(
@@ -831,39 +848,18 @@ class WebSearchInterceptionLogger(CustomLogger):
             metadata={"tool_type": "websearch", "response_format": response_format},
         )
 
-    async def async_should_run_responses_api_agentic_loop(
+    async def _should_run_responses_agentic_loop(
         self,
         response: Any,
-        model: str,
-        input: Any,
-        tools: Optional[List[Dict]],
+        tools: list[dict] | None,
         stream: bool,
         custom_llm_provider: str,
-        kwargs: Dict,
-        original_stream: Optional[bool] = None,
-    ) -> Tuple[bool, Dict]:
+    ) -> tuple[bool, dict]:
         """Detect ``litellm_web_search`` ``function_call`` items in a Responses-API response."""
-        verbose_logger.debug(
-            f"WebSearchInterception: Responses-API hook called! provider={custom_llm_provider}, stream={stream}"
-        )
-
-        if (
-            self.enabled_providers is not None
-            and custom_llm_provider not in self.enabled_providers
-        ):
-            verbose_logger.debug(
-                f"WebSearchInterception: Skipping provider {custom_llm_provider} "
-                f"(not in enabled list: {self.enabled_providers})"
-            )
+        if self.enabled_providers is not None and custom_llm_provider not in self.enabled_providers:
             return False, {}
 
-        has_websearch_tool = any(
-            is_web_search_tool_responses_api(t) for t in (tools or [])
-        )
-        if not has_websearch_tool:
-            verbose_logger.debug(
-                "WebSearchInterception: No web_search tool in Responses-API request"
-            )
+        if not any(is_web_search_tool_responses_api(t) for t in (tools or [])):
             return False, {}
 
         should_intercept, tool_calls = WebSearchTransformation.transform_request(
@@ -871,244 +867,87 @@ class WebSearchInterceptionLogger(CustomLogger):
             stream=stream,
             response_format="responses",
         )
-
         if not should_intercept:
-            verbose_logger.debug(
-                "WebSearchInterception: No litellm_web_search function_call in Responses-API output"
-            )
             return False, {}
 
-        verbose_logger.debug(
-            f"WebSearchInterception: Detected {len(tool_calls)} Responses-API function_call(s), "
-            "executing agentic loop"
-        )
-        return True, {
-            "tool_calls": tool_calls,
-            "tool_type": "websearch",
-            "provider": custom_llm_provider,
-            "response_format": "responses",
-        }
+        return True, {"tool_calls": tool_calls}
 
-    async def async_run_responses_api_agentic_loop(  # noqa: PLR0915
+    async def _build_responses_agentic_loop_plan(
         self,
-        tools: Dict,
+        tools: dict,
         model: str,
-        input: Any,
+        messages: list[dict],
         response: Any,
-        response_api_optional_request_params: Dict,
-        litellm_params: Dict,
-        logging_obj: Any,
-        stream: bool,
-        kwargs: Dict,
-        original_stream: Optional[bool] = None,
-    ) -> Any:
-        """Execute searches and re-run the Responses-API call with ``function_call_output`` items."""
+        kwargs: dict,
+    ) -> AgenticLoopPlan:
+        """Run searches and patch ``function_call_output`` items into the Responses-API ``input``.
+
+        The generic ``_execute_responses_agentic_plan`` re-runs the model with
+        the patched input and handles kwargs forwarding, depth/fingerprint
+        bookkeeping, provider prefixing, and provider-param propagation.
+        """
         tool_calls = tools["tool_calls"]
 
-        # Check depth + fingerprint cycle BEFORE issuing any work. Otherwise a
-        # client that drives the model into emitting ``litellm_web_search``
-        # calls past the cap still gets ``len(tool_calls)`` parallel Tavily
-        # requests per iteration before the loop aborts. Mirrors
-        # ``_check_agentic_loop_safety`` in the chat-completion path, which
-        # also runs before any rerun work.
-        depth = int(kwargs.get("_agentic_loop_depth", 0) or 0)
-        max_loops = max(int(kwargs.get("max_agentic_loops", 3) or 3), 1)
-        fingerprints = list(kwargs.get("_agentic_loop_fingerprints", []) or [])
-        try:
-            fingerprint = json.dumps(tool_calls, sort_keys=True, default=str)
-        except (TypeError, ValueError):
-            fingerprint = str(tool_calls)
-        if fingerprint in fingerprints:
-            raise ValueError(
-                "Responses-API agentic loop detected repeated tool-call "
-                "fingerprint; aborting rerun"
-            )
-        if depth >= max_loops:
-            raise ValueError(
-                f"Responses-API agentic loop exceeded max_agentic_loops={max_loops} for model={model}"
-            )
-
-        verbose_logger.debug(
-            f"WebSearchInterception: Executing Responses-API agentic loop for {len(tool_calls)} search(es)"
-        )
-
-        # Run searches in parallel.
-        search_tasks = []
-        for tool_call in tool_calls:
-            query = (tool_call.get("input") or {}).get("query")
-            if query:
-                search_tasks.append(self._execute_search(query))
-            else:
-                search_tasks.append(self._create_empty_search_result())
+        # Forward kwargs so per-key/per-team search-tool authorization is
+        # enforced (the auth context rides in litellm_metadata on kwargs).
+        search_tasks = [
+            self._execute_search(query, kwargs=kwargs)
+            if (query := (tool_call.get("input") or {}).get("query"))
+            else self._create_empty_search_result()
+            for tool_call in tool_calls
+        ]
         search_results = await asyncio.gather(*search_tasks, return_exceptions=True)
+        result_texts = self._search_results_to_texts(search_results)
 
-        result_texts: List[str] = []
-        for i, result in enumerate(search_results):
-            if isinstance(result, Exception):
-                verbose_logger.error(
-                    f"WebSearchInterception: Search {i} failed: {str(result)}"
-                )
-                result_texts.append(f"Search failed: {str(result)}")
-            elif isinstance(result, tuple) and len(result) == 2:
-                text_value, _ = result
-                result_texts.append(
-                    cast(str, text_value)
-                    if isinstance(text_value, str)
-                    else str(text_value)
-                )
-            else:
-                result_texts.append(str(result))
-
-        # Build follow-up ``input`` chain. Responses-API ``input`` accepts
-        # mixed message + function_call + function_call_output items. Strict
-        # providers (OpenAI-native) validate that every ``function_call_output``
-        # is preceded in the conversation by its assistant ``function_call``,
-        # and reject the follow-up otherwise. Forward the first response's
-        # full ``output`` (which already includes the function_call items
-        # alongside reasoning / text / message blocks) so the assistant turn
-        # stays intact, then append our paired ``function_call_output`` items.
-        if isinstance(input, str):
-            follow_up_input: List[Dict[str, Any]] = [
-                {"role": "user", "content": input},
-            ]
-        elif isinstance(input, list):
-            follow_up_input = list(input)
-        else:
-            follow_up_input = []
-
+        follow_up_input: list[dict[str, Any]] = list(messages)
         first_response_output = (
-            response.get("output", []) or []
-            if isinstance(response, dict)
-            else (getattr(response, "output", None) or [])
+            (response.get("output") or []) if isinstance(response, dict) else (getattr(response, "output", None) or [])
         )
         for item in first_response_output:
-            follow_up_input.append(
-                item if isinstance(item, dict) else self._dump_output_item(item)
-            )
-
+            follow_up_input.append(item if isinstance(item, dict) else self._dump_output_item(item))
         for tool_call, result_text in zip(tool_calls, result_texts):
-            call_id = tool_call.get("call_id") or tool_call.get("id") or ""
             follow_up_input.append(
                 {
                     "type": "function_call_output",
-                    "call_id": call_id,
+                    "call_id": tool_call.get("call_id") or tool_call.get("id") or "",
                     "output": result_text,
                 }
             )
 
-        # Re-run the Responses-API call. ``previous_response_id`` would be a
-        # one-line shortcut, but only works when ``store=True`` and isn't
-        # supported by all backends — rebuilding the input chain works
-        # universally and matches how the chat-completion path handles this.
-        followup_kwargs = self._prepare_followup_kwargs(kwargs)
-        # Strip Responses-API-only flags and the converted-stream marker.
-        followup_kwargs.pop("response_id", None)
-
-        followup_params = dict(response_api_optional_request_params or {})
-        followup_params.pop("stream", None)
-        followup_params["tools"] = followup_kwargs.pop(
-            "tools", followup_params.get("tools")
-        )
-
-        # Reconstruct ``provider/model`` for the follow-up call. ``model`` here
-        # is the bare backend ID (e.g. ``openai.gpt-5.5``) because the
-        # litellm.aresponses dispatcher already stripped the ``bedrock_mantle/``
-        # prefix before reaching the HTTP handler. Without the prefix,
-        # ``get_llm_provider`` raises ``LLM Provider NOT provided``.
-        custom_llm_provider = (
-            (litellm_params or {}).get("custom_llm_provider")
-            or kwargs.get("custom_llm_provider")
-            or ""
-        )
-        full_model_name = model
-        if (
-            custom_llm_provider
-            and "/" not in model
-            and not model.startswith(f"{custom_llm_provider}/")
-        ):
-            full_model_name = f"{custom_llm_provider}/{model}"
-
-        # Forward provider-specific params from the original ``litellm_params``
-        # (e.g. ``aws_region_name``, ``api_base``) so the follow-up call lands
-        # on the same backend region as the initial call. Without this, a
-        # bedrock_mantle request whose model registration sets
-        # ``aws_region_name=us-east-2`` falls back to whatever the global
-        # default points at (``BEDROCK_MANTLE_REGION`` env, otherwise
-        # us-east-1) and 404s on the follow-up.
-        _PROVIDER_PARAM_KEYS = (
-            "aws_region_name",
-            "aws_access_key_id",
-            "aws_secret_access_key",
-            "aws_session_token",
-            "aws_role_name",
-            "aws_session_name",
-            "aws_profile_name",
-            "aws_web_identity_token",
-            "aws_sts_endpoint",
-            "aws_bedrock_runtime_endpoint",
-            "api_base",
-            "api_key",
-            "api_version",
-        )
-        for k in _PROVIDER_PARAM_KEYS:
-            v = (litellm_params or {}).get(k)
-            if v is not None and k not in followup_params:
-                followup_params[k] = v
-
-        # Forward caller-context fields the proxy uses for budget / spend
-        # attribution. Without ``metadata`` / ``litellm_metadata`` / ``user``,
-        # the internal follow-up call is logged against an empty key/team and
-        # bypasses budgets configured on the original API key.
-        # ``litellm_logging_obj`` is intentionally excluded — see
-        # ``_prepare_followup_kwargs`` — so the follow-up creates its own.
-        _ATTRIBUTION_KEYS = (
-            "metadata",
-            "litellm_metadata",
-            "user",
-            "user_api_key",
-            "user_api_key_alias",
-            "user_api_key_user_id",
-            "user_api_key_team_id",
-            "user_api_key_team_alias",
-            "user_api_key_org_id",
-            "proxy_server_request",
-        )
-        for k in _ATTRIBUTION_KEYS:
-            v = (litellm_params or {}).get(k)
-            if v is not None and k not in followup_kwargs:
-                followup_kwargs[k] = v
-
-        # Loop-state propagation. ``max_agentic_loops`` must travel with the
-        # follow-up call so the cap a deployment configured up-front isn't
-        # silently reset to the default on each hop.
-        followup_kwargs["_agentic_loop_depth"] = depth + 1
-        followup_kwargs["_agentic_loop_fingerprints"] = fingerprints + [fingerprint]
-        followup_kwargs["max_agentic_loops"] = max_loops
-
-        verbose_logger.debug(
-            "WebSearchInterception: Responses-API follow-up call "
-            f"[items={len(follow_up_input)} model={full_model_name} "
-            f"depth={depth + 1}/{max_loops}]"
-        )
-
-        return await litellm.aresponses(
-            model=full_model_name,
-            input=follow_up_input,
-            **followup_params,
-            **followup_kwargs,
+        return AgenticLoopPlan(
+            run_agentic_loop=True,
+            request_patch=AgenticLoopRequestPatch(model=model, messages=follow_up_input),
+            metadata={"tool_type": "websearch", "response_format": "responses"},
         )
 
     @staticmethod
-    def _dump_output_item(item: Any) -> Dict[str, Any]:
+    def _search_results_to_texts(search_results: list[Any]) -> list[str]:
+        """Coerce gathered search results (``(text, SearchResponse)`` tuples or errors) to text."""
+        texts: list[str] = []
+        for i, result in enumerate(search_results):
+            if isinstance(result, Exception):
+                verbose_logger.error(f"WebSearchInterception: Search {i} failed: {result}")
+                texts.append(f"Search failed: {result}")
+            elif isinstance(result, tuple) and len(result) == 2:
+                text_value = result[0]
+                texts.append(text_value if isinstance(text_value, str) else str(text_value))
+            else:
+                texts.append(str(result))
+        return texts
+
+    @staticmethod
+    def _dump_output_item(item: Any) -> dict[str, Any]:
         """Best-effort conversion of a Responses-API output item to a dict."""
+        if isinstance(item, dict):
+            return item
         if hasattr(item, "model_dump"):
-            return cast(Dict[str, Any], item.model_dump())
+            return item.model_dump()
         if hasattr(item, "dict"):
             try:
-                return cast(Dict[str, Any], item.dict())
+                return item.dict()
             except Exception:
                 pass
-        return {k: getattr(item, k) for k in dir(item) if not k.startswith("_")}
+        return dict(getattr(item, "__dict__", {}))
 
     @staticmethod
     def _resolve_max_tokens(

--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -7,6 +7,7 @@ server-side using litellm router's search tools.
 """
 
 import asyncio
+import json
 import math
 import uuid
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
@@ -19,9 +20,11 @@ from litellm.integrations.custom_logger import CustomLogger
 from litellm.integrations.websearch_interception.tools import (
     get_litellm_web_search_tool,
     get_litellm_web_search_tool_openai,
+    get_litellm_web_search_tool_responses_api,
     is_anthropic_native_web_search_tool,
     is_web_search_tool,
     is_web_search_tool_chat_completion,
+    is_web_search_tool_responses_api,
 )
 from litellm.integrations.websearch_interception.transformation import (
     WebSearchTransformation,
@@ -251,13 +254,33 @@ class WebSearchInterceptionLogger(CustomLogger):
         if not tools:
             return None
 
-        # Check if any tool is a web search tool (native or already LiteLLM standard)
-        has_websearch = any(is_web_search_tool(t) for t in tools)
+        # Branch on call surface. Chat Completions tools use the OpenAI-nested
+        # ``{"type": "function", "function": {...}}`` shape. Responses-API tools
+        # are flat (``{"type": "function", "name": "..."}``) and the server-hosted
+        # web search variant is ``{"type": "web_search"}`` — neither of which
+        # ``is_web_search_tool`` matches.
+        if call_type is None:
+            call_type_str = ""
+        else:
+            call_type_str = getattr(call_type, "value", None) or str(call_type)
+        is_responses_api_call = call_type_str == "aresponses"
+
+        if is_responses_api_call:
+            tool_predicate = is_web_search_tool_responses_api
+            standard_tool_factory = get_litellm_web_search_tool_responses_api
+        else:
+            tool_predicate = is_web_search_tool
+            standard_tool_factory = get_litellm_web_search_tool_openai
+
+        has_websearch = any(tool_predicate(t) for t in tools)
 
         if not has_websearch:
             return None
 
-        verbose_logger.debug("WebSearchInterception: Converting native web_search tools to LiteLLM standard")
+        verbose_logger.debug(
+            "WebSearchInterception: Converting native web_search tools to LiteLLM standard "
+            f"(call_type={call_type_str or 'unknown'})"
+        )
 
         # If the client sent an Anthropic-native web_search_* tool, mark the
         # request so the agentic loop emits native web_search_tool_result
@@ -270,9 +293,8 @@ class WebSearchInterceptionLogger(CustomLogger):
         # Convert native/custom web_search tools to LiteLLM standard
         converted_tools = []
         for tool in tools:
-            if is_web_search_tool(tool):
-                # Convert to LiteLLM standard web search tool
-                converted_tool = get_litellm_web_search_tool_openai()
+            if tool_predicate(tool):
+                converted_tool = standard_tool_factory()
                 converted_tools.append(converted_tool)
                 verbose_logger.debug(
                     f"WebSearchInterception: Converted {tool.get('name', 'unknown')} "
@@ -808,6 +830,285 @@ class WebSearchInterceptionLogger(CustomLogger):
             request_patch=request_patch,
             metadata={"tool_type": "websearch", "response_format": response_format},
         )
+
+    async def async_should_run_responses_api_agentic_loop(
+        self,
+        response: Any,
+        model: str,
+        input: Any,
+        tools: Optional[List[Dict]],
+        stream: bool,
+        custom_llm_provider: str,
+        kwargs: Dict,
+        original_stream: Optional[bool] = None,
+    ) -> Tuple[bool, Dict]:
+        """Detect ``litellm_web_search`` ``function_call`` items in a Responses-API response."""
+        verbose_logger.debug(
+            f"WebSearchInterception: Responses-API hook called! provider={custom_llm_provider}, stream={stream}"
+        )
+
+        if (
+            self.enabled_providers is not None
+            and custom_llm_provider not in self.enabled_providers
+        ):
+            verbose_logger.debug(
+                f"WebSearchInterception: Skipping provider {custom_llm_provider} "
+                f"(not in enabled list: {self.enabled_providers})"
+            )
+            return False, {}
+
+        has_websearch_tool = any(
+            is_web_search_tool_responses_api(t) for t in (tools or [])
+        )
+        if not has_websearch_tool:
+            verbose_logger.debug(
+                "WebSearchInterception: No web_search tool in Responses-API request"
+            )
+            return False, {}
+
+        should_intercept, tool_calls = WebSearchTransformation.transform_request(
+            response=response,
+            stream=stream,
+            response_format="responses",
+        )
+
+        if not should_intercept:
+            verbose_logger.debug(
+                "WebSearchInterception: No litellm_web_search function_call in Responses-API output"
+            )
+            return False, {}
+
+        verbose_logger.debug(
+            f"WebSearchInterception: Detected {len(tool_calls)} Responses-API function_call(s), "
+            "executing agentic loop"
+        )
+        return True, {
+            "tool_calls": tool_calls,
+            "tool_type": "websearch",
+            "provider": custom_llm_provider,
+            "response_format": "responses",
+        }
+
+    async def async_run_responses_api_agentic_loop(  # noqa: PLR0915
+        self,
+        tools: Dict,
+        model: str,
+        input: Any,
+        response: Any,
+        response_api_optional_request_params: Dict,
+        litellm_params: Dict,
+        logging_obj: Any,
+        stream: bool,
+        kwargs: Dict,
+        original_stream: Optional[bool] = None,
+    ) -> Any:
+        """Execute searches and re-run the Responses-API call with ``function_call_output`` items."""
+        tool_calls = tools["tool_calls"]
+
+        # Check depth + fingerprint cycle BEFORE issuing any work. Otherwise a
+        # client that drives the model into emitting ``litellm_web_search``
+        # calls past the cap still gets ``len(tool_calls)`` parallel Tavily
+        # requests per iteration before the loop aborts. Mirrors
+        # ``_check_agentic_loop_safety`` in the chat-completion path, which
+        # also runs before any rerun work.
+        depth = int(kwargs.get("_agentic_loop_depth", 0) or 0)
+        max_loops = max(int(kwargs.get("max_agentic_loops", 3) or 3), 1)
+        fingerprints = list(kwargs.get("_agentic_loop_fingerprints", []) or [])
+        try:
+            fingerprint = json.dumps(tool_calls, sort_keys=True, default=str)
+        except (TypeError, ValueError):
+            fingerprint = str(tool_calls)
+        if fingerprint in fingerprints:
+            raise ValueError(
+                "Responses-API agentic loop detected repeated tool-call "
+                "fingerprint; aborting rerun"
+            )
+        if depth >= max_loops:
+            raise ValueError(
+                f"Responses-API agentic loop exceeded max_agentic_loops={max_loops} for model={model}"
+            )
+
+        verbose_logger.debug(
+            f"WebSearchInterception: Executing Responses-API agentic loop for {len(tool_calls)} search(es)"
+        )
+
+        # Run searches in parallel.
+        search_tasks = []
+        for tool_call in tool_calls:
+            query = (tool_call.get("input") or {}).get("query")
+            if query:
+                search_tasks.append(self._execute_search(query))
+            else:
+                search_tasks.append(self._create_empty_search_result())
+        search_results = await asyncio.gather(*search_tasks, return_exceptions=True)
+
+        result_texts: List[str] = []
+        for i, result in enumerate(search_results):
+            if isinstance(result, Exception):
+                verbose_logger.error(
+                    f"WebSearchInterception: Search {i} failed: {str(result)}"
+                )
+                result_texts.append(f"Search failed: {str(result)}")
+            elif isinstance(result, tuple) and len(result) == 2:
+                text_value, _ = result
+                result_texts.append(
+                    cast(str, text_value)
+                    if isinstance(text_value, str)
+                    else str(text_value)
+                )
+            else:
+                result_texts.append(str(result))
+
+        # Build follow-up ``input`` chain. Responses-API ``input`` accepts
+        # mixed message + function_call + function_call_output items. Strict
+        # providers (OpenAI-native) validate that every ``function_call_output``
+        # is preceded in the conversation by its assistant ``function_call``,
+        # and reject the follow-up otherwise. Forward the first response's
+        # full ``output`` (which already includes the function_call items
+        # alongside reasoning / text / message blocks) so the assistant turn
+        # stays intact, then append our paired ``function_call_output`` items.
+        if isinstance(input, str):
+            follow_up_input: List[Dict[str, Any]] = [
+                {"role": "user", "content": input},
+            ]
+        elif isinstance(input, list):
+            follow_up_input = list(input)
+        else:
+            follow_up_input = []
+
+        first_response_output = (
+            response.get("output", []) or []
+            if isinstance(response, dict)
+            else (getattr(response, "output", None) or [])
+        )
+        for item in first_response_output:
+            follow_up_input.append(
+                item if isinstance(item, dict) else self._dump_output_item(item)
+            )
+
+        for tool_call, result_text in zip(tool_calls, result_texts):
+            call_id = tool_call.get("call_id") or tool_call.get("id") or ""
+            follow_up_input.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": result_text,
+                }
+            )
+
+        # Re-run the Responses-API call. ``previous_response_id`` would be a
+        # one-line shortcut, but only works when ``store=True`` and isn't
+        # supported by all backends — rebuilding the input chain works
+        # universally and matches how the chat-completion path handles this.
+        followup_kwargs = self._prepare_followup_kwargs(kwargs)
+        # Strip Responses-API-only flags and the converted-stream marker.
+        followup_kwargs.pop("response_id", None)
+
+        followup_params = dict(response_api_optional_request_params or {})
+        followup_params.pop("stream", None)
+        followup_params["tools"] = followup_kwargs.pop(
+            "tools", followup_params.get("tools")
+        )
+
+        # Reconstruct ``provider/model`` for the follow-up call. ``model`` here
+        # is the bare backend ID (e.g. ``openai.gpt-5.5``) because the
+        # litellm.aresponses dispatcher already stripped the ``bedrock_mantle/``
+        # prefix before reaching the HTTP handler. Without the prefix,
+        # ``get_llm_provider`` raises ``LLM Provider NOT provided``.
+        custom_llm_provider = (
+            (litellm_params or {}).get("custom_llm_provider")
+            or kwargs.get("custom_llm_provider")
+            or ""
+        )
+        full_model_name = model
+        if (
+            custom_llm_provider
+            and "/" not in model
+            and not model.startswith(f"{custom_llm_provider}/")
+        ):
+            full_model_name = f"{custom_llm_provider}/{model}"
+
+        # Forward provider-specific params from the original ``litellm_params``
+        # (e.g. ``aws_region_name``, ``api_base``) so the follow-up call lands
+        # on the same backend region as the initial call. Without this, a
+        # bedrock_mantle request whose model registration sets
+        # ``aws_region_name=us-east-2`` falls back to whatever the global
+        # default points at (``BEDROCK_MANTLE_REGION`` env, otherwise
+        # us-east-1) and 404s on the follow-up.
+        _PROVIDER_PARAM_KEYS = (
+            "aws_region_name",
+            "aws_access_key_id",
+            "aws_secret_access_key",
+            "aws_session_token",
+            "aws_role_name",
+            "aws_session_name",
+            "aws_profile_name",
+            "aws_web_identity_token",
+            "aws_sts_endpoint",
+            "aws_bedrock_runtime_endpoint",
+            "api_base",
+            "api_key",
+            "api_version",
+        )
+        for k in _PROVIDER_PARAM_KEYS:
+            v = (litellm_params or {}).get(k)
+            if v is not None and k not in followup_params:
+                followup_params[k] = v
+
+        # Forward caller-context fields the proxy uses for budget / spend
+        # attribution. Without ``metadata`` / ``litellm_metadata`` / ``user``,
+        # the internal follow-up call is logged against an empty key/team and
+        # bypasses budgets configured on the original API key.
+        # ``litellm_logging_obj`` is intentionally excluded — see
+        # ``_prepare_followup_kwargs`` — so the follow-up creates its own.
+        _ATTRIBUTION_KEYS = (
+            "metadata",
+            "litellm_metadata",
+            "user",
+            "user_api_key",
+            "user_api_key_alias",
+            "user_api_key_user_id",
+            "user_api_key_team_id",
+            "user_api_key_team_alias",
+            "user_api_key_org_id",
+            "proxy_server_request",
+        )
+        for k in _ATTRIBUTION_KEYS:
+            v = (litellm_params or {}).get(k)
+            if v is not None and k not in followup_kwargs:
+                followup_kwargs[k] = v
+
+        # Loop-state propagation. ``max_agentic_loops`` must travel with the
+        # follow-up call so the cap a deployment configured up-front isn't
+        # silently reset to the default on each hop.
+        followup_kwargs["_agentic_loop_depth"] = depth + 1
+        followup_kwargs["_agentic_loop_fingerprints"] = fingerprints + [fingerprint]
+        followup_kwargs["max_agentic_loops"] = max_loops
+
+        verbose_logger.debug(
+            "WebSearchInterception: Responses-API follow-up call "
+            f"[items={len(follow_up_input)} model={full_model_name} "
+            f"depth={depth + 1}/{max_loops}]"
+        )
+
+        return await litellm.aresponses(
+            model=full_model_name,
+            input=follow_up_input,
+            **followup_params,
+            **followup_kwargs,
+        )
+
+    @staticmethod
+    def _dump_output_item(item: Any) -> Dict[str, Any]:
+        """Best-effort conversion of a Responses-API output item to a dict."""
+        if hasattr(item, "model_dump"):
+            return cast(Dict[str, Any], item.model_dump())
+        if hasattr(item, "dict"):
+            try:
+                return cast(Dict[str, Any], item.dict())
+            except Exception:
+                pass
+        return {k: getattr(item, k) for k in dir(item) if not k.startswith("_")}
 
     @staticmethod
     def _resolve_max_tokens(

--- a/litellm/integrations/websearch_interception/tools.py
+++ b/litellm/integrations/websearch_interception/tools.py
@@ -82,6 +82,60 @@ def get_litellm_web_search_tool_openai() -> Dict[str, Any]:
     }
 
 
+def get_litellm_web_search_tool_responses_api() -> Dict[str, Any]:
+    """
+    Get the standard LiteLLM web search tool definition in OpenAI Responses API format.
+
+    Responses-API function tools are flat (no nested ``function`` key):
+    ``{"type": "function", "name": "...", "description": "...", "parameters": {...}}``.
+
+    Used by ``WebSearchInterceptionLogger.async_pre_call_deployment_hook`` for
+    ``call_type == "aresponses"`` to convert server-hosted ``web_search`` tools
+    (which providers like Bedrock Mantle reject) into a function-typed tool we
+    can intercept and execute server-side.
+    """
+    return {
+        "type": "function",
+        "name": LITELLM_WEB_SEARCH_TOOL_NAME,
+        "description": (
+            "Search the web for information. Use this when you need current "
+            "information or answers to questions that require up-to-date data."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "The search query to execute",
+                }
+            },
+            "required": ["query"],
+        },
+    }
+
+
+def is_web_search_tool_responses_api(tool: Dict[str, Any]) -> bool:
+    """
+    Check if a tool is a web search tool in OpenAI Responses API shape.
+
+    Detects:
+    - Server-hosted web search:  ``{"type": "web_search"}`` /
+      ``{"type": "web_search_preview"}`` (sent by Codex CLI and the OpenAI SDK
+      when ``web_search`` is enabled).
+    - LiteLLM standard, flat:    ``{"type": "function", "name": "litellm_web_search"}``
+    - Anthropic-native variants: ``{"type": "web_search_*"}`` (forwarded
+      verbatim by some clients).
+    """
+    tool_type = tool.get("type", "")
+    if not isinstance(tool_type, str):
+        return False
+    if tool_type == "web_search" or tool_type.startswith("web_search_"):
+        return True
+    if tool_type == "function" and tool.get("name") == LITELLM_WEB_SEARCH_TOOL_NAME:
+        return True
+    return False
+
+
 def is_web_search_tool_chat_completion(tool: Dict[str, Any]) -> bool:
     """
     Check if a tool is a web search tool for Chat Completions API (strict check).

--- a/litellm/integrations/websearch_interception/tools.py
+++ b/litellm/integrations/websearch_interception/tools.py
@@ -82,7 +82,7 @@ def get_litellm_web_search_tool_openai() -> Dict[str, Any]:
     }
 
 
-def get_litellm_web_search_tool_responses_api() -> Dict[str, Any]:
+def get_litellm_web_search_tool_responses_api() -> dict[str, Any]:
     """
     Get the standard LiteLLM web search tool definition in OpenAI Responses API format.
 
@@ -90,31 +90,14 @@ def get_litellm_web_search_tool_responses_api() -> Dict[str, Any]:
     ``{"type": "function", "name": "...", "description": "...", "parameters": {...}}``.
 
     Used by ``WebSearchInterceptionLogger.async_pre_call_deployment_hook`` for
-    ``call_type == "aresponses"`` to convert server-hosted ``web_search`` tools
+    Responses-API call types to convert server-hosted ``web_search`` tools
     (which providers like Bedrock Mantle reject) into a function-typed tool we
     can intercept and execute server-side.
     """
-    return {
-        "type": "function",
-        "name": LITELLM_WEB_SEARCH_TOOL_NAME,
-        "description": (
-            "Search the web for information. Use this when you need current "
-            "information or answers to questions that require up-to-date data."
-        ),
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "query": {
-                    "type": "string",
-                    "description": "The search query to execute",
-                }
-            },
-            "required": ["query"],
-        },
-    }
+    return {"type": "function", **get_litellm_web_search_tool_openai()["function"]}
 
 
-def is_web_search_tool_responses_api(tool: Dict[str, Any]) -> bool:
+def is_web_search_tool_responses_api(tool: dict[str, Any]) -> bool:
     """
     Check if a tool is a web search tool in OpenAI Responses API shape.
 

--- a/litellm/integrations/websearch_interception/transformation.py
+++ b/litellm/integrations/websearch_interception/transformation.py
@@ -66,7 +66,7 @@ class WebSearchTransformation:
     @staticmethod
     def _detect_from_responses_api_response(
         response: Any,
-    ) -> Tuple[bool, List[Dict]]:
+    ) -> tuple[bool, list[dict]]:
         """Parse OpenAI Responses-API response for ``litellm_web_search`` function calls.
 
         The Responses API returns ``output`` as a list of items; tool calls
@@ -82,7 +82,7 @@ class WebSearchTransformation:
         else:
             output = getattr(response, "output", None) or []
 
-        tool_calls: List[Dict] = []
+        tool_calls: list[dict] = []
         for item in output:
             if isinstance(item, dict):
                 item_type = item.get("type")
@@ -105,8 +105,7 @@ class WebSearchTransformation:
                     parsed_arguments = json.loads(arguments)
                 except json.JSONDecodeError:
                     verbose_logger.warning(
-                        "WebSearchInterception: Failed to parse Responses-API "
-                        f"function_call arguments: {arguments}"
+                        f"WebSearchInterception: Failed to parse Responses-API function_call arguments: {arguments}"
                     )
                     parsed_arguments = {}
             elif isinstance(arguments, dict):
@@ -125,8 +124,7 @@ class WebSearchTransformation:
                 }
             )
             verbose_logger.debug(
-                f"WebSearchInterception: Found Responses-API function_call "
-                f"name={item_name} call_id={call_id}"
+                f"WebSearchInterception: Found Responses-API function_call name={item_name} call_id={call_id}"
             )
 
         return len(tool_calls) > 0, tool_calls

--- a/litellm/integrations/websearch_interception/transformation.py
+++ b/litellm/integrations/websearch_interception/transformation.py
@@ -57,10 +57,79 @@ class WebSearchTransformation:
             return False, []
 
         # Parse non-streaming response based on format
+        if response_format == "responses":
+            return WebSearchTransformation._detect_from_responses_api_response(response)
         if response_format == "openai":
             return WebSearchTransformation._detect_from_openai_response(response)
+        return WebSearchTransformation._detect_from_non_streaming_response(response)
+
+    @staticmethod
+    def _detect_from_responses_api_response(
+        response: Any,
+    ) -> Tuple[bool, List[Dict]]:
+        """Parse OpenAI Responses-API response for ``litellm_web_search`` function calls.
+
+        The Responses API returns ``output`` as a list of items; tool calls
+        appear as ``{"type": "function_call", "call_id": "...", "name": "...",
+        "arguments": "<json string>"}``. Pre-request conversion replaces all
+        web-search tools with the LiteLLM standard ``litellm_web_search``
+        function tool, so the only name we need to recognize here is the
+        standard one. ``call_id`` is preserved as ``id`` so the agentic loop
+        can pair it with a ``function_call_output`` item.
+        """
+        if isinstance(response, dict):
+            output = response.get("output", []) or []
         else:
-            return WebSearchTransformation._detect_from_non_streaming_response(response)
+            output = getattr(response, "output", None) or []
+
+        tool_calls: List[Dict] = []
+        for item in output:
+            if isinstance(item, dict):
+                item_type = item.get("type")
+                item_name = item.get("name")
+                call_id = item.get("call_id") or item.get("id")
+                arguments = item.get("arguments")
+            else:
+                item_type = getattr(item, "type", None)
+                item_name = getattr(item, "name", None)
+                call_id = getattr(item, "call_id", None) or getattr(item, "id", None)
+                arguments = getattr(item, "arguments", None)
+
+            if item_type != "function_call":
+                continue
+            if item_name != LITELLM_WEB_SEARCH_TOOL_NAME:
+                continue
+
+            if isinstance(arguments, str):
+                try:
+                    parsed_arguments = json.loads(arguments)
+                except json.JSONDecodeError:
+                    verbose_logger.warning(
+                        "WebSearchInterception: Failed to parse Responses-API "
+                        f"function_call arguments: {arguments}"
+                    )
+                    parsed_arguments = {}
+            elif isinstance(arguments, dict):
+                parsed_arguments = arguments
+            else:
+                parsed_arguments = {}
+
+            tool_calls.append(
+                {
+                    "id": call_id,
+                    "call_id": call_id,
+                    "type": "function_call",
+                    "name": item_name,
+                    "input": parsed_arguments,
+                    "arguments": parsed_arguments,
+                }
+            )
+            verbose_logger.debug(
+                f"WebSearchInterception: Found Responses-API function_call "
+                f"name={item_name} call_id={call_id}"
+            )
+
+        return len(tool_calls) > 0, tool_calls
 
     @staticmethod
     def _detect_from_non_streaming_response(

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2657,9 +2657,11 @@ class BaseLLMHTTPHandler:
         )
 
         result = final_response if final_response is not None else initial_response
-        if litellm_params.get("_code_interpreter_interception_converted_stream") and not litellm_params.get(
-            "_agentic_loop_depth"
-        ):
+
+        converted_stream = litellm_params.get("_code_interpreter_interception_converted_stream") or litellm_params.get(
+            "_websearch_interception_converted_stream"
+        )
+        if converted_stream and not litellm_params.get("_agentic_loop_depth"):
             return self._wrap_responses_response_as_fake_stream(
                 result=result,
                 model=model,
@@ -2667,170 +2669,8 @@ class BaseLLMHTTPHandler:
                 logging_obj=logging_obj,
                 custom_llm_provider=custom_llm_provider,
             )
-        transformed_response = result
-        # Agentic-loop hook dispatch (e.g. websearch interception). Mirrors
-        # ``_call_agentic_chat_completion_hooks`` and ``_call_agentic_completion_hooks``
-        # used by the Chat Completions and Anthropic Messages paths. The hook
-        # has access to the full transformed response and can re-run the
-        # Responses-API call with ``function_call_output`` items spliced into
-        # ``input``.
-        # Stash custom_llm_provider on litellm_params so the hook can
-        # reconstruct the ``provider/model`` string for follow-up calls.
-        # GenericLiteLLMParams declares ``custom_llm_provider`` as an
-        # optional field, so the dict often holds it as None — meaning
-        # ``setdefault`` would skip the assignment. Overwrite explicitly.
-        agentic_litellm_params = dict(litellm_params)
-        if not agentic_litellm_params.get("custom_llm_provider"):
-            agentic_litellm_params["custom_llm_provider"] = custom_llm_provider
 
-        agentic_response: Optional[Any] = None
-        try:
-            agentic_response = await self._call_agentic_responses_api_hooks(
-                response=transformed_response,
-                model=model,
-                input=input,
-                response_api_optional_request_params=response_api_optional_request_params,
-                litellm_params=agentic_litellm_params,
-                logging_obj=logging_obj,
-                stream=stream,
-                custom_llm_provider=custom_llm_provider,
-            )
-        except Exception as e:
-            verbose_logger.exception(
-                f"LiteLLM.AgenticHookError: Exception in Responses-API agentic hooks: {str(e)}"
-            )
-
-        final_response = (
-            agentic_response if agentic_response is not None else transformed_response
-        )
-
-        # If a callback (e.g. websearch interception) silently converted a
-        # client-requested stream=True call to stream=False so it could
-        # consume the response, the proxy SSE layer still expects an async
-        # iterator on the way out. Wrap a completed ``ResponsesAPIResponse``
-        # in ``CachedResponsesAPIStreamingIterator`` (the same wrapper the
-        # cache hit path uses) so ``async for chunk in stream_iterator``
-        # works downstream. Mirrors the chat-completion path that sets
-        # ``model_call_details["websearch_interception_converted_stream"]``
-        # from the same flag for the same reason.
-        converted_stream = bool(
-            agentic_litellm_params.get(
-                "_websearch_interception_converted_stream", False
-            )
-        )
-        if (
-            converted_stream
-            and getattr(logging_obj, "model_call_details", None) is not None
-        ):
-            logging_obj.model_call_details[
-                "websearch_interception_converted_stream"
-            ] = True
-        if converted_stream and not isinstance(
-            final_response, BaseResponsesAPIStreamingIterator
-        ):
-            from litellm.responses.streaming_iterator import (
-                CachedResponsesAPIStreamingIterator,
-            )
-
-            return CachedResponsesAPIStreamingIterator(
-                response=final_response,
-                logging_obj=logging_obj,
-                request_data=request_context,
-                call_type=CallTypes.responses.value,
-            )
-
-        return final_response
-
-    async def _call_agentic_responses_api_hooks(
-        self,
-        response: Any,
-        model: str,
-        input: Union[str, ResponseInputParam],
-        response_api_optional_request_params: Dict,
-        litellm_params: Dict,
-        logging_obj: "LiteLLMLoggingObj",
-        stream: bool,
-        custom_llm_provider: str,
-    ) -> Optional[Any]:
-        """Dispatch ``async_should_run_responses_api_agentic_loop`` /
-        ``async_run_responses_api_agentic_loop`` for any ``CustomLogger`` in
-        ``litellm.callbacks`` that overrides them. Returns the agentic-loop
-        response if any callback ran, else ``None``."""
-        from litellm._logging import verbose_logger
-        from litellm.integrations.custom_logger import CustomLogger
-
-        callbacks = litellm.callbacks + (logging_obj.dynamic_success_callbacks or [])
-        tools = response_api_optional_request_params.get("tools", []) or []
-
-        # Surface the original (pre-conversion) stream value so custom loggers
-        # can distinguish "client requested streaming, we converted internally"
-        # from "client requested non-streaming". By the time this dispatcher
-        # runs, ``stream`` itself reflects the post-conversion value.
-        original_stream = stream or bool(
-            litellm_params.get("_websearch_interception_converted_stream", False)
-        )
-
-        # Plumb agentic-loop safety state into the hook so re-entrant calls
-        # can bound depth + detect cycles. Defaults match
-        # ``_get_agentic_loop_settings`` so the chat-completion and Responses-
-        # API paths share the same semantics.
-        loop_state = {
-            "_agentic_loop_depth": int(
-                litellm_params.get("_agentic_loop_depth", 0) or 0
-            ),
-            "max_agentic_loops": int(litellm_params.get("max_agentic_loops", 3) or 3),
-            "_agentic_loop_fingerprints": list(
-                litellm_params.get("_agentic_loop_fingerprints", []) or []
-            ),
-        }
-
-        for callback in callbacks:
-            if not isinstance(callback, CustomLogger):
-                continue
-
-            try:
-                should_run, hook_tools = (
-                    await callback.async_should_run_responses_api_agentic_loop(
-                        response=response,
-                        model=model,
-                        input=input,
-                        tools=tools,
-                        stream=stream,
-                        original_stream=original_stream,
-                        custom_llm_provider=custom_llm_provider,
-                        kwargs=dict(loop_state),
-                    )
-                )
-            except Exception as e:
-                verbose_logger.exception(
-                    "LiteLLM.AgenticHookError: Exception in "
-                    f"async_should_run_responses_api_agentic_loop: {str(e)}"
-                )
-                continue
-
-            if not should_run:
-                continue
-
-            try:
-                return await callback.async_run_responses_api_agentic_loop(
-                    tools=hook_tools,
-                    model=model,
-                    input=input,
-                    response=response,
-                    response_api_optional_request_params=response_api_optional_request_params,
-                    litellm_params=litellm_params,
-                    logging_obj=logging_obj,
-                    stream=stream,
-                    original_stream=original_stream,
-                    kwargs=dict(loop_state),
-                )
-            except Exception as e:
-                verbose_logger.exception(
-                    "LiteLLM.AgenticHookError: Exception in "
-                    f"async_run_responses_api_agentic_loop: {str(e)}"
-                )
-
-        return None
+        return result
 
     async def async_delete_response_api_handler(
         self,
@@ -5183,9 +5023,19 @@ class BaseLLMHTTPHandler:
         kwargs_for_followup["max_agentic_loops"] = max_loops
         kwargs_for_followup["_agentic_loop_fingerprints"] = fingerprints + [fingerprint]
 
+        # Reconstruct ``provider/model`` for the follow-up. ``model`` may be the
+        # bare backend id (the aresponses dispatcher strips the provider), and
+        # ``get_llm_provider`` raises without a prefix. Guard on the provider
+        # prefix specifically (not any ``/``) so a backend id that naturally
+        # contains a slash still gets qualified.
+        followup_model = patch.model or model
+        provider = kwargs.get("custom_llm_provider")
+        if provider and not followup_model.startswith(f"{provider}/"):
+            followup_model = f"{provider}/{followup_model}"
+
         try:
             response = await litellm.aresponses(
-                model=patch.model or model,
+                model=followup_model,
                 input=patch.messages,
                 **optional_params,
                 **kwargs_for_followup,
@@ -5383,6 +5233,13 @@ class BaseLLMHTTPHandler:
         from litellm._logging import verbose_logger
         from litellm.integrations.custom_logger import CustomLogger
 
+        if not self._has_agentic_completion_hook(logging_obj):
+            return None
+
+        kwargs = {
+            **kwargs,
+            "_agentic_loop_api_surface": kwargs.get("_agentic_loop_api_surface") or api_surface,
+        }
         callbacks = litellm.callbacks + (logging_obj.dynamic_success_callbacks or [])
         tools = anthropic_messages_optional_request_params.get("tools", [])
         depth, max_loops, fingerprints = self._get_agentic_loop_settings(kwargs=kwargs)

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2667,7 +2667,170 @@ class BaseLLMHTTPHandler:
                 logging_obj=logging_obj,
                 custom_llm_provider=custom_llm_provider,
             )
-        return result
+        transformed_response = result
+        # Agentic-loop hook dispatch (e.g. websearch interception). Mirrors
+        # ``_call_agentic_chat_completion_hooks`` and ``_call_agentic_completion_hooks``
+        # used by the Chat Completions and Anthropic Messages paths. The hook
+        # has access to the full transformed response and can re-run the
+        # Responses-API call with ``function_call_output`` items spliced into
+        # ``input``.
+        # Stash custom_llm_provider on litellm_params so the hook can
+        # reconstruct the ``provider/model`` string for follow-up calls.
+        # GenericLiteLLMParams declares ``custom_llm_provider`` as an
+        # optional field, so the dict often holds it as None — meaning
+        # ``setdefault`` would skip the assignment. Overwrite explicitly.
+        agentic_litellm_params = dict(litellm_params)
+        if not agentic_litellm_params.get("custom_llm_provider"):
+            agentic_litellm_params["custom_llm_provider"] = custom_llm_provider
+
+        agentic_response: Optional[Any] = None
+        try:
+            agentic_response = await self._call_agentic_responses_api_hooks(
+                response=transformed_response,
+                model=model,
+                input=input,
+                response_api_optional_request_params=response_api_optional_request_params,
+                litellm_params=agentic_litellm_params,
+                logging_obj=logging_obj,
+                stream=stream,
+                custom_llm_provider=custom_llm_provider,
+            )
+        except Exception as e:
+            verbose_logger.exception(
+                f"LiteLLM.AgenticHookError: Exception in Responses-API agentic hooks: {str(e)}"
+            )
+
+        final_response = (
+            agentic_response if agentic_response is not None else transformed_response
+        )
+
+        # If a callback (e.g. websearch interception) silently converted a
+        # client-requested stream=True call to stream=False so it could
+        # consume the response, the proxy SSE layer still expects an async
+        # iterator on the way out. Wrap a completed ``ResponsesAPIResponse``
+        # in ``CachedResponsesAPIStreamingIterator`` (the same wrapper the
+        # cache hit path uses) so ``async for chunk in stream_iterator``
+        # works downstream. Mirrors the chat-completion path that sets
+        # ``model_call_details["websearch_interception_converted_stream"]``
+        # from the same flag for the same reason.
+        converted_stream = bool(
+            agentic_litellm_params.get(
+                "_websearch_interception_converted_stream", False
+            )
+        )
+        if (
+            converted_stream
+            and getattr(logging_obj, "model_call_details", None) is not None
+        ):
+            logging_obj.model_call_details[
+                "websearch_interception_converted_stream"
+            ] = True
+        if converted_stream and not isinstance(
+            final_response, BaseResponsesAPIStreamingIterator
+        ):
+            from litellm.responses.streaming_iterator import (
+                CachedResponsesAPIStreamingIterator,
+            )
+
+            return CachedResponsesAPIStreamingIterator(
+                response=final_response,
+                logging_obj=logging_obj,
+                request_data=request_context,
+                call_type=CallTypes.responses.value,
+            )
+
+        return final_response
+
+    async def _call_agentic_responses_api_hooks(
+        self,
+        response: Any,
+        model: str,
+        input: Union[str, ResponseInputParam],
+        response_api_optional_request_params: Dict,
+        litellm_params: Dict,
+        logging_obj: "LiteLLMLoggingObj",
+        stream: bool,
+        custom_llm_provider: str,
+    ) -> Optional[Any]:
+        """Dispatch ``async_should_run_responses_api_agentic_loop`` /
+        ``async_run_responses_api_agentic_loop`` for any ``CustomLogger`` in
+        ``litellm.callbacks`` that overrides them. Returns the agentic-loop
+        response if any callback ran, else ``None``."""
+        from litellm._logging import verbose_logger
+        from litellm.integrations.custom_logger import CustomLogger
+
+        callbacks = litellm.callbacks + (logging_obj.dynamic_success_callbacks or [])
+        tools = response_api_optional_request_params.get("tools", []) or []
+
+        # Surface the original (pre-conversion) stream value so custom loggers
+        # can distinguish "client requested streaming, we converted internally"
+        # from "client requested non-streaming". By the time this dispatcher
+        # runs, ``stream`` itself reflects the post-conversion value.
+        original_stream = stream or bool(
+            litellm_params.get("_websearch_interception_converted_stream", False)
+        )
+
+        # Plumb agentic-loop safety state into the hook so re-entrant calls
+        # can bound depth + detect cycles. Defaults match
+        # ``_get_agentic_loop_settings`` so the chat-completion and Responses-
+        # API paths share the same semantics.
+        loop_state = {
+            "_agentic_loop_depth": int(
+                litellm_params.get("_agentic_loop_depth", 0) or 0
+            ),
+            "max_agentic_loops": int(litellm_params.get("max_agentic_loops", 3) or 3),
+            "_agentic_loop_fingerprints": list(
+                litellm_params.get("_agentic_loop_fingerprints", []) or []
+            ),
+        }
+
+        for callback in callbacks:
+            if not isinstance(callback, CustomLogger):
+                continue
+
+            try:
+                should_run, hook_tools = (
+                    await callback.async_should_run_responses_api_agentic_loop(
+                        response=response,
+                        model=model,
+                        input=input,
+                        tools=tools,
+                        stream=stream,
+                        original_stream=original_stream,
+                        custom_llm_provider=custom_llm_provider,
+                        kwargs=dict(loop_state),
+                    )
+                )
+            except Exception as e:
+                verbose_logger.exception(
+                    "LiteLLM.AgenticHookError: Exception in "
+                    f"async_should_run_responses_api_agentic_loop: {str(e)}"
+                )
+                continue
+
+            if not should_run:
+                continue
+
+            try:
+                return await callback.async_run_responses_api_agentic_loop(
+                    tools=hook_tools,
+                    model=model,
+                    input=input,
+                    response=response,
+                    response_api_optional_request_params=response_api_optional_request_params,
+                    litellm_params=litellm_params,
+                    logging_obj=logging_obj,
+                    stream=stream,
+                    original_stream=original_stream,
+                    kwargs=dict(loop_state),
+                )
+            except Exception as e:
+                verbose_logger.exception(
+                    "LiteLLM.AgenticHookError: Exception in "
+                    f"async_run_responses_api_agentic_loop: {str(e)}"
+                )
+
+        return None
 
     async def async_delete_response_api_handler(
         self,

--- a/litellm/types/integrations/custom_logger.py
+++ b/litellm/types/integrations/custom_logger.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 
 CHAT_COMPLETION_AGENTIC_SURFACE = "chat_completions"
+RESPONSES_AGENTIC_SURFACE = "responses"
 CODE_INTERPRETER_INTERCEPTION_PREFIX = "_code_interpreter_interception"
 NON_CODE_INTERPRETER_INTERCEPTION_INTERNAL_PREFIXES = frozenset(
     ("_websearch_interception", "_compression_interception")

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_responses_api.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_responses_api.py
@@ -1,0 +1,445 @@
+"""
+Unit tests for WebSearchInterceptionLogger on the OpenAI Responses API path.
+
+Covers the call_type=="aresponses" branch of async_pre_call_deployment_hook,
+the new Responses-API output parser, the should-run hook, and the agentic
+loop that rebuilds the input chain with function_call_output items.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import litellm
+from litellm.integrations.websearch_interception.handler import (
+    WebSearchInterceptionLogger,
+)
+from litellm.integrations.websearch_interception.tools import (
+    get_litellm_web_search_tool_responses_api,
+    is_web_search_tool_responses_api,
+)
+from litellm.integrations.websearch_interception.transformation import (
+    WebSearchTransformation,
+)
+from litellm.types.utils import LlmProviders
+
+
+@pytest.fixture
+def logger() -> WebSearchInterceptionLogger:
+    return WebSearchInterceptionLogger(
+        enabled_providers=[LlmProviders.BEDROCK_MANTLE, LlmProviders.OPENAI],
+        search_tool_name="tavily-search",
+    )
+
+
+def test_is_web_search_tool_responses_api_detects_codex_shape() -> None:
+    assert is_web_search_tool_responses_api({"type": "web_search"})
+    assert is_web_search_tool_responses_api({"type": "web_search_preview"})
+    assert is_web_search_tool_responses_api({"type": "web_search_20250305"})
+    assert is_web_search_tool_responses_api(
+        {"type": "function", "name": "litellm_web_search"}
+    )
+    assert not is_web_search_tool_responses_api({"type": "function", "name": "foo"})
+    assert not is_web_search_tool_responses_api({"type": "image_generation"})
+    assert not is_web_search_tool_responses_api({})
+
+
+def test_get_litellm_web_search_tool_responses_api_is_flat() -> None:
+    tool = get_litellm_web_search_tool_responses_api()
+    # Flat shape — no nested ``function`` key (which would be Chat-Completions style).
+    assert tool["type"] == "function"
+    assert tool["name"] == "litellm_web_search"
+    assert "parameters" in tool
+    assert "function" not in tool
+
+
+def test_responses_api_response_parser_finds_function_call() -> None:
+    response = {
+        "output": [
+            {"type": "reasoning", "id": "rs_1", "summary": []},
+            {
+                "type": "function_call",
+                "call_id": "call_abc",
+                "name": "litellm_web_search",
+                "arguments": json.dumps({"query": "weather hong kong"}),
+            },
+        ]
+    }
+    should, calls = WebSearchTransformation.transform_request(
+        response=response, stream=False, response_format="responses"
+    )
+    assert should is True
+    assert len(calls) == 1
+    assert calls[0]["call_id"] == "call_abc"
+    assert calls[0]["input"]["query"] == "weather hong kong"
+
+
+def test_responses_api_response_parser_ignores_other_function_calls() -> None:
+    response = {
+        "output": [
+            {
+                "type": "function_call",
+                "call_id": "call_xyz",
+                "name": "calculator",
+                "arguments": json.dumps({"x": 1}),
+            }
+        ]
+    }
+    should, calls = WebSearchTransformation.transform_request(
+        response=response, stream=False, response_format="responses"
+    )
+    assert should is False
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_pre_call_hook_aresponses_uses_flat_shape(
+    logger: WebSearchInterceptionLogger,
+) -> None:
+    kwargs = {
+        "model": "openai.gpt-5.5",
+        "custom_llm_provider": "bedrock_mantle",
+        "tools": [{"type": "web_search"}],
+        "stream": True,
+    }
+    out = await logger.async_pre_call_deployment_hook(kwargs, call_type="aresponses")
+    assert out is not None
+    converted = out["tools"][0]
+    # Flat — no nested ``function`` key.
+    assert converted["type"] == "function"
+    assert converted["name"] == "litellm_web_search"
+    assert "function" not in converted
+    # Streaming converted to non-streaming for interception.
+    assert out["stream"] is False
+    assert out["_websearch_interception_converted_stream"] is True
+
+
+@pytest.mark.asyncio
+async def test_pre_call_hook_aresponses_skips_disabled_provider(
+    logger: WebSearchInterceptionLogger,
+) -> None:
+    # vertex_ai isn't in the logger's enabled list.
+    kwargs = {
+        "model": "publishers/google/models/gemini-1.5-pro",
+        "custom_llm_provider": "vertex_ai",
+        "tools": [{"type": "web_search"}],
+    }
+    out = await logger.async_pre_call_deployment_hook(kwargs, call_type="aresponses")
+    assert out is None
+
+
+@pytest.mark.asyncio
+async def test_should_run_responses_api_hook_returns_tool_calls(
+    logger: WebSearchInterceptionLogger,
+) -> None:
+    response = {
+        "output": [
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "litellm_web_search",
+                "arguments": json.dumps({"query": "btc price"}),
+            }
+        ]
+    }
+    should, hook_tools = await logger.async_should_run_responses_api_agentic_loop(
+        response=response,
+        model="openai.gpt-5.5",
+        input="hi",
+        tools=[{"type": "web_search"}],
+        stream=False,
+        custom_llm_provider="bedrock_mantle",
+        kwargs={},
+    )
+    assert should is True
+    assert hook_tools["response_format"] == "responses"
+    assert len(hook_tools["tool_calls"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_run_responses_api_hook_preserves_assistant_turn_then_appends_outputs(
+    logger: WebSearchInterceptionLogger,
+) -> None:
+    """The follow-up ``input`` must carry the user message, then the entire
+    first-turn assistant ``output`` (reasoning + function_call), then the
+    paired ``function_call_output`` items. Strict providers (OpenAI-native)
+    400 if a ``function_call_output`` is not preceded by its matching
+    ``function_call`` from the same conversation turn — see
+    https://platform.openai.com/docs/api-reference/responses."""
+
+    fake_search = MagicMock()
+    fake_search.results = [
+        MagicMock(title="t", url="https://example.com", snippet="snippet"),
+    ]
+
+    captured = {}
+
+    async def fake_aresponses(**kwargs):
+        captured.update(kwargs)
+        return {"id": "resp_final", "output": [{"type": "message"}]}
+
+    initial_response = {
+        "id": "resp_initial",
+        "output": [
+            {"type": "reasoning", "id": "rs_1", "summary": []},
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "litellm_web_search",
+                "arguments": '{"query": "btc price"}',
+            },
+        ],
+    }
+
+    with (
+        patch.object(litellm, "asearch", new=AsyncMock(return_value=fake_search)),
+        patch.object(litellm, "aresponses", new=AsyncMock(side_effect=fake_aresponses)),
+    ):
+        await logger.async_run_responses_api_agentic_loop(
+            tools={
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "call_id": "call_1",
+                        "type": "function_call",
+                        "name": "litellm_web_search",
+                        "input": {"query": "btc price"},
+                        "arguments": {"query": "btc price"},
+                    }
+                ],
+                "response_format": "responses",
+            },
+            model="openai.gpt-5.5",
+            input="What's the BTC price?",
+            response=initial_response,
+            response_api_optional_request_params={"tools": [{"type": "function"}]},
+            litellm_params={},
+            logging_obj=MagicMock(),
+            stream=False,
+            kwargs={},
+        )
+
+    follow_up_input = captured["input"]
+    assert follow_up_input[0] == {"role": "user", "content": "What's the BTC price?"}
+    assert follow_up_input[1]["type"] == "reasoning"
+    assert follow_up_input[2]["type"] == "function_call"
+    assert follow_up_input[2]["call_id"] == "call_1"
+    assert follow_up_input[2]["name"] == "litellm_web_search"
+    assert follow_up_input[3]["type"] == "function_call_output"
+    assert follow_up_input[3]["call_id"] == "call_1"
+    assert "snippet" in follow_up_input[3]["output"]
+
+
+@pytest.mark.asyncio
+async def test_run_responses_api_hook_aborts_on_max_loops(
+    logger: WebSearchInterceptionLogger,
+) -> None:
+    """Depth guard prevents a model from inducing unbounded recursion by
+    keeping it returning the same ``litellm_web_search`` tool call."""
+
+    asearch_mock = AsyncMock()
+    aresponses_mock = AsyncMock()
+
+    with (
+        patch.object(litellm, "asearch", new=asearch_mock),
+        patch.object(litellm, "aresponses", new=aresponses_mock),
+    ):
+        with pytest.raises(ValueError, match="exceeded max_agentic_loops"):
+            await logger.async_run_responses_api_agentic_loop(
+                tools={
+                    "tool_calls": [
+                        {
+                            "id": "c",
+                            "call_id": "c",
+                            "type": "function_call",
+                            "name": "litellm_web_search",
+                            "input": {"query": "q"},
+                            "arguments": {"query": "q"},
+                        }
+                    ],
+                    "response_format": "responses",
+                },
+                model="openai.gpt-5.5",
+                input="hi",
+                response={"id": "r", "output": []},
+                response_api_optional_request_params={},
+                litellm_params={},
+                logging_obj=MagicMock(),
+                stream=False,
+                kwargs={
+                    "_agentic_loop_depth": 3,
+                    "max_agentic_loops": 3,
+                    "_agentic_loop_fingerprints": [],
+                },
+            )
+
+    # Guard MUST run before any work — capped-out clients shouldn't burn
+    # parallel Tavily calls per iteration.
+    asearch_mock.assert_not_called()
+    aresponses_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_responses_api_hook_propagates_max_agentic_loops(
+    logger: WebSearchInterceptionLogger,
+) -> None:
+    """Re-entrant call must carry ``max_agentic_loops`` forward; otherwise a
+    deployment-configured cap silently resets to the default on each hop."""
+
+    fake_search = MagicMock()
+    fake_search.results = [MagicMock(title="t", url="u", snippet="s")]
+    captured = {}
+
+    async def fake_aresponses(**kwargs):
+        captured.update(kwargs)
+        return {"id": "r2", "output": []}
+
+    with (
+        patch.object(litellm, "asearch", new=AsyncMock(return_value=fake_search)),
+        patch.object(litellm, "aresponses", new=AsyncMock(side_effect=fake_aresponses)),
+    ):
+        await logger.async_run_responses_api_agentic_loop(
+            tools={
+                "tool_calls": [
+                    {
+                        "id": "c",
+                        "call_id": "c",
+                        "type": "function_call",
+                        "name": "litellm_web_search",
+                        "input": {"query": "q"},
+                        "arguments": {"query": "q"},
+                    }
+                ],
+                "response_format": "responses",
+            },
+            model="openai.gpt-5.5",
+            input="hi",
+            response={"id": "r1", "output": []},
+            response_api_optional_request_params={},
+            litellm_params={},
+            logging_obj=MagicMock(),
+            stream=False,
+            kwargs={
+                "_agentic_loop_depth": 1,
+                "max_agentic_loops": 7,
+                "_agentic_loop_fingerprints": [],
+            },
+        )
+
+    assert captured["max_agentic_loops"] == 7
+    assert captured["_agentic_loop_depth"] == 2
+    assert len(captured["_agentic_loop_fingerprints"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_run_responses_api_hook_propagates_caller_attribution(
+    logger: WebSearchInterceptionLogger,
+) -> None:
+    """Internal follow-up call must carry caller-attribution fields
+    (``metadata``, ``litellm_metadata``, ``user``, ``user_api_key_*``) so
+    proxy budget / spend logging accounts the call against the original
+    API key and team rather than an empty owner."""
+
+    fake_search = MagicMock()
+    fake_search.results = [MagicMock(title="t", url="u", snippet="s")]
+    captured = {}
+
+    async def fake_aresponses(**kwargs):
+        captured.update(kwargs)
+        return {"id": "r2", "output": []}
+
+    with (
+        patch.object(litellm, "asearch", new=AsyncMock(return_value=fake_search)),
+        patch.object(litellm, "aresponses", new=AsyncMock(side_effect=fake_aresponses)),
+    ):
+        await logger.async_run_responses_api_agentic_loop(
+            tools={
+                "tool_calls": [
+                    {
+                        "id": "c",
+                        "call_id": "c",
+                        "type": "function_call",
+                        "name": "litellm_web_search",
+                        "input": {"query": "q"},
+                        "arguments": {"query": "q"},
+                    }
+                ],
+                "response_format": "responses",
+            },
+            model="openai.gpt-5.5",
+            input="hi",
+            response={"id": "r1", "output": []},
+            response_api_optional_request_params={},
+            litellm_params={
+                "metadata": {"trace_id": "abc"},
+                "litellm_metadata": {"user_api_key_alias": "qmachu"},
+                "user": "u-1",
+                "user_api_key": "sk-test",
+                "user_api_key_user_id": "u-1",
+                "user_api_key_team_id": "t-1",
+                "user_api_key_team_alias": "team-a",
+                "user_api_key_org_id": "o-1",
+                "proxy_server_request": {"arrival_time": "now"},
+            },
+            logging_obj=MagicMock(),
+            stream=False,
+            kwargs={},
+        )
+
+    assert captured["metadata"] == {"trace_id": "abc"}
+    assert captured["litellm_metadata"] == {"user_api_key_alias": "qmachu"}
+    assert captured["user"] == "u-1"
+    assert captured["user_api_key"] == "sk-test"
+    assert captured["user_api_key_team_id"] == "t-1"
+    assert captured["user_api_key_team_alias"] == "team-a"
+    assert captured["user_api_key_org_id"] == "o-1"
+    assert captured["proxy_server_request"] == {"arrival_time": "now"}
+
+
+@pytest.mark.asyncio
+async def test_run_responses_api_hook_aborts_on_repeated_fingerprint(
+    logger: WebSearchInterceptionLogger,
+) -> None:
+    """Cycle break: same tool_calls fingerprint twice in a row aborts."""
+
+    fake_search = MagicMock()
+    fake_search.results = [MagicMock(title="t", url="u", snippet="s")]
+
+    tool_calls = [
+        {
+            "id": "c",
+            "call_id": "c",
+            "type": "function_call",
+            "name": "litellm_web_search",
+            "input": {"query": "q"},
+            "arguments": {"query": "q"},
+        }
+    ]
+    import json as _json
+
+    seen_fingerprint = _json.dumps(tool_calls, sort_keys=True, default=str)
+
+    with (
+        patch.object(litellm, "asearch", new=AsyncMock(return_value=fake_search)),
+        patch.object(litellm, "aresponses", new=AsyncMock()),
+    ):
+        with pytest.raises(ValueError, match="repeated tool-call fingerprint"):
+            await logger.async_run_responses_api_agentic_loop(
+                tools={
+                    "tool_calls": tool_calls,
+                    "response_format": "responses",
+                },
+                model="openai.gpt-5.5",
+                input="hi",
+                response={"id": "r", "output": []},
+                response_api_optional_request_params={},
+                litellm_params={},
+                logging_obj=MagicMock(),
+                stream=False,
+                kwargs={
+                    "_agentic_loop_depth": 0,
+                    "max_agentic_loops": 5,
+                    "_agentic_loop_fingerprints": [seen_fingerprint],
+                },
+            )

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_responses_api.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_responses_api.py
@@ -1,9 +1,13 @@
 """
 Unit tests for WebSearchInterceptionLogger on the OpenAI Responses API path.
 
-Covers the call_type=="aresponses" branch of async_pre_call_deployment_hook,
-the new Responses-API output parser, the should-run hook, and the agentic
-loop that rebuilds the input chain with function_call_output items.
+The Responses surface rides the shared agentic-loop mechanism
+(``async_should_run_agentic_loop`` / ``async_build_agentic_loop_plan`` ->
+``_execute_responses_agentic_plan``), gated by the ``_agentic_loop_api_surface``
+== ``responses`` marker, the same way ``code_interpreter_interception`` does.
+These tests cover tool detection, the deployment-hook tool conversion (sync and
+async call types), surface routing, plan construction, search-tool auth
+forwarding, and end-to-end dispatch through the shared mechanism.
 """
 
 import json
@@ -22,6 +26,8 @@ from litellm.integrations.websearch_interception.tools import (
 from litellm.integrations.websearch_interception.transformation import (
     WebSearchTransformation,
 )
+from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+from litellm.types.integrations.custom_logger import RESPONSES_AGENTIC_SURFACE
 from litellm.types.utils import LlmProviders
 
 
@@ -31,6 +37,21 @@ def logger() -> WebSearchInterceptionLogger:
         enabled_providers=[LlmProviders.BEDROCK_MANTLE, LlmProviders.OPENAI],
         search_tool_name="tavily-search",
     )
+
+
+def _responses_with_search_call(query: str = "btc price") -> dict:
+    return {
+        "id": "resp_initial",
+        "output": [
+            {"type": "reasoning", "id": "rs_1", "summary": []},
+            {
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "litellm_web_search",
+                "arguments": json.dumps({"query": query}),
+            },
+        ],
+    }
 
 
 def test_is_web_search_tool_responses_api_detects_codex_shape() -> None:
@@ -47,7 +68,6 @@ def test_is_web_search_tool_responses_api_detects_codex_shape() -> None:
 
 def test_get_litellm_web_search_tool_responses_api_is_flat() -> None:
     tool = get_litellm_web_search_tool_responses_api()
-    # Flat shape — no nested ``function`` key (which would be Chat-Completions style).
     assert tool["type"] == "function"
     assert tool["name"] == "litellm_web_search"
     assert "parameters" in tool
@@ -55,23 +75,14 @@ def test_get_litellm_web_search_tool_responses_api_is_flat() -> None:
 
 
 def test_responses_api_response_parser_finds_function_call() -> None:
-    response = {
-        "output": [
-            {"type": "reasoning", "id": "rs_1", "summary": []},
-            {
-                "type": "function_call",
-                "call_id": "call_abc",
-                "name": "litellm_web_search",
-                "arguments": json.dumps({"query": "weather hong kong"}),
-            },
-        ]
-    }
     should, calls = WebSearchTransformation.transform_request(
-        response=response, stream=False, response_format="responses"
+        response=_responses_with_search_call("weather hong kong"),
+        stream=False,
+        response_format="responses",
     )
     assert should is True
     assert len(calls) == 1
-    assert calls[0]["call_id"] == "call_abc"
+    assert calls[0]["call_id"] == "call_1"
     assert calls[0]["input"]["query"] == "weather hong kong"
 
 
@@ -94,32 +105,32 @@ def test_responses_api_response_parser_ignores_other_function_calls() -> None:
 
 
 @pytest.mark.asyncio
-async def test_pre_call_hook_aresponses_uses_flat_shape(
-    logger: WebSearchInterceptionLogger,
+@pytest.mark.parametrize("call_type", ["aresponses", "responses"])
+async def test_pre_call_hook_responses_uses_flat_shape(
+    logger: WebSearchInterceptionLogger, call_type: str
 ) -> None:
+    # Both the async (``aresponses``) and sync (``responses``) Responses call
+    # types must convert the server-hosted tool to the flat function shape.
     kwargs = {
         "model": "openai.gpt-5.5",
         "custom_llm_provider": "bedrock_mantle",
         "tools": [{"type": "web_search"}],
         "stream": True,
     }
-    out = await logger.async_pre_call_deployment_hook(kwargs, call_type="aresponses")
+    out = await logger.async_pre_call_deployment_hook(kwargs, call_type=call_type)
     assert out is not None
     converted = out["tools"][0]
-    # Flat — no nested ``function`` key.
     assert converted["type"] == "function"
     assert converted["name"] == "litellm_web_search"
     assert "function" not in converted
-    # Streaming converted to non-streaming for interception.
     assert out["stream"] is False
     assert out["_websearch_interception_converted_stream"] is True
 
 
 @pytest.mark.asyncio
-async def test_pre_call_hook_aresponses_skips_disabled_provider(
+async def test_pre_call_hook_responses_skips_disabled_provider(
     logger: WebSearchInterceptionLogger,
 ) -> None:
-    # vertex_ai isn't in the logger's enabled list.
     kwargs = {
         "model": "publishers/google/models/gemini-1.5-pro",
         "custom_llm_provider": "vertex_ai",
@@ -130,316 +141,252 @@ async def test_pre_call_hook_aresponses_skips_disabled_provider(
 
 
 @pytest.mark.asyncio
-async def test_should_run_responses_api_hook_returns_tool_calls(
+async def test_should_run_agentic_loop_routes_responses_surface(
     logger: WebSearchInterceptionLogger,
 ) -> None:
-    response = {
-        "output": [
-            {
-                "type": "function_call",
-                "call_id": "call_1",
-                "name": "litellm_web_search",
-                "arguments": json.dumps({"query": "btc price"}),
-            }
-        ]
-    }
-    should, hook_tools = await logger.async_should_run_responses_api_agentic_loop(
-        response=response,
+    # With the responses surface marker set, the shared hook must dispatch to
+    # the Responses detection (which reads ``output[].function_call``), not the
+    # Anthropic detection (which reads ``content[].tool_use``).
+    should, hook_tools = await logger.async_should_run_agentic_loop(
+        response=_responses_with_search_call(),
         model="openai.gpt-5.5",
-        input="hi",
+        messages=[{"role": "user", "content": "hi"}],
         tools=[{"type": "web_search"}],
         stream=False,
         custom_llm_provider="bedrock_mantle",
-        kwargs={},
+        kwargs={"_agentic_loop_api_surface": RESPONSES_AGENTIC_SURFACE},
     )
     assert should is True
-    assert hook_tools["response_format"] == "responses"
     assert len(hook_tools["tool_calls"]) == 1
 
 
 @pytest.mark.asyncio
-async def test_run_responses_api_hook_preserves_assistant_turn_then_appends_outputs(
+async def test_build_plan_responses_preserves_assistant_turn_then_appends_outputs(
     logger: WebSearchInterceptionLogger,
 ) -> None:
-    """The follow-up ``input`` must carry the user message, then the entire
-    first-turn assistant ``output`` (reasoning + function_call), then the
-    paired ``function_call_output`` items. Strict providers (OpenAI-native)
-    400 if a ``function_call_output`` is not preceded by its matching
-    ``function_call`` from the same conversation turn — see
-    https://platform.openai.com/docs/api-reference/responses."""
-
+    # The plan's follow-up ``input`` must carry the user message, then the
+    # entire first-turn assistant ``output`` (reasoning + function_call), then
+    # the paired ``function_call_output`` items. Strict providers 400 if a
+    # ``function_call_output`` is not preceded by its matching ``function_call``.
     fake_search = MagicMock()
-    fake_search.results = [
-        MagicMock(title="t", url="https://example.com", snippet="snippet"),
-    ]
+    fake_search.results = [MagicMock(title="t", url="https://example.com", snippet="s")]
 
-    captured = {}
+    with patch.object(litellm, "asearch", new=AsyncMock(return_value=fake_search)):
+        plan = await logger.async_build_agentic_loop_plan(
+            tools={
+                "tool_calls": [
+                    {"call_id": "call_1", "input": {"query": "btc price"}},
+                ],
+                "response_format": "responses",
+            },
+            model="openai.gpt-5.5",
+            messages=[{"role": "user", "content": "what is btc?"}],
+            response=_responses_with_search_call(),
+            anthropic_messages_provider_config=MagicMock(),
+            anthropic_messages_optional_request_params={"tools": []},
+            logging_obj=MagicMock(),
+            stream=False,
+            kwargs={
+                "_agentic_loop_api_surface": RESPONSES_AGENTIC_SURFACE,
+                "custom_llm_provider": "bedrock_mantle",
+            },
+        )
+
+    assert plan.run_agentic_loop is True
+    # The plan carries the bare backend id; the shared executor
+    # (_execute_responses_agentic_plan) re-prefixes provider/model for the
+    # follow-up call — covered by test_generic_dispatch_runs_websearch_on_responses_surface.
+    assert plan.request_patch.model == "openai.gpt-5.5"
+
+    items = plan.request_patch.messages
+    assert items[0] == {"role": "user", "content": "what is btc?"}
+    types = [it.get("type") for it in items if isinstance(it, dict) and "type" in it]
+    assert "reasoning" in types
+    assert "function_call" in types
+    outputs = [it for it in items if it.get("type") == "function_call_output"]
+    assert len(outputs) == 1
+    assert outputs[0]["call_id"] == "call_1"
+
+
+@pytest.mark.asyncio
+async def test_build_plan_responses_forwards_auth_to_search(
+    logger: WebSearchInterceptionLogger,
+) -> None:
+    # Regression guard: the search must be executed WITH the caller's kwargs so
+    # per-key/per-team search-tool authorization is enforced. Dropping kwargs
+    # (as an earlier revision did) silently skips the ACL check.
+    captured: dict = {}
+
+    async def fake_execute_search(query, kwargs=None):
+        captured["kwargs"] = kwargs
+        return ("result text", None)
+
+    hook_kwargs = {
+        "_agentic_loop_api_surface": RESPONSES_AGENTIC_SURFACE,
+        "custom_llm_provider": "bedrock_mantle",
+        "litellm_metadata": {"user_api_key_auth": {"api_key": "sk-sentinel"}},
+    }
+    with patch.object(logger, "_execute_search", side_effect=fake_execute_search):
+        await logger.async_build_agentic_loop_plan(
+            tools={
+                "tool_calls": [{"call_id": "call_1", "input": {"query": "q"}}],
+                "response_format": "responses",
+            },
+            model="openai.gpt-5.5",
+            messages=[{"role": "user", "content": "hi"}],
+            response=_responses_with_search_call(),
+            anthropic_messages_provider_config=MagicMock(),
+            anthropic_messages_optional_request_params={"tools": []},
+            logging_obj=MagicMock(),
+            stream=False,
+            kwargs=hook_kwargs,
+        )
+
+    assert captured["kwargs"] is not None
+    assert (
+        captured["kwargs"].get("litellm_metadata", {}).get("user_api_key_auth")
+        == {"api_key": "sk-sentinel"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_generic_dispatch_runs_websearch_on_responses_surface() -> None:
+    # End-to-end: the shared ``_call_agentic_completion_hooks`` with
+    # api_surface="responses" must route to the websearch plan and re-run the
+    # model via ``litellm.aresponses`` with the patched input chain — proving
+    # the surface marker + plan mechanism replaces the old bespoke dispatcher.
+    logger = WebSearchInterceptionLogger(
+        enabled_providers=[LlmProviders.BEDROCK_MANTLE],
+        search_tool_name="tavily-search",
+    )
+    handler = BaseLLMHTTPHandler()
+
+    captured: dict = {}
 
     async def fake_aresponses(**kwargs):
         captured.update(kwargs)
         return {"id": "resp_final", "output": [{"type": "message"}]}
 
-    initial_response = {
-        "id": "resp_initial",
-        "output": [
-            {"type": "reasoning", "id": "rs_1", "summary": []},
-            {
-                "type": "function_call",
-                "call_id": "call_1",
-                "name": "litellm_web_search",
-                "arguments": '{"query": "btc price"}',
-            },
-        ],
-    }
+    async def fake_execute_search(query, kwargs=None):
+        return (f"results for {query}", None)
 
-    with (
-        patch.object(litellm, "asearch", new=AsyncMock(return_value=fake_search)),
-        patch.object(litellm, "aresponses", new=AsyncMock(side_effect=fake_aresponses)),
-    ):
-        await logger.async_run_responses_api_agentic_loop(
-            tools={
-                "tool_calls": [
-                    {
-                        "id": "call_1",
-                        "call_id": "call_1",
-                        "type": "function_call",
-                        "name": "litellm_web_search",
-                        "input": {"query": "btc price"},
-                        "arguments": {"query": "btc price"},
-                    }
-                ],
-                "response_format": "responses",
-            },
-            model="openai.gpt-5.5",
-            input="What's the BTC price?",
-            response=initial_response,
-            response_api_optional_request_params={"tools": [{"type": "function"}]},
-            litellm_params={},
-            logging_obj=MagicMock(),
-            stream=False,
-            kwargs={},
-        )
+    logging_obj = MagicMock()
+    logging_obj.dynamic_success_callbacks = []
+    logging_obj.litellm_call_id = "call-xyz"
 
-    follow_up_input = captured["input"]
-    assert follow_up_input[0] == {"role": "user", "content": "What's the BTC price?"}
-    assert follow_up_input[1]["type"] == "reasoning"
-    assert follow_up_input[2]["type"] == "function_call"
-    assert follow_up_input[2]["call_id"] == "call_1"
-    assert follow_up_input[2]["name"] == "litellm_web_search"
-    assert follow_up_input[3]["type"] == "function_call_output"
-    assert follow_up_input[3]["call_id"] == "call_1"
-    assert "snippet" in follow_up_input[3]["output"]
-
-
-@pytest.mark.asyncio
-async def test_run_responses_api_hook_aborts_on_max_loops(
-    logger: WebSearchInterceptionLogger,
-) -> None:
-    """Depth guard prevents a model from inducing unbounded recursion by
-    keeping it returning the same ``litellm_web_search`` tool call."""
-
-    asearch_mock = AsyncMock()
-    aresponses_mock = AsyncMock()
-
-    with (
-        patch.object(litellm, "asearch", new=asearch_mock),
-        patch.object(litellm, "aresponses", new=aresponses_mock),
-    ):
-        with pytest.raises(ValueError, match="exceeded max_agentic_loops"):
-            await logger.async_run_responses_api_agentic_loop(
-                tools={
-                    "tool_calls": [
-                        {
-                            "id": "c",
-                            "call_id": "c",
-                            "type": "function_call",
-                            "name": "litellm_web_search",
-                            "input": {"query": "q"},
-                            "arguments": {"query": "q"},
-                        }
-                    ],
-                    "response_format": "responses",
-                },
+    original_callbacks = litellm.callbacks
+    litellm.callbacks = [logger]
+    try:
+        with (
+            patch.object(logger, "_execute_search", side_effect=fake_execute_search),
+            patch.object(
+                litellm, "aresponses", new=AsyncMock(side_effect=fake_aresponses)
+            ),
+        ):
+            result = await handler._call_agentic_completion_hooks(
+                response=_responses_with_search_call(),
                 model="openai.gpt-5.5",
-                input="hi",
-                response={"id": "r", "output": []},
-                response_api_optional_request_params={},
-                litellm_params={},
-                logging_obj=MagicMock(),
-                stream=False,
-                kwargs={
-                    "_agentic_loop_depth": 3,
-                    "max_agentic_loops": 3,
-                    "_agentic_loop_fingerprints": [],
+                messages=[{"role": "user", "content": "what is btc?"}],
+                anthropic_messages_provider_config=MagicMock(),
+                anthropic_messages_optional_request_params={
+                    "tools": [{"type": "function", "name": "litellm_web_search"}]
                 },
+                logging_obj=logging_obj,
+                stream=False,
+                custom_llm_provider="bedrock_mantle",
+                kwargs={"custom_llm_provider": "bedrock_mantle"},
+                api_surface="responses",
             )
+    finally:
+        litellm.callbacks = original_callbacks
 
-    # Guard MUST run before any work — capped-out clients shouldn't burn
-    # parallel Tavily calls per iteration.
-    asearch_mock.assert_not_called()
-    aresponses_mock.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_run_responses_api_hook_propagates_max_agentic_loops(
-    logger: WebSearchInterceptionLogger,
-) -> None:
-    """Re-entrant call must carry ``max_agentic_loops`` forward; otherwise a
-    deployment-configured cap silently resets to the default on each hop."""
-
-    fake_search = MagicMock()
-    fake_search.results = [MagicMock(title="t", url="u", snippet="s")]
-    captured = {}
-
-    async def fake_aresponses(**kwargs):
-        captured.update(kwargs)
-        return {"id": "r2", "output": []}
-
-    with (
-        patch.object(litellm, "asearch", new=AsyncMock(return_value=fake_search)),
-        patch.object(litellm, "aresponses", new=AsyncMock(side_effect=fake_aresponses)),
-    ):
-        await logger.async_run_responses_api_agentic_loop(
-            tools={
-                "tool_calls": [
-                    {
-                        "id": "c",
-                        "call_id": "c",
-                        "type": "function_call",
-                        "name": "litellm_web_search",
-                        "input": {"query": "q"},
-                        "arguments": {"query": "q"},
-                    }
-                ],
-                "response_format": "responses",
-            },
-            model="openai.gpt-5.5",
-            input="hi",
-            response={"id": "r1", "output": []},
-            response_api_optional_request_params={},
-            litellm_params={},
-            logging_obj=MagicMock(),
-            stream=False,
-            kwargs={
-                "_agentic_loop_depth": 1,
-                "max_agentic_loops": 7,
-                "_agentic_loop_fingerprints": [],
-            },
-        )
-
-    assert captured["max_agentic_loops"] == 7
-    assert captured["_agentic_loop_depth"] == 2
-    assert len(captured["_agentic_loop_fingerprints"]) == 1
-
-
-@pytest.mark.asyncio
-async def test_run_responses_api_hook_propagates_caller_attribution(
-    logger: WebSearchInterceptionLogger,
-) -> None:
-    """Internal follow-up call must carry caller-attribution fields
-    (``metadata``, ``litellm_metadata``, ``user``, ``user_api_key_*``) so
-    proxy budget / spend logging accounts the call against the original
-    API key and team rather than an empty owner."""
-
-    fake_search = MagicMock()
-    fake_search.results = [MagicMock(title="t", url="u", snippet="s")]
-    captured = {}
-
-    async def fake_aresponses(**kwargs):
-        captured.update(kwargs)
-        return {"id": "r2", "output": []}
-
-    with (
-        patch.object(litellm, "asearch", new=AsyncMock(return_value=fake_search)),
-        patch.object(litellm, "aresponses", new=AsyncMock(side_effect=fake_aresponses)),
-    ):
-        await logger.async_run_responses_api_agentic_loop(
-            tools={
-                "tool_calls": [
-                    {
-                        "id": "c",
-                        "call_id": "c",
-                        "type": "function_call",
-                        "name": "litellm_web_search",
-                        "input": {"query": "q"},
-                        "arguments": {"query": "q"},
-                    }
-                ],
-                "response_format": "responses",
-            },
-            model="openai.gpt-5.5",
-            input="hi",
-            response={"id": "r1", "output": []},
-            response_api_optional_request_params={},
-            litellm_params={
-                "metadata": {"trace_id": "abc"},
-                "litellm_metadata": {"user_api_key_alias": "qmachu"},
-                "user": "u-1",
-                "user_api_key": "sk-test",
-                "user_api_key_user_id": "u-1",
-                "user_api_key_team_id": "t-1",
-                "user_api_key_team_alias": "team-a",
-                "user_api_key_org_id": "o-1",
-                "proxy_server_request": {"arrival_time": "now"},
-            },
-            logging_obj=MagicMock(),
-            stream=False,
-            kwargs={},
-        )
-
-    assert captured["metadata"] == {"trace_id": "abc"}
-    assert captured["litellm_metadata"] == {"user_api_key_alias": "qmachu"}
-    assert captured["user"] == "u-1"
-    assert captured["user_api_key"] == "sk-test"
-    assert captured["user_api_key_team_id"] == "t-1"
-    assert captured["user_api_key_team_alias"] == "team-a"
-    assert captured["user_api_key_org_id"] == "o-1"
-    assert captured["proxy_server_request"] == {"arrival_time": "now"}
-
-
-@pytest.mark.asyncio
-async def test_run_responses_api_hook_aborts_on_repeated_fingerprint(
-    logger: WebSearchInterceptionLogger,
-) -> None:
-    """Cycle break: same tool_calls fingerprint twice in a row aborts."""
-
-    fake_search = MagicMock()
-    fake_search.results = [MagicMock(title="t", url="u", snippet="s")]
-
-    tool_calls = [
-        {
-            "id": "c",
-            "call_id": "c",
-            "type": "function_call",
-            "name": "litellm_web_search",
-            "input": {"query": "q"},
-            "arguments": {"query": "q"},
-        }
+    # The follow-up model call ran, carrying the rebuilt input chain.
+    assert captured, "expected a follow-up litellm.aresponses call"
+    assert captured["model"] == "bedrock_mantle/openai.gpt-5.5"
+    followup_outputs = [
+        it
+        for it in captured["input"]
+        if isinstance(it, dict) and it.get("type") == "function_call_output"
     ]
-    import json as _json
+    assert len(followup_outputs) == 1
+    assert result == {"id": "resp_final", "output": [{"type": "message"}]}
 
-    seen_fingerprint = _json.dumps(tool_calls, sort_keys=True, default=str)
 
-    with (
-        patch.object(litellm, "asearch", new=AsyncMock(return_value=fake_search)),
-        patch.object(litellm, "aresponses", new=AsyncMock()),
+@pytest.mark.asyncio
+async def test_build_plan_responses_coerces_search_failure(
+    logger: WebSearchInterceptionLogger,
+) -> None:
+    # A failed search must not abort the loop: it is coerced to text and the
+    # function_call_output still pairs with its call_id.
+    async def boom(query, kwargs=None):
+        raise RuntimeError("tavily down")
+
+    with patch.object(logger, "_execute_search", side_effect=boom):
+        plan = await logger.async_build_agentic_loop_plan(
+            tools={"tool_calls": [{"call_id": "call_1", "input": {"query": "q"}}]},
+            model="openai.gpt-5.5",
+            messages=[{"role": "user", "content": "hi"}],
+            response=_responses_with_search_call(),
+            anthropic_messages_provider_config=MagicMock(),
+            anthropic_messages_optional_request_params={"tools": []},
+            logging_obj=MagicMock(),
+            stream=False,
+            kwargs={"_agentic_loop_api_surface": RESPONSES_AGENTIC_SURFACE},
+        )
+
+    outputs = [
+        it for it in plan.request_patch.messages if it.get("type") == "function_call_output"
+    ]
+    assert len(outputs) == 1
+    assert outputs[0]["call_id"] == "call_1"
+    assert "Search failed" in outputs[0]["output"]
+
+
+@pytest.mark.asyncio
+async def test_build_plan_responses_missing_query_still_pairs_output(
+    logger: WebSearchInterceptionLogger,
+) -> None:
+    # A tool_call with no query falls to the empty-result branch but still
+    # emits a paired function_call_output so strict providers accept the input.
+    with patch.object(
+        logger, "_execute_search", new=AsyncMock(side_effect=AssertionError("should not run"))
     ):
-        with pytest.raises(ValueError, match="repeated tool-call fingerprint"):
-            await logger.async_run_responses_api_agentic_loop(
-                tools={
-                    "tool_calls": tool_calls,
-                    "response_format": "responses",
-                },
-                model="openai.gpt-5.5",
-                input="hi",
-                response={"id": "r", "output": []},
-                response_api_optional_request_params={},
-                litellm_params={},
-                logging_obj=MagicMock(),
-                stream=False,
-                kwargs={
-                    "_agentic_loop_depth": 0,
-                    "max_agentic_loops": 5,
-                    "_agentic_loop_fingerprints": [seen_fingerprint],
-                },
-            )
+        plan = await logger.async_build_agentic_loop_plan(
+            tools={"tool_calls": [{"call_id": "call_1", "input": {}}]},
+            model="openai.gpt-5.5",
+            messages=[{"role": "user", "content": "hi"}],
+            response=_responses_with_search_call(),
+            anthropic_messages_provider_config=MagicMock(),
+            anthropic_messages_optional_request_params={"tools": []},
+            logging_obj=MagicMock(),
+            stream=False,
+            kwargs={"_agentic_loop_api_surface": RESPONSES_AGENTIC_SURFACE},
+        )
+
+    outputs = [
+        it for it in plan.request_patch.messages if it.get("type") == "function_call_output"
+    ]
+    assert len(outputs) == 1
+    assert outputs[0]["call_id"] == "call_1"
+
+
+def test_dump_output_item_variants() -> None:
+    dump = WebSearchInterceptionLogger._dump_output_item
+
+    # dict passes through unchanged
+    assert dump({"type": "message", "x": 1}) == {"type": "message", "x": 1}
+
+    # object exposing model_dump()
+    class WithModelDump:
+        def model_dump(self):
+            return {"type": "reasoning", "id": "rs_1"}
+
+    assert dump(WithModelDump()) == {"type": "reasoning", "id": "rs_1"}
+
+    # plain object -> __dict__ fallback
+    class Plain:
+        def __init__(self):
+            self.type = "function_call"
+            self.call_id = "c1"
+
+    assert dump(Plain()) == {"type": "function_call", "call_id": "c1"}


### PR DESCRIPTION
## Relevant issues

Supersedes #29807 (its author @Quentin-M is preserved as the first commit here). Adds `websearch_interception` support on the OpenAI **Responses API** surface (`/v1/responses`), unblocking clients like the Codex CLI that send a server-hosted `web_search` tool to providers that reject it (e.g. **Bedrock Mantle**, which 400s with `"Live web access is not yet available…"`).

## Linear ticket

<!-- external contributor -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (4/5; both inline P2s addressed)

## Type

🧹 Refactoring
🆕 New Feature

## Changes

Reworks #29807 to **ride the shared agentic-loop mechanism** (`async_should_run_agentic_loop` / `async_build_agentic_loop_plan` → `_execute_responses_agentic_plan`) that `code_interpreter_interception` already uses, instead of a parallel dispatcher. A new `RESPONSES_AGENTIC_SURFACE` marker lets the shared hooks distinguish the Responses surface from Anthropic Messages. **Net −470 lines** vs. the parallel approach, and it removes several sharp edges in the original:

- **Search-tool authorization is enforced on the Responses path** — searches run with the caller's `kwargs` (auth rides in `litellm_metadata`), so per-key / per-team ACLs apply, matching the chat and anthropic paths.
- **Loop-safety runs once, centrally, outside the per-callback try/except** via `_check_agentic_loop_safety`, so a capped-out loop surfaces an error instead of returning a response with a dangling internal `function_call`.
- **One dispatcher** — no second dispatch after the code-interpreter converted-stream early return, so a streaming request carrying both a `code_interpreter` and a `web_search` tool no longer skips web search. Converted-stream wrapping is unified on `_wrap_responses_response_as_fake_stream`.
- **The sync Responses path works** (`litellm.responses` / `Router.responses`): the deployment hook converts tools for both the `"responses"` and `"aresponses"` call types.
- **Provider prefixing is centralized** in `_execute_responses_agentic_plan` (so `code_interpreter` benefits too), guarded on the provider prefix rather than any `/`.
- Drops hand-rolled loop-safety, allow-list param forwarding, and unused `original_stream` plumbing; the shared executor forwards kwargs by deny-list.
- Updates `ARCHITECTURE.md` to document the Responses surface.

## Screenshots / Proof of Fix

**End-to-end (original, from #29807):** the base commit was validated against a real Bedrock Mantle GPT‑5.5 endpoint through a LiteLLM proxy with a Tavily `search_tools` entry — a `/v1/responses` request carrying a native `web_search` tool returned a searched, cited answer instead of the mantle 400. This PR preserves that behavior and re-runs it through the shared mechanism.

**Tests (this PR, commit `586eb4b`):** the rewritten `test_websearch_responses_api.py` covers the full path end-to-end at the dispatch layer — surface routing, plan construction, search-tool auth forwarding (regression guard for the ACL fix), and dispatch through `_call_agentic_completion_hooks` (asserts the follow-up `litellm.aresponses` call runs with the rebuilt `input` chain). Full run:

```
$ pytest tests/test_litellm/integrations/websearch_interception/ \
         tests/test_litellm/integrations/code_interpreter_interception/ -q
172 passed, 2 skipped
$ ruff format --check <changed files>   # clean
$ ruff check litellm/integrations/websearch_interception/ ...  # clean
```

Config to reproduce the live run:

```yaml
litellm_settings:
  callbacks: ["websearch_interception"]
  websearch_interception_params:
    enabled_providers: ["bedrock_mantle"]
    search_tool_name: "tavily-search"
search_tools:
  - search_tool_name: "tavily-search"
    litellm_params:
      search_provider: tavily
      api_key: os.environ/TAVILY_API_KEY
model_list:
  - model_name: gpt-5.5
    litellm_params:
      model: bedrock_mantle/openai.gpt-5.5
      aws_region_name: us-east-1
```
