### PR TITLE
fix(crusoe): update base URL to current endpoint

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -108,7 +108,7 @@
     "api_base_env": "AIHUBMIX_API_BASE"
   },
   "crusoe": {
-    "base_url": "https://managed-inference-api-proxy.crusoecloud.com/v1",
+    "base_url": "https://api.inference.crusoecloud.com/v1",
     "api_key_env": "CRUSOE_API_KEY",
     "api_base_env": "CRUSOE_API_BASE",
     "param_mappings": {

--- a/tests/llm_translation/test_crusoe.py
+++ b/tests/llm_translation/test_crusoe.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import litellm
 
-CRUSOE_API_BASE = "https://managed-inference-api-proxy.crusoecloud.com/v1"
+CRUSOE_API_BASE = "https://api.inference.crusoecloud.com/v1"
 
 
 def test_crusoe_json_registry():

--- a/tests/test_litellm/llms/crusoe/test_crusoe.py
+++ b/tests/test_litellm/llms/crusoe/test_crusoe.py
@@ -1,7 +1,7 @@
 import os
 from unittest.mock import patch
 
-CRUSOE_API_BASE = "https://managed-inference-api-proxy.crusoecloud.com/v1"
+CRUSOE_API_BASE = "https://api.inference.crusoecloud.com/v1"
 
 
 def test_crusoe_json_registry():


### PR DESCRIPTION
## Title

fix(crusoe): update base URL to current endpoint

## Relevant issues

N/A — endpoint correction for the Crusoe provider added in #23195.

## Type

🐛 Bug Fix

## Changes

Crusoe's managed inference endpoint moved. This updates the provider's default base URL from `https://managed-inference-api-proxy.crusoecloud.com/v1` to the current documented endpoint `https://api.inference.crusoecloud.com/v1` (see https://docs.crusoecloud.com/managed-inference/overview).

- `litellm/llms/openai_like/providers.json` — `crusoe.base_url` updated
- `tests/llm_translation/test_crusoe.py` / `tests/test_litellm/llms/crusoe/test_crusoe.py` — expected URL updated

`CRUSOE_API_BASE` env override behavior is unchanged, so anyone pinned to the old proxy URL can keep using it. I maintain Crusoe's ecosystem integrations (original provider PR: #23195).
