### PR TITLE
fix(proxy): harden token-counting endpoints against event-loop starvation and error reflection

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -286,6 +286,14 @@ SYSTEM_MESSAGE_TOKEN_COUNT = int(os.getenv("SYSTEM_MESSAGE_TOKEN_COUNT", 4))
 TOOL_CHOICE_OBJECT_TOKEN_COUNT = int(os.getenv("TOOL_CHOICE_OBJECT_TOKEN_COUNT", 4))
 DEFAULT_MOCK_RESPONSE_PROMPT_TOKEN_COUNT = int(os.getenv("DEFAULT_MOCK_RESPONSE_PROMPT_TOKEN_COUNT", 10))
 DEFAULT_MOCK_RESPONSE_COMPLETION_TOKEN_COUNT = int(os.getenv("DEFAULT_MOCK_RESPONSE_COMPLETION_TOKEN_COUNT", 20))
+# Bounds for the proxy token-counting endpoints (/utils/token_counter and /v1/messages/count_tokens),
+# enforced per worker process. Local tokenization is CPU-bound and offloaded to the default executor,
+# whose work queue is unbounded — these caps keep queued payload memory and per-request CPU bounded.
+# Max tokenization jobs in flight at once; excess requests receive a 429.
+TOKEN_COUNTER_MAX_CONCURRENCY = int(os.getenv("TOKEN_COUNTER_MAX_CONCURRENCY", 32))
+# Max combined characters (all string fields) accepted per token-count request; larger requests receive a 400.
+# 10M chars ~ 2.5M tokens, comfortably above the largest mainstream model context windows.
+TOKEN_COUNTER_MAX_REQUEST_CHARS = int(os.getenv("TOKEN_COUNTER_MAX_REQUEST_CHARS", 10_000_000))
 MAX_SHORT_SIDE_FOR_IMAGE_HIGH_RES = int(os.getenv("MAX_SHORT_SIDE_FOR_IMAGE_HIGH_RES", 768))
 MAX_LONG_SIDE_FOR_IMAGE_HIGH_RES = int(os.getenv("MAX_LONG_SIDE_FOR_IMAGE_HIGH_RES", 2000))
 MAX_TILE_WIDTH = int(os.getenv("MAX_TILE_WIDTH", 512))

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -289,11 +289,12 @@ DEFAULT_MOCK_RESPONSE_COMPLETION_TOKEN_COUNT = int(os.getenv("DEFAULT_MOCK_RESPO
 # Bounds for the proxy token-counting endpoints (/utils/token_counter and /v1/messages/count_tokens),
 # enforced per worker process. Local tokenization is CPU-bound and offloaded to the default executor,
 # whose work queue is unbounded — these caps keep queued payload memory and per-request CPU bounded.
+# Fixed defaults for now; these could be made env-configurable in a follow-up if maintainers prefer.
 # Max tokenization jobs in flight at once; excess requests receive a 429.
-TOKEN_COUNTER_MAX_CONCURRENCY = int(os.getenv("TOKEN_COUNTER_MAX_CONCURRENCY", "32"))
+TOKEN_COUNTER_MAX_CONCURRENCY = 32
 # Max combined characters (all string fields) accepted per token-count request; larger requests receive a 400.
 # 10M chars ~ 2.5M tokens, comfortably above the largest mainstream model context windows.
-TOKEN_COUNTER_MAX_REQUEST_CHARS = int(os.getenv("TOKEN_COUNTER_MAX_REQUEST_CHARS", "10000000"))
+TOKEN_COUNTER_MAX_REQUEST_CHARS = 10_000_000
 MAX_SHORT_SIDE_FOR_IMAGE_HIGH_RES = int(os.getenv("MAX_SHORT_SIDE_FOR_IMAGE_HIGH_RES", 768))
 MAX_LONG_SIDE_FOR_IMAGE_HIGH_RES = int(os.getenv("MAX_LONG_SIDE_FOR_IMAGE_HIGH_RES", 2000))
 MAX_TILE_WIDTH = int(os.getenv("MAX_TILE_WIDTH", 512))

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -290,10 +290,10 @@ DEFAULT_MOCK_RESPONSE_COMPLETION_TOKEN_COUNT = int(os.getenv("DEFAULT_MOCK_RESPO
 # enforced per worker process. Local tokenization is CPU-bound and offloaded to the default executor,
 # whose work queue is unbounded — these caps keep queued payload memory and per-request CPU bounded.
 # Max tokenization jobs in flight at once; excess requests receive a 429.
-TOKEN_COUNTER_MAX_CONCURRENCY = int(os.getenv("TOKEN_COUNTER_MAX_CONCURRENCY", 32))
+TOKEN_COUNTER_MAX_CONCURRENCY = int(os.getenv("TOKEN_COUNTER_MAX_CONCURRENCY", "32"))
 # Max combined characters (all string fields) accepted per token-count request; larger requests receive a 400.
 # 10M chars ~ 2.5M tokens, comfortably above the largest mainstream model context windows.
-TOKEN_COUNTER_MAX_REQUEST_CHARS = int(os.getenv("TOKEN_COUNTER_MAX_REQUEST_CHARS", 10_000_000))
+TOKEN_COUNTER_MAX_REQUEST_CHARS = int(os.getenv("TOKEN_COUNTER_MAX_REQUEST_CHARS", "10000000"))
 MAX_SHORT_SIDE_FOR_IMAGE_HIGH_RES = int(os.getenv("MAX_SHORT_SIDE_FOR_IMAGE_HIGH_RES", 768))
 MAX_LONG_SIDE_FOR_IMAGE_HIGH_RES = int(os.getenv("MAX_LONG_SIDE_FOR_IMAGE_HIGH_RES", 2000))
 MAX_TILE_WIDTH = int(os.getenv("MAX_TILE_WIDTH", 512))

--- a/litellm/proxy/anthropic_endpoints/endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/endpoints.py
@@ -302,11 +302,17 @@ async def count_tokens(
             status_code=status_code,
             detail=detail,
         )
+    except (ValueError, TypeError):
+        verbose_proxy_logger.exception("litellm.proxy.anthropic_endpoints.count_tokens(): invalid request payload")
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "Invalid request: could not tokenize the provided messages"},
+        )
     except Exception as e:
         verbose_proxy_logger.exception(
             "litellm.proxy.anthropic_endpoints.count_tokens(): Exception occurred - {}".format(str(e))
         )
-        raise HTTPException(status_code=500, detail={"error": f"Internal server error: {str(e)}"})
+        raise HTTPException(status_code=500, detail={"error": "Internal server error"})
 
 
 @router.post(

--- a/litellm/proxy/anthropic_endpoints/endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/endpoints.py
@@ -302,7 +302,7 @@ async def count_tokens(
             status_code=status_code,
             detail=detail,
         )
-    except (ValueError, TypeError):
+    except (ValueError, TypeError, AttributeError, KeyError, IndexError):
         verbose_proxy_logger.exception("litellm.proxy.anthropic_endpoints.count_tokens(): invalid request payload")
         raise HTTPException(
             status_code=400,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -10621,7 +10621,10 @@ async def token_counter(request: TokenCountRequest, call_endpoint: bool = False)
     if prompt is None and messages is None and contents is None:
         raise HTTPException(status_code=400, detail="prompt or messages or contents must be provided")
 
-    if _count_request_string_chars(prompt, messages, contents, tools, system) > TOKEN_COUNTER_MAX_REQUEST_CHARS:
+    if (
+        _count_request_string_chars(request.model, prompt, messages, contents, tools, system)
+        > TOKEN_COUNTER_MAX_REQUEST_CHARS
+    ):
         raise HTTPException(
             status_code=400,
             detail={"error": "Request payload too large for token counting"},

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -10678,7 +10678,7 @@ async def token_counter(request: TokenCountRequest, call_endpoint: bool = False)
                 custom_tokenizer=_tokenizer_used,  # type: ignore
             ),
         )
-    except (ValueError, TypeError):
+    except (ValueError, TypeError, AttributeError, KeyError, IndexError):
         verbose_proxy_logger.exception(
             "litellm.proxy.proxy_server.token_counter(): could not tokenize the provided messages/prompt"
         )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -210,7 +210,7 @@ def generate_feedback_box():
 import contextlib
 from collections import defaultdict
 from contextlib import asynccontextmanager
-from functools import lru_cache, partial
+from functools import lru_cache
 
 import litellm
 import litellm._redis
@@ -10574,6 +10574,28 @@ async def _try_provider_token_count(
 _token_count_semaphore = asyncio.Semaphore(TOKEN_COUNTER_MAX_CONCURRENCY)
 
 
+def _select_tokenizer_and_count(
+    model_to_use: str,
+    custom_tokenizer: CustomHuggingfaceTokenizer | None,
+    prompt: str | None,
+    messages: list | None,
+) -> tuple[str, int]:
+    """Select the tokenizer for a model and count tokens with it.
+
+    Runs in the executor thread: tokenizer selection can synchronously load a
+    HuggingFace tokenizer for some model names (a blocking download/parse), so
+    it must stay off the event loop alongside the count itself.
+    """
+    _tokenizer_used = litellm.utils._select_tokenizer(model=model_to_use, custom_tokenizer=custom_tokenizer)
+    total_tokens = litellm.token_counter(
+        model=model_to_use,
+        text=prompt,
+        messages=messages,
+        custom_tokenizer=_tokenizer_used,  # type: ignore
+    )
+    return str(_tokenizer_used["type"]), total_tokens
+
+
 def _count_request_string_chars(*fields: object) -> int:
     """Sum the length of every string leaf in the given token-count request fields."""
     total = 0
@@ -10605,8 +10627,6 @@ async def token_counter(request: TokenCountRequest, call_endpoint: bool = False)
     Returns:
         TokenCountResponse
     """
-    from litellm import token_counter
-
     global llm_router
 
     prompt = request.prompt
@@ -10705,20 +10725,15 @@ async def token_counter(request: TokenCountRequest, call_endpoint: bool = False)
             detail={"error": "Too many concurrent token counting requests. Please retry later."},
         )
     try:
-        _tokenizer_used = litellm.utils._select_tokenizer(model=model_to_use, custom_tokenizer=custom_tokenizer)
-
-        tokenizer_used = str(_tokenizer_used["type"])
         loop = asyncio.get_running_loop()
         async with _token_count_semaphore:
-            total_tokens = await loop.run_in_executor(
+            tokenizer_used, total_tokens = await loop.run_in_executor(
                 None,
-                partial(
-                    token_counter,
-                    model=model_to_use,
-                    text=prompt,
-                    messages=messages,
-                    custom_tokenizer=_tokenizer_used,  # type: ignore
-                ),
+                _select_tokenizer_and_count,
+                model_to_use,
+                custom_tokenizer,
+                prompt,
+                messages,
             )
     except (ValueError, TypeError, AttributeError, KeyError, IndexError):
         verbose_proxy_logger.exception(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -210,7 +210,7 @@ def generate_feedback_box():
 import contextlib
 from collections import defaultdict
 from contextlib import asynccontextmanager
-from functools import lru_cache
+from functools import lru_cache, partial
 
 import litellm
 import litellm._redis
@@ -10663,15 +10663,29 @@ async def token_counter(request: TokenCountRequest, call_endpoint: bool = False)
             Optional[CustomHuggingfaceTokenizer],
             model_info.get("custom_tokenizer", None),
         )
-    _tokenizer_used = litellm.utils._select_tokenizer(model=model_to_use, custom_tokenizer=custom_tokenizer)
+    try:
+        _tokenizer_used = litellm.utils._select_tokenizer(model=model_to_use, custom_tokenizer=custom_tokenizer)
 
-    tokenizer_used = str(_tokenizer_used["type"])
-    total_tokens = token_counter(
-        model=model_to_use,
-        text=prompt,
-        messages=messages,
-        custom_tokenizer=_tokenizer_used,  # type: ignore
-    )
+        tokenizer_used = str(_tokenizer_used["type"])
+        loop = asyncio.get_running_loop()
+        total_tokens = await loop.run_in_executor(
+            None,
+            partial(
+                token_counter,
+                model=model_to_use,
+                text=prompt,
+                messages=messages,
+                custom_tokenizer=_tokenizer_used,  # type: ignore
+            ),
+        )
+    except (ValueError, TypeError):
+        verbose_proxy_logger.exception(
+            "litellm.proxy.proxy_server.token_counter(): could not tokenize the provided messages/prompt"
+        )
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "Invalid request: could not tokenize the provided messages/prompt"},
+        )
     return TokenCountResponse(
         total_tokens=total_tokens,
         request_model=request.model,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -10583,6 +10583,7 @@ def _count_request_string_chars(*fields: object) -> int:
         if isinstance(node, str):
             total += len(node)
         elif isinstance(node, dict):
+            stack.extend(node.keys())
             stack.extend(node.values())
         elif isinstance(node, (list, tuple)):
             stack.extend(node)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -234,6 +234,8 @@ from litellm.constants import (
     PROXY_BATCH_WRITE_AT,
     PROXY_BUDGET_RESCHEDULER_MAX_TIME,
     PROXY_BUDGET_RESCHEDULER_MIN_TIME,
+    TOKEN_COUNTER_MAX_CONCURRENCY,
+    TOKEN_COUNTER_MAX_REQUEST_CHARS,
 )
 from litellm.exceptions import RejectedRequestError
 from litellm.integrations.custom_guardrail import ModifyResponseException
@@ -313,6 +315,7 @@ from litellm.proxy.common_utils.model_listing_utils import TeamModelNameTranslat
 from litellm.proxy.common_utils.openai_endpoint_utils import (
     remove_sensitive_info_from_deployment,
 )
+from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
 from litellm.proxy.common_utils.proxy_state import ProxyState
 from litellm.proxy.common_utils.reset_budget_job import ResetBudgetJob
 from litellm.proxy.common_utils.swagger_utils import ERROR_RESPONSES
@@ -10565,6 +10568,27 @@ async def _try_provider_token_count(
     return result
 
 
+# Bounds concurrent local tokenization work. `run_in_executor(None, ...)` queues into the
+# process-wide default executor, whose work queue is unbounded — without this cap, token-count
+# requests submitted faster than they complete would accumulate their payloads in memory.
+_token_count_semaphore = asyncio.Semaphore(TOKEN_COUNTER_MAX_CONCURRENCY)
+
+
+def _count_request_string_chars(*fields: Any) -> int:
+    """Sum the length of every string leaf in the given token-count request fields."""
+    total = 0
+    stack: List[Any] = [field for field in fields if field is not None]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, str):
+            total += len(node)
+        elif isinstance(node, dict):
+            stack.extend(node.values())
+        elif isinstance(node, (list, tuple)):
+            stack.extend(node)
+    return total
+
+
 @router.post(
     "/utils/token_counter",
     tags=["llm utils"],
@@ -10595,6 +10619,12 @@ async def token_counter(request: TokenCountRequest, call_endpoint: bool = False)
     #########################################################
     if prompt is None and messages is None and contents is None:
         raise HTTPException(status_code=400, detail="prompt or messages or contents must be provided")
+
+    if _count_request_string_chars(prompt, messages, contents, tools, system) > TOKEN_COUNTER_MAX_REQUEST_CHARS:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "Request payload too large for token counting"},
+        )
 
     deployment: Optional[Dict[str, Any]] = None
     litellm_model_name = None
@@ -10663,21 +10693,29 @@ async def token_counter(request: TokenCountRequest, call_endpoint: bool = False)
             Optional[CustomHuggingfaceTokenizer],
             model_info.get("custom_tokenizer", None),
         )
+
+    # Try-acquire: when the bound is saturated, reject instead of queueing unboundedly.
+    # No await between this check and the acquire below, so the acquire never blocks.
+    if _token_count_semaphore.locked():
+        raise ProxyRateLimitError(
+            detail={"error": "Too many concurrent token counting requests. Please retry later."},
+        )
     try:
         _tokenizer_used = litellm.utils._select_tokenizer(model=model_to_use, custom_tokenizer=custom_tokenizer)
 
         tokenizer_used = str(_tokenizer_used["type"])
         loop = asyncio.get_running_loop()
-        total_tokens = await loop.run_in_executor(
-            None,
-            partial(
-                token_counter,
-                model=model_to_use,
-                text=prompt,
-                messages=messages,
-                custom_tokenizer=_tokenizer_used,  # type: ignore
-            ),
-        )
+        async with _token_count_semaphore:
+            total_tokens = await loop.run_in_executor(
+                None,
+                partial(
+                    token_counter,
+                    model=model_to_use,
+                    text=prompt,
+                    messages=messages,
+                    custom_tokenizer=_tokenizer_used,  # type: ignore
+                ),
+            )
     except (ValueError, TypeError, AttributeError, KeyError, IndexError):
         verbose_proxy_logger.exception(
             "litellm.proxy.proxy_server.token_counter(): could not tokenize the provided messages/prompt"

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -10574,10 +10574,10 @@ async def _try_provider_token_count(
 _token_count_semaphore = asyncio.Semaphore(TOKEN_COUNTER_MAX_CONCURRENCY)
 
 
-def _count_request_string_chars(*fields: Any) -> int:
+def _count_request_string_chars(*fields: object) -> int:
     """Sum the length of every string leaf in the given token-count request fields."""
     total = 0
-    stack: List[Any] = [field for field in fields if field is not None]
+    stack: list[object] = [field for field in fields if field is not None]
     while stack:
         node = stack.pop()
         if isinstance(node, str):

--- a/tests/proxy_unit_tests/test_proxy_token_counter.py
+++ b/tests/proxy_unit_tests/test_proxy_token_counter.py
@@ -2,6 +2,7 @@
 # 1. Generate a Key, and use it to make a call
 
 
+import asyncio
 import json
 import logging
 import os
@@ -1364,3 +1365,86 @@ async def test_anthropic_endpoint_429_rate_limit_error_format():
     finally:
         anthropic_endpoints._read_request_body = original_read_request_body
         proxy_server.token_counter = original_token_counter
+
+
+@pytest.mark.asyncio
+async def test_proxy_token_counter_malformed_content_returns_400():
+    """`/utils/token_counter` maps malformed message content to 400, not 500.
+
+    A content block that survives Pydantic but breaks the tokenizer used to
+    raise an unhandled ValueError (surfaced as a 500). It must now be a 400
+    whose body does not leak internal exception text.
+    """
+    import litellm.proxy.proxy_server as proxy_server
+
+    setattr(proxy_server, "llm_router", None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await token_counter(
+            request=TokenCountRequest(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": [123]}],
+            )
+        )
+
+    assert exc_info.value.status_code == 400
+    detail = str(exc_info.value.detail)
+    assert "subscriptable" not in detail
+    assert "Traceback" not in detail
+
+
+@pytest.mark.asyncio
+async def test_proxy_token_counter_offloads_to_executor():
+    """The CPU-bound count runs off the event loop via run_in_executor."""
+    import litellm.proxy.proxy_server as proxy_server
+
+    setattr(proxy_server, "llm_router", None)
+
+    loop = asyncio.get_running_loop()
+    real_run_in_executor = loop.run_in_executor
+    calls = []
+
+    def spy_run_in_executor(executor, func, *args):
+        calls.append(func)
+        return real_run_in_executor(executor, func, *args)
+
+    with patch.object(loop, "run_in_executor", side_effect=spy_run_in_executor):
+        response = await token_counter(
+            request=TokenCountRequest(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": "Hello world"}],
+            )
+        )
+
+    assert response.total_tokens > 0
+    assert len(calls) >= 1
+
+
+@pytest.mark.asyncio
+async def test_anthropic_count_tokens_malformed_messages_returns_400():
+    """`/v1/messages/count_tokens` no longer reflects internal errors as 500.
+
+    `messages=[123]` fails TokenCountRequest validation; previously the raw
+    error was echoed at status 500. It must now be a 400 with no internal text.
+    """
+    import litellm.proxy.anthropic_endpoints.endpoints as anthropic_endpoints
+
+    mock_request = MagicMock(spec=Request)
+    mock_user_api_key_dict = MagicMock()
+
+    async def mock_read_request_body(request):
+        return {"model": "claude-3-sonnet-20240229", "messages": [123]}
+
+    original_read_request_body = anthropic_endpoints._read_request_body
+    anthropic_endpoints._read_request_body = mock_read_request_body
+
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await anthropic_count_tokens(mock_request, mock_user_api_key_dict)
+
+        assert exc_info.value.status_code == 400
+        detail = str(exc_info.value.detail)
+        assert "validation error" not in detail.lower()
+        assert "TokenCountRequest" not in detail
+    finally:
+        anthropic_endpoints._read_request_body = original_read_request_body

--- a/tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py
@@ -382,3 +382,107 @@ class TestCountTokensErrorHandling:
             response = await ep.count_tokens(mock_request, mock_user_api_key_dict)
 
         assert response == {"input_tokens": 15}
+
+    @pytest.mark.asyncio
+    async def test_oversized_payload_returns_400(self):
+        """A payload exceeding the token-counting size cap must surface as 400.
+
+        The internal token_counter raises HTTPException(400) before offloading
+        the count; the wrapper's `except HTTPException: raise` passes it through.
+        """
+        from fastapi import HTTPException, Request
+
+        import litellm.proxy.anthropic_endpoints.endpoints as ep
+        import litellm.proxy.proxy_server as proxy_server
+
+        setattr(proxy_server, "llm_router", None)
+
+        mock_request = MagicMock(spec=Request)
+        mock_user_api_key_dict = MagicMock()
+
+        async def mock_read_request_body(request):
+            return {
+                "model": "claude-3-sonnet-20240229",
+                "messages": [{"role": "user", "content": "a" * 200}],
+            }
+
+        with (
+            patch.object(ep, "_read_request_body", new=mock_read_request_body),
+            patch.object(proxy_server, "TOKEN_COUNTER_MAX_REQUEST_CHARS", 100),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await ep.count_tokens(mock_request, mock_user_api_key_dict)
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == {"error": "Request payload too large for token counting"}
+
+    @pytest.mark.asyncio
+    async def test_saturated_concurrency_returns_429(self):
+        """A saturated tokenization concurrency bound must surface as 429.
+
+        The internal token_counter raises ProxyRateLimitError (an HTTPException
+        subclass) when the bound cannot be acquired; the wrapper's
+        `except HTTPException: raise` passes the 429 through untouched.
+        """
+        import asyncio
+
+        from fastapi import HTTPException, Request
+
+        import litellm.proxy.anthropic_endpoints.endpoints as ep
+        import litellm.proxy.proxy_server as proxy_server
+
+        setattr(proxy_server, "llm_router", None)
+
+        mock_request = MagicMock(spec=Request)
+        mock_user_api_key_dict = MagicMock()
+
+        async def mock_read_request_body(request):
+            return {
+                "model": "claude-3-sonnet-20240229",
+                "messages": [{"role": "user", "content": "Hello"}],
+            }
+
+        with (
+            patch.object(ep, "_read_request_body", new=mock_read_request_body),
+            patch.object(proxy_server, "_token_count_semaphore", asyncio.Semaphore(0)),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await ep.count_tokens(mock_request, mock_user_api_key_dict)
+
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.detail == {"error": "Too many concurrent token counting requests. Please retry later."}
+
+    @pytest.mark.asyncio
+    async def test_unexpected_internal_error_returns_generic_500(self):
+        """An unexpected internal failure must map to a generic 500.
+
+        The terminal `except Exception` handler must not reflect the internal
+        exception text back to the client.
+        """
+        from fastapi import HTTPException, Request
+
+        import litellm.proxy.anthropic_endpoints.endpoints as ep
+        import litellm.proxy.proxy_server as proxy_server
+
+        mock_request = MagicMock(spec=Request)
+        mock_user_api_key_dict = MagicMock()
+
+        async def mock_read_request_body(request):
+            return {
+                "model": "claude-3-sonnet-20240229",
+                "messages": [{"role": "user", "content": "Hello"}],
+            }
+
+        async def mock_token_counter(request, call_endpoint=False):
+            raise RuntimeError("secret internal failure detail")
+
+        with (
+            patch.object(ep, "_read_request_body", new=mock_read_request_body),
+            patch.object(proxy_server, "token_counter", new=mock_token_counter),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await ep.count_tokens(mock_request, mock_user_api_key_dict)
+
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.detail == {"error": "Internal server error"}
+        assert "secret internal failure detail" not in str(exc_info.value.detail)

--- a/tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py
@@ -233,3 +233,105 @@ class TestStripTotalTokensFeatureFlag(unittest.TestCase):
         import litellm
 
         assert litellm.strip_anthropic_total_tokens is False
+
+
+class TestCountTokensErrorHandling:
+    """`/v1/messages/count_tokens` must not leak internal errors on bad input."""
+
+    @pytest.mark.asyncio
+    async def test_malformed_messages_returns_400_without_reflection(self):
+        """A malformed messages payload should map to 400, not a reflected 500.
+
+        `messages=[123]` fails TokenCountRequest validation; previously the
+        terminal `except Exception` echoed the raw internal error at status 500.
+        It must now be a 400 whose body carries no internal exception text.
+        """
+        from fastapi import HTTPException, Request
+
+        import litellm.proxy.anthropic_endpoints.endpoints as ep
+
+        mock_request = MagicMock(spec=Request)
+        mock_user_api_key_dict = MagicMock()
+
+        async def mock_read_request_body(request):
+            return {
+                "model": "claude-3-sonnet-20240229",
+                "messages": [123],
+            }
+
+        with patch.object(ep, "_read_request_body", new=mock_read_request_body):
+            with pytest.raises(HTTPException) as exc_info:
+                await ep.count_tokens(mock_request, mock_user_api_key_dict)
+
+        assert exc_info.value.status_code == 400
+        detail = str(exc_info.value.detail)
+        assert "validation error" not in detail.lower()
+        assert "TokenCountRequest" not in detail
+        assert "pydantic" not in detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_malformed_content_block_returns_400_without_reflection(self):
+        """A content block that breaks the tokenizer must surface as 400.
+
+        The internal proxy token_counter now raises HTTPException(400) for such
+        input; the wrapper's `except HTTPException: raise` passes it through so
+        the client never sees the raw ValueError text.
+        """
+        from fastapi import HTTPException, Request
+
+        import litellm.proxy.anthropic_endpoints.endpoints as ep
+        import litellm.proxy.proxy_server as proxy_server
+
+        setattr(proxy_server, "llm_router", None)
+
+        mock_request = MagicMock(spec=Request)
+        mock_user_api_key_dict = MagicMock()
+
+        async def mock_read_request_body(request):
+            return {
+                "model": "gpt-3.5-turbo",
+                "messages": [{"role": "user", "content": [123]}],
+            }
+
+        with patch.object(ep, "_read_request_body", new=mock_read_request_body):
+            with pytest.raises(HTTPException) as exc_info:
+                await ep.count_tokens(mock_request, mock_user_api_key_dict)
+
+        assert exc_info.value.status_code == 400
+        detail = str(exc_info.value.detail)
+        assert "subscriptable" not in detail
+        assert "Traceback" not in detail
+
+    @pytest.mark.asyncio
+    async def test_wellformed_request_still_counts(self):
+        """A valid request must still return the Anthropic-shaped token count."""
+        from fastapi import Request
+
+        import litellm.proxy.anthropic_endpoints.endpoints as ep
+        import litellm.proxy.proxy_server as proxy_server
+        from litellm.types.utils import TokenCountResponse
+
+        mock_request = MagicMock(spec=Request)
+        mock_user_api_key_dict = MagicMock()
+
+        async def mock_read_request_body(request):
+            return {
+                "model": "claude-3-sonnet-20240229",
+                "messages": [{"role": "user", "content": "Hello Claude!"}],
+            }
+
+        async def mock_token_counter(request, call_endpoint=False):
+            return TokenCountResponse(
+                total_tokens=15,
+                request_model="claude-3-sonnet-20240229",
+                model_used="claude-3-sonnet-20240229",
+                tokenizer_type="openai_tokenizer",
+            )
+
+        with (
+            patch.object(ep, "_read_request_body", new=mock_read_request_body),
+            patch.object(proxy_server, "token_counter", new=mock_token_counter),
+        ):
+            response = await ep.count_tokens(mock_request, mock_user_api_key_dict)
+
+        assert response == {"input_tokens": 15}

--- a/tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py
@@ -303,6 +303,53 @@ class TestCountTokensErrorHandling:
         assert "Traceback" not in detail
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "tokenizer_error",
+        [
+            AttributeError("'NoneType' object has no attribute 'get'"),
+            KeyError("type"),
+            IndexError("list index out of range"),
+        ],
+    )
+    async def test_tokenizer_attribute_error_returns_400_not_500(self, tokenizer_error):
+        """Non-(ValueError/TypeError) tokenizer failures must also map to 400.
+
+        AttributeError/KeyError/IndexError raised deep inside the tokenizer
+        used to fall through to the terminal `except Exception` and surface as
+        a 500. They must now be a 400 whose body carries no internal exception
+        text.
+        """
+        from fastapi import HTTPException, Request
+
+        import litellm.proxy.anthropic_endpoints.endpoints as ep
+        import litellm.proxy.proxy_server as proxy_server
+
+        mock_request = MagicMock(spec=Request)
+        mock_user_api_key_dict = MagicMock()
+
+        async def mock_read_request_body(request):
+            return {
+                "model": "claude-3-sonnet-20240229",
+                "messages": [{"role": "user", "content": "Hello"}],
+            }
+
+        async def mock_token_counter(request, call_endpoint=False):
+            raise tokenizer_error
+
+        with (
+            patch.object(ep, "_read_request_body", new=mock_read_request_body),
+            patch.object(proxy_server, "token_counter", new=mock_token_counter),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await ep.count_tokens(mock_request, mock_user_api_key_dict)
+
+        assert exc_info.value.status_code == 400
+        detail = str(exc_info.value.detail)
+        assert "NoneType" not in detail
+        assert "attribute" not in detail
+        assert "Internal server error" not in detail
+
+    @pytest.mark.asyncio
     async def test_wellformed_request_still_counts(self):
         """A valid request must still return the Anthropic-shaped token count."""
         from fastapi import Request

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -9872,6 +9872,34 @@ async def test_token_counter_oversized_dict_key_returns_400():
 
 
 @pytest.mark.asyncio
+async def test_token_counter_oversized_model_name_returns_400():
+    """An oversized `model` string must also trip the size cap.
+
+    The model name becomes a key in the tokenizer selection LRU cache, so
+    excluding it from the cap would let a caller pin arbitrarily large strings
+    in memory across requests via distinct oversized model names.
+    """
+    from fastapi import HTTPException
+
+    from litellm.proxy._types import TokenCountRequest
+    from litellm.proxy.proxy_server import token_counter
+
+    setattr(proxy_server_module, "llm_router", None)
+
+    oversized_model = "a" * (proxy_server_module.TOKEN_COUNTER_MAX_REQUEST_CHARS + 1)
+    with pytest.raises(HTTPException) as exc_info:
+        await token_counter(
+            request=TokenCountRequest(
+                model=oversized_model,
+                messages=[{"role": "user", "content": "Hello world"}],
+            )
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == {"error": "Request payload too large for token counting"}
+
+
+@pytest.mark.asyncio
 async def test_token_counter_saturated_concurrency_returns_429():
     """When the tokenization concurrency bound is saturated, excess requests get 429.
 

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -9802,3 +9802,57 @@ async def test_token_counter_offloads_counting_to_executor():
 
     assert response.total_tokens > 0
     assert len(calls) >= 1
+
+
+@pytest.mark.asyncio
+async def test_token_counter_oversized_payload_returns_400():
+    """A payload whose combined string size exceeds the cap must map to 400.
+
+    The cap bounds per-request memory/CPU before the count is offloaded to the
+    executor; the body must carry only the generic error message.
+    """
+    from fastapi import HTTPException
+
+    from litellm.proxy._types import TokenCountRequest
+    from litellm.proxy.proxy_server import token_counter
+
+    setattr(proxy_server_module, "llm_router", None)
+
+    oversized_content = "a" * (proxy_server_module.TOKEN_COUNTER_MAX_REQUEST_CHARS + 1)
+    with pytest.raises(HTTPException) as exc_info:
+        await token_counter(
+            request=TokenCountRequest(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": oversized_content}],
+            )
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == {"error": "Request payload too large for token counting"}
+
+
+@pytest.mark.asyncio
+async def test_token_counter_saturated_concurrency_returns_429():
+    """When the tokenization concurrency bound is saturated, excess requests get 429.
+
+    The bound try-acquires: it must reject immediately instead of queueing more
+    payloads into the default executor's unbounded work queue.
+    """
+    from fastapi import HTTPException
+
+    from litellm.proxy._types import TokenCountRequest
+    from litellm.proxy.proxy_server import token_counter
+
+    setattr(proxy_server_module, "llm_router", None)
+
+    with patch.object(proxy_server_module, "_token_count_semaphore", asyncio.Semaphore(0)):
+        with pytest.raises(HTTPException) as exc_info:
+            await token_counter(
+                request=TokenCountRequest(
+                    model="gpt-3.5-turbo",
+                    messages=[{"role": "user", "content": "Hello world"}],
+                )
+            )
+
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.detail == {"error": "Too many concurrent token counting requests. Please retry later."}

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -9805,6 +9805,45 @@ async def test_token_counter_offloads_counting_to_executor():
 
 
 @pytest.mark.asyncio
+async def test_token_counter_selects_tokenizer_off_the_event_loop():
+    """Tokenizer selection must run inside the executor, not on the event loop.
+
+    `_select_tokenizer` can synchronously load a HuggingFace tokenizer for some
+    model names (a blocking download/parse), so running it inline before the
+    executor dispatch would block the loop. We spy on `_select_tokenizer` and
+    assert every call happens on a thread other than the event-loop's.
+    """
+    import threading
+
+    import litellm.utils as litellm_utils
+
+    from litellm.proxy._types import TokenCountRequest
+    from litellm.proxy.proxy_server import token_counter
+
+    setattr(proxy_server_module, "llm_router", None)
+
+    loop_thread_ident = threading.get_ident()
+    select_thread_idents = []
+    real_select_tokenizer = litellm_utils._select_tokenizer
+
+    def spy_select_tokenizer(*args, **kwargs):
+        select_thread_idents.append(threading.get_ident())
+        return real_select_tokenizer(*args, **kwargs)
+
+    with patch.object(litellm_utils, "_select_tokenizer", side_effect=spy_select_tokenizer):
+        response = await token_counter(
+            request=TokenCountRequest(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": "Hello world"}],
+            )
+        )
+
+    assert response.total_tokens > 0
+    assert len(select_thread_idents) >= 1
+    assert all(ident != loop_thread_ident for ident in select_thread_idents)
+
+
+@pytest.mark.asyncio
 async def test_token_counter_oversized_payload_returns_400():
     """A payload whose combined string size exceeds the cap must map to 400.
 

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -9720,6 +9720,40 @@ async def test_token_counter_malformed_message_returns_400_without_reflection():
 
 
 @pytest.mark.asyncio
+async def test_token_counter_tokenizer_attribute_error_returns_400_without_reflection():
+    """An AttributeError raised deep inside the tokenizer must also map to 400.
+
+    Only ValueError/TypeError used to be caught, so an AttributeError from a
+    content block of an unexpected shape escaped the handler and surfaced as a
+    500. It must now be a 400 whose body carries no internal exception text.
+    """
+    from fastapi import HTTPException
+
+    from litellm.proxy._types import TokenCountRequest
+    from litellm.proxy.proxy_server import token_counter
+
+    setattr(proxy_server_module, "llm_router", None)
+
+    with patch(
+        "litellm.token_counter",
+        side_effect=AttributeError("'dict' object has no attribute 'startswith'"),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await token_counter(
+                request=TokenCountRequest(
+                    model="gpt-3.5-turbo",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+            )
+
+    assert exc_info.value.status_code == 400
+    detail = str(exc_info.value.detail)
+    assert "attribute" not in detail
+    assert "startswith" not in detail
+    assert "Traceback" not in detail
+
+
+@pytest.mark.asyncio
 async def test_token_counter_wellformed_message_still_counts():
     """A well-formed request must still return a positive token count."""
     from litellm.proxy._types import TokenCountRequest

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -9832,6 +9832,46 @@ async def test_token_counter_oversized_payload_returns_400():
 
 
 @pytest.mark.asyncio
+async def test_token_counter_oversized_dict_key_returns_400():
+    """An oversized string hidden in a dict KEY must also trip the size cap.
+
+    Dict keys (e.g. property names in a tool JSON schema) are tokenized just
+    like values, so counting only `dict.values()` would let a caller bypass
+    the cap while still consuming the full tokenization cost.
+    """
+    from fastapi import HTTPException
+
+    from litellm.proxy._types import TokenCountRequest
+    from litellm.proxy.proxy_server import token_counter
+
+    setattr(proxy_server_module, "llm_router", None)
+
+    oversized_key = "a" * (proxy_server_module.TOKEN_COUNTER_MAX_REQUEST_CHARS + 1)
+    with pytest.raises(HTTPException) as exc_info:
+        await token_counter(
+            request=TokenCountRequest(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": "Hello world"}],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {oversized_key: {"type": "string"}},
+                            },
+                        },
+                    }
+                ],
+            )
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == {"error": "Request payload too large for token counting"}
+
+
+@pytest.mark.asyncio
 async def test_token_counter_saturated_concurrency_returns_429():
     """When the tokenization concurrency bound is saturated, excess requests get 429.
 

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -9686,3 +9686,85 @@ async def test_startup_survives_database_read_failure_for_coordination_redis():
         )
 
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_token_counter_malformed_message_returns_400_without_reflection():
+    """`/utils/token_counter` must map a malformed message payload to HTTP 400.
+
+    A content block that survives Pydantic validation but breaks the tokenizer
+    (e.g. a bare int inside `content`) used to raise an unhandled ValueError,
+    which FastAPI surfaces as a 500. It should now be a 400 whose body does not
+    leak the internal exception text or a traceback.
+    """
+    from fastapi import HTTPException
+
+    from litellm.proxy._types import TokenCountRequest
+    from litellm.proxy.proxy_server import token_counter
+
+    setattr(proxy_server_module, "llm_router", None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await token_counter(
+            request=TokenCountRequest(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": [123]}],
+            )
+        )
+
+    assert exc_info.value.status_code == 400
+    detail = str(exc_info.value.detail)
+    assert "int" not in detail
+    assert "subscriptable" not in detail
+    assert "Traceback" not in detail
+
+
+@pytest.mark.asyncio
+async def test_token_counter_wellformed_message_still_counts():
+    """A well-formed request must still return a positive token count."""
+    from litellm.proxy._types import TokenCountRequest
+    from litellm.proxy.proxy_server import token_counter
+
+    setattr(proxy_server_module, "llm_router", None)
+
+    response = await token_counter(
+        request=TokenCountRequest(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": "Hello world"}],
+        )
+    )
+
+    assert response.total_tokens > 0
+    assert response.request_model == "gpt-3.5-turbo"
+
+
+@pytest.mark.asyncio
+async def test_token_counter_offloads_counting_to_executor():
+    """The synchronous, CPU-bound count must run off the event loop.
+
+    We spy on the running loop's `run_in_executor` and assert the handler
+    dispatches the count through it rather than blocking the loop inline.
+    """
+    loop = asyncio.get_running_loop()
+    real_run_in_executor = loop.run_in_executor
+    calls = []
+
+    def spy_run_in_executor(executor, func, *args):
+        calls.append(func)
+        return real_run_in_executor(executor, func, *args)
+
+    from litellm.proxy._types import TokenCountRequest
+    from litellm.proxy.proxy_server import token_counter
+
+    setattr(proxy_server_module, "llm_router", None)
+
+    with patch.object(loop, "run_in_executor", side_effect=spy_run_in_executor):
+        response = await token_counter(
+            request=TokenCountRequest(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": "Hello world"}],
+            )
+        )
+
+    assert response.total_tokens > 0
+    assert len(calls) >= 1


### PR DESCRIPTION
## Relevant issues

None; this is a self-discovered robustness issue in the proxy token-counting endpoints. Reproduction is included below

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Problem

Two proxy token-counting handlers share the same synchronous, CPU-bound path and neither guards it

`/utils/token_counter` (`litellm/proxy/proxy_server.py::token_counter`) and `/v1/messages/count_tokens` (`litellm/proxy/anthropic_endpoints/endpoints.py::count_tokens`, which wraps the former) call `litellm.token_counter` directly on the asyncio event loop. Tokenization is pure-Python and unbounded, so a single large `messages` payload pins the loop and freezes the worker for every other concurrent request on it, including `/health/liveliness`. That is an authenticated denial of service against the whole worker, not just the caller

The same call has no error handling for malformed-but-valid-JSON content. A non-dict message element (for example `messages: [123]`, which fails `TokenCountRequest` validation) or a bad content block (for example `content: [123]`, which reaches `_count_content_list` in `litellm/litellm_core_utils/token_counter.py` and raises `'int' object is not subscriptable`) surfaces as HTTP 500 on `/utils/token_counter`. On `/v1/messages/count_tokens` the terminal `except Exception` catches it and reflects the raw internal text back to the client as `Internal server error: <exception>`, which is both the wrong status for bad client input and an information leak

## Fix

Offload the count off the event loop with `await asyncio.get_running_loop().run_in_executor(None, partial(token_counter, ...))`, matching how `litellm/main.py` already offloads synchronous work, so the loop stays responsive while a big count runs

Wrap `_select_tokenizer` plus the count in `try/except (ValueError, TypeError)` in both handlers and raise `HTTPException(status_code=400, ...)` with a fixed generic message, logging the real detail server-side via `verbose_proxy_logger.exception(...)`. `pydantic.ValidationError` subclasses `ValueError`, so the Anthropic wrapper's malformed-model case is covered too. The Anthropic handler's `except HTTPException: raise` already passes the internal 400 straight through, and I changed its terminal 500 body to a static `Internal server error` so it no longer echoes `str(e)`

Review feedback on this PR flagged that the executor offload alone still leaves an unbounded queue: `run_in_executor(None, ...)` feeds the process-wide default `ThreadPoolExecutor`, whose work queue is unbounded, and these routes do not go through the proxy's parallel-request limiter (which is per-key, unlimited by default, and would need auth/cache plumbing these routes don't have). A caller submitting counts faster than they complete would therefore accumulate queued payloads in memory. I bounded the single dispatch point both ways, using existing repo primitives:

- Concurrency bound: a module-level `asyncio.Semaphore(TOKEN_COUNTER_MAX_CONCURRENCY)` (default 32, env-overridable, per worker process) gates the executor dispatch with a try-acquire — when the bound is saturated the request is rejected with a `ProxyRateLimitError` (litellm's documented class for internal 429s, itself an `HTTPException`) carrying a generic message, instead of queueing. There is no `await` between the `locked()` check and the acquire, so admitted requests never block. 32 matches the default executor's worker ceiling (`min(32, os.cpu_count() + 4)`), so admissions beyond it could only ever queue, never run sooner; normal counts take milliseconds and should never see it
- Input-size cap: before any tokenization work, the handler sums every string leaf across `prompt`/`messages`/`contents`/`tools`/`system` (an iterative walk, so base64 image blocks are counted too) and rejects payloads above `TOKEN_COUNTER_MAX_REQUEST_CHARS` (default 10,000,000 chars, env-overridable) with a generic 400. 10M chars is roughly 2.5M tokens — above the largest mainstream context windows — while capping worst-case in-flight memory at roughly 32 x 10MB per worker instead of unbounded. The guard sits before the provider-endpoint path too, so a clearly-oversized payload is rejected locally instead of being forwarded to the Anthropic/Google count APIs

Both the 400 and the 429 propagate through the Anthropic wrapper's `except HTTPException: raise`, so `/v1/messages/count_tokens` stays consistent with `/utils/token_counter` with no extra branching there. Two trade-offs worth noting: the bound try-acquires rather than briefly waiting, so a legitimate burst beyond the per-worker limit gets a retryable 429 (the env var is there if a deployment needs more), and I kept 400 rather than 413 for the oversized case to match the endpoint's other validation errors

## Testing

Added regression tests under `tests/test_litellm/` so they run under `make test-unit`, plus the canonical `tests/proxy_unit_tests/test_proxy_token_counter.py` which already drives both handlers directly. They cover the 400 mapping, the absence of internal text in the response body, the executor offload (by spying on the running loop's `run_in_executor`), the oversized-payload 400 on both endpoints, the saturated-bound 429 on both endpoints (patching the semaphore to `asyncio.Semaphore(0)`), the terminal generic-500 path on the Anthropic wrapper (unexpected `RuntimeError` must not be reflected), and no regression on well-formed input

```
python -m pytest tests/proxy_unit_tests/test_proxy_token_counter.py tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py "tests/test_litellm/proxy/test_proxy_server.py" -k "token_counter or count_tokens or CountTokens" -q
42 passed, 2 skipped, 249 deselected
```

## Screenshots / Proof of Fix

Ran a local proxy against a minimal config (`master_key: sk-1234`, `gpt-3.5-turbo`) so no third-party keys are needed for the malformed-input and event-loop behavior. Before is the pristine tree at `10d5804b`; after is this branch

Error handling, before (pristine `10d5804b`)

```
$ curl -s -w '\nHTTP=%{http_code}\n' -X POST localhost:4002/v1/messages/count_tokens \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model":"gpt-3.5-turbo","messages":[123]}'
{"detail":{"error":"Internal server error: 1 validation error for TokenCountRequest\nmessages.0\n  Input should be a valid dictionary [type=dict_type, input_value=123, input_type=int] ..."}}
HTTP=500

$ curl -s -w '\nHTTP=%{http_code}\n' -X POST localhost:4002/v1/messages/count_tokens \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model":"gpt-3.5-turbo","messages":[{"role":"user","content":[123]}]}'
{"detail":{"error":"Internal server error: Error getting number of tokens from content list: 'int' object is not subscriptable, default_token_count=None"}}
HTTP=500

$ curl -s -w '\nHTTP=%{http_code}\n' -X POST localhost:4002/utils/token_counter \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model":"gpt-3.5-turbo","messages":[{"role":"user","content":[123]}]}'
{"error":{"message":"Internal server error","type":"internal_server_error"}}
HTTP=500
```

Error handling, after (this branch)

```
$ curl -s -w '\nHTTP=%{http_code}\n' -X POST localhost:4001/v1/messages/count_tokens \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model":"gpt-3.5-turbo","messages":[123]}'
{"detail":{"error":"Invalid request: could not tokenize the provided messages"}}
HTTP=400

$ curl -s -w '\nHTTP=%{http_code}\n' -X POST localhost:4001/utils/token_counter \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model":"gpt-3.5-turbo","messages":[{"role":"user","content":[123]}]}'
{"detail":{"error":"Invalid request: could not tokenize the provided messages/prompt"}}
HTTP=400

$ curl -s -w '\nHTTP=%{http_code}\n' -X POST localhost:4001/utils/token_counter \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model":"gpt-3.5-turbo","messages":[{"role":"user","content":"Hello world"}]}'
{"total_tokens":9,"request_model":"gpt-3.5-turbo","model_used":"gpt-3.5-turbo","tokenizer_type":"openai_tokenizer", ...}
HTTP=200
```

Event loop, before (pristine `10d5804b`): fire an ~87MB count, then probe `/health/liveliness` every 200ms. The first probe blocks for the whole count

```
BIG_COUNT(before): HTTP=200 time=2.570s   -> total_tokens=18000008
[BEFORE] liveliness probe 1 -> HTTP=200 took 2.097s
[BEFORE] liveliness probe 2 -> HTTP=200 took 0.029s
[BEFORE] liveliness probe 3 -> HTTP=200 took 0.029s
...
```

Event loop, after (this branch): same probing. The ~87MB payload is now rejected up front by the size cap instead of tokenizing for ~2.6s, on both endpoints

```
$ curl -s -w '\nHTTP=%{http_code} time=%{time_total}s\n' -X POST localhost:4010/utils/token_counter \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' --data-binary @big-18M-chars.json
{"detail":{"error":"Request payload too large for token counting"}}
HTTP=400 time=0.031471s

$ curl -s -w '\nHTTP=%{http_code} time=%{time_total}s\n' -X POST localhost:4010/v1/messages/count_tokens \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' --data-binary @big-18M-chars.json
{"detail":{"error":"Request payload too large for token counting"}}
HTTP=400 time=0.257308s
```

Bounded tokenization queue, after (this branch): started the proxy with `TOKEN_COUNTER_MAX_CONCURRENCY=1`, fired 12 parallel under-cap counts (~8.4M chars each), and probed `/health/liveliness` every 200ms while they ran. Exactly one is admitted and completes; the excess is rejected immediately with 429 instead of queueing, and the loop stays responsive

```
liveliness probe 1 -> HTTP=200 took 0.002516s
liveliness probe 2 -> HTTP=200 took 0.002165s
liveliness probe 3 -> HTTP=200 took 0.001947s
liveliness probe 4 -> HTTP=200 took 0.002001s
liveliness probe 5 -> HTTP=200 took 0.002001s
--- status codes of the 12 parallel counts:
   1 200
  11 429
--- sample 429 body:
{"detail":{"error":"Too many concurrent token counting requests. Please retry later."}}
--- the admitted request's body:
{"total_tokens":1400008,"request_model":"gpt-3.5-turbo","model_used":"gpt-3.5-turbo","tokenizer_type":"openai_tokenizer", ...}
```

## Type

🐛 Bug Fix

## Changes

`litellm/proxy/proxy_server.py`: in the `/utils/token_counter` handler, dispatch the synchronous `litellm.token_counter` through `run_in_executor` and wrap `_select_tokenizer` plus the count in `try/except (ValueError, TypeError)` that raises a 400 with a generic message and logs the detail server-side. Gate the dispatch behind a module-level `asyncio.Semaphore(TOKEN_COUNTER_MAX_CONCURRENCY)` that try-acquires and raises `ProxyRateLimitError` (429) when saturated, and reject payloads whose combined string size exceeds `TOKEN_COUNTER_MAX_REQUEST_CHARS` with a generic 400 before any tokenization work (`_count_request_string_chars` helper). Import `partial` alongside the existing `lru_cache`

`litellm/proxy/anthropic_endpoints/endpoints.py`: add an `except (ValueError, TypeError)` branch to `count_tokens` that raises a 400 with a generic message, and change the terminal 500 body to a static `Internal server error` so it stops reflecting `str(e)`. The new 400/429 guards flow through its existing `except HTTPException: raise` untouched, so no gating change is needed here

`litellm/constants.py`: add `TOKEN_COUNTER_MAX_CONCURRENCY` (default 32) and `TOKEN_COUNTER_MAX_REQUEST_CHARS` (default 10,000,000), both env-overridable via the existing `int(os.getenv(...))` pattern and enforced per worker process

Tests: `tests/test_litellm/proxy/test_proxy_server.py`, `tests/test_litellm/proxy/anthropic_endpoints/test_endpoints.py`, and `tests/proxy_unit_tests/test_proxy_token_counter.py`
