### PR TITLE
feat(guardrails): add Straiker DefendAI guardrail

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/straiker/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/straiker/__init__.py
@@ -1,0 +1,41 @@
+from typing import TYPE_CHECKING
+
+import litellm
+from litellm.types.guardrails import SupportedGuardrailIntegrations
+from litellm.types.proxy.guardrails.guardrail_hooks.straiker import (
+    StraikerGuardrailConfigModel,
+)
+
+from .straiker import StraikerGuardrail
+
+if TYPE_CHECKING:
+    from litellm.types.guardrails import Guardrail, LitellmParams
+
+
+def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"):
+    config_values = {
+        field: value
+        for field in StraikerGuardrailConfigModel.model_fields
+        if field != "optional_params"
+        for value in [getattr(litellm_params, field, None)]
+        if value is not None
+    }
+    config = StraikerGuardrailConfigModel.model_validate(config_values)
+    _callback = StraikerGuardrail(
+        **config.model_dump(exclude={"optional_params"}),
+        guardrail_name=guardrail.get("guardrail_name", "straiker"),
+        event_hook=litellm_params.mode,
+        default_on=litellm_params.default_on,
+    )
+
+    litellm.logging_callback_manager.add_litellm_callback(_callback)
+    return _callback
+
+
+guardrail_initializer_registry = {
+    SupportedGuardrailIntegrations.STRAIKER.value: initialize_guardrail,
+}
+
+guardrail_class_registry = {
+    SupportedGuardrailIntegrations.STRAIKER.value: StraikerGuardrail,
+}

