### PR TITLE
fix(guardrails): run apply_guardrail-style model-level pre_call guardrails at deployment hook

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -515,6 +515,18 @@ class CustomGuardrail(CustomLogger):
                     return True
         return False
 
+    def uses_apply_guardrail_interface(self) -> bool:
+        return type(self).apply_guardrail is not CustomGuardrail.apply_guardrail
+
+    def _deployment_pre_call_target(self) -> "CustomLogger":
+        if not self.uses_apply_guardrail_interface():
+            return self
+        try:
+            from litellm.proxy.utils import unified_guardrail
+        except ImportError:
+            return self
+        return unified_guardrail
+
     async def async_pre_call_deployment_hook(
         self, kwargs: Dict[str, Any], call_type: Optional[CallTypes]
     ) -> Optional[dict]:
@@ -533,7 +545,10 @@ class CustomGuardrail(CustomLogger):
 
         # CHECK IF GUARDRAIL REJECTS THE REQUEST
         if call_type == CallTypes.completion or call_type == CallTypes.acompletion:
-            result = await self.async_pre_call_hook(
+            target = self._deployment_pre_call_target()
+            if target is not self:
+                kwargs["guardrail_to_apply"] = self
+            result = await target.async_pre_call_hook(
                 user_api_key_dict=UserAPIKeyAuth(
                     user_id=kwargs.get("user_api_key_user_id"),
                     team_id=kwargs.get("user_api_key_team_id"),
@@ -543,7 +558,7 @@ class CustomGuardrail(CustomLogger):
                 ),
                 cache=dc,
                 data=kwargs,
-                call_type=call_type.value or "acompletion",  # type: ignore
+                call_type="completion" if call_type == CallTypes.completion else "acompletion",
             )
 
             if result is not None and isinstance(result, dict):

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -523,8 +523,12 @@ class CustomGuardrail(CustomLogger):
             return self
         try:
             from litellm.proxy.utils import unified_guardrail
-        except ImportError:
-            return self
+        except ImportError as e:
+            raise ImportError(
+                f"Guardrail {self.guardrail_name or type(self).__name__} implements apply_guardrail, which needs "
+                "the litellm proxy dependencies to run at the deployment level. "
+                "Install them with: pip install 'litellm[proxy]'"
+            ) from e
         return unified_guardrail
 
     async def async_pre_call_deployment_hook(

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -959,7 +959,7 @@ class ProxyLogging:
             Result from the guardrail execution
         """
         # Use unified_guardrail if callback has apply_guardrail method
-        has_apply_guardrail = "apply_guardrail" in type(callback).__dict__
+        has_apply_guardrail = callback.uses_apply_guardrail_interface()
         use_unified = has_apply_guardrail and not (
             hook_type == "during_call" and getattr(callback, "use_native_during_call_hook", False)
         )

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -959,7 +959,7 @@ class ProxyLogging:
             Result from the guardrail execution
         """
         # Use unified_guardrail if callback has apply_guardrail method
-        has_apply_guardrail = callback.uses_apply_guardrail_interface()
+        has_apply_guardrail = "apply_guardrail" in type(callback).__dict__
         use_unified = has_apply_guardrail and not (
             hook_type == "during_call" and getattr(callback, "use_native_during_call_hook", False)
         )

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -1614,3 +1614,86 @@ class TestGuardrailInterventionClassification:
 
         slg = request_data["metadata"]["standard_logging_guardrail_information"][0]
         assert slg["guardrail_status"] == "guardrail_intervened"
+
+
+class _ApplyStyleGuardrail(CustomGuardrail):
+    """Overrides only apply_guardrail, like openai_moderation; async_pre_call_hook stays the CustomLogger no-op."""
+
+    def __init__(self, block: bool):
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        super().__init__(
+            guardrail_name="apply-style-guardrail",
+            event_hook=GuardrailEventHooks.pre_call,
+            default_on=False,
+        )
+        self.block = block
+        self.apply_called = False
+        self.seen_texts = None
+
+    async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
+        from fastapi import HTTPException
+
+        self.apply_called = True
+        self.seen_texts = inputs.get("texts")
+        if self.block:
+            raise HTTPException(status_code=400, detail={"error": "Violated moderation policy"})
+        return inputs
+
+
+class TestApplyGuardrailStyleDeploymentDispatch:
+    """LIT-4217 regression: model-level guardrails that implement only the
+    unified apply_guardrail interface must execute in
+    async_pre_call_deployment_hook instead of silently hitting the
+    async_pre_call_hook no-op."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("call_type", [CallTypes.completion, CallTypes.acompletion])
+    async def test_blocks_when_requested_via_model_level_guardrails(self, call_type):
+        from fastapi import HTTPException
+
+        guardrail = _ApplyStyleGuardrail(block=True)
+        kwargs = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "flagged content"}],
+            "guardrails": ["apply-style-guardrail"],
+            "metadata": {},
+        }
+
+        with pytest.raises(HTTPException):
+            await guardrail.async_pre_call_deployment_hook(kwargs, call_type)
+
+        assert guardrail.apply_called is True
+        assert guardrail.seen_texts == ["flagged content"]
+
+    @pytest.mark.asyncio
+    async def test_pass_path_runs_guardrail_and_strips_dispatch_key(self):
+        guardrail = _ApplyStyleGuardrail(block=False)
+        kwargs = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "hello"}],
+            "guardrails": ["apply-style-guardrail"],
+            "metadata": {},
+        }
+
+        result = await guardrail.async_pre_call_deployment_hook(kwargs, CallTypes.acompletion)
+
+        assert guardrail.apply_called is True
+        assert result is not None
+        assert "guardrail_to_apply" not in result
+        assert result["messages"] == [{"role": "user", "content": "hello"}]
+
+    @pytest.mark.asyncio
+    async def test_skips_when_not_requested(self):
+        guardrail = _ApplyStyleGuardrail(block=True)
+        kwargs = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "hello"}],
+            "guardrails": ["some-other-guardrail"],
+            "metadata": {},
+        }
+
+        result = await guardrail.async_pre_call_deployment_hook(kwargs, CallTypes.acompletion)
+
+        assert guardrail.apply_called is False
+        assert result is not None

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -1697,3 +1697,22 @@ class TestApplyGuardrailStyleDeploymentDispatch:
 
         assert guardrail.apply_called is False
         assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_fails_closed_when_proxy_extras_missing(self):
+        import sys
+        from unittest.mock import patch
+
+        guardrail = _ApplyStyleGuardrail(block=True)
+        kwargs = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "flagged content"}],
+            "guardrails": ["apply-style-guardrail"],
+            "metadata": {},
+        }
+
+        with patch.dict(sys.modules, {"litellm.proxy.utils": None}):
+            with pytest.raises(ImportError, match="litellm\\[proxy\\]"):
+                await guardrail.async_pre_call_deployment_hook(kwargs, CallTypes.acompletion)
+
+        assert guardrail.apply_called is False


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4217

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy plus Postgres, real OpenAI traffic. Config attaches the guardrail at the model level only, with `default_on: false`:

```yaml
model_list:
  - model_name: openai-gpt-4.1-mini-2025-04-14
    litellm_params:
      model: gpt-4.1-mini
      api_key: os.environ/OPENAI_API_KEY
      guardrails: ["openai-moderation-pre"]

guardrails:
  - guardrail_name: openai-moderation-pre
    litellm_params:
      guardrail: openai_moderation
      mode: pre_call
      api_key: os.environ/OPENAI_API_KEY
      default_on: false

general_settings:
  master_key: sk-1234
```

Before the fix (captured at `539bc30e04`, current `litellm_internal_staging` HEAD): flagged content sails through to OpenAI and returns 200 even though the model has a pre_call moderation guardrail attached

```bash
curl -s -w '\nHTTP %{http_code}\n' -X POST http://localhost:4217/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"openai-gpt-4.1-mini-2025-04-14","messages":[{"role":"user","content":"<flagged content>"}]}'
```

```json
{"choices":[{"message":{"content":"I'm sorry you're feeling this way. It might help to talk to someone you trust about what's going on. ...","role":"assistant"}}]}
HTTP 200
```

After the fix (captured at `962c49553e`): the identical request is blocked before reaching the provider

```json
{"error":{"message":"Violated OpenAI moderation policy","type":"None","param":"None","code":"400","provider_specific_fields":{"error":"Violated OpenAI moderation policy","moderation_result":{"violated_categories":["harassment","harassment/threatening","violence"],"category_scores":{"harassment":0.649,"harassment/threatening":0.794,"violence":0.953, ...}}}}}
HTTP 400
```

Benign content on the same model still completes (HTTP 200), and the pre-existing request-body path (`"guardrails": ["openai-moderation-pre"]` in the body) still blocks with HTTP 400 including the `guardrail_name`/`guardrail_mode` fields, both also captured at `962c49553e`. The proxy debug log shows exactly one moderation API call per blocked request, so the request-body and model-level paths do not double-run

### Dual-override guardrail parity (presidio, bedrock, enkryptai, live)

To validate the behavior change for guardrails that override both `async_pre_call_hook` and `apply_guardrail`, presidio was exercised live against real analyzer and anonymizer containers (`mcr.microsoft.com/presidio-analyzer`, `mcr.microsoft.com/presidio-anonymizer`) with the guardrail attached at the model level (`mode: pre_call`, `default_on: false`) and real OpenAI traffic. The prompt embeds a name, phone number, and email and asks the model to repeat them verbatim, so the assistant reply reveals exactly what the provider received

```bash
curl -s -X POST http://localhost:4217/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"openai-gpt-4.1-mini-2025-04-14","messages":[{"role":"user","content":"My name is Jane Doe, my phone number is 212-555-0123, and my email is jane.doe@example.com. Repeat back exactly the name, phone number, and email I just gave you, verbatim, with no extra words."}]}'
```

All three variants returned a byte-identical assistant reply, HTTP 200:

```text
My name is <PERSON>, my phone number is <PHONE_NUMBER>, and my email is <EMAIL_ADDRESS>.
```

1. Old model-level path (`a89f9af353` with `litellm/integrations/custom_guardrail.py` reverted to base): masked via presidio's own `async_pre_call_hook`
2. New model-level path (`a89f9af353` as-is): masked via `unified_guardrail` -> `apply_guardrail`; the debug log shows exactly one `Running UnifiedLLMGuardrails pre-call hook` for the request, proving the new dispatch executed
3. Request-body path (`a89f9af353`, `"guardrails": ["presidio-pre"]` in the body): masked via the unchanged canonical path

So for the most divergent-looking dual-override guardrail, the new model-level dispatch produces output identical to both the previous behavior and the request-body path

The same base-vs-fix comparison was run live for bedrock (temporary guardrail with a VIOLENCE HIGH content filter, real AWS ApplyGuardrail calls) and enkryptai (real detect API with a prompt-injection policy), on both the model-level and request-body paths. Every cell is identical before and after this PR: bedrock request-body blocks with 400 and the contentPolicy assessment on both; enkryptai blocks the injection prompt with the same status and detection body on all four cells. Two pre-existing issues surfaced by this exercise reproduce identically on the base branch and are unaffected by this PR: model-level bedrock guardrail calls fail 403 because the deployment's provider api_key is picked up as an AWS bearer token (tracked in LIT-4425), and enkryptai blocks surface as a ValueError mapped to 500 rather than a 400. panw_prisma_airs is the one dual-override guardrail not exercised live; no vendor credentials were available

The legacy-only style (a custom guardrail overriding `async_pre_call_hook` and not `apply_guardrail`) was also validated live base-vs-fix with a keyword-blocking guardrail attached at the model level: blocked content returns the same 400 with the guardrail's own error body on both paths and both code versions, and benign content completes with 200 on all cells. The block message originates inside the guardrail's `async_pre_call_hook`, confirming the new dispatch takes the `target = self` branch for legacy guardrails and leaves them untouched

## Type

🐛 Bug Fix

## Changes

Root cause: `ProxyLogging.pre_call_hook` runs before routing, so it cannot see a deployment's `litellm_params.guardrails` (no deployment is selected yet and `metadata.model_info.id` does not exist). The intended enforcement point for model-level guardrails is `CustomGuardrail.async_pre_call_deployment_hook` (#12968, #30543), which runs after the router spreads the chosen deployment's `litellm_params` into the request kwargs. That hook correctly decided the guardrail should run, then dispatched only to `self.async_pre_call_hook`, which is the inherited `CustomLogger` no-op for guardrails that implement the unified `apply_guardrail` interface (`openai_moderation` and most current guardrails). The guardrail was selected and then silently did nothing, so flagged requests returned 200 unless the client also passed `"guardrails"` in the request body

Fix: the deployment hook now dispatches through the same `unified_guardrail` path that `ProxyLogging._execute_guardrail_hook` already uses on the request-body path whenever the guardrail class overrides `apply_guardrail`. The override check lives in a new `CustomGuardrail.uses_apply_guardrail_interface()` helper, which is MRO-aware (it also catches an override inherited from an intermediate class). The request-body dispatch in `_execute_guardrail_hook` is left byte-identical to the current behavior; consolidating the remaining dispatch checks onto the shared helper is deferred to LIT-4417 because the existing pipeline tests drive that path with spec'd mocks that need reworking first. On a base SDK install without proxy extras the hook fails closed: instead of silently skipping the guardrail (the pre-fix behavior, which is a bypass of a configured security control) or crashing with a bare ModuleNotFoundError, it raises an ImportError naming the guardrail and telling the user to install `litellm[proxy]`. The change also replaces a banned `# type: ignore` on the `call_type` argument with a typed conditional literal

Regression tests live in `tests/test_litellm/integrations/test_custom_guardrail.py` (the mapped file for the changed module): an `apply_guardrail`-only guardrail with `default_on: false` must block through the deployment hook for both `completion` and `acompletion`, must strip the internal dispatch key on the pass path, and must not run when a different guardrail is requested. The blocking and pass-path tests fail on the unfixed code

## Behavior changes

Guardrails that override both `async_pre_call_hook` and `apply_guardrail` (presidio, bedrock, panw_prisma_airs, enkryptai) and are attached at the model level now route through the unified `apply_guardrail` path at the deployment hook. This matches how the request-body path already dispatches them (`_execute_guardrail_hook` prefers unified for any guardrail defining `apply_guardrail`), so the two attachment styles now behave identically for these guardrails. No opt-out flag is added on purpose; the previous model-level behavior for them diverged from the request-body behavior for the same guardrail, which had no value worth preserving

On base SDK installs without proxy extras, an apply_guardrail-style guardrail requested at the deployment level now raises an actionable ImportError instead of silently doing nothing. Silent skip of a configured guardrail is the same failure class this PR fixes, so fail-closed is deliberate

A block raised from the model-level path does not include the `guardrail_name`/`guardrail_mode` enrichment fields the request-body path adds. That parity gap, model-level enforcement for non-completion call types (embeddings, Responses API, anthropic_messages), model-level `during_call` guardrails, and consolidating the remaining `"apply_guardrail" in type(...).__dict__` dispatch checks are tracked in LIT-4417

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
