### PR TITLE
fix(redaction): redact assistant tool call arguments in spend logs

### DIFF
--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -51,6 +51,11 @@ def _redact_tool_call_arguments(tool_calls):
             function.arguments = "redacted-by-litellm"
 
 
+def _redact_function_call_arguments(function_call):
+    if function_call is not None and getattr(function_call, "arguments", None) is not None:
+        function_call.arguments = "redacted-by-litellm"
+
+
 def _redact_choice_content(choice):
     """Helper to redact content in a choice (message or delta)."""
     if isinstance(choice, litellm.Choices):
@@ -60,6 +65,7 @@ def _redact_choice_content(choice):
         if hasattr(choice.message, "thinking_blocks"):
             choice.message.thinking_blocks = None
         _redact_tool_call_arguments(getattr(choice.message, "tool_calls", None))
+        _redact_function_call_arguments(getattr(choice.message, "function_call", None))
     elif isinstance(choice, litellm.utils.StreamingChoices):
         choice.delta.content = "redacted-by-litellm"
         if hasattr(choice.delta, "reasoning_content"):
@@ -67,6 +73,7 @@ def _redact_choice_content(choice):
         if hasattr(choice.delta, "thinking_blocks"):
             choice.delta.thinking_blocks = None
         _redact_tool_call_arguments(getattr(choice.delta, "tool_calls", None))
+        _redact_function_call_arguments(getattr(choice.delta, "function_call", None))
 
 
 def _redact_responses_api_output(output_items):
@@ -149,6 +156,11 @@ def _redact_tool_call_arguments_dict(tool_calls, redacted_str: str):
             function["arguments"] = redacted_str
 
 
+def _redact_function_call_arguments_dict(function_call, redacted_str: str):
+    if isinstance(function_call, dict) and "arguments" in function_call:
+        function_call["arguments"] = redacted_str
+
+
 def _redact_model_response_dict_choices(choices, redacted_str: str):
     for choice in choices:
         if isinstance(choice, dict):
@@ -161,6 +173,7 @@ def _redact_model_response_dict_choices(choices, redacted_str: str):
                 if "audio" in choice["message"]:
                     choice["message"]["audio"] = None
                 _redact_tool_call_arguments_dict(choice["message"].get("tool_calls"), redacted_str)
+                _redact_function_call_arguments_dict(choice["message"].get("function_call"), redacted_str)
             elif "delta" in choice and isinstance(choice["delta"], dict):
                 choice["delta"]["content"] = redacted_str
                 if "reasoning_content" in choice["delta"]:
@@ -170,6 +183,7 @@ def _redact_model_response_dict_choices(choices, redacted_str: str):
                 if "audio" in choice["delta"]:
                     choice["delta"]["audio"] = None
                 _redact_tool_call_arguments_dict(choice["delta"].get("tool_calls"), redacted_str)
+                _redact_function_call_arguments_dict(choice["delta"].get("function_call"), redacted_str)
         else:
             _redact_choice_content(choice)
 