--- a/litellm/proxy/guardrails/guardrail_hooks/straiker/straiker.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/straiker/straiker.py
@@ -1,0 +1,792 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import random
+import time
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+from fastapi import HTTPException
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from litellm.exceptions import BadRequestError, Timeout
+from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+from litellm.llms.custom_httpx.http_handler import (
+    get_async_httpx_client,
+    httpxSpecialProvider,
+)
+from litellm.proxy.common_utils.callback_utils import (
+    get_metadata_variable_name_from_kwargs,
+)
+from litellm.types.guardrails import GuardrailEventHooks
+from litellm.types.utils import CallTypes
+
+if TYPE_CHECKING:
+    from litellm.types.proxy.guardrails.guardrail_hooks.base import GuardrailConfigModel
+
+log = logging.getLogger("straiker.guardrail")
+
+DEFAULT_API_BASE = "https://api.prod.straiker.ai"
+DEFAULT_MAX_PAYLOAD_BYTES = 524288
+RETRY_STATUS = frozenset({408, 429, 500, 502, 503, 504})
+
+
+def _as_dict(value: Any) -> dict:
+    return value if isinstance(value, dict) else {}
+
+
+class DetectResponse(BaseModel):
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    score: float = Field(ge=0.0, le=1.0)
+    turn_id: str | None = Field(default=None, alias="turnId")
+    verdict: bool | None = None
+    explanation: str | None = None
+    debug: dict | None = None
+    custom: dict | None = None
+
+
+DetectResponse.model_rebuild()
+
+
+def _extract_text_content(content: Any) -> str:
+    texts: list[str] = []
+    pending = [content]
+    while pending:
+        value = pending.pop()
+        if isinstance(value, str):
+            if value:
+                texts.append(value)
+            continue
+        if isinstance(value, list):
+            pending.extend(reversed(value))
+            continue
+        if not isinstance(value, dict):
+            continue
+        block_type = value.get("type")
+        if block_type in ("text", "input_text", "output_text"):
+            text = value.get("text")
+            if isinstance(text, str) and text:
+                texts.append(text)
+        elif block_type == "tool_result":
+            pending.append(value.get("content"))
+    return "\n".join(texts)
+
+
+def _last_user_prompt(messages: list[dict]) -> str:
+    for m in reversed(messages or []):
+        if m.get("role") == "user":
+            return _extract_text_content(m.get("content"))
+    return ""
+
+
+def _has_scannable_input(messages: list[dict]) -> bool:
+    return bool(_last_user_prompt(messages)) or any(
+        message.get("role") == "tool" and bool(_extract_text_content(message.get("content")))
+        for message in messages
+        if isinstance(message, dict)
+    )
+
+
+def _get_field(value: Any, field: str) -> Any:
+    if isinstance(value, dict):
+        return value.get(field)
+    return getattr(value, field, None)
+
+
+def _transform_tool_calls(tcs: Any) -> list[dict] | None:
+    if not isinstance(tcs, list):
+        return None
+
+    def transform(tc: Any) -> dict[str, Any]:
+        fn = _get_field(tc, "function") or _get_field(tc, "func")
+        name = _get_field(fn, "name") if fn is not None else _get_field(tc, "name")
+        args = _get_field(fn, "arguments") if fn is not None else _get_field(tc, "input")
+        if isinstance(args, str):
+            try:
+                tool_input = json.loads(args)
+            except (json.JSONDecodeError, TypeError):
+                tool_input = {"_raw": args}
+        else:
+            tool_input = args
+        return {"id": _get_field(tc, "id"), "name": name, "input": tool_input}
+
+    return [transform(tc) for tc in tcs if isinstance(tc, dict) or hasattr(tc, "function")]
+
+
+def _build_agentic_messages(req_messages: list[dict], app_response: str | None) -> list[dict]:
+    out = []
+    for m in req_messages or []:
+        if not isinstance(m, dict):
+            continue
+        content = m.get("content")
+        content_blocks = content if isinstance(content, list) else []
+        tool_results = [
+            block for block in content_blocks if isinstance(block, dict) and block.get("type") == "tool_result"
+        ]
+        native_tool_calls = [
+            block for block in content_blocks if isinstance(block, dict) and block.get("type") == "tool_use"
+        ]
+        text = _extract_text_content(
+            [
+                block
+                for block in content_blocks
+                if not isinstance(block, dict) or block.get("type") not in ("tool_result", "tool_use")
+            ]
+            if content_blocks
+            else content
+        )
+        existing_tool_calls = m.get("tool_calls")
+        tool_calls = [
+            *(existing_tool_calls if isinstance(existing_tool_calls, list) else []),
+            *native_tool_calls,
+        ]
+        entry: dict[str, Any] = {"role": m.get("role")}
+        if text:
+            entry["content"] = text
+        if tool_calls:
+            entry["tool_calls"] = _transform_tool_calls(tool_calls)
+        if m.get("tool_call_id"):
+            entry["tool_call_id"] = m["tool_call_id"]
+        if m.get("name"):
+            entry["tool_name"] = m["name"]
+        elif m.get("tool_name"):
+            entry["tool_name"] = m["tool_name"]
+        if not tool_results or len(entry) > 1:
+            out.append(entry)
+        out.extend(
+            {
+                "role": "tool",
+                "content": _extract_text_content(tool_result.get("content")),
+                "tool_call_id": tool_result.get("tool_use_id"),
+            }
+            for tool_result in tool_results
+        )
+    if app_response and app_response != "N/A":
+        out.append({"role": "assistant", "content": app_response})
+    return out
+
+
+def _has_meaningful_tool_calls(tool_calls: Any) -> bool:
+    if not isinstance(tool_calls, list) or not tool_calls:
+        return False
+    return any(bool(_get_field(_get_field(tc, "function"), "name") or _get_field(tc, "name")) for tc in tool_calls)
+
+
+def _responses_output(response: Any) -> tuple[list[str], list[dict[str, Any]]]:
+    output = _get_field(response, "output")
+    if not isinstance(output, list):
+        return [], []
+    texts = [
+        text
+        for item in output
+        if _get_field(item, "type") == "message"
+        for block in (_get_field(item, "content") or [])
+        if _get_field(block, "type") == "output_text"
+        for text in [_get_field(block, "text")]
+        if isinstance(text, str) and text
+    ]
+    tool_calls = [
+        {
+            "id": _get_field(item, "call_id") or _get_field(item, "id"),
+            "function": {
+                "name": _get_field(item, "name"),
+                "arguments": _get_field(item, "arguments"),
+            },
+        }
+        for item in output
+        if _get_field(item, "type") == "function_call"
+    ]
+    return texts, tool_calls
+
+
+def _structured_log(level: int, event: str, **fields: Any) -> None:
+    payload = {"event": event, **fields}
+    log.log(level, json.dumps(payload, default=str))
+
+
+def _resolve_session_id(data: dict, meta: dict) -> str:
+    requester_metadata = _as_dict(meta.get("requester_metadata"))
+    return (
+        meta.get("session_id")
+        or requester_metadata.get("session_id")
+        or data.get("litellm_call_id")
+        or "litellm-session"
+    )
+
+
+def _resolve_user_name(data: dict, meta: dict) -> str:
+    return meta.get("user_name") or data.get("user") or "litellm"
+
+
+def _resolve_provider(data: dict, model: str | None) -> str | None:
+    litellm_params = _as_dict(data.get("litellm_params"))
+    custom_llm_provider = data.get("custom_llm_provider") or litellm_params.get("custom_llm_provider")
+    if custom_llm_provider:
+        return custom_llm_provider
+    if not model:
+        return None
+    try:
+        _, provider, _, _ = get_llm_provider(
+            model=model,
+            api_base=data.get("api_base") or litellm_params.get("api_base"),
+            api_key=data.get("api_key") or litellm_params.get("api_key"),
+        )
+    except BadRequestError:
+        return None
+    return provider or None
+
+
+def _redact_endpoint(endpoint: str) -> str:
+    try:
+        parsed = urlsplit(endpoint)
+    except (UnicodeError, ValueError):
+        return endpoint.split("#", 1)[0].split("?", 1)[0]
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))
+
+
+def _resolve_destination(data: dict) -> str:
+    litellm_params = _as_dict(data.get("litellm_params"))
+    api_base = data.get("api_base") or litellm_params.get("api_base")
+    if isinstance(api_base, str):
+        try:
+            hostname = urlsplit(api_base).hostname
+        except ValueError:
+            hostname = None
+        if hostname:
+            return hostname
+    return "unknown"
+
+
+def _extract_litellm_context(data: dict, meta: dict) -> dict:
+    proxy_req = _as_dict(data.get("proxy_server_request"))
+    identity_fields = {
+        "key_alias": meta.get("user_api_key_alias"),
+        "key_team": meta.get("user_api_key_team_alias") or meta.get("user_api_key_team_id"),
+        "end_user": meta.get("user_api_key_end_user_id") or data.get("user"),
+        "request_id": data.get("litellm_call_id") or meta.get("litellm_call_id"),
+        "endpoint": proxy_req.get("url") or meta.get("endpoint"),
+    }
+    normalized_identity_fields = {
+        key: _redact_endpoint(value) if key == "endpoint" and isinstance(value, str) else value
+        for key, value in identity_fields.items()
+    }
+    context = {
+        "temperature": data.get("temperature"),
+        "max_tokens": data.get("max_tokens"),
+        "stream": data.get("stream"),
+        "call_type": data.get("call_type") or data.get("litellm_call_type"),
+    }
+    return {
+        **{key: value for key, value in context.items() if value is not None},
+        **normalized_identity_fields,
+    }
+
+
+class StraikerGuardrail(CustomGuardrail):
+    @staticmethod
+    def get_config_model() -> type[GuardrailConfigModel]:
+        from litellm.types.proxy.guardrails.guardrail_hooks.straiker import (
+            StraikerGuardrailConfigModel,
+        )
+
+        return StraikerGuardrailConfigModel
+
+    @classmethod
+    def get_supported_event_hooks(cls) -> list[GuardrailEventHooks]:
+        return [
+            GuardrailEventHooks.pre_call,
+            GuardrailEventHooks.during_call,
+            GuardrailEventHooks.post_call,
+        ]
+
+    def __init__(
+        self,
+        api_key: str,
+        api_base: str = DEFAULT_API_BASE,
+        agentic: bool = False,
+        source: str = "litellm",
+        threshold: float = 0.5,
+        timeout: float = 5.0,
+        unreachable_fallback: str = "fail_closed",
+        max_retries: int = 2,
+        initial_backoff: float = 0.1,
+        max_backoff: float = 2.0,
+        max_payload_bytes: int = DEFAULT_MAX_PAYLOAD_BYTES,
+        custom_headers: dict[str, str] | None = None,
+        verbose: bool = False,
+        dedup_iterations: bool = True,
+        async_handler: httpx.AsyncClient | None = None,
+        **kwargs,
+    ) -> None:
+        if not api_key:
+            raise ValueError("api_key must be non-empty")
+        if unreachable_fallback not in ("fail_open", "fail_closed"):
+            raise ValueError(f"unreachable_fallback must be 'fail_open' or 'fail_closed'; got {unreachable_fallback!r}")
+
+        self.api_key = api_key
+        self.api_base = api_base.rstrip("/")
+        self.agentic = bool(agentic)
+        self.source = source
+        self.threshold = float(threshold)
+        self.timeout = float(timeout)
+        self.unreachable_fallback = unreachable_fallback
+        self.max_retries = max(0, int(max_retries))
+        self.initial_backoff = max(0.0, float(initial_backoff))
+        self.max_backoff = max(self.initial_backoff, float(max_backoff))
+        self.max_payload_bytes = int(max_payload_bytes)
+        self.custom_headers = dict(custom_headers) if custom_headers else {}
+        self.verbose = bool(verbose)
+        self.dedup_iterations = bool(dedup_iterations)
+
+        self.async_handler = async_handler or get_async_httpx_client(
+            llm_provider=httpxSpecialProvider.GuardrailCallback,
+        )
+
+        kwargs.setdefault("supported_event_hooks", list(self.get_supported_event_hooks()))
+        super().__init__(**kwargs)
+
+    def _detect_url(self) -> str:
+        suffix = "?agentic" if self.agentic else ""
+        return f"{self.api_base}/api/v1/detect{suffix}"
+
+    def _agent_source(self, agent_id: str | None) -> str:
+        if agent_id:
+            return agent_id
+        return self.source
+
+    def _build_payload(
+        self,
+        *,
+        messages: list[dict],
+        app_response: str,
+        data: dict,
+        hook: str,
+        finish_reason: str | None = None,
+    ) -> dict:
+        metadata_field = get_metadata_variable_name_from_kwargs(data)
+        metadata_value = data.get(metadata_field)
+        meta = _as_dict(metadata_value)
+        net = _as_dict(meta.get("network"))
+        model = data.get("model", "unknown") or "unknown"
+        litellm_params = _as_dict(data.get("litellm_params"))
+        model_id = litellm_params.get("model") or model
+        provider = _resolve_provider(data, model)
+        destination = _resolve_destination(data)
+        ctx = _extract_litellm_context(data, meta)
+        agent_id = meta.get("agent_id")
+        agent_source = self._agent_source(agent_id)
+        session_id = _resolve_session_id(data, meta)
+        user_name = _resolve_user_name(data, meta)
+        user_role = meta.get("user_role") or "public"
+        trace_id = meta.get("trace_id") or meta.get("litellm_trace_id") or data.get("litellm_trace_id")
+        agent_role = meta.get("agent_role")
+        request_id = data.get("litellm_call_id") or meta.get("litellm_call_id")
+        ip = meta.get("requester_ip_address") or net.get("IP") or "127.0.0.1"
+        ua = meta.get("user_agent") or net.get("User-Agent") or "litellm-proxy"
+        event_type = "during_call" if hook == "moderation" else hook
+
+        network = {"IP": ip, "User-Agent": ua, "Content-Type": "application/json"}
+        hook_tag = f"litellm/{hook}"
+        metadata = {
+            "session_id": session_id,
+            "user_name": user_name,
+            "user_role": user_role,
+            "client_ip": ip,
+            "user_agent": ua,
+            "app_name": agent_source,
+            "gateway": "litellm",
+            "integration": "litellm-straiker",
+            "agent_id": agent_id,
+            "agent_role": agent_role,
+            "model_id": model_id,
+            "model_provider": provider,
+            "event_type": event_type,
+            "litellm_hook": hook,
+            "hook_tag": hook_tag,
+            "trace_id": trace_id,
+            "request_id": request_id,
+            "finish_reason": finish_reason,
+        }
+        metadata = {k: v for k, v in metadata.items() if v is not None}
+        annotations = {
+            "gateway": "litellm",
+            "integration": "litellm-straiker",
+            "source": "litellm",
+            "model": model,
+            "provider": provider,
+            "agent_role": agent_role,
+            "hook": hook,
+            "litellm_hook": hook,
+            "hook_tag": hook_tag,
+            "trace_id": trace_id,
+        }
+        annotations = {k: v for k, v in annotations.items() if v is not None}
+        annotations.update(ctx)
+
+        if self.agentic:
+            return {
+                "source": agent_source,
+                "destination": destination,
+                "messages": _build_agentic_messages(messages, app_response),
+                "session_id": session_id,
+                "user_name": user_name,
+                "user_role": user_role,
+                "metadata": metadata,
+                "network": network,
+                "annotations": annotations,
+            }
+        return {
+            "prompt": _last_user_prompt(messages),
+            "app_response": app_response or "N/A",
+            "rag_content": "N/A",
+            "session_id": session_id,
+            "user_name": user_name,
+            "user_role": user_role,
+            "metadata": metadata,
+            "network": network,
+            "annotations": annotations,
+        }
+
+    def _build_headers(self) -> dict[str, str]:
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "X-Straiker-Smart-Publish": "true",
+        }
+        if self.verbose:
+            headers["Straiker-Debug"] = "TRUE"
+        for k, v in self.custom_headers.items():
+            if k.lower() in ("authorization", "x-straiker-smart-publish"):
+                continue
+            headers[k] = v
+        return headers
+
+    @staticmethod
+    def _triggered_categories(debug_envelope: dict | None) -> list[str]:
+        if not isinstance(debug_envelope, dict):
+            return []
+        detections = debug_envelope.get("detections") or {}
+        block = detections.get("block") or {}
+        if not isinstance(block, dict):
+            return []
+        return sorted(name for name, score in block.items() if isinstance(score, (int, float)) and score > 0)
+
+    async def _call_straiker(self, payload: dict) -> tuple[float | None, str | None, str | None, DetectResponse | None]:
+        try:
+            body_bytes = len(json.dumps(payload, default=str).encode("utf-8"))
+        except (TypeError, ValueError, OverflowError) as error:
+            return None, None, f"request serialization failed: {error}", None
+        if body_bytes > self.max_payload_bytes:
+            return (
+                None,
+                None,
+                (f"payload {body_bytes}B exceeds max_payload_bytes {self.max_payload_bytes}; detection unavailable"),
+                None,
+            )
+
+        url = self._detect_url()
+        headers = self._build_headers()
+        last_err: str | None = None
+        attempts = self.max_retries + 1
+
+        for attempt in range(attempts):
+            t0 = time.monotonic()
+            try:
+                resp = await self.async_handler.post(url, json=payload, headers=headers, timeout=self.timeout)
+                elapsed_ms = int((time.monotonic() - t0) * 1000)
+                if resp.status_code == 200:
+                    try:
+                        parsed = DetectResponse.model_validate(resp.json())
+                    except (ValidationError, json.JSONDecodeError) as ve:
+                        return None, None, f"invalid response schema: {ve}", None
+                    return parsed.score, parsed.turn_id, None, parsed
+                last_err = f"HTTP {resp.status_code}: {resp.text[:200]}"
+                if resp.status_code not in RETRY_STATUS:
+                    return None, None, last_err, None
+            except (httpx.RequestError, asyncio.TimeoutError, Timeout) as e:
+                elapsed_ms = int((time.monotonic() - t0) * 1000)
+                last_err = f"{type(e).__name__}: {e}"
+            except (json.JSONDecodeError, TypeError, ValueError) as e:
+                return None, None, f"{type(e).__name__}: {e}", None
+
+            if attempt < attempts - 1:
+                backoff = min(self.initial_backoff * (2**attempt), self.max_backoff)
+                sleep_s = random.uniform(0, backoff)
+                _structured_log(
+                    logging.DEBUG,
+                    "straiker.retry",
+                    attempt=attempt + 1,
+                    max_attempts=attempts,
+                    error=last_err,
+                    sleep_s=round(sleep_s, 3),
+                    elapsed_ms=elapsed_ms,
+                )
+                await asyncio.sleep(sleep_s)
+
+        return None, None, last_err or "unknown error", None
+
+    def _should_dedup_pre(self, msgs: list[dict]) -> bool:
+        if not (self.agentic and self.dedup_iterations):
+            return False
+        last = msgs[-1] if msgs else {}
+        last_role = last.get("role") if isinstance(last, dict) else None
+        return last_role not in ("user", "tool")
+
+    def _messages_for_call(self, data: dict, call_type: str) -> list[dict]:
+        try:
+            normalized = self.get_guardrails_messages_for_call_type(call_type=CallTypes(call_type), data=data)
+        except (TypeError, ValueError):
+            normalized = None
+        return normalized if normalized is not None else data.get("messages") or []
+
+    def _build_block_detail(
+        self,
+        hook_label: str,
+        score: float | None,
+        turn_id: str | None,
+        triggered: list[str],
+        debug_envelope: dict | None,
+    ) -> dict:
+        detail = {
+            "message": f"Straiker: threat detected ({hook_label})",
+            "score": score,
+            "turn_id": turn_id,
+            "code": "403",
+            "x-straiker-score": score,
+            "x-straiker-turn-id": turn_id,
+            "x-straiker-verdict": "block",
+        }
+        if self.verbose:
+            detail["x-straiker-triggered-categories"] = triggered
+            detail["straiker_debug"] = debug_envelope
+        return detail
+
+    def _raise_unavailable(self) -> None:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "error": {
+                    "message": "Straiker detection unavailable",
+                    "code": "503",
+                    "x-straiker-verdict": "error",
+                }
+            },
+        )
+
+    async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
+        msgs = self._messages_for_call(data, call_type)
+        if not _has_scannable_input(msgs):
+            return data
+
+        model = data.get("model")
+        if self._should_dedup_pre(msgs):
+            return data
+
+        payload = self._build_payload(messages=msgs, app_response="N/A", data=data, hook="pre_call")
+        t0 = time.monotonic()
+        score, turn_id, err, parsed = await self._call_straiker(payload)
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+
+        if err is not None:
+            _structured_log(
+                logging.ERROR,
+                "straiker.error",
+                hook="pre_call",
+                error=err,
+                fallback=self.unreachable_fallback,
+                elapsed_ms=elapsed_ms,
+            )
+            if self.unreachable_fallback == "fail_open":
+                return data
+            self._raise_unavailable()
+
+        verdict = "block" if (score is not None and score > self.threshold) else "allow"
+        debug_envelope = getattr(parsed, "debug", None) if parsed is not None else None
+        triggered = self._triggered_categories(debug_envelope)
+        _structured_log(
+            logging.INFO,
+            "straiker.score",
+            hook="pre_call",
+            score=score,
+            turn_id=turn_id,
+            verdict=verdict,
+            execution_ms=elapsed_ms,
+            model=model,
+            triggered_categories=triggered or None,
+        )
+
+        if verdict == "block":
+            detail = self._build_block_detail("pre-call", score, turn_id, triggered, debug_envelope)
+            raise HTTPException(status_code=403, detail={"error": detail})
+        return data
+
+    async def async_moderation_hook(self, data, user_api_key_dict, call_type):
+        msgs = self._messages_for_call(data, call_type)
+        if not _has_scannable_input(msgs):
+            return data
+
+        model = data.get("model")
+        if self._should_dedup_pre(msgs):
+            return data
+
+        payload = self._build_payload(messages=msgs, app_response="N/A", data=data, hook="moderation")
+        t0 = time.monotonic()
+        score, turn_id, err, parsed = await self._call_straiker(payload)
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+
+        if err is not None:
+            _structured_log(
+                logging.ERROR,
+                "straiker.error",
+                hook="moderation",
+                error=err,
+                fallback=self.unreachable_fallback,
+                elapsed_ms=elapsed_ms,
+            )
+            if self.unreachable_fallback == "fail_open":
+                return data
+            self._raise_unavailable()
+
+        verdict = "block" if (score is not None and score > self.threshold) else "allow"
+        debug_envelope = getattr(parsed, "debug", None) if parsed is not None else None
+        triggered = self._triggered_categories(debug_envelope)
+        _structured_log(
+            logging.INFO,
+            "straiker.score",
+            hook="moderation",
+            score=score,
+            turn_id=turn_id,
+            verdict=verdict,
+            execution_ms=elapsed_ms,
+            model=model,
+            triggered_categories=triggered or None,
+        )
+
+        if verdict == "block":
+            detail = self._build_block_detail("during-call", score, turn_id, triggered, debug_envelope)
+            raise HTTPException(status_code=403, detail={"error": detail})
+        return data
+
+    async def async_post_call_success_hook(self, data, user_api_key_dict, response):
+        output = _get_field(response, "output")
+        is_responses_response = isinstance(output, list) and _get_field(response, "choices") is None
+        raw_call_type = data.get("call_type") or data.get("litellm_call_type")
+        call_type = raw_call_type if isinstance(raw_call_type, str) else "responses" if is_responses_response else ""
+        msgs = list(self._messages_for_call(data, call_type))
+        if not _has_scannable_input(msgs):
+            return response
+
+        model = data.get("model")
+        if is_responses_response:
+            response_texts, response_tool_calls = _responses_output(response)
+        else:
+            response_messages = [
+                message
+                for choice in (_get_field(response, "choices") or [])
+                for message in [_get_field(choice, "message")]
+                if message is not None
+            ]
+            response_texts = [
+                text
+                for message in response_messages
+                for text in [_extract_text_content(_get_field(message, "content"))]
+                if text
+            ]
+            response_tool_calls = [
+                tool_call for message in response_messages for tool_call in (_get_field(message, "tool_calls") or [])
+            ]
+        app_response = "\n".join(response_texts)
+
+        if not app_response and not _has_meaningful_tool_calls(response_tool_calls):
+            return response
+
+        finish_reason = "tool_calls" if _has_meaningful_tool_calls(response_tool_calls) else None
+        if finish_reason is None:
+            if is_responses_response:
+                finish_reason = (
+                    "stop"
+                    if any(_get_field(item, "status") == "completed" for item in output if item is not None)
+                    else None
+                )
+            else:
+                finish_reason = next(
+                    (
+                        reason
+                        for choice in (_get_field(response, "choices") or [])
+                        for reason in [_get_field(choice, "finish_reason")]
+                        if isinstance(reason, str) and reason
+                    ),
+                    None,
+                )
+
+        assistant_message: dict[str, Any] = {"role": "assistant"}
+        if app_response:
+            assistant_message["content"] = app_response
+        if response_tool_calls:
+            assistant_message["tool_calls"] = response_tool_calls
+        msgs.append(assistant_message)
+
+        normalized_tool_calls = _transform_tool_calls(response_tool_calls) or []
+        non_agentic_response = "\n".join(
+            part
+            for part in (
+                app_response,
+                json.dumps(normalized_tool_calls, default=str) if normalized_tool_calls else "",
+            )
+            if part
+        )
+        payload = self._build_payload(
+            messages=msgs,
+            app_response="N/A" if self.agentic else non_agentic_response,
+            data=data,
+            hook="post_call",
+            finish_reason=finish_reason,
+        )
+        t0 = time.monotonic()
+        score, turn_id, err, parsed = await self._call_straiker(payload)
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+
+        if err is not None:
+            _structured_log(
+                logging.ERROR,
+                "straiker.error",
+                hook="post_call",
+                error=err,
+                fallback=self.unreachable_fallback,
+                elapsed_ms=elapsed_ms,
+            )
+            return response
+
+        verdict = "block" if (score is not None and score > self.threshold) else "allow"
+        debug_envelope = getattr(parsed, "debug", None) if parsed is not None else None
+        triggered = self._triggered_categories(debug_envelope)
+        _structured_log(
+            logging.INFO,
+            "straiker.score",
+            hook="post_call",
+            score=score,
+            turn_id=turn_id,
+            verdict=verdict,
+            execution_ms=elapsed_ms,
+            model=model,
+            triggered_categories=triggered or None,
+        )
+
+        if hasattr(response, "_hidden_params") and isinstance(response._hidden_params, dict):
+            hidden = {
+                "score": score,
+                "turn_id": turn_id,
+                "verdict": verdict,
+            }
+            if self.verbose:
+                hidden["triggered_categories"] = triggered
+                hidden["straiker_debug"] = debug_envelope
+            straiker_hidden = response._hidden_params.setdefault("straiker", {})
+            if isinstance(straiker_hidden, dict):
+                straiker_hidden.update(hidden)
+        return response

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -123,6 +123,7 @@ class SupportedGuardrailIntegrations(Enum):
     VIGIL_GUARD = "vigil_guard"
     REPELLOAI = "repelloai"
     HEADROOM = "headroom"
