### PR TITLE
feat(prometheus): expose video duration and image count consumption metrics

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -239,6 +239,18 @@ class PrometheusLogger(CustomLogger):
                 labelnames=self.get_labels_for_metric("litellm_output_audio_tokens_metric"),
             )
 
+            self.litellm_video_duration_seconds_metric = self._counter_factory(
+                "litellm_video_duration_seconds_metric",
+                "Seconds of video generated, from usage.duration_seconds on video generation calls",
+                labelnames=self.get_labels_for_metric("litellm_video_duration_seconds_metric"),
+            )
+
+            self.litellm_images_generated_metric = self._counter_factory(
+                "litellm_images_generated_metric",
+                "Number of images generated, from the image generation response",
+                labelnames=self.get_labels_for_metric("litellm_images_generated_metric"),
+            )
+
             # Remaining Budget for Team
             self.litellm_remaining_team_budget_metric = self._gauge_factory(
                 "litellm_remaining_team_budget_metric",
@@ -1336,6 +1348,12 @@ class PrometheusLogger(CustomLogger):
             label_context=label_context,
         )
 
+        self._increment_media_generation_metrics(
+            standard_logging_payload=standard_logging_payload,
+            enum_values=enum_values,
+            label_context=label_context,
+        )
+
         # MCP tool call metrics
         self._increment_mcp_tool_call_metrics(
             standard_logging_payload=standard_logging_payload,
@@ -1459,8 +1477,65 @@ class PrometheusLogger(CustomLogger):
             ),
         ]
 
