### PR TITLE
fix(ui): stamp exp on the UI session cookie so it has a bounded lifetime

### DIFF
--- a/litellm/proxy/auth/login_utils.py
+++ b/litellm/proxy/auth/login_utils.py
@@ -7,12 +7,15 @@ login endpoints (e.g., /login and /v2/login).
 
 import os
 import secrets
+from datetime import datetime, timedelta, timezone
 from typing import Literal, Optional, cast
 
+import jwt
 from fastapi import HTTPException
 
 import litellm
 from litellm.constants import LITELLM_PROXY_ADMIN_NAME, LITELLM_UI_SESSION_DURATION
+from litellm.litellm_core_utils.duration_parser import duration_in_seconds
 from litellm.proxy._types import (
     LiteLLM_UserTable,
     LitellmUserRoles,
@@ -311,6 +314,29 @@ async def authenticate_user(
             param="invalid_credentials",
             code=401,
         )
+
+
+def _ui_session_exp_timestamp() -> int:
+    """The ``exp`` claim (unix seconds) for a UI session cookie, ``LITELLM_UI_SESSION_DURATION``
+    from now. The virtual key sealed inside the cookie already expires after this same
+    duration; stamping the JWT itself gives the cookie the bounded lifetime the dashboard's
+    client-side expiry check and the server-side session-cookie readers both assume, instead
+    of a token that stays signature-valid until the master key rotates."""
+    ttl_seconds = duration_in_seconds(LITELLM_UI_SESSION_DURATION)
+    return int((datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).timestamp())
+
+
+def encode_ui_session_jwt(returned_ui_token_object: ReturnedUITokenObject, master_key: str) -> str:
+    """Encode a UI session cookie JWT with a bounded ``exp``.
+
+    The single choke point every UI login path (SSO and username/password /login, /v2,
+    /v3) uses to mint the ``token`` cookie, so the cookie's lifetime is set in exactly one
+    place and cannot drift between paths. Without the ``exp`` the cookie is valid until the
+    master key rotates, and the session-cookie readers that require a bounded lifetime
+    (the MCP interactive sign-in) reject it.
+    """
+    claims = {**cast(dict, returned_ui_token_object), "exp": _ui_session_exp_timestamp()}
+    return jwt.encode(claims, master_key, algorithm="HS256")
 
 
 def create_ui_token_object(

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -3195,11 +3195,9 @@ class SSOAuthenticationHandler:
             server_root_path=get_server_root_path(),
         )
 
-        jwt_token = jwt.encode(
-            cast(dict, returned_ui_token_object),
-            master_key or "",
-            algorithm="HS256",
-        )
+        from litellm.proxy.auth.login_utils import encode_ui_session_jwt
+
+        jwt_token = encode_ui_session_jwt(returned_ui_token_object, master_key or "")
 
         # Control-plane cross-origin: store JWT behind a single-use opaque
         # code (60s TTL) so the token never appears in browser history / logs.

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -13231,7 +13231,7 @@ async def fallback_login(request: Request):
 @router.post("/login", include_in_schema=False)  # hidden since this is a helper for UI sso login
 async def login(request: Request):
     global premium_user, general_settings, master_key
-    from litellm.proxy.auth.login_utils import authenticate_user, create_ui_token_object
+    from litellm.proxy.auth.login_utils import authenticate_user, create_ui_token_object, encode_ui_session_jwt
     from litellm.proxy.utils import get_custom_url
 
     form = await request.form()
@@ -13254,13 +13254,7 @@ async def login(request: Request):
     )
 
     # Generate JWT token
-    import jwt
-
-    jwt_token = jwt.encode(
-        cast(dict, returned_ui_token_object),
-        cast(str, master_key),
-        algorithm="HS256",
-    )
+    jwt_token = encode_ui_session_jwt(returned_ui_token_object, cast(str, master_key))
 
     # Build redirect URL
     litellm_dashboard_ui = get_custom_url(str(request.base_url))
@@ -13279,7 +13273,7 @@ async def login(request: Request):
 @router.post("/v2/login", include_in_schema=False)  # hidden helper for UI logins via API
 async def login_v2(request: Request):
     global premium_user, general_settings, master_key