+    STRAIKER = "straiker"
 
 
 class Role(Enum):

--- a/litellm/types/proxy/guardrails/guardrail_hooks/straiker.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/straiker.py
@@ -1,0 +1,98 @@
+from typing import Dict, Literal, Optional
+
+from pydantic import Field
+
+from .base import GuardrailConfigModel
+
+
+class StraikerGuardrailConfigModel(GuardrailConfigModel):
+    api_key: str = Field(
+        min_length=1,
+        description="Straiker DefendAI API key (Bearer token). Env: STRAIKER_API_KEY.",
+        json_schema_extra={"secret": True},
+    )
+
+    api_base: str = Field(
+        default="https://api.prod.straiker.ai",
+        description="Straiker API base URL. Use the regional variant for non-US tenants.",
+    )
+
+    agentic: bool = Field(
+        default=False,
+        description=(
+            "When true, posts the full messages[] (with tool_calls + tool results) to "
+            "/api/v1/detect for multi-turn / tool-using agents."
+        ),
+    )
+
+    source: str = Field(
+        default="litellm",
+        description="Application name registered in the Straiker Defend Console.",
+    )
+
+    threshold: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description="Block when score > threshold. post_call is observability-only and never blocks.",
+    )
+
+    timeout: float = Field(
+        default=5.0,
+        gt=0.0,
+        description="Per-attempt HTTP timeout in seconds.",
+    )
+
+    max_retries: int = Field(
+        default=2,
+        ge=0,
+        description="Retries on transient HTTP (408/429/5xx) and network errors.",
+    )
+
+    initial_backoff: float = Field(
+        default=0.1,
+        ge=0.0,
+        description="Initial retry backoff in seconds.",
+    )
+
+    max_backoff: float = Field(
+        default=2.0,
+        ge=0.0,
+        description="Maximum retry backoff in seconds.",
+    )
+
+    unreachable_fallback: Literal["fail_open", "fail_closed"] = Field(
+        default="fail_closed",
+        description="Behavior when Straiker is unreachable after retries.",
+    )
+
+    max_payload_bytes: int = Field(
+        default=524288,
+        gt=0,
+        description="Maximum serialized request payload size sent to Straiker.",
+    )
+
+    custom_headers: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Additional HTTP headers sent to Straiker, excluding Authorization.",
+    )
+
+    verbose: bool = Field(
+        default=False,
+        description=(
+            "Sends Straiker-Debug header; block responses include the full per-category "
+            "detection envelope and triggered_categories."
+        ),
+    )
+
+    dedup_iterations: bool = Field(
+        default=True,
+        description=(
+            "Suppress assistant-only pre-call and during-call continuations in agentic mode. "
+            "User turns, tool results, and completed outputs are still scored."
+        ),
+    )
+
+    @staticmethod
+    def ui_friendly_name() -> str:
+        return "Straiker"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_straiker.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_straiker.py
@@ -1,0 +1,1147 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import litellm
+import httpx
+import pytest
+from pydantic import ValidationError
+from starlette.exceptions import HTTPException
+
+from litellm.proxy.guardrails.guardrail_hooks.straiker import initialize_guardrail
+from litellm.proxy.guardrails.guardrail_hooks.straiker.straiker import (
+    StraikerGuardrail,
+    _has_meaningful_tool_calls,
+    _last_user_prompt,
+    _resolve_provider,
+    _resolve_session_id,
+    _resolve_user_name,
+)
+from litellm.proxy.guardrails.guardrail_registry import (
+    guardrail_class_registry,
+    guardrail_initializer_registry,
+)
+from litellm.types.guardrails import GuardrailEventHooks, LitellmParams
+from litellm.types.llms.openai import ResponsesAPIResponse
+from litellm.types.proxy.guardrails.guardrail_hooks.straiker import (
+    StraikerGuardrailConfigModel,
+)
+from litellm.types.utils import (
+    ChatCompletionMessageToolCall,
+    Choices,
+    Function,
+    Message,
+    ModelResponse,
+)
+
+
+def _mock_response(score: float, debug: dict = None) -> MagicMock:
+    body = {"score": score, "turnId": "test-turn-id"}
+    if debug is not None:
+        body["debug"] = debug
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = 200
+    resp.json.return_value = body
+    resp.text = ""
+    return resp
+
+
+def _make_guardrail(**overrides) -> StraikerGuardrail:
+    defaults = {
+        "api_key": "test-key",
+        "api_base": "https://test.straiker.ai",
+        "threshold": 0.5,
+        "max_retries": 0,
+        "guardrail_name": "straiker-pre",
+        "event_hook": "pre_call",
+        "async_handler": MagicMock(spec=httpx.AsyncClient),
+        "verbose": True,
+    }
+    defaults.update(overrides)
+    g = StraikerGuardrail(**defaults)
+    g.async_handler.post = AsyncMock()
+    return g
+
+
+def test_straiker_in_initializer_registry():
+    assert "straiker" in guardrail_initializer_registry
+
+
+def test_straiker_in_class_registry():
+    assert "straiker" in guardrail_class_registry
+    assert guardrail_class_registry["straiker"] is StraikerGuardrail
+
+
+def test_ui_friendly_name():
+    assert StraikerGuardrailConfigModel.ui_friendly_name() == "Straiker"
+    assert StraikerGuardrail.get_config_model() is StraikerGuardrailConfigModel
+
+
+def test_invalid_unreachable_fallback_rejected_at_init():
+    with pytest.raises(ValueError):
+        StraikerGuardrail(api_key="test", unreachable_fallback="invalid")
+
+
+@pytest.mark.asyncio
+async def test_pre_call_blocks_when_score_above_threshold():
+    g = _make_guardrail()
+    g.async_handler.post.return_value = _mock_response(0.9, debug={"detections": {"block": {"prompt_injection": 1}}})
+    data = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "test prompt"}],
+    }
+    with pytest.raises(HTTPException) as exc:
+        await g.async_pre_call_hook(user_api_key_dict=None, cache=None, data=data, call_type="completion")
+    assert exc.value.status_code == 403
+    err = exc.value.detail["error"]
+    assert err["x-straiker-verdict"] == "block"
+    assert err["x-straiker-score"] == 0.9
+    assert err["x-straiker-triggered-categories"] == ["prompt_injection"]
+
+
+@pytest.mark.asyncio
+async def test_pre_call_allows_when_score_below_threshold():
+    g = _make_guardrail()
+    g.async_handler.post.return_value = _mock_response(0.1)
+    data = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "benign"}],
+    }
+    result = await g.async_pre_call_hook(user_api_key_dict=None, cache=None, data=data, call_type="completion")
+    assert result is data
+
+
+@pytest.mark.asyncio
+async def test_pre_call_fail_open_returns_data_when_straiker_unreachable():
+    g = _make_guardrail(unreachable_fallback="fail_open")
+    g.async_handler.post.side_effect = httpx.ConnectError("boom")
+    data = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "x"}]}
+    result = await g.async_pre_call_hook(user_api_key_dict=None, cache=None, data=data, call_type="completion")
+    assert result is data
+
+
+@pytest.mark.asyncio
+async def test_pre_call_fail_closed_raises_503_when_straiker_unreachable():
+    g = _make_guardrail(unreachable_fallback="fail_closed")
+    g.async_handler.post.side_effect = httpx.ConnectError("boom")
+    data = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "x"}]}
+    with pytest.raises(HTTPException) as exc:
+        await g.async_pre_call_hook(user_api_key_dict=None, cache=None, data=data, call_type="completion")
+    assert exc.value.status_code == 503
+    assert exc.value.detail["error"]["x-straiker-verdict"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_pre_call_litellm_timeout_uses_fail_closed_fallback():
+    g = _make_guardrail(unreachable_fallback="fail_closed")
+    g.async_handler.post.side_effect = litellm.Timeout(
+        message="Straiker timed out",
+        model="straiker",
+        llm_provider="straiker",
+    )
+    data = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "x"}]}
+
+    with pytest.raises(HTTPException) as exc:
+        await g.async_pre_call_hook(user_api_key_dict=None, cache=None, data=data, call_type="completion")
+
+    assert exc.value.status_code == 503
+    assert exc.value.detail["error"]["x-straiker-verdict"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_pre_call_retries_transient_failure_then_succeeds():
+    g = _make_guardrail(max_retries=1, initial_backoff=0, max_backoff=0)
+    transient_response = MagicMock(spec=httpx.Response)
+    transient_response.status_code = 503
+    transient_response.text = "temporarily unavailable"
+    g.async_handler.post.side_effect = [transient_response, _mock_response(0.1)]
+    data = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "x"}]}
+
+    result = await g.async_pre_call_hook(user_api_key_dict=None, cache=None, data=data, call_type="completion")
+
+    assert result is data
+    assert g.async_handler.post.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_pre_call_missing_score_uses_fail_closed_fallback():
+    g = _make_guardrail(unreachable_fallback="fail_closed")
+    g.async_handler.post.return_value = _mock_response(0.1)
+    g.async_handler.post.return_value.json.return_value = {"turnId": "missing-score"}
+    data = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "x"}]}
+
+    with pytest.raises(HTTPException) as exc:
+        await g.async_pre_call_hook(user_api_key_dict=None, cache=None, data=data, call_type="completion")
+
+    assert exc.value.status_code == 503
+    assert exc.value.detail["error"]["message"] == "Straiker detection unavailable"
+    assert "missing-score" not in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_pre_call_serialization_type_error_uses_generic_fail_closed_response():
+    g = _make_guardrail(unreachable_fallback="fail_closed")
+    g.async_handler.post.side_effect = TypeError("raw serialization detail")
+    data = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "x"}]}
+
+    with pytest.raises(HTTPException) as exc:
+        await g.async_pre_call_hook(user_api_key_dict=None, cache=None, data=data, call_type="completion")
+
+    assert exc.value.status_code == 503
+    assert exc.value.detail["error"]["message"] == "Straiker detection unavailable"
+    assert "raw serialization detail" not in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_pre_call_vendor_error_body_is_not_reflected():
+    g = _make_guardrail(unreachable_fallback="fail_closed")
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = 400
+    response.text = "vendor secret detail"
+    g.async_handler.post.return_value = response
+    data = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "x"}]}
+
+    with pytest.raises(HTTPException) as exc:
+        await g.async_pre_call_hook(user_api_key_dict=None, cache=None, data=data, call_type="completion")
+
+    assert exc.value.detail["error"]["message"] == "Straiker detection unavailable"
+    assert "vendor secret detail" not in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_agentic_dedup_scans_pre_when_last_role_is_tool():
+    g = _make_guardrail(agentic=True, dedup_iterations=True)
+    g.async_handler.post.return_value = _mock_response(0.1)
+    data = {
+        "model": "gpt-4o-mini",
+        "messages": [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "calling tool"},
+            {"role": "tool", "content": "tool result"},
+        ],
+    }
+    result = await g.async_pre_call_hook(user_api_key_dict=None, cache=None, data=data, call_type="completion")
+    assert result is data
+    g.async_handler.post.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_agentic_dedup_suppresses_assistant_only_continuation():
+    g = _make_guardrail(agentic=True, dedup_iterations=True)
+    data = {
+        "model": "gpt-4o-mini",
+        "messages": [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "continuing"},
+        ],
+    }
+
+    result = await g.async_pre_call_hook(user_api_key_dict=None, cache=None, data=data, call_type="completion")
+
+    assert result is data
+    g.async_handler.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_agentic_dedup_disabled_scans_assistant_continuation():
+    g = _make_guardrail(agentic=True, dedup_iterations=False)
+    g.async_handler.post.return_value = _mock_response(0.1)
+    data = {
+        "model": "gpt-4o-mini",
+        "messages": [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "continuing"},
+        ],
+    }
+    await g.async_pre_call_hook(user_api_key_dict=None, cache=None, data=data, call_type="completion")
+    g.async_handler.post.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_oversized_payload_fail_open_bypasses_detection():
+    g = _make_guardrail(max_payload_bytes=100, unreachable_fallback="fail_open")
+    huge_content = "x" * 1000
+    data = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": huge_content}],
+    }
+    result = await g.async_pre_call_hook(user_api_key_dict=None, cache=None, data=data, call_type="completion")
+    assert result is data
+    g.async_handler.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_oversized_payload_fail_closed_raises_503():
+    g = _make_guardrail(max_payload_bytes=100, unreachable_fallback="fail_closed")
+    data = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "x" * 1000}],
+    }
+
+    with pytest.raises(HTTPException) as exc:
+        await g.async_pre_call_hook(user_api_key_dict=None, cache=None, data=data, call_type="completion")
+
+    assert exc.value.status_code == 503
+    assert "detection unavailable" in exc.value.detail["error"]["message"]
+    g.async_handler.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pre_call_normalizes_responses_api_input():
+    g = _make_guardrail()
+    g.async_handler.post.return_value = _mock_response(0.1)
+    data = {"model": "gpt-4o-mini", "input": "responses api prompt"}
+
+    result = await g.async_pre_call_hook(user_api_key_dict=None, cache=None, data=data, call_type="responses")
+
+    assert result is data
+    payload = g.async_handler.post.call_args.kwargs["json"]
+    assert payload["prompt"] == "responses api prompt"
+
+
+@pytest.mark.asyncio
+async def test_agentic_request_uses_configured_api_base_and_protected_headers():
+    g = _make_guardrail(
+        api_base="https://detect.example/",
+        agentic=True,
+        custom_headers={
+            "authorization": "Bearer untrusted",
+            "X-Straiker-Smart-Publish": "false",
+            "X-Tenant": "tenant-1",
+        },
+    )
+    g.async_handler.post.return_value = _mock_response(0.1)
+    data = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "x"}]}
+
+    await g.async_pre_call_hook(user_api_key_dict=None, cache=None, data=data, call_type="completion")
+
+    assert g.async_handler.post.call_args.args == ("https://detect.example/api/v1/detect?agentic",)
+    assert g.async_handler.post.call_args.kwargs["headers"] == {
+        "Authorization": "Bearer test-key",
+        "Content-Type": "application/json",
+        "X-Straiker-Smart-Publish": "true",
+        "Straiker-Debug": "TRUE",
+        "X-Tenant": "tenant-1",
+    }
+    assert g.async_handler.post.call_args.kwargs["timeout"] == 5.0
+    metadata = g.async_handler.post.call_args.kwargs["json"]["metadata"]
+    assert metadata["event_type"] == "pre_call"
+    assert "finish_reason" not in metadata
+
+
+@pytest.mark.asyncio
+async def test_pre_call_sends_app_session_id_when_provided():
+    g = _make_guardrail()
+    g.async_handler.post.return_value = _mock_response(0.1)
+    data = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "x"}],
+        "metadata": {"session_id": "my-app-session-42"},
+    }
+    await g.async_pre_call_hook(user_api_key_dict=None, cache=None, data=data, call_type="completion")
+    sent_payload = g.async_handler.post.call_args.kwargs["json"]
+    assert sent_payload["session_id"] == "my-app-session-42"
+
+
+@pytest.mark.asyncio
+async def test_pre_call_falls_back_to_litellm_call_id_when_no_app_session():
+    g = _make_guardrail()
+    g.async_handler.post.return_value = _mock_response(0.1)
+    data = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "x"}],
+        "litellm_call_id": "litellm-uuid-abc-123",
+    }
+    await g.async_pre_call_hook(user_api_key_dict=None, cache=None, data=data, call_type="completion")
+    sent_payload = g.async_handler.post.call_args.kwargs["json"]
+    assert sent_payload["session_id"] == "litellm-uuid-abc-123"
+
+
+@pytest.mark.asyncio
+async def test_pre_call_falls_back_to_placeholder_when_no_session_id_anywhere():
+    g = _make_guardrail()
+    g.async_handler.post.return_value = _mock_response(0.1)
+    data = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "x"}]}
+    await g.async_pre_call_hook(user_api_key_dict=None, cache=None, data=data, call_type="completion")
+    sent_payload = g.async_handler.post.call_args.kwargs["json"]
+    assert sent_payload["session_id"] == "litellm-session"
+
+
+def test_resolve_session_id_precedence():
+    assert _resolve_session_id({}, {"session_id": "from-meta"}) == "from-meta"
+    assert (
+        _resolve_session_id(
+            {"litellm_call_id": "from-call"},
+            {"requester_metadata": {"session_id": "from-requester"}},
+        )
+        == "from-requester"
+    )
+    data = {
+        "litellm_metadata": {"session_id": "from-litellm-meta"},
+        "litellm_call_id": "from-call",
+    }
+    assert _resolve_session_id(data, data["litellm_metadata"]) == "from-litellm-meta"
+    assert _resolve_session_id({"litellm_call_id": "from-call"}, {}) == "from-call"
+    assert _resolve_session_id({}, {}) == "litellm-session"
+
+
+def test_resolve_user_name_precedence():
+    assert _resolve_user_name({}, {"user_name": "explicit"}) == "explicit"
+    assert _resolve_user_name({"user": "from-data"}, {}) == "from-data"
+    assert _resolve_user_name({}, {}) == "litellm"
+
+
+def test_last_user_prompt_returns_most_recent_user_turn():
+    msgs = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "response"},
+        {"role": "user", "content": "second"},
+    ]
+    assert _last_user_prompt(msgs) == "second"
+
+
+def test_last_user_prompt_handles_multimodal_content():
+    msgs = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "first"},
+                {"type": "image_url", "image_url": {"url": "https://example.test"}},
+                {"type": "text", "text": "second"},
+            ],
+        }
+    ]
+    assert _last_user_prompt(msgs) == "first\nsecond"
+
+
+def test_last_user_prompt_handles_deeply_nested_content_without_recursion():
+    content = {"type": "text", "text": "deep"}
+    for _ in range(2000):
+        content = [content]
+
+    assert _last_user_prompt([{"role": "user", "content": content}]) == "deep"
+
+
+def test_last_user_prompt_returns_empty_when_no_user_turn():
+    assert _last_user_prompt([{"role": "assistant", "content": "x"}]) == ""
+    assert _last_user_prompt([]) == ""
+
+
+def test_has_meaningful_tool_calls_requires_function_name():
+    assert _has_meaningful_tool_calls([{"function": {"name": "get_weather"}}]) is True
+    assert _has_meaningful_tool_calls([{"name": "get_weather"}]) is True
+    assert _has_meaningful_tool_calls([{"function": {}}]) is False
+    assert _has_meaningful_tool_calls([]) is False
+    assert _has_meaningful_tool_calls(None) is False
+
+
+def test_has_meaningful_tool_calls_supports_litellm_objects():
+    tool_call = ChatCompletionMessageToolCall(
+        id="call-1",
+        function=Function(name="get_weather", arguments='{"city":"Paris"}'),
+    )
+
+    assert _has_meaningful_tool_calls([tool_call]) is True
+
+
+@pytest.mark.asyncio
+async def test_during_call_blocks_when_score_above_threshold():
+    g = _make_guardrail(event_hook="during_call")
+    g.async_handler.post.return_value = _mock_response(0.9)
+    data = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "test prompt"}]}
+
+    with pytest.raises(HTTPException) as exc:
+        await g.async_moderation_hook(data=data, user_api_key_dict=None, call_type="completion")
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail["error"]["message"] == "Straiker: threat detected (during-call)"
+    assert g.async_handler.post.call_args.kwargs["json"]["annotations"]["hook"] == "moderation"
+    assert g.async_handler.post.call_args.kwargs["json"]["metadata"]["event_type"] == "during_call"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("hook", ["pre", "during"])
+async def test_anthropic_tool_result_is_scanned_and_tool_use_is_preserved(hook):
+    g = _make_guardrail(agentic=True, dedup_iterations=True)
+    g.async_handler.post.return_value = _mock_response(0.1)
+    data = {
+        "model": "anthropic/claude-sonnet-4-5",
+        "messages": [
+            {"role": "user", "content": "look this up"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "checking"},
+                    {
+                        "type": "tool_use",
+                        "id": "tool-1",
+                        "name": "lookup",
+                        "input": {"query": "sensitive"},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool-1",
+                        "content": [{"type": "text", "text": "tool secret"}],
+                    }
+                ],
+            },
+        ],
+    }
+
+    if hook == "pre":
+        result = await g.async_pre_call_hook(
+            user_api_key_dict=None,
+            cache=None,
+            data=data,
+            call_type="anthropic_messages",
+        )
+    else:
+        result = await g.async_moderation_hook(
+            data=data,
+            user_api_key_dict=None,
+            call_type="anthropic_messages",
+        )
+
+    assert result is data
+    assert g.async_handler.post.call_args.kwargs["json"]["messages"] == [
+        {"role": "user", "content": "look this up"},
+        {
+            "role": "assistant",
+            "content": "checking",
+            "tool_calls": [
+                {
+                    "id": "tool-1",
+                    "name": "lookup",
+                    "input": {"query": "sensitive"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "content": "tool secret",
+            "tool_call_id": "tool-1",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_post_call_combines_all_choices_and_tool_calls_once():
+    g = _make_guardrail(agentic=True)
+    g.async_handler.post.return_value = _mock_response(0.1)
+    response = ModelResponse(
+        choices=[
+            Choices(
+                index=0,
+                message=Message(
+                    role="assistant",
+                    content="first",
+                    tool_calls=[
+                        ChatCompletionMessageToolCall(
+                            id="call-1",
+                            function=Function(name="get_weather", arguments='{"city":"Paris"}'),
+                        )
+                    ],
+                ),
+            ),
+            Choices(
+                index=1,
+                message=Message(
+                    role="assistant",
+                    content="second",
+                    tool_calls=[
+                        ChatCompletionMessageToolCall(
+                            id="call-2",
+                            function=Function(name="get_time", arguments="not-json"),
+                        )
+                    ],
+                ),
+            ),
+        ]
+    )
+    data = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "question"}],
+    }
+
+    result = await g.async_post_call_success_hook(data=data, user_api_key_dict=None, response=response)
+
+    assert result is response
+    g.async_handler.post.assert_called_once()
+    payload = g.async_handler.post.call_args.kwargs["json"]
+    assert payload["messages"] == [
+        {"role": "user", "content": "question"},
+        {
+            "role": "assistant",
+            "content": "first\nsecond",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "name": "get_weather",
+                    "input": {"city": "Paris"},
+                },
+                {
+                    "id": "call-2",
+                    "name": "get_time",
+                    "input": {"_raw": "not-json"},
+                },
+            ],
+        },
+    ]
+    assert payload["metadata"]["finish_reason"] == "tool_calls"
+
+
+@pytest.mark.asyncio
+async def test_post_call_sends_provider_finish_reason_for_final_response():
+    g = _make_guardrail(agentic=True)
+    g.async_handler.post.return_value = _mock_response(0.1)
+    response = ModelResponse(
+        choices=[
+            Choices(
+                index=0,
+                finish_reason="stop",
+                message=Message(role="assistant", content="done"),
+            )
+        ]
+    )
+    data = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "question"}],
+    }
+
+    await g.async_post_call_success_hook(data=data, user_api_key_dict=None, response=response)
+
+    payload = g.async_handler.post.call_args.kwargs["json"]
+    assert payload["metadata"]["finish_reason"] == "stop"
+    assert payload["metadata"]["event_type"] == "post_call"
+
+
+@pytest.mark.asyncio
+async def test_post_call_fail_closed_returns_response_for_malformed_detection():
+    g = _make_guardrail(unreachable_fallback="fail_closed")
+    g.async_handler.post.return_value = _mock_response(0.1)
+    g.async_handler.post.return_value.json.return_value = {"turnId": "missing-score"}
+    response = ModelResponse(
+        choices=[
+            Choices(
+                index=0,
+                message=Message(role="assistant", content="provider response"),
+            )
+        ]
+    )
+    data = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "question"}],
+    }
+
+    result = await g.async_post_call_success_hook(data=data, user_api_key_dict=None, response=response)
+
+    assert result is response
+    assert result.choices[0].message.content == "provider response"
+
+
+@pytest.mark.asyncio
+async def test_post_call_oversized_payload_remains_observability_only():
+    g = _make_guardrail(max_payload_bytes=100, unreachable_fallback="fail_closed")
+    response = ModelResponse(
+        choices=[
+            Choices(
+                index=0,
+                message=Message(role="assistant", content="provider response"),
+            )
+        ]
+    )
+    data = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "x" * 1000}],
+    }
+
+    result = await g.async_post_call_success_hook(data=data, user_api_key_dict=None, response=response)
+
+    assert result is response
+    assert result.choices[0].message.content == "provider response"
+    g.async_handler.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_post_call_normalizes_malformed_nested_metadata_and_endpoint():
+    g = _make_guardrail(agentic=True)
+    g.async_handler.post.return_value = _mock_response(0.1)
+    response = ModelResponse(
+        choices=[
+            Choices(
+                index=0,
+                message=Message(role="assistant", content="provider response"),
+            )
+        ]
+    )
+    data = {
+        "model": "openai/gpt-4o-mini",
+        "messages": [{"role": "user", "content": "question"}],
+        "litellm_metadata": {
+            "network": "malformed",
+            "requester_metadata": ["malformed"],
+            "endpoint": "https://[invalid?token=secret#fragment",
+        },
+        "proxy_server_request": "malformed",
+    }
+
+    result = await g.async_post_call_success_hook(data=data, user_api_key_dict=None, response=response)
+
+    assert result is response
+    payload = g.async_handler.post.call_args.kwargs["json"]
+    assert payload["network"]["IP"] == "127.0.0.1"
+    assert payload["annotations"]["endpoint"] == "https://[invalid"
+
+
+@pytest.mark.asyncio
+async def test_post_call_scans_real_responses_api_output_once():
+    g = _make_guardrail(agentic=True)
+    g.async_handler.post.return_value = _mock_response(0.1)
+    response = ResponsesAPIResponse(
+        id="resp-1",
+        created_at=0,
+        output=[
+            {
+                "type": "message",
+                "id": "msg-1",
+                "status": "completed",
+                "role": "assistant",
+                "content": [
+                    {"type": "output_text", "text": "first"},
+                    {"type": "output_text", "text": "second"},
+                ],
+            },
+            {
+                "type": "function_call",
+                "id": "fc-1",
+                "call_id": "call-1",
+                "name": "lookup",
+                "arguments": '{"query":"secret"}',
+            },
+        ],
+    )
+    data = {
+        "model": "openai/gpt-4o-mini",
+        "call_type": "responses",
+        "input": "question",
+    }
+
+    result = await g.async_post_call_success_hook(data=data, user_api_key_dict=None, response=response)
+
+    assert result is response
+    g.async_handler.post.assert_called_once()
+    assert g.async_handler.post.call_args.kwargs["json"]["messages"] == [
+        {"role": "user", "content": "question"},
+        {
+            "role": "assistant",
+            "content": "first\nsecond",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "name": "lookup",
+                    "input": {"query": "secret"},
+                }
+            ],
+        },
+    ]
+    assert g.async_handler.post.call_args.kwargs["json"]["metadata"]["finish_reason"] == "tool_calls"
+
+
+def test_agent_id_is_used_as_source_and_app_name():
+    g = _make_guardrail(agentic=True, source="litellm-gw")
+    payload = g._build_payload(
+        messages=[{"role": "user", "content": "hi"}],
+        app_response="N/A",
+        data={
+            "model": "openai/gpt-4o-mini",
+            "litellm_metadata": {"agent_id": "agent-one"},
+        },
+        hook="pre_call",
+    )
+    assert payload["source"] == "agent-one"
+    assert payload["metadata"]["app_name"] == "agent-one"
+    assert "agent_role" not in payload["metadata"]
+    assert "agent_role" not in payload["annotations"]
+
+
+def test_two_agent_ids_sharing_one_model_remain_distinct():
+    g = _make_guardrail(agentic=True, source="litellm-gw")
+    identities = {
+        (
+            payload["source"],
+            payload["metadata"]["app_name"],
+        )
+        for agent_id in ("agent-one", "agent-two")
+        for payload in (
+            g._build_payload(
+                messages=[{"role": "user", "content": "hi"}],
+                app_response="N/A",
+                data={
+                    "model": "openai/gpt-4o-mini",
+                    "litellm_metadata": {"agent_id": agent_id},
+                },
+                hook="pre_call",
+            ),
+        )
+    }
+    assert identities == {
+        ("agent-one", "agent-one"),
+        ("agent-two", "agent-two"),
+    }
+
+
+def test_one_agent_id_remains_stable_across_models():
+    g = _make_guardrail(agentic=True, source="litellm-gw")
+    sources = {
+        g._build_payload(
+            messages=[{"role": "user", "content": "hi"}],
+            app_response="N/A",
+            data={
+                "model": model,
+                "litellm_metadata": {"agent_id": "stable-agent"},
+            },
+            hook="pre_call",
+        )["source"]
+        for model in ("openai/gpt-4o-mini", "anthropic/claude-3-5-sonnet")
+    }
+    assert sources == {"stable-agent"}
+
+
+def test_agent_source_falls_back_to_configured_source():
+    g = _make_guardrail(agentic=True, source="litellm-gw")
+    payload = g._build_payload(
+        messages=[{"role": "user", "content": "hi"}],
+        app_response="N/A",
+        data={"model": "openai/gpt-4o-mini"},
+        hook="pre_call",
+    )
+    assert payload["source"] == "litellm-gw"
+    assert payload["metadata"]["app_name"] == "litellm-gw"
+
+
+def test_authoritative_litellm_metadata_takes_precedence():
+    g = _make_guardrail(agentic=True)
+    payload = g._build_payload(
+        messages=[{"role": "user", "content": "hi"}],
+        app_response="N/A",
+        data={
+            "model": "openai/gpt-4o-mini",
+            "metadata": {
+                "agent_id": "caller-agent",
+                "session_id": "caller-session",
+                "user_api_key_alias": "caller-alias",
+            },
+            "litellm_metadata": {
+                "agent_id": "trusted-agent",
+                "session_id": "trusted-session",
+                "user_api_key_alias": "trusted-alias",
+            },
+        },
+        hook="pre_call",
+    )
+    assert payload["source"] == "trusted-agent"
+    assert payload["session_id"] == "trusted-session"
+    assert payload["annotations"]["key_alias"] == "trusted-alias"
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        ({"custom_llm_provider": "azure"}, "azure"),
+        ({"litellm_params": {"custom_llm_provider": "bedrock"}}, "bedrock"),
+    ],
+)
+def test_provider_prefers_custom_llm_provider(data, expected):
+    assert _resolve_provider(data, "unregistered-model") == expected
+
+
+def test_provider_uses_canonical_resolver_fallback():
+    assert _resolve_provider({}, "openai/gpt-4o-mini") == "openai"
+
+
+def test_agentic_payload_marks_litellm_gateway_and_model():
+    g = _make_guardrail(agentic=True)
+    payload = g._build_payload(
+        messages=[{"role": "user", "content": "hi"}],
+        app_response="N/A",
+        data={
+            "model": "customer-facing-alias",
+            "litellm_call_id": "request-123",
+            "litellm_trace_id": "trace-123",
+            "litellm_params": {
+                "model": "openai/gpt-4o-mini",
+                "custom_llm_provider": "openai",
+            },
+            "litellm_metadata": {
+                "agent_id": "agent-123",
+                "agent_role": "researcher",
+                "requester_ip_address": "203.0.113.10",
+                "user_agent": "test-client/1.0",
+            },
+        },
+        hook="pre_call",
+    )
+    md = payload["metadata"]
+    assert md["gateway"] == "litellm"
+    assert md["integration"] == "litellm-straiker"
+    assert md["model_id"] == "openai/gpt-4o-mini"
+    assert md["model_provider"] == "openai"
+    assert md["event_type"] == "pre_call"
+    assert md["client_ip"] == "203.0.113.10"
+    assert md["user_agent"] == "test-client/1.0"
+    assert md["trace_id"] == "trace-123"
+    assert md["request_id"] == "request-123"
+    assert md["agent_id"] == "agent-123"
+    assert md["agent_role"] == "researcher"
+    assert md["app_name"] == "agent-123"
+    assert "model" not in md
+    assert "provider" not in md
+    assert "remote_ip" not in md
+    assert "source" not in md
+    assert payload["network"] == {
+        "IP": "203.0.113.10",
+        "User-Agent": "test-client/1.0",
+        "Content-Type": "application/json",
+    }
+    assert payload["annotations"]["model"] == "customer-facing-alias"
+    assert payload["annotations"]["gateway"] == "litellm"
+
+
+def test_normalized_metadata_is_forwarded_and_endpoint_is_redacted():
+    g = _make_guardrail(agentic=True)
+    data = {
+        "model": "openai/gpt-4o-mini",
+        "litellm_call_id": "call-123",
+        "temperature": 0.2,
+        "litellm_metadata": {
+            "user_api_key_alias": "team-key",
+            "user_api_key_team_alias": "team",
+            "user_api_key_end_user_id": "end-user",
+        },
+        "proxy_server_request": {"url": "https://proxy.test/v1/chat/completions?api_key=secret#fragment"},
+    }
+    ann = g._build_payload(
+        messages=[{"role": "user", "content": "hi"}],
+        app_response="N/A",
+        data=data,
+        hook="pre_call",
+    )["annotations"]
+    assert ann["temperature"] == 0.2
+    assert {key: ann[key] for key in ("key_alias", "key_team", "end_user", "request_id", "endpoint")} == {
+        "key_alias": "team-key",
+        "key_team": "team",
+        "end_user": "end-user",
+        "request_id": "call-123",
+        "endpoint": "https://proxy.test/v1/chat/completions",
+    }
+
+
+def test_all_normalized_identity_fields_are_forwarded_when_missing():
+    g = _make_guardrail(agentic=True)
+    annotations = g._build_payload(
+        messages=[{"role": "user", "content": "hi"}],
+        app_response="N/A",
+        data={"model": "openai/gpt-4o-mini"},
+        hook="pre_call",
+    )["annotations"]
+
+    assert {key: annotations[key] for key in ("key_alias", "key_team", "end_user", "request_id", "endpoint")} == {
+        "key_alias": None,
+        "key_team": None,
+        "end_user": None,
+        "request_id": None,
+        "endpoint": None,
+    }
+
+
+def test_destination_uses_request_api_base_hostname():
+    g = _make_guardrail(agentic=True)
+    payload = g._build_payload(
+        messages=[{"role": "user", "content": "hi"}],
+        app_response="N/A",
+        data={
+            "model": "openai/gpt-4o-mini",
+            "api_base": "https://user:secret@dynamic.example:8443/v1?token=secret#fragment",
+            "litellm_params": {"api_base": "https://other.example/v1"},
+        },
+        hook="pre_call",
+    )
+    assert payload["destination"] == "dynamic.example"
+    assert "upstream_api_base" not in payload["annotations"]
+
+
+def test_destination_uses_litellm_params_api_base_hostname():
+    g = _make_guardrail(agentic=True)
+    payload = g._build_payload(
+        messages=[{"role": "user", "content": "hi"}],
+        app_response="N/A",
+        data={
+            "model": "openai/gpt-4o-mini",
+            "litellm_params": {"api_base": "https://nested.example/v1?token=secret"},
+        },
+        hook="pre_call",
+    )
+    assert payload["destination"] == "nested.example"
+
+
+def test_destination_is_unknown_without_api_base():
+    g = _make_guardrail(agentic=True)
+    payload = g._build_payload(
+        messages=[{"role": "user", "content": "hi"}],
+        app_response="N/A",
+        data={"model": "openai/gpt-4o-mini"},
+        hook="pre_call",
+    )
+    assert payload["destination"] == "unknown"
+
+
+def test_supported_event_hooks_are_exact():
+    expected_hooks = [
+        GuardrailEventHooks.pre_call,
+        GuardrailEventHooks.during_call,
+        GuardrailEventHooks.post_call,
+    ]
+    assert StraikerGuardrail.get_supported_event_hooks() == expected_hooks
+    assert _make_guardrail().supported_event_hooks == expected_hooks
+
+
+def test_initializer_forwards_schema_visible_settings():
+    params = LitellmParams(
+        guardrail="straiker",
+        mode="pre_call",
+        api_key="initializer-key",
+        api_base="https://initializer.example",
+        timeout=3.5,
+        max_retries=4,
+        initial_backoff=0.25,
+        max_backoff=1.25,
+        max_payload_bytes=12345,
+        custom_headers={"X-Tenant": "tenant-1"},
+        verbose=False,
+        dedup_iterations=False,
+    )
+    callback = initialize_guardrail(params, {"guardrail_name": "straiker-initializer"})
+
+    try:
+        assert callback.timeout == 3.5
+        assert callback.max_retries == 4
+        assert callback.initial_backoff == 0.25
+        assert callback.max_backoff == 1.25
+        assert callback.max_payload_bytes == 12345
+        assert callback.custom_headers == {"X-Tenant": "tenant-1"}
+        assert callback.verbose is False
+        assert callback.dedup_iterations is False
+        assert callback.api_base == "https://initializer.example"
+        assert callback._detect_url() == "https://initializer.example/api/v1/detect"
+        assert not hasattr(callback, "destination")
+        assert not hasattr(callback, "enabled_models")
+        assert not hasattr(callback, "enumerate_agents")
+        assert not hasattr(callback, "forward_metadata_fields")
+    finally:
+        litellm.callbacks.remove(callback)
+
+
+def test_initializer_uses_schema_defaults_for_omitted_values():
+    params = LitellmParams(
+        guardrail="straiker",
+        mode="pre_call",
+        api_key="initializer-key",
+    )
+    callback = initialize_guardrail(params, {"guardrail_name": "straiker-defaults"})
+
+    try:
+        assert callback.timeout == 5.0
+        assert callback.verbose is False
+    finally:
+        litellm.callbacks.remove(callback)
+
+
+def test_initializer_rejects_invalid_threshold():
+    params = LitellmParams(
+        guardrail="straiker",
+        mode="pre_call",
+        api_key="initializer-key",
+        threshold=1.1,
+    )
+
+    with pytest.raises(ValidationError):
+        initialize_guardrail(params, {"guardrail_name": "straiker-invalid"})
+
+
+def test_config_defaults_use_production_api_origin():
+    config = StraikerGuardrailConfigModel(api_key="test")
+
+    assert config.api_base == "https://api.prod.straiker.ai"
+    assert config.verbose is False
+    callback = StraikerGuardrail(api_key="test")
+    assert callback.api_base == "https://api.prod.straiker.ai"
+    assert callback._detect_url() == "https://api.prod.straiker.ai/api/v1/detect"
+    assert callback.verbose is False
+
+
+def test_agentic_mode_uses_agentic_detect_endpoint():
+    callback = StraikerGuardrail(api_key="test", agentic=True)
+    assert callback._detect_url() == "https://api.prod.straiker.ai/api/v1/detect?agentic"
+
+
+def test_config_rejects_omitted_api_key() -> None:
+    with pytest.raises(ValidationError):
+        StraikerGuardrailConfigModel()
+
+
+def test_config_rejects_empty_api_key() -> None:
+    with pytest.raises(ValidationError):
+        StraikerGuardrailConfigModel(api_key="")
+
+
+def test_initializer_rejects_omitted_api_key() -> None:
+    params = LitellmParams(guardrail="straiker", mode="pre_call")
+
+    with pytest.raises(ValidationError):
+        initialize_guardrail(params, {"guardrail_name": "straiker-missing-key"})
+
+
+def test_initializer_rejects_empty_api_key() -> None:
+    params = LitellmParams(guardrail="straiker", mode="pre_call", api_key="")
+
+    with pytest.raises(ValidationError):
+        initialize_guardrail(params, {"guardrail_name": "straiker-empty-key"})
+
+
+def test_runtime_rejects_empty_api_key_even_when_environment_is_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STRAIKER_API_KEY", "environment-key")
+
+    with pytest.raises(ValueError, match="api_key must be non-empty"):
+        StraikerGuardrail(api_key="")
+
+
+def test_config_model_contains_all_initializer_options():
+    assert {
+        "api_key",
+        "api_base",
+        "agentic",
+        "source",
+        "threshold",
+        "timeout",
+        "unreachable_fallback",
+        "max_retries",
+        "initial_backoff",
+        "max_backoff",
+        "max_payload_bytes",
+        "custom_headers",
+        "verbose",
+        "dedup_iterations",
+    }.issubset(StraikerGuardrailConfigModel.model_fields)
+    assert {
+        "destination",
+        "enabled_models",
+        "enumerate_agents",
+        "forward_metadata_fields",
+    }.isdisjoint(StraikerGuardrailConfigModel.model_fields)
+    schema = StraikerGuardrailConfigModel.model_json_schema()
+    assert "api_key" in schema["required"]
+    assert schema["properties"]["api_key"]["minLength"] == 1
+    assert schema["properties"]["api_base"]["default"] == "https://api.prod.straiker.ai"

