### PR TITLE
fix(response): preserve provider status/message for non-OpenAI error bodies

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -52,7 +52,7 @@ _CHOICES_FIELDS: frozenset = frozenset(Choices.model_fields.keys())
 _MODEL_RESPONSE_FIELDS: frozenset = frozenset(ModelResponse.model_fields.keys()) | {"usage"}
 
 
-def _coerce_missing_choices_status(value: object) -> Optional[int]:
+def _coerce_missing_choices_status(value: object) -> int | None:
     if isinstance(value, bool):
         return None
     if isinstance(value, int):

--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -52,17 +52,43 @@ _CHOICES_FIELDS: frozenset = frozenset(Choices.model_fields.keys())
 _MODEL_RESPONSE_FIELDS: frozenset = frozenset(ModelResponse.model_fields.keys()) | {"usage"}
 
 
+def _coerce_missing_choices_status(value: object) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if 100 <= value <= 599 else None
+    if isinstance(value, str) and value.strip().isdigit():
+        status_code = int(value.strip())
+        return status_code if 100 <= status_code <= 599 else None
+    return None
+
+
 def _get_missing_choices_error_args(response_object: Mapping[str, object]) -> tuple[int, str]:
-    status_values = (response_object.get(field) for field in ("status", "status_code"))
+    error = response_object.get("error")
+    top_level_status_values = tuple(response_object.get(field) for field in ("status", "status_code"))
+    nested_status_values = (
+        tuple(error.get(field) for field in ("code", "status", "status_code")) if isinstance(error, dict) else ()
+    )
+    status_values = (
+        *(value for value in top_level_status_values if isinstance(value, int) and not isinstance(value, bool)),
+        *(value for value in top_level_status_values if isinstance(value, str)),
+        *nested_status_values,
+    )
     status_code = next(
-        (
-            value
-            for value in status_values
-            if isinstance(value, int) and not isinstance(value, bool) and 100 <= value <= 599
-        ),
+        (value for candidate in status_values if (value := _coerce_missing_choices_status(candidate)) is not None),
         500,
     )