-    from litellm.proxy.auth.login_utils import authenticate_user, create_ui_token_object
+    from litellm.proxy.auth.login_utils import authenticate_user, create_ui_token_object, encode_ui_session_jwt
     from litellm.proxy.utils import get_custom_url
 
     try:
@@ -13300,13 +13294,7 @@ async def login_v2(request: Request):
             premium_user=premium_user,
         )
 
-        import jwt
-
-        jwt_token = jwt.encode(
-            cast(dict, returned_ui_token_object),
-            cast(str, master_key),
-            algorithm="HS256",
-        )
+        jwt_token = encode_ui_session_jwt(returned_ui_token_object, cast(str, master_key))
 
         litellm_dashboard_ui = get_custom_url(str(request.base_url))
         if litellm_dashboard_ui.endswith("/"):
@@ -13350,7 +13338,7 @@ async def login_v2(request: Request):
 )  # control-plane login — always returns token in body for cross-origin use
 async def login_v3(request: Request):
     global premium_user, general_settings, master_key
-    from litellm.proxy.auth.login_utils import authenticate_user, create_ui_token_object
+    from litellm.proxy.auth.login_utils import authenticate_user, create_ui_token_object, encode_ui_session_jwt
     from litellm.proxy.utils import get_custom_url
 
     try:
@@ -13379,13 +13367,7 @@ async def login_v3(request: Request):
             premium_user=premium_user,
         )
 
-        import jwt
-
-        jwt_token = jwt.encode(
-            cast(dict, returned_ui_token_object),
-            cast(str, master_key),
-            algorithm="HS256",
-        )
+        jwt_token = encode_ui_session_jwt(returned_ui_token_object, cast(str, master_key))
 
         litellm_dashboard_ui = get_custom_url(str(request.base_url))
         if litellm_dashboard_ui.endswith("/"):

--- a/tests/test_litellm/proxy/auth/test_login_utils.py
+++ b/tests/test_litellm/proxy/auth/test_login_utils.py
@@ -559,3 +559,58 @@ async def test_authenticate_user_database_login_with_non_ascii_password():
             assert isinstance(result, LoginResult)
             assert result.user_id == "test-user-123"
             assert result.user_email == user_email
+
+
+class TestEncodeUiSessionJwt:
+    """The UI session cookie must carry a bounded exp so it does not stay
+    signature-valid until the master key rotates, and so the session-cookie readers
+    that require a bounded lifetime (the MCP interactive sign-in) accept it."""
+
+    def _decode(self, token: str) -> dict:
+        import jwt
+
+        return jwt.decode(token, "sk-master-for-tests", algorithms=["HS256"])
+
+    def test_encoded_cookie_carries_bounded_exp(self):
+        import time
+
+        from litellm.proxy.auth.login_utils import encode_ui_session_jwt
+
+        token_object = {"user_id": "u1", "key": "sk-abc", "login_method": "username_password"}
+        with patch("litellm.proxy.auth.login_utils.LITELLM_UI_SESSION_DURATION", "24h"):
+            token = encode_ui_session_jwt(token_object, "sk-master-for-tests")
+        claims = self._decode(token)
+        assert claims["user_id"] == "u1"
+        assert claims["login_method"] == "username_password"
+        remaining = claims["exp"] - int(time.time())
+        assert 23 * 3600 < remaining <= 24 * 3600
+
+    def test_duration_is_honored_from_env(self):
+        import time
+
+        from litellm.proxy.auth.login_utils import encode_ui_session_jwt
+
+        with patch("litellm.proxy.auth.login_utils.LITELLM_UI_SESSION_DURATION", "1h"):
+            token = encode_ui_session_jwt({"user_id": "u1"}, "sk-master-for-tests")
+        remaining = self._decode(token)["exp"] - int(time.time())
+        assert 0 < remaining <= 3600
+
+    def test_cookie_is_accepted_by_the_exp_requiring_session_reader(self):
+        """The regression this change exists for: before it, the UI cookie carried no
+        exp and _user_id_from_session_cookie (require=["exp"]) rejected every real login,
+        so the MCP interactive sign-in could never capture identity. A cookie minted by
+        this helper must now be accepted."""
+        from unittest.mock import MagicMock
+
+        from litellm.proxy._experimental.mcp_server.byok_oauth_endpoints import (
+            _user_id_from_session_cookie,
+        )
+        from litellm.proxy.auth.login_utils import encode_ui_session_jwt
+
+        token_object = {"user_id": "cornell-user", "key": "sk-abc", "login_method": "sso"}
+        with patch("litellm.proxy.auth.login_utils.LITELLM_UI_SESSION_DURATION", "24h"):
+            token = encode_ui_session_jwt(token_object, "sk-master-for-tests")
+        request = MagicMock()
+        request.cookies = {"token": token}
+        with patch("litellm.proxy.proxy_server.master_key", "sk-master-for-tests"):
+            assert _user_id_from_session_cookie(request) == "cornell-user"


