### PR TITLE
fix: redact async complete streaming response for custom callbacks

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -73,6 +73,7 @@ from litellm.litellm_core_utils.model_param_helper import ModelParamHelper
 from litellm.litellm_core_utils.redact_messages import (
     redact_message_input_output_from_custom_logger,
     redact_message_input_output_from_logging,
+    redact_streaming_responses_for_custom_logger,
 )
 from litellm.llms.base_llm.ocr.transformation import OCRResponse
 from litellm.llms.base_llm.search.transformation import SearchResponse
@@ -2575,6 +2576,9 @@ class Logging(LiteLLMLoggingBaseClass):
                     # call redaction hook for custom logger
                     model_call_details = callback.redact_standard_logging_payload_from_model_call_details(
                         model_call_details=model_call_details
+                    )
+                    model_call_details = redact_streaming_responses_for_custom_logger(
+                        model_call_details=model_call_details, custom_logger=callback
                     )
                     ##################################
                     if self.stream is True:

--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -162,34 +162,23 @@ def perform_redaction(model_call_details: dict, result):
     redact_vertex_ai_metadata_from_litellm_params(model_call_details)
 
     # Redact streaming response
-    if model_call_details.get("stream", False) is True and "complete_streaming_response" in model_call_details:
-        _streaming_response = model_call_details["complete_streaming_response"]
-        if hasattr(_streaming_response, "choices"):
-            for choice in _streaming_response.choices:
-                _redact_choice_content(choice)
-            redact_vertex_ai_metadata_from_logged_object(_streaming_response)
-        elif hasattr(_streaming_response, "output"):
-            _redact_responses_api_output(_streaming_response.output)
-            # Redact reasoning field in ResponsesAPIResponse
-            if hasattr(_streaming_response, "reasoning") and _streaming_response.reasoning is not None:
-                _streaming_response.reasoning = None
-
-    if (
-        model_call_details.get("stream", False) is True
-        and "async_complete_streaming_response" in model_call_details
-    ):
-        _streaming_response = model_call_details["async_complete_streaming_response"]
-        if hasattr(_streaming_response, "choices"):
-            for choice in _streaming_response.choices:
-                _redact_choice_content(choice)
-        elif hasattr(_streaming_response, "output"):
-            _redact_responses_api_output(_streaming_response.output)
-            # Redact reasoning field in ResponsesAPIResponse
-            if (
-                hasattr(_streaming_response, "reasoning")
-                and _streaming_response.reasoning is not None
-            ):
-                _streaming_response.reasoning = None            
+    for _streaming_key in ("complete_streaming_response", "async_complete_streaming_response"):
+        if (
+            model_call_details.get("stream", False) is True
+            and _streaming_key in model_call_details
+        ):
+            _streaming_response = model_call_details[_streaming_key]
+            if _streaming_response is None:
+                continue
+            if hasattr(_streaming_response, "choices"):
+                for choice in _streaming_response.choices:
+                    _redact_choice_content(choice)
+                redact_vertex_ai_metadata_from_logged_object(_streaming_response)
+            elif hasattr(_streaming_response, "output"):
+                _redact_responses_api_output(_streaming_response.output)
+                # Redact reasoning field in ResponsesAPIResponse
+                if hasattr(_streaming_response, "reasoning") and _streaming_response.reasoning is not None:
+                    _streaming_response.reasoning = None
 
     # Redact result
     if result is not None:

--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -38,8 +38,43 @@ def redact_message_input_output_from_custom_logger(
     litellm_logging_obj: LiteLLMLoggingObject, result, custom_logger: CustomLogger
 ):
     if hasattr(custom_logger, "message_logging") and custom_logger.message_logging is not True:
-        return perform_redaction(litellm_logging_obj.model_call_details, result)
+        return perform_redaction(litellm_logging_obj.model_call_details, result, redact_streaming_responses=False)
     return result
