### PR TITLE
test(e2e): otel trace completeness on /chat/completions

### DIFF
--- a/tests/e2e/CLAUDE.md
+++ b/tests/e2e/CLAUDE.md
@@ -13,7 +13,7 @@ Each subdirectory under `tests/e2e/` is one suite, scoped to an endpoint family 
 - `realtime/` - realtime websocket sessions, including the pipecat audio path
 - `quota_management/` - quota enforcement and accounting, one subfolder per behavior: `budgets/` (budget definition, enforcement, and reset windows: key, team, tag, soft, multi-window) and `spend_tracking/` (spend logging and cost attribution on `/spend/*`)
 - `management/` - key/team/user/organization management routes: create/update/delete persistence via the info routes, team membership, and llm-only-key route denials; also the dashboard UI behavior on top of them, driven through the proxy-served UI at /ui with playwright (optional dep behind importorskip)
-- `logging/` - logging-integration delivery (datadog and friends), including OTEL trace-tree completeness read back from the compose stack's local Jaeger destination
+- `logging/` - logging-integration delivery (datadog and friends)
 - `security/` - secret handling and log-leak protection
 - `router/` - routing and reliability behavior (fallbacks, cooldowns)
 - `gateway/` - proxy configuration only (`litellm-config.yml`); no tests

--- a/tests/e2e/CLAUDE.md
+++ b/tests/e2e/CLAUDE.md
@@ -13,7 +13,7 @@ Each subdirectory under `tests/e2e/` is one suite, scoped to an endpoint family 
 - `realtime/` - realtime websocket sessions, including the pipecat audio path
 - `quota_management/` - quota enforcement and accounting, one subfolder per behavior: `budgets/` (budget definition, enforcement, and reset windows: key, team, tag, soft, multi-window) and `spend_tracking/` (spend logging and cost attribution on `/spend/*`)
 - `management/` - key/team/user/organization management routes: create/update/delete persistence via the info routes, team membership, and llm-only-key route denials; also the dashboard UI behavior on top of them, driven through the proxy-served UI at /ui with playwright (optional dep behind importorskip)
-- `logging/` - logging-integration delivery (datadog and friends)
+- `logging/` - logging-integration delivery (datadog and friends), including OTEL trace-tree completeness read back from the compose stack's local Jaeger destination
 - `security/` - secret handling and log-leak protection
 - `router/` - routing and reliability behavior (fallbacks, cooldowns)
 - `gateway/` - proxy configuration only (`litellm-config.yml`); no tests

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       redis:
         condition: service_healthy
       jaeger:
-        condition: service_started
+        condition: service_healthy
     env_file: .env
     environment:
       LITELLM_MASTER_KEY: sk-1234
@@ -132,3 +132,8 @@ services:
     image: jaegertracing/all-in-one:1.62.0
     ports:
       - "16686:16686"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:14269/"]
+      interval: 3s
+      timeout: 3s
+      retries: 20

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -18,6 +18,12 @@ configs:
           type: redis
           host: redis
           port: 6379
+        # OTEL v2 trace destination for the logging suite's trace-completeness
+        # tests: the arize_phoenix preset is OTLP with a configurable endpoint
+        # (PHOENIX_COLLECTOR_HTTP_ENDPOINT below points it at the jaeger service),
+        # so gen-AI spans export through a preset-owned provider - the code path
+        # where trace splits actually happen - with no cloud credentials needed.
+        callbacks: ["arize_phoenix"]
 
       router_settings:
         routing_strategy: simple-shuffle
@@ -68,9 +74,14 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      jaeger:
+        condition: service_started
     env_file: .env
     environment:
       LITELLM_MASTER_KEY: sk-1234
+      LITELLM_OTEL_V2: "true"
+      PHOENIX_COLLECTOR_HTTP_ENDPOINT: http://jaeger:4318/v1/traces
+      PHOENIX_API_KEY: local-jaeger-noauth
       DATABASE_URL: postgresql://litellm:litellm@db:5432/litellm
       UI_USERNAME: admin
       UI_PASSWORD: sk-1234
@@ -114,3 +125,10 @@ services:
       interval: 3s
       timeout: 3s
       retries: 20
+
+# throwaway OTEL trace destination (OTLP ingest on 4318 inside the network,
+# query API on host 16686 for test read-back; see E2E_OTEL_QUERY_URL)
+  jaeger:
+    image: jaegertracing/all-in-one:1.62.0
+    ports:
+      - "16686:16686"