-        for counter, metric_name, value in detail_metrics:
-            if not isinstance(value, (int, float)) or value <= 0:
+        PrometheusLogger._inc_sparse_usage_counters(
+            self,
+            detail_metrics,
+            enum_values=enum_values,
+            label_context=label_context,
+        )
+
+    def _increment_media_generation_metrics(
+        self,
+        standard_logging_payload: StandardLoggingPayload,
+        enum_values: UserAPIKeyLabelValues,
+        label_context: PrometheusLabelFactoryContext | None = None,
+    ) -> None:
+        """
+        Increment video-seconds and images-generated counters from
+        ``standard_logging_payload["metadata"]["usage_object"]``. Video
+        providers report ``duration_seconds`` there; image generation calls
+        report ``output_image_count``. Both are sparse: only emitted when the
+        value is present and > 0, so token-only call types are unaffected.
+        """
+        metadata = standard_logging_payload.get("metadata") or {}
+        usage_object = metadata.get("usage_object") if isinstance(metadata, dict) else None
+        if not isinstance(usage_object, dict):
+            return
+
+        media_metrics: list[tuple[Any, DEFINED_PROMETHEUS_METRICS, Any]] = [
+            (
+                self.litellm_video_duration_seconds_metric,
+                "litellm_video_duration_seconds_metric",
+                usage_object.get("duration_seconds"),
+            ),
+            (
+                self.litellm_images_generated_metric,
+                "litellm_images_generated_metric",
+                usage_object.get("output_image_count"),
+            ),
+        ]
+
+        PrometheusLogger._inc_sparse_usage_counters(
+            self,
+            media_metrics,
+            enum_values=enum_values,
+            label_context=label_context,
+        )
+
+    def _inc_sparse_usage_counters(
+        self,
+        counters_with_values: list[tuple[Any, DEFINED_PROMETHEUS_METRICS, Any]],
+        enum_values: UserAPIKeyLabelValues,
+        label_context: PrometheusLabelFactoryContext | None = None,
+    ) -> None:
+        """
+        Increment each ``(counter, metric_name, value)`` entry whose value is
+        a positive number. Non-numeric values (including booleans from
+        malformed provider usage dicts) and values <= 0 are skipped, keeping
+        scrape output sparse.
+        """
+        for counter, metric_name, value in counters_with_values:
+            if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
                 continue
             PrometheusLogger._inc_labeled_counter(
                 self,

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5212,9 +5212,14 @@ def get_standard_logging_object_payload(
         call_type = kwargs.get("call_type")
         cache_hit = kwargs.get("cache_hit", False)
         # Extract usage as a plain dict, avoiding Pydantic round-trip
-        usage_dict = StandardLoggingPayloadSetup.get_usage_as_dict(
+        raw_usage_dict = StandardLoggingPayloadSetup.get_usage_as_dict(
             response_obj=response_obj,
             combined_usage_object=cast(Optional[Usage], kwargs.get("combined_usage_object")),
+        )
+        usage_dict = (
+            {**raw_usage_dict, "output_image_count": len(init_response_obj.data)}
+            if isinstance(init_response_obj, ImageResponse) and init_response_obj.data
+            else raw_usage_dict
         )
 
         id = response_obj.get("id", kwargs.get("litellm_call_id"))

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -213,6 +213,8 @@ DEFINED_PROMETHEUS_METRICS = Literal[
     "litellm_input_audio_tokens_metric",
     "litellm_output_reasoning_tokens_metric",
     "litellm_output_audio_tokens_metric",
+    "litellm_video_duration_seconds_metric",
+    "litellm_images_generated_metric",
     "litellm_deployment_successful_fallbacks",
     "litellm_deployment_failed_fallbacks",
     "litellm_remaining_team_budget_metric",
@@ -506,6 +508,9 @@ class PrometheusMetricLabels:
     litellm_output_reasoning_tokens_metric = litellm_output_tokens_metric
     litellm_output_audio_tokens_metric = litellm_output_tokens_metric
 
+    litellm_video_duration_seconds_metric = litellm_output_tokens_metric
+    litellm_images_generated_metric = litellm_output_tokens_metric
+
     litellm_deployment_state = [
         UserAPIKeyLabelNames.v2_LITELLM_MODEL_NAME.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
@@ -717,6 +722,8 @@ class PrometheusMetricLabels:
             "litellm_input_tokens_metric",
             "litellm_total_tokens_metric",
             "litellm_output_tokens_metric",
+            "litellm_video_duration_seconds_metric",
+            "litellm_images_generated_metric",
         }
     )
     # Managed batch metrics

--- a/tests/test_litellm/integrations/test_prometheus_media_generation_metrics.py
+++ b/tests/test_litellm/integrations/test_prometheus_media_generation_metrics.py
@@ -1,0 +1,180 @@
+"""
+Unit tests for the video-seconds and images-generated Prometheus counters (LIT-4254).
+
+Video providers report ``duration_seconds`` inside the usage object that lands
+on ``standard_logging_payload["metadata"]["usage_object"]``; image generation
+calls report ``output_image_count`` there. Both counters are sparse: only
+incremented when the value is present and > 0.
+"""
+
+from typing import get_args
+from unittest.mock import MagicMock
+
+import pytest
+
+from litellm.integrations.prometheus import PrometheusLogger
+from litellm.types.integrations.prometheus import (
+    DEFINED_PROMETHEUS_METRICS,
+    PrometheusMetricLabels,
+    UserAPIKeyLabelValues,
+)
+
+MEDIA_GENERATION_METRICS = [
+    "litellm_video_duration_seconds_metric",
+    "litellm_images_generated_metric",
+]
+
+
+@pytest.fixture
+def sample_enum_values():
+    return UserAPIKeyLabelValues(
+        end_user="test-end-user",
+        hashed_api_key="test-key-hash",
+        api_key_alias="test-key-alias",
+        team="test-team",
+        team_alias="test-team-alias",
+        user="test-user",
+        model="sora-2",
+    )
+
+
+def _make_mock_logger():
+    logger = MagicMock()
+    for name in MEDIA_GENERATION_METRICS:
+        setattr(logger, name, MagicMock())
+    logger.get_labels_for_metric = MagicMock(
+        return_value=[
+            "model",
+            "hashed_api_key",
+            "api_key_alias",
+            "team",
+            "team_alias",
+            "end_user",
+            "user",
+        ]
+    )
+    return logger
+
+
+class TestMediaGenerationMetricsRegistration:
+    def test_metrics_in_defined_prometheus_metrics(self):
+        defined = get_args(DEFINED_PROMETHEUS_METRICS)
+        for name in MEDIA_GENERATION_METRICS:
+            assert name in defined, f"{name} missing from DEFINED_PROMETHEUS_METRICS"
+
+    def test_metric_labels_defined(self):
+        for name in MEDIA_GENERATION_METRICS:
+            assert hasattr(PrometheusMetricLabels, name), f"{name} missing from PrometheusMetricLabels"
+
+    def test_metrics_share_output_token_label_set(self):
+        assert (
+            PrometheusMetricLabels.litellm_video_duration_seconds_metric
+            == PrometheusMetricLabels.litellm_output_tokens_metric
+        )
+        assert (
+            PrometheusMetricLabels.litellm_images_generated_metric
+            == PrometheusMetricLabels.litellm_output_tokens_metric
+        )
+
+    def test_runtime_label_set_matches_output_tokens_metric(self):
+        """Full parity with litellm_output_tokens_metric, including the org labels
+        appended via _org_label_metrics, so existing token dashboards can be cloned."""
+        expected = PrometheusMetricLabels.get_labels("litellm_output_tokens_metric")
+        for name in MEDIA_GENERATION_METRICS:
+            assert PrometheusMetricLabels.get_labels(name) == expected
+
+
+class TestIncrementMediaGenerationMetrics:
+    def test_video_duration_incremented(self, sample_enum_values):
+        logger = _make_mock_logger()
+        payload = {"metadata": {"usage_object": {"duration_seconds": 8.0}}}
+
+        PrometheusLogger._increment_media_generation_metrics(
+            logger,
+            standard_logging_payload=payload,
+            enum_values=sample_enum_values,
+        )
+
+        logger.litellm_video_duration_seconds_metric.labels().inc.assert_called_once_with(8.0)
+        logger.litellm_images_generated_metric.labels.assert_not_called()
+
+    def test_image_count_incremented(self, sample_enum_values):
+        logger = _make_mock_logger()
+        payload = {
+            "metadata": {
+                "usage_object": {
+                    "prompt_tokens": 18,
+                    "completion_tokens": 391,
+                    "total_tokens": 409,
+                    "output_image_count": 2,
+                }
+            }
+        }
+
+        PrometheusLogger._increment_media_generation_metrics(
+            logger,
+            standard_logging_payload=payload,
+            enum_values=sample_enum_values,
+        )
+
+        logger.litellm_images_generated_metric.labels().inc.assert_called_once_with(2.0)
+        logger.litellm_video_duration_seconds_metric.labels.assert_not_called()
+
+    def test_token_only_usage_is_a_noop(self, sample_enum_values):
+        logger = _make_mock_logger()
+        payload = {
+            "metadata": {
+                "usage_object": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 20,
+                    "total_tokens": 30,
+                }
+            }
+        }
+
+        PrometheusLogger._increment_media_generation_metrics(
+            logger,
+            standard_logging_payload=payload,
+            enum_values=sample_enum_values,
+        )
+
+        for name in MEDIA_GENERATION_METRICS:
+            getattr(logger, name).labels.assert_not_called()
+
+    @pytest.mark.parametrize("bad_value", [0, 0.0, None, -4.0, "4", True])
+    def test_non_positive_or_non_numeric_values_are_ignored(self, sample_enum_values, bad_value):
+        logger = _make_mock_logger()
+        payload = {
+            "metadata": {
+                "usage_object": {
+                    "duration_seconds": bad_value,
+                    "output_image_count": bad_value,
+                }
+            }
+        }
+
+        PrometheusLogger._increment_media_generation_metrics(
+            logger,
+            standard_logging_payload=payload,
+            enum_values=sample_enum_values,
+        )
+
+        for name in MEDIA_GENERATION_METRICS:
+            getattr(logger, name).labels.assert_not_called()
+
+    def test_missing_usage_object_is_a_noop(self, sample_enum_values):
+        logger = _make_mock_logger()
+
+        for payload in ({"metadata": {}}, {"metadata": None}, {"metadata": {"usage_object": "redacted"}}):
+            PrometheusLogger._increment_media_generation_metrics(
+                logger,
+                standard_logging_payload=payload,
+                enum_values=sample_enum_values,
+            )
+
+        for name in MEDIA_GENERATION_METRICS:
+            getattr(logger, name).labels.assert_not_called()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -3707,3 +3707,69 @@ def test_set_cost_breakdown_stores_reasoning_cost():
         cost_for_built_in_tools_cost_usd_dollar=0.0,
     )
     assert "reasoning_cost" not in no_reasoning.cost_breakdown
+
+
+def _build_payload_for_media_response(logging_obj, init_response_obj, kwargs=None):
+    import datetime
+
+    from litellm.litellm_core_utils.litellm_logging import (
+        get_standard_logging_object_payload,
+    )
+
+    now = datetime.datetime.now()
+    return get_standard_logging_object_payload(
+        kwargs=kwargs or {"litellm_call_id": "media-call-id", "model": "test-model", "messages": []},
+        init_response_obj=init_response_obj,
+        start_time=now,
+        end_time=now,
+        logging_obj=logging_obj,
+        status="success",
+    )
+
+
+def test_image_response_sets_output_image_count_on_usage_object(logging_obj):
+    """Generated-image count must land on metadata.usage_object for callbacks (e.g. Prometheus)."""
+    from litellm.types.utils import ImageResponse
+
+    response = ImageResponse(created=1, data=[{"url": "https://img/1"}, {"url": "https://img/2"}])
+
+    payload = _build_payload_for_media_response(logging_obj, response)
+
+    assert payload is not None
+    assert payload["metadata"]["usage_object"]["output_image_count"] == 2
+
+
+def test_output_image_count_survives_message_redaction(logging_obj, monkeypatch):
+    """Redaction replaces the ImageResponse body, so the count must be captured pre-redaction."""
+    import litellm
+    from litellm.types.utils import ImageResponse
+
+    monkeypatch.setattr(litellm, "turn_off_message_logging", True)
+    response = ImageResponse(created=1, data=[{"url": "https://img/1"}])
+
+    payload = _build_payload_for_media_response(logging_obj, response)
+
+    assert payload is not None
+    assert payload["response"] == {"text": "redacted-by-litellm"}
+    assert payload["metadata"]["usage_object"]["output_image_count"] == 1
+
+
+def test_non_image_response_has_no_output_image_count(logging_obj):
+    payload = _build_payload_for_media_response(
+        logging_obj, {"id": "chatcmpl-1", "usage": {"prompt_tokens": 1, "completion_tokens": 2}}
+    )
+
+    assert payload is not None
+    assert "output_image_count" not in payload["metadata"]["usage_object"]
+
+
+def test_zero_token_video_usage_preserves_duration_seconds(logging_obj):
+    """Video usage bills by duration; the payload must keep duration_seconds even with zero tokens."""
+    payload = _build_payload_for_media_response(
+        logging_obj, {"id": "video-1", "usage": {"duration_seconds": 4.0}}
+    )
+
+    assert payload is not None
+    assert payload["metadata"]["usage_object"]["duration_seconds"] == 4.0
+    assert payload["total_tokens"] == 0
+    assert payload["completion_tokens"] == 0


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4254

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Verified against a live proxy (real Postgres, real OpenAI API calls) on localhost:4010 with `sora-2`, `gpt-image-2`, and `gpt-5.6` in the model list and `callbacks: ["prometheus"]`

Before the change, a video generation call bills $0.40 for 4 seconds of video but every output-usage metric stays at zero, and image generation is only visible as (misleading) image tokens

```
$ curl -sS http://localhost:4010/v1/videos -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"sora-2","prompt":"A hummingbird hovering over a red flower","seconds":"4","size":"720x1280"}'
{"id": "video_...", "status": "queued", "seconds": "4", "usage": {"duration_seconds": 4.0}}

$ curl -sS http://localhost:4010/v1/images/generations -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"gpt-image-2","prompt":"a watercolor fox","n":2,"size":"1024x1024","quality":"low"}'
# returns 2 images

$ curl -sS http://localhost:4010/metrics/ -H "Authorization: Bearer sk-1234" | grep -cE '^litellm_(video_duration_seconds|images_generated)'
0
$ curl -sS http://localhost:4010/metrics/ -H "Authorization: Bearer sk-1234" | grep '^litellm_spend_metric_total' | grep sora-2
litellm_spend_metric_total{...,model="sora-2",...} 0.4
$ curl -sS http://localhost:4010/metrics/ -H "Authorization: Bearer sk-1234" | grep '^litellm_output_tokens_metric_total' | grep sora-2
litellm_output_tokens_metric_total{...,model="sora-2",...} 0.0
```

After the change, the same calls emit the two new counters with the full `litellm_output_tokens_metric` label set (org labels included)

```
$ curl -sS http://localhost:4010/v1/videos ... '{"model":"sora-2",...,"seconds":"4",...}'   # 4s video
$ curl -sS http://localhost:4010/v1/images/generations ... '{"model":"gpt-image-2","n":2,...}'  # 2 images
$ curl -sS http://localhost:4010/v1/chat/completions ... '{"model":"gpt-5.6",...}'          # control

$ curl -sS http://localhost:4010/metrics/ -H "Authorization: Bearer sk-1234" | grep -E '^litellm_(video_duration_seconds|images_generated)_metric_total'
litellm_video_duration_seconds_metric_total{api_key_alias="None",api_provider="openai",end_user="None",hashed_api_key="litellm_proxy_master_key",model="sora-2",model_id="32fc4a...",org_alias="None",org_id="None",requested_model="sora-2",team="None",team_alias="None",user="default_user_id",user_email="None"} 4.0
litellm_images_generated_metric_total{api_key_alias="None",api_provider="openai",end_user="None",hashed_api_key="litellm_proxy_master_key",model="gpt-image-2",model_id="a9105...",org_alias="None",org_id="None",requested_model="gpt-image-2",team="None",team_alias="None",user="default_user_id",user_email="None"} 2.0
```

Chat completion token metrics are unchanged (`litellm_output_tokens_metric_total{model="gpt-5.6",...} 31.0` and no video/image counter rows for it)

<details><summary>Independent before/after re-run on a clean workspace (base 53aaabba5e vs PR commit 371997fa4b), same three real OpenAI calls through a local proxy</summary>

```
LIT-4254 / PR #33138 live verification
Real OpenAI calls via local proxy :4010 (sora-2, gpt-image-2, gpt-5.6)

========== BEFORE (litellm_internal_staging @ 53aaabba5e) ==========

# Video create response usage:
{'duration_seconds': 4.0}

# Image count:
2

# New media metrics present?
(none - bug confirmed)

# Spend billed anyway:
litellm_spend_metric_total{...,model="sora-2",...} 0.4
litellm_spend_metric_total{...,model="gpt-image-2",...} 0.011850...

# Misleading token signal for video:
litellm_output_tokens_metric_total{...,model="sora-2",...} 0.0

========== AFTER (PR branch @ 371997fa4b) ==========

# New media metrics (fix):
litellm_video_duration_seconds_metric_total{...,model="sora-2",requested_model="sora-2",...} 4.0
litellm_images_generated_metric_total{...,model="gpt-image-2",requested_model="gpt-image-2",...} 2.0

# Chat control still token-only:
litellm_output_tokens_metric_total{...,model="gpt-5.6",...} 4.0
(no media rows for gpt-5.6 - good)
```

</details>

## Type

🆕 New Feature

## Changes

Adds two Prometheus counters so Grafana dashboards get a real output-usage signal for video and image generation, which bill by duration and image count rather than tokens

`litellm_video_duration_seconds_metric` increments by `usage.duration_seconds` on successful video generation calls. All four video providers (OpenAI, Vertex AI, Gemini, RunwayML) already write `duration_seconds` into the response usage object and it already reaches `standard_logging_payload.metadata.usage_object`, so the prometheus callback just reads it

`litellm_images_generated_metric` increments by the number of images in the response. The count is captured in `get_standard_logging_object_payload` as `usage_object.output_image_count` before message redaction runs, because redaction replaces the whole `ImageResponse` body with `{"text": "redacted-by-litellm"}`; reading `response.data` at callback time would silently lose the metric on redaction-enabled deployments. The key is named `output_image_count` (not `image_count`) because `prompt_tokens_details.image_count` already exists in the same usage tree and means images sent to the model

Both metrics reuse the exact `litellm_output_tokens_metric` label set, including the `org_id`/`org_alias` labels appended via `_org_label_metrics`, so existing token dashboards can be cloned by swapping the metric name. Emission is sparse (only when the value is present and positive), mirroring the token detail metrics pattern; the shared guard-and-increment loop is extracted into `_inc_sparse_usage_counters` and now also rejects boolean values from malformed provider usage dicts

## Behavior changes

Spend logs metadata gains an additive `usage_object.output_image_count` key for image generation calls; all existing consumers read specific keys via `.get()` so this is backward compatible

On cache hits the images counter counts images served from cache, mirroring how token counters treat cache hits. Passthrough endpoints build their own logging payloads and do not emit these metrics

Video metrics fire on the create call (`POST /v1/videos`), where providers already report the requested duration; retrieval/status polling does not double count

## QA runbook

1. Add a video model (e.g. `openai/sora-2`), an image model (e.g. `openai/gpt-image-2`), and `callbacks: ["prometheus"]` to the proxy config, then start the proxy
2. `curl -sS http://localhost:4000/v1/videos -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"sora-2","prompt":"test","seconds":"4","size":"720x1280"}'`
3. `curl -sS http://localhost:4000/v1/images/generations -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"gpt-image-2","prompt":"test","n":2,"quality":"low"}'`
4. `curl -sS http://localhost:4000/metrics/ -H "Authorization: Bearer sk-1234" | grep -E 'litellm_(video_duration_seconds|images_generated)_metric_total'` and confirm 4.0 and 2.0 with the standard user/team/key/model labels
5. Run a chat completion and confirm token metrics behave exactly as before

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive observability and logging metadata (`output_image_count`); sparse counters and refactored increment helper do not change auth, billing, or existing token metric behavior.
> 
> **Overview**
> Adds **Prometheus counters** for non-token media usage so proxy `/metrics` reflects video and image generation the same way token dashboards do.
> 
> **`litellm_video_duration_seconds_metric`** increments from `usage_object.duration_seconds` on successful video calls. **`litellm_images_generated_metric`** increments from `usage_object.output_image_count`, which **`get_standard_logging_object_payload`** now sets from `ImageResponse.data` length **before** message redaction (so redacted deployments still get the count). Both metrics reuse the **`litellm_output_tokens_metric`** label set (including org labels) and only emit when values are positive.
> 
> Token detail counter logic is refactored: the shared increment loop moves to **`_inc_sparse_usage_counters`**, which also skips booleans from malformed usage dicts. **`_increment_media_generation_metrics`** is wired into the success logging path alongside existing token/cache metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 371997fa4b9c5cb0756238e24f11bce9426f6c80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