--- a/ui/litellm-dashboard/public/assets/logos/straiker.svg
+++ b/ui/litellm-dashboard/public/assets/logos/straiker.svg
@@ -1,0 +1,9 @@
+<svg width="35" height="49" viewBox="0 0 35 49" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M27.0752 3.56763L22.0752 19.5676L16.5869 17.8528L18.7236 11.012L8.49805 19.3782L33.0723 25.9319L34.1514 30.9358L12.1514 48.9358L7.58691 45.8528L12.5869 29.8528L18.0752 31.5676L15.9375 38.4075L26.1631 30.0413L1.58984 23.4885L0.510742 18.4846L22.5107 0.484619L27.0752 3.56763Z" fill="url(#paint0_linear_193_10422)"/>
+<defs>
+<linearGradient id="paint0_linear_193_10422" x1="26.0107" y1="9.48462" x2="7.51631" y2="40.1868" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FFC971"/>
+<stop offset="1" stop-color="#F06D9A"/>
+</linearGradient>
+</defs>
+</svg>

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_garden_data.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_garden_data.ts
@@ -442,6 +442,16 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     tags: ["Security", "Policy", "Prompt Injection"],
     providerKey: "Repelloai",
   },
+  {
+    id: "straiker",
+    name: "Straiker",
+    description:
+      "Defend AI Agentic Guardrails: Indirect/Direct Prompt Injection, Tool Misuse, Malicious MCP and Skills",
+    category: "partner",
+    logo: `${ASSET_PREFIX}straiker.svg`,
+    tags: ["Agentic", "Prompt Injection", "Tool Misuse", "MCP", "Skills"],
+    providerKey: "Straiker",
+  },
 ];
 
 export const ALL_CARDS = [...LITELLM_CONTENT_FILTER_CARDS, ...PARTNER_GUARDRAIL_CARDS];

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info_helpers.tsx
@@ -166,6 +166,7 @@ export const guardrailLogoMap: Record<string, string> = {
   Akto: `${asset_logos_folder}akto.svg`,
   "Qostodian Nexus": `${asset_logos_folder}qohash.jpg`,
   "RepelloAI Argus": `${asset_logos_folder}repelloai.png`,
+  Straiker: `${asset_logos_folder}straiker.svg`,
 };
 
 export const getGuardrailLogoAndName = (guardrailValue: string): { logo: string; displayName: string } => {


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Ran a proxy built from this branch and sent live traffic that hit the real Straiker `/api/v1/detect` API and real OpenAI, not mocks

```bash
litellm --config straiker_qa_config.yaml --port 4000
```

Benign request passes through

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"What is the capital of Japan?"}],"metadata":{"session_id":"qa-benign"}}'
# HTTP 200 -> "The capital of Japan is Tokyo."
```

Attack inputs reach Straiker and are scored. The demo tenant used here has its controls in detect mode, so the faithful relay is allow (200). A direct call to `/api/v1/detect` with the same inputs shows the detections firing

```
prompt-injection-short   detect=['llm_evasion']
system-prompt-exfil      detect=['prompt_injection', 'llm_evasion']
credit-card              detect=['prompt_injection', 'credit_card_number']
```

When a control is in block mode the guardrail returns HTTP 403 with the score, turn id, verdict, and triggered categories in the error body. That path is covered by `test_pre_call_blocks_when_score_above_threshold`

Per-agent enumeration routes each `metadata.agent_id` to its own application in the Straiker Console, and requests without a `session_id` fall back to the LiteLLM call id so every turn stays addressable

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Say hi"}],"metadata":{"agent_id":"clinical-intake-agent"}}'
# HTTP 200
```