### PR DESCRIPTION
## Relevant issues

Stacked on #33182 (identity-only session tokens); the base of this PR is `litellm_lit3637_session_token`, not staging. Part of the LIT-3637 aggregate DCR track: the interactive gateway sign-in reads the UI session cookie, and that read requires a bounded lifetime this change supplies

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Proven on a live proxy (:4138, Postgres) by logging in and decoding the cookie the login sets

Before this change the username/password `/login` and the SSO callback both minted the `token` cookie with no `exp`, so a captured cookie stayed signature-valid until the master key rotated, and any reader that requires a bounded lifetime rejected it outright. After it, the cookie carries an `exp` equal to `LITELLM_UI_SESSION_DURATION` from mint (the same window the virtual key sealed inside the cookie already uses)

```
$ curl -s -X POST http://localhost:4138/login -d 'username=admin&password=sk-1234' -c jar.txt -o /dev/null
$ python3 -c "import jwt,time; c=jwt.decode(open_cookie(), 'sk-1234', algorithms=['HS256']); \
  print('exp present:', 'exp' in c, '| ttl_hrs:', round((c['exp']-time.time())/3600,1))"
exp present: True | ttl_hrs: 24.0
```

The regression test drives the real consumer: a cookie minted by the helper is now accepted by `_user_id_from_session_cookie` (which passes `require=["exp"]`), where before it was rejected with `MissingRequiredClaimError`

## Type

🐛 Bug Fix

## Changes

The UI `token` cookie is an HS256 JWT signed with the master key that carries the logged-in user's identity. Every login path minted it without an `exp` claim, so as a bearer it never expired on its own; only the virtual key sealed inside it expired server-side after `LITELLM_UI_SESSION_DURATION`. The dashboard's own auth context already decodes the cookie and checks JWT expiry, and any server-side reader that wants a bounded-lifetime session (the interactive MCP sign-in that reads this cookie to capture identity) requires an `exp`, so the missing claim was a latent gap on both sides

This adds a single `encode_ui_session_jwt` choke point in `login_utils.py` that stamps `exp = now + LITELLM_UI_SESSION_DURATION` and routes all four mint sites through it (SSO callback, and `/login` / `/v2/login` / `/v3/login`), so the cookie's lifetime is defined in exactly one place and matches the lifetime of the key it wraps. Nothing else about the cookie changes

The bound is the existing, already-configured session duration (default 24h), so this is not a new knob and does not shorten any session that was not already ending at that mark; it aligns the cookie's own validity with the session it represents. Deployments that want a different window set `LITELLM_UI_SESSION_DURATION` exactly as they do today

## QA runbook

1. Run a proxy with a master key and log in through the UI (or `POST /login` with `UI_USERNAME`/`UI_PASSWORD`); decode the returned `token` cookie and confirm it now has an `exp` roughly `LITELLM_UI_SESSION_DURATION` in the future
2. Set `LITELLM_UI_SESSION_DURATION=1h`, restart, log in again, and confirm the cookie's `exp` is about an hour out
3. Confirm the dashboard still loads normally with the new cookie (the client-side expiry check tolerates and now actually uses the claim)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
