### PR TITLE
feat(lasso): send source.type for Used By attribution

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/lasso/lasso.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/lasso/lasso.py
@@ -772,7 +772,13 @@ class LassoGuardrail(CustomGuardrail):
             data: Request data (used for conversation_id generation and tools extraction)
             cache: Cache instance for storing conversation_id (optional for post-call)
         """
-        payload: Dict[str, Any] = {"messages": messages, "messageType": message_type}
+        payload: Dict[str, Any] = {
+            "messages": messages,
+            "messageType": message_type,
+            # Drives the "Used By" badge on Lasso Application API Keys: every call from this
+            # integration is attributed as "litellm" on the keys list.
+            "source": {"type": "litellm"},
+        }
 
         # Add optional parameters if available
         if self.user_id:

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_lasso.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_lasso.py
@@ -693,6 +693,8 @@ class TestLassoGuardrail:
         assert prompt_payload["messages"] == messages
         assert prompt_payload["userId"] == "test-user"
         assert prompt_payload["sessionId"] == "test-conversation"
+        # Every call is attributed to the "litellm" integration for the "Used By" badge.
+        assert prompt_payload["source"] == {"type": "litellm"}
 
         # Test COMPLETION payload
         completion_messages = [{"role": "assistant", "content": "Test response"}]
@@ -703,6 +705,7 @@ class TestLassoGuardrail:
         assert completion_payload["messages"] == completion_messages
         assert completion_payload["userId"] == "test-user"
         assert completion_payload["sessionId"] == "test-conversation"
+        assert completion_payload["source"] == {"type": "litellm"}
 
     def test_header_preparation(self):
         """Test header preparation."""


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

All 38 tests in `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_lasso.py` pass locally, including the updated `test_payload_preparation_completion_vs_prompt` which asserts `source == {"type": "litellm"}` on both PROMPT and COMPLETION payloads

The only red check as of the last push is osv-scan, which fails on every open PR against `litellm_internal_staging` because of the pillow 12.2.0 advisories published 2026-07-13 (PYSEC-2026-2253 through 2257); the bump to 12.3.0 is in flight on the base branch and this PR touches no dependencies

## Type

New Feature

## Changes

The Lasso Generic Guardrail integration now stamps `source.type = "litellm"` on every `/gateway/v3/{classify,classifix}` payload it sends. This drives the "Used By" badge on the Lasso Application API Keys list; without it, all LiteLLM traffic shows as "N/A" on the keys page

Backwards compatible: `source` is an optional opaque object on the Lasso side and older Lasso servers ignore it

## Credit

Adopted from #29564 by @orgersh92. Mirrored onto a `litellm_` branch so CircleCI and the internal lint workflow run, preserving the original commit and author

## QA runbook

There are no Lasso credentials in the dev .env, so QA uses a local HTTP stub standing in for the Lasso API while the proxy handles a real request. Start a stub that records request bodies (for example `python -m http.server` behind a small handler, or `nc -l 9000`), then add a lasso guardrail to `litellm/proxy/dev_config.yaml` with `api_base: http://localhost:9000` and `mode: pre_call`, start the proxy with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug`, and send one chat completion through `curl http://localhost:4000/v1/chat/completions`. The JSON body the stub receives should contain `"source": {"type": "litellm"}` alongside `messages` and `messageType`. On a Lasso account, the same request attributes the calling API key as "litellm" in the Used By column of the Application API Keys page

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