+
+
+def redact_streaming_responses_for_custom_logger(model_call_details: dict, custom_logger: CustomLogger) -> dict:
+    """
+    Returns a copy of model_call_details whose streaming response entries are redacted deepcopies
+    when the custom logger has opted out of message logging. The shared model_call_details is left
+    untouched so other callbacks still receive the unredacted response.
+    """
+    if not (hasattr(custom_logger, "message_logging") and custom_logger.message_logging is not True):
+        return model_call_details
+    redacted_entries = {
+        streaming_key: _redacted_streaming_response_copy(model_call_details[streaming_key])
+        for streaming_key in ("complete_streaming_response", "async_complete_streaming_response")
+        if model_call_details.get(streaming_key) is not None
+    }
+    if not redacted_entries:
+        return model_call_details
+    return {**model_call_details, **redacted_entries}
+
+
+def _redacted_streaming_response_copy(streaming_response):
+    redacted_response = copy.deepcopy(streaming_response)
+    _redact_streaming_response(redacted_response)
+    return redacted_response
+
+
+def _redact_streaming_response(streaming_response):
+    if hasattr(streaming_response, "choices"):
+        for choice in streaming_response.choices:
+            _redact_choice_content(choice)
+        redact_vertex_ai_metadata_from_logged_object(streaming_response)
+    elif hasattr(streaming_response, "output"):
+        _redact_responses_api_output(streaming_response.output)
+        if hasattr(streaming_response, "reasoning") and streaming_response.reasoning is not None:
+            streaming_response.reasoning = None
 
 
 def _redact_choice_content(choice):
@@ -150,9 +185,13 @@ def _redact_model_response_dict_choices(choices, redacted_str: str):
             _redact_choice_content(choice)
 
 
-def perform_redaction(model_call_details: dict, result):
+def perform_redaction(model_call_details: dict, result, redact_streaming_responses: bool = True):
     """
     Performs the actual redaction on the logging object and result.
+
+    redact_streaming_responses=False skips the in-place redaction of the shared streaming
+    response entries; per-callback redaction hands each opted-out callback its own redacted
+    copy via redact_streaming_responses_for_custom_logger instead.
     """
     # Redact model_call_details
     model_call_details["messages"] = [{"role": "user", "content": "redacted-by-litellm"}]
@@ -162,20 +201,9 @@ def perform_redaction(model_call_details: dict, result):
     redact_vertex_ai_metadata_from_litellm_params(model_call_details)
 
     # Redact streaming response
-    for _streaming_key in ("complete_streaming_response", "async_complete_streaming_response"):
-        if model_call_details.get("stream", False) is True and _streaming_key in model_call_details:
-            _streaming_response = model_call_details[_streaming_key]
-            if _streaming_response is None:
-                continue
-            if hasattr(_streaming_response, "choices"):
-                for choice in _streaming_response.choices:
-                    _redact_choice_content(choice)
-                redact_vertex_ai_metadata_from_logged_object(_streaming_response)
-            elif hasattr(_streaming_response, "output"):
-                _redact_responses_api_output(_streaming_response.output)
-                # Redact reasoning field in ResponsesAPIResponse
-                if hasattr(_streaming_response, "reasoning") and _streaming_response.reasoning is not None:
-                    _streaming_response.reasoning = None
+    if redact_streaming_responses and model_call_details.get("stream", False) is True:
+        for _streaming_key in ("complete_streaming_response", "async_complete_streaming_response"):
+            _redact_streaming_response(model_call_details.get(_streaming_key))
 
     # Redact result
     if result is not None:

--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -174,6 +174,23 @@ def perform_redaction(model_call_details: dict, result):
             if hasattr(_streaming_response, "reasoning") and _streaming_response.reasoning is not None:
                 _streaming_response.reasoning = None
 
+    if (
+        model_call_details.get("stream", False) is True
+        and "async_complete_streaming_response" in model_call_details
+    ):
+        _streaming_response = model_call_details["async_complete_streaming_response"]
+        if hasattr(_streaming_response, "choices"):
+            for choice in _streaming_response.choices:
+                _redact_choice_content(choice)
+        elif hasattr(_streaming_response, "output"):
+            _redact_responses_api_output(_streaming_response.output)
+            # Redact reasoning field in ResponsesAPIResponse
+            if (
+                hasattr(_streaming_response, "reasoning")
+                and _streaming_response.reasoning is not None
+            ):
+                _streaming_response.reasoning = None            
+
     # Redact result
     if result is not None:
         # Check if result is a coroutine, async generator, or other async object - these cannot be deepcopied

--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -163,10 +163,7 @@ def perform_redaction(model_call_details: dict, result):
 
     # Redact streaming response
     for _streaming_key in ("complete_streaming_response", "async_complete_streaming_response"):
