### PR TITLE
fix(ui): respect litellm_key_header_name in BYOK credential save and workflow runs fetches

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -515,6 +515,152 @@
       "count": 2
     }
   },
+  "src/app/(dashboard)/mcp-servers/_components/MCPLogoSelector.test.tsx": {
+    "unused-imports/no-unused-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/MCPNetworkSettings.tsx": {
+    "react-hooks/immutability": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/MCPSubmissionsTab.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/MCPToolsetsTab.tsx": {
+    "no-nested-ternary": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    },
+    "unused-imports/no-unused-imports": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/OAuthFormFields.tsx": {
+    "no-nested-ternary": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/OpenAPIQuickPicker.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/ToolTestPanel.tsx": {
+    "no-nested-ternary": {
+      "count": 3
+    },
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/UserEnvVarsModal.tsx": {
+    "no-nested-ternary": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/create_mcp_server.tsx": {
+    "no-nested-ternary": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 4
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/mcp_connect.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "react-hooks/static-components": {
+      "count": 4
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/mcp_connection_status.tsx": {
+    "no-nested-ternary": {
+      "count": 3
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/mcp_discovery.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/mcp_server_cost_config.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/mcp_server_cost_display.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.tsx": {
+    "no-nested-ternary": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "react-hooks/immutability": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 5
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/mcp_server_view.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/mcp_servers.tsx": {
+    "no-nested-ternary": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/mcp_tool_configuration.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/mcp_tools.tsx": {
+    "no-nested-ternary": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 2
+    }
+  },
   "src/app/(dashboard)/memory/_components/MemoryView.tsx": {
     "react-hooks/set-state-in-effect": {
       "count": 1
@@ -1860,43 +2006,9 @@
       "count": 1
     }
   },
-  "src/components/mcp_tools/ByokCredentialModal.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/MCPLogoSelector.test.tsx": {
-    "unused-imports/no-unused-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/MCPNetworkSettings.tsx": {
-    "react-hooks/immutability": {
-      "count": 2
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/MCPSubmissionsTab.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
   "src/components/mcp_tools/MCPToolArgumentsForm.tsx": {
     "no-nested-ternary": {
       "count": 5
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/MCPToolsetsTab.tsx": {
-    "no-nested-ternary": {
-      "count": 1
-    },
-    "no-restricted-imports": {
-      "count": 1
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    },
-    "unused-imports/no-unused-imports": {
-      "count": 2
     }
   },
   "src/components/mcp_tools/McpCrudPermissionPanel.tsx": {
@@ -1905,123 +2017,6 @@
     },
     "no-restricted-imports": {
       "count": 1
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/OAuthFormFields.tsx": {
-    "no-nested-ternary": {
-      "count": 1
-    },
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/OpenAPIQuickPicker.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/ToolTestPanel.tsx": {
-    "no-nested-ternary": {
-      "count": 3
-    },
-    "no-restricted-imports": {
-      "count": 1
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/UserEnvVarsModal.tsx": {
-    "no-nested-ternary": {
-      "count": 2
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/create_mcp_server.tsx": {
-    "no-nested-ternary": {
-      "count": 1
-    },
-    "no-restricted-imports": {
-      "count": 1
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 4
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/mcp_connect.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
-    "react-hooks/static-components": {
-      "count": 4
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/mcp_connection_status.tsx": {
-    "no-nested-ternary": {
-      "count": 3
-    },
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/mcp_discovery.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 2
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/mcp_server_cost_config.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/mcp_server_cost_display.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.tsx": {
-    "no-nested-ternary": {
-      "count": 1
-    },
-    "no-restricted-imports": {
-      "count": 1
-    },
-    "react-hooks/immutability": {
-      "count": 1
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 5
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/mcp_server_view.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/mcp_servers.tsx": {
-    "no-nested-ternary": {
-      "count": 1
-    },
-    "no-restricted-imports": {
-      "count": 1
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 2
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/mcp_tool_configuration.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/mcp-servers/_components/mcp_tools.tsx": {
-    "no-nested-ternary": {
-      "count": 1
-    },
-    "no-restricted-imports": {
-      "count": 1
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 2
     }
   },
   "src/components/model_add/AddCredentialModal.tsx": {

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_servers.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_servers.tsx
@@ -684,7 +684,6 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
             refetch();
             setByokModalServer(null);
           }}
-          accessToken={accessToken || ""}
         />
       )}
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -2186,7 +2186,6 @@ const ChatUI: React.FC<ChatUIProps> = ({
             loadMCPServers();
             setByokModalServer(null);
           }}
-          accessToken={accessToken || ""}
         />
       )}
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/workflows/WorkflowRuns.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/workflows/WorkflowRuns.test.tsx
@@ -4,7 +4,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import WorkflowRuns from "./WorkflowRuns";
 
-vi.mock("@/components/networking", () => ({ proxyBaseUrl: "" }));
+vi.mock("@/components/networking", () => ({
+  proxyBaseUrl: "",
+  getGlobalLitellmHeaderName: () => "x-litellm-api-key",
+}));
 
 interface FakeRun {
   run_id: string;
@@ -77,5 +80,19 @@ describe("WorkflowRuns (migrated onto shared DataTable)", () => {
     render(<WorkflowRuns accessToken="tok" />);
 
     expect(await screen.findByText("No workflow runs yet")).toBeInTheDocument();
+  });
+
+  it("sends the configured litellm key header on every fetch instead of hardcoding Authorization", async () => {
+    const user = userEvent.setup();
+    const fetchSpy = mockFetch(RUNS);
+    vi.stubGlobal("fetch", fetchSpy);
+    render(<WorkflowRuns accessToken="tok" />);
+
+    await user.click(await screen.findByText("First run"));
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(3));
+    for (const [url, init] of fetchSpy.mock.calls as [string, RequestInit][]) {
+      expect(init.headers, url).toEqual({ "x-litellm-api-key": "Bearer tok" });
+    }
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/workflows/WorkflowRuns.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/workflows/WorkflowRuns.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback, useMemo } from "react";
 import { Button, Collapse, Drawer, Empty, Spin, Tooltip, Typography } from "antd";
 import { ReloadOutlined } from "@ant-design/icons";
 import type { ColumnDef, ColumnFiltersState } from "@tanstack/react-table";
-import { proxyBaseUrl } from "@/components/networking";
+import { getGlobalLitellmHeaderName, proxyBaseUrl } from "@/components/networking";
 import {
   DataTable,
   DataTableFilterDrawer,
@@ -507,7 +507,7 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
     setLoadingRuns(true);
     try {
       const res = await fetch(`${proxyBaseUrl ?? ""}/v1/workflows/runs?limit=100`, {
-        headers: { Authorization: `Bearer ${accessToken}` },
+        headers: { [getGlobalLitellmHeaderName()]: `Bearer ${accessToken}` },
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
@@ -531,10 +531,10 @@ const WorkflowRuns: React.FC<WorkflowRunsProps> = ({ accessToken }) => {
         const base = proxyBaseUrl ?? "";
         const [evRes, msgRes] = await Promise.all([
           fetch(`${base}/v1/workflows/runs/${run.run_id}/events`, {
-            headers: { Authorization: `Bearer ${accessToken}` },
+            headers: { [getGlobalLitellmHeaderName()]: `Bearer ${accessToken}` },
           }),
           fetch(`${base}/v1/workflows/runs/${run.run_id}/messages`, {
-            headers: { Authorization: `Bearer ${accessToken}` },
+            headers: { [getGlobalLitellmHeaderName()]: `Bearer ${accessToken}` },
           }),
         ]);
         const evData = evRes.ok ? await evRes.json() : { events: [] };

--- a/ui/litellm-dashboard/src/components/mcp_tools/ByokCredentialModal.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/ByokCredentialModal.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { registerAuthHeaderNameGetter, registerAuthTokenGetter, registerBaseUrlGetter } from "@/lib/http/runtime";
+import { ByokCredentialModal } from "./ByokCredentialModal";
+import type { MCPServer } from "./types";
+
+const fetchSpy = vi.hoisted(() => {
+  const spy = vi.fn<(request: Request) => Promise<Response>>();
+  vi.stubGlobal("fetch", spy);
+  return spy;
+});
+
+vi.mock("@/components/molecules/message_manager", () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+const SERVER = { server_id: "srv-1", alias: "Linear", server_name: "Linear" } as MCPServer;
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+
+async function fillAndSubmit(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByText("Continue to Authentication"));
+  await user.type(screen.getByPlaceholderText("Enter your API key"), "linear-key");
+  await user.click(screen.getByRole("button", { name: /Connect & Authorize/ }));
+}
+
+beforeEach(() => {
+  fetchSpy.mockReset();
+  registerBaseUrlGetter(() => "");
+  registerAuthTokenGetter(() => "sk-session");
+});
+
+describe("ByokCredentialModal", () => {
+  it("saves the credential with the session's configured litellm key header, not a hardcoded Authorization", async () => {
+    registerAuthHeaderNameGetter(() => "x-litellm-api-key");
+    fetchSpy.mockResolvedValue(jsonResponse({ server_id: "srv-1", has_credential: true }));
+    const onSuccess = vi.fn();
+    const user = userEvent.setup();
+    render(<ByokCredentialModal server={SERVER} open onClose={() => {}} onSuccess={onSuccess} />);
+
+    await fillAndSubmit(user);
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith("srv-1"));
+    const request = fetchSpy.mock.calls[0][0];
+    expect(request.method).toBe("POST");
+    expect(new URL(request.url).pathname).toBe("/v1/mcp/server/srv-1/user-credential");
+    expect(request.headers.get("x-litellm-api-key")).toBe("Bearer sk-session");
+    expect(request.headers.get("Authorization")).toBeNull();
+    expect(await request.json()).toEqual({ credential: "linear-key", save: true });
+  });
+
+  it("surfaces the backend's detail.error message when the save fails", async () => {
+    registerAuthHeaderNameGetter(() => "Authorization");
+    fetchSpy.mockResolvedValue(
+      jsonResponse({ detail: { error: "This MCP server does not support BYOK credentials" } }, 400),
+    );
+    const MessageManager = (await import("@/components/molecules/message_manager")).default;
+    const onSuccess = vi.fn();
+    const user = userEvent.setup();
+    render(<ByokCredentialModal server={SERVER} open onClose={() => {}} onSuccess={onSuccess} />);
+
+    await fillAndSubmit(user);
+
+    await waitFor(() =>
+      expect(MessageManager.error).toHaveBeenCalledWith("This MCP server does not support BYOK credentials"),
+    );
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/ui/litellm-dashboard/src/components/mcp_tools/ByokCredentialModal.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/ByokCredentialModal.tsx
@@ -3,6 +3,8 @@
 import React, { useState } from "react";
 import { Modal, Input, Switch } from "antd";
 import MessageManager from "@/components/molecules/message_manager";
+import { fetchClient } from "@/lib/http/api";
+import { ApiError } from "@/lib/http/client";
 import {
   KeyOutlined,
   LockOutlined,
@@ -14,21 +16,22 @@ import {
 } from "@ant-design/icons";
 import { MCPServer } from "./types";
 
+const byokSaveErrorMessage = (e: unknown): string => {
+  if (e instanceof ApiError) {
+    const detail = (e.body as { detail?: { error?: string } } | null)?.detail?.error;
+    if (detail) return detail;
+  }
+  return e instanceof Error && e.message ? e.message : "Failed to connect";
+};
+
 interface ByokCredentialModalProps {
   server: MCPServer;
   open: boolean;
   onClose: () => void;
   onSuccess: (serverId: string) => void;
-  accessToken: string;
 }
 
-export const ByokCredentialModal: React.FC<ByokCredentialModalProps> = ({
-  server,
-  open,
-  onClose,
-  onSuccess,
-  accessToken,
-}) => {
+export const ByokCredentialModal: React.FC<ByokCredentialModalProps> = ({ server, open, onClose, onSuccess }) => {
   const [step, setStep] = useState<1 | 2>(1);
   const [apiKey, setApiKey] = useState("");
   const [saveKey, setSaveKey] = useState(true);
@@ -52,23 +55,15 @@ export const ByokCredentialModal: React.FC<ByokCredentialModalProps> = ({
     }
     setLoading(true);
     try {
-      const response = await fetch(`/v1/mcp/server/${server.server_id}/user-credential`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${accessToken}`,
-        },
-        body: JSON.stringify({ credential: apiKey.trim(), save: saveKey }),
+      await fetchClient.POST("/v1/mcp/server/{server_id}/user-credential", {
+        params: { path: { server_id: server.server_id } },
+        body: { credential: apiKey.trim(), save: saveKey },
       });
-      if (!response.ok) {
-        const err = await response.json();
-        throw new Error(err?.detail?.error || "Failed to save credential");
-      }
       MessageManager.success(`Connected to ${serverDisplayName}`);
       onSuccess(server.server_id);
       handleClose();
-    } catch (e: any) {
-      MessageManager.error(e.message || "Failed to connect");
+    } catch (e) {
+      MessageManager.error(byokSaveErrorMessage(e));
     } finally {
       setLoading(false);
     }

--- a/ui/litellm-dashboard/src/components/networking.test.ts
+++ b/ui/litellm-dashboard/src/components/networking.test.ts
@@ -530,3 +530,67 @@ describe("buildModelGroupTestRequest", () => {
     expect(body).toEqual({ model: "text-embedding-3-small", input: "test from litellm" });
   });
 });
+
+describe("testMCPToolsListRequest auth headers", () => {
+  const originalFetch = global.fetch;
+
+  const captureFetch = () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => "application/json" },
+      json: vi.fn().mockResolvedValue({ tools: [] }),
+    } as any);
+    global.fetch = mockFetch as any;
+    return mockFetch;
+  };
+
+  const sentHeaders = (mockFetch: ReturnType<typeof vi.fn>): Record<string, string> =>
+    (mockFetch.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
+
+  afterEach(() => {
+    Networking.setGlobalLitellmHeaderName("Authorization");
+    global.fetch = originalFetch;
+  });
+
+  it("sends the litellm key under a custom litellm_key_header_name even when an upstream OAuth token uses Authorization", async () => {
+    Networking.setGlobalLitellmHeaderName("x-litellm-key");
+    const mockFetch = captureFetch();
+
+    await Networking.testMCPToolsListRequest("sk-key", {}, "upstream-oauth-token");
+
+    const headers = sentHeaders(mockFetch);
+    expect(headers["x-litellm-key"]).toBe("Bearer sk-key");
+    expect(headers["Authorization"]).toBe("Bearer upstream-oauth-token");
+  });
+
+  it("Bearer-prefixes x-litellm-api-key when it is the configured key header (raw values fail _get_bearer_token)", async () => {
+    Networking.setGlobalLitellmHeaderName("x-litellm-api-key");
+    const mockFetch = captureFetch();
+
+    await Networking.testMCPToolsListRequest("sk-key", {}, "upstream-oauth-token");
+
+    const headers = sentHeaders(mockFetch);
+    expect(headers["x-litellm-api-key"]).toBe("Bearer sk-key");
+    expect(headers["Authorization"]).toBe("Bearer upstream-oauth-token");
+  });
+
+  it("never clobbers the upstream OAuth token on default deployments", async () => {
+    const mockFetch = captureFetch();
+
+    await Networking.testMCPToolsListRequest("sk-key", {}, "upstream-oauth-token");
+
+    const headers = sentHeaders(mockFetch);
+    expect(headers["Authorization"]).toBe("Bearer upstream-oauth-token");
+    expect(headers["x-litellm-api-key"]).toBe("sk-key");
+  });
+
+  it("sends the litellm key as the bearer on default deployments without an OAuth token", async () => {
+    const mockFetch = captureFetch();
+
+    await Networking.testMCPToolsListRequest("sk-key", {});
+
+    const headers = sentHeaders(mockFetch);
+    expect(headers["Authorization"]).toBe("Bearer sk-key");
+  });
+});

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -6650,6 +6650,9 @@ export const testMCPToolsListRequest = async (
     };
     if (accessToken) {
       headers["x-litellm-api-key"] = accessToken;
+      if (globalLitellmHeaderName.toLowerCase() !== "authorization") {
+        headers[globalLitellmHeaderName] = `Bearer ${accessToken}`;
+      }
     }
     if (oauthAccessToken) {
       headers["Authorization"] = `Bearer ${oauthAccessToken}`;


### PR DESCRIPTION
## Relevant issues

Fixes #31807

## Linear ticket

Resolves LIT-4381

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The backend contract that makes the hardcoded header a hard failure (no fallback to Authorization once `litellm_key_header_name` is set):

```bash
# add to dev_config.yaml under general_settings:
#   litellm_key_header_name: x-litellm-api-key
curl -s -o /dev/null -w "%{http_code}\n" http://localhost:4000/v1/mcp/server/some-id/user-credential \
  -X POST -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-1234" -d '{"credential": "x", "save": true}'
# 401 (this is what the modal sent before this PR)

curl -s -o /dev/null -w "%{http_code}\n" http://localhost:4000/v1/mcp/server/some-id/user-credential \
  -X POST -H "Content-Type: application/json" \
  -H "x-litellm-api-key: Bearer sk-1234" -d '{"credential": "x", "save": true}'
# passes auth (404 for the made-up server id; the 401 is gone)
```

UI verification steps (screenshots to follow):

1. Set `litellm_key_header_name: x-litellm-api-key` under `general_settings` in the proxy config and start the proxy plus the dashboard dev server
2. Log in to the UI, open http://localhost:3000/?login=success&page=mcp-servers, pick a BYOK server, and save a credential through the Connect modal; before this PR the save fails, after it succeeds
3. Open the Workflow Runs page and confirm runs plus the detail drawer load
4. On the MCP servers page, create an OAuth MCP server and use the tools preview; before this PR the preview 401s on this config, after it lists tools

## Type

🐛 Bug Fix

## Changes

The proxy setting `general_settings.litellm_key_header_name` moves virtual-key auth to a custom header (for deployments where a gateway consumes or strips `Authorization`). The dashboard learns that name from the session JWT and exposes it via `getGlobalLitellmHeaderName()`, and both HTTP clients (`apiClient` and the typed `fetchClient`) resolve it per request. A handful of raw `fetch()` calls bypassed all of that with a hardcoded `Authorization` header, and since `user_api_key_auth` replaces the key with the custom header's value unconditionally (empty string when absent, `user_api_key_auth.py:1093`), those calls 401 on such deployments

This PR fixes the two sites that actually break:

`ByokCredentialModal` moves onto the typed `fetchClient`, which injects the key under the registered header name and rebases the URL onto the runtime proxy origin (the old call also hard-coded the UI origin, so it broke split-origin dev setups). The `accessToken` prop is removed; the client reads the session cookie. Its raw-fetch eslint suppression is pruned so the ban ratchets down

The three `WorkflowRuns.tsx` fetches swap the hardcoded header for `getGlobalLitellmHeaderName()`. Deliberately minimal since that page is slated for deprecation; no investment in typed-client migration there

`testMCPToolsListRequest`'s OAuth-preview branch had the same failure with a twist: `Authorization` legitimately carries the upstream MCP OAuth token there, so the litellm key traveled only in a raw `x-litellm-api-key` header. The custom-header extractor (`get_api_key_from_custom_header`) requires a Bearer prefix, so when the configured name is `x-litellm-api-key` the raw value resolved to an empty key, and any other configured name was never sent at all; both 401. The branch now also sends the Bearer-prefixed key under the configured name whenever it isn't `Authorization`, which never touches the upstream token and leaves default deployments byte-identical

One site named in the issue needs no change. `exchangeMcpOAuthToken` posts to `/v1/mcp/server/oauth/{id}/token`, whose auth dependency (`_mcp_oauth_user_api_key_auth`) reads `Authorization` directly with a session-cookie fallback and never consults `litellm_key_header_name`, so the hardcoded header there is correct

Regression tests pin every fixed site against a non-default header name: the modal test drives the real `fetchClient` middleware and asserts the request carries `x-litellm-api-key: Bearer <key>` and no `Authorization`, the WorkflowRuns test asserts all three fetches send only the configured header, and the `testMCPToolsListRequest` tests cover both custom-name flavors plus a guard that the upstream OAuth token is never clobbered on default deployments

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
