### PR TITLE
chore: add CODEOWNERS for ui and proxy UI build artifacts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+/ui/ @yuneng-jiang @ryan-crabbe-berri
+/litellm/proxy/_experimental/out/ @yuneng-jiang @ryan-crabbe-berri


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This adds a `.github/CODEOWNERS` file only, so there is no proxy or UI runtime surface to exercise. Verification done instead: both handles resolve to real GitHub accounts (`gh api users/yuneng-jiang` and `gh api users/ryan-crabbe-berri` each return a live user), and both target paths exist in the tree, `ui/` at the repo root and `litellm/proxy/_experimental/out/` tracked in git

```
$ gh api users/yuneng-jiang --jq .login
yuneng-jiang
$ gh api users/ryan-crabbe-berri --jq .login
ryan-crabbe-berri
```

One caveat a reviewer should confirm: GitHub silently ignores CODEOWNERS entries for users without write access to the repo, so both owners need to actually carry write access for these rules to take effect

## Type

🚄 Infrastructure

## Changes

Adds a `.github/CODEOWNERS` (none existed before) assigning @yuneng-jiang and @ryan-crabbe-berri as owners of two paths: the root `ui/` directory and the committed proxy UI build bundle at `litellm/proxy/_experimental/out/`. Both patterns are anchored with a leading slash so they match only those exact locations rather than any similarly named directory elsewhere in the tree

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