-        if (
-            model_call_details.get("stream", False) is True
-            and _streaming_key in model_call_details
-        ):
+        if model_call_details.get("stream", False) is True and _streaming_key in model_call_details:
             _streaming_response = model_call_details[_streaming_key]
             if _streaming_response is None:
                 continue

--- a/tests/logging_callback_tests/test_logging_redaction_e2e_test.py
+++ b/tests/logging_callback_tests/test_logging_redaction_e2e_test.py
@@ -128,34 +128,65 @@ async def test_redaction_with_custom_logger_streaming():
     litellm.turn_off_message_logging = True
     test_custom_logger = TestCustomLogger()
 
-    litellm_logging_obj = LoggingWithoutSyncSuccessHandler(
-        model="gpt-3.5-turbo",
-        messages=[{"role": "user", "content": "hi"}],
-        stream=True,
-        call_type="acompletion",
-        litellm_call_id="1234",
-        start_time=datetime.now(),
-        function_id="1234",
-        dynamic_async_success_callbacks=[test_custom_logger],
-    )
+    try:
+        litellm_logging_obj = LoggingWithoutSyncSuccessHandler(
+            model="gpt-5-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+            call_type="acompletion",
+            litellm_call_id="1234",
+            start_time=datetime.now(),
+            function_id="1234",
+            dynamic_async_success_callbacks=[test_custom_logger],
+        )
 
-    response = await litellm.acompletion(
-        model="gpt-3.5-turbo",
-        messages=[{"role": "user", "content": "hi"}],
-        mock_response="hello",
-        stream=True,
-        litellm_logging_obj=litellm_logging_obj,
-    )
-    
-    # Consume the stream to trigger logging
-    chunks = []
-    async for chunk in response:
-        chunks.append(chunk)
-    
-    await asyncio.sleep(1)
-    async_complete_streaming_response = test_custom_logger.response_obj
-    assert async_complete_streaming_response is not None    
-    assert (async_complete_streaming_response.choices[0].message.content == "redacted-by-litellm")
+        response = await litellm.acompletion(
+            model="gpt-5-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response="hello",
+            stream=True,
+            litellm_logging_obj=litellm_logging_obj,
+        )
+
+        # Consume the stream to trigger logging
+        chunks = []
+        async for chunk in response:
+            chunks.append(chunk)
+
+        await asyncio.sleep(1)
+        async_complete_streaming_response = test_custom_logger.response_obj
+        assert async_complete_streaming_response is not None
+        assert async_complete_streaming_response.choices[0].message.content == "redacted-by-litellm"
+    finally:
+        litellm.turn_off_message_logging = False
+
+
+@pytest.mark.asyncio
+async def test_streaming_redaction_scoped_to_opted_out_logger():
+    """One logger opting out of message logging must not blank the response for other loggers"""
+    litellm.turn_off_message_logging = False
+    opted_out_logger = TestCustomLogger(message_logging=False)
+    compliant_logger = TestCustomLogger()
+    litellm.callbacks = [opted_out_logger, compliant_logger]
+
+    try:
+        response = await litellm.acompletion(
+            model="gpt-5-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            mock_response="hello",
+            stream=True,
+        )
+        async for _ in response:
+            pass
+
+        await asyncio.sleep(1)
+        assert opted_out_logger.response_obj is not None
+        assert opted_out_logger.response_obj.choices[0].message.content == "redacted-by-litellm"
+        assert compliant_logger.response_obj is not None
+        assert compliant_logger.response_obj.choices[0].message.content == "hello"
+    finally:
+        litellm.callbacks = []
+
 
 @pytest.mark.asyncio
 async def test_redaction_responses_api():

--- a/tests/logging_callback_tests/test_logging_redaction_e2e_test.py
+++ b/tests/logging_callback_tests/test_logging_redaction_e2e_test.py
@@ -2,7 +2,7 @@ import io
 import os
 import sys
 
-from typing import Optional
+from typing import Optional, Union
 
 sys.path.insert(0, os.path.abspath("../.."))
 
@@ -12,6 +12,7 @@ import json
 import logging
 import time
 from unittest.mock import AsyncMock, patch
+from datetime import datetime
 
 import httpx
 import pytest