## Type

🆕 New Feature

## Changes

Adds Straiker DefendAI (https://straiker.ai) as a native partner guardrail. Straiker is an AI security platform providing runtime protection for agentic applications, with prompt injection, indirect prompt injection, tool misuse, data exfiltration, and PII detection

The guardrail supports all three hook points. `pre_call` and `during_call` (moderation) block with HTTP 403 when the score exceeds the configured threshold, and `post_call` runs as observability only. In agentic mode it posts the full `messages[]` (including tool calls and tool results) to `/api/v1/detect?agentic` so multi-turn conversations are scored in context, and it dedups intermediate agent iterations so one logical user prompt maps to one pre and one post entry rather than one per LLM round trip

Provider is resolved through the existing `get_llm_provider` helper, the request metadata key is resolved through `get_metadata_variable_name_from_kwargs`, and message shaping goes through `get_guardrails_messages_for_call_type` so the guardrail honors the proxy's per-call-type message handling instead of reading `data["messages"]` directly. The endpoint recorded in metadata is stripped of query and fragment so the detection payload stays privacy bounded. Fault tolerance covers retry with exponential backoff plus jitter on transient HTTP and network errors, a `fail_open` vs `fail_closed` choice on persistent unavailability, and a payload size guard. The httpx client is dependency injected so the unit tests exercise the hooks without patching the httpx class

The admin UI shows Straiker in the guardrail provider dropdown and the Guardrail Garden, driven by the Pydantic config model

## QA runbook

The unit suite covers block and allow on either side of the threshold, both fail modes on unavailability, agentic dedup on tool continuations, the payload size guard, per-agent enumeration via `agent_id`, the session id fallback chain, and the provider and destination resolution helpers

```bash
pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/test_straiker.py
# 66 passed
```

For a live check, register the guardrail against a Straiker application key and send the curl commands above. To see a 403 rather than a detect-mode allow, set one control to block mode in the Straiker Console for the application the key maps to

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
