### PR TITLE
fix(prometheus): read v3 rate limiter remaining values for per-key model gauges

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1716,6 +1716,35 @@ class PrometheusLogger(CustomLogger):
             amount=float(response_cost),
         )
 
+    @staticmethod
+    def _get_remaining_from_v3_rate_limit_headers(
+        standard_logging_payload: StandardLoggingPayload | None,
+        rate_limit_type: Literal["requests", "tokens"],
+    ) -> int | None:
+        """
+        Read the per-(key, model) remaining value emitted by the v3 rate
+        limiter (``parallel_request_limiter_v3.py``), which writes
+        ``x-ratelimit-model_per_key-remaining-{requests,tokens}`` into
+        ``standard_logging_object.hidden_params.additional_headers`` instead
+        of the ``litellm-key-remaining-*`` metadata keys the legacy limiter
+        sets. The header carries no model group; it always refers to this
+        request's model group, which is what the gauges are labeled with.
+        Values are written in-process as plain ints (never HTTP-serialized
+        strings), so anything else is rejected rather than coerced.
+        """
+        if standard_logging_payload is None:
+            return None
+        hidden_params = standard_logging_payload.get("hidden_params")
+        if hidden_params is None:
+            return None
+        additional_headers = hidden_params.get("additional_headers")
+        if additional_headers is None:
+            return None
+        value = dict(additional_headers).get(f"x-ratelimit-model_per_key-remaining-{rate_limit_type}")
+        if isinstance(value, bool) or not isinstance(value, int):
+            return None
+        return value
+
     def _set_virtual_key_rate_limit_metrics(
         self,
         user_api_key: Optional[str],
@@ -1733,11 +1762,20 @@ class PrometheusLogger(CustomLogger):
         model_group = get_model_group_from_litellm_kwargs(kwargs)
         remaining_requests_variable_name = f"litellm-key-remaining-requests-{model_group}"
         remaining_tokens_variable_name = f"litellm-key-remaining-tokens-{model_group}"
+        standard_logging_payload: StandardLoggingPayload | None = kwargs.get("standard_logging_object")
 
         remaining_requests = metadata.get(remaining_requests_variable_name)
         if remaining_requests is None:
+            remaining_requests = self._get_remaining_from_v3_rate_limit_headers(
+                standard_logging_payload=standard_logging_payload, rate_limit_type="requests"
+            )
+        if remaining_requests is None:
             remaining_requests = sys.maxsize
         remaining_tokens = metadata.get(remaining_tokens_variable_name)
+        if remaining_tokens is None:
+            remaining_tokens = self._get_remaining_from_v3_rate_limit_headers(
+                standard_logging_payload=standard_logging_payload, rate_limit_type="tokens"
+            )
         if remaining_tokens is None:
             remaining_tokens = sys.maxsize
 

--- a/tests/test_litellm/integrations/test_prometheus_rate_limit_labels.py
+++ b/tests/test_litellm/integrations/test_prometheus_rate_limit_labels.py
@@ -326,3 +326,148 @@ async def test_should_leave_rate_limit_labels_blank_for_non_rate_limit_failure()
     assert isinstance(enum_values, UserAPIKeyLabelValues)
     assert enum_values.rate_limit_category is None
     assert enum_values.rate_limit_type is None
+
+
+def _logger_with_mock_virtual_key_gauges() -> PrometheusLogger:
+    with patch(
+        "litellm.integrations.prometheus.PrometheusLogger.__init__", return_value=None
+    ):
+        logger = PrometheusLogger()
+    logger.litellm_remaining_api_key_requests_for_model = MagicMock()
+    logger.litellm_remaining_api_key_tokens_for_model = MagicMock()
+    logger.get_labels_for_metric = MagicMock(return_value=[])
+    return logger
+
+
+def _kwargs_with_v3_rate_limit_headers(additional_headers: dict) -> dict:
+    return {
+        "litellm_params": {"metadata": {"model_group": "gpt-4o-mini"}},
+        "standard_logging_object": {
+            "metadata": {},
+            "hidden_params": {"additional_headers": additional_headers},
+        },
+    }
+
+
+def _set_virtual_key_metrics(logger: PrometheusLogger, kwargs: dict) -> None:
+    logger._set_virtual_key_rate_limit_metrics(
+        user_api_key="test-hash",
+        user_api_key_alias="test-alias",
+        kwargs=kwargs,
+        metadata=kwargs["litellm_params"]["metadata"],
+        model_id="model-123",
+    )
+
+
+def test_should_read_v3_remaining_headers_when_metadata_keys_absent():
+    """
+    Regression for LIT-2577: the default v3 rate limiter writes remaining
+    per-(key, model) values into
+    ``standard_logging_object.hidden_params.additional_headers`` as
+    ``x-ratelimit-model_per_key-remaining-{requests,tokens}`` and never sets
+    the legacy ``litellm-key-remaining-*`` metadata keys, so the gauges were
+    pinned to ``sys.maxsize``.
+    """
+    logger = _logger_with_mock_virtual_key_gauges()
+    kwargs = _kwargs_with_v3_rate_limit_headers(
+        {
+            "x-ratelimit-model_per_key-remaining-requests": 42,
+            "x-ratelimit-model_per_key-remaining-tokens": 900,
+            "x-ratelimit-model_per_key-limit-requests": 100,
+            "x-ratelimit-model_per_key-limit-tokens": 1000,
+        }
+    )
+
+    _set_virtual_key_metrics(logger, kwargs)
+
+    logger.litellm_remaining_api_key_requests_for_model.labels.return_value.set.assert_called_once_with(
+        42
+    )
+    logger.litellm_remaining_api_key_tokens_for_model.labels.return_value.set.assert_called_once_with(
+        900
+    )
+
+
+def test_should_prefer_legacy_metadata_keys_over_v3_headers():
+    logger = _logger_with_mock_virtual_key_gauges()
+    kwargs = _kwargs_with_v3_rate_limit_headers(
+        {
+            "x-ratelimit-model_per_key-remaining-requests": 42,
+            "x-ratelimit-model_per_key-remaining-tokens": 900,
+        }
+    )
+    kwargs["litellm_params"]["metadata"].update(
+        {
+            "litellm-key-remaining-requests-gpt-4o-mini": 3,
+            "litellm-key-remaining-tokens-gpt-4o-mini": 200,
+        }
+    )
+
+    _set_virtual_key_metrics(logger, kwargs)
+
+    logger.litellm_remaining_api_key_requests_for_model.labels.return_value.set.assert_called_once_with(
+        3
+    )
+    logger.litellm_remaining_api_key_tokens_for_model.labels.return_value.set.assert_called_once_with(
+        200
+    )
+
+
+def test_should_treat_zero_v3_remaining_as_zero():
+    logger = _logger_with_mock_virtual_key_gauges()
+    kwargs = _kwargs_with_v3_rate_limit_headers(
+        {
+            "x-ratelimit-model_per_key-remaining-requests": 0,
+            "x-ratelimit-model_per_key-remaining-tokens": 0,
+        }
+    )
+
+    _set_virtual_key_metrics(logger, kwargs)
+
+    logger.litellm_remaining_api_key_requests_for_model.labels.return_value.set.assert_called_once_with(
+        0
+    )
+    logger.litellm_remaining_api_key_tokens_for_model.labels.return_value.set.assert_called_once_with(
+        0
+    )
+
+
+def test_should_keep_maxsize_sentinel_when_no_rate_limit_source_present():
+    import sys
+
+    logger = _logger_with_mock_virtual_key_gauges()
+    kwargs = {
+        "litellm_params": {"metadata": {"model_group": "gpt-4o-mini"}},
+        "standard_logging_object": {"metadata": {}, "hidden_params": {}},
+    }
+
+    _set_virtual_key_metrics(logger, kwargs)
+
+    logger.litellm_remaining_api_key_requests_for_model.labels.return_value.set.assert_called_once_with(
+        sys.maxsize
+    )
+    logger.litellm_remaining_api_key_tokens_for_model.labels.return_value.set.assert_called_once_with(
+        sys.maxsize
+    )
+
+
+@pytest.mark.parametrize("bad_value", ["not-a-number", None, True])
+def test_should_ignore_non_int_v3_header_values(bad_value):
+    import sys
+
+    logger = _logger_with_mock_virtual_key_gauges()
+    kwargs = _kwargs_with_v3_rate_limit_headers(
+        {
+            "x-ratelimit-model_per_key-remaining-requests": bad_value,
+            "x-ratelimit-model_per_key-remaining-tokens": bad_value,
+        }
+    )
+
+    _set_virtual_key_metrics(logger, kwargs)
+
+    logger.litellm_remaining_api_key_requests_for_model.labels.return_value.set.assert_called_once_with(
+        sys.maxsize
+    )
+    logger.litellm_remaining_api_key_tokens_for_model.labels.return_value.set.assert_called_once_with(
+        sys.maxsize
+    )


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-2577

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All runs against a live proxy (port 4577) with a real Postgres and real OpenAI calls. Setup: default settings (v3 rate limiter), prometheus callback enabled, virtual key with per-model limits

```bash
curl -sS http://localhost:4577/key/generate -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"key_alias":"lit2577-repro","model_rpm_limit":{"gpt-4o-mini":100},"model_tpm_limit":{"gpt-4o-mini":100000}}'
```

Before, at base commit 095ccd727d (unfixed). The response headers carry the real remaining values while the gauges are pinned to sys.maxsize

```bash
$ curl -sS -D - http://localhost:4577/v1/chat/completions -H "Authorization: Bearer $KEY" \
    -H "Content-Type: application/json" \
    -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"say hi"}]}' -o /dev/null | grep -i x-ratelimit-model_per_key-remaining
x-ratelimit-model_per_key-remaining-requests: 99
x-ratelimit-model_per_key-remaining-tokens: 98975

$ curl -sS http://localhost:4577/metrics/ | grep -E "^litellm_remaining_api_key_(requests|tokens)_for_model"
litellm_remaining_api_key_requests_for_model{api_key_alias="lit2577-repro",...,model="gpt-4o-mini",...} 9.223372036854776e+18
litellm_remaining_api_key_tokens_for_model{api_key_alias="lit2577-repro",...,model="gpt-4o-mini",...} 9.223372036854776e+18
```

After, at 2b4d1e5369 (this PR). Same curls; the gauges now match the headers

```bash
$ curl -sS -D - http://localhost:4577/v1/chat/completions ... | grep -i x-ratelimit-model_per_key-remaining
x-ratelimit-model_per_key-remaining-requests: 99
x-ratelimit-model_per_key-remaining-tokens: 98975

$ curl -sS http://localhost:4577/metrics/ | grep -E "^litellm_remaining_api_key_(requests|tokens)_for_model"
litellm_remaining_api_key_requests_for_model{api_key_alias="lit2577-repro",...,model="gpt-4o-mini",...} 99.0
litellm_remaining_api_key_tokens_for_model{api_key_alias="lit2577-repro",...,model="gpt-4o-mini",...} 98975.0
```

Streaming also lands in the gauges (a follow-up streaming request with the same key decrements them)

```bash
$ curl -sS http://localhost:4577/v1/chat/completions -H "Authorization: Bearer $KEY" \
    -H "Content-Type: application/json" \
    -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"say hi"}],"stream":true}' -o /dev/null

$ curl -sS http://localhost:4577/metrics/ | grep -E "^litellm_remaining_api_key_requests_for_model"
litellm_remaining_api_key_requests_for_model{api_key_alias="lit2577-repro",...} 98.0
```

A key without per-model limits keeps the sys.maxsize sentinel, unchanged from today

```bash
$ curl -sS http://localhost:4577/key/generate -H "Authorization: Bearer sk-1234" \
    -H "Content-Type: application/json" -d '{"key_alias":"lit2577-nolimits"}'
$ curl ... one completion with that key ...
$ curl -sS http://localhost:4577/metrics/ | grep nolimits
litellm_remaining_api_key_requests_for_model{api_key_alias="lit2577-nolimits",...} 9.223372036854776e+18
```

## Type

🐛 Bug Fix

## Changes

`litellm_remaining_api_key_requests_for_model` / `litellm_remaining_api_key_tokens_for_model` read their values from the request metadata keys `litellm-key-remaining-{requests,tokens}-{model_group}`, which only the legacy rate limiter (`LEGACY_MULTI_INSTANCE_RATE_LIMITING=true`) writes. The default v3 limiter writes remaining values into `standard_logging_object.hidden_params.additional_headers` as `x-ratelimit-model_per_key-remaining-{requests,tokens}` instead (present for both streaming and non-streaming since #32711), so under the default limiter the gauges always fell through to the sys.maxsize fallback and dashboards showed ~9.22e18 for every key

`_set_virtual_key_rate_limit_metrics` now falls back to the v3 values when the legacy metadata keys are absent. Legacy metadata keeps precedence, so deployments on the legacy limiter (or with a custom logger that populates those keys) are unaffected, and the sys.maxsize sentinel still means "no per-key-per-model limit configured". The v3 header names carry no model group; they always refer to the request's own model group, which is what the gauges are labeled with, so the existing label derivation is unchanged. Values are written in-process as plain ints; anything else (including bools) is rejected rather than coerced

Regression tests extend `tests/test_litellm/integrations/test_prometheus_rate_limit_labels.py`: reading the v3 values when metadata is absent, legacy precedence, zero remaining treated as a real value, sentinel when no source exists, and non-int rejection. The v3-read and zero tests fail on the unfixed code

Known sibling gap, deliberately out of scope: the client-facing `x-litellm-key-remaining-*` response headers built in `litellm/proxy/common_utils/callback_utils.py` read the same legacy metadata and are also empty under the v3 limiter; tracked in LIT-4410

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change to Prometheus gauge population with legacy metadata taking precedence; no auth or request-path behavior changes.
> 
> **Overview**
> Fixes **LIT-2577**: with the default v3 rate limiter, `litellm_remaining_api_key_requests_for_model` and `litellm_remaining_api_key_tokens_for_model` no longer stick at `sys.maxsize` (~9.22e18) because they only read legacy `litellm-key-remaining-*` metadata.
> 
> **`_set_virtual_key_rate_limit_metrics`** still uses those metadata keys first, then falls back to **`_get_remaining_from_v3_rate_limit_headers`**, which reads `x-ratelimit-model_per_key-remaining-{requests,tokens}` from `standard_logging_object.hidden_params.additional_headers` and accepts only plain `int` values (including `0`).
> 
> Regression tests in `test_prometheus_rate_limit_labels.py` cover v3 fallback, legacy precedence, zero remaining, missing sources, and invalid header values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b4d1e53699fd234c6b3064aa24e66d368a39a3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->