@@ -20,17 +21,24 @@ import litellm
 from litellm._logging import verbose_logger
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.responses.main import mock_responses_api_response
-from litellm.types.utils import StandardLoggingPayload
+from litellm.types.utils import (
+    ModelResponse,
+    ResponsesAPIResponse,
+    StandardLoggingPayload,
+    TextCompletionResponse,
+)
 
 
 class TestCustomLogger(CustomLogger):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.logged_standard_logging_payload: Optional[StandardLoggingPayload] = None
+        self.response_obj: Optional[Union[ModelResponse, TextCompletionResponse, ResponsesAPIResponse]] = None
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         standard_logging_payload = kwargs.get("standard_logging_object", None)
         self.logged_standard_logging_payload = standard_logging_payload
+        self.response_obj = response_obj
 
 
 @pytest.mark.asyncio
@@ -107,6 +115,47 @@ async def test_dynamic_turn_off_message_logging_overrides_global_off(dynamic_tur
     assert standard_logging_payload["response"]["choices"][0]["message"]["content"] == expected_response_content
     assert standard_logging_payload["messages"][0]["content"] == expected_message_content
 
+
+@pytest.mark.asyncio
+async def test_redaction_with_custom_logger_streaming():
+    """Test redaction of responses for custom logger callbacks"""
+    from litellm.litellm_core_utils.litellm_logging import Logging
+
+    class LoggingWithoutSyncSuccessHandler(Logging):
+        def success_handler(self, result=None, start_time=None, end_time=None, cache_hit=None, **kwargs):
+            pass
+
+    litellm.turn_off_message_logging = True
+    test_custom_logger = TestCustomLogger()
+
+    litellm_logging_obj = LoggingWithoutSyncSuccessHandler(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+        call_type="acompletion",
+        litellm_call_id="1234",
+        start_time=datetime.now(),
+        function_id="1234",
+        dynamic_async_success_callbacks=[test_custom_logger],
+    )
+
+    response = await litellm.acompletion(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "hi"}],
+        mock_response="hello",
+        stream=True,
+        litellm_logging_obj=litellm_logging_obj,
+    )
+    
+    # Consume the stream to trigger logging
+    chunks = []
+    async for chunk in response:
+        chunks.append(chunk)
+    
+    await asyncio.sleep(1)
+    async_complete_streaming_response = test_custom_logger.response_obj
+    assert async_complete_streaming_response is not None    
+    assert (async_complete_streaming_response.choices[0].message.content == "redacted-by-litellm")
 
 @pytest.mark.asyncio
 async def test_redaction_responses_api():

--- a/tests/test_litellm/litellm_core_utils/test_redact_messages.py
+++ b/tests/test_litellm/litellm_core_utils/test_redact_messages.py
@@ -461,7 +461,7 @@ class TestPerformRedaction:
             "async_complete_streaming_response": response_obj,
         }
 
-        result = perform_redaction(model_call_details, result=None)
+        perform_redaction(model_call_details, result=None)
 
         redacted_response = model_call_details["async_complete_streaming_response"]
         assert redacted_response.choices[0].message.content == "redacted-by-litellm"
@@ -484,7 +484,7 @@ class TestPerformRedaction:
             "complete_streaming_response": response_obj,
         }
 
-        result = perform_redaction(model_call_details, result=None)
+        perform_redaction(model_call_details, result=None)
 
         redacted_response = model_call_details["complete_streaming_response"]
         assert redacted_response.choices[0].message.content == "redacted-by-litellm"

--- a/tests/test_litellm/litellm_core_utils/test_redact_messages.py
+++ b/tests/test_litellm/litellm_core_utils/test_redact_messages.py
@@ -10,9 +10,11 @@ from types import SimpleNamespace
 import pytest
 
 import litellm
+from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.redact_messages import (
     _redact_responses_api_output,
     perform_redaction,
+    redact_streaming_responses_for_custom_logger,
     should_redact_message_logging,
 )
 from litellm.responses.main import mock_responses_api_response
@@ -488,3 +490,63 @@ class TestPerformRedaction:
 
         redacted_response = model_call_details["complete_streaming_response"]
         assert redacted_response.choices[0].message.content == "redacted-by-litellm"
