### PR TITLE
feat(focus): add opt-in end-user attribution

### DIFF
--- a/litellm/integrations/focus/database.py
+++ b/litellm/integrations/focus/database.py
@@ -11,6 +11,9 @@ import polars as pl
 class FocusLiteLLMDatabase:
     """Retrieves LiteLLM usage data for Focus export workflows."""
 
+    def __init__(self, *, include_end_user: bool = False) -> None:
+        self.include_end_user = include_end_user
+
     def _ensure_prisma_client(self):
         from litellm.proxy.proxy_server import prisma_client
 
@@ -30,6 +33,14 @@ class FocusLiteLLMDatabase:
     ) -> pl.DataFrame:
         """Return usage data for the requested window."""
         client = self._ensure_prisma_client()
+
+        if self.include_end_user:
+            return await self._get_spend_log_usage_data(
+                client=client,
+                limit=limit,
+                start_time_utc=start_time_utc,
+                end_time_utc=end_time_utc,
+            )
 
         where_clauses: list[str] = []
         query_params: list[Any] = []
@@ -99,6 +110,101 @@ class FocusLiteLLMDatabase:
             return pl.DataFrame(db_response, infer_schema_length=None)
         except Exception as exc:
             raise RuntimeError(f"Error retrieving usage data: {exc}") from exc
+
+    async def _get_spend_log_usage_data(
+        self,
+        *,
+        client: Any,
+        limit: Optional[int],
+        start_time_utc: Optional[datetime],
+        end_time_utc: Optional[datetime],
+    ) -> pl.DataFrame:
+        """Return exact request spend grouped by end user for Focus export."""
+        where_clauses: list[str] = []
+        query_params: list[Any] = []
+        placeholder_index = 1
+        if start_time_utc:
+            where_clauses.append(f'sl."startTime" >= ${placeholder_index}::timestamptz')
+            query_params.append(start_time_utc)
+            placeholder_index += 1
+        if end_time_utc:
+            where_clauses.append(f'sl."startTime" < ${placeholder_index}::timestamptz')
+            query_params.append(end_time_utc)
+            placeholder_index += 1
+
+        where_clause = ""
+        if where_clauses:
+            where_clause = "WHERE " + " AND ".join(where_clauses)
+
+        limit_clause = ""
+        if limit is not None:
+            try:
+                limit_value = int(limit)
+            except (TypeError, ValueError) as exc:
+                raise ValueError("limit must be an integer") from exc
+            if limit_value < 0:
+                raise ValueError("limit must be non-negative")
+            limit_clause = f" LIMIT ${placeholder_index}"
+            query_params.append(limit_value)
+
+        query = f"""
+        SELECT
+            MIN(sl.request_id) as id,
+            TO_CHAR(sl."startTime" AT TIME ZONE 'UTC', 'YYYY-MM-DD') as date,
+            NULLIF(sl."user", '') as user_id,
+            NULLIF(sl.end_user, '') as end_user,
+            sl.api_key,
+            NULLIF(sl.model, '') as model,
+            NULLIF(sl.model_group, '') as model_group,
+            NULLIF(sl.custom_llm_provider, '') as custom_llm_provider,
+            SUM(sl.prompt_tokens) as prompt_tokens,
+            SUM(sl.completion_tokens) as completion_tokens,
+            SUM(sl.spend) as spend,
+            COUNT(*) as api_requests,
+            COUNT(*) FILTER (WHERE sl.status = 'success') as successful_requests,
+            COUNT(*) FILTER (WHERE sl.status IS NOT NULL AND sl.status != 'success') as failed_requests,
+            MIN(sl."startTime") as created_at,
+            MAX(sl."endTime") as updated_at,
+            COALESCE(sl.team_id, vt.team_id) as team_id,
+            vt.key_alias as api_key_alias,
+            tt.team_alias,
+            ut.user_email as user_email,
+            COALESCE(sl.organization_id, vt.organization_id, tt.organization_id) as organization_id,
+            ot.organization_alias as organization_alias
+        FROM "LiteLLM_SpendLogs" sl
+        LEFT JOIN "LiteLLM_VerificationToken" vt ON sl.api_key = vt.token
+        LEFT JOIN "LiteLLM_TeamTable" tt
+            ON COALESCE(sl.team_id, vt.team_id) = tt.team_id
+        LEFT JOIN "LiteLLM_UserTable" ut
+            ON COALESCE(NULLIF(sl."user", ''), vt.user_id) = ut.user_id
+        LEFT JOIN "LiteLLM_OrganizationTable" ot
+            ON ot.organization_id = COALESCE(
+                sl.organization_id, vt.organization_id, tt.organization_id
+            )
+        {where_clause}
+        GROUP BY
+            TO_CHAR(sl."startTime" AT TIME ZONE 'UTC', 'YYYY-MM-DD'),
+            NULLIF(sl."user", ''),
+            NULLIF(sl.end_user, ''),
+            sl.api_key,
+            NULLIF(sl.model, ''),
+            NULLIF(sl.model_group, ''),
+            NULLIF(sl.custom_llm_provider, ''),
+            COALESCE(sl.team_id, vt.team_id),
+            vt.key_alias,
+            tt.team_alias,
+            ut.user_email,
+            COALESCE(sl.organization_id, vt.organization_id, tt.organization_id),
+            ot.organization_alias
+        ORDER BY date DESC, created_at DESC
+        {limit_clause}
+        """
+
+        try:
+            db_response = await client.db.query_raw(query, *query_params)
+            return pl.DataFrame(db_response, infer_schema_length=None)
+        except Exception as exc:
+            raise RuntimeError(f"Error retrieving end-user usage data: {exc}") from exc
 
     async def get_table_info(self) -> Dict[str, Any]:
         """Return metadata about the spend table for diagnostics."""