--- a/tests/e2e/e2e_config.py
+++ b/tests/e2e/e2e_config.py
@@ -24,6 +24,13 @@ CONTROL_PLANE_BASE_URL = os.environ.get(
 UI_USERNAME = os.environ.get("E2E_UI_USERNAME", "admin")
 UI_PASSWORD = os.environ.get("E2E_UI_PASSWORD", MASTER_KEY)
 
+CHEAP_ANTHROPIC_MODEL = os.environ.get("E2E_CHEAP_ANTHROPIC_MODEL", "claude-haiku-4-5")
+
+# Jaeger query API of the compose stack's OTEL trace destination (the `jaeger`
+# service in docker-compose.yml maps it to host 16686). Trace-completeness tests
+# read exported spans back through it.
+OTEL_QUERY_URL = os.environ.get("E2E_OTEL_QUERY_URL", "http://localhost:16686").rstrip("/")
+
 # Writes on the proxy are eventually consistent (e.g. spend rows flush on
 # proxy_batch_write_at, ~60s). Read-backs poll to this deadline, never sleep-once.
 POLL_TIMEOUT = float(os.environ.get("E2E_POLL_TIMEOUT", "120"))

--- a/tests/e2e/logging/conftest.py
+++ b/tests/e2e/logging/conftest.py
@@ -11,6 +11,7 @@ import os
 import pytest
 
 from logging_client import LangfuseCreds, LoggingClient, build_logging_client, load_langfuse_creds
+from otel_client import OtelReader, build_otel_reader
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -26,6 +27,12 @@ def client() -> LoggingClient:
     `scoped_key` clean up keys and teams, and adds `/metrics` scraping plus
     Langfuse read-back."""
     return build_logging_client()
+
+
+@pytest.fixture(scope="session")
+def otel_reader() -> OtelReader:
+    """Read-back client for the compose stack's Jaeger trace destination."""
+    return build_otel_reader()
 
 
 @pytest.fixture

--- a/tests/e2e/logging/otel_client.py
+++ b/tests/e2e/logging/otel_client.py
@@ -2,16 +2,25 @@
 Jaeger query API (the destination's own API - completeness is judged on what the
 backend actually holds, never on "export succeeded" proxy-side).
 
-A trace matches a call when the request's x-litellm-call-id or the unique prompt
-marker appears in any span tag. External reads go through ``e2e_http`` (the only
-module allowed to call ``requests.*``).
+Traces are fetched server-side by the ``litellm.call_id`` tag the gen-AI span
+carries (the request's x-litellm-call-id response header), so read-back is
+immune to the query page filling up with unrelated traffic (background jobs,
+other suites sharing the stack). Jaeger returns every span of a matching trace,
+so the completeness assertions see the whole tree. A failed query is a hard
+failure, never an empty result - an unreachable destination must not read as
+"the trace never arrived".
+
+External reads go through ``e2e_http`` (the only module allowed to call
+``requests.*``).
 """
 
 from __future__ import annotations
 
+import json
 import time
 from dataclasses import dataclass
 
+import pytest
 from pydantic import BaseModel, ConfigDict, Field
 
 from e2e_config import OTEL_QUERY_URL, POLL_INTERVAL, POLL_TIMEOUT
@@ -19,6 +28,8 @@ from e2e_http import URL, NoBody, Success, get
 
 #: OTEL resource service.name the proxy exports under (OTEL_SERVICE_NAME default).
 JAEGER_SERVICE = "litellm"
+#: Span tag carrying the request's x-litellm-call-id (stamped on the gen-AI span).
+CALL_ID_TAG = "litellm.call_id"
 
 
 class JaegerTag(BaseModel):
@@ -52,9 +63,6 @@ class JaegerSpan(BaseModel):
                 return str(tag.value)
         return ""
 
-    def tag_blob(self) -> str:
-        return " ".join(f"{tag.key}={tag.value}" for tag in self.tags)
-
 
 class JaegerTrace(BaseModel):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
@@ -74,52 +82,53 @@ class JaegerTracesPage(BaseModel):
 
 class _TracesQuery(BaseModel):
     service: str
-    limit: int = 200
+    tags: str
+    limit: int = 20
     lookback: str = "1h"
+
+
+def _settled(trace: JaegerTrace, names: set[str], prefixes: set[str]) -> bool:
+    present = set(trace.span_names())
+    return names.issubset(present) and all(
+        any(name.startswith(prefix) for name in present) for prefix in prefixes
+    )
 
 
 @dataclass(frozen=True, slots=True)
 class OtelReader:
     query_url: str
 
-    def _recent_traces(self) -> list[JaegerTrace]:
+    def traces_for_call(self, call_id: str) -> list[JaegerTrace]:
+        """Every trace holding a span tagged with this call id. Jaeger matches
+        spans server-side and returns their full traces; more than one hit for
+        one call IS the split-trace bug, so this never collapses to one."""
         result = get(
             URL(f"{self.query_url}/api/traces"),
             headers=NoBody(),
-            params=_TracesQuery(service=JAEGER_SERVICE),
+            params=_TracesQuery(service=JAEGER_SERVICE, tags=json.dumps({CALL_ID_TAG: call_id})),
             response_type=JaegerTracesPage,
             timeout=30.0,
         )
         match result:
             case Success(data=page):
                 return page.data
-            case _:
-                return []
-
-    def traces_for_call(self, *, call_id: str, marker: str) -> list[JaegerTrace]:
-        """Every trace holding the call: matched by the x-litellm-call-id or the
-        unique prompt marker in any span tag. More than one hit for one call IS
-        the split-trace bug, so this never collapses to a single trace."""
-        hits: list[JaegerTrace] = []
-        for trace in self._recent_traces():
-            blob = " ".join(span.tag_blob() for span in trace.spans)
-            if call_id in blob or marker in blob:
-                hits.append(trace)
-        return hits
+            case failure:
+                pytest.fail(f"Jaeger query API at {self.query_url} failed: {failure}")
 
     def poll_traces_for_call(
-        self, *, call_id: str, marker: str, settled_names: set[str]
+        self, *, call_id: str, settled_names: set[str], settled_prefixes: set[str]
     ) -> list[JaegerTrace]:
         """Poll until exactly one trace holds the call and it carries every span
-        name in ``settled_names`` (spans flush in batches, the cost write lands
-        after the response), then return the hits. At the deadline the last hits
-        are returned as-is so the caller's assertions report the real final
-        state - on a split trace this never settles and the orphan comes back."""
+        name in ``settled_names`` plus at least one name per prefix in
+        ``settled_prefixes`` (spans flush in batches, the cost write lands after
+        the response), then return the hits. At the deadline the last hits are
+        returned as-is so the caller's assertions report the real final state -
+        on a split trace this never settles and the orphan comes back."""
         deadline = time.monotonic() + POLL_TIMEOUT
         hits: list[JaegerTrace] = []
         while time.monotonic() < deadline:
-            hits = self.traces_for_call(call_id=call_id, marker=marker)
-            if len(hits) == 1 and settled_names.issubset(set(hits[0].span_names())):
+            hits = self.traces_for_call(call_id)
+            if len(hits) == 1 and _settled(hits[0], settled_names, settled_prefixes):
                 return hits
             time.sleep(POLL_INTERVAL)
         return hits

--- a/tests/e2e/logging/otel_client.py
+++ b/tests/e2e/logging/otel_client.py
@@ -1,0 +1,129 @@
+"""Jaeger read-back for the OTEL trace-completeness tests: typed models over the
+Jaeger query API (the destination's own API - completeness is judged on what the
+backend actually holds, never on "export succeeded" proxy-side).
+
+A trace matches a call when the request's x-litellm-call-id or the unique prompt
+marker appears in any span tag. External reads go through ``e2e_http`` (the only
+module allowed to call ``requests.*``).
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from e2e_config import OTEL_QUERY_URL, POLL_INTERVAL, POLL_TIMEOUT
+from e2e_http import URL, NoBody, Success, get
+
+#: OTEL resource service.name the proxy exports under (OTEL_SERVICE_NAME default).
+JAEGER_SERVICE = "litellm"
+
+
+class JaegerTag(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    key: str
+    value: str | int | float | bool | None = None
+
+
+class JaegerReference(BaseModel):
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    ref_type: str = Field(alias="refType")
+    trace_id: str = Field(alias="traceID")
+    span_id: str = Field(alias="spanID")
+
+
+class JaegerSpan(BaseModel):
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    span_id: str = Field(alias="spanID")
+    operation_name: str = Field(alias="operationName")
+    start_time: int = Field(default=0, alias="startTime")
+    references: list[JaegerReference] = []
+    tags: list[JaegerTag] = []
+
+    @property
+    def kind(self) -> str:
+        for tag in self.tags:
+            if tag.key == "span.kind":
+                return str(tag.value)
+        return ""
+
+    def tag_blob(self) -> str:
+        return " ".join(f"{tag.key}={tag.value}" for tag in self.tags)
+
+
+class JaegerTrace(BaseModel):
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    trace_id: str = Field(alias="traceID")
+    spans: list[JaegerSpan] = []
+
+    def span_names(self) -> list[str]:
+        return sorted(span.operation_name for span in self.spans)
+
+
+class JaegerTracesPage(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    data: list[JaegerTrace] = []
+
+
+class _TracesQuery(BaseModel):
+    service: str
+    limit: int = 200
+    lookback: str = "1h"
+
+
+@dataclass(frozen=True, slots=True)
+class OtelReader:
+    query_url: str
+
+    def _recent_traces(self) -> list[JaegerTrace]:
+        result = get(
+            URL(f"{self.query_url}/api/traces"),
+            headers=NoBody(),
+            params=_TracesQuery(service=JAEGER_SERVICE),
+            response_type=JaegerTracesPage,
+            timeout=30.0,
+        )
+        match result:
+            case Success(data=page):
+                return page.data
+            case _:
+                return []
+
+    def traces_for_call(self, *, call_id: str, marker: str) -> list[JaegerTrace]:
+        """Every trace holding the call: matched by the x-litellm-call-id or the
+        unique prompt marker in any span tag. More than one hit for one call IS
+        the split-trace bug, so this never collapses to a single trace."""
+        hits: list[JaegerTrace] = []
+        for trace in self._recent_traces():
+            blob = " ".join(span.tag_blob() for span in trace.spans)
+            if call_id in blob or marker in blob:
+                hits.append(trace)
+        return hits
+
+    def poll_traces_for_call(
+        self, *, call_id: str, marker: str, settled_names: set[str]
+    ) -> list[JaegerTrace]:
+        """Poll until exactly one trace holds the call and it carries every span
+        name in ``settled_names`` (spans flush in batches, the cost write lands
+        after the response), then return the hits. At the deadline the last hits
+        are returned as-is so the caller's assertions report the real final
+        state - on a split trace this never settles and the orphan comes back."""
+        deadline = time.monotonic() + POLL_TIMEOUT
+        hits: list[JaegerTrace] = []
+        while time.monotonic() < deadline:
+            hits = self.traces_for_call(call_id=call_id, marker=marker)
+            if len(hits) == 1 and settled_names.issubset(set(hits[0].span_names())):
+                return hits
+            time.sleep(POLL_INTERVAL)
+        return hits
+
+
+def build_otel_reader() -> OtelReader:
+    return OtelReader(query_url=OTEL_QUERY_URL)

--- a/tests/e2e/logging/test_otel_trace_e2e.py
+++ b/tests/e2e/logging/test_otel_trace_e2e.py
@@ -77,7 +77,7 @@ def _first_ok(client: LoggingClient, send: Callable[[], StreamingResponse]) -> S
 
 def _parent_ids(span_id: str, trace: JaegerTrace) -> list[str]:
     span = next(s for s in trace.spans if s.span_id == span_id)
-    return [ref.span_id for ref in span.references]
+    return [ref.span_id for ref in span.references if ref.ref_type == "CHILD_OF"]
 
 
 def _chain_reaches(span_id: str, root_id: str, trace: JaegerTrace) -> bool:
@@ -100,6 +100,10 @@ def _assert_complete_trace(hits: list[JaegerTrace], *, route: str, genai_span: s
     """The enforced behavior: the destination holds exactly one trace for the
     call, rooted at the SERVER span, with auth/db/cost children and the gen-AI
     span all connected into that one tree - no dangling parent references."""
+    assert hits, (
+        "no trace for this call arrived at the destination within the deadline "
+        "(nothing tagged with its call id was found)"
+    )
     assert len(hits) == 1, (
         f"expected exactly ONE trace for the call, got {len(hits)}: "
         f"{[(t.trace_id, t.span_names()) for t in hits]} - more than one trace for "
@@ -153,7 +157,7 @@ class TestOtelTraceCompleteness:
     ) -> None:
         """One successful non-streaming /chat/completions call must export ONE
         complete OTEL trace to the admin-owned destination (LIT-3787): a single
-        root SERVER span ("POST /v1/chat/completions") with the auth phase, db
+        root SERVER span ("POST /chat/completions") with the auth phase, db
         lookup, and cost write under it, and the gen-AI CLIENT span ("chat
         <model>") parented into the same tree - exactly one trace for the call,
         no dangling parent references.
@@ -169,7 +173,6 @@ class TestOtelTraceCompleteness:
         for every OpenAI-compatible SDK; trace completeness must hold here
         before anywhere else.
         """
-        # the exact path chat_raw posts to; the root SERVER span is named after it
         route = "/chat/completions"
         _assert_otel_destination_configured(client)
 
@@ -184,7 +187,7 @@ class TestOtelTraceCompleteness:
 
         hits = otel_reader.poll_traces_for_call(
             call_id=outcome.call_id,
-            marker=marker,
             settled_names=_settled_names(route=route, genai_span=f"chat {MODEL}"),
+            settled_prefixes={DB_SPAN_PREFIX},
         )
         _assert_complete_trace(hits, route=route, genai_span=f"chat {MODEL}")

--- a/tests/e2e/logging/test_otel_trace_e2e.py
+++ b/tests/e2e/logging/test_otel_trace_e2e.py
@@ -1,0 +1,190 @@
+"""Live e2e: OTEL trace completeness on the admin-owned destination (LIT-3787).
+
+Covers logging.otel.success.exports_metric: a successful non-streaming call must
+land at the OTEL destination as ONE connected trace - a single root SERVER span
+with the auth phase, db lookups, and cost write under it, and the gen-AI CLIENT
+span parented into the same tree. The regression this pins: the proxy publishing
+the global TracerProvider before callbacks init made server spans export through
+a different provider than the preset's gen-AI spans, so the destination received
+the gen-AI span alone, dangling (fixed in #30590; verified failing at its parent
+commit 1bd603d1ac).
+
+Both halves of the contract are asserted: the recorded state (the proxy reports
+the OTEL v2 logger active via /health/readiness/details) and the enforced
+behavior (the complete span tree at the destination, read back through the
+destination's own query API - never proxy-side "export succeeded" logs).
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+
+import pytest
+from pydantic import BaseModel, ConfigDict
+
+from e2e_config import CHEAP_ANTHROPIC_MODEL, unique_marker
+from e2e_http import NoBody, StreamingResponse, require_successful_call
+from lifecycle import ResourceManager
+from logging_client import LoggingClient
+from otel_client import JaegerTrace, OtelReader
+
+pytestmark = pytest.mark.e2e
+
+MODEL = CHEAP_ANTHROPIC_MODEL
+COST_SPAN = "batch_write_to_db _PROXY_track_cost_callback"
+DB_SPAN_PREFIX = "postgres "
+#: The active OTEL v2 logger's name in /health/readiness/details success_callbacks.
+OTEL_V2_LOGGER_NAME = "OpenTelemetryV2"
+
+
+class _ReadinessDetails(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    success_callbacks: list[str] = []
+
+
+def _assert_otel_destination_configured(client: LoggingClient) -> None:
+    """Recorded state: the proxy reports the OTEL v2 logger among its active
+    callbacks, so a missing/failed destination config fails here, before any
+    traffic-based assertion can time out confusingly."""
+    result = client.gateway.probe("/health/readiness/details", params=NoBody())
+    assert result.status_code == 200, (
+        f"/health/readiness/details must answer 200, got {result.status_code}: {result.body[:300]}"
+    )
+    details = _ReadinessDetails.model_validate_json(result.body)
+    assert OTEL_V2_LOGGER_NAME in details.success_callbacks, (
+        f"the proxy must report the {OTEL_V2_LOGGER_NAME} callback active "
+        f"(LITELLM_OTEL_V2 + arize_phoenix preset in the compose config); got: {details.success_callbacks}"
+    )
+
+
+def _first_ok(client: LoggingClient, send: Callable[[], StreamingResponse]) -> StreamingResponse:
+    """First successful call on a fresh key. A fresh key may briefly 401 until
+    the data plane's auth cache picks it up, so retry on 401 to a deadline; a
+    401 is rejected before the LLM call so it exports no gen-AI span and cannot
+    contaminate the trace assertions. Any other failure is behavior under test
+    and fails hard."""
+    deadline = time.monotonic() + client.gateway.poll_timeout
+    while True:
+        outcome = send()
+        if outcome.ok:
+            return outcome
+        if outcome.status_code != 401 or time.monotonic() >= deadline:
+            require_successful_call(outcome)
+        time.sleep(client.gateway.poll_interval)
+
+
+def _parent_ids(span_id: str, trace: JaegerTrace) -> list[str]:
+    span = next(s for s in trace.spans if s.span_id == span_id)
+    return [ref.span_id for ref in span.references]
+
+
+def _chain_reaches(span_id: str, root_id: str, trace: JaegerTrace) -> bool:
+    """Walk parent references (within the trace) from span_id up to root_id."""
+    seen: set[str] = set()
+    in_trace = {s.span_id for s in trace.spans}
+    current = span_id
+    while current not in seen:
+        if current == root_id:
+            return True
+        seen.add(current)
+        parents = [p for p in _parent_ids(current, trace) if p in in_trace]
+        if not parents:
+            return False
+        current = parents[0]
+    return False
+
+
+def _assert_complete_trace(hits: list[JaegerTrace], *, route: str, genai_span: str) -> None:
+    """The enforced behavior: the destination holds exactly one trace for the
+    call, rooted at the SERVER span, with auth/db/cost children and the gen-AI
+    span all connected into that one tree - no dangling parent references."""
+    assert len(hits) == 1, (
+        f"expected exactly ONE trace for the call, got {len(hits)}: "
+        f"{[(t.trace_id, t.span_names()) for t in hits]} - more than one trace for "
+        "one call is the split-trace bug (gen-AI span exported away from its root)"
+    )
+    trace = hits[0]
+    names = trace.span_names()
+    in_trace = {span.span_id for span in trace.spans}
+
+    dangling = [
+        span.operation_name
+        for span in trace.spans
+        if span.references and not any(ref.span_id in in_trace for ref in span.references)
+    ]
+    assert not dangling, (
+        f"span(s) {dangling} reference a parent that never reached the destination "
+        f"(orphaned trace); spans present: {names}"
+    )
+
+    roots = [span for span in trace.spans if not span.references]
+    assert len(roots) == 1, f"expected exactly one root span, got {[s.operation_name for s in roots]}; spans: {names}"
+    root = roots[0]
+    assert root.operation_name == f"POST {route}", (
+        f"the root must be the SERVER span 'POST {route}', got {root.operation_name!r}"
+    )
+    assert root.kind == "server", f"the root span must have kind=server, got {root.kind!r}"
+
+    assert f"auth {route}" in names, f"auth phase span 'auth {route}' missing; spans: {names}"
+    assert any(name.startswith(DB_SPAN_PREFIX) for name in names), (
+        f"no db ('{DB_SPAN_PREFIX}*') span in the trace; spans: {names}"
+    )
+    assert COST_SPAN in names, f"cost write span {COST_SPAN!r} missing; spans: {names}"
+
+    genai = next((span for span in trace.spans if span.operation_name == genai_span), None)
+    assert genai is not None, f"gen-AI span {genai_span!r} missing; spans: {names}"
+    assert genai.kind == "client", f"gen-AI span must have kind=client, got {genai.kind!r}"
+    assert _chain_reaches(genai.span_id, root.span_id, trace), (
+        f"gen-AI span {genai_span!r} is in the trace but its parent chain does not "
+        f"reach the root SERVER span; spans: {names}"
+    )
+
+
+def _settled_names(*, route: str, genai_span: str) -> set[str]:
+    return {f"POST {route}", f"auth {route}", COST_SPAN, genai_span}
+
+
+class TestOtelTraceCompleteness:
+    @pytest.mark.covers("logging.otel.success.exports_metric")
+    def test_chat_completions_exports_complete_trace(
+        self, client: LoggingClient, otel_reader: OtelReader, resources: ResourceManager
+    ) -> None:
+        """One successful non-streaming /chat/completions call must export ONE
+        complete OTEL trace to the admin-owned destination (LIT-3787): a single
+        root SERVER span ("POST /v1/chat/completions") with the auth phase, db
+        lookup, and cost write under it, and the gen-AI CLIENT span ("chat
+        <model>") parented into the same tree - exactly one trace for the call,
+        no dangling parent references.
+
+        If the trace splits, the gen-AI span lands alone as an orphan: in the
+        customer's observability tool the LLM call shows up with no request
+        context (trace stuck "in progress", no root), and the server trace shows
+        a request with no LLM call inside. Latency breakdown (gateway overhead
+        vs model time), per-request cost attribution, and root-causing a slow or
+        failed call all silently break - spans still arrive, so nothing alerts.
+
+        /chat/completions is the proxy's highest-traffic route and the default
+        for every OpenAI-compatible SDK; trace completeness must hold here
+        before anywhere else.
+        """
+        # the exact path chat_raw posts to; the root SERVER span is named after it
+        route = "/chat/completions"
+        _assert_otel_destination_configured(client)
+
+        key = client.key_with_alias(f"otel-trace-chat-{unique_marker()}", models=[MODEL])
+        resources.defer(lambda: client.delete_key(key))
+
+        marker = unique_marker()
+        outcome = _first_ok(
+            client, lambda: client.chat_raw(key, MODEL, f"reply with one word {marker}", max_tokens=16)
+        )
+        assert outcome.call_id is not None, "success response must carry x-litellm-call-id"
+
+        hits = otel_reader.poll_traces_for_call(
+            call_id=outcome.call_id,
+            marker=marker,
+            settled_names=_settled_names(route=route, genai_span=f"chat {MODEL}"),
+        )
+        _assert_complete_trace(hits, route=route, genai_span=f"chat {MODEL}")

--- a/tests/e2e/logging/test_otel_trace_e2e.py
+++ b/tests/e2e/logging/test_otel_trace_e2e.py
@@ -155,23 +155,21 @@ class TestOtelTraceCompleteness:
     def test_chat_completions_exports_complete_trace(
         self, client: LoggingClient, otel_reader: OtelReader, resources: ResourceManager
     ) -> None:
-        """One successful non-streaming /chat/completions call must export ONE
-        complete OTEL trace to the admin-owned destination (LIT-3787): a single
-        root SERVER span ("POST /chat/completions") with the auth phase, db
-        lookup, and cost write under it, and the gen-AI CLIENT span ("chat
-        <model>") parented into the same tree - exactly one trace for the call,
-        no dangling parent references.
+        """This test verifies that a successful non-streaming
+        /chat/completions request produces one complete OTEL trace.
 
-        If the trace splits, the gen-AI span lands alone as an orphan: in the
-        customer's observability tool the LLM call shows up with no request
-        context (trace stuck "in progress", no root), and the server trace shows
-        a request with no LLM call inside. Latency breakdown (gateway overhead
-        vs model time), per-request cost attribution, and root-causing a slow or
-        failed call all silently break - spans still arrive, so nothing alerts.
+        The trace should have a single server root span for the incoming request, with
+        the authentication, database, and cost-recording work beneath it. The span for
+        the actual model call must also belong to that same trace, rather than being
+        exported separately with a missing parent.
 
-        /chat/completions is the proxy's highest-traffic route and the default
-        for every OpenAI-compatible SDK; trace completeness must hold here
-        before anywhere else.
+        This matters because a split trace is easy to miss: all of the spans may still
+        arrive, but the model call appears without the surrounding request context.
+        That makes it difficult to understand where time was spent, connect the model
+        cost to the original request, or investigate a slow or failed call.
+
+        /chat/completions is the main OpenAI-compatible route used by most customers,
+        so it is important that trace parenting works correctly on this path.
         """
         route = "/chat/completions"
         _assert_otel_destination_configured(client)


### PR DESCRIPTION
## Relevant issues

## Linear ticket

https://linear.app/litellm-ai/issue/LIT-3787

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This PR is the first of a 3-PR stack (chat_completions -> messages -> responses, one LIT-3787 scenario each); the two follow-ups are based on this branch.

Verification was run on 2026-07-13 at the stack tip f354f98929, which contains all three tests including this PR's chat test. This machine has no docker buildx, so the two proxies under test ran from source at exact git refs (`uv run --extra proxy --extra extra_proxy python litellm/proxy/proxy_cli.py`); same code paths, no image build. Outputs are pasted verbatim.

1. Pass on current code: bring up the tests/e2e compose stack (which this PR extends with a `jaeger` service and the `arize_phoenix` OTEL v2 destination pointed at it) and run the suite:

   ```
   $ cd tests/e2e && docker compose -p e2e_otel_pr1 up -d
   $ curl -fs http://localhost:4000/health/liveliness
   "I'm alive!"
   $ LITELLM_PROXY_URL=http://localhost:4000 uv run pytest logging/test_otel_trace_e2e.py -v
   logging/test_otel_trace_e2e.py::TestOtelTraceCompleteness::test_chat_completions_exports_complete_trace PASSED
   logging/test_otel_trace_e2e.py::TestOtelTraceCompleteness::test_messages_exports_complete_trace PASSED
   logging/test_otel_trace_e2e.py::TestOtelTraceCompleteness::test_responses_exports_complete_trace PASSED
   ============================== 3 passed in 19.43s ==============================
   ```

   The settled chat trace at the Jaeger destination, fetched through its query API by the `litellm.call_id` span tag:

   ```
   - [server] POST /chat/completions
     - [internal] auth /chat/completions
       - [client] postgres get_data
     - [client] chat claude-haiku-4-5
     - [client] batch_write_to_db _PROXY_track_cost_callback
     - [client] postgres get_key_object
   ```

2. Fail-before-fix: the same tests against a proxy built from **1bd603d1ac**, the parent of #30590 ("one v2 logger owns the global provider"), the commit that fixed server spans exporting through a different provider than the preset's gen-AI spans. DB on a fresh port, PHOENIX_COLLECTOR_HTTP_ENDPOINT at a second throwaway Jaeger:

   ```
   $ LITELLM_PROXY_URL=http://localhost:4611 E2E_OTEL_QUERY_URL=http://localhost:16690 \
       uv run pytest logging/test_otel_trace_e2e.py
   E  AssertionError: span(s) ['chat claude-haiku-4-5'] reference a parent that never
      reached the destination (orphaned trace); spans present: ['chat claude-haiku-4-5']
   E  AssertionError: span(s) ['chat claude-haiku-4-5'] reference a parent that never
      reached the destination (orphaned trace); spans present: ['chat claude-haiku-4-5']
   E  AssertionError: span(s) ['chat gpt-5.5'] reference a parent that never
      reached the destination (orphaned trace); spans present: ['chat gpt-5.5']
   ======================== 3 failed in 364.91s (0:06:04) =========================
   ```

   Exactly the LIT-3787 failure mode: the destination received each gen-AI span alone, dangling. A rubber-stamp test would have passed here.

3. Static gates at the same commit:

   ```
   $ make lint-e2e-basedpyright
   0 errors, 0 warnings, 0 notes
   $ cd tests/e2e && uv run python -m coverage_registry.collector --strict
   Logging & Guardrails                  5/51        9.8%
   ```

   Logging & Guardrails moves 4/51 -> 5/51 (the `logging.otel.success.exports_metric` P0 cell gains its first covering test).

Before:
<img width="1728" height="233" alt="image" src="https://github.com/user-attachments/assets/1d7bd6f1-2913-4f4d-9131-51d84034e24c" />

After:
<img width="1728" height="856" alt="image" src="https://github.com/user-attachments/assets/9b0e6cb8-e0ff-43c8-ad4d-799924559a8b" />
## Type

✅ Test

## Changes

The `logging.otel.success.exports_metric` registry cell is a P0 row with no covering test: nothing proved that a successful call actually lands at an OTEL destination as one COMPLETE trace (LIT-3787). The regression class is real; #30590 fixed the proxy publishing the global TracerProvider before callback init, which orphaned every gen-AI span on the preset backend.

- `docker-compose.yml`: adds a throwaway `jaeger` service (OTLP ingest in-network, query API on host 16686, healthchecked on its admin port so the depends_on condition is accurate) and configures the proxy with `LITELLM_OTEL_V2=true` + `callbacks: ["arize_phoenix"]` + `PHOENIX_COLLECTOR_HTTP_ENDPOINT=http://jaeger:4318/v1/traces`. The arize_phoenix preset is used deliberately: the orphan bug lives on the preset-owned-provider path; a generic `callbacks: ["otel"]` with `OTEL_*` envs would send both providers to the same endpoint and could never fail. No cloud credentials involved.
- `logging/otel_client.py` (new): typed models over the Jaeger query API. Traces are fetched server-side by the `litellm.call_id` span tag (the request's x-litellm-call-id response header), so read-back is immune to the query page filling with unrelated traffic; the stack's own background jobs alone can push a request trace past a recent-traces page. A failed query hard-fails instead of reading as "the trace never arrived", and the settle predicate waits for every span name the assertion demands, including the prefix-matched db span (poll to the shared deadline, never sleep-once).
- `logging/test_otel_trace_e2e.py` (new): `test_chat_completions_exports_complete_trace`, asserting both halves: recorded state (`/health/readiness/details` reports the `OpenTelemetryV2` callback active) and enforced behavior (exactly ONE trace for the call's call id; single root SERVER span `POST /chat/completions`; `auth`/`postgres`/`batch_write_to_db _PROXY_track_cost_callback` children; gen-AI CLIENT span `chat <model>` whose CHILD_OF parent chain reaches the root; no span referencing a parent absent from the trace). First call retries on 401 to a deadline (fresh-key propagation; a 401 never reaches the LLM so it exports no gen-AI span).
- `e2e_config.py`: `OTEL_QUERY_URL` (env `E2E_OTEL_QUERY_URL`) and `CHEAP_ANTHROPIC_MODEL` (env `E2E_CHEAP_ANTHROPIC_MODEL`); the latter is the identical line #32914 adds, so whichever merges second is a trivial dedupe.

Known deferral: the registry row also lists `embeddings` in `exercised_on` with no covering test yet; the responses surface is added by the top PR of this stack, and the embeddings surface stays a tracked follow-up under LIT-3787 rather than silently dropped from the row.

## Behavior changes

None to the product; all changes are under tests/e2e. The shared compose stack gains a jaeger container and a globally active OTEL v2 callback (extra span export only; no request behavior change for other suites).

## QA runbook

- tests/e2e/logging/test_otel_trace_e2e.py::TestOtelTraceCompleteness::test_chat_completions_exports_complete_trace - one successful chat call shows up at the OTEL destination as one connected trace tree
  - [x] GET /health/readiness/details with the master key and confirm `OpenTelemetryV2` appears in `success_callbacks`
  - [x] POST /key/generate with `{"models":["claude-haiku-4-5"],"key_alias":"otel-trace-chat-<uniq>"}` and save the returned key
  - [x] POST /chat/completions (non-streaming, `max_tokens: 16`, a unique phrase in the prompt) with the key; if the very first call 401s, retry it for a few seconds (fresh key propagating; a 401 exports no spans); confirm 200 and note the `x-litellm-call-id` response header
  - [x] Open Jaeger at http://localhost:16686, service `litellm`, and search by tag `litellm.call_id=<that id>`; keep refreshing until the trace appears (spans flush in batches; the cost write lands last)
  - [x] Confirm exactly ONE trace holds the call-id; a second trace with the same call-id is the split-trace bug
  - [x] Confirm a single root span `POST /chat/completions` (kind server) and that no span references a parent missing from the trace
  - [x] Confirm the children: `auth /chat/completions`, a `postgres ...` span, and `batch_write_to_db _PROXY_track_cost_callback`
  - [x] Confirm `chat claude-haiku-4-5` (kind client) is in the SAME trace and its parent chain reaches the root
  - [x] POST /key/delete to clean up

Final attestation: "I agree this test is testing what the writer wanted to test."

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to tests/e2e; compose gains an extra Jaeger service and global OTEL callback export only, with no product runtime behavior changes.
> 
> **Overview**
> Adds **e2e coverage** for registry cell `logging.otel.success.exports_metric` (LIT-3787): a successful `/chat/completions` call must export **one connected OTEL trace** to the destination, not a split tree where the gen-AI span orphans from the server root.
> 
> The shared **compose stack** gains a **Jaeger** OTLP sink and enables **OTEL v2** via the `arize_phoenix` preset (preset-owned provider path where split-trace bugs show up). **`otel_client.OtelReader`** polls Jaeger by `litellm.call_id` and asserts a single trace with expected auth, postgres, cost, and gen-AI spans parented under `POST /chat/completions`. **`test_chat_completions_exports_complete_trace`** also checks `/health/readiness/details` lists `OpenTelemetryV2` before traffic.
> 
> **`e2e_config`** adds `E2E_OTEL_QUERY_URL` and `E2E_CHEAP_ANTHROPIC_MODEL`; logging **conftest** wires a session `otel_reader` fixture. Docs in **`tests/e2e/CLAUDE.md`** note OTEL trace read-back under `logging/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e7af95dd503638c37f48e70c9aa5c6e13c75978. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->