+
+    def test_streaming_responses_untouched_when_disabled(self):
+        response_obj = litellm.ModelResponse(
+            choices=[
+                litellm.Choices(
+                    message=litellm.Message(content="secret content", role="assistant")
+                )
+            ]
+        )
+
+        model_call_details = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "prompt": "hi",
+            "input": "hi",
+            "stream": True,
+            "async_complete_streaming_response": response_obj,
+        }
+
+        perform_redaction(model_call_details, result=None, redact_streaming_responses=False)
+
+        assert response_obj.choices[0].message.content == "secret content"
+
+
+class TestRedactStreamingResponsesForCustomLogger:
+    def _model_call_details(self):
+        response_obj = litellm.ModelResponse(
+            choices=[
+                litellm.Choices(
+                    message=litellm.Message(content="secret content", role="assistant")
+                )
+            ]
+        )
+        return {
+            "stream": True,
+            "async_complete_streaming_response": response_obj,
+        }, response_obj
+
+    def test_opted_out_logger_gets_redacted_copy(self):
+        model_call_details, response_obj = self._model_call_details()
+        opted_out_logger = CustomLogger(message_logging=False)
+
+        redacted_details = redact_streaming_responses_for_custom_logger(
+            model_call_details=model_call_details, custom_logger=opted_out_logger
+        )
+
+        redacted_response = redacted_details["async_complete_streaming_response"]
+        assert redacted_response.choices[0].message.content == "redacted-by-litellm"
+        assert response_obj.choices[0].message.content == "secret content"
+        assert model_call_details["async_complete_streaming_response"] is response_obj
+
+    def test_compliant_logger_gets_shared_response(self):
+        model_call_details, response_obj = self._model_call_details()
+        compliant_logger = CustomLogger()
+
+        result_details = redact_streaming_responses_for_custom_logger(
+            model_call_details=model_call_details, custom_logger=compliant_logger
+        )
+
+        assert result_details is model_call_details
+        assert response_obj.choices[0].message.content == "secret content"

--- a/tests/test_litellm/litellm_core_utils/test_redact_messages.py
+++ b/tests/test_litellm/litellm_core_utils/test_redact_messages.py
@@ -442,3 +442,49 @@ class TestPerformRedaction:
         assert "vertex_ai_url_context_metadata" not in hidden_params
         assert "vertex_ai_safety_ratings" not in hidden_params
         assert "vertex_ai_citation_metadata" not in hidden_params
+
+    def test_redact_async_complete_streaming_response(self):
+        """Test that async_complete_streaming_response is properly redacted."""
+        response_obj = litellm.ModelResponse(
+            choices=[
+                litellm.Choices(
+                    message=litellm.Message(content="secret content", role="assistant")
+                )
+            ]
+        )
+
+        model_call_details = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "prompt": "hi",
+            "input": "hi",
+            "stream": True,
+            "async_complete_streaming_response": response_obj,
+        }
+
+        result = perform_redaction(model_call_details, result=None)
+
+        redacted_response = model_call_details["async_complete_streaming_response"]
+        assert redacted_response.choices[0].message.content == "redacted-by-litellm"
+
+    def test_redact_complete_streaming_response(self):
+        """Test that complete_streaming_response is properly redacted."""
+        response_obj = litellm.ModelResponse(
+            choices=[
+                litellm.Choices(
+                    message=litellm.Message(content="secret content", role="assistant")
+                )
+            ]
+        )
+
+        model_call_details = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "prompt": "hi",
+            "input": "hi",
+            "stream": True,
+            "complete_streaming_response": response_obj,
+        }
+
+        result = perform_redaction(model_call_details, result=None)
+
+        redacted_response = model_call_details["complete_streaming_response"]
+        assert redacted_response.choices[0].message.content == "redacted-by-litellm"


### PR DESCRIPTION
## Relevant issues

Probably fixes #9664 #8315

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on localhost, real gpt-5.2 calls, custom callback printing the response it receives. Config: `turn_off_message_logging: true`, one custom callback, streaming requests

Before, at base commit 095ccd727d (proxy on :4023): every one of 30 streamed responses reached the callback unredacted

```
for i in $(seq 1 30); do curl -s -o /dev/null http://localhost:4023/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.2","stream":true,"messages":[{"role":"user","content":"reply with only the word pineapple"}]}'; done
grep "RACE_CALLBACK_SAW" proxy_race_before.log | sort | uniq -c
  30 RACE_CALLBACK_SAW: 'pineapple'
```

