### PR TITLE
fix(ui): drop w-full from page-content wrappers to remove 32px horizontal overflow

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.tsx
@@ -296,7 +296,7 @@ const ModelsAndEndpointsView: React.FC<ModelDashboardProps> = ({ premiumUser, te
   }
 
   return (
-    <div className="w-full mx-4 h-[75vh]">
+    <div className="mx-4 h-[75vh]">
       <Grid numItems={1} className="gap-2 p-8 w-full mt-2">
         <Col numColSpan={1} className="flex flex-col gap-2">
           {/* Model Management Header */}

--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/organizations.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/organizations.tsx
@@ -191,7 +191,7 @@ const OrganizationsTable: React.FC<OrganizationsTableProps> = ({
   }
 
   return (
-    <div className="w-full mx-4 h-[75vh]">
+    <div className="mx-4 h-[75vh]">
       <Grid numItems={1} className="gap-2 p-8 w-full mt-2">
         <Col numColSpan={1} className="flex flex-col gap-2">
           {(userRole === "Admin" || userRole === "Org Admin") && (

--- a/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/index.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/index.tsx
@@ -115,7 +115,7 @@ const TagManagement: React.FC<TagProps> = ({ accessToken, userID, userRole }) =>
   }, [accessToken]);
 
   return (
-    <div className="w-full mx-4 h-[75vh]">
+    <div className="mx-4 h-[75vh]">
       {selectedTagId ? (
         <TagInfoView
           tagId={selectedTagId}

--- a/ui/litellm-dashboard/src/app/(dashboard)/vector-stores/_components/index.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/vector-stores/_components/index.tsx
@@ -138,7 +138,7 @@ const VectorStoreManagement: React.FC<VectorStoreProps> = ({ accessToken, userID
       />
     </div>
   ) : (
-    <div className="w-full mx-4 h-[75vh]">
+    <div className="mx-4 h-[75vh]">
       <div className="gap-2 p-8 h-[75vh] w-full mt-2">
         <div className="flex justify-between mt-2 w-full items-center mb-4">
           <h1>Vector Store Management</h1>

--- a/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
@@ -382,7 +382,7 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
   }
 
   return (
-    <div className="w-full mx-4 h-[75vh]">
+    <div className="mx-4 h-[75vh]">
       {publicPage == false ? (
         <div className="w-full m-2 mt-2 p-8">
           {/* Header with Title, Description and URL */}

--- a/ui/litellm-dashboard/src/components/settings.tsx
+++ b/ui/litellm-dashboard/src/components/settings.tsx
@@ -566,7 +566,7 @@ const Settings: React.FC<SettingsPageProps> = ({ accessToken, userRole, userID, 
   }
 
   return (
-    <div className="w-full mx-4">
+    <div className="mx-4">
       <Grid numItems={1} className="gap-2 p-8 w-full mt-2">
         <TabGroup>
           <TabList variant="line" defaultValue="1">


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Verified live against a dev server (`npm run dev` in `ui/litellm-dashboard`) pointed at a local proxy on port 4000, at commit af184eb19a. For each page I measured the scrollable `main`'s horizontal overflow (`scrollWidth - clientWidth`). Since the fix is a single-token removal, before/after were captured on the same commit by toggling the `w-full` class back onto the wrapper in the DOM, which isolates that wrapper as the exact source of the overflow

| Page | Route | Overflow with `w-full` (before) | Overflow without `w-full` (this PR) |
| --- | --- | --- | --- |
| Models + Endpoints | /models-and-endpoints | 32px | 0px |
| Tag Management | /tag-management | 32px | 0px |
| Organizations | /organizations | 32px | 0px |
| Vector Stores | /vector-stores | 32px | 0px |
| AI Hub | /model-hub-table | 32px | 0px |
| Logging & Alerts | /logging-and-alerts | 32px | 0px |

Every page drops from a 32px horizontal overflow (the scrollbar under the pagination) to 0, and re-adding `w-full` reproduces exactly 32px again, so the wrapper is confirmed as the cause on each page

## Type

🐛 Bug Fix

## Changes

Several dashboard pages wrap their content in a div styled `w-full mx-4 h-[75vh]` (Logging & Alerts uses `w-full mx-4`). `w-full` sets width to 100% of the scrollable `main`, and `mx-4` adds 16px of margin on each side, so the element's margin-box is `100% + 32px` and overflows `main` by exactly 32px. Because `main` is `overflow-y-auto`, its `overflow-x` computes to `auto`, so the overflow surfaces as a horizontal scrollbar along the bottom of the whole content area under the pagination

The wrapped block is already full width without `w-full`, so removing that one token keeps the layout and takes the overflow to 0. This is the same fix already applied to the Virtual Keys page in #33112, extended to the remaining pages that share the wrapper: Models + Endpoints, Tag Management, Organizations, Vector Stores, AI Hub, and Logging & Alerts

The change is limited to removing `w-full` from those six wrappers; no other markup or styling was touched. It is a Tailwind-class-only change with no runtime logic, so there is no meaningful unit test to add (jsdom has no layout engine, and a className-absence assertion would be non-substantive coverage-filler); the regression guard is the live overflow measurement above

Before (scrollbar at the very bottom):
<img width="1612" height="919" alt="image" src="https://github.com/user-attachments/assets/d5aa0c08-7c10-4e2d-886b-5ebc2672d07a" />


After:
<img width="1610" height="1391" alt="image" src="https://github.com/user-attachments/assets/fc67f734-95cc-4946-a5a6-70dc95f3d6f9" />