-    message_values = (response_object.get(field) for field in ("response", "message"))
+    nested_message_values = (
+        tuple(error.get(field) for field in ("message", "response"))
+        if isinstance(error, dict)
+        else (error,)
+        if isinstance(error, str)
+        else ()
+    )
+    message_values = (
+        *(response_object.get(field) for field in ("response", "message")),
+        *nested_message_values,
+    )
     message = next(
         (value for value in message_values if isinstance(value, str) and value.strip()),
         (f"LiteLLM: provider returned a response with no 'choices'. Raw keys: {list(response_object.keys())}"),
@@ -601,7 +627,12 @@ def convert_to_model_response_object(
     ### CHECK IF ERROR IN RESPONSE ### - openrouter returns these in the dictionary
     # Some OpenAI-compatible providers (e.g., Apertis) return empty error objects
     # even on success. Only raise if the error contains meaningful data.
-    if response_object is not None and "error" in response_object and response_object["error"] is not None:
+    if (
+        response_object is not None
+        and "error" in response_object
+        and response_object["error"] is not None
+        and not (response_type == "completion" and not response_object.get("choices"))
+    ):
         error_obj = response_object["error"]
         has_meaningful_error = False
 

--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -3,7 +3,7 @@ import json
 import re
 import time
 import traceback
-from typing import Dict, Iterable, List, Literal, Optional, Tuple, Union, cast
+from typing import Dict, Iterable, List, Literal, Mapping, Optional, Tuple, Union, cast
 
 import litellm
 from litellm._logging import verbose_logger
@@ -50,6 +50,24 @@ from .get_headers import get_response_headers
 _MESSAGE_FIELDS: frozenset = frozenset(Message.model_fields.keys())
 _CHOICES_FIELDS: frozenset = frozenset(Choices.model_fields.keys())
 _MODEL_RESPONSE_FIELDS: frozenset = frozenset(ModelResponse.model_fields.keys()) | {"usage"}
+
+
+def _get_missing_choices_error_args(response_object: Mapping[str, object]) -> tuple[int, str]:
+    status_values = (response_object.get(field) for field in ("status", "status_code"))
+    status_code = next(
+        (
+            value
+            for value in status_values
+            if isinstance(value, int) and not isinstance(value, bool) and 100 <= value <= 599
+        ),
+        500,
+    )
+    message_values = (response_object.get(field) for field in ("response", "message"))
+    message = next(
+        (value for value in message_values if isinstance(value, str) and value.strip()),
+        (f"LiteLLM: provider returned a response with no 'choices'. Raw keys: {list(response_object.keys())}"),
+    )
+    return status_code, message
 
 
 def _normalize_images_for_message(
@@ -181,11 +199,10 @@ async def convert_to_streaming_response_async(
     if not response_object.get("choices"):
         from litellm.exceptions import APIError
 
+        status_code, message = _get_missing_choices_error_args(response_object)
         raise APIError(
-            status_code=500,
-            message=(
-                f"LiteLLM: provider returned a response with no 'choices'. Raw keys: {list(response_object.keys())}"
-            ),
+            status_code=status_code,
+            message=message,
             llm_provider="",
             model="",
         )
@@ -291,11 +308,10 @@ def convert_to_streaming_response(
     if not response_object.get("choices"):
         from litellm.exceptions import APIError
 
+        status_code, message = _get_missing_choices_error_args(response_object)
         raise APIError(
-            status_code=500,
-            message=(
-                f"LiteLLM: provider returned a response with no 'choices'. Raw keys: {list(response_object.keys())}"
-            ),
+            status_code=status_code,
+            message=message,
             llm_provider="",
             model="",
         )
@@ -631,12 +647,10 @@ def convert_to_model_response_object(
             if not response_object.get("choices") or not isinstance(response_object["choices"], Iterable):
                 from litellm.exceptions import APIError
 
+                status_code, message = _get_missing_choices_error_args(response_object)
                 raise APIError(
-                    status_code=500,
-                    message=(
-                        "LiteLLM: provider returned a response with no 'choices'. "
-                        f"Raw keys: {list(response_object.keys())}"
-                    ),
+                    status_code=status_code,
+                    message=message,
                     llm_provider="",
                     model="",
                 )

--- a/tests/test_litellm/litellm_core_utils/llm_response_utils/test_convert_dict_to_response.py
+++ b/tests/test_litellm/litellm_core_utils/llm_response_utils/test_convert_dict_to_response.py
@@ -3,6 +3,8 @@ import pytest
 from litellm.exceptions import APIError
 from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
     convert_to_model_response_object,
+    convert_to_streaming_response,
+    convert_to_streaming_response_async,
 )
 from litellm.types.utils import ModelResponse
 
@@ -37,6 +39,81 @@ def test_non_openai_error_uses_status_code_and_message_fields():
 
     assert exc_info.value.status_code == 401
     assert "Invalid provider credentials" in exc_info.value.message
+
+
+def test_non_openai_error_coerces_numeric_string_status():
+    with pytest.raises(APIError) as exc_info:
+        convert_to_model_response_object(
+            response_object={
+                "status": "400",
+                "response": "Token is invalid [2]",
+                "choices": None,
+            },
+            model_response_object=ModelResponse(),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "Token is invalid [2]" in exc_info.value.message
+
+
+@pytest.mark.parametrize("code", [401, "401"])
+def test_non_openai_error_uses_nested_error_object(code):
+    with pytest.raises(APIError) as exc_info:
+        convert_to_model_response_object(
+            response_object={
+                "error": {"message": "Invalid credentials", "code": code},
+                "choices": None,
+            },
+            model_response_object=ModelResponse(),
+        )
+
+    assert exc_info.value.status_code == 401
+    assert "Invalid credentials" in exc_info.value.message
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_status", "expected_message"),
+    [
+        ({"response": "Provider unavailable", "status": "503"}, 503, "Provider unavailable"),
+        ("Provider request failed", 500, "Provider request failed"),
+    ],
+)
+def test_non_openai_error_uses_nested_error_message_variants(error, expected_status, expected_message):
+    with pytest.raises(APIError) as exc_info:
+        convert_to_model_response_object(
+            response_object={"error": error, "choices": None},
+            model_response_object=ModelResponse(),
+        )
+
+    assert exc_info.value.status_code == expected_status
+    assert expected_message in exc_info.value.message
+
+
+def test_streaming_non_openai_error_uses_provider_status_and_message():
+    response_object = {
+        "error": {"message": "Invalid credentials", "code": 401},
+        "choices": None,
+    }
+
+    with pytest.raises(APIError) as exc_info:
+        next(convert_to_streaming_response(response_object))
+
+    assert exc_info.value.status_code == 401
+    assert "Invalid credentials" in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_non_openai_error_uses_provider_status_and_message():
+    response_object = {
+        "error": {"message": "Invalid credentials", "code": 401},
+        "choices": None,
+    }
+
+    with pytest.raises(APIError) as exc_info:
+        await convert_to_streaming_response_async(response_object).__anext__()
+
+    assert exc_info.value.status_code == 401
+    assert "Invalid credentials" in exc_info.value.message
 
 
 @pytest.mark.parametrize("response_object", [{"choices": None}, {}])

--- a/tests/test_litellm/litellm_core_utils/llm_response_utils/test_convert_dict_to_response.py
+++ b/tests/test_litellm/litellm_core_utils/llm_response_utils/test_convert_dict_to_response.py
@@ -1,0 +1,60 @@
+import pytest
+
+from litellm.exceptions import APIError
+from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
+    convert_to_model_response_object,
+)
+from litellm.types.utils import ModelResponse
+
+
+def test_non_openai_error_preserves_provider_status_and_message():
+    response_object = {
+        "response": "Token is invalid [2]",
+        "status": 400,
+        "choices": None,
+    }
+
+    with pytest.raises(APIError) as exc_info:
+        convert_to_model_response_object(
+            response_object=response_object,
+            model_response_object=ModelResponse(),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "Token is invalid [2]" in exc_info.value.message
+
+
+def test_non_openai_error_uses_status_code_and_message_fields():
+    with pytest.raises(APIError) as exc_info:
+        convert_to_model_response_object(
+            response_object={
+                "status_code": 401,
+                "message": "Invalid provider credentials",
+                "choices": None,
+            },
+            model_response_object=ModelResponse(),
+        )
+
+    assert exc_info.value.status_code == 401
+    assert "Invalid provider credentials" in exc_info.value.message
+
+
+@pytest.mark.parametrize("response_object", [{"choices": None}, {}])
+def test_missing_or_none_choices_raises_api_error(response_object):
+    with pytest.raises(APIError):
+        convert_to_model_response_object(
+            response_object=response_object,
+            model_response_object=ModelResponse(),
+        )
+
+
+def test_missing_provider_status_uses_default_status_and_fallback_message():
+    with pytest.raises(APIError) as exc_info:
+        convert_to_model_response_object(
+            response_object={"choices": None, "provider_data": "unexpected"},
+            model_response_object=ModelResponse(),
+        )
+
+    assert exc_info.value.status_code == 500
+    assert "no 'choices'" in exc_info.value.message
+    assert "provider_data" in exc_info.value.message


### PR DESCRIPTION
## Relevant issues

Fixes #33148

## Summary

When an OpenAI-compatible provider returns a non-OpenAI-shaped error body, LiteLLM already raises `APIError` instead of asserting on `choices`. This change preserves the provider status and message on that path instead of always fabricating `status_code=500` with only raw key metadata

The missing-choices path now accepts valid integer or numeric-string status values from top-level `status` and `status_code` fields. It also reads status and message details from nested error objects, including `code`, `status`, `status_code`, `message`, and `response`

Completion bodies with an `error` field and no choices now reach the missing-choices handler instead of being intercepted by the earlier generic error branch. The same normalization is used for regular completions, synchronous streaming, and asynchronous streaming

## Changes

Added focused regression coverage for integer and numeric-string status codes, nested error objects and string errors, missing or null choices, the default 500 fallback, synchronous streaming, and asynchronous streaming

## Verification

```bash
python3 -m pytest tests/test_litellm/litellm_core_utils/llm_response_utils/test_convert_dict_to_response.py -q
```

Result: 12 passed

## Backwards compatibility

Successful completion payloads are unchanged. Bodies without a usable provider status or message still raise `APIError` with status 500 and the existing missing-choices fallback text