--- a/litellm/integrations/focus/export_engine.py
+++ b/litellm/integrations/focus/export_engine.py
@@ -23,6 +23,7 @@ class FocusExportEngine:
         provider: str,
         export_format: str,
         prefix: str,
+        include_end_user: bool = False,
         destination_config: Optional[dict[str, Any]] = None,
     ) -> None:
         self.provider = provider
@@ -35,7 +36,7 @@ class FocusExportEngine:
         )
         self._serializer = self._init_serializer()
         self._transformer = FocusTransformer()
-        self._database = FocusLiteLLMDatabase()
+        self._database = FocusLiteLLMDatabase(include_end_user=include_end_user)
 
     def _init_serializer(self) -> FocusSerializer:
         if self.export_format == "csv":

--- a/litellm/integrations/focus/focus_logger.py
+++ b/litellm/integrations/focus/focus_logger.py
@@ -34,6 +34,7 @@ class FocusLogger(CustomLogger):
         cron_offset_minute: Optional[int] = None,
         interval_seconds: Optional[int] = None,
         prefix: Optional[str] = None,
+        include_end_user: Optional[bool] = None,
         destination_config: Optional[dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
@@ -56,6 +57,11 @@ class FocusLogger(CustomLogger):
                 )
         env_prefix = os.getenv("FOCUS_PREFIX")
         self.prefix: str = prefix if prefix is not None else (env_prefix if env_prefix else "focus_exports")
+        self.include_end_user = (
+            include_end_user
+            if include_end_user is not None
+            else os.getenv("FOCUS_INCLUDE_END_USER", "false").lower() in {"1", "true", "yes"}
+        )
 
         self._destination_config = destination_config
         self._engine: Optional["FocusExportEngine"] = None
@@ -69,6 +75,7 @@ class FocusLogger(CustomLogger):
                 provider=self.provider,
                 export_format=self.export_format,
                 prefix=self.prefix,
+                include_end_user=self.include_end_user,
                 destination_config=self._destination_config,
             )
         return self._engine

