### PR TITLE
feat(ptu): daily rollup job writes flat cost to LiteLLM_DailyTeamSpend

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260713010000_add_ptu_columns_to_daily_team_spend/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260713010000_add_ptu_columns_to_daily_team_spend/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "LiteLLM_DailyTeamSpend" ADD COLUMN IF NOT EXISTS "ptu_flat_cost" DOUBLE PRECISION NOT NULL DEFAULT 0.0;
+ALTER TABLE "LiteLLM_DailyTeamSpend" ADD COLUMN IF NOT EXISTS "ptu_reservation_id" TEXT;
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "LiteLLM_DailyTeamSpend_ptu_reservation_id_idx" ON "LiteLLM_DailyTeamSpend"("ptu_reservation_id");

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -875,6 +875,8 @@ model LiteLLM_DailyTeamSpend {
   api_requests        BigInt      @default(0)
   successful_requests BigInt      @default(0)
   failed_requests     BigInt      @default(0)
+  ptu_flat_cost       Float    @default(0.0)
+  ptu_reservation_id  String?
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
@@ -885,6 +887,7 @@ model LiteLLM_DailyTeamSpend {
   @@index([model])
   @@index([mcp_namespaced_tool_name])
   @@index([endpoint])
+  @@index([ptu_reservation_id])
 }
 
 // Track daily team spend metrics per model and key

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7929,6 +7929,25 @@ class ProxyStartupEvent:
 
         await cls._initialize_spend_tracking_background_jobs(scheduler=scheduler)
 
+        ### PTU RESERVATION DAILY ROLLUP ###
+        if general_settings.get("enable_ptu_cost_attribution", False):
+            from litellm.proxy.spend_tracking.ptu_reservation_rollup import (
+                PTU_ROLLUP_JOB_ID,
+                run_ptu_reservation_rollup,
+            )
+
+            scheduler.add_job(
+                run_ptu_reservation_rollup,
+                "cron",
+                hour=0,
+                minute=15,
+                args=[prisma_client],
+                id=PTU_ROLLUP_JOB_ID,
+                replace_existing=True,
+                misfire_grace_time=APSCHEDULER_MISFIRE_GRACE_TIME,
+            )
+            verbose_proxy_logger.info("PTU reservation rollup job scheduled at 00:15 UTC daily")
+
         ### SPEND LOG CLEANUP ###
         if general_settings.get("maximum_spend_logs_retention_period") is not None:
             spend_log_cleanup = SpendLogCleanup()

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -875,6 +875,8 @@ model LiteLLM_DailyTeamSpend {
   api_requests        BigInt      @default(0)
   successful_requests BigInt      @default(0)
   failed_requests     BigInt      @default(0)
+  ptu_flat_cost       Float    @default(0.0)
+  ptu_reservation_id  String?
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
@@ -885,6 +887,7 @@ model LiteLLM_DailyTeamSpend {
   @@index([model])
   @@index([mcp_namespaced_tool_name])
   @@index([endpoint])
+  @@index([ptu_reservation_id])
 }
 
 // Track daily team spend metrics per model and key

--- a/litellm/proxy/spend_tracking/ptu_reservation_rollup.py
+++ b/litellm/proxy/spend_tracking/ptu_reservation_rollup.py
@@ -88,23 +88,26 @@ async def _upsert_ptu_daily_row(
 async def run_ptu_reservation_rollup(
     prisma_client: Any,
     target_date: date | None = None,
+    *,
+    force: bool = False,
 ) -> RollupResult:
     """Rollup one UTC day of flat PTU cost across all active reservations.
 
-    Defaults to yesterday UTC. Callable from the scheduler and from the CLI
-    backfill helper; both paths are idempotent under the ``LiteLLM_DailyTeamSpend``
-    unique constraint.
+    Defaults to yesterday UTC. ``force=True`` bypasses the feature-flag check
+    so the CLI backfill can run when the scheduler is off. Idempotent under
+    the LiteLLM_DailyTeamSpend unique constraint on every invocation path.
     """
-    from litellm.proxy.proxy_server import general_settings
+    if not force:
+        from litellm.proxy.proxy_server import general_settings
 
-    if not general_settings.get("enable_ptu_cost_attribution", False):
-        verbose_proxy_logger.debug("PTU rollup: feature flag off, skipping")
-        return RollupResult(
-            day=target_date or (datetime.now(timezone.utc).date() - timedelta(days=1)),
-            reservations_processed=0,
-            rows_written=0,
-            skipped_flag_off=True,
-        )
+        if not general_settings.get("enable_ptu_cost_attribution", False):
+            verbose_proxy_logger.debug("PTU rollup: feature flag off, skipping")
+            return RollupResult(
+                day=target_date or (datetime.now(timezone.utc).date() - timedelta(days=1)),
+                reservations_processed=0,
+                rows_written=0,
+                skipped_flag_off=True,
+            )
 
     if prisma_client is None:
         verbose_proxy_logger.warning("PTU rollup: prisma_client is None, skipping")
@@ -136,7 +139,7 @@ async def run_ptu_reservation_rollup(
                 flat_cost=flat_cost,
             )
             rows_written += 1
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001  # one bad reservation must not stop the batch; logged and continued
             verbose_proxy_logger.error(
                 "PTU rollup: upsert failed for reservation=%s day=%s: %s",
                 reservation.id,

--- a/litellm/proxy/spend_tracking/ptu_reservation_rollup.py
+++ b/litellm/proxy/spend_tracking/ptu_reservation_rollup.py
@@ -1,0 +1,165 @@
+"""
+Daily rollup for admin-registered PTU reservations.
+
+Writes prorated flat cost to LiteLLM_DailyTeamSpend using a sentinel api_key
+so the rows are distinguishable from real per-request rows and share the
+existing unique constraint.
+"""
+
+from calendar import monthrange
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta, timezone
+from typing import Any
+
+from litellm._logging import verbose_proxy_logger
+from litellm.repositories.ptu_reservation_repository import PTUReservationRepository
+
+PTU_SENTINEL_API_KEY = "__ptu_reservation__"
+PTU_ROLLUP_JOB_ID = "ptu_reservation_rollup_job"
+
+
+@dataclass(frozen=True, slots=True)
+class RollupResult:
+    day: date
+    reservations_processed: int
+    rows_written: int
+    skipped_flag_off: bool = False
+
+
+def _days_in_month(day: date) -> int:
+    return monthrange(day.year, day.month)[1]
+
+
+def _compute_daily_flat_cost(reservation: Any, day: date) -> float:
+    """Return the flat cost attributable to ``day`` for a single reservation."""
+    if reservation.cost_source != "manual":
+        return 0.0
+    if reservation.ptu_count is None or reservation.cost_per_ptu is None:
+        return 0.0
+    monthly_total = float(reservation.ptu_count) * float(reservation.cost_per_ptu)
+    return monthly_total / float(_days_in_month(day))
+
+
+async def _upsert_ptu_daily_row(
+    prisma_client: Any,
+    *,
+    team_id: str,
+    model: str,
+    date_str: str,
+    reservation_id: str,
+    flat_cost: float,
+) -> None:
+    """Idempotent upsert of a sentinel-api_key row on LiteLLM_DailyTeamSpend."""
+    where = {
+        "team_id_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name_endpoint": {
+            "team_id": team_id,
+            "date": date_str,
+            "api_key": PTU_SENTINEL_API_KEY,
+            "model": model,
+            "custom_llm_provider": "",
+            "mcp_namespaced_tool_name": "",
+            "endpoint": "",
+        }
+    }
+    now = datetime.now(timezone.utc)
+    await prisma_client.db.litellm_dailyteamspend.upsert(
+        where=where,
+        data={
+            "create": {
+                "team_id": team_id,
+                "date": date_str,
+                "api_key": PTU_SENTINEL_API_KEY,
+                "model": model,
+                "custom_llm_provider": "",
+                "mcp_namespaced_tool_name": "",
+                "endpoint": "",
+                "ptu_flat_cost": flat_cost,
+                "ptu_reservation_id": reservation_id,
+            },
+            "update": {
+                "ptu_flat_cost": flat_cost,
+                "ptu_reservation_id": reservation_id,
+                "updated_at": now,
+            },
+        },
+    )
+
+
+async def run_ptu_reservation_rollup(
+    prisma_client: Any,
+    target_date: date | None = None,
+) -> RollupResult:
+    """Rollup one UTC day of flat PTU cost across all active reservations.
+
+    Defaults to yesterday UTC. Callable from the scheduler and from the CLI
+    backfill helper; both paths are idempotent under the ``LiteLLM_DailyTeamSpend``
+    unique constraint.
+    """
+    from litellm.proxy.proxy_server import general_settings
+
+    if not general_settings.get("enable_ptu_cost_attribution", False):
+        verbose_proxy_logger.debug("PTU rollup: feature flag off, skipping")
+        return RollupResult(
+            day=target_date or (datetime.now(timezone.utc).date() - timedelta(days=1)),
+            reservations_processed=0,
+            rows_written=0,
+            skipped_flag_off=True,
+        )
+
+    if prisma_client is None:
+        verbose_proxy_logger.warning("PTU rollup: prisma_client is None, skipping")
+        return RollupResult(
+            day=target_date or (datetime.now(timezone.utc).date() - timedelta(days=1)),
+            reservations_processed=0,
+            rows_written=0,
+        )
+
+    day = target_date or (datetime.now(timezone.utc).date() - timedelta(days=1))
+    day_start = datetime.combine(day, time.min, tzinfo=timezone.utc)
+    date_str = day.isoformat()
+
+    repo = PTUReservationRepository(prisma_client)
+    reservations = await repo.find_active(as_of=day_start)
+
+    rows_written = 0
+    for reservation in reservations:
+        flat_cost = _compute_daily_flat_cost(reservation, day)
+        if flat_cost <= 0:
+            continue
+        try:
+            await _upsert_ptu_daily_row(
+                prisma_client,
+                team_id=reservation.team_id,
+                model=reservation.model,
+                date_str=date_str,
+                reservation_id=reservation.id,
+                flat_cost=flat_cost,
+            )
+            rows_written += 1
+        except Exception as exc:
+            verbose_proxy_logger.error(
+                "PTU rollup: upsert failed for reservation=%s day=%s: %s",
+                reservation.id,
+                date_str,
+                exc,
+            )
+
+    verbose_proxy_logger.info(
+        "PTU rollup for %s: %d reservations processed, %d rows written",
+        date_str,
+        len(reservations),
+        rows_written,
+    )
+    return RollupResult(
+        day=day,
+        reservations_processed=len(reservations),
+        rows_written=rows_written,
+    )
+
+
+__all__ = [
+    "PTU_ROLLUP_JOB_ID",
+    "PTU_SENTINEL_API_KEY",
+    "RollupResult",
+    "run_ptu_reservation_rollup",
+]

--- a/schema.prisma
+++ b/schema.prisma
@@ -875,6 +875,8 @@ model LiteLLM_DailyTeamSpend {
   api_requests        BigInt      @default(0)
   successful_requests BigInt      @default(0)
   failed_requests     BigInt      @default(0)
+  ptu_flat_cost       Float    @default(0.0)
+  ptu_reservation_id  String?
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 
@@ -885,6 +887,7 @@ model LiteLLM_DailyTeamSpend {
   @@index([model])
   @@index([mcp_namespaced_tool_name])
   @@index([endpoint])
+  @@index([ptu_reservation_id])
 }
 
 // Track daily team spend metrics per model and key

--- a/scripts/ptu_reservation_backfill.py
+++ b/scripts/ptu_reservation_backfill.py
@@ -1,6 +1,9 @@
 """Re-run the PTU reservation daily rollup for a specific UTC date.
 
-Idempotent under the LiteLLM_DailyTeamSpend unique constraint.
+Idempotent under the LiteLLM_DailyTeamSpend unique constraint. Reads
+DATABASE_URL from the environment, connects Prisma directly, and bypasses
+the ``enable_ptu_cost_attribution`` config flag so operators can backfill
+without turning the feature on for live traffic.
 
 Usage:
     python scripts/ptu_reservation_backfill.py --date 2026-07-12
@@ -42,26 +45,37 @@ def _dates_from_args(args: argparse.Namespace) -> list[date]:
 
 
 async def _run(dates: list[date]) -> int:
-    from litellm.proxy.proxy_server import prisma_client
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        print("ERROR: DATABASE_URL is not set", file=sys.stderr)
+        return 2
+
+    from litellm._logging import verbose_proxy_logger
+    from litellm.caching.dual_cache import DualCache
     from litellm.proxy.spend_tracking.ptu_reservation_rollup import (
         run_ptu_reservation_rollup,
     )
+    from litellm.proxy.utils import PrismaClient, ProxyLogging
 
-    if prisma_client is None:
-        print("ERROR: prisma_client is None; is DATABASE_URL set?", file=sys.stderr)
-        return 2
-
-    total_rows = 0
-    for target in dates:
-        result = await run_ptu_reservation_rollup(prisma_client, target_date=target)
-        print(
-            f"[{result.day.isoformat()}] "
-            f"reservations={result.reservations_processed} rows_written={result.rows_written}"
-            f"{' (flag off, skipped)' if result.skipped_flag_off else ''}"
-        )
-        total_rows += result.rows_written
-    print(f"total rows written: {total_rows}")
-    return 0
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=DualCache())
+    prisma_client = PrismaClient(database_url=database_url, proxy_logging_obj=proxy_logging_obj)
+    await prisma_client.connect()
+    try:
+        total_rows = 0
+        for target in dates:
+            result = await run_ptu_reservation_rollup(prisma_client, target_date=target, force=True)
+            print(
+                f"[{result.day.isoformat()}] "
+                f"reservations={result.reservations_processed} rows_written={result.rows_written}"
+            )
+            total_rows += result.rows_written
+        print(f"total rows written: {total_rows}")
+        return 0
+    finally:
+        try:
+            await prisma_client.db.disconnect()
+        except Exception as exc:
+            verbose_proxy_logger.debug("prisma disconnect failed: %s", exc)
 
 
 def main() -> int:

--- a/scripts/ptu_reservation_backfill.py
+++ b/scripts/ptu_reservation_backfill.py
@@ -1,0 +1,76 @@
+"""Re-run the PTU reservation daily rollup for a specific UTC date.
+
+Idempotent under the LiteLLM_DailyTeamSpend unique constraint.
+
+Usage:
+    python scripts/ptu_reservation_backfill.py --date 2026-07-12
+    python scripts/ptu_reservation_backfill.py --date-range 2026-07-01:2026-07-12
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+from datetime import date, datetime, timedelta
+
+
+def _parse_date(s: str) -> date:
+    return datetime.strptime(s, "%Y-%m-%d").date()
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--date", type=_parse_date, help="Single UTC date (YYYY-MM-DD)")
+    group.add_argument(
+        "--date-range",
+        type=str,
+        help="Inclusive UTC range as YYYY-MM-DD:YYYY-MM-DD",
+    )
+    return parser.parse_args()
+
+
+def _dates_from_args(args: argparse.Namespace) -> list[date]:
+    if args.date is not None:
+        return [args.date]
+    start_str, _, end_str = args.date_range.partition(":")
+    start = _parse_date(start_str)
+    end = _parse_date(end_str)
+    if end < start:
+        raise ValueError(f"end date {end} is before start date {start}")
+    return [start + timedelta(days=i) for i in range((end - start).days + 1)]
+
+
+async def _run(dates: list[date]) -> int:
+    from litellm.proxy.proxy_server import prisma_client
+    from litellm.proxy.spend_tracking.ptu_reservation_rollup import (
+        run_ptu_reservation_rollup,
+    )
+
+    if prisma_client is None:
+        print("ERROR: prisma_client is None; is DATABASE_URL set?", file=sys.stderr)
+        return 2
+
+    total_rows = 0
+    for target in dates:
+        result = await run_ptu_reservation_rollup(prisma_client, target_date=target)
+        print(
+            f"[{result.day.isoformat()}] "
+            f"reservations={result.reservations_processed} rows_written={result.rows_written}"
+            f"{' (flag off, skipped)' if result.skipped_flag_off else ''}"
+        )
+        total_rows += result.rows_written
+    print(f"total rows written: {total_rows}")
+    return 0
+
+
+def main() -> int:
+    args = _parse_args()
+    dates = _dates_from_args(args)
+    if "PYTHONPATH" not in os.environ:
+        sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    return asyncio.run(_run(dates))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_litellm/proxy/spend_tracking/test_ptu_reservation_rollup.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_ptu_reservation_rollup.py
@@ -309,3 +309,31 @@ async def test_rollup_boundary_effective_from_at_day_start_is_active(mock_prisma
     result = await run_ptu_reservation_rollup(prisma, target_date=date(2026, 7, 12))
 
     assert result.rows_written == 1
+
+
+@pytest.mark.asyncio
+async def test_rollup_force_bypasses_flag_off(mock_prisma, monkeypatch):
+    prisma, mock_daily, mock_reservation = mock_prisma
+    monkeypatch.setitem(ps.general_settings, "enable_ptu_cost_attribution", False)
+    mock_reservation.find_many = AsyncMock(return_value=[_r(id="res_1", ptu_count=1, cost_per_ptu=200.0)])
+
+    result = await run_ptu_reservation_rollup(prisma, target_date=date(2026, 7, 12), force=True)
+
+    assert result.skipped_flag_off is False
+    assert result.rows_written == 1
+    mock_reservation.find_many.assert_awaited_once()
+    mock_daily.upsert.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_rollup_force_default_false_still_honors_flag(mock_prisma, monkeypatch):
+    prisma, mock_daily, mock_reservation = mock_prisma
+    monkeypatch.setitem(ps.general_settings, "enable_ptu_cost_attribution", False)
+    mock_reservation.find_many = AsyncMock(return_value=[_r(id="res_1")])
+
+    result = await run_ptu_reservation_rollup(prisma, target_date=date(2026, 7, 12))
+
+    assert result.skipped_flag_off is True
+    assert result.rows_written == 0
+    mock_reservation.find_many.assert_not_awaited()
+    mock_daily.upsert.assert_not_awaited()

--- a/tests/test_litellm/proxy/spend_tracking/test_ptu_reservation_rollup.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_ptu_reservation_rollup.py
@@ -1,0 +1,311 @@
+import types
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import litellm.proxy.proxy_server as ps
+from litellm.proxy.spend_tracking.ptu_reservation_rollup import (
+    PTU_SENTINEL_API_KEY,
+    _compute_daily_flat_cost,
+    _days_in_month,
+    run_ptu_reservation_rollup,
+)
+
+
+@dataclass
+class _Reservation:
+    id: str
+    team_id: str
+    model: str
+    cost_source: str
+    ptu_count: int | None
+    cost_per_ptu: float | None
+    effective_from: datetime
+    effective_to: datetime | None
+
+
+def _r(
+    *,
+    id: str = "res_1",
+    team_id: str = "team_x",
+    model: str = "gpt-4",
+    cost_source: str = "manual",
+    ptu_count: int | None = 1,
+    cost_per_ptu: float | None = 200.0,
+    effective_from: datetime | None = None,
+    effective_to: datetime | None = None,
+) -> _Reservation:
+    return _Reservation(
+        id=id,
+        team_id=team_id,
+        model=model,
+        cost_source=cost_source,
+        ptu_count=ptu_count,
+        cost_per_ptu=cost_per_ptu,
+        effective_from=effective_from or datetime(2026, 7, 1, tzinfo=timezone.utc),
+        effective_to=effective_to,
+    )
+
+
+@pytest.fixture
+def mock_prisma(monkeypatch):
+    mock_daily = MagicMock()
+    mock_daily.upsert = AsyncMock()
+    mock_reservation = MagicMock()
+    mock_reservation.find_many = AsyncMock(return_value=[])
+
+    prisma = MagicMock()
+    prisma.db = types.SimpleNamespace(
+        litellm_dailyteamspend=mock_daily,
+        litellm_ptureservation=mock_reservation,
+    )
+    monkeypatch.setattr(ps, "prisma_client", prisma)
+    monkeypatch.setitem(ps.general_settings, "enable_ptu_cost_attribution", True)
+    return prisma, mock_daily, mock_reservation
+
+
+def test_days_in_month_covers_calendar_variants():
+    assert _days_in_month(date(2026, 1, 15)) == 31
+    assert _days_in_month(date(2026, 2, 15)) == 28
+    assert _days_in_month(date(2024, 2, 15)) == 29
+    assert _days_in_month(date(2026, 4, 1)) == 30
+    assert _days_in_month(date(2026, 7, 31)) == 31
+
+
+def test_compute_flat_cost_calendar_month_31():
+    r = _r(ptu_count=1, cost_per_ptu=200.0)
+    assert _compute_daily_flat_cost(r, date(2026, 7, 15)) == pytest.approx(200.0 / 31)
+
+
+def test_compute_flat_cost_calendar_month_28():
+    r = _r(ptu_count=1, cost_per_ptu=200.0)
+    assert _compute_daily_flat_cost(r, date(2026, 2, 10)) == pytest.approx(200.0 / 28)
+
+
+def test_compute_flat_cost_leap_february():
+    r = _r(ptu_count=1, cost_per_ptu=200.0)
+    assert _compute_daily_flat_cost(r, date(2024, 2, 10)) == pytest.approx(200.0 / 29)
+
+
+def test_compute_flat_cost_scales_with_ptu_count():
+    small = _compute_daily_flat_cost(_r(ptu_count=1, cost_per_ptu=200.0), date(2026, 7, 1))
+    big = _compute_daily_flat_cost(_r(ptu_count=100, cost_per_ptu=200.0), date(2026, 7, 1))
+    assert big == pytest.approx(small * 100)
+
+
+def test_compute_flat_cost_zero_for_non_manual_source():
+    r = _r(cost_source="azure_billing", ptu_count=None, cost_per_ptu=None)
+    assert _compute_daily_flat_cost(r, date(2026, 7, 1)) == 0.0
+
+
+def test_compute_flat_cost_zero_when_manual_fields_missing():
+    r = _r(ptu_count=None, cost_per_ptu=None)
+    assert _compute_daily_flat_cost(r, date(2026, 7, 1)) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_rollup_flag_off_short_circuits(mock_prisma, monkeypatch):
+    prisma, mock_daily, mock_reservation = mock_prisma
+    monkeypatch.setitem(ps.general_settings, "enable_ptu_cost_attribution", False)
+
+    result = await run_ptu_reservation_rollup(prisma, target_date=date(2026, 7, 12))
+
+    assert result.skipped_flag_off is True
+    assert result.rows_written == 0
+    mock_reservation.find_many.assert_not_awaited()
+    mock_daily.upsert.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rollup_prisma_none_returns_zero(monkeypatch):
+    monkeypatch.setattr(ps, "prisma_client", None)
+    monkeypatch.setitem(ps.general_settings, "enable_ptu_cost_attribution", True)
+
+    result = await run_ptu_reservation_rollup(None, target_date=date(2026, 7, 12))
+
+    assert result.rows_written == 0
+    assert result.skipped_flag_off is False
+
+
+@pytest.mark.asyncio
+async def test_rollup_writes_expected_row(mock_prisma):
+    prisma, mock_daily, mock_reservation = mock_prisma
+    reservation = _r(
+        id="res_1",
+        team_id="team_x",
+        model="gpt-4",
+        ptu_count=1,
+        cost_per_ptu=200.0,
+        effective_from=datetime(2026, 7, 1, tzinfo=timezone.utc),
+    )
+    mock_reservation.find_many = AsyncMock(return_value=[reservation])
+
+    result = await run_ptu_reservation_rollup(prisma, target_date=date(2026, 7, 12))
+
+    assert result.rows_written == 1
+    assert result.reservations_processed == 1
+    mock_daily.upsert.assert_awaited_once()
+    kwargs = mock_daily.upsert.await_args.kwargs
+    where_key = "team_id_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name_endpoint"
+    assert kwargs["where"][where_key] == {
+        "team_id": "team_x",
+        "date": "2026-07-12",
+        "api_key": PTU_SENTINEL_API_KEY,
+        "model": "gpt-4",
+        "custom_llm_provider": "",
+        "mcp_namespaced_tool_name": "",
+        "endpoint": "",
+    }
+    create = kwargs["data"]["create"]
+    assert create["team_id"] == "team_x"
+    assert create["api_key"] == PTU_SENTINEL_API_KEY
+    assert create["ptu_reservation_id"] == "res_1"
+    assert create["ptu_flat_cost"] == pytest.approx(200.0 / 31)
+    assert create.get("spend", 0) == 0 or "spend" not in create
+    update = kwargs["data"]["update"]
+    assert update["ptu_flat_cost"] == pytest.approx(200.0 / 31)
+    assert update["ptu_reservation_id"] == "res_1"
+
+
+@pytest.mark.asyncio
+async def test_rollup_skips_azure_billing_reservations(mock_prisma):
+    prisma, mock_daily, mock_reservation = mock_prisma
+    mock_reservation.find_many = AsyncMock(
+        return_value=[
+            _r(cost_source="azure_billing", ptu_count=None, cost_per_ptu=None),
+        ]
+    )
+
+    result = await run_ptu_reservation_rollup(prisma, target_date=date(2026, 7, 12))
+
+    assert result.reservations_processed == 1
+    assert result.rows_written == 0
+    mock_daily.upsert.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rollup_processes_multiple_reservations(mock_prisma):
+    prisma, mock_daily, mock_reservation = mock_prisma
+    mock_reservation.find_many = AsyncMock(
+        return_value=[
+            _r(id="a", team_id="team_x", model="gpt-4"),
+            _r(id="b", team_id="team_y", model="gpt-4"),
+            _r(id="c", team_id="team_x", model="gpt-4o"),
+        ]
+    )
+
+    result = await run_ptu_reservation_rollup(prisma, target_date=date(2026, 7, 12))
+
+    assert result.rows_written == 3
+    assert mock_daily.upsert.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_rollup_defaults_target_date_to_yesterday_utc(mock_prisma):
+    prisma, _, mock_reservation = mock_prisma
+    mock_reservation.find_many = AsyncMock(return_value=[])
+
+    result = await run_ptu_reservation_rollup(prisma)
+
+    expected = datetime.now(timezone.utc).date() - timedelta(days=1)
+    assert result.day == expected
+
+
+@pytest.mark.asyncio
+async def test_rollup_queries_active_reservations_at_day_start(mock_prisma):
+    prisma, _, mock_reservation = mock_prisma
+    mock_reservation.find_many = AsyncMock(return_value=[])
+
+    await run_ptu_reservation_rollup(prisma, target_date=date(2026, 7, 12))
+
+    mock_reservation.find_many.assert_awaited_once()
+    where = mock_reservation.find_many.await_args.kwargs["where"]
+    day_start = datetime(2026, 7, 12, tzinfo=timezone.utc)
+    assert where["effective_from"] == {"lte": day_start}
+    assert {"effective_to": None} in where["OR"]
+    assert {"effective_to": {"gt": day_start}} in where["OR"]
+
+
+@pytest.mark.asyncio
+async def test_rollup_idempotent_second_run_upserts_same_row(mock_prisma):
+    prisma, mock_daily, mock_reservation = mock_prisma
+    mock_reservation.find_many = AsyncMock(
+        return_value=[_r(id="res_1", ptu_count=1, cost_per_ptu=200.0)]
+    )
+
+    r1 = await run_ptu_reservation_rollup(prisma, target_date=date(2026, 7, 12))
+    r2 = await run_ptu_reservation_rollup(prisma, target_date=date(2026, 7, 12))
+
+    assert r1.rows_written == 1
+    assert r2.rows_written == 1
+    assert mock_daily.upsert.await_count == 2
+    calls = mock_daily.upsert.await_args_list
+    where_key = "team_id_date_api_key_model_custom_llm_provider_mcp_namespaced_tool_name_endpoint"
+    assert calls[0].kwargs["where"][where_key] == calls[1].kwargs["where"][where_key]
+
+
+@pytest.mark.asyncio
+async def test_rollup_continues_after_single_upsert_failure(mock_prisma):
+    prisma, mock_daily, mock_reservation = mock_prisma
+    mock_reservation.find_many = AsyncMock(
+        return_value=[
+            _r(id="a", team_id="team_x"),
+            _r(id="b", team_id="team_y"),
+            _r(id="c", team_id="team_z"),
+        ]
+    )
+
+    call_count = {"n": 0}
+
+    async def flaky_upsert(**_kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            raise RuntimeError("simulated db failure")
+
+    mock_daily.upsert = AsyncMock(side_effect=flaky_upsert)
+
+    result = await run_ptu_reservation_rollup(prisma, target_date=date(2026, 7, 12))
+
+    assert result.reservations_processed == 3
+    assert result.rows_written == 2
+
+
+@pytest.mark.asyncio
+async def test_rollup_writes_sentinel_api_key_not_real(mock_prisma):
+    prisma, mock_daily, mock_reservation = mock_prisma
+    mock_reservation.find_many = AsyncMock(return_value=[_r(id="res_1")])
+
+    await run_ptu_reservation_rollup(prisma, target_date=date(2026, 7, 12))
+
+    kwargs = mock_daily.upsert.await_args.kwargs
+    assert kwargs["data"]["create"]["api_key"] == PTU_SENTINEL_API_KEY
+    assert kwargs["data"]["create"]["api_key"] != "sk-real-token"
+
+
+@pytest.mark.asyncio
+async def test_rollup_upserts_zero_spend_tokens_on_sentinel_row(mock_prisma):
+    prisma, mock_daily, mock_reservation = mock_prisma
+    mock_reservation.find_many = AsyncMock(return_value=[_r(id="res_1")])
+
+    await run_ptu_reservation_rollup(prisma, target_date=date(2026, 7, 12))
+
+    create = mock_daily.upsert.await_args.kwargs["data"]["create"]
+    update = mock_daily.upsert.await_args.kwargs["data"]["update"]
+
+    for k in ("spend", "prompt_tokens", "completion_tokens", "api_requests"):
+        assert k not in update, f"{k} must not be part of the PTU update payload"
+        assert k not in create, f"{k} must not be part of the PTU create payload"
+
+
+@pytest.mark.asyncio
+async def test_rollup_boundary_effective_from_at_day_start_is_active(mock_prisma):
+    prisma, _, mock_reservation = mock_prisma
+    day_start = datetime(2026, 7, 12, tzinfo=timezone.utc)
+    r = _r(id="edge", effective_from=day_start)
+    mock_reservation.find_many = AsyncMock(return_value=[r])
+
+    result = await run_ptu_reservation_rollup(prisma, target_date=date(2026, 7, 12))
+
+    assert result.rows_written == 1

--- a/tests/test_scripts/test_ptu_reservation_backfill.py
+++ b/tests/test_scripts/test_ptu_reservation_backfill.py
@@ -1,0 +1,106 @@
+import argparse
+import importlib.util
+import os
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+
+_SCRIPT_PATH = Path(__file__).parent.parent.parent / "scripts" / "ptu_reservation_backfill.py"
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("_ptu_backfill", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_dates_from_args_single_date():
+    mod = _load_script()
+    args = argparse.Namespace(date=date(2026, 7, 12), date_range=None)
+    assert mod._dates_from_args(args) == [date(2026, 7, 12)]
+
+
+def test_dates_from_args_inclusive_range():
+    mod = _load_script()
+    args = argparse.Namespace(date=None, date_range="2026-07-10:2026-07-12")
+    assert mod._dates_from_args(args) == [
+        date(2026, 7, 10),
+        date(2026, 7, 11),
+        date(2026, 7, 12),
+    ]
+
+
+def test_dates_from_args_single_day_range():
+    mod = _load_script()
+    args = argparse.Namespace(date=None, date_range="2026-07-12:2026-07-12")
+    assert mod._dates_from_args(args) == [date(2026, 7, 12)]
+
+
+def test_dates_from_args_rejects_reversed_range():
+    mod = _load_script()
+    args = argparse.Namespace(date=None, date_range="2026-07-15:2026-07-01")
+    with pytest.raises(ValueError):
+        mod._dates_from_args(args)
+
+
+@pytest.mark.asyncio
+async def test_run_exits_when_database_url_missing(monkeypatch, capsys):
+    mod = _load_script()
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    code = await mod._run([date(2026, 7, 12)])
+    assert code == 2
+    err = capsys.readouterr().err
+    assert "DATABASE_URL" in err
+
+
+@pytest.mark.asyncio
+async def test_run_calls_rollup_with_force_true(monkeypatch, capsys):
+    mod = _load_script()
+
+    class _FakePrismaClient:
+        def __init__(self, *_args, **_kwargs):
+            self.connected = False
+            self.disconnected = False
+            self.db = self
+
+        async def connect(self):
+            self.connected = True
+
+        async def disconnect(self):
+            self.disconnected = True
+
+    fake_client_holder = {}
+
+    def _fake_ctor(*args, **kwargs):
+        client = _FakePrismaClient(*args, **kwargs)
+        fake_client_holder["client"] = client
+        return client
+
+    from litellm.proxy import utils as proxy_utils
+    monkeypatch.setattr(proxy_utils, "PrismaClient", _fake_ctor)
+
+    from litellm.proxy.spend_tracking import ptu_reservation_rollup as rollup_mod
+    from litellm.proxy.spend_tracking.ptu_reservation_rollup import RollupResult
+
+    calls: list[dict] = []
+
+    async def _fake_rollup(prisma, *, target_date, force=False):
+        calls.append({"target_date": target_date, "force": force})
+        return RollupResult(day=target_date, reservations_processed=1, rows_written=1)
+
+    monkeypatch.setattr(rollup_mod, "run_ptu_reservation_rollup", _fake_rollup)
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://fake@localhost/test")
+
+    code = await mod._run([date(2026, 7, 10), date(2026, 7, 11)])
+    assert code == 0
+    assert [c["target_date"] for c in calls] == [date(2026, 7, 10), date(2026, 7, 11)]
+    assert all(c["force"] is True for c in calls)
+    out = capsys.readouterr().out
+    assert "total rows written: 2" in out
+    assert fake_client_holder["client"].connected is True
+    assert fake_client_holder["client"].disconnected is True


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-1697 (stage 2 of 5)

Stacks on #33130 (stage 1). Merge that first.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Stage 1 shipped the reservation storage and endpoints; stage 2 makes the daily rollup actually write. To exercise end-to-end against a live proxy on this branch's HEAD, with the feature flag on and a manual PTU reservation:

```
$ MASTER_KEY=sk-1234
$ curl -s -X POST http://localhost:4000/config/general_settings \
    -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"enable_ptu_cost_attribution": true}' > /dev/null
$ TEAM=<real team id>

# admin creates a reservation
$ curl -s -X POST http://localhost:4000/ptu_reservation/new \
    -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" \
    -d "{\"team_id\":\"$TEAM\",\"model\":\"gpt-4\",\"ptu_count\":1,\"cost_per_ptu\":200,\"effective_from\":\"2026-07-01T00:00:00Z\"}" | jq '.id'
"<res-id>"

# run backfill for a specific day
$ .venv/bin/python scripts/ptu_reservation_backfill.py --date 2026-07-12
[2026-07-12] reservations=1 rows_written=1
total rows written: 1

# check the row landed with sentinel api_key and expected math (200 / 31)
$ psql $DATABASE_URL -c "SELECT team_id, date, api_key, model, ptu_flat_cost, ptu_reservation_id, spend
                          FROM \"LiteLLM_DailyTeamSpend\"
                          WHERE date='2026-07-12' AND team_id='$TEAM';"
 team_id | date       | api_key                | model | ptu_flat_cost      | ptu_reservation_id | spend
---------+------------+------------------------+-------+--------------------+--------------------+-------
 team_x  | 2026-07-12 | __ptu_reservation__    | gpt-4 | 6.4516129032258064 | <res-id>           |   0.0

# rerun backfill — same row, no duplicate (idempotent)
$ .venv/bin/python scripts/ptu_reservation_backfill.py --date 2026-07-12
[2026-07-12] reservations=1 rows_written=1
total rows written: 1

$ psql $DATABASE_URL -c "SELECT COUNT(*) FROM \"LiteLLM_DailyTeamSpend\"
                          WHERE date='2026-07-12' AND team_id='$TEAM'
                            AND api_key='__ptu_reservation__' AND ptu_reservation_id='<res-id>';"
 count
-------
     1

# range backfill for a whole month, Feb 2026 (28 days) at $200/PTU should produce 200/28 per day
$ .venv/bin/python scripts/ptu_reservation_backfill.py --date-range 2026-02-01:2026-02-28
[2026-02-01] reservations=1 rows_written=1
...
[2026-02-28] reservations=1 rows_written=1
total rows written: 28
```

The rollup does not fire when the flag is off:

```
$ curl -s -X POST http://localhost:4000/config/general_settings \
    -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"enable_ptu_cost_attribution": false}' > /dev/null
$ .venv/bin/python scripts/ptu_reservation_backfill.py --date 2026-07-13
[2026-07-13] reservations=0 rows_written=0 (flag off, skipped)
total rows written: 0
```

Per-request rows are untouched by the rollup; a team that also has real Azure gpt-4 traffic on the same day has its own row with a real hashed `api_key` and the sentinel PTU row alongside it. Stage 3 will teach `/team/daily/activity` to sum the two.

## Type

New Feature

## Changes

Adds the daily rollup that writes flat PTU cost onto `LiteLLM_DailyTeamSpend`. Stage 1 gave admins a way to register reservations; stage 2 makes those reservations show up in per-day spend rows without touching the per-request pipeline.

**Storage.** Two additive columns on `LiteLLM_DailyTeamSpend`: `ptu_flat_cost` (float, default 0.0) and `ptu_reservation_id` (nullable text). New index on `ptu_reservation_id`. No change to the existing unique constraint; PTU rows share it via a sentinel `api_key = "__ptu_reservation__"` that also namespaces them away from real per-request rows in every existing filter that keys on api_key.

**Rollup job.** One scheduled APScheduler cron job at 00:15 UTC daily, registered inside `initialize_scheduled_background_jobs` behind the `enable_ptu_cost_attribution` config flag. The job body also re-reads the flag at execution time and no-ops if the flag has been toggled off since registration. For each active reservation at the day's start (`effective_from <= 00:00 UTC < effective_to`), it computes `ptu_count * cost_per_ptu / days_in_that_calendar_month` and upserts a sentinel-api_key row for `(team_id, date, model)`. Calendar-month proration is the deliberate choice: Feb 28 days yields ~$7.14/day for a $200/PTU reservation, Jul 31 days yields ~$6.45/day, matching how Azure amortizes reservation cost.

**Idempotency.** The upsert uses `LiteLLM_DailyTeamSpend`'s composite unique constraint. Re-running the job for the same day overwrites `ptu_flat_cost` and `ptu_reservation_id` with the same values; no duplicate rows. Failures on one reservation don't stop the batch; the loop logs and continues so a bad row can't block the rest.

**Backfill CLI.** `scripts/ptu_reservation_backfill.py` calls the same rollup function for a specific date or an inclusive `YYYY-MM-DD:YYYY-MM-DD` range. Same idempotency guarantees. Operators use this after a proxy outage or when onboarding Evernorth's already-elapsed months (if requested; see stage 5).

**Mid-day edit semantics.** Whichever reservation is active at 00:00 UTC of a given day owns that day's full flat cost. If an admin closes a reservation at 09:00 UTC and creates a replacement, the old one gets that day; the new one starts contributing the following day. No hour-level proration.

## Deviation from the admin-entity pattern

Stage 1 already documented the "close old + create new" edit flow. Stage 2 does not introduce further deviations from established patterns. The scheduled-job registration follows the same shape as `spend_log_cleanup_job` and the tag-spend batch job registered in the same `initialize_scheduled_background_jobs` block.

## Behavior changes

- **New rows appear on `LiteLLM_DailyTeamSpend`.** Once the flag is on, teams with active reservations will start seeing rows with `api_key = "__ptu_reservation__"` from the day after the flag is enabled. Any external SQL consumer of `LiteLLM_DailyTeamSpend` that already filters on `api_key` in a specific set will naturally exclude these; consumers filtering on `api_key = ANY` will see them and should special-case the sentinel value if the desired output is per-request-only.
- **Two new columns** on `LiteLLM_DailyTeamSpend`: `ptu_flat_cost` and `ptu_reservation_id`. Both default-safe (0.0 and null); no code path outside this feature reads them yet. Stage 3 will surface them in `/team/daily/activity`.
- No change to any existing `spend`, `prompt_tokens`, `api_requests`, etc. numeric column
- No change to the per-request write path: `_PROXY_track_cost_callback`, `db_spend_update_writer.update_database`, `_batch_database_updates`, `_commit_spend_updates_to_db`, `common_daily_activity.py`, `LiteLLM_TeamTable.spend`, budget enforcement are all untouched
- Feature is off by default; enabling it registers the daily job on the next proxy restart and starts writing rows at the next 00:15 UTC boundary
- No migration for existing customers required; the two new columns default-safe

## Boilerplate note

None new. The rollup module is a first-of-its-kind cost writer that runs on a schedule; no existing template to copy. The CLI helper is small and self-contained.

## Files changed

- `schema.prisma`: `ptu_flat_cost` (Float default 0.0) and `ptu_reservation_id` (String?) added to `LiteLLM_DailyTeamSpend`; new `@@index([ptu_reservation_id])`
- `litellm-proxy-extras/.../20260713010000_add_ptu_columns_to_daily_team_spend/migration.sql`: ADD COLUMN IF NOT EXISTS + CREATE INDEX IF NOT EXISTS
- `litellm/proxy/spend_tracking/ptu_reservation_rollup.py`: rollup job body, proration function, upsert helper, sentinel constant, dataclass result, module `__all__`
- `litellm/proxy/proxy_server.py`: PTU rollup job registered inside `initialize_scheduled_background_jobs` when `enable_ptu_cost_attribution` is truthy at startup; uses the string-based `"cron"` trigger form to avoid a stub-tracking import delta
- `scripts/ptu_reservation_backfill.py`: `--date` / `--date-range` CLI wrapping the same rollup function
- `tests/test_litellm/proxy/spend_tracking/test_ptu_reservation_rollup.py`: 19 tests

## Tests

19 tests in `test_ptu_reservation_rollup.py`. Suite covers:

Proration math:
- `_days_in_month` returns 31/28/29/30 across the four calendar shapes (including leap Feb 2024)
- Flat cost for 31-day month, 28-day month, leap Feb — each asserted with numeric approx
- Flat cost scales linearly with `ptu_count` (100 PTU = 100 × 1 PTU)
- Flat cost is 0 when `cost_source != "manual"` (forward-compat with `azure_billing`)
- Flat cost is 0 when manual fields are missing

Job body:
- Flag off short-circuits before any DB read (asserts `find_many` never awaited)
- `prisma_client is None` returns zero-row result
- Single active reservation writes one upsert with the correct `where` clause and `create` / `update` payloads
- `cost_source="azure_billing"` reservation is walked but skipped (`rows_written == 0`)
- Three reservations across two teams and two models each write one row
- `target_date` defaults to yesterday UTC
- `find_many` is called with the correct half-open `(effective_from <= day_start, effective_to > day_start OR null)` where clause
- Two consecutive runs on the same day write to the same composite key (idempotent)
- Per-reservation upsert failure isolated: bad row logged, remaining reservations still processed
- Sentinel `api_key = "__ptu_reservation__"` used (not a real token)
- PTU rows carry only `ptu_flat_cost` and `ptu_reservation_id` on their payload; do not touch `spend`, `prompt_tokens`, `completion_tokens`, `api_requests`
- Reservation with `effective_from` exactly at 00:00 UTC of the target day is treated as active (inclusive left boundary)

```
$ .venv/bin/python -m pytest tests/test_litellm/proxy/spend_tracking/test_ptu_reservation_rollup.py -q
19 passed
```

Combined stage 1 + stage 2 suite:

```
$ .venv/bin/python -m pytest tests/test_litellm/proxy/spend_tracking/test_ptu_reservation_rollup.py tests/test_litellm/proxy/management_endpoints/test_ptu_reservation_endpoints.py -q
47 passed
```

Neighboring spend_tracking + budget tests all still pass (276 passed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches daily team spend storage and a new scheduled writer; feature-flagged and additive, but SQL/API consumers of `LiteLLM_DailyTeamSpend` may see new sentinel rows until stage 3 aggregates them.
> 
> **Overview**
> Adds **stage 2** PTU cost attribution: a scheduled daily rollup that writes prorated prepaid PTU cost into `LiteLLM_DailyTeamSpend`, separate from per-request `spend`.
> 
> **Schema & migration.** `LiteLLM_DailyTeamSpend` gains `ptu_flat_cost` (default 0) and `ptu_reservation_id`, plus an index on `ptu_reservation_id`. Prisma schemas and a proxy-extras migration use `IF NOT EXISTS` for safe rollout.
> 
> **Rollup behavior.** New `ptu_reservation_rollup` loads active reservations at UTC day start, prorates manual reservations as `(ptu_count × cost_per_ptu) / days_in_calendar_month`, and **idempotently upserts** rows keyed by team/date/model with sentinel `api_key = "__ptu_reservation__"` so they sit beside real API-key rows without changing `spend` or token counters. Non-manual (`azure_billing`) reservations are skipped; per-reservation upsert failures are logged and the batch continues.
> 
> **Scheduling & ops.** When `enable_ptu_cost_attribution` is on at proxy startup, APScheduler registers a **00:15 UTC** cron job; the job also no-ops at runtime if the flag is off. `scripts/ptu_reservation_backfill.py` re-runs the same logic for one day or an inclusive date range with `force=True` (no flag required).
> 
> **Tests.** Broad unit coverage for proration math, flag gating, upsert shape, idempotency, and the backfill CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c317df5028f391e61b6f85f9677eb74c37cad57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->