--- a/litellm/litellm_core_utils/redact_messages.py
+++ b/litellm/litellm_core_utils/redact_messages.py
@@ -42,6 +42,15 @@ def redact_message_input_output_from_custom_logger(
     return result
 
 
+def _redact_tool_call_arguments(tool_calls):
+    if not tool_calls:
+        return
+    for tool_call in tool_calls:
+        function = getattr(tool_call, "function", None)
+        if function is not None and getattr(function, "arguments", None) is not None:
+            function.arguments = "redacted-by-litellm"
+
+
 def _redact_choice_content(choice):
     """Helper to redact content in a choice (message or delta)."""
     if isinstance(choice, litellm.Choices):
@@ -50,12 +59,14 @@ def _redact_choice_content(choice):
             choice.message.reasoning_content = "redacted-by-litellm"
         if hasattr(choice.message, "thinking_blocks"):
             choice.message.thinking_blocks = None
+        _redact_tool_call_arguments(getattr(choice.message, "tool_calls", None))
     elif isinstance(choice, litellm.utils.StreamingChoices):
         choice.delta.content = "redacted-by-litellm"
         if hasattr(choice.delta, "reasoning_content"):
             choice.delta.reasoning_content = "redacted-by-litellm"
         if hasattr(choice.delta, "thinking_blocks"):
             choice.delta.thinking_blocks = None
+        _redact_tool_call_arguments(getattr(choice.delta, "tool_calls", None))
 
 
 def _redact_responses_api_output(output_items):
@@ -127,6 +138,17 @@ def _redact_standard_logging_object(model_call_details: dict):
             standard_logging_object["response"] = {"text": redacted_str}
 
 
+def _redact_tool_call_arguments_dict(tool_calls, redacted_str: str):
+    if not isinstance(tool_calls, list):
+        return
+    for tool_call in tool_calls:
+        if not isinstance(tool_call, dict):
+            continue
+        function = tool_call.get("function")
+        if isinstance(function, dict) and "arguments" in function:
+            function["arguments"] = redacted_str
+
+
 def _redact_model_response_dict_choices(choices, redacted_str: str):
     for choice in choices:
         if isinstance(choice, dict):
@@ -138,6 +160,7 @@ def _redact_model_response_dict_choices(choices, redacted_str: str):
                     choice["message"]["thinking_blocks"] = None
                 if "audio" in choice["message"]:
                     choice["message"]["audio"] = None
+                _redact_tool_call_arguments_dict(choice["message"].get("tool_calls"), redacted_str)
             elif "delta" in choice and isinstance(choice["delta"], dict):
                 choice["delta"]["content"] = redacted_str
                 if "reasoning_content" in choice["delta"]:
@@ -146,6 +169,7 @@ def _redact_model_response_dict_choices(choices, redacted_str: str):
                     choice["delta"]["thinking_blocks"] = None
                 if "audio" in choice["delta"]:
                     choice["delta"]["audio"] = None
+                _redact_tool_call_arguments_dict(choice["delta"].get("tool_calls"), redacted_str)
         else:
             _redact_choice_content(choice)
 

--- a/tests/test_litellm/litellm_core_utils/test_redact_messages.py
+++ b/tests/test_litellm/litellm_core_utils/test_redact_messages.py
@@ -364,6 +364,30 @@ class TestPerformRedaction:
         delta_call = redacted["choices"][1]["delta"]["tool_calls"][0]
         assert delta_call["function"]["arguments"] == "redacted-by-litellm"
 
+    def test_redacts_tool_call_arguments_in_streaming_choices(self):
+        tool_call = {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": '{"city": "sensitive city"}'},
+        }
+        streaming_choice = litellm.utils.StreamingChoices(
+            delta=litellm.utils.Delta(
+                content="delta content",
+                role="assistant",
+                tool_calls=[dict(tool_call)],
+            )
+        )
+        details = {
+            "stream": True,
+            "complete_streaming_response": SimpleNamespace(choices=[streaming_choice]),
+        }
+
+        perform_redaction(details, None)
+
+        redacted_call = streaming_choice.delta.tool_calls[0]
+        assert redacted_call.function.arguments == "redacted-by-litellm"
+        assert redacted_call.function.name == "get_weather"
+
     def test_redacts_response_output_objects_with_top_level_text(self):
         output_items = [
             SimpleNamespace(text="top-level output"),

--- a/tests/test_litellm/litellm_core_utils/test_redact_messages.py
+++ b/tests/test_litellm/litellm_core_utils/test_redact_messages.py
@@ -318,6 +318,52 @@ class TestPerformRedaction:
         assert choice.message.content == "redacted-by-litellm"
         assert choice.message.reasoning_content == "redacted-by-litellm"
 
+    def test_redacts_tool_call_arguments(self):
+        tool_call = {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": '{"city": "sensitive city"}'},
+        }
+        result = litellm.ModelResponse(
+            choices=[
+                litellm.Choices(
+                    message=litellm.Message(
+                        content="message content",
+                        role="assistant",
+                        tool_calls=[dict(tool_call)],
+                    )
+                )
+            ]
+        )
+
+        redacted = perform_redaction({}, result)
+
+        redacted_call = redacted.choices[0].message.tool_calls[0]
+        assert redacted_call.function.arguments == "redacted-by-litellm"
+        assert redacted_call.function.name == "get_weather"
+
+    def test_redacts_tool_call_arguments_in_dict_choices(self):
+        tool_call = {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": '{"city": "sensitive city"}'},
+        }
+        result = {
+            "choices": [
+                {"message": {"content": "message content", "tool_calls": [dict(tool_call)]}},
+                {"delta": {"content": "delta content", "tool_calls": [dict(tool_call)]}},
+            ]
+        }
+
+        redacted = perform_redaction({}, result)
+
+        message_call = redacted["choices"][0]["message"]["tool_calls"][0]
+        assert message_call["function"]["arguments"] == "redacted-by-litellm"
+        assert message_call["function"]["name"] == "get_weather"
+
+        delta_call = redacted["choices"][1]["delta"]["tool_calls"][0]
+        assert delta_call["function"]["arguments"] == "redacted-by-litellm"
+
     def test_redacts_response_output_objects_with_top_level_text(self):
         output_items = [
             SimpleNamespace(text="top-level output"),

--- a/tests/test_litellm/litellm_core_utils/test_redact_messages.py
+++ b/tests/test_litellm/litellm_core_utils/test_redact_messages.py
@@ -411,6 +411,40 @@ class TestPerformRedaction:
         assert tool_calls[1] == {"type": "function"}
         assert tool_calls[2]["function"]["arguments"] == "redacted-by-litellm"
 
+    def test_redacts_legacy_function_call_arguments_object(self):
+        result = litellm.ModelResponse(
+            choices=[
+                litellm.Choices(
+                    message=litellm.Message(
+                        content="message content",
+                        role="assistant",
+                        function_call={"name": "get_weather", "arguments": '{"city": "sensitive city"}'},
+                    )
+                )
+            ]
+        )
+
+        redacted = perform_redaction({}, result)
+
+        function_call = redacted.choices[0].message.function_call
+        assert function_call.arguments == "redacted-by-litellm"
+        assert function_call.name == "get_weather"
+
+    def test_redacts_legacy_function_call_arguments_dict(self):
+        function_call = {"name": "get_weather", "arguments": '{"city": "sensitive city"}'}
+        result = {
+            "choices": [
+                {"message": {"content": "message content", "function_call": dict(function_call)}},
+                {"delta": {"content": "delta content", "function_call": dict(function_call)}},
+            ]
+        }
+
+        redacted = perform_redaction({}, result)
+
+        assert redacted["choices"][0]["message"]["function_call"]["arguments"] == "redacted-by-litellm"
+        assert redacted["choices"][0]["message"]["function_call"]["name"] == "get_weather"
+        assert redacted["choices"][1]["delta"]["function_call"]["arguments"] == "redacted-by-litellm"
+
     def test_redacts_response_output_objects_with_top_level_text(self):
         output_items = [
             SimpleNamespace(text="top-level output"),

--- a/tests/test_litellm/litellm_core_utils/test_redact_messages.py
+++ b/tests/test_litellm/litellm_core_utils/test_redact_messages.py
@@ -388,6 +388,29 @@ class TestPerformRedaction:
         assert redacted_call.function.arguments == "redacted-by-litellm"
         assert redacted_call.function.name == "get_weather"
 
+    def test_redacts_tool_calls_skips_malformed_entries(self):
+        result = {
+            "choices": [
+                {
+                    "message": {
+                        "content": "message content",
+                        "tool_calls": [
+                            "not-a-dict",
+                            {"type": "function"},
+                            {"function": {"name": "safe", "arguments": '{"k": "secret"}'}},
+                        ],
+                    }
+                }
+            ]
+        }
+
+        redacted = perform_redaction({}, result)
+
+        tool_calls = redacted["choices"][0]["message"]["tool_calls"]
+        assert tool_calls[0] == "not-a-dict"
+        assert tool_calls[1] == {"type": "function"}
+        assert tool_calls[2]["function"]["arguments"] == "redacted-by-litellm"
+
     def test_redacts_response_output_objects_with_top_level_text(self):
         output_items = [
             SimpleNamespace(text="top-level output"),


### PR DESCRIPTION
## Relevant issues

Fixes #33107

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This is a redaction bug, so the observable difference is what ends up in the spend log for an assistant response that contains tool calls, with message redaction enabled (`turn_off_message_logging: true`, or `store_prompts_in_spend_logs: false`, or the per-request header)

Before this change, the message content is redacted but the tool call is left intact, so the arguments the model generated (which routinely echo user data) are written to the log in the clear:

```json
"choices": [{"message": {
  "content": "redacted-by-litellm",
  "tool_calls": [{"id": "call_1", "type": "function",
    "function": {"name": "lookup_customer", "arguments": "{\"email\": \"jane.doe@example.com\"}"}}]
}}]
```

After this change the arguments are redacted while the tool name and call structure stay intact, so token counts and metrics are unaffected:

```json
"choices": [{"message": {
  "content": "redacted-by-litellm",
  "tool_calls": [{"id": "call_1", "type": "function",
    "function": {"name": "lookup_customer", "arguments": "redacted-by-litellm"}}]
}}]
```

I verified this at the redaction layer rather than against a live proxy, since reproducing the spend-log entry end to end needs the proxy running with a real tool-calling model. The behavior is pinned by the added regression tests, which fail on the current code (arguments are not redacted) and pass with the fix, across the object response path, the dict response path, and the streaming delta path

## Type

🐛 Bug Fix

## Changes

`_redact_choice_content` and `_redact_model_response_dict_choices` in `litellm/litellm_core_utils/redact_messages.py` redacted `content`, `reasoning_content`, `thinking_blocks` and `audio`, but never `tool_calls`. Every redaction path funnels through these two helpers (the direct result, the streaming `complete_streaming_response`, and the `standard_logging_object` response), so assistant tool call arguments survived redaction everywhere

This adds `tool_calls` argument redaction to both helpers, for the message choice and the streaming delta, in both the object form (`litellm.Choices` / `StreamingChoices`) and the dict form. Only `function.arguments` is blanked; the tool name, id and overall structure are preserved, consistent with how `content` is replaced with a placeholder rather than dropped

## QA runbook

The regression tests are `TestPerformRedaction::test_redacts_tool_call_arguments` (object `ModelResponse` path) and `TestPerformRedaction::test_redacts_tool_call_arguments_in_dict_choices` (dict message and delta paths) in `tests/test_litellm/litellm_core_utils/test_redact_messages.py`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