--- a/litellm/integrations/focus/transformer.py
+++ b/litellm/integrations/focus/transformer.py
@@ -16,6 +16,7 @@ _TAG_KEYS = (
     "organization_alias",
     "user_id",
     "user_email",
+    "end_user",
     "api_key_alias",
     "model",
     "model_group",

--- a/litellm/integrations/vantage/vantage_logger.py
+++ b/litellm/integrations/vantage/vantage_logger.py
@@ -31,6 +31,7 @@ class VantageLogger(FocusLogger):
         VANTAGE_BASE_URL: Optional base URL override (default: https://api.vantage.sh)
         VANTAGE_EXPORT_FREQUENCY: Export frequency — "hourly" (default), "daily", or "interval"
         VANTAGE_EXPORT_INTERVAL_SECONDS: Interval in seconds when frequency is "interval"
+        VANTAGE_INCLUDE_END_USER: Export exact request spend with end-user tags when true
     """
 
     def __init__(
@@ -41,12 +42,18 @@ class VantageLogger(FocusLogger):
         base_url: Optional[str] = None,
         frequency: Optional[str] = None,
         interval_seconds: Optional[int] = None,
+        include_end_user: Optional[bool] = None,
         **kwargs: Any,
     ) -> None:
         resolved_api_key = api_key or os.getenv("VANTAGE_API_KEY")
         resolved_token = integration_token or os.getenv("VANTAGE_INTEGRATION_TOKEN")
         resolved_base_url = base_url or os.getenv("VANTAGE_BASE_URL", "https://api.vantage.sh")
         resolved_frequency = (frequency or os.getenv("VANTAGE_EXPORT_FREQUENCY") or "hourly").lower()
+        resolved_include_end_user = (
+            include_end_user
+            if include_end_user is not None
+            else os.getenv("VANTAGE_INCLUDE_END_USER", "false").lower() in {"1", "true", "yes"}
+        )
 
         raw_interval = interval_seconds or os.getenv("VANTAGE_EXPORT_INTERVAL_SECONDS")
         resolved_interval: Optional[int] = None
@@ -72,6 +79,7 @@ class VantageLogger(FocusLogger):
             export_format="csv",
             frequency=resolved_frequency,
             interval_seconds=resolved_interval,
+            include_end_user=resolved_include_end_user,
             prefix="vantage_exports",
             destination_config=destination_config,
             **kwargs,

--- a/tests/test_litellm/integrations/focus/test_focus_database.py
+++ b/tests/test_litellm/integrations/focus/test_focus_database.py
@@ -9,11 +9,11 @@ import pytest
 from litellm.integrations.focus.database import FocusLiteLLMDatabase
 
 
-def _setup_db(monkeypatch: pytest.MonkeyPatch, query_return):
+def _setup_db(monkeypatch: pytest.MonkeyPatch, query_return, *, include_end_user: bool = False):
     """Create a database instance with a stubbed prisma client."""
     query_mock = AsyncMock(return_value=query_return)
     mock_client = SimpleNamespace(db=SimpleNamespace(query_raw=query_mock))
-    db = FocusLiteLLMDatabase()
+    db = FocusLiteLLMDatabase(include_end_user=include_end_user)
     monkeypatch.setattr(db, "_ensure_prisma_client", lambda: mock_client)
     return db, query_mock
 
@@ -81,9 +81,36 @@ async def test_should_join_organization_table(monkeypatch: pytest.MonkeyPatch):
     await db.get_usage_data()
 
     query_text, *_ = query_mock.await_args.args
-    assert (
-        "COALESCE(vt.organization_id, tt.organization_id) as organization_id"
-        in query_text
-    )
+    assert "COALESCE(vt.organization_id, tt.organization_id) as organization_id" in query_text
     assert "ot.organization_alias as organization_alias" in query_text
     assert 'LEFT JOIN "LiteLLM_OrganizationTable" ot' in query_text
+
+
+@pytest.mark.asyncio
+async def test_should_use_exact_spend_logs_when_end_user_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    start = datetime(2026, 7, 13, tzinfo=timezone.utc)
+    end = datetime(2026, 7, 14, tzinfo=timezone.utc)
+    db, query_mock = _setup_db(monkeypatch, [], include_end_user=True)
+
+    await db.get_usage_data(start_time_utc=start, end_time_utc=end)
+
+    query_text, *params = query_mock.await_args.args
+    assert 'FROM "LiteLLM_SpendLogs" sl' in query_text
+    assert "NULLIF(sl.end_user, '') as end_user" in query_text
+    assert 'sl."startTime" >= $1::timestamptz' in query_text
+    assert 'sl."startTime" < $2::timestamptz' in query_text
+    assert 'FROM "LiteLLM_DailyEndUserSpend"' not in query_text
+    assert params == [start, end]
+
+
+@pytest.mark.asyncio
+async def test_should_keep_daily_export_as_default(monkeypatch: pytest.MonkeyPatch):
+    db, query_mock = _setup_db(monkeypatch, [])
+
+    await db.get_usage_data()
+
+    query_text, *_ = query_mock.await_args.args
+    assert 'FROM "LiteLLM_DailyUserSpend" dus' in query_text
+    assert 'FROM "LiteLLM_SpendLogs" sl' not in query_text

--- a/tests/test_litellm/integrations/focus/test_focus_transformer.py
+++ b/tests/test_litellm/integrations/focus/test_focus_transformer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
+import json
 
 import polars as pl
 
@@ -67,3 +68,9 @@ def test_consumed_and_pricing_quantity_match():
     """ConsumedQuantity and PricingQuantity must always be equal."""
     result = _transform([_base_row(api_requests=42)])
     assert result["ConsumedQuantity"][0] == result["PricingQuantity"][0]
+
+
+def test_end_user_is_included_in_focus_tags():
+    result = _transform([_base_row(end_user="customer@example.com")])
+
+    assert json.loads(result["Tags"][0])["end_user"] == "customer@example.com"

--- a/tests/test_litellm/integrations/focus/test_vantage_logger.py
+++ b/tests/test_litellm/integrations/focus/test_vantage_logger.py
@@ -1,0 +1,26 @@
+"""Tests for Vantage end-user export configuration."""
+
+import pytest
+
+from litellm.integrations.vantage.vantage_logger import VantageLogger
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes"])
+def test_vantage_end_user_export_can_be_enabled_by_environment(monkeypatch: pytest.MonkeyPatch, value: str):
+    monkeypatch.setenv("VANTAGE_INCLUDE_END_USER", value)
+
+    logger = VantageLogger(api_key="test-key", integration_token="test-token")
+
+    assert logger.include_end_user is True
+    assert logger._ensure_engine()._database.include_end_user is True
+
+
+def test_vantage_end_user_export_is_disabled_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("VANTAGE_INCLUDE_END_USER", raising=False)
+
+    logger = VantageLogger(api_key="test-key", integration_token="test-token")
+
+    assert logger.include_end_user is False
+    assert logger._ensure_engine()._database.include_end_user is False


### PR DESCRIPTION
## Title

Add opt-in end-user attribution to FOCUS and Vantage exports.

## What changed

- Add an opt-in `include_end_user` mode to the FOCUS export pipeline.
- Read exact request costs from `LiteLLM_SpendLogs` when enabled, where the existing `end_user` dimension is available.
- Aggregate request spend by UTC day, end user, key, model, team, and organization.
- Add `end_user` to FOCUS `Tags`.
- Expose the mode through `FOCUS_INCLUDE_END_USER` and `VANTAGE_INCLUDE_END_USER`.
- Keep the existing `LiteLLM_DailyUserSpend` export path unchanged by default.

## Why

The existing FOCUS/Vantage exporter reads `LiteLLM_DailyUserSpend`, which does not contain the end-user dimension recorded in spend logs. Joining the separate daily user and daily end-user aggregates risks duplicate or incorrectly reconciled costs. The opt-in request-spend path preserves exact attribution without changing existing behavior.

## Safety

- Disabled by default.
- Uses half-open scheduled windows (`startTime >= start`, `startTime < end`) so a request belongs to exactly one export window.
- Does not monkey-patch LiteLLM internals.
- Does not alter the current daily export query or database schema.
- Requires PostgreSQL execution and dry-run spend reconciliation before production enablement.

## Tests

- Entire `tests/test_litellm/integrations/focus` suite passes: 85 tests.
- Added coverage for the request-spend query selection and parameterization.
- Added coverage that `end_user` is emitted in FOCUS tags.
- Added coverage that Vantage end-user mode is disabled by default and can be enabled explicitly.