After, at 0d215c87d9 (proxy on :4021), same 30 requests plus 1 smoke test

```
  31 RACE_CALLBACK_SAW: 'redacted-by-litellm'
```

No-regression check for the per-callback scoping: global redaction off, two callbacks, only `audit_logger` has `message_logging=False`. Before, at 095ccd727d, the opted-out logger leaked; after, at 0d215c87d9, it is redacted while the compliant logger keeps receiving the real response

```
before (proxy on :4024)             after (proxy on :4022)
  3 ANALYTICS_SAW: 'pineapple'        3 ANALYTICS_SAW: 'pineapple'
  3 AUDIT_SAW: 'pineapple'            3 AUDIT_SAW: 'redacted-by-litellm'
```

Regression tests fail with the fix reverted and pass with it applied (2 failed at base, 41 passed on this branch across tests/test_litellm/litellm_core_utils/test_redact_messages.py and tests/logging_callback_tests/test_logging_redaction_e2e_test.py)

A separate QA anti-regression matrix was run against three commits (base 095ccd727d, the adopted fix before per-callback scoping 7b719e9671, final 0d215c87d9): 220 live streaming requests through a local proxy hitting real gpt-5.2, all HTTP 200, output fully deterministic (every callback line was either the original content or redacted-by-litellm, nothing else)

| Case (global redaction off unless stated) | Final HEAD result |
|---|---|
| Single default logger (no-regression control) | 10/10 original, response structure identical to base |
| message_logging=False logger then default logger | 30/30 redacted, 30/30 original |
| Reversed callback order | identical results, order-independent |
| Two default loggers | 10/10 plus 10/10 original, identical to base |
| Two message_logging=False loggers | 10/10 plus 10/10 redacted, streams complete |
| Global turn_off_message_logging with two default loggers | 10/10 plus 10/10 redacted |
| 30x stability, both orders | 60/60 per order, zero mixed results |

Object identity captured per commit for the two-logger case: at base both loggers received the same raw object (the leak); at 7b719e9671 both received the same redacted object (over-redaction); at final HEAD the opted-out logger received an isolated redacted deepcopy while the default logger kept the untouched original. Identity and mutation assertions also verified in unit tests: the returned redacted entries are distinct objects, the shared dict and originals are unmodified, missing or None streaming keys do not raise, and a default logger receives the same dict object back. The 70 pre-existing failures in the full tests/logging_callback_tests/ directory reproduce identically at base (credential and network dependent suites); the failed-set diff between base and final is empty in both directions

## Type

🐛 Bug Fix

## Changes

When a streamed response finishes, the assembled response object is stored in model_call_details under two keys: complete_streaming_response (read by the sync success_handler) and async_complete_streaming_response (read by async_success_handler, which serves most custom logger callbacks). perform_redaction only redacted the first key. Because both keys alias the same object, whether a custom logger with message logging disabled received redacted or raw content depended on whether the sync handler's thread happened to run perform_redaction first; on the live proxy the async path consistently won, so the response leaked on every streamed request

The adopted fix makes perform_redaction walk both streaming keys so the globally enabled redaction path is deterministic

On top of the adopted commits, this PR scopes per-callback redaction so it no longer mutates shared state. perform_redaction previously redacted the shared streaming response in place when invoked for a single callback with message_logging=False, which would have blanked the response for every other callback on the same request (verified live before the change: a compliant second logger received the redacted placeholder instead of the real response). redact_message_input_output_from_custom_logger now skips the shared in-place streaming redaction and the delivery path hands the opted-out callback a redacted deepcopy via redact_streaming_responses_for_custom_logger, mirroring the existing copy-on-redact pattern of redact_standard_logging_payload_from_model_call_details. Global turn_off_message_logging still redacts the shared entries in place, which is the intended request-wide behavior

A sibling gap where TextCompletionResponse streaming responses are never redacted is tracked in LIT-4404 and left out of this PR to keep the adopted change isolated

Adaptation made while mirroring onto litellm_internal_staging: the deduplicated loop keeps the redact_vertex_ai_metadata_from_logged_object call that staging's sync branch already had, so no existing redaction is lost

## Credit

Adopted from #22897 by @curious-broccoli (Moritz Müller). Mirrored onto a litellm_ branch so CircleCI and the internal lint workflow run

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
