### PR TITLE
feat(prometheus): add model_group to provider prompt-cache metrics

### DIFF
--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -698,9 +698,12 @@ class PrometheusMetricLabels:
     litellm_cache_misses_metric = _cache_metric_labels
     litellm_cached_tokens_metric = _cache_metric_labels
 
-    # Provider prompt-caching metrics - track tokens read/written to provider caches
-    litellm_provider_cache_read_input_tokens_metric = _cache_metric_labels
-    litellm_provider_cache_creation_input_tokens_metric = _cache_metric_labels
+    # Provider prompt-caching metrics additionally carry model_group so cache
+    # reads/writes can be split per model group (api_provider is already
+    # inherited from _cache_metric_labels).
+    _provider_cache_metric_labels = _cache_metric_labels + [UserAPIKeyLabelNames.MODEL_GROUP.value]
+    litellm_provider_cache_read_input_tokens_metric = _provider_cache_metric_labels
+    litellm_provider_cache_creation_input_tokens_metric = _provider_cache_metric_labels
 
     # Metrics whose emission paths supply org context (used by get_labels)
     _org_label_metrics: ClassVar[frozenset] = frozenset(

--- a/tests/test_litellm/integrations/test_prometheus_cache_metrics.py
+++ b/tests/test_litellm/integrations/test_prometheus_cache_metrics.py
@@ -5,7 +5,7 @@ Run with: uv run pytest tests/test_litellm/integrations/test_prometheus_cache_me
 """
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from litellm.types.integrations.prometheus import UserAPIKeyLabelValues
 
 
@@ -46,9 +46,7 @@ class TestPrometheusCacheMetrics:
         assert hasattr(PrometheusMetricLabels, "litellm_cache_hits_metric")
         assert hasattr(PrometheusMetricLabels, "litellm_cache_misses_metric")
         assert hasattr(PrometheusMetricLabels, "litellm_cached_tokens_metric")
-        assert hasattr(
-            PrometheusMetricLabels, "litellm_provider_cache_read_input_tokens_metric"
-        )
+        assert hasattr(PrometheusMetricLabels, "litellm_provider_cache_read_input_tokens_metric")
         assert hasattr(
             PrometheusMetricLabels,
             "litellm_provider_cache_creation_input_tokens_metric",
@@ -68,14 +66,8 @@ class TestPrometheusCacheMetrics:
             assert label in PrometheusMetricLabels.litellm_cache_hits_metric
             assert label in PrometheusMetricLabels.litellm_cache_misses_metric
             assert label in PrometheusMetricLabels.litellm_cached_tokens_metric
-            assert (
-                label
-                in PrometheusMetricLabels.litellm_provider_cache_read_input_tokens_metric
-            )
-            assert (
-                label
-                in PrometheusMetricLabels.litellm_provider_cache_creation_input_tokens_metric
-            )
+            assert label in PrometheusMetricLabels.litellm_provider_cache_read_input_tokens_metric
+            assert label in PrometheusMetricLabels.litellm_provider_cache_creation_input_tokens_metric
 
     def test_increment_cache_metrics_on_cache_hit(self, sample_enum_values):
         """Test that cache hit increments the correct metrics"""
@@ -132,20 +124,14 @@ class TestPrometheusCacheMetrics:
 
         # Verify cached tokens metric was incremented with total_tokens
         mock_logger.litellm_cached_tokens_metric.labels.assert_called()
-        mock_logger.litellm_cached_tokens_metric.labels().inc.assert_called_once_with(
-            100
-        )
+        mock_logger.litellm_cached_tokens_metric.labels().inc.assert_called_once_with(100)
 
         # Verify cache misses metric was NOT called
         mock_logger.litellm_cache_misses_metric.labels.assert_not_called()
 
         # Verify provider prompt caching metrics were incremented
-        mock_logger.litellm_provider_cache_read_input_tokens_metric.labels().inc.assert_called_once_with(
-            25
-        )
-        mock_logger.litellm_provider_cache_creation_input_tokens_metric.labels().inc.assert_called_once_with(
-            10
-        )
+        mock_logger.litellm_provider_cache_read_input_tokens_metric.labels().inc.assert_called_once_with(25)
+        mock_logger.litellm_provider_cache_creation_input_tokens_metric.labels().inc.assert_called_once_with(10)
 
     def test_increment_cache_metrics_on_cache_miss(self, sample_enum_values):
         """Test that cache miss increments the correct metrics"""
@@ -204,14 +190,10 @@ class TestPrometheusCacheMetrics:
         mock_logger.litellm_cached_tokens_metric.labels.assert_not_called()
 
         # Provider prompt caching metrics should still be emitted
-        mock_logger.litellm_provider_cache_read_input_tokens_metric.labels().inc.assert_called_once_with(
-            20
-        )
+        mock_logger.litellm_provider_cache_read_input_tokens_metric.labels().inc.assert_called_once_with(20)
         mock_logger.litellm_provider_cache_creation_input_tokens_metric.labels.assert_not_called()
 
-    def test_provider_cache_read_does_not_fallback_on_explicit_zero(
-        self, sample_enum_values
-    ):
+    def test_provider_cache_read_does_not_fallback_on_explicit_zero(self, sample_enum_values):
         """Explicit cache_read_input_tokens=0 must not trigger fallback to cached_tokens."""
         mock_logger = MagicMock()
 
@@ -311,10 +293,24 @@ class TestPrometheusCacheMetrics:
         mock_logger.litellm_cached_tokens_metric.labels.assert_not_called()
 
         # Provider prompt caching metrics should still be emitted
-        mock_logger.litellm_provider_cache_read_input_tokens_metric.labels().inc.assert_called_once_with(
-            25
-        )
+        mock_logger.litellm_provider_cache_read_input_tokens_metric.labels().inc.assert_called_once_with(25)
         mock_logger.litellm_provider_cache_creation_input_tokens_metric.labels.assert_not_called()
+
+    def test_provider_cache_metrics_include_model_group(self):
+        """Provider-cache metrics carry both api_provider (inherited) and model_group."""
+        from litellm.types.integrations.prometheus import PrometheusMetricLabels
+
+        for metric in (
+            "litellm_provider_cache_read_input_tokens_metric",
+            "litellm_provider_cache_creation_input_tokens_metric",
+        ):
+            labels = PrometheusMetricLabels.get_labels(metric)
+            assert "model_group" in labels
+            assert "api_provider" in labels
+
+        # model_group is scoped to the provider-cache metrics; the LiteLLM
+        # response-cache metrics keep their existing label set.
+        assert "model_group" not in PrometheusMetricLabels.get_labels("litellm_cache_hits_metric")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Relevant issues

Relates to #18382 (caching Prometheus metrics).

## What & why

`litellm_provider_cache_read_input_tokens_metric` and `litellm_provider_cache_creation_input_tokens_metric` recently gained `api_provider` (via `_cache_metric_labels`), which lets you attribute provider-side prompt-cache reads/writes to a specific provider. This PR adds the companion **`model_group`** label to those two metrics.

Together they let you break provider prompt-cache read/write tokens down by **provider _and_ model group** — e.g. when one model group is load-balanced across providers, or one provider serves several model groups, you can see which model group's prompt cache is warm vs. being re-created each turn. That's the signal needed to spot prompt-cache shatter per model group, not just per provider.

## Design

- Adds `model_group` to a provider-cache-specific label list (`_cache_metric_labels + [model_group]`), scoped to the two provider-cache metrics. The LiteLLM response-cache metrics (`litellm_cache_hits_metric` etc.) keep their existing label set.
- Unconditional, mirroring the recent unconditional `api_provider` addition to these metrics.
- No emission-path change needed: `_increment_cache_metrics` already builds the label-values object with `model_group`, so it populates automatically once declared.
- This adds one label to the two provider-cache counters, so their series cardinality grows by the number of distinct model groups (same tradeoff as the existing `api_provider` label).

## Testing

```
uv run pytest tests/test_litellm/integrations/test_prometheus_cache_metrics.py -v
```
New test asserts both provider-cache metrics carry `model_group` (and the inherited `api_provider`), and that `model_group` is not leaked onto the LiteLLM response-cache metrics.

## Type

🆕 Enhancement — additive label on two counters (no behavior change).