### PR TITLE
feat(mcp): admit gateway DCR session bearers at the aggregate /mcp scope

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -131,11 +131,9 @@ def _is_mcp_admitted_user_subject(user_api_key_auth: UserAPIKeyAuth | None) -> b
     """True when this auth is a keyless subject admitted by the gateway session / bridge user
     path, as opposed to a JWT or other keyless auth that merely lacks a ``team_id``.
 
-    Reads the server-only ``UserAPIKeyAuth.mcp_admitted_user_subject`` field, set exclusively by
-    ``_reload_admitted_user`` at admission. It is deliberately NOT a ``metadata`` key: virtual-key
-    metadata is caller-controlled at key creation, so a metadata marker could be forged on a
-    personal key to gain the team-inherited grant union or to dodge the caller-Authorization
-    egress scrub. This field cannot be set from caller input."""
+    Reads the server-only ``mcp_admitted_user_subject`` field, set only by ``_reload_admitted_user``. It
+    is deliberately NOT a ``metadata`` key, which is caller-controlled at key creation and so forgeable
+    on a personal key to gain the team grant union or dodge the egress scrub; this field cannot be."""
     return user_api_key_auth is not None and user_api_key_auth.mcp_admitted_user_subject is True
 
 
@@ -391,11 +389,9 @@ class MCPRequestHandler:
             and oauth2_headers
             and is_session_bearer_shaped(oauth2_headers["Authorization"])
         ):
-            # A gateway DCR session bearer at the aggregate /mcp scope: open the
-            # identity-only session token and admit under the live litellm user it
-            # references. A session-shaped bearer that does not open fails closed with
-            # the aggregate invalid_token challenge; a non-session bearer never reaches
-            # here (is_session_bearer_shaped is false) and falls through to the oauth2 arm.
+            # A gateway DCR session bearer at the aggregate /mcp scope: open the identity-only session
+            # token and admit under the live litellm user. One that does not open fails closed with the
+            # aggregate invalid_token challenge; a non-session bearer falls through to the oauth2 arm.
             validated_user_api_key_auth = await MCPRequestHandler._admit_gateway_session(
                 authorization_value=oauth2_headers["Authorization"],
                 request=request,
@@ -431,13 +427,10 @@ class MCPRequestHandler:
                     bearer_presented=False,
                 )
 
-        # Leak-defense (single chokepoint): a gateway admission credential — the session bearer or the
-        # bridge envelope — is NEVER a valid upstream MCP token. Scrub it from EVERY egress header context
-        # (top-level Authorization, the deprecated `x-mcp-auth`, and per-server `x-mcp-{alias}-authorization`)
-        # so no client-forwarded, OBO-subject, or passthrough path can send it upstream, where a hostile
-        # server could capture and replay it against the aggregate endpoint as this user. Anchored to the
-        # credential SHAPE, so a legitimate upstream/passthrough token (never session- or envelope-shaped)
-        # is forwarded unchanged; per-server vaulted credentials (resolved at egress) are unaffected.
+        # Leak-defense (single chokepoint): a gateway admission credential (session bearer or bridge
+        # envelope) is NEVER a valid upstream token. Scrub it from EVERY egress context so no
+        # client-forwarded, OBO, or passthrough path can send it upstream for replay. Anchored to the
+        # credential SHAPE, so a legitimate upstream/passthrough token is forwarded unchanged.
         raw_headers = dict(headers)
         (
             oauth2_headers,
@@ -463,10 +456,9 @@ class MCPRequestHandler:
 
     @staticmethod
     def _is_gateway_admission_credential(value: str | None) -> bool:
-        """True when a header value is a gateway admission credential — a session bearer (``llm_session_`` /
-        ``llm_srefresh_``) or a bridge envelope. Such a value proves who signed in to the GATEWAY; it is
-        never a valid credential for an UPSTREAM MCP server, so it must never be forwarded, where a hostile
-        upstream could capture and replay it against the aggregate ``/mcp`` endpoint as this user."""
+        """True when a header value is a gateway admission credential — a session bearer or bridge
+        envelope. It proves who signed in to the GATEWAY, never a valid UPSTREAM token, so it must never
+        be forwarded (a hostile upstream could capture and replay it against the aggregate ``/mcp`` scope)."""
         return value is not None and (is_session_bearer_shaped(value) or is_bridge_envelope_shaped(value))
 
     @staticmethod
@@ -478,13 +470,10 @@ class MCPRequestHandler:
         mcp_server_auth_headers: dict[str, dict[str, str]] | None,
     ) -> tuple[dict[str, str] | None, dict[str, str], str | None, dict[str, dict[str, str]] | None]:
         """Remove any gateway admission credential from EVERY egress header context, keyed on the credential
-        SHAPE: the top-level ``Authorization`` (``oauth2_headers`` + ``raw_headers``), the deprecated
-        ``x-mcp-auth`` (``mcp_auth_header``), and per-server ``x-mcp-{alias}-authorization``
-        (``mcp_server_auth_headers``). A legitimate upstream/passthrough token is never session- or
-        envelope-shaped, so it is forwarded unchanged; the per-server token the bridge arm injects is the
-        real upstream credential (also not gateway-shaped), so it survives. An admitted subject's top-level
-        Authorization IS the admission bearer, so it is dropped unconditionally as defense-in-depth even
-        though it is already gateway-shaped."""
+        SHAPE: top-level ``Authorization`` (oauth2 + raw), the deprecated ``x-mcp-auth``, and per-server
+        ``x-mcp-{alias}-authorization``. A legitimate upstream/passthrough token is never gateway-shaped so
+        it survives (including the real upstream token the bridge arm injects per-server); an admitted
+        subject's top-level Authorization is dropped unconditionally as defense-in-depth."""
         cred = MCPRequestHandler._is_gateway_admission_credential
 
         # 1. Top-level Authorization → oauth2_headers.
@@ -745,21 +734,12 @@ class MCPRequestHandler:
     ) -> UserAPIKeyAuth:
         """Open a gateway DCR session bearer and admit the live litellm user it references.
 
-        The custody sibling of :meth:`_admit_dcr_bridge_delegate`: the session token seals
-        no upstream credential (those are vaulted per user and resolved at egress), so this
-        admits identity only and injects no per-server header. The token's signature proves
-        the user signed in when it was minted, but authorization is resolved fresh here, the
-        sealed ``user_id`` reloads the current user record through the SAME
-        :meth:`_reload_admitted_user` the bridge user-subject path uses, and the admitted
-        identity runs through the centralized policy gate, so the user's present team, org,
-        budget, and SCIM state gate the request rather than a snapshot frozen at mint time.
-
-        Fails closed with the aggregate ``invalid_token`` challenge on an expired, tampered,
-        or foreign token, on a refresh token presented at the tool edge, and when the
-        referenced user is missing, deactivated, or rejected by the policy gate. The
-        pre-DB gates (size, IP, route allowlist) run first, mirroring the bridge arm and the
-        standard pipeline, so a caller blocked by IP or route is turned away before any
-        crypto or DB read."""
+        Identity-only sibling of :meth:`_admit_dcr_bridge_delegate`: the session token seals no
+        upstream credential (those are vaulted per user, resolved at egress), so authorization is
+        resolved fresh via :meth:`_reload_admitted_user` + the centralized policy gate rather than a
+        mint-time snapshot. Pre-DB gates (size, IP, route allowlist) run first, mirroring the standard
+        pipeline. Fails closed with the aggregate ``invalid_token`` challenge on an expired, tampered,
+        foreign, or refresh token, or a missing/deactivated/policy-rejected user."""
         from litellm.proxy._experimental.mcp_server.outbound_credentials.session_credentials import (
             NotSessionBearer,
             SessionBearerAdmitted,
@@ -842,34 +822,18 @@ class MCPRequestHandler:
 
     @staticmethod
     async def _reload_admitted_user(user_id: str) -> UserAPIKeyAuth:
-        """Reload the live user an interactively-minted envelope references and admit them as
-        themselves.
+        """Reload the live user an interactively-minted envelope references and admit them as themselves.
 
-        The DCR client authenticates via SSO at the bridged authorize, which yields a user
-        subject rather than a virtual key, so the envelope admits under the user's own
-        identity: the reloaded ``user_id``, the user's own MCP object permission, and the user's
-        ``org_id`` ride on the returned ``UserAPIKeyAuth``, and the SAME ``get_allowed_mcp_servers``
-        the key path uses then computes which servers the user may reach, so the user's litellm MCP
-        grants and access groups gate the request exactly as a key's do. Because the returned auth is
-        stamped ``mcp_admitted_user_subject`` (below), ``get_allowed_mcp_servers`` unions the servers the
-        user reaches through ANY of their teams on top of these direct grants — a ``UserAPIKeyAuth``
-        pins one ``team_id`` but a user belongs to many, so the team fan-out happens off the marker, not
-        the single ``team_id``. Each source is bounded by ITS OWN org: the user's direct grants by the
-        bound ``org_id`` (their primary org), and each team's grant by that team's owning org inside
-        ``_allowed_mcp_servers_for_single_team`` — so a user who spans organizations does not leak one
-        org's servers past another org's ceiling. The caller's centralized policy gate enforces the
-        user's live budget and org state, and a SCIM-deactivated owner fails closed.
+        The user's own object permission and ``org_id`` ride on the returned ``UserAPIKeyAuth``, and the
+        SAME ``get_allowed_mcp_servers`` the key path uses gates the request. The ``mcp_admitted_user_subject``
+        marker (set below) makes that resolver union the servers the user reaches through ANY of their teams
+        on top of these direct grants, each source bounded by ITS OWN org, so a user spanning organizations
+        cannot leak one org's servers past another's ceiling.
 
-        Error handling mirrors the key path's retryable-503 contract, but ``get_user_object`` defeats a
-        type-based check: where ``get_key_object`` raises a typed ``ProxyException`` for a missing key
-        and lets a DB outage propagate raw, ``get_user_object`` catches every DB failure and re-raises a
-        bare ``ValueError``, so a missing user and a real outage look identical and the original error
-        survives only as ``__context__``. ``_raise_503_if_db_unavailable`` therefore walks the cause
-        chain: a transient DB outage still surfaces as a retryable 503, while a missing user, or any
-        other non-outage resolution failure, fails closed as a 401 rather than an opaque 500. The
-        object-permission load shares this one boundary, so an outage there is classified the same
-        way (``get_object_permission`` itself swallows a failed load to ``None``, matching how
-        ``get_key_object`` best-effort-loads a key's object permission)."""
+        Error handling: ``get_user_object`` catches every DB failure and re-raises a bare ``ValueError``, so a
+        missing user and a real outage look identical (the cause survives only as ``__context__``).
+        ``_raise_503_if_db_unavailable`` walks the cause chain so an outage stays a retryable 503 while any
+        other failure fails closed as 401, not an opaque 500; the object-permission load shares that boundary."""
         from litellm.proxy.auth.auth_checks import get_object_permission, get_user_object
         from litellm.proxy.proxy_server import prisma_client, user_api_key_cache
 
@@ -907,49 +871,35 @@ class MCPRequestHandler:
             org_id=user_object.organization_id,
             object_permission=object_permission,
             object_permission_id=user_object.object_permission_id,
-            # Copy the live user's rate limits, exactly as the standard user-subject auth path does
-            # (user_api_key_auth.py). The parallel limiter reads these off the auth object rather than
-            # re-fetching, and treats None as sys.maxsize (unlimited), so a keyless admitted user with
-            # them unset would invoke tools past their configured user RPM/TPM.
-            #
-            # Rate-limit model for the keyless admitted subject: bounded by their USER rpm/tpm
-            # (copied here; those descriptors key off user_id, which is set) AND by the per-server
-            # mcp_rpm_limit of EVERY team it reaches servers through, stamped below. Per-KEY MCP
-            # limits genuinely do not apply, because there is no key.
+            # Copy the live user's rate limits, as the standard user-subject path does: the parallel
+            # limiter reads these off the auth object and treats None as unlimited, so a keyless subject
+            # with them unset would outrun its user RPM/TPM. (Per-team mcp_rpm_limit is stamped below;
+            # per-KEY limits do not apply, there being no key.)
             user_tpm_limit=user_object.tpm_limit,
             user_rpm_limit=user_object.rpm_limit,
         )
-        # Set the server-only admission marker AFTER construction: the before-validator strips it
-        # from any validated input, so a post-construction assignment is the only way to set it, and
-        # caller-supplied data (key metadata, JWT claims) can never forge it.
+        # Server-only marker, set AFTER construction: the before-validator strips it from any validated
+        # input, so caller-supplied data (key metadata, JWT claims) can never forge it.
         admitted.mcp_admitted_user_subject = True
-        # Carry each granting team's per-server MCP rpm limit. A key is pinned to one team so the
-        # limiter reads team_metadata directly; this subject reaches servers through several teams
-        # under its own identity, so without this the team ceiling silently does not apply to it and
-        # a cross-team user outruns every team's mcp_rpm_limit. Resolved from the same roster-checked
-        # sources the grant union uses, so a team can only throttle what it actually granted.
+        # Carry each granting team's per-server mcp_rpm_limit: this subject reaches servers through
+        # several teams under its own identity, so without this a cross-team user outruns every team's
+        # limit. Resolved from the same roster-checked sources as the grant union, so a team throttles
+        # only what it granted.
         admitted.mcp_source_team_rpm_limits = await MCPRequestHandler._admitted_subject_team_rpm_limits(admitted)
         return admitted
 
     @staticmethod
     async def _admitted_subject_team_rpm_limits(auth: UserAPIKeyAuth) -> dict[str, dict[str, int]] | None:
-        """``team_id -> mcp_rpm_limit`` for every team this subject reaches servers through, with each
-        team's map filtered to the servers THAT team's grant actually reaches.
+        """``team_id -> mcp_rpm_limit`` for every team this subject reaches servers through, each map
+        filtered to the servers THAT team's grant actually reaches.
 
-        A limit rides the same scope as the access it bounds: a team's throttle exists to cap usage of
-        the access the team granted, so a roster team whose grant does not reach a server (not granted,
-        blocked, org-forbidden, opted out) must not be charged when the user reaches that server
-        through a DIFFERENT team — otherwise this user's calls drain a bucket shared by that team's own
-        keys for access the team never provided. The grant scope comes from the SAME
-        ``get_allowed_mcp_servers(source)`` call authorization uses, so the throttle scope cannot
-        diverge from the access scope. Limit maps are keyed by server name/alias (the limiter matches
-        on the called server's name) while grants are ids, so each key is resolved through
-        ``expand_permission_list`` — the one existing name->id owner — before the membership check.
-
-        Returns None when no team contributes an applicable limit, so the limiter adds no descriptors
-        rather than empty ones. A lookup failure narrows to None rather than raising: rate limiting
-        must not be able to deny a request that authorization already allowed, and the user's own
-        rpm/tpm still bounds them."""
+        A limit rides the same scope as the access it bounds, so a roster team is charged only for a
+        server its OWN grant reaches (never one the user reaches through a different team, which would
+        drain a bucket shared by that team's keys for access it never provided). Grant scope comes from
+        the SAME ``get_allowed_mcp_servers(source)`` authorization uses; limit-map keys are names/aliases
+        so each is resolved to an id via ``expand_permission_list`` before the membership check. Returns
+        None (no descriptors) when nothing applies; a lookup failure narrows to None rather than raising,
+        since rate limiting must not deny a request authorization already allowed."""
         from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
             global_mcp_server_manager,
         )
@@ -969,12 +919,9 @@ class MCPRequestHandler:
                     for server_id in global_mcp_server_manager.expand_permission_list([server_name]):
                         if server_id not in granted_ids:
                             continue
-                        # Charge ONLY the source the call is attributed to — the same single source
-                        # billing picks, from the same owner. Adding a descriptor for every granting
-                        # team let one cross-team user drain several teams' SHARED buckets at once,
-                        # blocking their other members for access those teams did not provide on
-                        # this call; and when the user's OWN grant reaches the server, no team
-                        # provided it, so no team bucket is charged at all.
+                        # Charge ONLY the source billing attributes the call to (same owner), so one
+                        # cross-team user cannot drain several teams' shared buckets on a single call,
+                        # and a server the user's OWN grant reaches charges no team bucket.
                         attributed = await MCPRequestHandler.attributing_source_for_server(
                             auth, server_id, source_grants=source_grants
                         )
@@ -1358,11 +1305,10 @@ class MCPRequestHandler:
         from litellm.proxy.proxy_server import general_settings
 
         try:
-            # A keyless admitted subject is resolved entirely per source, BEFORE any single-source
-            # rule runs here. Ordering matters: the no_mcp_servers opt-out below reads the caller's
-            # own object_permission, so leaving it above this branch let a user's own opt-out zero
-            # their TEAMS' grants too — the sources are independent, and an opt-out on one of them
-            # must silence only that one (it is applied per source, inside the recursive call).
+            # A keyless admitted subject resolves per source BEFORE any single-source rule here. Ordering
+            # matters: the no_mcp_servers opt-out below reads the caller's own object_permission, so above
+            # this branch a user's own opt-out would wrongly zero their TEAMS' grants too (each source is
+            # independent; an opt-out silences only its own source, inside the recursive call).
             if _is_mcp_admitted_user_subject(user_api_key_auth) and user_api_key_auth is not None:
                 return await MCPRequestHandler._resolve_admitted_subject_servers(user_api_key_auth)
 
@@ -1484,22 +1430,14 @@ class MCPRequestHandler:
         has_lower_level_mcp_restrictions: bool,
         keyless_source: bool = False,
     ) -> list[str]:
-        """Cap the resolved server list by this caller's org ceiling. If the org names an explicit MCP
-        list, lower-level restrictions are intersected with it, else the org list becomes the ceiling.
-        No org, or an empty org list, leaves the result unchanged.
+        """Cap the resolved server list by this caller's org ceiling: an explicit org list intersects
+        lower-level restrictions (else becomes the ceiling); no org or an empty list leaves it unchanged.
 
-        ``keyless_source`` marks one grant source of a keyless admitted subject and governs BOTH
-        org divergences, because they are the same fact about that caller shape.
-
-        First, what an UNRESOLVABLE ceiling means. A virtual key keeps the
-        long-standing fail-open behavior (a DB blip must not lock working keys out mid-incident). A
-        keyless admitted subject fails CLOSED, because its only org bound is this ceiling: silently
-        dropping it on a transient fault would widen a cross-org user to servers their team's org
-        forbids, which is a privilege escalation rather than an availability blip.
-
-        Second, whether the org list may SUBSTITUTE for absent lower-level grants. For a key it may
-        (that is the key ceiling model). For a source it may only ever intersect, because the
-        admitted model is a union of grants and a ceiling that grants is not a ceiling."""
+        ``keyless_source`` governs both divergences for a keyless admitted source. An UNRESOLVABLE ceiling
+        fails CLOSED for it (its only org bound is this ceiling, so dropping it on a fault would escalate a
+        cross-org user) while a key stays fail-open. And an org list may only ever INTERSECT a source (the
+        admitted model unions grants, so a ceiling must not become one), whereas for a key it may
+        substitute, that being the key ceiling model."""
         if not (user_api_key_auth and user_api_key_auth.org_id):
             return allowed_mcp_servers
         allowed_mcp_servers_for_org = await MCPRequestHandler._get_allowed_mcp_servers_for_org(user_api_key_auth)
@@ -1512,12 +1450,8 @@ class MCPRequestHandler:
         if len(allowed_mcp_servers_for_org) == 0:
             return allowed_mcp_servers
         if has_lower_level_mcp_restrictions or keyless_source:
-            # Lower-level restrictions exist, so org can only cap them.
-            #
-            # A keyless admitted source ALWAYS takes this arm: its model is a union of GRANTS, so an
-            # org list may only narrow what a source already grants, never become one. Letting it
-            # substitute would hand every admitted user with an org_id that org's whole server list
-            # without any direct or team grant — a ceiling silently acting as a grant.
+            # Org can only cap lower-level restrictions. A keyless admitted source ALWAYS takes this
+            # arm: its model unions GRANTS, so an org list may only narrow a source, never become one.
             capped = [s for s in allowed_mcp_servers if s in allowed_mcp_servers_for_org]
         else:
             # No lower-level restrictions → org list becomes the ceiling.
@@ -1535,15 +1469,12 @@ class MCPRequestHandler:
     ) -> UserAPIKeyAuth:
         """A plain, UNMARKED auth describing ONE grant source of an admitted subject.
 
-        Only the fields the resolver actually consults are carried. Everything else is left at its
-        default on purpose: ``api_key``/``token`` stay unset (this is not a key), budget, spend and
-        rate-limit fields stay unset because the admitted subject's own user-level limits are what
-        the request is metered against and cloning them per source would show the limiter N copies of
-        the same descriptor, and ``user_role`` stays unset because an admin role would grant every
-        server if this auth ever reached the server-manager wrapper. The admission marker cannot be
-        set through the constructor at all (a before-validator pops it), so each source is resolved
-        as an ordinary caller and cannot re-enter the admitted path.
-        """
+        Only the fields the resolver consults are carried; everything else is left at its default on
+        purpose: no ``api_key``/``token`` (not a key), no budget/spend/rate-limit (the subject's own
+        user-level limits meter the request, and per-source copies would double descriptors), no
+        ``user_role`` (an admin role would grant every server at the server-manager wrapper). The
+        admission marker cannot be set via the constructor (a before-validator pops it), so each source
+        resolves as an ordinary caller and cannot re-enter the admitted path."""
         scoped = UserAPIKeyAuth(
             user_id=auth.user_id,
             team_id=team_id,
@@ -1551,9 +1482,8 @@ class MCPRequestHandler:
             parent_otel_span=auth.parent_otel_span,
         )
         if carry_user_grants:
-            # The user's OWN grants. A team source deliberately carries none of these: the resolver
-            # loads that team's object_permission and access groups from team_id itself, and mixing
-            # the user's in would widen the team source with grants the team never made.
+            # The user's OWN grants. A team source carries none of these (the resolver loads the team's
+            # own object_permission from team_id); mixing them in would widen the team with grants it never made.
             scoped.object_permission = auth.object_permission
             scoped.object_permission_id = auth.object_permission_id
             scoped.access_group_ids = auth.access_group_ids
@@ -1564,17 +1494,11 @@ class MCPRequestHandler:
         """The independent sources a keyless admitted subject reaches MCP servers through: their own
         direct grants, plus every team they are a live roster member of.
 
-        Each team source carries that TEAM's org as its ``org_id``, which is what makes the canonical
-        resolver apply the team's OWN owning-org ceiling to it — a cross-org user's teams are each
-        bounded by their own org rather than by the caller's home org. A team with no organization
-        falls back to the user's org so it is bounded rather than unbounded.
-
-        Roster membership is checked HERE because it is a property of the source list, not of any one
-        resolution: a key is structurally pinned to a team it belongs to, while a user's cached
-        ``teams`` array can name a team whose ``members_with_roles`` no longer contains them (SCIM
-        group sync, or cache lag after a team_member_delete), and JWT auth can rewrite that array
-        outright. The roster is the source of truth for revocation.
-        """
+        Each team source carries that TEAM's org (falling back to the user's), so the canonical resolver
+        applies the team's OWN owning-org ceiling — a cross-org user's teams are each bounded by their
+        own org, not the caller's home org. Roster membership is checked HERE (not per resolution)
+        because a user's cached ``teams`` array can name a team whose ``members_with_roles`` no longer
+        lists them; the roster is the source of truth for revocation."""
         from litellm.proxy.proxy_server import prisma_client
 
         sources = [
@@ -1622,11 +1546,9 @@ class MCPRequestHandler:
                 proxy_logging_obj=proxy_logging_obj,
             )
         except Exception as e:  # noqa: BLE001  # per-source isolation: one team's blip must not deny the others
-            # The unit of fault isolation is the SOURCE: a team that cannot be resolved contributes
-            # nothing this request (fail closed for that team alone — access only ever narrows),
-            # while the user's own grants and every other resolvable team stand. Raising here
-            # instead would collapse the whole union to deny-all because one team's row was
-            # momentarily unreadable, on the servers, tools and throttle axes alike.
+            # Fault isolation is per SOURCE: an unresolvable team contributes nothing (fail closed for
+            # it alone, access only narrows) while every other source stands. Raising would collapse the
+            # whole union to deny-all over one momentarily-unreadable row.
             verbose_logger.warning(f"MCP admitted-subject source team {team_id!r} unresolvable, skipping: {str(e)}")
             return None
         if team_obj is None:
@@ -1634,14 +1556,11 @@ class MCPRequestHandler:
         member_user_ids = {getattr(m, "user_id", None) for m in (team_obj.members_with_roles or [])} - {None}
         if auth.user_id not in member_user_ids:
             return None
-        # A team over its own max budget — or owned by an org over ITS budget — is not a live
-        # grantor, exactly as it is not for a virtual key pinned to it (common_checks rejects that
-        # key outright). Enforced with the SAME owners the key path uses (_team_max_budget_check /
-        # _organization_max_budget_check, cross-pod Redis-first spend), targeted at the TEAM's org
-        # via the scoped source view, so a cross-org team is judged by its own org's budget. This is
-        # budget ENFORCEMENT of an already-exceeded state; ATTRIBUTION of new spend stays with the
-        # user (documented deferral) — the two are different questions. Sitting here, no consumer of
-        # the source list (servers, tools, throttle stamping) can ever see an over-budget team.
+        # A team (or its owning org) over budget is not a live grantor, exactly as it is not for a key
+        # pinned to it. Enforced via the SAME owners the key path uses (_team_max_budget_check /
+        # _organization_max_budget_check), targeted at the TEAM's org through the scoped source view, so
+        # no consumer of the source list ever sees an over-budget team. This is ENFORCEMENT of an
+        # already-exceeded state; ATTRIBUTION of new spend stays with the user (documented deferral).
         from litellm.exceptions import BudgetExceededError
         from litellm.proxy.auth.auth_checks import (
             _organization_max_budget_check,
@@ -1696,16 +1615,11 @@ class MCPRequestHandler:
     async def billing_auth_for_tool_call(auth: UserAPIKeyAuth, tool_name: str) -> UserAPIKeyAuth:
         """The auth object a tool call's SPEND should be recorded against.
 
-        Returns ``auth`` unchanged for every caller that is not a keyless admitted subject, so key
-        and JWT billing is byte-identical. For an admitted subject whose call is reached through a
-        team's grant, returns a copy carrying that team's ``team_id`` and its owning ``org_id`` so
-        the team's budget accumulates and the correct organization is charged.
-
-        Inert rather than wrong when the target server cannot be resolved from the tool name (a
-        display-name override, or a REST caller passing server_id with an unprefixed name): billing
-        then falls back to today's user-level attribution instead of guessing a team. Resolution
-        reuses the manager's own tool-name lookup rather than re-deriving prefix rules that live
-        there."""
+        ``auth`` unchanged for any non-admitted caller (key/JWT billing byte-identical). For an admitted
+        subject whose call is reached through a team's grant, a copy carrying that team's ``team_id`` and
+        owning ``org_id`` so the team's budget accumulates and the right org is charged. Falls back to
+        user-level attribution (rather than guessing a team) when the tool name does not resolve to a
+        server, reusing the manager's own tool-name lookup."""
         if not _is_mcp_admitted_user_subject(auth):
             return auth
         try:
@@ -1733,19 +1647,14 @@ class MCPRequestHandler:
         server_id: str,
         source_grants: list[tuple[UserAPIKeyAuth, set[str]]] | None = None,
     ) -> UserAPIKeyAuth | None:
-        """The source a billable call to ``server_id`` is attributed to, or None to bill the caller
-        as themselves (their own grant reaches it, or nothing does).
+        """The source a billable call to ``server_id`` is attributed to, or None to bill the caller as
+        themselves (their own grant reaches it, or nothing does).
 
-        A keyless admitted subject carries no ``team_id``, so downstream spend skipped team updates
-        entirely and charged the user's PRIMARY org — a team-derived call neither accumulated its
-        team's budget (so that budget could never begin to block) nor charged the org that owns the
-        granting team. Attribution restores both.
-
-        The rule: a user's OWN grant is not "through a team", so it bills the user. Otherwise the
-        call is billed to a granting team — deterministically the lowest ``team_id`` when several
-        grant the same server, so the choice is stable, reproducible and auditable rather than
-        dependent on dict ordering. Reads the one grant owner, so the team that gets billed is
-        always a team that actually granted the server."""
+        The rule: a user's OWN grant is not "through a team", so it bills the user; otherwise the call
+        bills a granting team, deterministically the lowest ``team_id`` when several grant the server so
+        the pick is stable rather than dict-ordering-dependent. Reads the one grant owner, so the billed
+        team is always one that actually granted the server (restoring the team budget accrual and
+        owning-org charge that a keyless, team_id-less subject otherwise skipped)."""
         source_grants = source_grants or await MCPRequestHandler.admitted_source_grants(auth)
         granting = [(source, granted) for source, granted in source_grants if server_id in granted]
         if not granting:
@@ -1768,14 +1677,10 @@ class MCPRequestHandler:
             global_mcp_server_manager,
         )
 
-        # An OPEN channel (operator-opened allow_all_keys, the user's own BYOM submission) makes the
-        # server REACHABLE through the user themselves — no grant source names it, so without this
-        # the union below would return [] and leave it listable but uninvokable. Reachability is ALL
-        # it confers: it is not a waiver of the ceilings that bound the server. The user's own
-        # mcp_tool_permissions and their org's tool ceiling still bind, which is what a virtual key
-        # on the same allow_all server gets (its key_tools and _apply_agent_and_org_tool_ceilings
-        # both run). Returning None here instead skipped both and let a session holder invoke tools
-        # their own or their org's policy excludes.
+        # An OPEN channel (allow_all_keys, the user's own BYOM) makes the server REACHABLE through the
+        # user, though no grant source names it — without this the union returns [], listable but
+        # uninvokable. Reachability is ALL it confers, NOT a ceiling waiver: the user's own
+        # mcp_tool_permissions and org tool ceiling still bind, exactly as a key's do on an allow_all server.
         reachable_via_open_channel = server_id in await global_mcp_server_manager.operator_open_server_ids(auth)
 
         allowed: set[str] = set()
@@ -1867,12 +1772,9 @@ class MCPRequestHandler:
             return None
 
         try:
-            # FIRST statement, mirroring get_allowed_mcp_servers: a keyless admitted subject is
-            # resolved per grant source and shares NOTHING with the single-credential prelude below.
-            # Ordering is the invariant, not a nicety — when this branch sat after the prelude, a
-            # fault in a lookup the subject never uses (its own mcp_toolsets, its team_obj_perm) hit
-            # the fail-closed handler and denied tools its teams did grant. Nothing that resolves a
-            # single credential's scope may run before this line.
+            # FIRST statement, mirroring get_allowed_mcp_servers: a keyless admitted subject resolves per
+            # source and shares nothing with the single-credential prelude below. Ordering is the invariant:
+            # sat after the prelude, a fault in a lookup the subject never uses denied tools its teams grant.
             if _is_mcp_admitted_user_subject(user_api_key_auth):
                 return await MCPRequestHandler._resolve_admitted_subject_tools(server_id, user_api_key_auth)
 
@@ -1917,9 +1819,6 @@ class MCPRequestHandler:
                 else None
             )
 
-            # A keyless gateway/bridge-admitted user has no single team_id, so team_obj_perm above is
-            # None and the single-team lookup yields allow-all — silently dropping every team's
-            # per-server tool exclusions. Resolve it as the union over the sources that grant the
             # Apply same inheritance logic as get_allowed_mcp_servers
             if team_tools:
                 if key_tools:
@@ -1938,15 +1837,10 @@ class MCPRequestHandler:
 
         except Exception as e:
             verbose_logger.warning(f"Failed to get allowed tools for server: {str(e)}")
-            # Fail CLOSED for a keyless admitted subject: ANY error resolving the tool allowlist
-            # (multi-team fan-out, org/agent lookups) must deny the server's tools ([]) for this
-            # request rather than collapse to allow-all (None), mirroring the fail-closed server
-            # path. Key/JWT auth keeps its prior allow-all-on-error behavior.
-            #
-            # keyless_source matters as much as the marker: each source of an admitted subject is
-            # resolved through an UNMARKED auth, so without it a fault under a source returned None,
-            # and None wins the union as allow-all — dropping every team and org tool ceiling on a
-            # blip. The marker alone only covers a fault raised before the fan-out.
+            # Fail CLOSED for a keyless admitted subject: ANY error must deny the server's tools ([]),
+            # not collapse to allow-all (None); key/JWT auth keeps its prior allow-all-on-error. Both
+            # keyless_source AND the marker are needed: each source resolves through an UNMARKED auth, so
+            # without keyless_source a fault under a source returns None and wins the union as allow-all.
             return [] if (keyless_source or _is_mcp_admitted_user_subject(user_api_key_auth)) else None
 
     @staticmethod
@@ -1957,16 +1851,12 @@ class MCPRequestHandler:
         keyless_source: bool = False,
     ) -> list[str] | None:
         """Narrow a key/team tool allowlist by the agent's tool permissions and the caller's org tool
-        ceiling. Each level only ever intersects, and None at a level means "no restriction from this
-        level".
+        ceiling. Each level only intersects; None at a level means no restriction from it.
 
-        An UNRESOLVABLE org ceiling (``_get_org_object_permission`` raises: the org names a permission
-        that cannot be loaded) is decided here, per caller shape, mirroring the servers axis: a
-        virtual key keeps its long-standing fail-open — the org step is skipped and the key/team/agent
-        restrictions already computed STAND (letting the raise escape would collapse them to
-        allow-all, which is fail-open WIDER than before the fault). A keyless admitted source
-        re-raises, and the outer handler denies tools for that one source while the subject's other
-        sources stand — its only org bound is this ceiling, so skipping it would widen access."""
+        An UNRESOLVABLE org ceiling is decided per caller shape, mirroring the servers axis: a key stays
+        fail-open (skip the org step, keep the key/team/agent restrictions; letting the raise escape
+        would collapse them to allow-all, WIDER than before the fault), while a keyless source re-raises
+        so the outer handler denies that one source (its only org bound is this ceiling)."""
         from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
             global_mcp_server_manager,
         )
@@ -2346,9 +2236,8 @@ class MCPRequestHandler:
             verbose_logger.debug("prisma_client is None")
             return None
 
-        # An ABSENT org is a determinate fact, not a failure: a team's organization_id can point at a
-        # row that was deleted or has not synced yet, and get_org_object raises for that. It places no
-        # ceiling, exactly as a key with a dangling org_id is not locked out.
+        # A team's organization_id can point at a deleted or not-yet-synced row; get_org_object raises
+        # OrganizationNotFoundError for that. That is a determinate ABSENCE (no ceiling), handled below.
         try:
             org_obj = await get_org_object(
                 org_id=user_api_key_auth.org_id,
@@ -2358,20 +2247,17 @@ class MCPRequestHandler:
                 proxy_logging_obj=proxy_logging_obj,
             )
         except OrganizationNotFoundError as e:
-            # CONFIRMED absent (deleted org, not-yet-synced organization_id): a determinate fact, so
-            # it places no ceiling. Every OTHER exception is an operational failure and propagates —
-            # caught upstream as an unresolvable ceiling, which denies for a keyless source and stays
-            # fail-open for a key. Catching bare Exception here treated a DB outage as "no org", which
-            # silently dropped a real org's ceiling for exactly as long as the outage lasted.
+            # CONFIRMED absent: places no ceiling. Every OTHER exception propagates as an unresolvable
+            # ceiling (denies for a keyless source, fail-open for a key); catching bare Exception here
+            # would treat a DB outage as "no org" and silently drop a real ceiling for its duration.
             verbose_logger.debug(f"MCP org ceiling: org {user_api_key_auth.org_id!r} does not exist: {e}")
             return None
 
         if org_obj is None or not org_obj.object_permission_id:
             return None
 
-        # From here the org NAMES a permission. Failing to read it is INDETERMINATE, so it must not
-        # collapse into the same None that means "no ceiling" -- that is what would silently drop a
-        # real ceiling on a transient fault. Raise and let each caller pick fail-open or fail-closed.
+        # The org NAMES a permission; failing to read it is INDETERMINATE and must not collapse into the
+        # None that means "no ceiling". Raise and let each caller pick fail-open or fail-closed.
         object_permission = await get_object_permission(
             object_permission_id=org_obj.object_permission_id,
             prisma_client=prisma_client,
@@ -2420,9 +2306,8 @@ class MCPRequestHandler:
             all_servers = direct_mcp_servers + access_group_servers + tool_perm_servers
             return list(set(all_servers))
         except Exception as e:
-            # None = the org ceiling could NOT be resolved, which is not the same fact as [] = the
-            # org places no restriction. Collapsing the two is what let a transient DB fault silently
-            # remove an org's ceiling; the caller picks fail-open or fail-closed from this signal.
+            # None = ceiling UNRESOLVED, distinct from [] = org places no restriction. Collapsing them
+            # let a DB fault silently drop a ceiling; the caller picks fail-open/closed from this signal.
             verbose_logger.warning(f"Failed to get allowed MCP servers for org: {str(e)}")
             return None
 

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -25,6 +25,9 @@ from litellm.proxy._experimental.mcp_server.outbound_credentials.bridge_credenti
 from litellm.proxy._experimental.mcp_server.outbound_credentials.envelope import (
     EnvelopeIdentity,
 )
+from litellm.proxy._experimental.mcp_server.outbound_credentials.session_credentials import (
+    is_session_bearer_shaped,
+)
 from litellm.proxy._types import (
     UI_TEAM_ID,
     LiteLLM_TeamTable,
@@ -124,6 +127,29 @@ def _has_client_supplied_mcp_auth(
     return bool(mcp_auth_header) or bool(mcp_server_auth_headers)
 
 
+def _is_mcp_admitted_user_subject(user_api_key_auth: UserAPIKeyAuth | None) -> bool:
+    """True when this auth is a keyless subject admitted by the gateway session / bridge user
+    path, as opposed to a JWT or other keyless auth that merely lacks a ``team_id``.
+
+    Reads the server-only ``UserAPIKeyAuth.mcp_admitted_user_subject`` field, set exclusively by
+    ``_reload_admitted_user`` at admission. It is deliberately NOT a ``metadata`` key: virtual-key
+    metadata is caller-controlled at key creation, so a metadata marker could be forged on a
+    personal key to gain the team-inherited grant union or to dodge the caller-Authorization
+    egress scrub. This field cannot be set from caller input."""
+    return user_api_key_auth is not None and user_api_key_auth.mcp_admitted_user_subject is True
+
+
+def _is_aggregate_mcp_scope(route: str, mcp_servers: list[str] | None) -> bool:
+    """True when a request targets the aggregate ``/mcp`` endpoint rather than any named
+    server. Named targets arrive either through ``x-mcp-servers`` (``mcp_servers``) or a
+    path segment (``/mcp/{server}`` / ``/{server}/mcp``); the aggregate scope has neither.
+    The gateway-DCR session arm and challenge fire only here, so a per-server flow is never
+    affected."""
+    if mcp_servers:
+        return False
+    return len(MCPRequestHandler._extract_target_server_names_from_path(route)) == 0
+
+
 def _is_aggregate_gateway_dcr_challenge_scope(
     route: str,
     mcp_servers: list[str] | None,
@@ -141,11 +167,9 @@ def _is_aggregate_gateway_dcr_challenge_scope(
     client. Fails closed to the original admission error otherwise."""
     if not _is_litellm_auth_admission_error(exc):
         return False
-    if mcp_servers:
-        return False
     if _has_client_supplied_mcp_auth(mcp_auth_header, mcp_server_auth_headers):
         return False
-    return len(MCPRequestHandler._extract_target_server_names_from_path(route)) == 0
+    return _is_aggregate_mcp_scope(route, mcp_servers)
 
 
 def _aggregate_gateway_dcr_challenge(request: Request, invalid_token: bool) -> HTTPException:
@@ -362,6 +386,21 @@ class MCPRequestHandler:
                 request=request,
                 route=request_route,
             )
+        elif (
+            _is_aggregate_mcp_scope(request_route, mcp_servers)
+            and oauth2_headers
+            and is_session_bearer_shaped(oauth2_headers["Authorization"])
+        ):
+            # A gateway DCR session bearer at the aggregate /mcp scope: open the
+            # identity-only session token and admit under the live litellm user it
+            # references. A session-shaped bearer that does not open fails closed with
+            # the aggregate invalid_token challenge; a non-session bearer never reaches
+            # here (is_session_bearer_shaped is false) and falls through to the oauth2 arm.
+            validated_user_api_key_auth = await MCPRequestHandler._admit_gateway_session(
+                authorization_value=oauth2_headers["Authorization"],
+                request=request,
+                route=request_route,
+            )
         elif oauth2_headers:
             # Authorization on a non-delegated server: the bearer must be a real
             # LiteLLM credential, so a failed validation is a genuine 401/403 and
@@ -392,14 +431,86 @@ class MCPRequestHandler:
                     bearer_presented=False,
                 )
 
+        # Leak-defense (single chokepoint): a gateway admission credential — the session bearer or the
+        # bridge envelope — is NEVER a valid upstream MCP token. Scrub it from EVERY egress header context
+        # (top-level Authorization, the deprecated `x-mcp-auth`, and per-server `x-mcp-{alias}-authorization`)
+        # so no client-forwarded, OBO-subject, or passthrough path can send it upstream, where a hostile
+        # server could capture and replay it against the aggregate endpoint as this user. Anchored to the
+        # credential SHAPE, so a legitimate upstream/passthrough token (never session- or envelope-shaped)
+        # is forwarded unchanged; per-server vaulted credentials (resolved at egress) are unaffected.
+        raw_headers = dict(headers)
+        (
+            oauth2_headers,
+            raw_headers,
+            mcp_auth_header,
+            mcp_server_auth_headers,
+        ) = MCPRequestHandler._scrub_gateway_admission_credentials(
+            admitted=_is_mcp_admitted_user_subject(validated_user_api_key_auth),
+            oauth2_headers=oauth2_headers,
+            raw_headers=raw_headers,
+            mcp_auth_header=mcp_auth_header,
+            mcp_server_auth_headers=mcp_server_auth_headers,
+        )
+
         return (
             validated_user_api_key_auth,
             mcp_auth_header,
             mcp_servers,
             mcp_server_auth_headers,
             oauth2_headers,
-            dict(headers),
+            raw_headers,
         )
+
+    @staticmethod
+    def _is_gateway_admission_credential(value: str | None) -> bool:
+        """True when a header value is a gateway admission credential — a session bearer (``llm_session_`` /
+        ``llm_srefresh_``) or a bridge envelope. Such a value proves who signed in to the GATEWAY; it is
+        never a valid credential for an UPSTREAM MCP server, so it must never be forwarded, where a hostile
+        upstream could capture and replay it against the aggregate ``/mcp`` endpoint as this user."""
+        return value is not None and (is_session_bearer_shaped(value) or is_bridge_envelope_shaped(value))
+
+    @staticmethod
+    def _scrub_gateway_admission_credentials(
+        admitted: bool,
+        oauth2_headers: dict[str, str] | None,
+        raw_headers: dict[str, str],
+        mcp_auth_header: str | None,
+        mcp_server_auth_headers: dict[str, dict[str, str]] | None,
+    ) -> tuple[dict[str, str] | None, dict[str, str], str | None, dict[str, dict[str, str]] | None]:
+        """Remove any gateway admission credential from EVERY egress header context, keyed on the credential
+        SHAPE: the top-level ``Authorization`` (``oauth2_headers`` + ``raw_headers``), the deprecated
+        ``x-mcp-auth`` (``mcp_auth_header``), and per-server ``x-mcp-{alias}-authorization``
+        (``mcp_server_auth_headers``). A legitimate upstream/passthrough token is never session- or
+        envelope-shaped, so it is forwarded unchanged; the per-server token the bridge arm injects is the
+        real upstream credential (also not gateway-shaped), so it survives. An admitted subject's top-level
+        Authorization IS the admission bearer, so it is dropped unconditionally as defense-in-depth even
+        though it is already gateway-shaped."""
+        cred = MCPRequestHandler._is_gateway_admission_credential
+
+        # 1. Top-level Authorization → oauth2_headers.
+        authz = oauth2_headers.get("Authorization") if oauth2_headers else None
+        if admitted or cred(authz):
+            oauth2_headers = None
+
+        # 2. raw_headers: drop the admitted subject's Authorization, and ANY header whose value is a
+        #    gateway credential (covers x-mcp-auth and x-mcp-{alias}-authorization in their raw form).
+        raw_headers = {
+            k: v for k, v in raw_headers.items() if not ((admitted and k.lower() == "authorization") or cred(v))
+        }
+
+        # 3. Deprecated x-mcp-auth value.
+        if cred(mcp_auth_header):
+            mcp_auth_header = None
+
+        # 4. Per-server x-mcp-{alias}-authorization values (drop the value, then any now-empty server dict).
+        if mcp_server_auth_headers:
+            stripped = {
+                alias: {h: val for h, val in hdrs.items() if not cred(val)}
+                for alias, hdrs in mcp_server_auth_headers.items()
+            }
+            mcp_server_auth_headers = {alias: hdrs for alias, hdrs in stripped.items() if hdrs}
+
+        return oauth2_headers, raw_headers, mcp_auth_header, mcp_server_auth_headers
 
     @staticmethod
     def _extract_target_server_names_from_path(path: str) -> List[str]:
@@ -627,6 +738,71 @@ class MCPRequestHandler:
                 assert_never(result)
 
     @staticmethod
+    async def _admit_gateway_session(
+        authorization_value: str,
+        request: Request,
+        route: str,
+    ) -> UserAPIKeyAuth:
+        """Open a gateway DCR session bearer and admit the live litellm user it references.
+
+        The custody sibling of :meth:`_admit_dcr_bridge_delegate`: the session token seals
+        no upstream credential (those are vaulted per user and resolved at egress), so this
+        admits identity only and injects no per-server header. The token's signature proves
+        the user signed in when it was minted, but authorization is resolved fresh here, the
+        sealed ``user_id`` reloads the current user record through the SAME
+        :meth:`_reload_admitted_user` the bridge user-subject path uses, and the admitted
+        identity runs through the centralized policy gate, so the user's present team, org,
+        budget, and SCIM state gate the request rather than a snapshot frozen at mint time.
+
+        Fails closed with the aggregate ``invalid_token`` challenge on an expired, tampered,
+        or foreign token, on a refresh token presented at the tool edge, and when the
+        referenced user is missing, deactivated, or rejected by the policy gate. The
+        pre-DB gates (size, IP, route allowlist) run first, mirroring the bridge arm and the
+        standard pipeline, so a caller blocked by IP or route is turned away before any
+        crypto or DB read."""
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.session_credentials import (
+            NotSessionBearer,
+            SessionBearerAdmitted,
+            SessionBearerInvalid,
+            resolve_session_bearer,
+            session_keys_from_master_key,
+        )
+        from litellm.proxy.proxy_server import master_key
+
+        if not master_key:
+            raise HTTPException(status_code=500, detail="Server misconfigured: master_key is not set")
+
+        await MCPRequestHandler._run_pre_db_read_auth_checks(request=request, route=route)
+
+        keys = session_keys_from_master_key(master_key)
+        result = resolve_session_bearer(authorization_value, keys, datetime.now(timezone.utc))
+        match result:
+            case SessionBearerAdmitted():
+                try:
+                    admitted = await MCPRequestHandler._reload_admitted_user(result.principal.user_id)
+                    await MCPRequestHandler._enforce_admitted_live_policy(
+                        admitted=admitted, request=request, route=route
+                    )
+                except HTTPException as exc:
+                    # A cryptographically valid bearer whose referenced user is now missing or
+                    # SCIM-deactivated is an invalid_token at the aggregate scope: relay the RFC 9728
+                    # challenge so the DCR client re-authorizes, matching the SessionBearerInvalid
+                    # arm, instead of a bare 401 with no WWW-Authenticate. A 503 (DB outage) is a
+                    # transient availability failure, not an auth failure, so it passes through.
+                    if exc.status_code == 401:
+                        raise _aggregate_gateway_dcr_challenge(request, invalid_token=True) from exc
+                    raise
+                return admitted
+            case SessionBearerInvalid():
+                raise _aggregate_gateway_dcr_challenge(request, invalid_token=True)
+            case NotSessionBearer():
+                # Unreachable: the arm is entered only for an is_session_bearer_shaped
+                # value. Kept for match exhaustiveness and fails closed regardless.
+                raise _aggregate_gateway_dcr_challenge(request, invalid_token=True)
+            case _:
+                assert_never(result)
+
+    @staticmethod
     async def _run_pre_db_read_auth_checks(request: Request, route: str) -> None:
         """Run the proxy-wide gates ``user_api_key_auth`` applies before any key lookup: the
         request-size and body-safety limits, the IP allowlist, and the ``general_settings``
@@ -671,14 +847,18 @@ class MCPRequestHandler:
 
         The DCR client authenticates via SSO at the bridged authorize, which yields a user
         subject rather than a virtual key, so the envelope admits under the user's own
-        identity: the reloaded ``user_id`` and the user's own MCP object permission ride on the
-        returned ``UserAPIKeyAuth``, and the SAME ``get_allowed_mcp_servers`` the key path uses then
-        computes which servers the user may reach, so the user's litellm MCP grants and access groups
-        gate the request exactly as a key's do. Only the user's OWN object permission is bound: a
-        ``UserAPIKeyAuth`` carries a single ``team_id`` while a user may belong to many teams, so
-        team-inherited MCP grants for a user are a follow-up (they need a many-teams union
-        ``get_allowed_mcp_servers`` does not do off one auth object). The caller's centralized policy
-        gate enforces the user's live budget and org state, and a SCIM-deactivated owner fails closed.
+        identity: the reloaded ``user_id``, the user's own MCP object permission, and the user's
+        ``org_id`` ride on the returned ``UserAPIKeyAuth``, and the SAME ``get_allowed_mcp_servers``
+        the key path uses then computes which servers the user may reach, so the user's litellm MCP
+        grants and access groups gate the request exactly as a key's do. Because the returned auth is
+        stamped ``mcp_admitted_user_subject`` (below), ``get_allowed_mcp_servers`` unions the servers the
+        user reaches through ANY of their teams on top of these direct grants — a ``UserAPIKeyAuth``
+        pins one ``team_id`` but a user belongs to many, so the team fan-out happens off the marker, not
+        the single ``team_id``. Each source is bounded by ITS OWN org: the user's direct grants by the
+        bound ``org_id`` (their primary org), and each team's grant by that team's owning org inside
+        ``_allowed_mcp_servers_for_single_team`` — so a user who spans organizations does not leak one
+        org's servers past another org's ceiling. The caller's centralized policy gate enforces the
+        user's live budget and org state, and a SCIM-deactivated owner fails closed.
 
         Error handling mirrors the key path's retryable-503 contract, but ``get_user_object`` defeats a
         type-based check: where ``get_key_object`` raises a typed ``ProxyException`` for a missing key
@@ -721,12 +901,92 @@ class MCPRequestHandler:
             raise HTTPException(status_code=401, detail="Invalid or expired credential")
         if isinstance(user_object.metadata, dict) and user_object.metadata.get("scim_active") is False:
             raise HTTPException(status_code=401, detail="Invalid or expired credential")
-        return UserAPIKeyAuth(
+        admitted = UserAPIKeyAuth(
             user_id=user_object.user_id,
             user_role=user_object.user_role,
+            org_id=user_object.organization_id,
             object_permission=object_permission,
             object_permission_id=user_object.object_permission_id,
+            # Copy the live user's rate limits, exactly as the standard user-subject auth path does
+            # (user_api_key_auth.py). The parallel limiter reads these off the auth object rather than
+            # re-fetching, and treats None as sys.maxsize (unlimited), so a keyless admitted user with
+            # them unset would invoke tools past their configured user RPM/TPM.
+            #
+            # Rate-limit model for the keyless admitted subject: bounded by their USER rpm/tpm
+            # (copied here; those descriptors key off user_id, which is set) AND by the per-server
+            # mcp_rpm_limit of EVERY team it reaches servers through, stamped below. Per-KEY MCP
+            # limits genuinely do not apply, because there is no key.
+            user_tpm_limit=user_object.tpm_limit,
+            user_rpm_limit=user_object.rpm_limit,
         )
+        # Set the server-only admission marker AFTER construction: the before-validator strips it
+        # from any validated input, so a post-construction assignment is the only way to set it, and
+        # caller-supplied data (key metadata, JWT claims) can never forge it.
+        admitted.mcp_admitted_user_subject = True
+        # Carry each granting team's per-server MCP rpm limit. A key is pinned to one team so the
+        # limiter reads team_metadata directly; this subject reaches servers through several teams
+        # under its own identity, so without this the team ceiling silently does not apply to it and
+        # a cross-team user outruns every team's mcp_rpm_limit. Resolved from the same roster-checked
+        # sources the grant union uses, so a team can only throttle what it actually granted.
+        admitted.mcp_source_team_rpm_limits = await MCPRequestHandler._admitted_subject_team_rpm_limits(admitted)
+        return admitted
+
+    @staticmethod
+    async def _admitted_subject_team_rpm_limits(auth: UserAPIKeyAuth) -> dict[str, dict[str, int]] | None:
+        """``team_id -> mcp_rpm_limit`` for every team this subject reaches servers through, with each
+        team's map filtered to the servers THAT team's grant actually reaches.
+
+        A limit rides the same scope as the access it bounds: a team's throttle exists to cap usage of
+        the access the team granted, so a roster team whose grant does not reach a server (not granted,
+        blocked, org-forbidden, opted out) must not be charged when the user reaches that server
+        through a DIFFERENT team — otherwise this user's calls drain a bucket shared by that team's own
+        keys for access the team never provided. The grant scope comes from the SAME
+        ``get_allowed_mcp_servers(source)`` call authorization uses, so the throttle scope cannot
+        diverge from the access scope. Limit maps are keyed by server name/alias (the limiter matches
+        on the called server's name) while grants are ids, so each key is resolved through
+        ``expand_permission_list`` — the one existing name->id owner — before the membership check.
+
+        Returns None when no team contributes an applicable limit, so the limiter adds no descriptors
+        rather than empty ones. A lookup failure narrows to None rather than raising: rate limiting
+        must not be able to deny a request that authorization already allowed, and the user's own
+        rpm/tpm still bounds them."""
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+
+        try:
+            limits: dict[str, dict[str, int]] = {}
+            source_grants = await MCPRequestHandler.admitted_source_grants(auth)
+            for source, granted_ids in source_grants:
+                if not source.team_id:
+                    continue
+                team_obj = await MCPRequestHandler._roster_team_object(source.team_id, auth)
+                team_limit = (team_obj.metadata or {}).get("mcp_rpm_limit") if team_obj is not None else None
+                if not isinstance(team_limit, dict) or not team_limit:
+                    continue
+                applicable: dict[str, int] = {}
+                for server_name, rpm in team_limit.items():
+                    for server_id in global_mcp_server_manager.expand_permission_list([server_name]):
+                        if server_id not in granted_ids:
+                            continue
+                        # Charge ONLY the source the call is attributed to — the same single source
+                        # billing picks, from the same owner. Adding a descriptor for every granting
+                        # team let one cross-team user drain several teams' SHARED buckets at once,
+                        # blocking their other members for access those teams did not provide on
+                        # this call; and when the user's OWN grant reaches the server, no team
+                        # provided it, so no team bucket is charged at all.
+                        attributed = await MCPRequestHandler.attributing_source_for_server(
+                            auth, server_id, source_grants=source_grants
+                        )
+                        if attributed is not None and attributed.team_id == source.team_id:
+                            applicable[server_name] = rpm
+                            break
+                if applicable:
+                    limits[source.team_id] = applicable
+            return limits or None
+        except Exception as e:  # noqa: BLE001  # throttling metadata must never fail an allowed request
+            verbose_logger.warning(f"Failed to resolve per-team MCP rpm limits for admitted subject: {str(e)}")
+            return None
 
     @staticmethod
     async def _reload_admitted_key(key_hash: str) -> UserAPIKeyAuth:
@@ -1075,6 +1335,8 @@ class MCPRequestHandler:
     @staticmethod
     async def get_allowed_mcp_servers(
         user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+        *,
+        keyless_source: bool = False,
     ) -> List[str]:
         """
         Get list of allowed MCP servers for the given user/key based on permissions.
@@ -1096,6 +1358,14 @@ class MCPRequestHandler:
         from litellm.proxy.proxy_server import general_settings
 
         try:
+            # A keyless admitted subject is resolved entirely per source, BEFORE any single-source
+            # rule runs here. Ordering matters: the no_mcp_servers opt-out below reads the caller's
+            # own object_permission, so leaving it above this branch let a user's own opt-out zero
+            # their TEAMS' grants too — the sources are independent, and an opt-out on one of them
+            # must silence only that one (it is applied per source, inside the recursive call).
+            if _is_mcp_admitted_user_subject(user_api_key_auth) and user_api_key_auth is not None:
+                return await MCPRequestHandler._resolve_admitted_subject_servers(user_api_key_auth)
+
             # Get allowed servers from key and team
             allowed_mcp_servers_for_key = await MCPRequestHandler._get_allowed_mcp_servers_for_key(user_api_key_auth)
 
@@ -1125,8 +1395,18 @@ class MCPRequestHandler:
                 # team's by default. With require_key_mcp_access_defined the
                 # team is a ceiling rather than a default, so the key must
                 # grant servers explicitly (or via an access group) to reach
-                # any — it inherits none.
-                base = set() if general_settings.get("require_key_mcp_access_defined", False) else team_set
+                # any — it inherits none. That ceiling is for VIRTUAL KEYS that
+                # can declare their own access; a keyless gateway/bridge-admitted
+                # user has no key to declare access on — team membership IS their
+                # only access path — so the flag must not zero their team grants.
+                # A keyless admitted subject returned above and never reaches this virtual-key ceiling,
+                # so require_key_mcp_access_defined can only ever zero a real key's inherited team grants.
+                # ``keyless_source`` marks one grant source of an admitted subject, which has no key
+                # to declare access on, so the flag must not zero its team grants.
+                require_key_access = (
+                    general_settings.get("require_key_mcp_access_defined", False) and not keyless_source
+                )
+                base = team_set if not require_key_access else set()
             else:
                 base = key_set & team_set  # both restrict → intersect
 
@@ -1185,23 +1465,330 @@ class MCPRequestHandler:
             #########################################################
             # Apply org-level ceiling if org_id is set
             #########################################################
-            if user_api_key_auth and user_api_key_auth.org_id:
-                allowed_mcp_servers_for_org = await MCPRequestHandler._get_allowed_mcp_servers_for_org(
-                    user_api_key_auth
-                )
-                if len(allowed_mcp_servers_for_org) > 0:
-                    if has_lower_level_mcp_restrictions:
-                        # Lower-level restrictions exist, so org can only cap them.
-                        allowed_mcp_servers = [s for s in allowed_mcp_servers if s in allowed_mcp_servers_for_org]
-                    else:
-                        # No lower-level restrictions → org list becomes the ceiling
-                        allowed_mcp_servers = allowed_mcp_servers_for_org
-                    verbose_logger.debug(f"Applied org ceiling filter. Final allowed servers: {allowed_mcp_servers}")
+            allowed_mcp_servers = await MCPRequestHandler._apply_primary_org_ceiling(
+                allowed_mcp_servers,
+                user_api_key_auth,
+                has_lower_level_mcp_restrictions,
+                keyless_source=keyless_source,
+            )
 
             return list(set(allowed_mcp_servers))
         except Exception as e:
             verbose_logger.warning(f"Failed to get allowed MCP servers: {str(e)}")
             return []
+
+    @staticmethod
+    async def _apply_primary_org_ceiling(
+        allowed_mcp_servers: list[str],
+        user_api_key_auth: UserAPIKeyAuth | None,
+        has_lower_level_mcp_restrictions: bool,
+        keyless_source: bool = False,
+    ) -> list[str]:
+        """Cap the resolved server list by this caller's org ceiling. If the org names an explicit MCP
+        list, lower-level restrictions are intersected with it, else the org list becomes the ceiling.
+        No org, or an empty org list, leaves the result unchanged.
+
+        ``keyless_source`` marks one grant source of a keyless admitted subject and governs BOTH
+        org divergences, because they are the same fact about that caller shape.
+
+        First, what an UNRESOLVABLE ceiling means. A virtual key keeps the
+        long-standing fail-open behavior (a DB blip must not lock working keys out mid-incident). A
+        keyless admitted subject fails CLOSED, because its only org bound is this ceiling: silently
+        dropping it on a transient fault would widen a cross-org user to servers their team's org
+        forbids, which is a privilege escalation rather than an availability blip.
+
+        Second, whether the org list may SUBSTITUTE for absent lower-level grants. For a key it may
+        (that is the key ceiling model). For a source it may only ever intersect, because the
+        admitted model is a union of grants and a ceiling that grants is not a ceiling."""
+        if not (user_api_key_auth and user_api_key_auth.org_id):
+            return allowed_mcp_servers
+        allowed_mcp_servers_for_org = await MCPRequestHandler._get_allowed_mcp_servers_for_org(user_api_key_auth)
+        if allowed_mcp_servers_for_org is None:
+            verbose_logger.warning(
+                f"MCP org ceiling unresolved for org_id={user_api_key_auth.org_id!r}; "
+                f"{'denying (keyless admitted subject)' if keyless_source else 'leaving uncapped (key auth)'}"
+            )
+            return [] if keyless_source else allowed_mcp_servers
+        if len(allowed_mcp_servers_for_org) == 0:
+            return allowed_mcp_servers
+        if has_lower_level_mcp_restrictions or keyless_source:
+            # Lower-level restrictions exist, so org can only cap them.
+            #
+            # A keyless admitted source ALWAYS takes this arm: its model is a union of GRANTS, so an
+            # org list may only narrow what a source already grants, never become one. Letting it
+            # substitute would hand every admitted user with an org_id that org's whole server list
+            # without any direct or team grant — a ceiling silently acting as a grant.
+            capped = [s for s in allowed_mcp_servers if s in allowed_mcp_servers_for_org]
+        else:
+            # No lower-level restrictions → org list becomes the ceiling.
+            capped = allowed_mcp_servers_for_org
+        verbose_logger.debug(f"Applied org ceiling filter. Final allowed servers: {capped}")
+        return capped
+
+    @staticmethod
+    def _scoped_source_auth(
+        auth: UserAPIKeyAuth,
+        *,
+        team_id: str | None,
+        org_id: str | None,
+        carry_user_grants: bool,
+    ) -> UserAPIKeyAuth:
+        """A plain, UNMARKED auth describing ONE grant source of an admitted subject.
+
+        Only the fields the resolver actually consults are carried. Everything else is left at its
+        default on purpose: ``api_key``/``token`` stay unset (this is not a key), budget, spend and
+        rate-limit fields stay unset because the admitted subject's own user-level limits are what
+        the request is metered against and cloning them per source would show the limiter N copies of
+        the same descriptor, and ``user_role`` stays unset because an admin role would grant every
+        server if this auth ever reached the server-manager wrapper. The admission marker cannot be
+        set through the constructor at all (a before-validator pops it), so each source is resolved
+        as an ordinary caller and cannot re-enter the admitted path.
+        """
+        scoped = UserAPIKeyAuth(
+            user_id=auth.user_id,
+            team_id=team_id,
+            org_id=org_id,
+            parent_otel_span=auth.parent_otel_span,
+        )
+        if carry_user_grants:
+            # The user's OWN grants. A team source deliberately carries none of these: the resolver
+            # loads that team's object_permission and access groups from team_id itself, and mixing
+            # the user's in would widen the team source with grants the team never made.
+            scoped.object_permission = auth.object_permission
+            scoped.object_permission_id = auth.object_permission_id
+            scoped.access_group_ids = auth.access_group_ids
+        return scoped
+
+    @staticmethod
+    async def _admitted_subject_sources(auth: UserAPIKeyAuth) -> list[UserAPIKeyAuth]:
+        """The independent sources a keyless admitted subject reaches MCP servers through: their own
+        direct grants, plus every team they are a live roster member of.
+
+        Each team source carries that TEAM's org as its ``org_id``, which is what makes the canonical
+        resolver apply the team's OWN owning-org ceiling to it — a cross-org user's teams are each
+        bounded by their own org rather than by the caller's home org. A team with no organization
+        falls back to the user's org so it is bounded rather than unbounded.
+
+        Roster membership is checked HERE because it is a property of the source list, not of any one
+        resolution: a key is structurally pinned to a team it belongs to, while a user's cached
+        ``teams`` array can name a team whose ``members_with_roles`` no longer contains them (SCIM
+        group sync, or cache lag after a team_member_delete), and JWT auth can rewrite that array
+        outright. The roster is the source of truth for revocation.
+        """
+        from litellm.proxy.proxy_server import prisma_client
+
+        sources = [
+            MCPRequestHandler._scoped_source_auth(auth, team_id=None, org_id=auth.org_id, carry_user_grants=True)
+        ]
+        if not auth.user_id or prisma_client is None:
+            return sources
+        for team_id in await MCPRequestHandler._resolve_user_team_ids(auth.user_id, auth):
+            team_obj = await MCPRequestHandler._roster_team_object(team_id, auth)
+            if team_obj is None:
+                continue
+            sources.append(
+                MCPRequestHandler._scoped_source_auth(
+                    auth,
+                    team_id=team_id,
+                    org_id=team_obj.organization_id or auth.org_id,
+                    carry_user_grants=False,
+                )
+            )
+        return sources
+
+    @staticmethod
+    async def _roster_team_object(team_id: str, auth: UserAPIKeyAuth) -> LiteLLM_TeamTable | None:
+        """The team row for ``team_id``, but ONLY when ``auth``'s user is a live roster member of it.
+
+        The single owner of "is this team really one of this subject's sources", so the grant union
+        and the per-team rate limits cannot disagree about which teams count. A team lingering in the
+        user's cached ``teams`` array whose ``members_with_roles`` no longer lists them returns None
+        here, which is what revokes both its grants and its throttle in one place."""
+        from litellm.proxy.auth.auth_checks import get_team_object
+        from litellm.proxy.proxy_server import (
+            prisma_client,
+            proxy_logging_obj,
+            user_api_key_cache,
+        )
+
+        if prisma_client is None or not auth.user_id:
+            return None
+        try:
+            team_obj: LiteLLM_TeamTable | None = await get_team_object(
+                team_id=team_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                parent_otel_span=auth.parent_otel_span,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+        except Exception as e:  # noqa: BLE001  # per-source isolation: one team's blip must not deny the others
+            # The unit of fault isolation is the SOURCE: a team that cannot be resolved contributes
+            # nothing this request (fail closed for that team alone — access only ever narrows),
+            # while the user's own grants and every other resolvable team stand. Raising here
+            # instead would collapse the whole union to deny-all because one team's row was
+            # momentarily unreadable, on the servers, tools and throttle axes alike.
+            verbose_logger.warning(f"MCP admitted-subject source team {team_id!r} unresolvable, skipping: {str(e)}")
+            return None
+        if team_obj is None:
+            return None
+        member_user_ids = {getattr(m, "user_id", None) for m in (team_obj.members_with_roles or [])} - {None}
+        if auth.user_id not in member_user_ids:
+            return None
+        # A team over its own max budget — or owned by an org over ITS budget — is not a live
+        # grantor, exactly as it is not for a virtual key pinned to it (common_checks rejects that
+        # key outright). Enforced with the SAME owners the key path uses (_team_max_budget_check /
+        # _organization_max_budget_check, cross-pod Redis-first spend), targeted at the TEAM's org
+        # via the scoped source view, so a cross-org team is judged by its own org's budget. This is
+        # budget ENFORCEMENT of an already-exceeded state; ATTRIBUTION of new spend stays with the
+        # user (documented deferral) — the two are different questions. Sitting here, no consumer of
+        # the source list (servers, tools, throttle stamping) can ever see an over-budget team.
+        from litellm.exceptions import BudgetExceededError
+        from litellm.proxy.auth.auth_checks import (
+            _organization_max_budget_check,
+            _team_max_budget_check,
+        )
+
+        source_view = MCPRequestHandler._scoped_source_auth(
+            auth, team_id=team_id, org_id=team_obj.organization_id or auth.org_id, carry_user_grants=False
+        )
+        try:
+            await _team_max_budget_check(
+                team_object=team_obj, valid_token=source_view, proxy_logging_obj=proxy_logging_obj
+            )
+            await _organization_max_budget_check(
+                valid_token=source_view,
+                team_object=team_obj,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+        except BudgetExceededError as e:
+            verbose_logger.info(f"MCP admitted-subject source team {team_id!r} over budget, not a grantor: {str(e)}")
+            return None
+        except Exception as e:  # noqa: BLE001  # per-source isolation: a budget-check fault narrows, never raises
+            verbose_logger.warning(f"MCP budget check failed for source team {team_id!r}, skipping source: {str(e)}")
+            return None
+        return team_obj
+
+    @staticmethod
+    async def admitted_source_grants(auth: UserAPIKeyAuth) -> list[tuple[UserAPIKeyAuth, set[str]]]:
+        """``(source, the servers that source grants)`` for every source of an admitted subject.
+
+        THE owner of "which source reaches which server". The reachable union, the per-team throttle
+        scope, the tool union and billing attribution are all just different reads of this one
+        answer — computing it separately per consumer is how they drift (a throttle map scoped by
+        roster instead of by grant charged unrelated teams' buckets)."""
+        return [
+            (source, set(await MCPRequestHandler.get_allowed_mcp_servers(source, keyless_source=True)))
+            for source in await MCPRequestHandler._admitted_subject_sources(auth)
+        ]
+
+    @staticmethod
+    async def _resolve_admitted_subject_servers(auth: UserAPIKeyAuth) -> list[str]:
+        """Union of what each of the admitted subject's sources reaches, each answered by the
+        canonical resolver so no rule is reimplemented for this caller shape."""
+        reachable: set[str] = set()
+        for _source, granted in await MCPRequestHandler.admitted_source_grants(auth):
+            reachable.update(granted)
+        return list(reachable)
+
+    @staticmethod
+    async def billing_auth_for_tool_call(auth: UserAPIKeyAuth, tool_name: str) -> UserAPIKeyAuth:
+        """The auth object a tool call's SPEND should be recorded against.
+
+        Returns ``auth`` unchanged for every caller that is not a keyless admitted subject, so key
+        and JWT billing is byte-identical. For an admitted subject whose call is reached through a
+        team's grant, returns a copy carrying that team's ``team_id`` and its owning ``org_id`` so
+        the team's budget accumulates and the correct organization is charged.
+
+        Inert rather than wrong when the target server cannot be resolved from the tool name (a
+        display-name override, or a REST caller passing server_id with an unprefixed name): billing
+        then falls back to today's user-level attribution instead of guessing a team. Resolution
+        reuses the manager's own tool-name lookup rather than re-deriving prefix rules that live
+        there."""
+        if not _is_mcp_admitted_user_subject(auth):
+            return auth
+        try:
+            from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+                global_mcp_server_manager,
+            )
+
+            server = global_mcp_server_manager._get_mcp_server_from_tool_name(tool_name)
+            if server is None:
+                return auth
+            source = await MCPRequestHandler.attributing_source_for_server(auth, server.server_id)
+            if source is None or not source.team_id:
+                return auth
+            billed = auth.model_copy()
+            billed.team_id = source.team_id
+            billed.org_id = source.org_id
+            return billed
+        except Exception as e:  # noqa: BLE001  # attribution must never fail an authorized call
+            verbose_logger.warning(f"MCP billing attribution failed for {tool_name!r}, billing the user: {str(e)}")
+            return auth
+
+    @staticmethod
+    async def attributing_source_for_server(
+        auth: UserAPIKeyAuth,
+        server_id: str,
+        source_grants: list[tuple[UserAPIKeyAuth, set[str]]] | None = None,
+    ) -> UserAPIKeyAuth | None:
+        """The source a billable call to ``server_id`` is attributed to, or None to bill the caller
+        as themselves (their own grant reaches it, or nothing does).
+
+        A keyless admitted subject carries no ``team_id``, so downstream spend skipped team updates
+        entirely and charged the user's PRIMARY org — a team-derived call neither accumulated its
+        team's budget (so that budget could never begin to block) nor charged the org that owns the
+        granting team. Attribution restores both.
+
+        The rule: a user's OWN grant is not "through a team", so it bills the user. Otherwise the
+        call is billed to a granting team — deterministically the lowest ``team_id`` when several
+        grant the same server, so the choice is stable, reproducible and auditable rather than
+        dependent on dict ordering. Reads the one grant owner, so the team that gets billed is
+        always a team that actually granted the server."""
+        source_grants = source_grants or await MCPRequestHandler.admitted_source_grants(auth)
+        granting = [(source, granted) for source, granted in source_grants if server_id in granted]
+        if not granting:
+            return None
+        for source, _granted in granting:
+            if source.team_id is None:
+                return None  # the user's own grant reaches it: their spend, their org
+        return min((source for source, _ in granting), key=lambda s: s.team_id or "")
+
+    @staticmethod
+    async def _resolve_admitted_subject_tools(server_id: str, auth: UserAPIKeyAuth) -> list[str] | None:
+        """Effective tool allowlist on ``server_id`` for an admitted subject, as the union over the
+        sources that actually grant that server.
+
+        A source that does not grant the server contributes nothing, so its tool rules cannot leak
+        onto a server reached through a different source. A source that grants the server with no
+        tool restriction means the user can use every tool on it, so allow-all wins the union. When
+        no source grants the server the result is ``[]`` — deny all, fail closed."""
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+
+        # An OPEN channel (operator-opened allow_all_keys, the user's own BYOM submission) makes the
+        # server REACHABLE through the user themselves — no grant source names it, so without this
+        # the union below would return [] and leave it listable but uninvokable. Reachability is ALL
+        # it confers: it is not a waiver of the ceilings that bound the server. The user's own
+        # mcp_tool_permissions and their org's tool ceiling still bind, which is what a virtual key
+        # on the same allow_all server gets (its key_tools and _apply_agent_and_org_tool_ceilings
+        # both run). Returning None here instead skipped both and let a session holder invoke tools
+        # their own or their org's policy excludes.
+        reachable_via_open_channel = server_id in await global_mcp_server_manager.operator_open_server_ids(auth)
+
+        allowed: set[str] = set()
+        for source, granted in await MCPRequestHandler.admitted_source_grants(auth):
+            # The open channel is evaluated against the user's OWN source (team_id is None), so that
+            # source's restrictions apply to it; a team's rules never ride an open-channel server.
+            if server_id not in granted and not (reachable_via_open_channel and source.team_id is None):
+                continue
+            tools = await MCPRequestHandler.get_allowed_tools_for_server(server_id, source, keyless_source=True)
+            if tools is None:
+                return None
+            allowed.update(tools)
+        return sorted(allowed)
 
     @staticmethod
     def _get_key_object_permission(
@@ -1262,6 +1849,8 @@ class MCPRequestHandler:
     async def get_allowed_tools_for_server(
         server_id: str,
         user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+        *,
+        keyless_source: bool = False,
     ) -> Optional[List[str]]:
         """
         Get list of allowed tool names for a specific server based on key/team permissions.
@@ -1278,6 +1867,15 @@ class MCPRequestHandler:
             return None
 
         try:
+            # FIRST statement, mirroring get_allowed_mcp_servers: a keyless admitted subject is
+            # resolved per grant source and shares NOTHING with the single-credential prelude below.
+            # Ordering is the invariant, not a nicety — when this branch sat after the prelude, a
+            # fault in a lookup the subject never uses (its own mcp_toolsets, its team_obj_perm) hit
+            # the fail-closed handler and denied tools its teams did grant. Nothing that resolves a
+            # single credential's scope may run before this line.
+            if _is_mcp_admitted_user_subject(user_api_key_auth):
+                return await MCPRequestHandler._resolve_admitted_subject_tools(server_id, user_api_key_auth)
+
             # Get key and team object permissions (already loaded in main auth flow)
             key_obj_perm = MCPRequestHandler._get_key_object_permission(user_api_key_auth)
             team_obj_perm = await MCPRequestHandler._get_team_object_permission(user_api_key_auth)
@@ -1319,6 +1917,9 @@ class MCPRequestHandler:
                 else None
             )
 
+            # A keyless gateway/bridge-admitted user has no single team_id, so team_obj_perm above is
+            # None and the single-team lookup yields allow-all — silently dropping every team's
+            # per-server tool exclusions. Resolve it as the union over the sources that grant the
             # Apply same inheritance logic as get_allowed_mcp_servers
             if team_tools:
                 if key_tools:
@@ -1331,42 +1932,82 @@ class MCPRequestHandler:
                 # No team restrictions → use key restrictions
                 allowed_tools = cast(List[str], key_tools)
 
-            # Intersect with agent's tool permissions if agent_id is set
-            if user_api_key_auth.agent_id:
-                # Pre-fetch agent object_permission once to avoid duplicate DB query
-                agent_obj_perm = await MCPRequestHandler._get_agent_object_permission(user_api_key_auth)
-                agent_tools = await MCPRequestHandler._get_agent_tool_permissions_for_server(
-                    server_id=server_id,
-                    user_api_key_auth=user_api_key_auth,
-                    agent_object_permission=agent_obj_perm,
-                )
-                if agent_tools is not None:
-                    if allowed_tools is not None:
-                        allowed_tools = list(set(allowed_tools) & set(agent_tools))
-                    else:
-                        allowed_tools = agent_tools
-
-            # Apply org-level tool ceiling if org_id is set
-            if user_api_key_auth.org_id:
-                # _get_org_object_permission uses user_api_key_cache, so this is not a
-                # fresh DB round-trip when get_allowed_mcp_servers was already called.
-                org_obj_perm = await MCPRequestHandler._get_org_object_permission(user_api_key_auth)
-                org_tools = (
-                    global_mcp_server_manager.expand_tool_permissions(org_obj_perm.mcp_tool_permissions).get(server_id)
-                    if org_obj_perm and org_obj_perm.mcp_tool_permissions
-                    else None
-                )
-                if org_tools is not None:
-                    if allowed_tools is not None:
-                        allowed_tools = list(set(allowed_tools) & set(org_tools))
-                    else:
-                        allowed_tools = list(org_tools)
-
-            return allowed_tools
+            return await MCPRequestHandler._apply_agent_and_org_tool_ceilings(
+                allowed_tools, server_id, user_api_key_auth, keyless_source=keyless_source
+            )
 
         except Exception as e:
             verbose_logger.warning(f"Failed to get allowed tools for server: {str(e)}")
-            return None
+            # Fail CLOSED for a keyless admitted subject: ANY error resolving the tool allowlist
+            # (multi-team fan-out, org/agent lookups) must deny the server's tools ([]) for this
+            # request rather than collapse to allow-all (None), mirroring the fail-closed server
+            # path. Key/JWT auth keeps its prior allow-all-on-error behavior.
+            #
+            # keyless_source matters as much as the marker: each source of an admitted subject is
+            # resolved through an UNMARKED auth, so without it a fault under a source returned None,
+            # and None wins the union as allow-all — dropping every team and org tool ceiling on a
+            # blip. The marker alone only covers a fault raised before the fan-out.
+            return [] if (keyless_source or _is_mcp_admitted_user_subject(user_api_key_auth)) else None
+
+    @staticmethod
+    async def _apply_agent_and_org_tool_ceilings(
+        allowed_tools: list[str] | None,
+        server_id: str,
+        user_api_key_auth: UserAPIKeyAuth,
+        keyless_source: bool = False,
+    ) -> list[str] | None:
+        """Narrow a key/team tool allowlist by the agent's tool permissions and the caller's org tool
+        ceiling. Each level only ever intersects, and None at a level means "no restriction from this
+        level".
+
+        An UNRESOLVABLE org ceiling (``_get_org_object_permission`` raises: the org names a permission
+        that cannot be loaded) is decided here, per caller shape, mirroring the servers axis: a
+        virtual key keeps its long-standing fail-open — the org step is skipped and the key/team/agent
+        restrictions already computed STAND (letting the raise escape would collapse them to
+        allow-all, which is fail-open WIDER than before the fault). A keyless admitted source
+        re-raises, and the outer handler denies tools for that one source while the subject's other
+        sources stand — its only org bound is this ceiling, so skipping it would widen access."""
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+
+        if user_api_key_auth.agent_id:
+            # Pre-fetch agent object_permission once to avoid a duplicate DB query.
+            agent_obj_perm = await MCPRequestHandler._get_agent_object_permission(user_api_key_auth)
+            agent_tools = await MCPRequestHandler._get_agent_tool_permissions_for_server(
+                server_id=server_id,
+                user_api_key_auth=user_api_key_auth,
+                agent_object_permission=agent_obj_perm,
+            )
+            if agent_tools is not None:
+                allowed_tools = (
+                    list(set(allowed_tools) & set(agent_tools)) if allowed_tools is not None else agent_tools
+                )
+
+        if user_api_key_auth.org_id:
+            # _get_org_object_permission uses user_api_key_cache, so this is not a fresh DB round-trip
+            # when get_allowed_mcp_servers was already called.
+            try:
+                org_obj_perm = await MCPRequestHandler._get_org_object_permission(user_api_key_auth)
+            except Exception as e:  # noqa: BLE001  # unresolvable org ceiling, decided per caller shape
+                if keyless_source:
+                    raise
+                verbose_logger.warning(
+                    f"MCP org tool ceiling unresolvable for org_id={user_api_key_auth.org_id!r}; "
+                    f"skipping org intersect, key/team/agent restrictions stand: {str(e)}"
+                )
+                return allowed_tools
+            org_tools = (
+                global_mcp_server_manager.expand_tool_permissions(org_obj_perm.mcp_tool_permissions).get(server_id)
+                if org_obj_perm and org_obj_perm.mcp_tool_permissions
+                else None
+            )
+            if org_tools is not None:
+                allowed_tools = (
+                    list(set(allowed_tools) & set(org_tools)) if allowed_tools is not None else list(org_tools)
+                )
+
+        return allowed_tools
 
     @staticmethod
     async def is_tool_allowed_for_server(
@@ -1537,10 +2178,96 @@ class MCPRequestHandler:
 
     @staticmethod
     async def _get_allowed_mcp_servers_for_team(
-        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
-    ) -> List[str]:
+        user_api_key_auth: UserAPIKeyAuth | None = None,
+    ) -> list[str]:
+        """Get allowed MCP servers a caller inherits from the team it is pinned to.
+
+        Exactly one team, or none. A subject that reaches servers through SEVERAL teams does not
+        fan out here: it is resolved one source per team in ``_resolve_admitted_subject_servers``,
+        and each of those sources pins a single ``team_id`` before reaching this point. Keeping the
+        fan-out here as well would be a second multi-team path to drift from that one.
         """
-        Get allowed MCP servers for a team.
+        team_ids = await MCPRequestHandler._team_ids_for_mcp_grant(user_api_key_auth)
+        if not team_ids:
+            return []
+        return await MCPRequestHandler._allowed_mcp_servers_for_single_team(team_ids[0], user_api_key_auth)
+
+    @staticmethod
+    async def _team_ids_for_mcp_grant(user_api_key_auth: UserAPIKeyAuth | None) -> list[str]:
+        """The team ids whose MCP grants a caller inherits.
+
+        A caller with an explicit ``team_id`` uses that single team; every other caller inherits no
+        team grants. That covers key auth and JWT auth (a keyless ``user_id`` auth with no team_id,
+        which must NOT silently gain the union across every team the user belongs to), and it covers
+        each single-source auth an admitted subject fans out into — those pin a team_id, so they land
+        on the first branch. The admitted subject itself never reaches here: it resolves per source
+        in ``_resolve_admitted_subject_servers`` before this point. The ``UI_TEAM_ID`` sentinel
+        resolves to no teams exactly as before."""
+        if user_api_key_auth is None or not user_api_key_auth.team_id:
+            return []
+        return [] if user_api_key_auth.team_id == UI_TEAM_ID else [user_api_key_auth.team_id]
+
+    @staticmethod
+    async def _resolve_user_team_ids(user_id: str, user_api_key_auth: UserAPIKeyAuth) -> list[str]:
+        """The distinct team ids a user belongs to, from the live user record. Returns [] on
+        no DB, a missing user, or any resolution failure so a lookup blip narrows access
+        rather than raising; the caller's direct grants still apply."""
+        from litellm.proxy.auth.auth_checks import get_user_object
+        from litellm.proxy.proxy_server import (
+            prisma_client,
+            proxy_logging_obj,
+            user_api_key_cache,
+        )
+
+        if prisma_client is None:
+            return []
+        try:
+            user_object = await get_user_object(
+                user_id=user_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                user_id_upsert=False,
+                parent_otel_span=user_api_key_auth.parent_otel_span,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+        except Exception as e:  # noqa: BLE001  # a team-resolution blip narrows access, never raises
+            verbose_logger.warning(f"Failed to resolve user teams for MCP grant: {str(e)}")
+            return []
+        if user_object is None or not user_object.teams:
+            return []
+        return list(dict.fromkeys(t for t in user_object.teams if t and t != UI_TEAM_ID))
+
+    @staticmethod
+    async def _team_granted_servers(team_obj: LiteLLM_TeamTable, team_access_group_servers: list[str]) -> set[str]:
+        """The raw MCP-server set a team grants (before any org ceiling): its object_permission (direct
+        ``mcp_servers``, the ``all_proxy_servers`` sentinel → the full registry, legacy access groups,
+        tool-perm-referenced servers) unioned with its unified ``access_group_ids`` servers."""
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+
+        object_permissions = team_obj.object_permission
+        if object_permissions is None:
+            return set(team_access_group_servers)
+        if SpecialMCPServerName.all_proxy_servers.value in (object_permissions.mcp_servers or []):
+            return set(global_mcp_server_manager.get_registry().keys())
+        legacy_access_group_servers = await MCPRequestHandler._get_mcp_servers_from_access_groups(
+            object_permissions.mcp_access_groups or []
+        )
+        return (
+            set(global_mcp_server_manager.expand_permission_list(object_permissions.mcp_servers or []))
+            | set(legacy_access_group_servers)
+            | set(global_mcp_server_manager.expand_tool_permissions(object_permissions.mcp_tool_permissions).keys())
+            | set(team_access_group_servers)
+        )
+
+    @staticmethod
+    async def _allowed_mcp_servers_for_single_team(
+        team_id: str,
+        user_api_key_auth: UserAPIKeyAuth | None,
+    ) -> list[str]:
+        """Allowed MCP servers granted by ONE team (its raw grant, then capped by the team's own org
+        for a keyless admitted subject).
 
         Unions two sources:
         - Legacy team.object_permission (mcp_servers, mcp_access_groups,
@@ -1551,9 +2278,6 @@ class MCPRequestHandler:
           the gate (no assigned_team_ids check needed here).
         """
         try:
-            from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
-                global_mcp_server_manager,
-            )
             from litellm.proxy.auth.auth_checks import (
                 _get_mcp_server_ids_from_access_groups,
                 get_team_object,
@@ -1564,22 +2288,24 @@ class MCPRequestHandler:
                 user_api_key_cache,
             )
 
-            if user_api_key_auth is None or not user_api_key_auth.team_id or prisma_client is None:
+            if not team_id or team_id == UI_TEAM_ID or prisma_client is None:
                 return []
 
-            if user_api_key_auth.team_id == UI_TEAM_ID:
-                return []
-
-            team_obj: Optional[LiteLLM_TeamTable] = await get_team_object(
-                team_id=user_api_key_auth.team_id,
+            parent_otel_span = user_api_key_auth.parent_otel_span if user_api_key_auth is not None else None
+            team_obj: LiteLLM_TeamTable | None = await get_team_object(
+                team_id=team_id,
                 prisma_client=prisma_client,
                 user_api_key_cache=user_api_key_cache,
-                parent_otel_span=user_api_key_auth.parent_otel_span,
+                parent_otel_span=parent_otel_span,
                 proxy_logging_obj=proxy_logging_obj,
             )
             if team_obj is None:
                 return []
-
+            if team_obj.blocked:
+                # A blocked team grants nothing. The central policy gate enforces this for a key
+                # pinned to a single team_id, but a keyless admitted identity (no team_id) unions
+                # across all of its teams and would otherwise inherit a blocked team's MCP grants.
+                return []
             team_access_group_servers = await _get_mcp_server_ids_from_access_groups(
                 access_group_ids=team_obj.access_group_ids or [],
                 prisma_client=prisma_client,
@@ -1587,27 +2313,8 @@ class MCPRequestHandler:
                 proxy_logging_obj=proxy_logging_obj,
             )
 
-            object_permissions = team_obj.object_permission
-            if object_permissions is None:
-                return list(set(team_access_group_servers))
-
-            if SpecialMCPServerName.all_proxy_servers.value in (object_permissions.mcp_servers or []):
-                return list(global_mcp_server_manager.get_registry().keys())
-
-            direct_mcp_servers = global_mcp_server_manager.expand_permission_list(object_permissions.mcp_servers or [])
-
-            legacy_access_group_servers = await MCPRequestHandler._get_mcp_servers_from_access_groups(
-                object_permissions.mcp_access_groups or []
-            )
-
-            tool_perm_servers = list(
-                global_mcp_server_manager.expand_tool_permissions(object_permissions.mcp_tool_permissions).keys()
-            )
-
-            all_servers = (
-                direct_mcp_servers + legacy_access_group_servers + tool_perm_servers + team_access_group_servers
-            )
-            return list(set(all_servers))
+            servers = await MCPRequestHandler._team_granted_servers(team_obj, team_access_group_servers)
+            return list(servers)
         except Exception as e:
             verbose_logger.warning(f"Failed to get allowed MCP servers for team: {str(e)}")
             return []
@@ -1621,7 +2328,11 @@ class MCPRequestHandler:
         ``get_object_permission`` helpers so MCP requests share the same
         ``user_api_key_cache`` entries as the rest of the proxy.
         """
-        from litellm.proxy.auth.auth_checks import get_object_permission, get_org_object
+        from litellm.proxy.auth.auth_checks import (
+            OrganizationNotFoundError,
+            get_object_permission,
+            get_org_object,
+        )
         from litellm.proxy.proxy_server import (
             prisma_client,
             proxy_logging_obj,
@@ -1635,6 +2346,9 @@ class MCPRequestHandler:
             verbose_logger.debug("prisma_client is None")
             return None
 
+        # An ABSENT org is a determinate fact, not a failure: a team's organization_id can point at a
+        # row that was deleted or has not synced yet, and get_org_object raises for that. It places no
+        # ceiling, exactly as a key with a dangling org_id is not locked out.
         try:
             org_obj = await get_org_object(
                 org_id=user_api_key_auth.org_id,
@@ -1643,20 +2357,34 @@ class MCPRequestHandler:
                 parent_otel_span=user_api_key_auth.parent_otel_span,
                 proxy_logging_obj=proxy_logging_obj,
             )
-
-            if org_obj is None or not org_obj.object_permission_id:
-                return None
-
-            return await get_object_permission(
-                object_permission_id=org_obj.object_permission_id,
-                prisma_client=prisma_client,
-                user_api_key_cache=user_api_key_cache,
-                parent_otel_span=user_api_key_auth.parent_otel_span,
-                proxy_logging_obj=proxy_logging_obj,
-            )
-        except Exception as e:
-            verbose_logger.warning(f"Failed to get org object permission: {str(e)}")
+        except OrganizationNotFoundError as e:
+            # CONFIRMED absent (deleted org, not-yet-synced organization_id): a determinate fact, so
+            # it places no ceiling. Every OTHER exception is an operational failure and propagates —
+            # caught upstream as an unresolvable ceiling, which denies for a keyless source and stays
+            # fail-open for a key. Catching bare Exception here treated a DB outage as "no org", which
+            # silently dropped a real org's ceiling for exactly as long as the outage lasted.
+            verbose_logger.debug(f"MCP org ceiling: org {user_api_key_auth.org_id!r} does not exist: {e}")
             return None
+
+        if org_obj is None or not org_obj.object_permission_id:
+            return None
+
+        # From here the org NAMES a permission. Failing to read it is INDETERMINATE, so it must not
+        # collapse into the same None that means "no ceiling" -- that is what would silently drop a
+        # real ceiling on a transient fault. Raise and let each caller pick fail-open or fail-closed.
+        object_permission = await get_object_permission(
+            object_permission_id=org_obj.object_permission_id,
+            prisma_client=prisma_client,
+            user_api_key_cache=user_api_key_cache,
+            parent_otel_span=user_api_key_auth.parent_otel_span,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+        if object_permission is None:
+            raise ValueError(
+                f"org {user_api_key_auth.org_id!r} names object_permission_id "
+                f"{org_obj.object_permission_id!r} which could not be loaded"
+            )
+        return object_permission
 
     @staticmethod
     async def _get_allowed_mcp_servers_for_org(
@@ -1692,8 +2420,11 @@ class MCPRequestHandler:
             all_servers = direct_mcp_servers + access_group_servers + tool_perm_servers
             return list(set(all_servers))
         except Exception as e:
+            # None = the org ceiling could NOT be resolved, which is not the same fact as [] = the
+            # org places no restriction. Collapsing the two is what let a transient DB fault silently
+            # remove an org's ceiling; the caller picks fail-open or fail-closed from this signal.
             verbose_logger.warning(f"Failed to get allowed MCP servers for org: {str(e)}")
-            return []
+            return None
 
     @staticmethod
     async def _get_allowed_mcp_servers_for_end_user(

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -33,6 +33,7 @@ from litellm.proxy._experimental.mcp_server.bridge_token_flow import (
     _finish_bridge_mint,
     _prepare_bridge_mint,
     _prepare_bridge_refresh,
+    _reload_active_user_by_id,
 )
 from litellm.proxy._experimental.mcp_server.faults import (
     CallerRejected,
@@ -42,6 +43,14 @@ from litellm.proxy._experimental.mcp_server.faults import (
     classify_upstream_token_rejection,
     dcr_fault_detail,
     render_token_fault,
+)
+from litellm.proxy._experimental.mcp_server.gateway_dcr_flow import (
+    aggregate_authorize,
+    aggregate_token,
+    complete_connect_flow,
+    is_gateway_dcr_client_id,
+    register_aggregate_client,
+    relative_request_url,
 )
 from litellm.proxy._experimental.mcp_server.oauth_utils import (
     TOKEN_NO_CACHE_HEADERS,
@@ -324,14 +333,25 @@ def redeem_passthrough_authorization_code(
     return sealed
 
 
+def _session_cookie_user_id(request: Request) -> str | None:
+    """The signed-in litellm user for a browser request, or ``None``. Thin wrapper so the
+    aggregate DCR flow's verbs receive the identity as a plain value instead of parsing
+    cookies themselves."""
+    from litellm.proxy._experimental.mcp_server.byok_oauth_endpoints import (  # noqa: PLC0415  # circular import at module load
+        _user_id_from_session_cookie,
+    )
+
+    return _user_id_from_session_cookie(request)
+
+
 def _redirect_to_litellm_login(request: Request) -> RedirectResponse:
     """Send an unauthenticated browser through litellm login before the interactive bridge authorize
     can capture its identity. The bridge oauth_delegate flow seals the SSO user into the gateway code,
-    so a session is required; without one there is nothing to bind. After login the user re-initiates
-    the connection, which then finds the session cookie (the seamless return-to round-trip, which is
-    origin-validated against the control-plane URL, is a follow-up)."""
+    so a session is required; without one there is nothing to bind. A same-origin relative
+    ``return_to`` (honored by the SSO callback) brings the browser straight back to this authorize
+    request after login instead of stranding it on the dashboard."""
     base_url = get_request_base_url(request)
-    return RedirectResponse(f"{base_url}/sso/key/generate")
+    return RedirectResponse(f"{base_url}/sso/key/generate?{urlencode({'return_to': relative_request_url(request)})}")
 
 
 # LIT-4197: some upstream authorization servers reject an over-long ``state``
@@ -1601,6 +1621,18 @@ async def authorize(
         global_mcp_server_manager,
     )
 
+    if mcp_server_name is None and client_id and is_gateway_dcr_client_id(client_id):
+        return aggregate_authorize(
+            request=request,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            state=state,
+            code_challenge=code_challenge,
+            code_challenge_method=code_challenge_method,
+            response_type=response_type,
+            session_user_id=_session_cookie_user_id(request),
+        )
+
     lookup_name: Optional[str] = mcp_server_name or client_id
     client_ip = IPAddressUtils.get_mcp_client_ip(request)
     mcp_server = (
@@ -1664,6 +1696,25 @@ async def token_endpoint(
         global_mcp_server_manager,
     )
 
+    if mcp_server_name is None and is_gateway_dcr_client_id(client_id):
+        from litellm.proxy.proxy_server import (  # noqa: PLC0415  # circular import at module load
+            master_key,
+            user_api_key_cache,
+        )
+
+        return await aggregate_token(
+            request=request,
+            grant_type=grant_type,
+            code=code,
+            redirect_uri=redirect_uri,
+            client_id=client_id,
+            code_verifier=code_verifier,
+            refresh_token=refresh_token,
+            master_key=master_key,
+            reload_user=_reload_active_user_by_id,
+            cache=user_api_key_cache,
+        )
+
     lookup_name = mcp_server_name or client_id
     client_ip = IPAddressUtils.get_mcp_client_ip(request)
     mcp_server = global_mcp_server_manager.get_mcp_server_by_name(lookup_name, client_ip=client_ip)
@@ -1682,6 +1733,21 @@ async def token_endpoint(
         code_verifier=code_verifier,
         refresh_token=refresh_token,
         scope=scope,
+    )
+
+
+@router.post("/authorize/complete")
+async def authorize_complete(request: Request, flow: str = Form(...)):
+    """Finish an aggregate connect flow: mint the gateway authorization code for the
+    signed-in user and redirect back to the DCR client. POST plus the per-flow HttpOnly
+    cookie set at /authorize; an anonymous or bad-flow request just 400s."""
+    from litellm.proxy.proxy_server import user_api_key_cache  # noqa: PLC0415  # circular import at module load
+
+    return await complete_connect_flow(
+        request=request,
+        flow_handle=flow,
+        session_user_id=_session_cookie_user_id(request),
+        cache=user_api_key_cache,
     )
 
 
@@ -2422,6 +2488,13 @@ async def register_client(request: Request, mcp_server_name: Optional[str] = Non
     }
     client_ip = IPAddressUtils.get_mcp_client_ip(request)
     if not mcp_server_name:
+        # A real DCR request carries redirect_uris (RFC 7591): route it to the aggregate DCR
+        # endpoint the aggregate authorization-server metadata advertises. A single-server
+        # deployment registers at /{server}/register instead (its bare-origin discovery
+        # advertises that), so this does not affect it. A request without redirect_uris is not
+        # a DCR request, so the legacy single-server-or-dummy fallback is kept for it.
+        if data.get("redirect_uris"):
+            return await register_aggregate_client(request=request, request_body=data)
         resolved = _resolve_oauth2_server_for_root_endpoints(client_ip=client_ip)
         if resolved:
             return await register_client_with_server(

--- a/litellm/proxy/_experimental/mcp_server/gateway_dcr_flow.py
+++ b/litellm/proxy/_experimental/mcp_server/gateway_dcr_flow.py
@@ -1,0 +1,637 @@
+"""The gateway-level DCR flow for the aggregate ``/mcp`` endpoint (``mcp_gateway_dcr``).
+
+An OAuth-only DCR client (Claude Desktop, Claude Code, MCP Inspector) pointed at the
+aggregate ``/mcp`` endpoint discovers the gateway as its authorization server (PR 1 of
+this track) and then walks the flow implemented here:
+
+1. ``POST /register``: stateless dynamic client registration. The ``client_id`` IS the
+   registration: the client's redirect URIs are sealed into it with the repo's
+   authenticated symmetric helper, so nothing is persisted and a forged or tampered
+   client_id simply fails to open. Clients are always public (``token_endpoint_auth_method
+   "none"``); PKCE S256 is what protects the code.
+2. ``GET /authorize``: validates the client and redirect URI, requires S256 PKCE, and
+   interposes LiteLLM sign-in. Without a session cookie the browser is sent through
+   ``/sso/key/generate`` with a same-origin ``return_to`` so it lands back here after
+   login. With a session, the flow parameters and the SSO user are sealed into a per-flow
+   HttpOnly cookie (the same pattern as the upstream OAuth state relay) and the browser is
+   sent to the connect page, where the user authorizes individual servers (vaulting those
+   tokens server-side) before finishing.
+3. ``POST /authorize/complete``: the deliberate finish step. A POST (not GET) bound to the
+   SameSite=Lax flow cookie, so a cross-site link cannot silently mint a code with the
+   victim's session, and the signed-in user must match the user sealed into the flow.
+   Mints a short-lived, single-use, gateway-sealed authorization code and redirects to the
+   client's registered redirect URI.
+4. ``POST /token``: exchanges the code (PKCE-verified, client- and redirect-bound,
+   single-use) for the identity-only session tokens of
+   :mod:`.outbound_credentials.session_token`, re-validating that the litellm user is
+   still active first; the ``refresh_token`` grant rotates the pair the same way.
+
+Nothing here stores state server-side except the single-use code guard (a TTL cache
+entry). Every sealed value is authenticated encryption over the proxy salt/master key
+family, opened totally (bad input maps to an OAuth error, never a raise), and every
+identity is a stable reference re-validated live at mint, refresh, and (in the admission
+PR) tool-call time. Upstream server credentials never appear anywhere in this flow; they
+are vaulted per user by the existing ``/v1/mcp`` authorize endpoints and resolved at
+egress by user id.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+from base64 import urlsafe_b64encode
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Awaitable, Callable, Literal, TypeVar
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+from fastapi import HTTPException, Request
+from fastapi.responses import JSONResponse, RedirectResponse, Response
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from typing_extensions import assert_never
+
+from litellm._logging import verbose_logger
+from litellm.caching.caching import DualCache
+from litellm.proxy._experimental.mcp_server.oauth_utils import (
+    TOKEN_NO_CACHE_HEADERS,
+    get_request_base_url,
+    is_loopback_redirect_host,
+    validate_redirect_uri_shape,
+)
+from litellm.proxy._experimental.mcp_server.outbound_credentials.session_credentials import (
+    SessionRefreshOpened,
+    open_session_refresh_bearer,
+    session_keys_from_master_key,
+)
+from litellm.proxy._experimental.mcp_server.outbound_credentials.session_token import (
+    SESSION_REFRESH_TTL_SECONDS,
+    MintedSessionToken,
+    SessionKeys,
+    SessionPrincipal,
+    mint_session_refresh_token,
+    mint_session_token,
+)
+from litellm.proxy.common_utils.encrypt_decrypt_utils import (
+    decrypt_value_helper,
+    encrypt_value_helper,
+)
+
+GATEWAY_DCR_CLIENT_ID_PREFIX = "llm_dcrc_"
+"""Marker prefix on every gateway-issued DCR client_id so the root authorize/token
+endpoints can route an aggregate-flow request without decrypting, and existing per-server
+flows (whose client_ids are upstream-issued) are never captured by the aggregate arm."""
+
+GATEWAY_AUTH_CODE_PREFIX = "llm_gcode_"
+"""Marker prefix on the gateway-sealed authorization code, distinct from the bridge
+``llm_bcode_`` so neither flow can consume the other's codes."""
+
+CONNECT_FLOW_COOKIE_PREFIX = "mcp_connect_flow_"
+"""Per-flow HttpOnly cookie holding the sealed connect flow, keyed by a short random
+handle carried in the connect-page URL (the same handle-plus-cookie pattern as the
+``mcp_oauth_state_`` upstream relay, for the same reasons: replica-safe with no
+server-side session store, and the sealed value never appears in a URL)."""
+
+CONNECT_FLOW_TTL_SECONDS = 600
+GATEWAY_AUTH_CODE_TTL_SECONDS = 120
+_CLAIM_TTL_BUFFER_SECONDS = 60
+_USED_CODE_CACHE_PREFIX = "mcp_gateway_dcr_code_used:"
+_USED_FLOW_CACHE_PREFIX = "mcp_gateway_dcr_flow_used:"
+_USED_REFRESH_CACHE_PREFIX = "mcp_gateway_dcr_refresh_used:"
+
+MAX_REDIRECT_URIS = 3
+MAX_REDIRECT_URI_LENGTH = 256
+MAX_CLIENT_ID_LENGTH = 2048
+"""Registration bounds. They exist to bound the sealed client_id, which rides inside
+every session-token claim set: 3 URIs of 256 bytes seal to roughly 1.2KB, comfortably
+under this cap and under the session token's own 4KB ceiling. Claude Desktop and MCP
+Inspector register one or two redirect URIs."""
+
+MAX_STATE_LENGTH = 1024
+"""Bound on the client ``state`` sealed into the flow cookie and echoed on the auth-code
+redirect. An unbounded ``state`` can push the sealed cookie past the browser's ~4KB cap
+(silently dropped, breaking the flow); spec clients send a short opaque value."""
+
+MIN_CODE_VERIFIER_LENGTH = 43
+MAX_CODE_VERIFIER_LENGTH = 128
+"""RFC 7636 section 4.1 bounds for the PKCE ``code_verifier``. Enforced so an out-of-range
+verifier gets a clean ``invalid_request`` instead of an opaque PKCE-mismatch."""
+
+_UNPREFIXED = ""
+"""Prefix for a sealed value that carries no wire marker because it is never routed by
+prefix (the connect flow lives only in its own per-handle cookie, opened by that one
+handle). Named so the empty-string argument to ``_seal`` / ``_open_sealed`` reads as
+deliberate rather than a typo."""
+
+_CLIENT_RECORD_DEBUG_KEY = "gateway_dcr_client"
+_CONNECT_FLOW_DEBUG_KEY = "gateway_connect_flow"
+_AUTH_CODE_DEBUG_KEY = "gateway_authorization_code"
+
+ReloadUserFailure = Literal["unresolvable", "unavailable", "no_active_key"]
+ReloadUser = Callable[[str], Awaitable[ReloadUserFailure | None]]
+"""Injected live-user revalidation (the token endpoint's mirror of admission):
+``None`` means the user is active; ``unavailable`` is a retryable DB outage; anything
+else fails the grant closed."""
+
+
+class GatewayDcrClient(BaseModel):
+    """The registration record sealed into a gateway DCR ``client_id``.
+
+    ``extra="forbid"`` so a sealed value of another type (an auth code, a connect flow)
+    that happened to decrypt under the shared key can never validate as a client record:
+    cross-type confusion is rejected at the model boundary, not left to differing required
+    fields."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+    redirect_uris: tuple[str, ...] = Field(min_length=1, max_length=MAX_REDIRECT_URIS)
+    iat: int
+
+
+class _ConnectFlow(BaseModel):
+    """One in-flight authorize: the SSO user it belongs to and the client parameters
+    needed to mint the code at the finish step. Sealed into the per-flow cookie. ``jti``
+    makes the flow single-use at complete; ``extra="forbid"`` rejects cross-type
+    confusion."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+    user_id: str = Field(min_length=1)
+    client_id: str = Field(min_length=1)
+    redirect_uri: str = Field(min_length=1)
+    state: str
+    code_challenge: str = Field(min_length=1)
+    jti: str = Field(min_length=1)
+    exp: int
+
+
+class _GatewayAuthCode(BaseModel):
+    """The gateway-sealed authorization code: the user consent it represents and the
+    bindings the token endpoint must verify (client, redirect URI, PKCE challenge),
+    plus a ``jti`` for the single-use guard. ``extra="forbid"`` rejects cross-type
+    confusion."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+    user_id: str = Field(min_length=1)
+    client_id: str = Field(min_length=1)
+    redirect_uri: str = Field(min_length=1)
+    code_challenge: str = Field(min_length=1)
+    jti: str = Field(min_length=1)
+    iat: int
+    exp: int
+
+
+def is_gateway_dcr_client_id(client_id: str | None) -> bool:
+    """Cheap prefix routing test so the root endpoints only enter the aggregate arm for
+    clients this flow registered; every other client_id keeps today's behavior."""
+    return client_id is not None and client_id.startswith(GATEWAY_DCR_CLIENT_ID_PREFIX)
+
+
+def _oauth_error(status_code: int, error: str, description: str) -> JSONResponse:
+    """RFC 6749 section 5.2 / RFC 7591 section 3.2.2 error body. Descriptions carry no
+    token, code, or URL material so they are safe to relay to any client."""
+    return JSONResponse(
+        status_code=status_code,
+        content={"error": error, "error_description": description},
+        headers=TOKEN_NO_CACHE_HEADERS,
+    )
+
+
+def _seal(prefix: str, payload: BaseModel) -> str:
+    return prefix + encrypt_value_helper(payload.model_dump_json())
+
+
+_SealedModelT = TypeVar("_SealedModelT", bound=BaseModel)
+
+
+def _open_sealed(value: str, prefix: str, model: type[_SealedModelT], debug_key: str) -> _SealedModelT | None:
+    """Open a sealed value totally: anything that is not prefix-shaped, does not decrypt,
+    or does not validate returns ``None`` for the caller to map onto an OAuth error."""
+    if not value.startswith(prefix):
+        return None
+    decrypted = decrypt_value_helper(value[len(prefix) :], debug_key, return_original_value=False)
+    if not isinstance(decrypted, str):
+        return None
+    try:
+        return model.model_validate_json(decrypted)
+    except ValidationError:
+        return None
+
+
+def open_gateway_dcr_client(client_id: str) -> GatewayDcrClient | None:
+    return _open_sealed(client_id, GATEWAY_DCR_CLIENT_ID_PREFIX, GatewayDcrClient, _CLIENT_RECORD_DEBUG_KEY)
+
+
+async def register_aggregate_client(request: Request, request_body: Mapping[str, object]) -> Response:
+    """RFC 7591 dynamic registration against the gateway itself, statelessly.
+
+    Only ``redirect_uris`` is authoritative; every client is registered as a public
+    ``token_endpoint_auth_method "none"`` client regardless of what it asked for (RFC
+    7591 lets the server override metadata), because the gateway never issues client
+    secrets: possession of a secret would add nothing over the mandatory S256 PKCE, and a
+    stateless registration has nowhere to keep one. Nothing is persisted, so open
+    registration cannot be used to fill storage.
+
+    Redirect-URI *hygiene* is not decided here: :func:`validate_redirect_uri_shape` is
+    the single owner of that rule across the MCP OAuth surface, so allowlisted native
+    callbacks (``cursor://``) are accepted and fragments, missing hosts, userinfo
+    (``https://claude.ai@attacker.example/cb``) and backslash hosts are rejected exactly
+    as they are on /authorize and /callback.
+
+    What this endpoint does decide is its own trust policy, which is deliberately wider
+    than :func:`validate_trusted_redirect_uri`'s: registration is *public*, so any https
+    client may register (that is what lets a hosted MCP client register at all), and the
+    controls are mandatory S256 PKCE plus the consent screen showing the client origin.
+    http is confined to loopback per RFC 8252 section 7.3.
+    """
+    raw_uris = request_body.get("redirect_uris")
+    if not isinstance(raw_uris, list) or not raw_uris or len(raw_uris) > MAX_REDIRECT_URIS:
+        return _oauth_error(
+            400,
+            "invalid_redirect_uri",
+            f"redirect_uris must be a list of 1 to {MAX_REDIRECT_URIS} URIs",
+        )
+    if not all(isinstance(uri, str) and len(uri) <= MAX_REDIRECT_URI_LENGTH for uri in raw_uris):
+        return _oauth_error(
+            400,
+            "invalid_redirect_uri",
+            f"each redirect URI must be a string of at most {MAX_REDIRECT_URI_LENGTH} characters",
+        )
+    for uri in raw_uris:
+        parsed = urlparse(uri)
+        try:
+            if validate_redirect_uri_shape(parsed):
+                continue  # allowlisted native callback, e.g. cursor://
+        except HTTPException as exc:
+            # The shared validator speaks HTTP; RFC 7591 registration answers with an OAuth
+            # error object, so translate the shape without re-deciding the rule.
+            return _oauth_error(400, "invalid_redirect_uri", str(exc.detail))
+        if parsed.scheme == "https" or (parsed.scheme == "http" and is_loopback_redirect_host(parsed)):
+            continue
+        return _oauth_error(
+            400,
+            "invalid_redirect_uri",
+            "each redirect URI must be https, http on a loopback host, or a registered native callback",
+        )
+    now = datetime.now(timezone.utc)
+    client_id = _seal(
+        GATEWAY_DCR_CLIENT_ID_PREFIX, GatewayDcrClient(redirect_uris=tuple(raw_uris), iat=int(now.timestamp()))
+    )
+    if len(client_id) > MAX_CLIENT_ID_LENGTH:
+        return _oauth_error(400, "invalid_client_metadata", "registered metadata is too large")
+    return JSONResponse(
+        status_code=201,
+        content={
+            "client_id": client_id,
+            "client_id_issued_at": int(now.timestamp()),
+            "redirect_uris": list(raw_uris),
+            "token_endpoint_auth_method": "none",
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+        },
+    )
+
+
+def _flow_cookie_name(handle: str) -> str:
+    return f"{CONNECT_FLOW_COOKIE_PREFIX}{handle}"
+
+
+def _cookie_path_and_secure(request: Request) -> tuple[str, bool]:
+    parsed = urlparse(get_request_base_url(request))
+    return parsed.path or "/", parsed.scheme == "https"
+
+
+def _append_query_params(url: str, params: dict[str, str]) -> str:
+    parsed = urlparse(url)
+    query = parse_qsl(parsed.query, keep_blank_values=True) + list(params.items())
+    return urlunparse(parsed._replace(query=urlencode(query)))
+
+
+def relative_request_url(request: Request) -> str:
+    """The request's own path and query as a same-origin ``return_to`` target for the
+    login round-trip; relative by construction, so it can never leave the gateway."""
+    path = request.url.path
+    return f"{path}?{request.url.query}" if request.url.query else path
+
+
+def aggregate_authorize(
+    request: Request,
+    client_id: str,
+    redirect_uri: str,
+    state: str,
+    code_challenge: str | None,
+    code_challenge_method: str | None,
+    response_type: str | None,
+    session_user_id: str | None,
+) -> Response:
+    """The aggregate authorize verb: validate the client, require S256 PKCE, interpose
+    LiteLLM sign-in, and hand the browser to the connect page with the flow sealed into a
+    per-flow cookie.
+
+    Validation failures respond directly with 400 and never redirect: per RFC 6749
+    section 4.1.2.1 an unvalidated redirect URI must not receive an error redirect, and
+    once the client is at fault there is no trusted place to send the browser.
+    """
+    client = open_gateway_dcr_client(client_id)
+    if client is None:
+        return _oauth_error(400, "invalid_client", "unknown or malformed client_id")
+    if redirect_uri not in client.redirect_uris:
+        return _oauth_error(400, "invalid_request", "redirect_uri is not registered for this client")
+    if response_type != "code":
+        return _oauth_error(400, "unsupported_response_type", "response_type must be 'code'")
+    if not code_challenge or code_challenge_method != "S256":
+        return _oauth_error(
+            400,
+            "invalid_request",
+            "PKCE is required: send code_challenge with code_challenge_method=S256",
+        )
+    if len(state) > MAX_STATE_LENGTH:
+        return _oauth_error(400, "invalid_request", f"state must be at most {MAX_STATE_LENGTH} characters")
+    base_url = get_request_base_url(request)
+    if session_user_id is None:
+        login_url = f"{base_url}/sso/key/generate?{urlencode({'return_to': relative_request_url(request)})}"
+        return RedirectResponse(login_url, status_code=303)
+    now = datetime.now(timezone.utc)
+    handle = secrets.token_urlsafe(24)
+    flow = _ConnectFlow(
+        user_id=session_user_id,
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        state=state,
+        code_challenge=code_challenge,
+        jti=secrets.token_urlsafe(24),
+        exp=int(now.timestamp()) + CONNECT_FLOW_TTL_SECONDS,
+    )
+    connect_url = _append_query_params(
+        f"{base_url}/ui/chat/integrations",
+        {"connect_flow": handle, "connect_client": _origin_only(redirect_uri)},
+    )
+    response = RedirectResponse(connect_url, status_code=303)
+    path, secure = _cookie_path_and_secure(request)
+    response.set_cookie(
+        key=_flow_cookie_name(handle),
+        value=_seal(_UNPREFIXED, flow),
+        max_age=CONNECT_FLOW_TTL_SECONDS,
+        path=path,
+        secure=secure,
+        httponly=True,
+        samesite="lax",
+    )
+    return response
+
+
+def _origin_only(url: str) -> str:
+    """Scheme+host for display on the connect page; never the full redirect URI, whose
+    path or query could carry values that do not belong in a page URL or logs."""
+    parsed = urlparse(url)
+    return f"{parsed.scheme}://{parsed.netloc}" if parsed.netloc else ""
+
+
+async def complete_connect_flow(
+    request: Request,
+    flow_handle: str,
+    session_user_id: str | None,
+    cache: DualCache,
+) -> Response:
+    """The deliberate finish step of the connect flow: mint the gateway authorization
+    code and send the browser back to the client.
+
+    Reached by POST so a cross-site GET cannot trigger it, and bound to the HttpOnly
+    per-flow cookie plus an exact match between the signed-in user and the user sealed
+    into the flow: a link crafted by another party dies here with ``access_denied``
+    instead of minting a code for the victim's identity. The flow is single-use (an atomic
+    claim on its ``jti``), so a double-submit cannot mint two codes from one sign-in.
+    """
+    sealed_flow = request.cookies.get(_flow_cookie_name(flow_handle))
+    if sealed_flow is None:
+        return _oauth_error(400, "invalid_request", "unknown or expired connect flow")
+    flow = _open_sealed(sealed_flow, _UNPREFIXED, _ConnectFlow, _CONNECT_FLOW_DEBUG_KEY)
+    if flow is None:
+        return _oauth_error(400, "invalid_request", "unknown or expired connect flow")
+    now = datetime.now(timezone.utc)
+    if now.timestamp() >= flow.exp:
+        return _oauth_error(400, "invalid_request", "the connect flow has expired; restart the connection")
+    if session_user_id is None:
+        return _oauth_error(401, "login_required", "sign in to LiteLLM to finish connecting")
+    if session_user_id != flow.user_id:
+        return _oauth_error(403, "access_denied", "the signed-in user does not match this connect flow")
+    if not await _SingleUseGuard(cache).claim(
+        f"{_USED_FLOW_CACHE_PREFIX}{flow.jti}", CONNECT_FLOW_TTL_SECONDS + _CLAIM_TTL_BUFFER_SECONDS
+    ):
+        return _oauth_error(400, "invalid_request", "this connect flow was already completed; restart the connection")
+    code = _seal(
+        GATEWAY_AUTH_CODE_PREFIX,
+        _GatewayAuthCode(
+            user_id=flow.user_id,
+            client_id=flow.client_id,
+            redirect_uri=flow.redirect_uri,
+            code_challenge=flow.code_challenge,
+            jti=secrets.token_urlsafe(24),
+            iat=int(now.timestamp()),
+            exp=int(now.timestamp()) + GATEWAY_AUTH_CODE_TTL_SECONDS,
+        ),
+    )
+    params = {"code": code, **({"state": flow.state} if flow.state else {})}
+    response = RedirectResponse(_append_query_params(flow.redirect_uri, params), status_code=303)
+    path, secure = _cookie_path_and_secure(request)
+    response.delete_cookie(key=_flow_cookie_name(flow_handle), path=path, secure=secure, httponly=True, samesite="lax")
+    return response
+
+
+def _pkce_verifier_matches(code_verifier: str, code_challenge: str) -> bool:
+    """RFC 7636 S256 verification, total over hostile input. The comparison is over bytes
+    so a non-ASCII ``code_challenge`` (which reaches here unvalidated from the client's
+    authorize request) simply fails to match instead of raising ``TypeError`` the way
+    ``hmac.compare_digest`` does on two ``str`` with non-ASCII content. The verifier is
+    ASCII per spec; a compliant client's challenge is base64url and matches."""
+    digest = hashlib.sha256(code_verifier.encode("ascii", "replace")).digest()
+    computed = urlsafe_b64encode(digest).rstrip(b"=")
+    return hmac.compare_digest(computed, code_challenge.encode("utf-8"))
+
+
+class _SingleUseGuard:
+    """Atomic single-use claim for a one-time id (an auth-code, connect-flow ``jti``, or refresh-token
+    ``jti``) over the injected proxy cache.
+
+    Uses an atomic increment rather than a get-then-set: two concurrent redemptions of the same id
+    cannot both observe "unused", because exactly one increment returns 1. The claim IS the gate, so it
+    fails closed. Crucially, the increment must be recorded in a backend SHARED across replicas, or the
+    single-use property is per-worker only (each replica's in-memory counter returns 1, so a captured
+    id replays through a different worker):
+
+    - When a Redis backend is configured it is the SOLE authority: the claim goes straight to Redis
+      (``INCR`` is atomic across replicas), and any Redis fault fails the claim CLOSED — it never falls
+      back to the per-worker in-memory count (``DualCache.async_increment_cache`` does fall back, which
+      is exactly the replay window this avoids).
+    - With no Redis configured (single-replica) the in-memory increment is authoritative within the one
+      process. A multi-worker deployment must run Redis for the guarantee to hold across workers.
+
+    The id's own TTL is the outer bound. For the auth code, PKCE binding is the primary defense against
+    interception; this makes the RFC 6749 4.1.2 single-use property reliable on top of it."""
+
+    def __init__(self, cache: DualCache) -> None:
+        self._cache = cache
+
+    async def claim(self, key: str, ttl_seconds: int) -> bool:
+        """Atomically claim ``key``. ``True`` iff this caller is the first (increment to 1); ``False``
+        on a replay (>1) or when the claim could not be recorded in the shared backend (fail closed)."""
+        from litellm.proxy.proxy_server import redis_usage_cache  # noqa: PLC0415  # circular import at module load
+
+        # Resolve the shared authority HERE rather than trusting the injected cache: callers pass
+        # user_api_key_cache, which only carries a redis_cache when enable_redis_auth_cache is set
+        # (off by default), so a guard that read its injected cache silently degraded every claim to
+        # a per-worker count on a stock multi-worker deployment. redis_usage_cache is the store the
+        # proxy already treats as cross-worker, so no call site can wire the guarantee away.
+        redis_cache = redis_usage_cache or getattr(self._cache, "redis_cache", None)
+        if redis_cache is not None:
+            # Shared, atomic authority for multi-replica deployments. Claim ONLY against Redis and fail
+            # CLOSED on any Redis fault (async_increment re-raises) rather than fall back to the
+            # per-worker in-memory count, which would let each replica observe count==1 and replay the id.
+            try:
+                count = await redis_cache.async_increment(key, 1, ttl=ttl_seconds)
+            except Exception as e:  # noqa: BLE001  # ANY Redis fault fails the single-use claim closed
+                verbose_logger.warning(
+                    "mcp gateway single-use claim: shared cache backend unavailable, failing closed: %s", e
+                )
+                return False
+            return count == 1
+        # No shared backend configured (single-replica): the in-memory increment is authoritative.
+        count = await self._cache.async_increment_cache(key, 1, ttl=ttl_seconds, local_only=True)
+        return count == 1
+
+
+def _session_token_pair(principal: SessionPrincipal, keys: SessionKeys, now: datetime) -> Response:
+    access = mint_session_token(principal, keys, now)
+    refresh = mint_session_refresh_token(principal, keys, now)
+    if not isinstance(access, MintedSessionToken) or not isinstance(refresh, MintedSessionToken):
+        return _oauth_error(500, "server_error", "failed to mint the session credential")
+    return JSONResponse(
+        status_code=200,
+        content={
+            "access_token": access.token.get_secret_value(),
+            "token_type": "Bearer",
+            "expires_in": int((access.expires_at - now).total_seconds()),
+            "refresh_token": refresh.token.get_secret_value(),
+        },
+        headers=TOKEN_NO_CACHE_HEADERS,
+    )
+
+
+def _reload_failure_response(failure: ReloadUserFailure) -> Response:
+    """Map the live-user revalidation failure onto its OAuth error, exhaustively, so a new
+    ``ReloadUserFailure`` member is a type error here rather than silently 400ing."""
+    match failure:
+        case "unavailable":
+            return _oauth_error(503, "temporarily_unavailable", "the gateway database is unavailable; retry")
+        case "unresolvable":
+            return _oauth_error(500, "server_error", "the gateway is not configured to resolve users")
+        case "no_active_key":
+            return _oauth_error(400, "invalid_grant", "the user for this grant is no longer active")
+        case _:
+            assert_never(failure)
+
+
+async def aggregate_token(
+    request: Request,
+    grant_type: str,
+    code: str | None,
+    redirect_uri: str | None,
+    client_id: str,
+    code_verifier: str | None,
+    refresh_token: str | None,
+    master_key: str | None,
+    reload_user: ReloadUser,
+    cache: DualCache,
+) -> Response:
+    """The aggregate token verb: authorization_code and refresh_token grants for the
+    identity-only session pair. Every path re-validates the litellm user live before
+    minting, so a deactivated user cannot obtain or renew a session."""
+    if master_key is None:
+        verbose_logger.error("mcp_gateway_dcr token grant rejected: no master_key configured")
+        return _oauth_error(500, "server_error", "the gateway has no master key configured")
+    keys = session_keys_from_master_key(master_key)
+    now = datetime.now(timezone.utc)
+    if grant_type == "authorization_code":
+        return await _authorization_code_grant(
+            code=code,
+            redirect_uri=redirect_uri,
+            client_id=client_id,
+            code_verifier=code_verifier,
+            keys=keys,
+            now=now,
+            reload_user=reload_user,
+            guard=_SingleUseGuard(cache),
+        )
+    if grant_type == "refresh_token":
+        return await _refresh_token_grant(
+            refresh_token=refresh_token,
+            client_id=client_id,
+            keys=keys,
+            now=now,
+            reload_user=reload_user,
+            guard=_SingleUseGuard(cache),
+        )
+    return _oauth_error(400, "unsupported_grant_type", "grant_type must be authorization_code or refresh_token")
+
+
+async def _authorization_code_grant(
+    code: str | None,
+    redirect_uri: str | None,
+    client_id: str,
+    code_verifier: str | None,
+    keys: SessionKeys,
+    now: datetime,
+    reload_user: ReloadUser,
+    guard: _SingleUseGuard,
+) -> Response:
+    if not code or not redirect_uri or not code_verifier:
+        return _oauth_error(400, "invalid_request", "code, redirect_uri, and code_verifier are required")
+    if not MIN_CODE_VERIFIER_LENGTH <= len(code_verifier) <= MAX_CODE_VERIFIER_LENGTH:
+        return _oauth_error(400, "invalid_request", "code_verifier must be 43 to 128 characters (RFC 7636)")
+    parsed = _open_sealed(code, GATEWAY_AUTH_CODE_PREFIX, _GatewayAuthCode, _AUTH_CODE_DEBUG_KEY)
+    if parsed is None:
+        return _oauth_error(400, "invalid_grant", "the authorization code is invalid")
+    if now.timestamp() >= parsed.exp:
+        return _oauth_error(400, "invalid_grant", "the authorization code has expired")
+    if client_id != parsed.client_id or redirect_uri != parsed.redirect_uri:
+        return _oauth_error(400, "invalid_grant", "the authorization code was issued to a different client")
+    if not _pkce_verifier_matches(code_verifier, parsed.code_challenge):
+        return _oauth_error(400, "invalid_grant", "PKCE verification failed")
+    # Revalidate the user BEFORE claiming the code, so a transient DB outage (a retryable
+    # 503) does not consume a still-valid code and force the client to restart sign-in.
+    failure = await reload_user(parsed.user_id)
+    if failure is not None:
+        return _reload_failure_response(failure)
+    # Atomic single-use claim is the gate: on a concurrent double-redeem exactly one caller
+    # wins, and a claim that cannot be recorded fails closed.
+    if not await guard.claim(
+        f"{_USED_CODE_CACHE_PREFIX}{parsed.jti}", GATEWAY_AUTH_CODE_TTL_SECONDS + _CLAIM_TTL_BUFFER_SECONDS
+    ):
+        return _oauth_error(400, "invalid_grant", "the authorization code was already used")
+    return _session_token_pair(SessionPrincipal(user_id=parsed.user_id, client_id=client_id), keys, now)
+
+
+async def _refresh_token_grant(
+    refresh_token: str | None,
+    client_id: str,
+    keys: SessionKeys,
+    now: datetime,
+    reload_user: ReloadUser,
+    guard: _SingleUseGuard,
+) -> Response:
+    if not refresh_token:
+        return _oauth_error(400, "invalid_request", "refresh_token is required")
+    opened = open_session_refresh_bearer(refresh_token, keys, now, expected_client_id=client_id)
+    if not isinstance(opened, SessionRefreshOpened):
+        return _oauth_error(400, "invalid_grant", "the refresh token is invalid for this client")
+    failure = await reload_user(opened.principal.user_id)
+    if failure is not None:
+        return _reload_failure_response(failure)
+    # Refresh-token rotation (OAuth 2.0 Security BCP section 4.13): the presented refresh token is
+    # single-use. Claim its jti before issuing the replacement pair, so a captured or replayed
+    # refresh token cannot mint a second pair after the legitimate holder rotated. Claimed AFTER
+    # user revalidation so a transient DB 503 does not burn a still-valid token; a claim that
+    # cannot be recorded fails closed, exactly like the authorization-code path.
+    if not await guard.claim(
+        f"{_USED_REFRESH_CACHE_PREFIX}{opened.jti}", SESSION_REFRESH_TTL_SECONDS + _CLAIM_TTL_BUFFER_SECONDS
+    ):
+        return _oauth_error(400, "invalid_grant", "the refresh token was already used")
+    return _session_token_pair(opened.principal, keys, now)

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -49,6 +49,7 @@ from litellm.litellm_core_utils.url_utils import SSRFError, async_safe_get
 from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
 from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
     MCPRequestHandler,
+    _is_mcp_admitted_user_subject,
 )
 from litellm.proxy._experimental.mcp_server.exceptions import (
     MCPServerListError,
@@ -2197,6 +2198,56 @@ class MCPServerManager:
 
         return [server_id for server_id in submitted_server_ids if self.get_mcp_server_by_id(server_id) is not None]
 
+    async def operator_open_server_ids(
+        self,
+        user_api_key_auth: UserAPIKeyAuth | None = None,
+        *,
+        allow_all_server_ids: list[str] | None = None,
+        submitted_server_ids: list[str] | None = None,
+    ) -> set:
+        """Servers reachable through OPEN channels rather than a grant: operator-opened
+        ``allow_all_keys`` servers, plus the caller's own active BYOM submissions when the caller
+        carries no explicit ``mcp_servers`` scope.
+
+        The single owner of that question for BOTH axes. The server union in
+        ``get_allowed_mcp_servers`` adds these ids, and the admitted subject's tool resolution asks
+        the same question to treat an open-channel server as default-open for tools — exactly how a
+        virtual key experiences it. Encoding the channel membership twice is how a server ends up
+        listable but uninvokable.
+
+        Empty inside a toolset scope: toolset_mcp_route / dynamic_mcp_route set
+        ``_mcp_active_toolset_id`` before calling the handler, pinning the request to the toolset's
+        own servers (checking op.mcp_toolsets==[] instead would false-positive on DB-default rows
+        where Postgres initialises the column to ARRAY[]::TEXT[]).
+
+        ``allow_all_server_ids`` / ``submitted_server_ids`` are injectable so the server union,
+        which precomputes both for its fallback path, does not compute them twice."""
+        from litellm.proxy._experimental.mcp_server.mcp_context import (  # noqa: PLC0415
+            _mcp_active_toolset_id,
+        )
+
+        if _mcp_active_toolset_id.get() is not None:
+            return set()
+        if allow_all_server_ids is None:
+            allow_all_server_ids = self.get_allow_all_keys_server_ids()
+        open_ids = set(allow_all_server_ids)
+        key_object_permission = user_api_key_auth.object_permission if user_api_key_auth else None
+        # "Explicitly scoped, so do not widen with BYOM" is a rule about a CREDENTIAL that carries
+        # its own mcp_servers list. It does not describe a keyless admitted subject: its
+        # object_permission is the user's own row, whose mcp_servers column is [] by DB default, so
+        # applying this rule would hide almost every admitted user's OWN submitted servers. Their
+        # submissions are theirs by authorship, and their scope comes from the per-source union.
+        has_explicit_object_permission = (
+            not _is_mcp_admitted_user_subject(user_api_key_auth)
+            and key_object_permission is not None
+            and (key_object_permission.mcp_servers is not None)
+        )
+        if not has_explicit_object_permission:
+            if submitted_server_ids is None:
+                submitted_server_ids = await self._get_active_submitted_mcp_server_ids_for_user(user_api_key_auth)
+            open_ids.update(submitted_server_ids)
+        return open_ids
+
     async def get_allowed_mcp_servers(self, user_api_key_auth: Optional[UserAPIKeyAuth] = None) -> list[str]:
         """
         Get the allowed MCP Servers for the user.
@@ -2210,11 +2261,22 @@ class MCPServerManager:
 
         allow_all_server_ids = self.get_allow_all_keys_server_ids()
 
+        # A keyless admitted subject is resolved per grant source, and channel decisions that are
+        # absolute for a scoped KEY credential are not absolute for it: its own opt-out silences its
+        # own source (handled per source in the resolver), never its teams' grants, and its admin
+        # role does not swallow the grant model — a session bearer is a third-party client
+        # credential, not the dashboard, so an admin signing in through the connect flow gets their
+        # grants like anyone else rather than handing the client the full registry ahead of every
+        # per-team org ceiling.
+        is_admitted_subject = _is_mcp_admitted_user_subject(user_api_key_auth)
+
         # The key explicitly opted out of every MCP server. Return zero before
         # layering on allow_all_keys or submitted servers so the opt-out is absolute.
         key_object_permission = user_api_key_auth.object_permission if user_api_key_auth else None
-        if key_object_permission is not None and (
-            SpecialMCPServerNames.no_mcp_servers.value in (key_object_permission.mcp_servers or [])
+        if (
+            not is_admitted_subject
+            and key_object_permission is not None
+            and (SpecialMCPServerNames.no_mcp_servers.value in (key_object_permission.mcp_servers or []))
         ):
             return []
 
@@ -2234,8 +2296,14 @@ class MCPServerManager:
         )
 
         try:
-            # If admin but NO explicit object permission, get all servers
-            if user_api_key_auth and _user_has_admin_view(user_api_key_auth) and not has_explicit_object_permission:
+            # If admin but NO explicit object permission, get all servers (never for an admitted
+            # subject — see is_admitted_subject above)
+            if (
+                user_api_key_auth
+                and not is_admitted_subject
+                and _user_has_admin_view(user_api_key_auth)
+                and not has_explicit_object_permission
+            ):
                 verbose_logger.debug("Admin user without explicit object_permission - returning all servers")
                 return list(self.get_registry().keys())
 
@@ -2243,19 +2311,13 @@ class MCPServerManager:
             allowed_mcp_servers = await MCPRequestHandler.get_allowed_mcp_servers(user_api_key_auth)
             verbose_logger.debug(f"Allowed MCP Servers for user api key auth: {allowed_mcp_servers}")
             combined_servers = set(allowed_mcp_servers)
-            # Only skip allow_all_keys servers when the request is inside a toolset
-            # scope.  toolset_mcp_route / dynamic_mcp_route set _mcp_active_toolset_id
-            # before calling the handler — that ContextVar is the reliable signal.
-            # Using op.mcp_toolsets==[] would false-positive on DB-default rows where
-            # Postgres initialises the column to ARRAY[]::TEXT[].
-            from litellm.proxy._experimental.mcp_server.mcp_context import (  # noqa: PLC0415
-                _mcp_active_toolset_id,
+            combined_servers.update(
+                await self.operator_open_server_ids(
+                    user_api_key_auth,
+                    allow_all_server_ids=allow_all_server_ids,
+                    submitted_server_ids=submitted_server_ids,
+                )
             )
-
-            in_toolset_scope = _mcp_active_toolset_id.get() is not None
-            if not in_toolset_scope:
-                combined_servers.update(allow_all_server_ids)
-                combined_servers.update(submitted_server_ids)
 
             # For anonymous callers (no user_id, no role), also surface any
             # servers the operator has opted into upstream-delegated auth.

--- a/litellm/proxy/_experimental/mcp_server/oauth_utils.py
+++ b/litellm/proxy/_experimental/mcp_server/oauth_utils.py
@@ -343,8 +343,36 @@ def _parse_redirect_uri_for_validation(redirect_uri: str) -> ParseResult:
         )
 
 
-def _validate_trusted_http_redirect_shape(parsed: ParseResult) -> bool:
-    """Return True when ``parsed`` is an allowlisted native callback (caller may return)."""
+def is_loopback_redirect_host(parsed: ParseResult) -> bool:
+    """True when the redirect host is loopback (RFC 8252 section 7.3).
+
+    Shared by every redirect-URI policy in the MCP OAuth surface so that none of them
+    hand-rolls its own host list: a literal ``("localhost", "127.0.0.1", "::1")`` tuple
+    silently misses the rest of 127.0.0.0/8 and IPv6-mapped forms.
+    """
+    host = (parsed.hostname or "").lower()
+    if host == "localhost":
+        return True
+    try:
+        return ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def validate_redirect_uri_shape(parsed: ParseResult) -> bool:
+    """Validate redirect-URI *hygiene* and resolve allowlisted native callbacks.
+
+    Returns True when ``parsed`` is an allowlisted native callback (the caller may accept
+    it outright); returns False for http/https, leaving the trust decision to the caller;
+    raises for a URI that no policy should ever accept (bad scheme, fragment, missing
+    host, userinfo, backslash in the host).
+
+    This is deliberately separate from :func:`validate_trusted_redirect_uri`, which adds
+    the *first-party* trust policy (same-origin, loopback, ops allowlist) appropriate to
+    the proxy's own OAuth endpoints. Public dynamic-client registration accepts any https
+    client and relies on PKCE plus the consent screen instead, so it shares this hygiene
+    rule but not that trust policy.
+    """
     if parsed.scheme not in ("http", "https"):
         if _matches_trusted_native_redirect_uri(parsed):
             return True
@@ -396,14 +424,8 @@ def _trusted_redirect_uri_is_allowed(
         ):
             return True
 
-    host = (parsed.hostname or "").lower()
-    if host == "localhost":
+    if is_loopback_redirect_host(parsed):
         return True
-    try:
-        if ip_address(host).is_loopback:
-            return True
-    except ValueError:
-        pass
 
     if parsed.scheme == "https":
         for entry in _parse_trusted_redirect_origins():
@@ -522,7 +544,7 @@ def validate_trusted_redirect_uri(request: Request, redirect_uri: str) -> None:
     :func:`validate_loopback_redirect_uri`.
     """
     parsed = _parse_redirect_uri_for_validation(redirect_uri)
-    if _validate_trusted_http_redirect_shape(parsed):
+    if validate_redirect_uri_shape(parsed):
         return
     redirect_netloc = _strip_default_port(parsed.scheme, parsed.netloc)
     proxy_base = _resolve_proxy_base_for_redirect(request)

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/session_credentials.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/session_credentials.py
@@ -149,6 +149,7 @@ class SessionRefreshOpened(BaseModel):
     model_config = ConfigDict(frozen=True)
     tag: Literal["opened"] = "opened"
     principal: SessionPrincipal
+    jti: str
 
 
 class SessionRefreshInvalid(BaseModel):
@@ -187,4 +188,4 @@ def open_session_refresh_bearer(
         return SessionRefreshInvalid()
     if opened.principal.client_id != expected_client_id:
         return SessionRefreshInvalid()
-    return SessionRefreshOpened(principal=opened.principal)
+    return SessionRefreshOpened(principal=opened.principal, jti=opened.jti)

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/session_token.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/session_token.py
@@ -113,10 +113,12 @@ class MintedSessionToken(BaseModel):
 
 
 class OpenedSessionToken(BaseModel):
-    """A validated session token of either kind: the principal it was minted for."""
+    """A validated session token of either kind: the principal it was minted for, plus the
+    ``jti`` so the token endpoint can enforce single-use rotation on a refresh token."""
 
     model_config = ConfigDict(frozen=True)
     principal: SessionPrincipal
+    jti: str
 
 
 class SessionTokenTooLarge(BaseModel):
@@ -320,7 +322,9 @@ def _open(
         return SessionMalformed()
     if now.timestamp() >= claims.exp:
         return SessionExpired()
-    return OpenedSessionToken(principal=SessionPrincipal(user_id=claims.user_id, client_id=claims.client_id))
+    return OpenedSessionToken(
+        principal=SessionPrincipal(user_id=claims.user_id, client_id=claims.client_id), jti=claims.jti
+    )
 
 
 def _decode_claims(

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -977,7 +977,17 @@ if MCP_AVAILABLE:
                     data = await add_litellm_data_to_request(
                         data=body_data,
                         request=request,
-                        user_api_key_dict=user_api_key_auth,
+                        # Bill a team-derived call to the team that granted it. A keyless admitted
+                        # subject carries no team_id, so spend skipped team updates entirely and
+                        # charged the user's PRIMARY org — the granting team's budget never
+                        # accumulated (so it could never begin to block) and, cross-org, the wrong
+                        # organization was charged. This is the ACCOUNTING half; the enforcement
+                        # half (an already-over-budget team stops granting) lives in the source gate.
+                        # Authorization is unaffected: it ran before this, and the union is resolved
+                        # from the untouched auth object passed to call_mcp_tool below.
+                        user_api_key_dict=await MCPRequestHandler.billing_auth_for_tool_call(
+                            user_api_key_auth, tool_name=name
+                        ),
                         proxy_config=proxy_config,
                     )
                 else:

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2605,6 +2605,17 @@ class UserAPIKeyAuth(LiteLLM_VerificationTokenView):  # the expected response ob
     user_max_budget: Optional[float] = None
     request_route: Optional[str] = None
     is_session_token: bool = False
+    # Server-only marker set exclusively by the MCP gateway admission path
+    # (_reload_admitted_user) for a keyless user-subject admitted via a gateway DCR session
+    # bearer or bridge envelope. Not a DB column and never populated from caller-controlled key
+    # metadata or JWT claims, so it cannot be forged to gain the team-inherited MCP grant union
+    # or to escape the caller-Authorization egress scrub. exclude=True keeps it out of serialization.
+    mcp_admitted_user_subject: bool = Field(default=False, exclude=True)
+    # team_id -> that team's mcp_rpm_limit map, for a keyless admitted subject that reaches MCP
+    # servers through several teams at once and therefore has no single team_id for the limiter to
+    # key off. Server-only and stripped from validated input for the same reason as the marker
+    # above: a forged entry would let a caller pick which team's rpm bucket it is charged against.
+    mcp_source_team_rpm_limits: dict[str, dict[str, int]] | None = Field(default=None, exclude=True)
     budget_reservation: Optional[Dict[str, Any]] = Field(default=None, exclude=True)
     budget_throttle_pct: Optional[float] = Field(default=None, exclude=True)
     user: Optional[Any] = None  # Expanded user object when expand=user is used
@@ -2625,6 +2636,11 @@ class UserAPIKeyAuth(LiteLLM_VerificationTokenView):  # the expected response ob
         # If values is already an instance (not a dict), return it as-is
         if not isinstance(values, dict):
             return values
+        # mcp_admitted_user_subject is a server-only marker, set ONLY by the MCP gateway admission
+        # path via post-construction assignment. Strip it from any validated input (constructor
+        # kwargs, model_validate, a JWT/key claim splat) so it can never be forged from caller data.
+        values.pop("mcp_admitted_user_subject", None)
+        values.pop("mcp_source_team_rpm_limits", None)
         if values.get("api_key") is not None:
             values.update({"token": cls._safe_hash_litellm_api_key(values.get("api_key"))})
             if isinstance(values.get("api_key"), str):

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2661,6 +2661,15 @@ async def get_managed_vector_store_rows_by_uuids(
     return result
 
 
+class OrganizationNotFoundError(Exception):
+    """The organization row is CONFIRMED absent, as opposed to a lookup that failed.
+
+    Subclasses Exception so every existing except Exception caller keeps its current
+    behavior; it exists so a caller that wants to treat "no such org" as "no restriction" can do
+    that WITHOUT also swallowing an outage and silently dropping a real org ceiling.
+    """
+
+
 @log_db_metrics
 async def get_org_object(
     org_id: str,
@@ -2707,24 +2716,29 @@ async def get_org_object(
             query_kwargs["include"] = {"litellm_budget_table": True}
 
         response = await OrganizationRepository(prisma_client).table.find_unique(**query_kwargs)
-
-        if response is None:
-            raise Exception
-
-        _org_obj = LiteLLM_OrganizationTable(**response.model_dump())
-        # Cache the result
-        await user_api_key_cache.async_set_cache(
-            key=cache_key,
-            value=_org_obj,
-            model_type=LiteLLM_OrganizationTable,
-            ttl=DEFAULT_IN_MEMORY_TTL,
-        )
-
-        return _org_obj
     except Exception:
-        raise Exception(
+        # An operational failure (DB down, timeout, cache fault) is NOT the same fact as a confirmed
+        # missing row, and relabelling it as "doesn't exist" made every caller unable to tell them
+        # apart — a caller that treats absence as "this org places no restriction" then drops a real
+        # org ceiling during an outage. Propagate the real error; callers that already catch
+        # Exception are unaffected.
+        raise
+
+    if response is None:
+        raise OrganizationNotFoundError(
             f"Organization doesn't exist in db. Organization={org_id}. Create organization via `/organization/new` call."
         )
+
+    _org_obj = LiteLLM_OrganizationTable(**response.model_dump())
+    # Cache the result
+    await user_api_key_cache.async_set_cache(
+        key=cache_key,
+        value=_org_obj,
+        model_type=LiteLLM_OrganizationTable,
+        ttl=DEFAULT_IN_MEMORY_TTL,
+    )
+
+    return _org_obj
 
 
 async def _get_resources_from_access_groups(

--- a/litellm/proxy/auth/login_utils.py
+++ b/litellm/proxy/auth/login_utils.py
@@ -7,12 +7,15 @@ login endpoints (e.g., /login and /v2/login).
 
 import os
 import secrets
+from datetime import datetime, timedelta, timezone
 from typing import Literal, Optional, cast
 
+import jwt
 from fastapi import HTTPException
 
 import litellm
 from litellm.constants import LITELLM_PROXY_ADMIN_NAME, LITELLM_UI_SESSION_DURATION
+from litellm.litellm_core_utils.duration_parser import duration_in_seconds
 from litellm.proxy._types import (
     LiteLLM_UserTable,
     LitellmUserRoles,
@@ -311,6 +314,29 @@ async def authenticate_user(
             param="invalid_credentials",
             code=401,
         )
+
+
+def _ui_session_exp_timestamp() -> int:
+    """The ``exp`` claim (unix seconds) for a UI session cookie, ``LITELLM_UI_SESSION_DURATION``
+    from now. The virtual key sealed inside the cookie already expires after this same
+    duration; stamping the JWT itself gives the cookie the bounded lifetime the dashboard's
+    client-side expiry check and the server-side session-cookie readers both assume, instead
+    of a token that stays signature-valid until the master key rotates."""
+    ttl_seconds = duration_in_seconds(LITELLM_UI_SESSION_DURATION)
+    return int((datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)).timestamp())
+
+
+def encode_ui_session_jwt(returned_ui_token_object: ReturnedUITokenObject, master_key: str) -> str:
+    """Encode a UI session cookie JWT with a bounded ``exp``.
+
+    The single choke point every UI login path (SSO and username/password /login, /v2,
+    /v3) uses to mint the ``token`` cookie, so the cookie's lifetime is set in exactly one
+    place and cannot drift between paths. Without the ``exp`` the cookie is valid until the
+    master key rotates, and the session-cookie readers that require a bounded lifetime
+    (the MCP interactive sign-in) reject it.
+    """
+    claims = {**cast(dict, returned_ui_token_object), "exp": _ui_session_exp_timestamp()}
+    return jwt.encode(claims, master_key, algorithm="HS256")
 
 
 def create_ui_token_object(

--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -1781,28 +1781,38 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         """
         from litellm.proxy.auth.auth_utils import get_team_mcp_rpm_limit
 
-        if not mcp_server_name or not user_api_key_dict.team_id:
+        if not mcp_server_name:
             return
 
-        mcp_rpm_limit = get_team_mcp_rpm_limit(user_api_key_dict)
-        if not mcp_rpm_limit:
-            return
+        # Which teams' buckets does this call charge? A key is pinned to exactly one team. A keyless
+        # MCP-admitted subject reaches servers through SEVERAL teams at once and has no team_id, so
+        # without the second source below its calls charged no team bucket at all and it outran every
+        # team's mcp_rpm_limit. Every applicable team is charged rather than one being picked: the
+        # limiter enforces all descriptors, so each team's own ceiling binds on a call made through
+        # its grant, and there is no arbitrary attribution when several teams grant the same server.
+        team_limits: list[tuple[str | None, dict[str, int] | None]] = []
+        if user_api_key_dict.team_id:
+            team_limits.append((user_api_key_dict.team_id, get_team_mcp_rpm_limit(user_api_key_dict)))
+        for source_team_id, source_limit in (user_api_key_dict.mcp_source_team_rpm_limits or {}).items():
+            team_limits.append((source_team_id, source_limit))
 
-        server_rpm_limit = mcp_rpm_limit.get(mcp_server_name)
-        if server_rpm_limit is None:
-            return
-
-        descriptors.append(
-            RateLimitDescriptor(
-                key="mcp_per_team",
-                value=f"{user_api_key_dict.team_id}:{mcp_server_name}",
-                rate_limit={
-                    "requests_per_unit": server_rpm_limit,
-                    "tokens_per_unit": None,
-                    "window_size": self.window_size,
-                },
+        for team_id, mcp_rpm_limit in team_limits:
+            if not team_id or not mcp_rpm_limit:
+                continue
+            server_rpm_limit = mcp_rpm_limit.get(mcp_server_name)
+            if server_rpm_limit is None:
+                continue
+            descriptors.append(
+                RateLimitDescriptor(
+                    key="mcp_per_team",
+                    value=f"{team_id}:{mcp_server_name}",
+                    rate_limit={
+                        "requests_per_unit": server_rpm_limit,
+                        "tokens_per_unit": None,
+                        "window_size": self.window_size,
+                    },
+                )
             )
-        )
 
     def _should_enforce_rate_limit(
         self,

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     import httpx
 
 import jwt
-from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
 from fastapi.responses import RedirectResponse
 
 import litellm
@@ -965,15 +965,8 @@ async def google_login(
             state=cli_state,
             request=request,
         )
-        if return_to is not None and sso_redirect is not None:
-            if SSOAuthenticationHandler._validate_return_to(return_to):
-                sso_redirect.set_cookie(
-                    key="litellm_cp_return_to",
-                    value=return_to,
-                    max_age=600,
-                    httponly=True,
-                    samesite="lax",
-                )
+        if sso_redirect is not None:
+            _persist_return_to_cookie(sso_redirect, return_to)
         return sso_redirect
 
     from fastapi.responses import HTMLResponse
@@ -982,13 +975,19 @@ async def google_login(
         os.getenv("LITELLM_HIDE_DEFAULT_CREDENTIALS_HINT", "false").lower() == "true"
         or general_settings.get("hide_default_credentials_hint", False) is True
     )
-    return HTMLResponse(
+    form_response = HTMLResponse(
         content=build_ui_login_form(
             show_deprecation_banner=True,
             hide_default_credentials_hint=hide_default_credentials_hint,
         ),
         status_code=200,
     )
+    # Preserve return_to across the username/password sign-in too, via the SAME shared, never-raising
+    # helper the SSO branch uses, so /login can resume the connect flow instead of dead-ending at the
+    # dashboard. One implementation → the two sign-in branches cannot diverge (and the login form always
+    # renders, since the helper never raises on a bad return_to).
+    _persist_return_to_cookie(form_response, return_to)
+    return form_response
 
 
 def generic_response_convertor(
@@ -2418,6 +2417,92 @@ async def sso_readiness():
     )
 
 
+def _is_same_origin_return_path(return_to: str) -> bool:
+    """True for a strictly relative return path that stays on the gateway's own origin by
+    construction, and is therefore safe to honor without a configured ``control_plane_url``.
+    Used by the MCP gateway DCR authorize round-trip so a browser sent through login lands
+    back on the authorize request.
+
+    Requires a single leading ``/`` (not protocol-relative ``//``), no backslash (browsers
+    fold ``\\`` to ``/``, so ``/\\evil.com`` would escape the origin), and no control or
+    whitespace characters. Rejecting control chars keeps a ``\\r\\n``/tab-bearing value out
+    of the redirect ``Location`` and the ``litellm_cp_return_to`` cookie entirely, rather
+    than relying on downstream header encoding to neutralize it."""
+    if not return_to.startswith("/") or return_to.startswith("//") or "\\" in return_to:
+        return False
+    return not any(ord(ch) < 0x20 or ch in (" ", "\x7f") for ch in return_to)
+
+
+async def _sso_return_to_redirect(
+    return_to: str | None,
+    jwt_token: str,
+    redis_usage_cache,
+    user_api_key_cache,
+) -> RedirectResponse | None:
+    """Resolve the post-SSO redirect for a ``return_to``, or None to fall through to the dashboard.
+
+    Two arms, both clearing the one-shot ``litellm_cp_return_to`` cookie:
+    - **Same-origin relative path** (the MCP gateway DCR authorize round-trip): set the session cookie
+      exactly like the dashboard path, then send the browser back where it came from.
+    - **Control-plane cross-origin** (``control_plane_url``): stash the JWT behind a single-use opaque
+      code (60s TTL) so the token never lands in browser history/logs; the control plane redeems it via
+      ``POST /v3/login/exchange``.
+
+    Extracted from ``get_redirect_response_from_openid`` to keep that method inside the complexity
+    budget; behavior is identical to the inline arms it replaces (including letting
+    ``_validate_return_to`` raise for a mismatched absolute return_to, as before)."""
+    if return_to is None:
+        return None
+
+    if _is_same_origin_return_path(return_to):
+        redirect_response = RedirectResponse(url=return_to, status_code=303)
+        redirect_response.set_cookie(key="token", value=jwt_token)
+        redirect_response.delete_cookie("litellm_cp_return_to")
+        return redirect_response
+
+    if SSOAuthenticationHandler._validate_return_to(return_to):
+        code = secrets.token_urlsafe(32)
+        cache_key = f"login_code:{code}"
+        cache_value = {"token": jwt_token, "redirect_url": return_to}
+        if redis_usage_cache is not None:
+            await redis_usage_cache.async_set_cache(key=cache_key, value=cache_value, ttl=60)
+        else:
+            await user_api_key_cache.async_set_cache(key=cache_key, value=cache_value, ttl=60)
+
+        separator = "&" if "?" in return_to else "?"
+        redirect_url = return_to + separator + urlencode({"login": "success", "code": code})
+        verbose_proxy_logger.info("Cross-origin SSO: redirecting to control plane with login code")
+        redirect_response = RedirectResponse(url=redirect_url, status_code=303)
+        redirect_response.delete_cookie("litellm_cp_return_to")
+        return redirect_response
+
+    return None
+
+
+def _persist_return_to_cookie(response: Response, return_to: str | None) -> None:
+    """Best-effort: persist a SAFE ``return_to`` on ``response`` as the one-shot ``litellm_cp_return_to``
+    cookie so ANY sign-in path — SSO / Okta / generic OR the username/password form — can resume there
+    afterwards. THIS is the single source of truth, called by every sign-in branch so they cannot
+    diverge (a per-branch reimplementation is exactly how the two drifted before). Honors a strictly
+    relative same-origin path, and (when ``control_plane_url`` is configured) a return_to matching that
+    origin. It NEVER raises: a mismatched or invalid ``return_to`` is simply not stored, so it can never
+    block sign-in — the login entrypoint must always render."""
+    if return_to is None:
+        return
+    try:
+        safe = _is_same_origin_return_path(return_to) or SSOAuthenticationHandler._validate_return_to(return_to)
+    except HTTPException:
+        return  # a non-matching absolute return_to is ignored, never blocks sign-in
+    if safe:
+        response.set_cookie(
+            key="litellm_cp_return_to",
+            value=return_to,
+            max_age=600,
+            httponly=True,
+            samesite="lax",
+        )
+
+
 class SSOAuthenticationHandler:
     """
     Handler for SSO Authentication across all SSO providers
@@ -3055,7 +3140,6 @@ class SSOAuthenticationHandler:
         return_to: Optional[str] = None,
         sso_assertion: SSOIdentityAssertion | None = None,
     ) -> RedirectResponse:
-        import jwt
 
         from litellm.proxy.proxy_server import (
             general_settings,
@@ -3219,30 +3303,21 @@ class SSOAuthenticationHandler:
             server_root_path=get_server_root_path(),
         )
 
-        jwt_token = jwt.encode(
-            cast(dict, returned_ui_token_object),
-            master_key or "",
-            algorithm="HS256",
+        from litellm.proxy.auth.login_utils import encode_ui_session_jwt
+
+        jwt_token = encode_ui_session_jwt(returned_ui_token_object, master_key or "")
+
+        # Post-SSO return_to handling (the same-origin DCR round-trip and the control-plane
+        # cross-origin code exchange) lives in one shared helper so this method stays inside the
+        # complexity budget. None falls through to the dashboard redirect below.
+        return_to_redirect = await _sso_return_to_redirect(
+            return_to=return_to,
+            jwt_token=jwt_token,
+            redis_usage_cache=redis_usage_cache,
+            user_api_key_cache=user_api_key_cache,
         )
-
-        # Control-plane cross-origin: store JWT behind a single-use opaque
-        # code (60s TTL) so the token never appears in browser history / logs.
-        # The control plane redeems it via POST /v3/login/exchange.
-        if return_to is not None and SSOAuthenticationHandler._validate_return_to(return_to):
-            code = secrets.token_urlsafe(32)
-            cache_key = f"login_code:{code}"
-            cache_value = {"token": jwt_token, "redirect_url": return_to}
-            if redis_usage_cache is not None:
-                await redis_usage_cache.async_set_cache(key=cache_key, value=cache_value, ttl=60)
-            else:
-                await user_api_key_cache.async_set_cache(key=cache_key, value=cache_value, ttl=60)
-
-            separator = "&" if "?" in return_to else "?"
-            redirect_url = return_to + separator + urlencode({"login": "success", "code": code})
-            verbose_proxy_logger.info("Cross-origin SSO: redirecting to control plane with login code")
-            redirect_response = RedirectResponse(url=redirect_url, status_code=303)
-            redirect_response.delete_cookie("litellm_cp_return_to")
-            return redirect_response
+        if return_to_redirect is not None:
+            return return_to_redirect
 
         if user_id is not None and isinstance(user_id, str):
             litellm_dashboard_ui += "?login=success"

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -13472,7 +13472,7 @@ async def fallback_login(request: Request):
 @router.post("/login", include_in_schema=False)  # hidden since this is a helper for UI sso login
 async def login(request: Request):
     global premium_user, general_settings, master_key
-    from litellm.proxy.auth.login_utils import authenticate_user, create_ui_token_object
+    from litellm.proxy.auth.login_utils import authenticate_user, create_ui_token_object, encode_ui_session_jwt
     from litellm.proxy.utils import get_custom_url
 
     form = await request.form()
@@ -13495,13 +13495,7 @@ async def login(request: Request):
     )
 
     # Generate JWT token
-    import jwt
-
-    jwt_token = jwt.encode(
-        cast(dict, returned_ui_token_object),
-        cast(str, master_key),
-        algorithm="HS256",
-    )
+    jwt_token = encode_ui_session_jwt(returned_ui_token_object, cast(str, master_key))
 
     # Build redirect URL
     litellm_dashboard_ui = get_custom_url(str(request.base_url))
@@ -13511,16 +13505,51 @@ async def login(request: Request):
         litellm_dashboard_ui += "/ui/"
     litellm_dashboard_ui += "?login=success"
 
+    # Honor a same-origin return_to preserved by the sign-in page (e.g. the aggregate DCR connect flow's
+    # authorize round-trip), mirroring the SSO callback; otherwise land on the dashboard. Gated by
+    # _is_same_origin_return_path (strictly relative path) so it can never be an open redirect, and the
+    # one-shot cookie is cleared after use.
+    from litellm.proxy.management_endpoints.ui_sso import _sso_return_to_redirect
+
+    # Resume through the SAME resumer the SSO callback uses, rather than a second, narrower arm.
+    # _persist_return_to_cookie stores both shapes it accepts (a relative same-origin path AND a
+    # control_plane_url-matching absolute URL); honoring only the relative one here silently dropped
+    # the control-plane case, landing the user on the dashboard. One function decides how a stored
+    # return_to is honored for EVERY sign-in branch, so the write and read sets cannot diverge: it
+    # sets the token cookie on the same-origin arm and hands off via a one-time login code on the
+    # cross-origin arm, and clears the one-shot cookie in both.
+    cp_return_to = request.cookies.get("litellm_cp_return_to")
+    if cp_return_to:
+        try:
+            resumed = await _sso_return_to_redirect(
+                return_to=cp_return_to,
+                jwt_token=jwt_token,
+                redis_usage_cache=redis_usage_cache,
+                user_api_key_cache=user_api_key_cache,
+            )
+        except Exception:  # noqa: BLE001  # resuming must NEVER block a completed sign-in
+            # The symmetric half of _persist_return_to_cookie's "never raises" contract. The resumer
+            # rejects a return_to that no longer matches control_plane_url (a config change between
+            # the cookie's write and this read), and the user has ALREADY authenticated here —
+            # failing their login over a stale one-shot cookie is the worst possible outcome. Land
+            # on the dashboard instead; the cookie is cleared below either way.
+            verbose_proxy_logger.info("Ignoring stale litellm_cp_return_to cookie; landing on dashboard")
+            resumed = None
+        if resumed is not None:
+            return resumed
+
     # Create redirect response with cookie
     redirect_response = RedirectResponse(url=litellm_dashboard_ui, status_code=303)
     redirect_response.set_cookie(key="token", value=jwt_token)
+    if cp_return_to:
+        redirect_response.delete_cookie(key="litellm_cp_return_to")
     return redirect_response
 
 
 @router.post("/v2/login", include_in_schema=False)  # hidden helper for UI logins via API
 async def login_v2(request: Request):
     global premium_user, general_settings, master_key
-    from litellm.proxy.auth.login_utils import authenticate_user, create_ui_token_object
+    from litellm.proxy.auth.login_utils import authenticate_user, create_ui_token_object, encode_ui_session_jwt
     from litellm.proxy.utils import get_custom_url
 
     try:
@@ -13541,13 +13570,7 @@ async def login_v2(request: Request):
             premium_user=premium_user,
         )
 
-        import jwt
-
-        jwt_token = jwt.encode(
-            cast(dict, returned_ui_token_object),
-            cast(str, master_key),
-            algorithm="HS256",
-        )
+        jwt_token = encode_ui_session_jwt(returned_ui_token_object, cast(str, master_key))
 
         litellm_dashboard_ui = get_custom_url(str(request.base_url))
         if litellm_dashboard_ui.endswith("/"):
@@ -13591,7 +13614,7 @@ async def login_v2(request: Request):
 )  # control-plane login — always returns token in body for cross-origin use
 async def login_v3(request: Request):
     global premium_user, general_settings, master_key
-    from litellm.proxy.auth.login_utils import authenticate_user, create_ui_token_object
+    from litellm.proxy.auth.login_utils import authenticate_user, create_ui_token_object, encode_ui_session_jwt
     from litellm.proxy.utils import get_custom_url
 
     try:
@@ -13620,13 +13643,7 @@ async def login_v3(request: Request):
             premium_user=premium_user,
         )
 
-        import jwt
-
-        jwt_token = jwt.encode(
-            cast(dict, returned_ui_token_object),
-            cast(str, master_key),
-            algorithm="HS256",
-        )
+        jwt_token = encode_ui_session_jwt(returned_ui_token_object, cast(str, master_key))
 
         litellm_dashboard_ui = get_custom_url(str(request.base_url))
         if litellm_dashboard_ui.endswith("/"):

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -6405,28 +6405,33 @@ class TestGatewaySessionAdmission:
         # bridge envelope arm); the headers dict is whatever the request carried, here empty.
         assert not mcp_server_auth_headers
 
-    async def test_expired_session_fails_closed_with_invalid_token_challenge(self):
+    @pytest.mark.parametrize(
+        "scenario, expect_challenge",
+        [("expired", True), ("tampered", False), ("refresh_at_tool_edge", False), ("foreign_key", False)],
+    )
+    async def test_bad_session_bearer_fails_closed(self, scenario, expect_challenge):
+        # Every non-admissible session-shaped bearer fails closed with 401; a valid-but-unusable one
+        # (expired) additionally carries the invalid_token challenge so the DCR client re-authorizes.
         from datetime import datetime, timezone
 
-        mint, _refresh, principal, keys = self._session_bearer()
-        token = mint(principal, keys, datetime(2020, 1, 1, tzinfo=timezone.utc)).token.get_secret_value()
-        with (
-            patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
-        ):
+        if scenario == "expired":
+            mint, _refresh, principal, keys = self._session_bearer()
+            bearer = mint(principal, keys, datetime(2020, 1, 1, tzinfo=timezone.utc)).token.get_secret_value()
+        elif scenario == "tampered":
+            token = self._access_token()
+            bearer = token[:-3] + ("aaa" if not token.endswith("aaa") else "bbb")
+        elif scenario == "refresh_at_tool_edge":
+            _mint, refresh, principal, keys = self._session_bearer()
+            bearer = refresh(principal, keys, datetime(2030, 1, 1, tzinfo=timezone.utc)).token.get_secret_value()
+        else:  # foreign_key: minted under the real master key, presented while the proxy uses another
+            bearer = self._access_token()
+        master_key = "sk-a-totally-different-master-key" if scenario == "foreign_key" else self._MASTER_KEY
+        with patch("litellm.proxy.proxy_server.master_key", master_key):
             with pytest.raises(HTTPException) as exc_info:
-                await MCPRequestHandler.process_mcp_request(self._scope(token))
+                await MCPRequestHandler.process_mcp_request(self._scope(bearer))
         assert exc_info.value.status_code == 401
-        assert 'error="invalid_token"' in (exc_info.value.headers or {})["WWW-Authenticate"]
-
-    async def test_tampered_session_fails_closed(self):
-        token = self._access_token()
-        tampered = token[:-3] + ("aaa" if not token.endswith("aaa") else "bbb")
-        with (
-            patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
-        ):
-            with pytest.raises(HTTPException) as exc_info:
-                await MCPRequestHandler.process_mcp_request(self._scope(tampered))
-        assert exc_info.value.status_code == 401
+        if expect_challenge:
+            assert 'error="invalid_token"' in (exc_info.value.headers or {})["WWW-Authenticate"]
 
     async def test_deactivated_user_fails_with_invalid_token_challenge(self):
         """A cryptographically valid bearer whose referenced user is SCIM-deactivated must fail with
@@ -6466,27 +6471,6 @@ class TestGatewaySessionAdmission:
         assert oauth2_headers is None
         assert not any(k.lower() == "authorization" for k in (raw_headers or {}))
 
-    async def test_refresh_token_is_not_admitted_at_the_tool_edge(self):
-        from datetime import datetime, timezone
-
-        _mint, refresh, principal, keys = self._session_bearer()
-        refresh_token = refresh(principal, keys, datetime(2030, 1, 1, tzinfo=timezone.utc)).token.get_secret_value()
-        with (
-            patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
-        ):
-            with pytest.raises(HTTPException) as exc_info:
-                await MCPRequestHandler.process_mcp_request(self._scope(refresh_token))
-        assert exc_info.value.status_code == 401
-
-    async def test_foreign_key_session_fails_closed(self):
-        token = self._access_token()
-        with (
-            patch("litellm.proxy.proxy_server.master_key", "sk-a-totally-different-master-key"),
-        ):
-            with pytest.raises(HTTPException) as exc_info:
-                await MCPRequestHandler.process_mcp_request(self._scope(token))
-        assert exc_info.value.status_code == 401
-
     async def test_arm_does_not_fire_for_named_server(self):
         """A session-shaped bearer aimed at a named server (path scope) does not enter the
         aggregate arm; it is treated as an ordinary bearer on that server."""
@@ -6504,23 +6488,40 @@ class TestGatewaySessionAdmission:
         mock_auth.assert_called_once()
 
 
+def _make_team(team_id, mcp_servers, *, org_id=None, tool_perms=None, members=("sso-user",)):
+    from litellm.proxy._types import LiteLLM_ObjectPermissionTable, LiteLLM_TeamTable, Member
+
+    return LiteLLM_TeamTable(
+        team_id=team_id,
+        organization_id=org_id,
+        members_with_roles=[Member(user_id=u, role="user") for u in members],
+        access_group_ids=[],
+        object_permission=LiteLLM_ObjectPermissionTable(
+            object_permission_id=f"op-{team_id}", mcp_servers=mcp_servers, mcp_tool_permissions=tool_perms
+        ),
+    )
+
+
+def _make_admitted_subject(user_id, *, org_id=None, own_servers=None, own_tool_perms=None):
+    from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+    op = None
+    if own_servers is not None or own_tool_perms is not None:
+        op = LiteLLM_ObjectPermissionTable(
+            object_permission_id=f"userop-{user_id}",
+            mcp_servers=own_servers or [],
+            mcp_tool_permissions=own_tool_perms,
+        )
+    auth = UserAPIKeyAuth(user_id=user_id, api_key=None, org_id=org_id, object_permission=op)
+    auth.mcp_admitted_user_subject = True
+    return auth
+
+
 @pytest.mark.asyncio
 class TestUserSubjectTeamUnion:
     """_get_allowed_mcp_servers_for_team unions across ALL a user's teams for a keyless
     user-subject caller (the gateway DCR session bearer and bridge user-envelope), while a
     key-based caller keeps its single-team behavior byte-identically."""
-
-    def _team(self, team_id, mcp_servers, members=("sso-user",), tool_perms=None):
-        from litellm.proxy._types import LiteLLM_ObjectPermissionTable, LiteLLM_TeamTable, Member
-
-        return LiteLLM_TeamTable(
-            team_id=team_id,
-            members_with_roles=[Member(user_id=u, role="user") for u in members],
-            access_group_ids=[],
-            object_permission=LiteLLM_ObjectPermissionTable(
-                object_permission_id=f"op-{team_id}", mcp_servers=mcp_servers, mcp_tool_permissions=tool_perms
-            ),
-        )
 
     @contextlib.contextmanager
     def _patch(self, *, teams_by_id, user_teams=None, orgs_by_id=None):
@@ -6550,15 +6551,9 @@ class TestUserSubjectTeamUnion:
         ):
             yield
 
-    @staticmethod
-    def _admitted_subject(user_id):
-        auth = UserAPIKeyAuth(user_id=user_id, api_key=None)
-        auth.mcp_admitted_user_subject = True
-        return auth
-
     async def test_keyless_user_unions_servers_across_all_their_teams(self):
-        teams = {"team-a": self._team("team-a", ["srv1", "srv2"]), "team-b": self._team("team-b", ["srv2", "srv3"])}
-        auth = self._admitted_subject("sso-user")
+        teams = {"team-a": _make_team("team-a", ["srv1", "srv2"]), "team-b": _make_team("team-b", ["srv2", "srv3"])}
+        auth = _make_admitted_subject("sso-user")
         with self._patch(teams_by_id=teams, user_teams=["team-a", "team-b"]):
             result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
         assert set(result) == {"srv1", "srv2", "srv3"}
@@ -6566,7 +6561,7 @@ class TestUserSubjectTeamUnion:
     async def test_key_based_caller_uses_single_team_only(self):
         """A key-based caller (api_key set) with a team_id sees ONLY that team, even though the
         same user belongs to other teams: key auth must be byte-identical to before."""
-        teams = {"team-a": self._team("team-a", ["srv1"]), "team-b": self._team("team-b", ["srv2", "srv3"])}
+        teams = {"team-a": _make_team("team-a", ["srv1"]), "team-b": _make_team("team-b", ["srv2", "srv3"])}
         auth = UserAPIKeyAuth(user_id="sso-user", api_key="sk-hash", team_id="team-a")
         with self._patch(teams_by_id=teams, user_teams=["team-a", "team-b"]):
             result = await MCPRequestHandler._get_allowed_mcp_servers_for_team(auth)
@@ -6575,14 +6570,14 @@ class TestUserSubjectTeamUnion:
     async def test_keyless_user_with_explicit_team_id_uses_that_team_only(self):
         """A keyless caller that already pins a team_id (not the user-subject fan-out shape)
         resolves only that team; the union is strictly for the no-team-id user-subject case."""
-        teams = {"team-a": self._team("team-a", ["srv1"]), "team-b": self._team("team-b", ["srv2"])}
+        teams = {"team-a": _make_team("team-a", ["srv1"]), "team-b": _make_team("team-b", ["srv2"])}
         auth = UserAPIKeyAuth(user_id="sso-user", api_key=None, team_id="team-a")
         with self._patch(teams_by_id=teams, user_teams=["team-a", "team-b"]):
             result = await MCPRequestHandler._get_allowed_mcp_servers_for_team(auth)
         assert set(result) == {"srv1"}
 
     async def test_keyless_user_with_no_teams_gets_nothing_from_teams(self):
-        auth = self._admitted_subject("lonely-user")
+        auth = _make_admitted_subject("lonely-user")
         with self._patch(teams_by_id={}, user_teams=[]):
             result = await MCPRequestHandler._get_allowed_mcp_servers_for_team(auth)
         assert result == []
@@ -6606,7 +6601,7 @@ class TestUserSubjectTeamUnion:
         # those pins a team_id, so this helper only ever answers the single-team question. The fan-out
         # itself is _admitted_subject_sources' job, asserted below.
         with self._patch(teams_by_id={}, user_teams=["t2", "t3"]):
-            assert await MCPRequestHandler._team_ids_for_mcp_grant(self._admitted_subject("u")) == []
+            assert await MCPRequestHandler._team_ids_for_mcp_grant(_make_admitted_subject("u")) == []
         # keyless, no user_id -> nothing
         assert await MCPRequestHandler._team_ids_for_mcp_grant(UserAPIKeyAuth(api_key=None)) == []
         # keyless with a user_id but NOT admission-marked (JWT auth) -> nothing (unchanged behavior)
@@ -6629,9 +6624,9 @@ class TestUserSubjectTeamUnion:
         outage -> the keyless source denies."""
         from litellm.proxy.auth.auth_checks import OrganizationNotFoundError
 
-        teams = {"t1": self._team("t1", ["srv1"])}
+        teams = {"t1": _make_team("t1", ["srv1"])}
         teams["t1"].organization_id = "org-a"
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
 
         absent = AsyncMock(side_effect=OrganizationNotFoundError("Organization doesn't exist in db."))
         with self._patch(teams_by_id=teams, user_teams=["t1"]):
@@ -6657,7 +6652,7 @@ class TestUserSubjectTeamUnion:
         boom = AsyncMock(side_effect=RuntimeError("org lookup exploded"))
         # The subject must actually REACH something, or the assertion passes either way and pins
         # nothing (a fail-open mutant survived an earlier version of this test for exactly that).
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         auth.org_id = "org-a"
         auth.object_permission = LiteLLM_ObjectPermissionTable(object_permission_id="op-u", mcp_servers=["srv1"])
         with self._patch(teams_by_id={}, user_teams=[]):
@@ -6667,7 +6662,7 @@ class TestUserSubjectTeamUnion:
         assert admitted == [], "admitted subject must fail CLOSED when its org ceiling cannot resolve"
 
         key_auth = UserAPIKeyAuth(user_id="u", api_key="sk-hash", team_id="t1", org_id="org-a")
-        with self._patch(teams_by_id={"t1": self._team("t1", ["srv1"])}, user_teams=[]):
+        with self._patch(teams_by_id={"t1": _make_team("t1", ["srv1"])}, user_teams=[]):
             with patch.object(MCPRequestHandler, "_get_org_object_permission", boom):
                 keyed = await MCPRequestHandler.get_allowed_mcp_servers(key_auth)
         assert set(keyed) == {"srv1"}, "key auth must keep its long-standing fail-open behavior"
@@ -6679,11 +6674,11 @@ class TestUserSubjectTeamUnion:
         SAME source billing picks — one owner for both, so they cannot disagree."""
         from litellm.proxy.hooks.parallel_request_limiter_v3 import _PROXY_MaxParallelRequestsHandler_v3
 
-        t1 = self._team("t1", ["srv1"])
+        t1 = _make_team("t1", ["srv1"])
         t1.metadata = {"mcp_rpm_limit": {"srv1": 5}}
-        t2 = self._team("t2", ["srv1"])
+        t2 = _make_team("t2", ["srv1"])
         t2.metadata = {"mcp_rpm_limit": {"srv1": 9}}
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         with self._patch(teams_by_id={"t1": t1, "t2": t2}, user_teams=["t1", "t2"]):
             auth.mcp_source_team_rpm_limits = await MCPRequestHandler._admitted_subject_team_rpm_limits(auth)
             billed = await MCPRequestHandler.attributing_source_for_server(auth, "srv1")
@@ -6700,9 +6695,9 @@ class TestUserSubjectTeamUnion:
         """When the user's OWN grant reaches the server, no team provided the access, so no team
         bucket may be charged — the user's own rpm/tpm is what bounds them. Mirrors billing, which
         bills the user and their own org for exactly this case."""
-        t1 = self._team("t1", ["srv1"])
+        t1 = _make_team("t1", ["srv1"])
         t1.metadata = {"mcp_rpm_limit": {"srv1": 5}}
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         auth.object_permission = LiteLLM_ObjectPermissionTable(object_permission_id="op-u", mcp_servers=["srv1"])
         with self._patch(teams_by_id={"t1": t1}, user_teams=["t1"]):
             limits = await MCPRequestHandler._admitted_subject_team_rpm_limits(auth)
@@ -6732,9 +6727,9 @@ class TestUserSubjectTeamUnion:
         """ACCOUNTING half of team budgets. Without attribution the admitted auth kept team_id=None,
         so spend skipped team updates (the team's budget never accumulated, so it could never begin
         to block) and charged the user's PRIMARY org rather than the org owning the granting team."""
-        t_grant = self._team("t-grant", ["srv1"])
+        t_grant = _make_team("t-grant", ["srv1"])
         t_grant.organization_id = "org-team"
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         auth.org_id = "org-user-primary"
         with self._patch(teams_by_id={"t-grant": t_grant}, user_teams=["t-grant"]):
             source = await MCPRequestHandler.attributing_source_for_server(auth, "srv1")
@@ -6746,9 +6741,9 @@ class TestUserSubjectTeamUnion:
         """Asserted on billing_auth_for_tool_call itself, not on the source it picks: the source
         already carries the team's org by construction, so asserting there leaves the copy step
         unpinned (a mutant dropping org_id survived exactly that). This is the object spend reads."""
-        t_grant = self._team("t-grant", ["srv1"])
+        t_grant = _make_team("t-grant", ["srv1"])
         t_grant.organization_id = "org-team"
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         auth.org_id = "org-user-primary"
         server = MagicMock(server_id="srv1")
         with self._patch(teams_by_id={"t-grant": t_grant}, user_teams=["t-grant"]):
@@ -6766,8 +6761,8 @@ class TestUserSubjectTeamUnion:
         would charge that team for access it never provided."""
         from litellm.proxy._types import LiteLLM_ObjectPermissionTable
 
-        t_other = self._team("t-other", ["srv1"])
-        auth = self._admitted_subject("sso-user")
+        t_other = _make_team("t-other", ["srv1"])
+        auth = _make_admitted_subject("sso-user")
         auth.object_permission = LiteLLM_ObjectPermissionTable(object_permission_id="op-u", mcp_servers=["srv1"])
         with self._patch(teams_by_id={"t-other": t_other}, user_teams=["t-other"]):
             assert await MCPRequestHandler.attributing_source_for_server(auth, "srv1") is None
@@ -6775,8 +6770,8 @@ class TestUserSubjectTeamUnion:
     async def test_billing_attribution_is_deterministic_across_several_granting_teams(self):
         """When several teams grant the same server the pick must be stable and reproducible rather
         than dependent on dict/roster ordering, or the same call bills different teams run to run."""
-        teams = {"t-b": self._team("t-b", ["srv1"]), "t-a": self._team("t-a", ["srv1"])}
-        auth = self._admitted_subject("sso-user")
+        teams = {"t-b": _make_team("t-b", ["srv1"]), "t-a": _make_team("t-a", ["srv1"])}
+        auth = _make_admitted_subject("sso-user")
         with self._patch(teams_by_id=teams, user_teams=["t-b", "t-a"]):
             first = await MCPRequestHandler.attributing_source_for_server(auth, "srv1")
         with self._patch(teams_by_id=teams, user_teams=["t-a", "t-b"]):
@@ -6797,8 +6792,8 @@ class TestUserSubjectTeamUnion:
         such a fault hit the fail-closed handler and denied tools its teams did grant."""
         from litellm.proxy._types import LiteLLM_ObjectPermissionTable
 
-        teams = {"t1": self._team("t1", ["srv1"], tool_perms={"srv1": ["read"]})}
-        auth = self._admitted_subject("sso-user")
+        teams = {"t1": _make_team("t1", ["srv1"], tool_perms={"srv1": ["read"]})}
+        auth = _make_admitted_subject("sso-user")
         # The subject must carry a toolset, or the prelude never resolves one and the fault below is
         # unreachable — the branch could sit anywhere and the test would still pass (it did).
         auth.object_permission = LiteLLM_ObjectPermissionTable(object_permission_id="op-u", mcp_toolsets=["ts-1"])
@@ -6825,7 +6820,7 @@ class TestUserSubjectTeamUnion:
         manager._get_active_submitted_mcp_server_ids_for_user = AsyncMock(return_value=["srv-byom"])
         db_default_perm = LiteLLM_ObjectPermissionTable(object_permission_id="op-u", mcp_servers=[])
 
-        admitted = self._admitted_subject("sso-user")
+        admitted = _make_admitted_subject("sso-user")
         admitted.object_permission = db_default_perm
         scoped_key = UserAPIKeyAuth(user_id="u", api_key="sk-hash", object_permission=db_default_perm)
 
@@ -6840,7 +6835,7 @@ class TestUserSubjectTeamUnion:
         from litellm.proxy._types import LitellmUserRoles
 
         manager = self._manager_with(["srv-granted", "srv-secret"])
-        admitted = self._admitted_subject("admin-user")
+        admitted = _make_admitted_subject("admin-user")
         admitted.user_role = LitellmUserRoles.PROXY_ADMIN
         with patch.object(MCPRequestHandler, "get_allowed_mcp_servers", AsyncMock(return_value=["srv-granted"])):
             admitted_view = set(await manager.get_allowed_mcp_servers(admitted))
@@ -6863,7 +6858,7 @@ class TestUserSubjectTeamUnion:
         opt_out = LiteLLM_ObjectPermissionTable(
             object_permission_id="op-u", mcp_servers=[SpecialMCPServerNames.no_mcp_servers.value]
         )
-        admitted = self._admitted_subject("sso-user")
+        admitted = _make_admitted_subject("sso-user")
         admitted.object_permission = opt_out
         with patch.object(MCPRequestHandler, "get_allowed_mcp_servers", AsyncMock(return_value=["srv-team"])):
             admitted_view = set(await manager.get_allowed_mcp_servers(admitted))
@@ -6880,7 +6875,7 @@ class TestUserSubjectTeamUnion:
         session holder invoke tools their own policy excludes."""
         from litellm.proxy._types import LiteLLM_ObjectPermissionTable
 
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         # The user is restricted to `read` on srv-open, and NO grant source names that server —
         # it is reachable only through the open channel, which is exactly the bypass path.
         auth.object_permission = LiteLLM_ObjectPermissionTable(
@@ -6900,7 +6895,7 @@ class TestUserSubjectTeamUnion:
         source, so the source union alone returns [] — listable but uninvokable. The tools axis asks
         the same open-channel owner the server union uses, so the server is default-open for tools
         exactly as a virtual key experiences it."""
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         open_ids = AsyncMock(return_value={"srv-open"})
         with self._patch(teams_by_id={}, user_teams=[]):
             with patch(
@@ -6918,13 +6913,13 @@ class TestUserSubjectTeamUnion:
         not keep granting servers, tools or throttle scope to a keyless union subject either.
         Enforced through the SAME owner the key path uses (_team_max_budget_check). Distinct from
         budget ATTRIBUTION of new spend, which stays with the user (documented deferral)."""
-        t_over = self._team("t-over", ["srv1"])
+        t_over = _make_team("t-over", ["srv1"])
         t_over.max_budget = 10.0
         t_over.spend = 11.0
-        t_ok = self._team("t-ok", ["srv2"])
+        t_ok = _make_team("t-ok", ["srv2"])
         t_ok.max_budget = 10.0
         t_ok.spend = 1.0
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         with self._patch(teams_by_id={"t-over": t_over, "t-ok": t_ok}, user_teams=["t-over", "t-ok"]):
             servers = set(await MCPRequestHandler.get_allowed_mcp_servers(auth))
             limits = await MCPRequestHandler._admitted_subject_team_rpm_limits(auth)
@@ -6935,13 +6930,13 @@ class TestUserSubjectTeamUnion:
         """The org axis of the same rule, judged against the TEAM's own org (not the caller's
         primary): a team owned by an org over its budget grants nothing, exactly as a key in that
         org is rejected by _organization_max_budget_check."""
-        t_in_broke_org = self._team("t-b", ["srv1"])
+        t_in_broke_org = _make_team("t-b", ["srv1"])
         t_in_broke_org.organization_id = "org-broke"
         # object_permission_id=None: the org has NO MCP ceiling, so the source is denied by the
         # budget gate alone. A truthy auto-Mock id here made an earlier version of this test pass
         # through the org-CEILING fault path with the budget gate deleted — vacuous.
         org = MagicMock(object_permission_id=None, litellm_budget_table=MagicMock(max_budget=5.0), spend=9.0)
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         with self._patch(teams_by_id={"t-b": t_in_broke_org}, user_teams=["t-b"], orgs_by_id={"org-broke": org}):
             servers = await MCPRequestHandler.get_allowed_mcp_servers(auth)
         assert servers == [], "a team in an over-budget org must not grant through the union"
@@ -6953,8 +6948,8 @@ class TestUserSubjectTeamUnion:
         axis."""
         from litellm.proxy._types import LiteLLM_ObjectPermissionTable
 
-        t_ok = self._team("t-ok", ["srv1"], tool_perms={"srv1": ["read"]})
-        auth = self._admitted_subject("sso-user")
+        t_ok = _make_team("t-ok", ["srv1"], tool_perms={"srv1": ["read"]})
+        auth = _make_admitted_subject("sso-user")
         auth.object_permission = LiteLLM_ObjectPermissionTable(object_permission_id="op-u", mcp_servers=["srv-own"])
         teams = {"t-ok": t_ok}  # t-boom absent from the map -> our patched get_team_object RAISES for it
 
@@ -6993,17 +6988,17 @@ class TestUserSubjectTeamUnion:
         (else this user's calls drain a bucket shared by that team's keys for access the team never
         provided), not for map entries beyond its grant, and never when the team is blocked."""
         # t-granting grants srv1 and limits it; also names srv9 in its map, which it does NOT grant.
-        t_granting = self._team("t-granting", ["srv1"])
+        t_granting = _make_team("t-granting", ["srv1"])
         t_granting.metadata = {"mcp_rpm_limit": {"srv1": 5, "srv9": 7}}
         # t-other grants only srv2 but retains limit metadata for srv1 -> must not be charged for it.
-        t_other = self._team("t-other", ["srv2"])
+        t_other = _make_team("t-other", ["srv2"])
         t_other.metadata = {"mcp_rpm_limit": {"srv1": 3}}
         # t-blocked grants srv1 and limits it, but is blocked -> grants nothing, charges nothing.
-        t_blocked = self._team("t-blocked", ["srv1"])
+        t_blocked = _make_team("t-blocked", ["srv1"])
         t_blocked.metadata = {"mcp_rpm_limit": {"srv1": 2}}
         t_blocked.blocked = True
 
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         teams = {"t-granting": t_granting, "t-other": t_other, "t-blocked": t_blocked}
         with self._patch(teams_by_id=teams, user_teams=["t-granting", "t-other", "t-blocked"]):
             limits = await MCPRequestHandler._admitted_subject_team_rpm_limits(auth)
@@ -7015,9 +7010,9 @@ class TestUserSubjectTeamUnion:
     async def test_non_roster_team_rpm_limit_does_not_apply(self):
         """The roster gates grants and throttles through one owner, so a team the user was removed
         from neither grants servers nor gets charged for their calls."""
-        stale = self._team("t-stale", ["srv1"], members=("someone-else",))
+        stale = _make_team("t-stale", ["srv1"], members=("someone-else",))
         stale.metadata = {"mcp_rpm_limit": {"srv1": 1}}
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         with self._patch(teams_by_id={"t-stale": stale}, user_teams=["t-stale"]):
             limits = await MCPRequestHandler._admitted_subject_team_rpm_limits(auth)
         assert limits is None
@@ -7029,7 +7024,7 @@ class TestUserSubjectTeamUnion:
         org_id their whole org's server list with no direct or team grant behind it."""
         from litellm.proxy._types import LiteLLM_ObjectPermissionTable
 
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         auth.org_id = "org-a"  # org allows srv1+srv2; the user and their teams grant NOTHING
         org_perm = AsyncMock(
             return_value=LiteLLM_ObjectPermissionTable(object_permission_id="op-org-a", mcp_servers=["srv1", "srv2"])
@@ -7043,8 +7038,8 @@ class TestUserSubjectTeamUnion:
         """Each source is resolved through an UNMARKED auth, so a fault under a source must still
         deny. Returning None there would win the union as allow-all and drop every team/org tool
         ceiling on a DB blip -- the marker alone only covers faults raised before the fan-out."""
-        auth = self._admitted_subject("sso-user")
-        teams = {"t1": self._team("t1", ["srv1"])}
+        auth = _make_admitted_subject("sso-user")
+        teams = {"t1": _make_team("t1", ["srv1"])}
         # Fault INSIDE the tool resolution only. Faulting something the server path also uses would
         # make the source grant nothing, so the union would return [] without the tool path ever
         # running -- the test would pass while pinning nothing (an earlier version did exactly that).
@@ -7061,11 +7056,11 @@ class TestUserSubjectTeamUnion:
         virtual KEY still overrides team inheritance -- that is the key ceiling model, unchanged.)"""
         from litellm.proxy._types import LiteLLM_ObjectPermissionTable, SpecialMCPServerNames
 
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         auth.object_permission = LiteLLM_ObjectPermissionTable(
             object_permission_id="op-user", mcp_servers=[SpecialMCPServerNames.no_mcp_servers.value]
         )
-        with self._patch(teams_by_id={"t1": self._team("t1", ["srv1"])}, user_teams=["t1"]):
+        with self._patch(teams_by_id={"t1": _make_team("t1", ["srv1"])}, user_teams=["t1"]):
             result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
         assert set(result) == {"srv1"}, "the user's own opt-out must not zero their team's grants"
 
@@ -7077,11 +7072,11 @@ class TestUserSubjectTeamUnion:
         on. Each team source carries that team's own org, which is what makes the shared resolver apply
         the team's owning-org ceiling rather than the caller's home org."""
         teams = {
-            "t-member": self._team("t-member", ["srv1"], members=("sso-user",)),
-            "t-stale": self._team("t-stale", ["srv2"], members=("someone-else",)),
+            "t-member": _make_team("t-member", ["srv1"], members=("sso-user",)),
+            "t-stale": _make_team("t-stale", ["srv2"], members=("someone-else",)),
         }
         teams["t-member"].organization_id = "org-a"
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         with self._patch(teams_by_id=teams, user_teams=["t-member", "t-stale"]):
             sources = await MCPRequestHandler._admitted_subject_sources(auth)
 
@@ -7100,7 +7095,7 @@ class TestUserSubjectTeamUnion:
         user_id and (with no team claim) no team_id, but it is NOT admission-marked, so it must
         keep its prior behavior of inheriting no team grants rather than silently gaining the
         union across every team the user belongs to."""
-        teams = {"team-a": self._team("team-a", ["srv1"]), "team-b": self._team("team-b", ["srv2"])}
+        teams = {"team-a": _make_team("team-a", ["srv1"]), "team-b": _make_team("team-b", ["srv2"])}
         jwt_auth = UserAPIKeyAuth(user_id="jwt-user", api_key=None)  # no admission marker
         with self._patch(teams_by_id=teams, user_teams=["team-a", "team-b"]):
             result = await MCPRequestHandler._get_allowed_mcp_servers_for_team(jwt_auth)
@@ -7112,7 +7107,7 @@ class TestUserSubjectTeamUnion:
         metadata is caller-controlled at key creation. A user who sets
         ``mcp_admitted_user_subject: true`` in their own key's metadata (api_key present, no
         team_id) must NOT be treated as an admitted subject and must gain no cross-team union."""
-        teams = {"team-a": self._team("team-a", ["srv1"]), "team-b": self._team("team-b", ["srv2"])}
+        teams = {"team-a": _make_team("team-a", ["srv1"]), "team-b": _make_team("team-b", ["srv2"])}
         forged = UserAPIKeyAuth(
             user_id="attacker",
             api_key="sk-real-key",
@@ -7140,7 +7135,7 @@ class TestUserSubjectTeamUnion:
                 mcp_tool_permissions={"srv1": ["tool_a"]},
             ),
         )
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         with self._patch(teams_by_id={"team-a": team}, user_teams=["team-a"]):
             tools = await MCPRequestHandler.get_allowed_tools_for_server("srv1", auth)
         assert tools == ["tool_a"]
@@ -7158,8 +7153,8 @@ class TestUserSubjectTeamUnion:
             access_group_ids=[],
             object_permission=LiteLLM_ObjectPermissionTable(object_permission_id="op-blk", mcp_servers=["srv-secret"]),
         )
-        teams = {"team-ok": self._team("team-ok", ["srv-ok"]), "team-blocked": blocked}
-        auth = self._admitted_subject("sso-user")
+        teams = {"team-ok": _make_team("team-ok", ["srv-ok"]), "team-blocked": blocked}
+        auth = _make_admitted_subject("sso-user")
         with self._patch(teams_by_id=teams, user_teams=["team-ok", "team-blocked"]):
             result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
         assert set(result) == {"srv-ok"}
@@ -7169,8 +7164,8 @@ class TestUserSubjectTeamUnion:
         team's roster inherits nothing from it, even when the team id lingers in the user's (stale or
         cached) teams array. The team roster is the source of truth, so a removed or foreign
         membership revokes access at the union rather than granting it."""
-        teams = {"team-x": self._team("team-x", ["srv-x"], members=("someone-else",))}
-        auth = self._admitted_subject("sso-user")  # in user.teams for team-x, but NOT on its roster
+        teams = {"team-x": _make_team("team-x", ["srv-x"], members=("someone-else",))}
+        auth = _make_admitted_subject("sso-user")  # in user.teams for team-x, but NOT on its roster
         with self._patch(teams_by_id=teams, user_teams=["team-x"]):
             result = await MCPRequestHandler._get_allowed_mcp_servers_for_team(auth)
         assert result == []
@@ -7180,7 +7175,7 @@ class TestUserSubjectTeamUnion:
         must DENY the server's tools ([]) rather than collapse to allow-all (None). Patches an await
         OUTSIDE the multi-team fan-out (the team-object lookup) to prove the whole function fails
         closed, not just the one helper — mirroring the fail-closed server path."""
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         with patch.object(
             MCPRequestHandler,
             "_get_team_object_permission",
@@ -7208,36 +7203,6 @@ class TestAdmittedSubjectPerTeamOrgCap:
     grant (servers AND tools) is capped by that team's OWN org, and the user's direct grants by the
     user's own org — never the caller's primary org applied over the whole cross-org union. Guards the
     Veria 'team grants bypass their owning policies' finding."""
-
-    def _team(self, team_id, mcp_servers, *, org_id=None, tool_perms=None, members=("sso-user",)):
-        from litellm.proxy._types import LiteLLM_ObjectPermissionTable, LiteLLM_TeamTable, Member
-
-        return LiteLLM_TeamTable(
-            team_id=team_id,
-            organization_id=org_id,
-            members_with_roles=[Member(user_id=u, role="user") for u in members],
-            access_group_ids=[],
-            object_permission=LiteLLM_ObjectPermissionTable(
-                object_permission_id=f"op-{team_id}",
-                mcp_servers=mcp_servers,
-                mcp_tool_permissions=tool_perms,
-            ),
-        )
-
-    @staticmethod
-    def _admitted_subject(user_id, *, org_id=None, own_servers=None, own_tool_perms=None):
-        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
-
-        op = None
-        if own_servers is not None or own_tool_perms is not None:
-            op = LiteLLM_ObjectPermissionTable(
-                object_permission_id=f"userop-{user_id}",
-                mcp_servers=own_servers or [],
-                mcp_tool_permissions=own_tool_perms,
-            )
-        auth = UserAPIKeyAuth(user_id=user_id, api_key=None, org_id=org_id, object_permission=op)
-        auth.mcp_admitted_user_subject = True
-        return auth
 
     #: sentinel for org_perms: org has an object_permission_id but its load returns None (a swallowed
     #: DB error / dangling id), which _object_permission_for_org must treat as fail-closed.
@@ -7315,9 +7280,9 @@ class TestAdmittedSubjectPerTeamOrgCap:
     async def test_team_grant_capped_by_its_own_org(self):
         from litellm.proxy._types import LiteLLM_ObjectPermissionTable
 
-        teams = {"team-a": self._team("team-a", ["srv1", "srv2"], org_id="org-a")}
+        teams = {"team-a": _make_team("team-a", ["srv1", "srv2"], org_id="org-a")}
         org_perms = {"org-a": LiteLLM_ObjectPermissionTable(object_permission_id="orgop-org-a", mcp_servers=["srv1"])}
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         with self._patch(teams_by_id=teams, user_teams=["team-a"], org_perms=org_perms):
             result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
         assert set(result) == {"srv1"}  # srv2 capped out by org-a's ceiling
@@ -7326,14 +7291,14 @@ class TestAdmittedSubjectPerTeamOrgCap:
         from litellm.proxy._types import LiteLLM_ObjectPermissionTable
 
         teams = {
-            "team-a": self._team("team-a", ["srv1", "srv2"], org_id="org-a"),
-            "team-b": self._team("team-b", ["srv3", "srv4"], org_id="org-b"),
+            "team-a": _make_team("team-a", ["srv1", "srv2"], org_id="org-a"),
+            "team-b": _make_team("team-b", ["srv3", "srv4"], org_id="org-b"),
         }
         org_perms = {
             "org-a": LiteLLM_ObjectPermissionTable(object_permission_id="orgop-org-a", mcp_servers=["srv1"]),
             "org-b": LiteLLM_ObjectPermissionTable(object_permission_id="orgop-org-b", mcp_servers=["srv3"]),
         }
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         with self._patch(teams_by_id=teams, user_teams=["team-a", "team-b"], org_perms=org_perms):
             result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
         assert set(result) == {"srv1", "srv3"}  # each team clipped by its OWN org, then unioned
@@ -7341,9 +7306,9 @@ class TestAdmittedSubjectPerTeamOrgCap:
     async def test_all_proxy_grant_capped_by_org(self):
         from litellm.proxy._types import LiteLLM_ObjectPermissionTable, SpecialMCPServerName
 
-        teams = {"team-a": self._team("team-a", [SpecialMCPServerName.all_proxy_servers.value], org_id="org-a")}
+        teams = {"team-a": _make_team("team-a", [SpecialMCPServerName.all_proxy_servers.value], org_id="org-a")}
         org_perms = {"org-a": LiteLLM_ObjectPermissionTable(object_permission_id="orgop-org-a", mcp_servers=["srv1"])}
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         with self._patch(
             teams_by_id=teams, user_teams=["team-a"], org_perms=org_perms, registry=["srv1", "srv2", "srv3"]
         ):
@@ -7353,8 +7318,8 @@ class TestAdmittedSubjectPerTeamOrgCap:
         assert set(result) == {"srv1"}
 
     async def test_org_row_without_object_permission_does_not_cap(self):
-        teams = {"team-a": self._team("team-a", ["srv1", "srv2"], org_id="org-a")}
-        auth = self._admitted_subject("sso-user")
+        teams = {"team-a": _make_team("team-a", ["srv1", "srv2"], org_id="org-a")}
+        auth = _make_admitted_subject("sso-user")
         with self._patch(teams_by_id=teams, user_teams=["team-a"], org_perms={"org-a": None}):
             result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
         assert set(result) == {"srv1", "srv2"}  # empty ceiling = no restriction
@@ -7362,12 +7327,12 @@ class TestAdmittedSubjectPerTeamOrgCap:
     async def test_direct_grants_unioned_with_team_and_capped_by_user_org(self):
         from litellm.proxy._types import LiteLLM_ObjectPermissionTable
 
-        teams = {"team-a": self._team("team-a", ["srv1"], org_id="org-a")}
+        teams = {"team-a": _make_team("team-a", ["srv1"], org_id="org-a")}
         org_perms = {
             "org-a": None,  # the team's org imposes no ceiling
             "org-u": LiteLLM_ObjectPermissionTable(object_permission_id="orgop-org-u", mcp_servers=["srvD", "srv1"]),
         }
-        auth = self._admitted_subject("sso-user", org_id="org-u", own_servers=["srvD", "srvX"])
+        auth = _make_admitted_subject("sso-user", org_id="org-u", own_servers=["srvD", "srvX"])
         with self._patch(teams_by_id=teams, user_teams=["team-a"], org_perms=org_perms):
             result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
         # direct {srvD,srvX} ∩ user-org {srvD,srv1} = {srvD}; UNIONed with team {srv1} (not intersected).
@@ -7379,7 +7344,7 @@ class TestAdmittedSubjectPerTeamOrgCap:
 
         # A KEY (not admitted): the per-team org cap must NOT fire; the top-level primary-org cap applies,
         # byte-identical to before. team-a (org-a) grants {srv1,srv2}; the key's primary org is org-k.
-        teams = {"team-a": self._team("team-a", ["srv1", "srv2"], org_id="org-a")}
+        teams = {"team-a": _make_team("team-a", ["srv1", "srv2"], org_id="org-a")}
         org_perms = {
             "org-a": LiteLLM_ObjectPermissionTable(object_permission_id="orgop-org-a", mcp_servers=["srv2"]),
             "org-k": LiteLLM_ObjectPermissionTable(object_permission_id="orgop-org-k", mcp_servers=["srv1"]),
@@ -7397,7 +7362,7 @@ class TestAdmittedSubjectPerTeamOrgCap:
         from litellm.proxy._types import LiteLLM_ObjectPermissionTable
 
         # team grants srv1 with NO tool restriction; org-a restricts srv1's tools to {tool_a}.
-        teams = {"team-a": self._team("team-a", ["srv1"], org_id="org-a")}
+        teams = {"team-a": _make_team("team-a", ["srv1"], org_id="org-a")}
         org_perms = {
             "org-a": LiteLLM_ObjectPermissionTable(
                 object_permission_id="orgop-org-a",
@@ -7405,7 +7370,7 @@ class TestAdmittedSubjectPerTeamOrgCap:
                 mcp_tool_permissions={"srv1": ["tool_a"]},
             )
         }
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         with self._patch(teams_by_id=teams, user_teams=["team-a"], org_perms=org_perms):
             tools = await MCPRequestHandler.get_allowed_tools_for_server("srv1", auth)
         # Without the per-team org tool ceiling this would be None (all tools) — org-a's tool ceiling
@@ -7414,10 +7379,10 @@ class TestAdmittedSubjectPerTeamOrgCap:
 
     async def test_tool_union_across_cross_org_teams(self):
         teams = {
-            "team-a": self._team("team-a", ["srv1"], org_id="org-a", tool_perms={"srv1": ["t1"]}),
-            "team-b": self._team("team-b", ["srv1"], org_id="org-b", tool_perms={"srv1": ["t2"]}),
+            "team-a": _make_team("team-a", ["srv1"], org_id="org-a", tool_perms={"srv1": ["t1"]}),
+            "team-b": _make_team("team-b", ["srv1"], org_id="org-b", tool_perms={"srv1": ["t2"]}),
         }
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         with self._patch(teams_by_id=teams, user_teams=["team-a", "team-b"], org_perms={"org-a": None, "org-b": None}):
             tools = await MCPRequestHandler.get_allowed_tools_for_server("srv1", auth)
         assert set(tools) == {"t1", "t2"}
@@ -7425,7 +7390,7 @@ class TestAdmittedSubjectPerTeamOrgCap:
     async def test_tool_deny_all_when_team_grant_and_org_tool_ceiling_disjoint(self):
         from litellm.proxy._types import LiteLLM_ObjectPermissionTable
 
-        teams = {"team-a": self._team("team-a", ["srv1"], org_id="org-a", tool_perms={"srv1": ["t1"]})}
+        teams = {"team-a": _make_team("team-a", ["srv1"], org_id="org-a", tool_perms={"srv1": ["t1"]})}
         org_perms = {
             "org-a": LiteLLM_ObjectPermissionTable(
                 object_permission_id="orgop-org-a",
@@ -7433,7 +7398,7 @@ class TestAdmittedSubjectPerTeamOrgCap:
                 mcp_tool_permissions={"srv1": ["t2"]},
             )
         }
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         with self._patch(teams_by_id=teams, user_teams=["team-a"], org_perms=org_perms):
             tools = await MCPRequestHandler.get_allowed_tools_for_server("srv1", auth)
         # team {t1} ∩ org {t2} = {} → deny every tool ([]), NOT allow-all (None).
@@ -7446,8 +7411,8 @@ class TestAdmittedSubjectPerTeamOrgCap:
         synced). get_org_object RAISES a bare Exception for that; it must be treated as 'no ceiling' and
         must NOT lock the admitted subject out of the team's grants (parity with the key path, which
         tolerates a deleted org)."""
-        teams = {"team-a": self._team("team-a", ["srv1", "srv2"], org_id="org-gone")}
-        auth = self._admitted_subject("sso-user")
+        teams = {"team-a": _make_team("team-a", ["srv1", "srv2"], org_id="org-gone")}
+        auth = _make_admitted_subject("sso-user")
         with self._patch(teams_by_id=teams, user_teams=["team-a"], org_perms={}):  # org-gone absent → raises
             result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
         assert set(result) == {"srv1", "srv2"}
@@ -7456,8 +7421,8 @@ class TestAdmittedSubjectPerTeamOrgCap:
         """The org carries an object_permission_id but the permission load returns None (a swallowed DB
         error / dangling id). The ceiling cannot be verified, so the admitted subject must fail CLOSED
         for that team — NOT skip the ceiling, which would leak org-forbidden servers."""
-        teams = {"team-a": self._team("team-a", ["srv1", "srv2"], org_id="org-a")}
-        auth = self._admitted_subject("sso-user")
+        teams = {"team-a": _make_team("team-a", ["srv1", "srv2"], org_id="org-a")}
+        auth = _make_admitted_subject("sso-user")
         with self._patch(teams_by_id=teams, user_teams=["team-a"], org_perms={"org-a": self.LOAD_FAILS}):
             # Asserted through the PUBLIC resolver: the per-source org ceiling is applied there now,
             # so calling the single-team helper would return [] for an admitted subject either way
@@ -7473,9 +7438,9 @@ class TestAdmittedSubjectPerTeamOrgCap:
         grant would bypass every org ceiling and reach servers the user's home org forbids."""
         from litellm.proxy._types import LiteLLM_ObjectPermissionTable
 
-        teams = {"team-noorg": self._team("team-noorg", ["srv1", "srv2"], org_id=None)}
+        teams = {"team-noorg": _make_team("team-noorg", ["srv1", "srv2"], org_id=None)}
         org_perms = {"org-U": LiteLLM_ObjectPermissionTable(object_permission_id="orgop-org-U", mcp_servers=["srv1"])}
-        auth = self._admitted_subject("sso-user", org_id="org-U")
+        auth = _make_admitted_subject("sso-user", org_id="org-U")
         with self._patch(teams_by_id=teams, user_teams=["team-noorg"], org_perms=org_perms):
             result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
         # org-less team falls back to the user's primary org (org-U → {srv1}); srv2 capped out.
@@ -7485,8 +7450,8 @@ class TestAdmittedSubjectPerTeamOrgCap:
         """MEDIUM (greptile/cursor): when no source in the tool-resolution view grants the server (a
         TOCTOU/cache-lag inconsistency on a server that passed the server gate), the admitted path must
         fail CLOSED (deny all tools = []), NOT allow-all (None)."""
-        teams = {"team-a": self._team("team-a", ["srv1"], org_id="org-a")}
-        auth = self._admitted_subject("sso-user")
+        teams = {"team-a": _make_team("team-a", ["srv1"], org_id="org-a")}
+        auth = _make_admitted_subject("sso-user")
         with self._patch(teams_by_id=teams, user_teams=["team-a"], org_perms={"org-a": None}):
             # 'srv-nobody' is granted by neither the team nor the user directly → empty contributions.
             tools = await MCPRequestHandler.get_allowed_tools_for_server("srv-nobody", auth)
@@ -7495,9 +7460,7 @@ class TestAdmittedSubjectPerTeamOrgCap:
     async def test_tool_no_db_honors_in_memory_direct_restriction(self):
         """MEDIUM (cursor): with no DB, the tool path must still honor the user's OWN in-memory
         object_permission tool restriction (resolvable without a DB) rather than blanket-allow (None)."""
-        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
-
-        auth = self._admitted_subject(
+        auth = _make_admitted_subject(
             "sso-user", own_servers=["srv1"], own_tool_perms={"srv1": ["t1"]}
         )  # no org_id, direct grant of srv1 restricted to {t1}
         with patch("litellm.proxy.proxy_server.prisma_client", None):
@@ -7522,11 +7485,11 @@ class TestAdmittedSubjectPerTeamOrgCap:
 
         # team grants the config server BY ALIAS alongside a DB-style bare id; org-a's ceiling lists
         # ONLY the config server (also by alias).
-        teams = {"team-a": self._team("team-a", ["linear_cfg", "srv-db"], org_id="org-a")}
+        teams = {"team-a": _make_team("team-a", ["linear_cfg", "srv-db"], org_id="org-a")}
         org_perms = {
             "org-a": LiteLLM_ObjectPermissionTable(object_permission_id="orgop-org-a", mcp_servers=["linear_cfg"])
         }
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         with self._patch(
             teams_by_id=teams,
             user_teams=["team-a"],
@@ -7554,12 +7517,12 @@ class TestAdmittedSubjectPerTeamOrgCap:
         control.server_id = "control-id"
         control.alias = control.server_name = control.name = "control_alias"
 
-        teams = {"team-b": self._team("team-b", ["linear_cfg", "control_alias"], org_id="org-b")}
+        teams = {"team-b": _make_team("team-b", ["linear_cfg", "control_alias"], org_id="org-b")}
         # org-b's ceiling allows ONLY the control server, referenced by its RESOLVED server_id.
         org_perms = {
             "org-b": LiteLLM_ObjectPermissionTable(object_permission_id="orgop-org-b", mcp_servers=["control-id"])
         }
-        auth = self._admitted_subject("sso-user")
+        auth = _make_admitted_subject("sso-user")
         with self._patch(
             teams_by_id=teams,
             user_teams=["team-b"],

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -15,6 +15,7 @@ from starlette.datastructures import Headers
 
 from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
     MCPRequestHandler,
+    _is_mcp_admitted_user_subject,
 )
 from litellm.proxy._types import (
     LiteLLM_ObjectPermissionTable,
@@ -205,6 +206,31 @@ class TestMCPRequestHandler:
             result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
 
         assert sorted(result) == sorted(expected)
+
+    async def test_admitted_subject_not_zeroed_by_require_key_mcp_access_defined(self):
+        """10x-flow regression: with require_key_mcp_access_defined ON (team = ceiling for keys), a
+        keyless gateway/bridge-admitted subject whose ONLY access path is team membership must still
+        inherit the team's servers. The flag zeros empty *virtual keys* that must declare their own
+        access; a keyless admitted user has no key to declare it on, so it must not be zeroed."""
+        auth = UserAPIKeyAuth(api_key=None, user_id="sso-user")
+        auth.mcp_admitted_user_subject = True
+        with (
+            patch.object(
+                MCPRequestHandler, "_get_allowed_mcp_servers_for_key", new_callable=AsyncMock, return_value=[]
+            ),
+            patch.object(
+                MCPRequestHandler,
+                "_get_allowed_mcp_servers_for_team",
+                new_callable=AsyncMock,
+                return_value=["team_server1", "team_server2"],
+            ),
+            patch.object(
+                MCPRequestHandler, "_get_key_access_group_mcp_server_extras", new_callable=AsyncMock, return_value=[]
+            ),
+            patch("litellm.proxy.proxy_server.general_settings", {"require_key_mcp_access_defined": True}),
+        ):
+            result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
+        assert sorted(result) == ["team_server1", "team_server2"]
 
     @pytest.mark.parametrize(
         "key_servers,grants,expected,scenario",
@@ -5302,6 +5328,7 @@ class TestMCPDcrBridgeDelegateAdmission:
             self._patch_user_reload(
                 return_value=MagicMock(
                     user_id="sso-user-7",
+                    organization_id=None,
                     metadata={"scim_active": True},
                     user_role=None,
                     object_permission=None,
@@ -5344,6 +5371,7 @@ class TestMCPDcrBridgeDelegateAdmission:
             self._patch_user_reload(
                 return_value=MagicMock(
                     user_id="sso-user-7",
+                    organization_id=None,
                     metadata={"scim_active": True},
                     user_role=None,
                     object_permission=object_permission,
@@ -5421,7 +5449,9 @@ class TestMCPDcrBridgeDelegateAdmission:
         with (
             patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager") as mock_mgr,
             patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
-            self._patch_user_reload(return_value=MagicMock(user_id="offboarded-user", metadata={"scim_active": False})),
+            self._patch_user_reload(
+                return_value=MagicMock(user_id="offboarded-user", organization_id=None, metadata={"scim_active": False})
+            ),
         ):
             mock_mgr.get_mcp_server_by_name.return_value = self._bridge_delegate_server()
             with pytest.raises(HTTPException) as exc_info:
@@ -6204,7 +6234,9 @@ class TestAggregateGatewayDcrChallenge:
             with pytest.raises(HTTPException) as exc_info:
                 await MCPRequestHandler.process_mcp_request(self._scope())
         www_authenticate = (exc_info.value.headers or {})["WWW-Authenticate"]
-        assert 'resource_metadata="http://testserver/.well-known/oauth-protected-resource/litellm/mcp"' in www_authenticate
+        assert (
+            'resource_metadata="http://testserver/.well-known/oauth-protected-resource/litellm/mcp"' in www_authenticate
+        )
 
     async def test_no_challenge_for_explicit_litellm_key(self):
         """An explicit x-litellm-api-key declares a litellm-key client; a typo
@@ -6225,9 +6257,7 @@ class TestAggregateGatewayDcrChallenge:
             patch(self._AUTH_PATCH_TARGET, side_effect=self._auth_401()),
         ):
             with pytest.raises(ProxyException):
-                await MCPRequestHandler.process_mcp_request(
-                    self._scope(extra_headers=((b"x-mcp-servers", b"github"),))
-                )
+                await MCPRequestHandler.process_mcp_request(self._scope(extra_headers=((b"x-mcp-servers", b"github"),)))
 
     async def test_no_challenge_for_path_named_server(self):
         """/mcp/{server} targets one server; the aggregate challenge must not
@@ -6261,3 +6291,1394 @@ class TestAggregateGatewayDcrChallenge:
             with pytest.raises(ProxyException) as exc_info:
                 await MCPRequestHandler.process_mcp_request(self._scope())
         assert str(exc_info.value.code) == "500"
+
+
+@pytest.mark.asyncio
+class TestGatewaySessionAdmission:
+    """The aggregate /mcp session-bearer admission arm (mcp_gateway_dcr). A valid session
+    token admits under the LIVE litellm user it references; an invalid/expired/refresh/foreign
+    token fails closed with the aggregate invalid_token challenge; the arm fires ONLY at the
+    aggregate scope, never for named servers or per-server flows."""
+
+    _MASTER_KEY = "sk-gateway-session-admission-master-key"
+
+    def _session_bearer(self, user_id="sso-user-42", client_id="llm_dcrc_abc"):
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.session_credentials import (
+            session_keys_from_master_key,
+        )
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.session_token import (
+            SessionPrincipal,
+            mint_session_token,
+            mint_session_refresh_token,
+        )
+
+        keys = session_keys_from_master_key(self._MASTER_KEY)
+        principal = SessionPrincipal(user_id=user_id, client_id=client_id)
+        return mint_session_token, mint_session_refresh_token, principal, keys
+
+    def _access_token(self, **kw):
+        from datetime import datetime, timezone
+
+        mint, _refresh, principal, keys = self._session_bearer(**kw)
+        return mint(principal, keys, datetime(2030, 1, 1, tzinfo=timezone.utc)).token.get_secret_value()
+
+    def _scope(self, bearer, path="/mcp", extra_headers=()):
+        return {
+            "type": "http",
+            "method": "POST",
+            "path": path,
+            "headers": [(b"host", b"testserver"), (b"authorization", f"Bearer {bearer}".encode()), *extra_headers],
+        }
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _patch_user_reload(*, user_id, active=True, organization_id=None, tpm_limit=None, rpm_limit=None):
+        get_user_object = AsyncMock(
+            return_value=MagicMock(
+                user_id=user_id,
+                organization_id=organization_id,
+                metadata={"scim_active": active} if not active else {"scim_active": True},
+                user_role=None,
+                object_permission=None,
+                object_permission_id=None,
+                tpm_limit=tpm_limit,
+                rpm_limit=rpm_limit,
+            )
+        )
+        with (
+            patch("litellm.proxy.auth.auth_checks.get_user_object", get_user_object),
+            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        ):
+            yield get_user_object
+
+    async def test_session_admission_binds_org_id_so_the_org_ceiling_applies(self):
+        """The admitted auth carries the user's org_id, so get_allowed_mcp_servers keeps the
+        org-level MCP ceiling in force for a gateway session instead of skipping it."""
+        token = self._access_token(user_id="org-user")
+        with (
+            patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
+                new_callable=AsyncMock,
+            ),
+            self._patch_user_reload(user_id="org-user", organization_id="org-123"),
+        ):
+            auth_result, *_rest = await MCPRequestHandler.process_mcp_request(self._scope(token))
+        assert auth_result.org_id == "org-123"
+
+    async def test_session_admission_copies_user_rate_limits(self):
+        """Security regression: the reconstructed auth must carry the live user's RPM/TPM, exactly as
+        the standard user-subject path does. The parallel limiter reads these off the auth object and
+        treats None as unlimited, so a keyless subject with them unset would invoke tools past their
+        configured user rate limits."""
+        token = self._access_token(user_id="rl-user")
+        with (
+            patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
+                new_callable=AsyncMock,
+            ),
+            self._patch_user_reload(user_id="rl-user", tpm_limit=1000, rpm_limit=50),
+        ):
+            auth_result, *_rest = await MCPRequestHandler.process_mcp_request(self._scope(token))
+        assert auth_result.user_tpm_limit == 1000
+        assert auth_result.user_rpm_limit == 50
+
+    async def test_valid_session_admits_under_live_user_at_aggregate_scope(self):
+        token = self._access_token(user_id="sso-user-42")
+        with (
+            patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
+                new_callable=AsyncMock,
+            ) as mock_auth,
+            self._patch_user_reload(user_id="sso-user-42") as get_user_object,
+        ):
+            auth_result, _h, _servers, mcp_server_auth_headers, _o, _r = await MCPRequestHandler.process_mcp_request(
+                self._scope(token)
+            )
+        assert get_user_object.await_args.kwargs["user_id"] == "sso-user-42"
+        assert auth_result.user_id == "sso-user-42"
+        mock_auth.assert_not_called()
+        # Identity-only admission injects no per-server upstream credential (unlike the
+        # bridge envelope arm); the headers dict is whatever the request carried, here empty.
+        assert not mcp_server_auth_headers
+
+    async def test_expired_session_fails_closed_with_invalid_token_challenge(self):
+        from datetime import datetime, timezone
+
+        mint, _refresh, principal, keys = self._session_bearer()
+        token = mint(principal, keys, datetime(2020, 1, 1, tzinfo=timezone.utc)).token.get_secret_value()
+        with (
+            patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await MCPRequestHandler.process_mcp_request(self._scope(token))
+        assert exc_info.value.status_code == 401
+        assert 'error="invalid_token"' in (exc_info.value.headers or {})["WWW-Authenticate"]
+
+    async def test_tampered_session_fails_closed(self):
+        token = self._access_token()
+        tampered = token[:-3] + ("aaa" if not token.endswith("aaa") else "bbb")
+        with (
+            patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await MCPRequestHandler.process_mcp_request(self._scope(tampered))
+        assert exc_info.value.status_code == 401
+
+    async def test_deactivated_user_fails_with_invalid_token_challenge(self):
+        """A cryptographically valid bearer whose referenced user is SCIM-deactivated must fail with
+        the aggregate invalid_token challenge (WWW-Authenticate), matching the expired/tampered arms,
+        so the DCR client re-authorizes instead of getting a bare 401 with no challenge."""
+        token = self._access_token(user_id="offboarded-user")
+        with (
+            patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
+                new_callable=AsyncMock,
+            ),
+            self._patch_user_reload(user_id="offboarded-user", active=False),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await MCPRequestHandler.process_mcp_request(self._scope(token))
+        assert exc_info.value.status_code == 401
+        assert 'error="invalid_token"' in (exc_info.value.headers or {})["WWW-Authenticate"]
+
+    async def test_session_bearer_scrubbed_from_egress_header_contexts(self):
+        """Security regression (credential leak): after a keyless session admission, the session
+        bearer must be removed from BOTH returned egress header contexts (oauth2_headers and the raw
+        headers) so no passthrough/OBO egress can forward it upstream for replay as this user."""
+        token = self._access_token(user_id="sso-user-42")
+        with (
+            patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
+                new_callable=AsyncMock,
+            ),
+            self._patch_user_reload(user_id="sso-user-42"),
+        ):
+            _auth, _h, _servers, _msah, oauth2_headers, raw_headers = await MCPRequestHandler.process_mcp_request(
+                self._scope(token)
+            )
+        # the request carried "Authorization: Bearer <session>"; both egress contexts must be scrubbed
+        assert oauth2_headers is None
+        assert not any(k.lower() == "authorization" for k in (raw_headers or {}))
+
+    async def test_refresh_token_is_not_admitted_at_the_tool_edge(self):
+        from datetime import datetime, timezone
+
+        _mint, refresh, principal, keys = self._session_bearer()
+        refresh_token = refresh(principal, keys, datetime(2030, 1, 1, tzinfo=timezone.utc)).token.get_secret_value()
+        with (
+            patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await MCPRequestHandler.process_mcp_request(self._scope(refresh_token))
+        assert exc_info.value.status_code == 401
+
+    async def test_foreign_key_session_fails_closed(self):
+        token = self._access_token()
+        with (
+            patch("litellm.proxy.proxy_server.master_key", "sk-a-totally-different-master-key"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await MCPRequestHandler.process_mcp_request(self._scope(token))
+        assert exc_info.value.status_code == 401
+
+    async def test_arm_does_not_fire_for_named_server(self):
+        """A session-shaped bearer aimed at a named server (path scope) does not enter the
+        aggregate arm; it is treated as an ordinary bearer on that server."""
+        token = self._access_token()
+        with (
+            patch("litellm.proxy.proxy_server.master_key", self._MASTER_KEY),
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
+                new_callable=AsyncMock,
+                side_effect=ProxyException(message="bad key", type="auth_error", param="api_key", code=401),
+            ) as mock_auth,
+        ):
+            with pytest.raises((HTTPException, ProxyException)):
+                await MCPRequestHandler.process_mcp_request(self._scope(token, path="/mcp/github"))
+        mock_auth.assert_called_once()
+
+
+@pytest.mark.asyncio
+class TestUserSubjectTeamUnion:
+    """_get_allowed_mcp_servers_for_team unions across ALL a user's teams for a keyless
+    user-subject caller (the gateway DCR session bearer and bridge user-envelope), while a
+    key-based caller keeps its single-team behavior byte-identically."""
+
+    def _team(self, team_id, mcp_servers, members=("sso-user",), tool_perms=None):
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable, LiteLLM_TeamTable, Member
+
+        return LiteLLM_TeamTable(
+            team_id=team_id,
+            members_with_roles=[Member(user_id=u, role="user") for u in members],
+            access_group_ids=[],
+            object_permission=LiteLLM_ObjectPermissionTable(
+                object_permission_id=f"op-{team_id}", mcp_servers=mcp_servers, mcp_tool_permissions=tool_perms
+            ),
+        )
+
+    @contextlib.contextmanager
+    def _patch(self, *, teams_by_id, user_teams=None, orgs_by_id=None):
+        async def _get_team_object(team_id, **kw):
+            return teams_by_id.get(team_id)
+
+        async def _get_user_object(user_id, **kw):
+            return MagicMock(user_id=user_id, teams=user_teams or [])
+
+        async def _get_org_object(org_id, **kw):
+            return (orgs_by_id or {}).get(org_id)
+
+        async def _spend_from_fallback(counter_key, fallback_spend, max_budget=None, **kw):
+            # The budget owners read cross-pod spend Redis-first with the row's spend as fallback;
+            # unit tests have no Redis, so the fallback IS the spend.
+            return fallback_spend
+
+        with (
+            patch("litellm.proxy.auth.auth_checks.get_team_object", _get_team_object),
+            patch("litellm.proxy.auth.auth_checks.get_user_object", _get_user_object),
+            patch("litellm.proxy.auth.auth_checks.get_org_object", _get_org_object),
+            patch("litellm.proxy.auth.auth_checks._get_mcp_server_ids_from_access_groups", AsyncMock(return_value=[])),
+            patch("litellm.proxy.proxy_server.get_current_spend", _spend_from_fallback),
+            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+            patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        ):
+            yield
+
+    @staticmethod
+    def _admitted_subject(user_id):
+        auth = UserAPIKeyAuth(user_id=user_id, api_key=None)
+        auth.mcp_admitted_user_subject = True
+        return auth
+
+    async def test_keyless_user_unions_servers_across_all_their_teams(self):
+        teams = {"team-a": self._team("team-a", ["srv1", "srv2"]), "team-b": self._team("team-b", ["srv2", "srv3"])}
+        auth = self._admitted_subject("sso-user")
+        with self._patch(teams_by_id=teams, user_teams=["team-a", "team-b"]):
+            result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
+        assert set(result) == {"srv1", "srv2", "srv3"}
+
+    async def test_key_based_caller_uses_single_team_only(self):
+        """A key-based caller (api_key set) with a team_id sees ONLY that team, even though the
+        same user belongs to other teams: key auth must be byte-identical to before."""
+        teams = {"team-a": self._team("team-a", ["srv1"]), "team-b": self._team("team-b", ["srv2", "srv3"])}
+        auth = UserAPIKeyAuth(user_id="sso-user", api_key="sk-hash", team_id="team-a")
+        with self._patch(teams_by_id=teams, user_teams=["team-a", "team-b"]):
+            result = await MCPRequestHandler._get_allowed_mcp_servers_for_team(auth)
+        assert set(result) == {"srv1"}
+
+    async def test_keyless_user_with_explicit_team_id_uses_that_team_only(self):
+        """A keyless caller that already pins a team_id (not the user-subject fan-out shape)
+        resolves only that team; the union is strictly for the no-team-id user-subject case."""
+        teams = {"team-a": self._team("team-a", ["srv1"]), "team-b": self._team("team-b", ["srv2"])}
+        auth = UserAPIKeyAuth(user_id="sso-user", api_key=None, team_id="team-a")
+        with self._patch(teams_by_id=teams, user_teams=["team-a", "team-b"]):
+            result = await MCPRequestHandler._get_allowed_mcp_servers_for_team(auth)
+        assert set(result) == {"srv1"}
+
+    async def test_keyless_user_with_no_teams_gets_nothing_from_teams(self):
+        auth = self._admitted_subject("lonely-user")
+        with self._patch(teams_by_id={}, user_teams=[]):
+            result = await MCPRequestHandler._get_allowed_mcp_servers_for_team(auth)
+        assert result == []
+
+    async def test_ui_session_team_id_still_resolves_to_nothing(self):
+        from litellm.proxy._types import UI_TEAM_ID
+
+        auth = UserAPIKeyAuth(user_id="dash-user", api_key="sk-hash", team_id=UI_TEAM_ID)
+        with self._patch(teams_by_id={}, user_teams=["team-a"]):
+            result = await MCPRequestHandler._get_allowed_mcp_servers_for_team(auth)
+        assert result == []
+
+    async def test_team_ids_helper_gates_on_shape(self):
+        from litellm.proxy._types import UI_TEAM_ID
+
+        # key-based with team -> that team
+        assert await MCPRequestHandler._team_ids_for_mcp_grant(
+            UserAPIKeyAuth(api_key="sk", team_id="t1", user_id="u")
+        ) == ["t1"]
+        # An admitted subject never fans out HERE: it resolves one source per team first, and each of
+        # those pins a team_id, so this helper only ever answers the single-team question. The fan-out
+        # itself is _admitted_subject_sources' job, asserted below.
+        with self._patch(teams_by_id={}, user_teams=["t2", "t3"]):
+            assert await MCPRequestHandler._team_ids_for_mcp_grant(self._admitted_subject("u")) == []
+        # keyless, no user_id -> nothing
+        assert await MCPRequestHandler._team_ids_for_mcp_grant(UserAPIKeyAuth(api_key=None)) == []
+        # keyless with a user_id but NOT admission-marked (JWT auth) -> nothing (unchanged behavior)
+        with self._patch(teams_by_id={}, user_teams=["t2", "t3"]):
+            assert (
+                await MCPRequestHandler._team_ids_for_mcp_grant(UserAPIKeyAuth(api_key=None, user_id="jwt-user")) == []
+            )
+        # UI sentinel -> nothing
+        assert (
+            await MCPRequestHandler._team_ids_for_mcp_grant(
+                UserAPIKeyAuth(api_key="sk", team_id=UI_TEAM_ID, user_id="u")
+            )
+            == []
+        )
+
+    async def test_org_outage_is_not_treated_as_a_missing_org(self):
+        """A CONFIRMED-absent org places no ceiling; a FAILED lookup must not be read as the same
+        fact. get_org_object used to relabel every error as "doesn't exist", so a DB outage silently
+        dropped a real org's ceiling for as long as it lasted. Absent -> the team's grant stands;
+        outage -> the keyless source denies."""
+        from litellm.proxy.auth.auth_checks import OrganizationNotFoundError
+
+        teams = {"t1": self._team("t1", ["srv1"])}
+        teams["t1"].organization_id = "org-a"
+        auth = self._admitted_subject("sso-user")
+
+        absent = AsyncMock(side_effect=OrganizationNotFoundError("Organization doesn't exist in db."))
+        with self._patch(teams_by_id=teams, user_teams=["t1"]):
+            with patch("litellm.proxy.auth.auth_checks.get_org_object", absent):
+                reachable = await MCPRequestHandler.get_allowed_mcp_servers(auth)
+        assert set(reachable) == {"srv1"}, "a deleted org places no ceiling"
+
+        outage = AsyncMock(side_effect=RuntimeError("connection reset by peer"))
+        with self._patch(teams_by_id=teams, user_teams=["t1"]):
+            with patch("litellm.proxy.auth.auth_checks.get_org_object", outage):
+                reachable = await MCPRequestHandler.get_allowed_mcp_servers(auth)
+        assert reachable == [], "an unresolvable ceiling must deny a keyless source, not be skipped"
+
+    async def test_org_ceiling_fault_fails_closed_for_admitted_but_open_for_keys(self):
+        """An unresolvable org ceiling is NOT the same fact as "this org places no restriction".
+
+        For a virtual key the ceiling is one of several bounds and a DB blip must not lock working
+        keys out, so it stays fail-open. For a keyless admitted subject the per-source org ceiling is
+        the ONLY org bound, so dropping it on a fault would widen a cross-org user to servers their
+        team's org forbids. That is escalation, not an availability blip, so it fails closed."""
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        boom = AsyncMock(side_effect=RuntimeError("org lookup exploded"))
+        # The subject must actually REACH something, or the assertion passes either way and pins
+        # nothing (a fail-open mutant survived an earlier version of this test for exactly that).
+        auth = self._admitted_subject("sso-user")
+        auth.org_id = "org-a"
+        auth.object_permission = LiteLLM_ObjectPermissionTable(object_permission_id="op-u", mcp_servers=["srv1"])
+        with self._patch(teams_by_id={}, user_teams=[]):
+            assert set(await MCPRequestHandler.get_allowed_mcp_servers(auth)) == {"srv1"}  # control
+            with patch.object(MCPRequestHandler, "_get_org_object_permission", boom):
+                admitted = await MCPRequestHandler.get_allowed_mcp_servers(auth)
+        assert admitted == [], "admitted subject must fail CLOSED when its org ceiling cannot resolve"
+
+        key_auth = UserAPIKeyAuth(user_id="u", api_key="sk-hash", team_id="t1", org_id="org-a")
+        with self._patch(teams_by_id={"t1": self._team("t1", ["srv1"])}, user_teams=[]):
+            with patch.object(MCPRequestHandler, "_get_org_object_permission", boom):
+                keyed = await MCPRequestHandler.get_allowed_mcp_servers(key_auth)
+        assert set(keyed) == {"srv1"}, "key auth must keep its long-standing fail-open behavior"
+
+    async def test_only_the_attributing_team_bucket_is_charged(self):
+        """A team's mcp_rpm_limit bounds that team's SHARED bucket. Charging every granting team let
+        one cross-team user drain several teams' buckets on a single call, blocking their other
+        members for access those teams did not provide. Exactly one source is charged, and it is the
+        SAME source billing picks — one owner for both, so they cannot disagree."""
+        from litellm.proxy.hooks.parallel_request_limiter_v3 import _PROXY_MaxParallelRequestsHandler_v3
+
+        t1 = self._team("t1", ["srv1"])
+        t1.metadata = {"mcp_rpm_limit": {"srv1": 5}}
+        t2 = self._team("t2", ["srv1"])
+        t2.metadata = {"mcp_rpm_limit": {"srv1": 9}}
+        auth = self._admitted_subject("sso-user")
+        with self._patch(teams_by_id={"t1": t1, "t2": t2}, user_teams=["t1", "t2"]):
+            auth.mcp_source_team_rpm_limits = await MCPRequestHandler._admitted_subject_team_rpm_limits(auth)
+            billed = await MCPRequestHandler.attributing_source_for_server(auth, "srv1")
+        assert auth.mcp_source_team_rpm_limits == {"t1": {"srv1": 5}}, "t2's shared bucket is untouched"
+        assert billed is not None and billed.team_id == "t1", "throttling and billing pick the same source"
+
+        descriptors: list = []
+        limiter = _PROXY_MaxParallelRequestsHandler_v3(internal_usage_cache=MagicMock())
+        limiter._add_mcp_per_team_rate_limit_descriptor(auth, "srv1", descriptors)
+        charged = {d["value"]: d["rate_limit"]["requests_per_unit"] for d in descriptors}
+        assert charged == {"t1:srv1": 5}, "only the attributing team's bucket is charged"
+
+    async def test_direct_user_grant_charges_no_team_bucket(self):
+        """When the user's OWN grant reaches the server, no team provided the access, so no team
+        bucket may be charged — the user's own rpm/tpm is what bounds them. Mirrors billing, which
+        bills the user and their own org for exactly this case."""
+        t1 = self._team("t1", ["srv1"])
+        t1.metadata = {"mcp_rpm_limit": {"srv1": 5}}
+        auth = self._admitted_subject("sso-user")
+        auth.object_permission = LiteLLM_ObjectPermissionTable(object_permission_id="op-u", mcp_servers=["srv1"])
+        with self._patch(teams_by_id={"t1": t1}, user_teams=["t1"]):
+            limits = await MCPRequestHandler._admitted_subject_team_rpm_limits(auth)
+            billed = await MCPRequestHandler.attributing_source_for_server(auth, "srv1")
+        assert limits is None, "a direct user grant must not charge any team's shared bucket"
+        assert billed is None, "and billing agrees: the user is billed, not a team"
+
+    def _manager_with(self, server_ids, allow_all=()):
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import MCPServerManager
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
+        from litellm.types.mcp import MCPTransport
+
+        manager = MCPServerManager()
+        for sid in server_ids:
+            manager.registry[sid] = MCPServer(
+                server_id=sid,
+                name=sid,
+                server_name=sid,
+                url="https://example.com/mcp",
+                transport=MCPTransport.http,
+                allow_all_keys=sid in allow_all,
+            )
+        manager._get_active_submitted_mcp_server_ids_for_user = AsyncMock(return_value=[])
+        return manager
+
+    async def test_team_derived_call_bills_the_granting_team_and_its_org(self):
+        """ACCOUNTING half of team budgets. Without attribution the admitted auth kept team_id=None,
+        so spend skipped team updates (the team's budget never accumulated, so it could never begin
+        to block) and charged the user's PRIMARY org rather than the org owning the granting team."""
+        t_grant = self._team("t-grant", ["srv1"])
+        t_grant.organization_id = "org-team"
+        auth = self._admitted_subject("sso-user")
+        auth.org_id = "org-user-primary"
+        with self._patch(teams_by_id={"t-grant": t_grant}, user_teams=["t-grant"]):
+            source = await MCPRequestHandler.attributing_source_for_server(auth, "srv1")
+        assert source is not None and source.team_id == "t-grant"
+        assert source.org_id == "org-team", "the granting team's org is charged, not the user's primary"
+        assert auth.team_id is None and auth.org_id == "org-user-primary", "authz object untouched"
+
+    async def test_billing_auth_carries_team_and_org_onto_the_spend_object(self):
+        """Asserted on billing_auth_for_tool_call itself, not on the source it picks: the source
+        already carries the team's org by construction, so asserting there leaves the copy step
+        unpinned (a mutant dropping org_id survived exactly that). This is the object spend reads."""
+        t_grant = self._team("t-grant", ["srv1"])
+        t_grant.organization_id = "org-team"
+        auth = self._admitted_subject("sso-user")
+        auth.org_id = "org-user-primary"
+        server = MagicMock(server_id="srv1")
+        with self._patch(teams_by_id={"t-grant": t_grant}, user_teams=["t-grant"]):
+            with patch(
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager._get_mcp_server_from_tool_name",
+                MagicMock(return_value=server),
+            ):
+                billed = await MCPRequestHandler.billing_auth_for_tool_call(auth, tool_name="t-grant/tool_a")
+        assert (billed.team_id, billed.org_id) == ("t-grant", "org-team")
+        assert (auth.team_id, auth.org_id) == (None, "org-user-primary"), "authz object must be untouched"
+
+    async def test_own_grant_bills_the_user_not_a_team(self):
+        """A server the user's OWN grant reaches is not reached "through a team", so it bills the
+        user and their own org — attributing it to an unrelated team the user happens to belong to
+        would charge that team for access it never provided."""
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        t_other = self._team("t-other", ["srv1"])
+        auth = self._admitted_subject("sso-user")
+        auth.object_permission = LiteLLM_ObjectPermissionTable(object_permission_id="op-u", mcp_servers=["srv1"])
+        with self._patch(teams_by_id={"t-other": t_other}, user_teams=["t-other"]):
+            assert await MCPRequestHandler.attributing_source_for_server(auth, "srv1") is None
+
+    async def test_billing_attribution_is_deterministic_across_several_granting_teams(self):
+        """When several teams grant the same server the pick must be stable and reproducible rather
+        than dependent on dict/roster ordering, or the same call bills different teams run to run."""
+        teams = {"t-b": self._team("t-b", ["srv1"]), "t-a": self._team("t-a", ["srv1"])}
+        auth = self._admitted_subject("sso-user")
+        with self._patch(teams_by_id=teams, user_teams=["t-b", "t-a"]):
+            first = await MCPRequestHandler.attributing_source_for_server(auth, "srv1")
+        with self._patch(teams_by_id=teams, user_teams=["t-a", "t-b"]):
+            second = await MCPRequestHandler.attributing_source_for_server(auth, "srv1")
+        assert first is not None and first.team_id == "t-a"
+        assert second is not None and second.team_id == "t-a", "roster order must not change who is billed"
+
+    async def test_billing_auth_leaves_non_admitted_callers_untouched(self):
+        """Key and JWT billing must be byte-identical: the attribution wrapper returns the very same
+        object for anything that is not a keyless admitted subject."""
+        key_auth = UserAPIKeyAuth(user_id="u", api_key="sk-hash", team_id="t1", org_id="org-a")
+        assert await MCPRequestHandler.billing_auth_for_tool_call(key_auth, tool_name="srv1-tool") is key_auth
+
+    async def test_admitted_tools_never_run_the_single_credential_prelude(self):
+        """ORDERING is the invariant: the admitted branch is the FIRST statement of the tools
+        resolver, exactly as in the servers resolver. A fault in a lookup the subject never uses
+        (its own mcp_toolsets) must not reach it at all — when this branch sat after the prelude,
+        such a fault hit the fail-closed handler and denied tools its teams did grant."""
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        teams = {"t1": self._team("t1", ["srv1"], tool_perms={"srv1": ["read"]})}
+        auth = self._admitted_subject("sso-user")
+        # The subject must carry a toolset, or the prelude never resolves one and the fault below is
+        # unreachable — the branch could sit anywhere and the test would still pass (it did).
+        auth.object_permission = LiteLLM_ObjectPermissionTable(object_permission_id="op-u", mcp_toolsets=["ts-1"])
+        boom = AsyncMock(side_effect=RuntimeError("toolset resolution exploded"))
+        with self._patch(teams_by_id=teams, user_teams=["t1"]):
+            with patch(
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager.resolve_toolset_tool_permissions",
+                boom,
+            ):
+                tools = await MCPRequestHandler.get_allowed_tools_for_server("srv1", auth)
+        # The fault DOES fire, correctly, inside the subject's own source (which carries its
+        # toolsets) — that source contributes nothing. What must not happen is the top-level
+        # prelude running it first and denying the team's grant through the fail-closed handler.
+        assert tools == ["read"], "a fault in the subject's own toolsets must not deny its team's tools"
+
+    async def test_admitted_own_byom_servers_stay_open(self):
+        """BYOM suppression-by-explicit-scope is a rule about a CREDENTIAL carrying its own
+        mcp_servers list. An admitted subject's object_permission is the user's own row, whose
+        mcp_servers column is [] by DB default — applying the rule would hide almost every admitted
+        user's OWN submitted servers. A key with an explicit scope still gets no BYOM widening."""
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        manager = self._manager_with(["srv-byom"])
+        manager._get_active_submitted_mcp_server_ids_for_user = AsyncMock(return_value=["srv-byom"])
+        db_default_perm = LiteLLM_ObjectPermissionTable(object_permission_id="op-u", mcp_servers=[])
+
+        admitted = self._admitted_subject("sso-user")
+        admitted.object_permission = db_default_perm
+        scoped_key = UserAPIKeyAuth(user_id="u", api_key="sk-hash", object_permission=db_default_perm)
+
+        assert await manager.operator_open_server_ids(admitted) == {"srv-byom"}
+        assert await manager.operator_open_server_ids(scoped_key) == set(), "explicit key scope still suppresses BYOM"
+
+    async def test_admitted_admin_is_scoped_to_grants_not_full_registry(self):
+        """The wrapper's admin short-circuit hands the FULL registry to any admin-role auth before
+        the grant union or the per-team org ceilings run. A session bearer is a third-party client
+        credential, not the dashboard: an admin signing in through the connect flow gets their
+        grants like anyone else. A real admin key keeps the dashboard behavior unchanged."""
+        from litellm.proxy._types import LitellmUserRoles
+
+        manager = self._manager_with(["srv-granted", "srv-secret"])
+        admitted = self._admitted_subject("admin-user")
+        admitted.user_role = LitellmUserRoles.PROXY_ADMIN
+        with patch.object(MCPRequestHandler, "get_allowed_mcp_servers", AsyncMock(return_value=["srv-granted"])):
+            admitted_view = set(await manager.get_allowed_mcp_servers(admitted))
+            key_admin_view = set(
+                await manager.get_allowed_mcp_servers(
+                    UserAPIKeyAuth(user_id="admin-user", api_key="sk-hash", user_role=LitellmUserRoles.PROXY_ADMIN)
+                )
+            )
+        assert admitted_view == {"srv-granted"}, "an admitted admin gets their grants, not the registry"
+        assert key_admin_view == {"srv-granted", "srv-secret"}, "admin KEY behavior must be unchanged"
+
+    async def test_admitted_opt_out_via_wrapper_keeps_team_servers(self):
+        """The wrapper's no_mcp_servers early-return is a KEY rule (a scoped credential's opt-out is
+        absolute). The admitted subject's opt-out silences only its own source, which the resolver
+        enforces per source — the wrapper must defer to it, or the resolver-level rule is dead code
+        on the production path."""
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable, SpecialMCPServerNames
+
+        manager = self._manager_with(["srv-team"])
+        opt_out = LiteLLM_ObjectPermissionTable(
+            object_permission_id="op-u", mcp_servers=[SpecialMCPServerNames.no_mcp_servers.value]
+        )
+        admitted = self._admitted_subject("sso-user")
+        admitted.object_permission = opt_out
+        with patch.object(MCPRequestHandler, "get_allowed_mcp_servers", AsyncMock(return_value=["srv-team"])):
+            admitted_view = set(await manager.get_allowed_mcp_servers(admitted))
+            key_view = await manager.get_allowed_mcp_servers(
+                UserAPIKeyAuth(user_id="u", api_key="sk-hash", object_permission=opt_out)
+            )
+        assert "srv-team" in admitted_view, "user opt-out must not zero team grants on the wrapper path"
+        assert key_view == [], "a key's opt-out stays absolute"
+
+    async def test_open_channel_confers_reachability_not_a_ceiling_waiver(self):
+        """An open channel (allow_all_keys / own BYOM) makes a server REACHABLE. It is not a waiver
+        of the ceilings that bound it: the user's own mcp_tool_permissions still apply, exactly as a
+        virtual key's key_tools do on the same allow_all server. Returning None outright let a
+        session holder invoke tools their own policy excludes."""
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        auth = self._admitted_subject("sso-user")
+        # The user is restricted to `read` on srv-open, and NO grant source names that server —
+        # it is reachable only through the open channel, which is exactly the bypass path.
+        auth.object_permission = LiteLLM_ObjectPermissionTable(
+            object_permission_id="op-u", mcp_servers=[], mcp_tool_permissions={"srv-open": ["read"]}
+        )
+        open_ids = AsyncMock(return_value={"srv-open"})
+        with self._patch(teams_by_id={}, user_teams=[]):
+            with patch(
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager.operator_open_server_ids",
+                open_ids,
+            ):
+                tools = await MCPRequestHandler.get_allowed_tools_for_server("srv-open", auth)
+        assert tools == ["read"], "the user's own tool policy must still bind on an open-channel server"
+
+    async def test_open_channel_server_gets_default_open_tools_for_admitted(self):
+        """A server reachable through an open channel (allow_all_keys / own BYOM) is granted by NO
+        source, so the source union alone returns [] — listable but uninvokable. The tools axis asks
+        the same open-channel owner the server union uses, so the server is default-open for tools
+        exactly as a virtual key experiences it."""
+        auth = self._admitted_subject("sso-user")
+        open_ids = AsyncMock(return_value={"srv-open"})
+        with self._patch(teams_by_id={}, user_teams=[]):
+            with patch(
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager.operator_open_server_ids",
+                open_ids,
+            ):
+                open_tools = await MCPRequestHandler.get_allowed_tools_for_server("srv-open", auth)
+                closed_tools = await MCPRequestHandler.get_allowed_tools_for_server("srv-ungranted", auth)
+        assert open_tools is None, "open-channel server must be default-open for tools"
+        assert closed_tools == [], "a server no source or channel grants stays deny-all"
+
+    async def test_over_budget_team_grants_nothing_and_healthy_team_stands(self):
+        """Budget ENFORCEMENT is the sibling of blocked: a team that has already exceeded its
+        max_budget is rejected outright for a virtual key pinned to it (common_checks), so it must
+        not keep granting servers, tools or throttle scope to a keyless union subject either.
+        Enforced through the SAME owner the key path uses (_team_max_budget_check). Distinct from
+        budget ATTRIBUTION of new spend, which stays with the user (documented deferral)."""
+        t_over = self._team("t-over", ["srv1"])
+        t_over.max_budget = 10.0
+        t_over.spend = 11.0
+        t_ok = self._team("t-ok", ["srv2"])
+        t_ok.max_budget = 10.0
+        t_ok.spend = 1.0
+        auth = self._admitted_subject("sso-user")
+        with self._patch(teams_by_id={"t-over": t_over, "t-ok": t_ok}, user_teams=["t-over", "t-ok"]):
+            servers = set(await MCPRequestHandler.get_allowed_mcp_servers(auth))
+            limits = await MCPRequestHandler._admitted_subject_team_rpm_limits(auth)
+        assert servers == {"srv2"}, "an over-budget team must stop granting; the healthy team stands"
+        assert limits is None, "an over-budget team is not a source, so it stamps no throttle either"
+
+    async def test_team_in_over_budget_org_grants_nothing(self):
+        """The org axis of the same rule, judged against the TEAM's own org (not the caller's
+        primary): a team owned by an org over its budget grants nothing, exactly as a key in that
+        org is rejected by _organization_max_budget_check."""
+        t_in_broke_org = self._team("t-b", ["srv1"])
+        t_in_broke_org.organization_id = "org-broke"
+        # object_permission_id=None: the org has NO MCP ceiling, so the source is denied by the
+        # budget gate alone. A truthy auto-Mock id here made an earlier version of this test pass
+        # through the org-CEILING fault path with the budget gate deleted — vacuous.
+        org = MagicMock(object_permission_id=None, litellm_budget_table=MagicMock(max_budget=5.0), spend=9.0)
+        auth = self._admitted_subject("sso-user")
+        with self._patch(teams_by_id={"t-b": t_in_broke_org}, user_teams=["t-b"], orgs_by_id={"org-broke": org}):
+            servers = await MCPRequestHandler.get_allowed_mcp_servers(auth)
+        assert servers == [], "a team in an over-budget org must not grant through the union"
+
+    async def test_one_faulting_team_does_not_deny_the_other_sources(self):
+        """The unit of fault isolation is the SOURCE. One team's row being momentarily unreadable
+        contributes nothing for THAT team (access only narrows) while the user's own grants and every
+        other resolvable team stand — it must not collapse the whole union to deny-all on either
+        axis."""
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        t_ok = self._team("t-ok", ["srv1"], tool_perms={"srv1": ["read"]})
+        auth = self._admitted_subject("sso-user")
+        auth.object_permission = LiteLLM_ObjectPermissionTable(object_permission_id="op-u", mcp_servers=["srv-own"])
+        teams = {"t-ok": t_ok}  # t-boom absent from the map -> our patched get_team_object RAISES for it
+
+        async def _team_or_boom(team_id, **kw):
+            if team_id not in teams:
+                raise RuntimeError(f"transient DB blip loading {team_id}")
+            return teams[team_id]
+
+        with self._patch(teams_by_id=teams, user_teams=["t-boom", "t-ok"]):
+            with patch("litellm.proxy.auth.auth_checks.get_team_object", _team_or_boom):
+                servers = set(await MCPRequestHandler.get_allowed_mcp_servers(auth))
+                tools = await MCPRequestHandler.get_allowed_tools_for_server("srv1", auth)
+        assert servers == {"srv-own", "srv1"}, "healthy sources must stand when one team faults"
+        assert tools == ["read"], "the healthy team's tool grant must survive the other team's fault"
+
+    async def test_key_org_tool_ceiling_fault_keeps_key_restrictions(self):
+        """Virtual-key tools axis mirrors its servers axis on an unresolvable org ceiling: the org
+        intersect is SKIPPED and the key's own tool restrictions stand. Letting the fault escape
+        collapsed the whole resolution to None (allow-all), which is fail-open WIDER than before the
+        fault — key restrictions must never be dropped by an org lookup blip."""
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        key_auth = UserAPIKeyAuth(user_id="u", api_key="sk-hash", org_id="org-a")
+        key_auth.object_permission = LiteLLM_ObjectPermissionTable(
+            object_permission_id="op-k", mcp_servers=["srv1"], mcp_tool_permissions={"srv1": ["read"]}
+        )
+        boom = AsyncMock(side_effect=RuntimeError("org permission load exploded"))
+        with self._patch(teams_by_id={}, user_teams=[]):
+            with patch.object(MCPRequestHandler, "_get_org_object_permission", boom):
+                tools = await MCPRequestHandler.get_allowed_tools_for_server("srv1", key_auth)
+        assert tools == ["read"], "key tool restrictions must survive an unresolvable org ceiling"
+
+    async def test_team_rpm_limit_binds_only_within_that_teams_grant_scope(self):
+        """A limit rides the same scope as the access it bounds. A roster team is charged ONLY for
+        servers its own grant reaches: not for a server the user reaches through a DIFFERENT team
+        (else this user's calls drain a bucket shared by that team's keys for access the team never
+        provided), not for map entries beyond its grant, and never when the team is blocked."""
+        # t-granting grants srv1 and limits it; also names srv9 in its map, which it does NOT grant.
+        t_granting = self._team("t-granting", ["srv1"])
+        t_granting.metadata = {"mcp_rpm_limit": {"srv1": 5, "srv9": 7}}
+        # t-other grants only srv2 but retains limit metadata for srv1 -> must not be charged for it.
+        t_other = self._team("t-other", ["srv2"])
+        t_other.metadata = {"mcp_rpm_limit": {"srv1": 3}}
+        # t-blocked grants srv1 and limits it, but is blocked -> grants nothing, charges nothing.
+        t_blocked = self._team("t-blocked", ["srv1"])
+        t_blocked.metadata = {"mcp_rpm_limit": {"srv1": 2}}
+        t_blocked.blocked = True
+
+        auth = self._admitted_subject("sso-user")
+        teams = {"t-granting": t_granting, "t-other": t_other, "t-blocked": t_blocked}
+        with self._patch(teams_by_id=teams, user_teams=["t-granting", "t-other", "t-blocked"]):
+            limits = await MCPRequestHandler._admitted_subject_team_rpm_limits(auth)
+
+        assert limits == {"t-granting": {"srv1": 5}}, (
+            "only the granting team's bucket, and only for the server it grants"
+        )
+
+    async def test_non_roster_team_rpm_limit_does_not_apply(self):
+        """The roster gates grants and throttles through one owner, so a team the user was removed
+        from neither grants servers nor gets charged for their calls."""
+        stale = self._team("t-stale", ["srv1"], members=("someone-else",))
+        stale.metadata = {"mcp_rpm_limit": {"srv1": 1}}
+        auth = self._admitted_subject("sso-user")
+        with self._patch(teams_by_id={"t-stale": stale}, user_teams=["t-stale"]):
+            limits = await MCPRequestHandler._admitted_subject_team_rpm_limits(auth)
+        assert limits is None
+
+    async def test_org_list_caps_a_source_but_never_becomes_a_grant(self):
+        """The admitted model is a union of GRANTS, so an org allowlist may only narrow what a source
+        already grants. For a virtual key with no lower-level restriction the org list legitimately
+        BECOMES the allowed set, and inheriting that arm would hand every admitted user with an
+        org_id their whole org's server list with no direct or team grant behind it."""
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        auth = self._admitted_subject("sso-user")
+        auth.org_id = "org-a"  # org allows srv1+srv2; the user and their teams grant NOTHING
+        org_perm = AsyncMock(
+            return_value=LiteLLM_ObjectPermissionTable(object_permission_id="op-org-a", mcp_servers=["srv1", "srv2"])
+        )
+        with self._patch(teams_by_id={}, user_teams=[]):
+            with patch.object(MCPRequestHandler, "_get_org_object_permission", org_perm):
+                result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
+        assert result == [], "an org ceiling must not grant servers the user was never granted"
+
+    async def test_tool_ceiling_fails_closed_when_a_SOURCE_faults(self):
+        """Each source is resolved through an UNMARKED auth, so a fault under a source must still
+        deny. Returning None there would win the union as allow-all and drop every team/org tool
+        ceiling on a DB blip -- the marker alone only covers faults raised before the fan-out."""
+        auth = self._admitted_subject("sso-user")
+        teams = {"t1": self._team("t1", ["srv1"])}
+        # Fault INSIDE the tool resolution only. Faulting something the server path also uses would
+        # make the source grant nothing, so the union would return [] without the tool path ever
+        # running -- the test would pass while pinning nothing (an earlier version did exactly that).
+        boom = AsyncMock(side_effect=RuntimeError("org tool ceiling exploded"))
+        with self._patch(teams_by_id=teams, user_teams=["t1"]):
+            assert await MCPRequestHandler.get_allowed_mcp_servers(auth) == ["srv1"]  # control: granted
+            with patch.object(MCPRequestHandler, "_apply_agent_and_org_tool_ceilings", boom):
+                tools = await MCPRequestHandler.get_allowed_tools_for_server("srv1", auth)
+        assert tools == [], "a source-level fault must deny tools, never collapse to allow-all"
+
+    async def test_own_opt_out_silences_only_that_source_not_the_teams(self):
+        """no_mcp_servers on the USER's own grants opts that source out. It must not zero the teams:
+        the sources are independent, so an opt-out on one silences one. (The same sentinel on a
+        virtual KEY still overrides team inheritance -- that is the key ceiling model, unchanged.)"""
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable, SpecialMCPServerNames
+
+        auth = self._admitted_subject("sso-user")
+        auth.object_permission = LiteLLM_ObjectPermissionTable(
+            object_permission_id="op-user", mcp_servers=[SpecialMCPServerNames.no_mcp_servers.value]
+        )
+        with self._patch(teams_by_id={"t1": self._team("t1", ["srv1"])}, user_teams=["t1"]):
+            result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
+        assert set(result) == {"srv1"}, "the user's own opt-out must not zero their team's grants"
+
+    async def test_sources_fan_out_per_team_and_drop_non_roster_teams(self):
+        """The fan-out lives here now. One source per grant source: the user's own grants (no team_id,
+        carrying their object_permission) plus each team they are a LIVE roster member of. A team that
+        lingers in the user's cached `teams` array but no longer lists them in members_with_roles is
+        dropped, which is what revokes access after a team_member_delete the user row hasn't caught up
+        on. Each team source carries that team's own org, which is what makes the shared resolver apply
+        the team's owning-org ceiling rather than the caller's home org."""
+        teams = {
+            "t-member": self._team("t-member", ["srv1"], members=("sso-user",)),
+            "t-stale": self._team("t-stale", ["srv2"], members=("someone-else",)),
+        }
+        teams["t-member"].organization_id = "org-a"
+        auth = self._admitted_subject("sso-user")
+        with self._patch(teams_by_id=teams, user_teams=["t-member", "t-stale"]):
+            sources = await MCPRequestHandler._admitted_subject_sources(auth)
+
+        assert [(s.team_id, s.org_id) for s in sources] == [(None, None), ("t-member", "org-a")]
+        # The user's own source carries their grants; a team source must NOT, or the team would be
+        # widened by grants the team never made.
+        assert sources[0].object_permission is auth.object_permission
+        assert sources[1].object_permission is None
+        # Every source is an ordinary caller, so it cannot re-enter the admitted fan-out.
+        assert all(not s.mcp_admitted_user_subject for s in sources)
+        # Nothing that meters or elevates the request may ride along onto a per-source clone.
+        assert all(s.api_key is None and s.user_role is None for s in sources)
+
+    async def test_jwt_keyless_user_without_team_claim_does_not_union(self):
+        """Regression for the review finding: a JWT-authenticated caller is also keyless with a
+        user_id and (with no team claim) no team_id, but it is NOT admission-marked, so it must
+        keep its prior behavior of inheriting no team grants rather than silently gaining the
+        union across every team the user belongs to."""
+        teams = {"team-a": self._team("team-a", ["srv1"]), "team-b": self._team("team-b", ["srv2"])}
+        jwt_auth = UserAPIKeyAuth(user_id="jwt-user", api_key=None)  # no admission marker
+        with self._patch(teams_by_id=teams, user_teams=["team-a", "team-b"]):
+            result = await MCPRequestHandler._get_allowed_mcp_servers_for_team(jwt_auth)
+        assert result == []
+
+    async def test_forged_metadata_marker_on_a_real_key_grants_no_union(self):
+        """Security regression (forged admission marker): the admitted-subject marker is a
+        server-only ``UserAPIKeyAuth`` field, NOT a metadata key, precisely because virtual-key
+        metadata is caller-controlled at key creation. A user who sets
+        ``mcp_admitted_user_subject: true`` in their own key's metadata (api_key present, no
+        team_id) must NOT be treated as an admitted subject and must gain no cross-team union."""
+        teams = {"team-a": self._team("team-a", ["srv1"]), "team-b": self._team("team-b", ["srv2"])}
+        forged = UserAPIKeyAuth(
+            user_id="attacker",
+            api_key="sk-real-key",
+            metadata={"mcp_admitted_user_subject": True},  # caller-forged marker in key metadata
+        )
+        assert _is_mcp_admitted_user_subject(forged) is False
+        with self._patch(teams_by_id=teams, user_teams=["team-a", "team-b"]):
+            assert await MCPRequestHandler._team_ids_for_mcp_grant(forged) == []
+            assert await MCPRequestHandler._get_allowed_mcp_servers_for_team(forged) == []
+
+    async def test_admitted_subject_team_tool_restriction_binds(self):
+        """Security regression (team tool restrictions bypassed): a keyless admitted subject whose
+        granting team restricts ``srv1`` to ``{tool_a}`` must NOT receive allow-all on srv1. The
+        single-team-id tool lookup returns None (allow-all) for a keyless multi-team user, dropping
+        the exclusion; the union across granting teams restores it."""
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable, LiteLLM_TeamTable, Member
+
+        team = LiteLLM_TeamTable(
+            team_id="team-a",
+            members_with_roles=[Member(user_id="sso-user", role="user")],
+            access_group_ids=[],
+            object_permission=LiteLLM_ObjectPermissionTable(
+                object_permission_id="op-team-a",
+                mcp_servers=["srv1"],
+                mcp_tool_permissions={"srv1": ["tool_a"]},
+            ),
+        )
+        auth = self._admitted_subject("sso-user")
+        with self._patch(teams_by_id={"team-a": team}, user_teams=["team-a"]):
+            tools = await MCPRequestHandler.get_allowed_tools_for_server("srv1", auth)
+        assert tools == ["tool_a"]
+
+    async def test_blocked_team_grants_no_servers_to_admitted_subject(self):
+        """Security regression: a blocked team grants nothing. The central policy gate enforces this
+        for a key pinned to a single team_id, but a keyless admitted subject unions across ALL its
+        teams (no team_id), so a blocked team's MCP grants must be dropped at the per-team resolver."""
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable, LiteLLM_TeamTable, Member
+
+        blocked = LiteLLM_TeamTable(
+            team_id="team-blocked",
+            blocked=True,
+            members_with_roles=[Member(user_id="sso-user", role="user")],
+            access_group_ids=[],
+            object_permission=LiteLLM_ObjectPermissionTable(object_permission_id="op-blk", mcp_servers=["srv-secret"]),
+        )
+        teams = {"team-ok": self._team("team-ok", ["srv-ok"]), "team-blocked": blocked}
+        auth = self._admitted_subject("sso-user")
+        with self._patch(teams_by_id=teams, user_teams=["team-ok", "team-blocked"]):
+            result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
+        assert set(result) == {"srv-ok"}
+
+    async def test_admitted_subject_not_on_team_roster_gets_no_grant(self):
+        """Security regression (membership containment): a keyless subject whose user_id is NOT on a
+        team's roster inherits nothing from it, even when the team id lingers in the user's (stale or
+        cached) teams array. The team roster is the source of truth, so a removed or foreign
+        membership revokes access at the union rather than granting it."""
+        teams = {"team-x": self._team("team-x", ["srv-x"], members=("someone-else",))}
+        auth = self._admitted_subject("sso-user")  # in user.teams for team-x, but NOT on its roster
+        with self._patch(teams_by_id=teams, user_teams=["team-x"]):
+            result = await MCPRequestHandler._get_allowed_mcp_servers_for_team(auth)
+        assert result == []
+
+    async def test_tool_resolution_fails_closed_on_db_error(self):
+        """Security regression: ANY error resolving the tool allowlist for a keyless admitted subject
+        must DENY the server's tools ([]) rather than collapse to allow-all (None). Patches an await
+        OUTSIDE the multi-team fan-out (the team-object lookup) to prove the whole function fails
+        closed, not just the one helper — mirroring the fail-closed server path."""
+        auth = self._admitted_subject("sso-user")
+        with patch.object(
+            MCPRequestHandler,
+            "_get_team_object_permission",
+            new=AsyncMock(side_effect=RuntimeError("db blip")),
+        ):
+            tools = await MCPRequestHandler.get_allowed_tools_for_server("srv1", auth)
+        assert tools == []
+
+    async def test_admission_marker_cannot_be_set_from_validated_input(self):
+        """Defense-in-depth: the mcp_admitted_user_subject marker is server-only. Supplying it in any
+        validated input (constructor kwargs OR model_validate, e.g. a future JWT/key claim splat) is
+        stripped by the before-validator, so ONLY the admission path's post-construction assignment
+        can set it."""
+        via_kwarg = UserAPIKeyAuth(user_id="u", api_key=None, mcp_admitted_user_subject=True)
+        via_validate = UserAPIKeyAuth.model_validate({"user_id": "u", "mcp_admitted_user_subject": True})
+        assert via_kwarg.mcp_admitted_user_subject is False
+        assert via_validate.mcp_admitted_user_subject is False
+        assert _is_mcp_admitted_user_subject(via_kwarg) is False
+        assert _is_mcp_admitted_user_subject(via_validate) is False
+
+
+@pytest.mark.asyncio
+class TestAdmittedSubjectPerTeamOrgCap:
+    """A keyless admitted subject unions grants across teams that may span organizations. Each team's
+    grant (servers AND tools) is capped by that team's OWN org, and the user's direct grants by the
+    user's own org — never the caller's primary org applied over the whole cross-org union. Guards the
+    Veria 'team grants bypass their owning policies' finding."""
+
+    def _team(self, team_id, mcp_servers, *, org_id=None, tool_perms=None, members=("sso-user",)):
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable, LiteLLM_TeamTable, Member
+
+        return LiteLLM_TeamTable(
+            team_id=team_id,
+            organization_id=org_id,
+            members_with_roles=[Member(user_id=u, role="user") for u in members],
+            access_group_ids=[],
+            object_permission=LiteLLM_ObjectPermissionTable(
+                object_permission_id=f"op-{team_id}",
+                mcp_servers=mcp_servers,
+                mcp_tool_permissions=tool_perms,
+            ),
+        )
+
+    @staticmethod
+    def _admitted_subject(user_id, *, org_id=None, own_servers=None, own_tool_perms=None):
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        op = None
+        if own_servers is not None or own_tool_perms is not None:
+            op = LiteLLM_ObjectPermissionTable(
+                object_permission_id=f"userop-{user_id}",
+                mcp_servers=own_servers or [],
+                mcp_tool_permissions=own_tool_perms,
+            )
+        auth = UserAPIKeyAuth(user_id=user_id, api_key=None, org_id=org_id, object_permission=op)
+        auth.mcp_admitted_user_subject = True
+        return auth
+
+    #: sentinel for org_perms: org has an object_permission_id but its load returns None (a swallowed
+    #: DB error / dangling id), which _object_permission_for_org must treat as fail-closed.
+    LOAD_FAILS = "__load_fails__"
+
+    @contextlib.contextmanager
+    def _patch(self, *, teams_by_id, user_teams, org_perms=None, registry=None):
+        """org_perms: {org_id: LiteLLM_ObjectPermissionTable | None | LOAD_FAILS}.
+        - table  → org exists, ceiling = that permission.
+        - None   → org exists but carries no object_permission (no ceiling).
+        - LOAD_FAILS → org exists with an object_permission_id, but the permission load returns None.
+        - org_id ABSENT from the map → org row missing: get_org_object RAISES a bare Exception, exactly
+          as production does (it does NOT return None or raise HTTPException)."""
+        org_perms = org_perms or {}
+
+        async def _get_team_object(team_id, **kw):
+            return teams_by_id.get(team_id)
+
+        async def _get_user_object(user_id, **kw):
+            return MagicMock(user_id=user_id, teams=user_teams)
+
+        async def _get_org_object(org_id, **kw):
+            if org_id not in org_perms:
+                from litellm.proxy.auth.auth_checks import OrganizationNotFoundError
+
+                # matches production: a CONFIRMED-absent org raises this specific type, so callers
+                # can tell it apart from an outage (a bare Exception now means "lookup failed").
+                raise OrganizationNotFoundError(f"Organization doesn't exist. Org={org_id}.")
+            op = org_perms[org_id]
+            has_permission_id = op is not None  # a table OR LOAD_FAILS carries an id; None does not
+            return MagicMock(
+                organization_id=org_id,
+                object_permission_id=(f"orgop-{org_id}" if has_permission_id else None),
+                # Real typed values: the budget owners compare these, and a bare MagicMock attribute
+                # would explode the comparison and silently drop the source (bare-Mock rule).
+                litellm_budget_table=None,
+                spend=0.0,
+            )
+
+        async def _get_object_permission(object_permission_id, **kw):
+            for oid, op in org_perms.items():
+                if op is not None and op != self.LOAD_FAILS and object_permission_id == f"orgop-{oid}":
+                    return op
+            return None  # LOAD_FAILS (or an unknown id) → None, simulating get_object_permission's swallow
+
+        cms = [
+            patch("litellm.proxy.auth.auth_checks.get_team_object", _get_team_object),
+            patch("litellm.proxy.auth.auth_checks.get_user_object", _get_user_object),
+            patch("litellm.proxy.auth.auth_checks.get_org_object", _get_org_object),
+            patch("litellm.proxy.auth.auth_checks.get_object_permission", _get_object_permission),
+            patch(
+                "litellm.proxy.auth.auth_checks._get_mcp_server_ids_from_access_groups",
+                AsyncMock(return_value=[]),
+            ),
+            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+            patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        ]
+        if registry is not None:
+            from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+                global_mcp_server_manager,
+            )
+
+            # registry may be a list of bare server_ids (MagicMock servers) OR a dict of
+            # {server_id: server_obj} for tests that need real alias/name resolution (config servers).
+            reg = registry if isinstance(registry, dict) else {s: MagicMock() for s in registry}
+            cms.append(patch.object(global_mcp_server_manager, "get_registry", return_value=reg))
+        with contextlib.ExitStack() as es:
+            for cm in cms:
+                es.enter_context(cm)
+            yield
+
+    # ---- server axis ----
+
+    async def test_team_grant_capped_by_its_own_org(self):
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        teams = {"team-a": self._team("team-a", ["srv1", "srv2"], org_id="org-a")}
+        org_perms = {"org-a": LiteLLM_ObjectPermissionTable(object_permission_id="orgop-org-a", mcp_servers=["srv1"])}
+        auth = self._admitted_subject("sso-user")
+        with self._patch(teams_by_id=teams, user_teams=["team-a"], org_perms=org_perms):
+            result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
+        assert set(result) == {"srv1"}  # srv2 capped out by org-a's ceiling
+
+    async def test_cross_org_teams_each_capped_by_own_org(self):
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        teams = {
+            "team-a": self._team("team-a", ["srv1", "srv2"], org_id="org-a"),
+            "team-b": self._team("team-b", ["srv3", "srv4"], org_id="org-b"),
+        }
+        org_perms = {
+            "org-a": LiteLLM_ObjectPermissionTable(object_permission_id="orgop-org-a", mcp_servers=["srv1"]),
+            "org-b": LiteLLM_ObjectPermissionTable(object_permission_id="orgop-org-b", mcp_servers=["srv3"]),
+        }
+        auth = self._admitted_subject("sso-user")
+        with self._patch(teams_by_id=teams, user_teams=["team-a", "team-b"], org_perms=org_perms):
+            result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
+        assert set(result) == {"srv1", "srv3"}  # each team clipped by its OWN org, then unioned
+
+    async def test_all_proxy_grant_capped_by_org(self):
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable, SpecialMCPServerName
+
+        teams = {"team-a": self._team("team-a", [SpecialMCPServerName.all_proxy_servers.value], org_id="org-a")}
+        org_perms = {"org-a": LiteLLM_ObjectPermissionTable(object_permission_id="orgop-org-a", mcp_servers=["srv1"])}
+        auth = self._admitted_subject("sso-user")
+        with self._patch(
+            teams_by_id=teams, user_teams=["team-a"], org_perms=org_perms, registry=["srv1", "srv2", "srv3"]
+        ):
+            result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
+        # all_proxy expands to the whole registry, then org-a caps to {srv1} — the cell the old partial
+        # patch missed (it returned the full registry before capping).
+        assert set(result) == {"srv1"}
+
+    async def test_org_row_without_object_permission_does_not_cap(self):
+        teams = {"team-a": self._team("team-a", ["srv1", "srv2"], org_id="org-a")}
+        auth = self._admitted_subject("sso-user")
+        with self._patch(teams_by_id=teams, user_teams=["team-a"], org_perms={"org-a": None}):
+            result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
+        assert set(result) == {"srv1", "srv2"}  # empty ceiling = no restriction
+
+    async def test_direct_grants_unioned_with_team_and_capped_by_user_org(self):
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        teams = {"team-a": self._team("team-a", ["srv1"], org_id="org-a")}
+        org_perms = {
+            "org-a": None,  # the team's org imposes no ceiling
+            "org-u": LiteLLM_ObjectPermissionTable(object_permission_id="orgop-org-u", mcp_servers=["srvD", "srv1"]),
+        }
+        auth = self._admitted_subject("sso-user", org_id="org-u", own_servers=["srvD", "srvX"])
+        with self._patch(teams_by_id=teams, user_teams=["team-a"], org_perms=org_perms):
+            result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
+        # direct {srvD,srvX} ∩ user-org {srvD,srv1} = {srvD}; UNIONed with team {srv1} (not intersected).
+        # srvX capped out by the user's org; team's srv1 NOT clipped by the user's primary org.
+        assert set(result) == {"srvD", "srv1"}
+
+    async def test_single_team_key_uses_primary_org_cap_not_per_team(self):
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        # A KEY (not admitted): the per-team org cap must NOT fire; the top-level primary-org cap applies,
+        # byte-identical to before. team-a (org-a) grants {srv1,srv2}; the key's primary org is org-k.
+        teams = {"team-a": self._team("team-a", ["srv1", "srv2"], org_id="org-a")}
+        org_perms = {
+            "org-a": LiteLLM_ObjectPermissionTable(object_permission_id="orgop-org-a", mcp_servers=["srv2"]),
+            "org-k": LiteLLM_ObjectPermissionTable(object_permission_id="orgop-org-k", mcp_servers=["srv1"]),
+        }
+        key_auth = UserAPIKeyAuth(user_id="u", api_key="sk-hash", team_id="team-a", org_id="org-k")
+        with self._patch(teams_by_id=teams, user_teams=["team-a"], org_perms=org_perms):
+            result = await MCPRequestHandler.get_allowed_mcp_servers(key_auth)
+        # If the per-team (org-a) cap wrongly fired, team-a would clip to {srv2} then org-k → {} (empty).
+        # Correct key behavior: no per-team cap; primary-org (org-k) cap → {srv1}.
+        assert set(result) == {"srv1"}
+
+    # ---- tool axis ----
+
+    async def test_org_tool_ceiling_binds_when_team_places_no_tool_restriction(self):
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        # team grants srv1 with NO tool restriction; org-a restricts srv1's tools to {tool_a}.
+        teams = {"team-a": self._team("team-a", ["srv1"], org_id="org-a")}
+        org_perms = {
+            "org-a": LiteLLM_ObjectPermissionTable(
+                object_permission_id="orgop-org-a",
+                mcp_servers=["srv1"],
+                mcp_tool_permissions={"srv1": ["tool_a"]},
+            )
+        }
+        auth = self._admitted_subject("sso-user")
+        with self._patch(teams_by_id=teams, user_teams=["team-a"], org_perms=org_perms):
+            tools = await MCPRequestHandler.get_allowed_tools_for_server("srv1", auth)
+        # Without the per-team org tool ceiling this would be None (all tools) — org-a's tool ceiling
+        # would be bypassed exactly like the server case.
+        assert tools == ["tool_a"]
+
+    async def test_tool_union_across_cross_org_teams(self):
+        teams = {
+            "team-a": self._team("team-a", ["srv1"], org_id="org-a", tool_perms={"srv1": ["t1"]}),
+            "team-b": self._team("team-b", ["srv1"], org_id="org-b", tool_perms={"srv1": ["t2"]}),
+        }
+        auth = self._admitted_subject("sso-user")
+        with self._patch(teams_by_id=teams, user_teams=["team-a", "team-b"], org_perms={"org-a": None, "org-b": None}):
+            tools = await MCPRequestHandler.get_allowed_tools_for_server("srv1", auth)
+        assert set(tools) == {"t1", "t2"}
+
+    async def test_tool_deny_all_when_team_grant_and_org_tool_ceiling_disjoint(self):
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        teams = {"team-a": self._team("team-a", ["srv1"], org_id="org-a", tool_perms={"srv1": ["t1"]})}
+        org_perms = {
+            "org-a": LiteLLM_ObjectPermissionTable(
+                object_permission_id="orgop-org-a",
+                mcp_servers=["srv1"],
+                mcp_tool_permissions={"srv1": ["t2"]},
+            )
+        }
+        auth = self._admitted_subject("sso-user")
+        with self._patch(teams_by_id=teams, user_teams=["team-a"], org_perms=org_perms):
+            tools = await MCPRequestHandler.get_allowed_tools_for_server("srv1", auth)
+        # team {t1} ∩ org {t2} = {} → deny every tool ([]), NOT allow-all (None).
+        assert tools == []
+
+    # ---- error contract (adversarial-review findings) ----
+
+    async def test_missing_org_row_is_treated_as_no_ceiling_not_lockout(self):
+        """A team's organization_id may point to an org row that no longer exists (deleted / not yet
+        synced). get_org_object RAISES a bare Exception for that; it must be treated as 'no ceiling' and
+        must NOT lock the admitted subject out of the team's grants (parity with the key path, which
+        tolerates a deleted org)."""
+        teams = {"team-a": self._team("team-a", ["srv1", "srv2"], org_id="org-gone")}
+        auth = self._admitted_subject("sso-user")
+        with self._patch(teams_by_id=teams, user_teams=["team-a"], org_perms={}):  # org-gone absent → raises
+            result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
+        assert set(result) == {"srv1", "srv2"}
+
+    async def test_org_permission_load_failure_fails_closed(self):
+        """The org carries an object_permission_id but the permission load returns None (a swallowed DB
+        error / dangling id). The ceiling cannot be verified, so the admitted subject must fail CLOSED
+        for that team — NOT skip the ceiling, which would leak org-forbidden servers."""
+        teams = {"team-a": self._team("team-a", ["srv1", "srv2"], org_id="org-a")}
+        auth = self._admitted_subject("sso-user")
+        with self._patch(teams_by_id=teams, user_teams=["team-a"], org_perms={"org-a": self.LOAD_FAILS}):
+            # Asserted through the PUBLIC resolver: the per-source org ceiling is applied there now,
+            # so calling the single-team helper would return [] for an admitted subject either way
+            # and pin nothing.
+            result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
+        assert result == []  # fail closed, not {srv1, srv2}
+
+    # ---- open bot-thread findings (2026-07-21 re-review) ----
+
+    async def test_org_less_team_grant_capped_by_user_primary_org(self):
+        """HIGH (cursor): a team with NO organization_id must still be bounded by the user's PRIMARY
+        org — otherwise, since admitted subjects skip the top-level primary-org cap, an org-less team's
+        grant would bypass every org ceiling and reach servers the user's home org forbids."""
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        teams = {"team-noorg": self._team("team-noorg", ["srv1", "srv2"], org_id=None)}
+        org_perms = {"org-U": LiteLLM_ObjectPermissionTable(object_permission_id="orgop-org-U", mcp_servers=["srv1"])}
+        auth = self._admitted_subject("sso-user", org_id="org-U")
+        with self._patch(teams_by_id=teams, user_teams=["team-noorg"], org_perms=org_perms):
+            result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
+        # org-less team falls back to the user's primary org (org-U → {srv1}); srv2 capped out.
+        assert set(result) == {"srv1"}
+
+    async def test_tool_empty_contributions_fails_closed(self):
+        """MEDIUM (greptile/cursor): when no source in the tool-resolution view grants the server (a
+        TOCTOU/cache-lag inconsistency on a server that passed the server gate), the admitted path must
+        fail CLOSED (deny all tools = []), NOT allow-all (None)."""
+        teams = {"team-a": self._team("team-a", ["srv1"], org_id="org-a")}
+        auth = self._admitted_subject("sso-user")
+        with self._patch(teams_by_id=teams, user_teams=["team-a"], org_perms={"org-a": None}):
+            # 'srv-nobody' is granted by neither the team nor the user directly → empty contributions.
+            tools = await MCPRequestHandler.get_allowed_tools_for_server("srv-nobody", auth)
+        assert tools == []
+
+    async def test_tool_no_db_honors_in_memory_direct_restriction(self):
+        """MEDIUM (cursor): with no DB, the tool path must still honor the user's OWN in-memory
+        object_permission tool restriction (resolvable without a DB) rather than blanket-allow (None)."""
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        auth = self._admitted_subject(
+            "sso-user", own_servers=["srv1"], own_tool_perms={"srv1": ["t1"]}
+        )  # no org_id, direct grant of srv1 restricted to {t1}
+        with patch("litellm.proxy.proxy_server.prisma_client", None):
+            tools = await MCPRequestHandler.get_allowed_tools_for_server("srv1", auth)
+        assert tools == ["t1"]  # in-memory restriction honored, not widened to all tools
+
+    # ---- config.yaml-defined servers (incl. OAuth) ----
+
+    async def test_config_defined_oauth_server_by_alias_reached_and_org_capped(self):
+        """A config.yaml-defined MCP OAuth server flows through the SAME resolution as a DB server:
+        the team grant (and the org ceiling) reference it by ALIAS, expand_permission_list resolves it
+        via the config+DB registry union to its server_id, and the per-team org cap applies identically.
+        (The config server's OAuth *client* persistence is #33768 — an orthogonal egress concern; this
+        pins the grant/reachability side of the 10x flow for config-defined servers.)"""
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        cfg_server = MagicMock()
+        cfg_server.server_id = "cfg-oauth-1"
+        cfg_server.alias = "linear_cfg"
+        cfg_server.server_name = "linear_cfg"
+        cfg_server.name = "linear_cfg"
+
+        # team grants the config server BY ALIAS alongside a DB-style bare id; org-a's ceiling lists
+        # ONLY the config server (also by alias).
+        teams = {"team-a": self._team("team-a", ["linear_cfg", "srv-db"], org_id="org-a")}
+        org_perms = {
+            "org-a": LiteLLM_ObjectPermissionTable(object_permission_id="orgop-org-a", mcp_servers=["linear_cfg"])
+        }
+        auth = self._admitted_subject("sso-user")
+        with self._patch(
+            teams_by_id=teams,
+            user_teams=["team-a"],
+            org_perms=org_perms,
+            registry={"cfg-oauth-1": cfg_server},
+        ):
+            result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
+        # 'linear_cfg' alias resolves to the config server_id and survives org-a's ceiling; 'srv-db'
+        # (not in org-a's allowlist) is capped out — same per-team org cap, config server included.
+        assert set(result) == {"cfg-oauth-1"}
+
+    async def test_config_oauth_server_alias_resolution_feeds_the_org_cap(self):
+        """A config-defined OAuth server granted BY ALIAS whose OWN org forbids it is capped out — AND the
+        cap is proven to run on RESOLVED server_ids, not raw strings. A control config server, granted by
+        alias and allowed by the org via its RESOLVED id, must survive: that inclusion is impossible unless
+        expand_permission_list resolved the grant alias to the id the ceiling lists, so a broken alias path
+        yields {} and FAILS this test — whereas a bare `assert empty` would pass even if resolution never
+        ran (the weakness Cursor flagged)."""
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        forbidden = MagicMock()  # granted by alias, but its org forbids it → must be capped out
+        forbidden.server_id = "cfg-oauth-1"
+        forbidden.alias = forbidden.server_name = forbidden.name = "linear_cfg"
+        control = MagicMock()  # granted by alias, allowed by the org via its RESOLVED id → must survive
+        control.server_id = "control-id"
+        control.alias = control.server_name = control.name = "control_alias"
+
+        teams = {"team-b": self._team("team-b", ["linear_cfg", "control_alias"], org_id="org-b")}
+        # org-b's ceiling allows ONLY the control server, referenced by its RESOLVED server_id.
+        org_perms = {
+            "org-b": LiteLLM_ObjectPermissionTable(object_permission_id="orgop-org-b", mcp_servers=["control-id"])
+        }
+        auth = self._admitted_subject("sso-user")
+        with self._patch(
+            teams_by_id=teams,
+            user_teams=["team-b"],
+            org_perms=org_perms,
+            registry={"cfg-oauth-1": forbidden, "control-id": control},
+        ):
+            result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
+        # control survives ('control_alias' resolved to 'control-id', matching the id-based ceiling); the
+        # forbidden config server ('cfg-oauth-1') is capped out. A broken alias path → {} → fails here.
+        assert set(result) == {"control-id"}
+
+
+@pytest.mark.asyncio
+class TestSessionBearerEgressScrub:
+    """The gateway session bearer / bridge envelope is an admission credential, never an upstream token.
+    The leak-defense scrub is anchored to the credential SHAPE, so a session-shaped Authorization is
+    stripped from every egress context even when it reaches a non-aggregate scope that never set the
+    admission marker (design-review finding: a session bearer misdirected to a per-server true_passthrough
+    path would otherwise be forwarded upstream verbatim and replayed against the aggregate endpoint)."""
+
+    async def test_session_bearer_misdirected_to_passthrough_is_scrubbed(self):
+        from litellm.types.mcp import MCPAuth
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/mcp/passthrough_server",
+            "headers": [(b"authorization", b"Bearer llm_session_synthetic-shaped-token")],
+        }
+        ttp_server = MagicMock()
+        ttp_server.auth_type = MCPAuth.true_passthrough
+
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
+                new_callable=AsyncMock,
+            ) as mock_auth,
+            patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager") as mock_mgr,
+        ):
+            mock_mgr.get_mcp_server_by_name.return_value = ttp_server
+            (_auth, _mah, _srv, _sah, oauth2_headers, raw_headers) = await MCPRequestHandler.process_mcp_request(scope)
+
+        mock_auth.assert_not_called()  # true_passthrough → LiteLLM auth skipped (anonymous arm, no marker)
+        assert oauth2_headers is None  # session-shaped bearer scrubbed from oauth2 egress
+        assert all(k.lower() != "authorization" for k in raw_headers)  # ...and from raw egress headers
+
+    async def test_legitimate_upstream_token_is_not_scrubbed(self):
+        """A genuine upstream/passthrough token is never session- or envelope-shaped, so the shape-anchored
+        scrub must leave it intact for forwarding (guards against over-stripping)."""
+        from litellm.types.mcp import MCPAuth
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/mcp/passthrough_server",
+            "headers": [(b"authorization", b"Bearer real-upstream-opaque-token-xyz")],
+        }
+        ttp_server = MagicMock()
+        ttp_server.auth_type = MCPAuth.true_passthrough
+
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.user_api_key_auth",
+                new_callable=AsyncMock,
+            ),
+            patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager") as mock_mgr,
+        ):
+            mock_mgr.get_mcp_server_by_name.return_value = ttp_server
+            (_auth, _mah, _srv, _sah, oauth2_headers, _raw) = await MCPRequestHandler.process_mcp_request(scope)
+
+        assert oauth2_headers.get("Authorization") == "Bearer real-upstream-opaque-token-xyz"
+
+    async def test_scrub_removes_gateway_credential_from_every_egress_context(self):
+        """The scrub is anchored to the credential SHAPE and covers ALL egress contexts, not just
+        Authorization: a session bearer placed in x-mcp-auth OR a per-server x-mcp-{alias}-authorization
+        header is stripped too (the High-severity gap: those were forwarded upstream before)."""
+        sess = "Bearer llm_session_abc"
+        oauth2, raw, mcp_auth, per_server = MCPRequestHandler._scrub_gateway_admission_credentials(
+            admitted=False,
+            oauth2_headers={"Authorization": sess},
+            raw_headers={
+                "authorization": sess,
+                "x-mcp-auth": "llm_session_xyz",
+                "x-mcp-github-authorization": "llm_session_ghi",
+            },
+            mcp_auth_header="llm_session_xyz",
+            mcp_server_auth_headers={"github": {"Authorization": "llm_session_ghi"}},
+        )
+        assert oauth2 is None
+        assert "authorization" not in {k.lower() for k in raw}
+        assert all("llm_session_" not in v for v in raw.values())  # x-mcp-auth + per-server raw values gone
+        assert mcp_auth is None  # deprecated x-mcp-auth value scrubbed
+        assert per_server == {}  # per-server session bearer removed → now-empty server dict dropped
+
+    async def test_scrub_keeps_real_upstream_tokens(self):
+        """A legitimate upstream token is never session-/envelope-shaped, so every context is forwarded
+        unchanged — guards against over-stripping a real credential the caller meant for the upstream."""
+        oauth2, raw, mcp_auth, per_server = MCPRequestHandler._scrub_gateway_admission_credentials(
+            admitted=False,
+            oauth2_headers={"Authorization": "Bearer real-upstream-xyz"},
+            raw_headers={"authorization": "Bearer real-upstream-xyz", "x-mcp-github-authorization": "Bearer gh_real"},
+            mcp_auth_header="some-api-key-123",
+            mcp_server_auth_headers={"github": {"Authorization": "Bearer gh_real"}},
+        )
+        assert oauth2 == {"Authorization": "Bearer real-upstream-xyz"}
+        assert raw["authorization"] == "Bearer real-upstream-xyz"
+        assert mcp_auth == "some-api-key-123"
+        assert per_server == {"github": {"Authorization": "Bearer gh_real"}}
+
+    async def test_scrub_admitted_drops_authorization_but_keeps_injected_upstream_token(self):
+        """An admitted subject's top-level Authorization is dropped unconditionally, while the real
+        upstream token the bridge arm INJECTS into a per-server header (not gateway-shaped) survives."""
+        oauth2, raw, mcp_auth, per_server = MCPRequestHandler._scrub_gateway_admission_credentials(
+            admitted=True,
+            oauth2_headers={"Authorization": "Bearer llm_session_abc"},
+            raw_headers={"authorization": "Bearer llm_session_abc"},
+            mcp_auth_header=None,
+            mcp_server_auth_headers={"github": {"Authorization": "Bearer gh_injected_upstream"}},
+        )
+        assert oauth2 is None
+        assert "authorization" not in {k.lower() for k in raw}
+        assert per_server == {"github": {"Authorization": "Bearer gh_injected_upstream"}}

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -3302,19 +3302,20 @@ async def test_token_root_does_not_resolve_private_server_for_external_client():
 
 
 @pytest.mark.asyncio
-async def test_register_root_resolves_single_oauth2_server():
-    """When /register is hit without server name and exactly 1 OAuth2 server exists, resolve it."""
-    try:
-        from fastapi import Request
+async def test_register_root_does_aggregate_dcr_not_single_server_resolution():
+    """Root /register is the aggregate DCR endpoint: it mints a stateless llm_dcrc_ client
+    from the request's redirect_uris and does NOT resolve a single configured oauth2 server
+    (a single-server deployment registers at /{server}/register instead)."""
+    import json
 
-        from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
-            register_client,
-        )
-        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
-            global_mcp_server_manager,
-        )
-    except ImportError:
-        pytest.skip("MCP discoverable endpoints not available")
+    from fastapi import Request
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        register_client,
+    )
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
 
     global_mcp_server_manager.registry.clear()
     oauth2_server = _create_oauth2_server()
@@ -3325,33 +3326,37 @@ async def test_register_root_resolves_single_oauth2_server():
     mock_request.headers = {}
 
     try:
-        with patch(
-            "litellm.proxy._experimental.mcp_server.discoverable_endpoints._read_request_body",
-            new=AsyncMock(return_value={}),
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.discoverable_endpoints._read_request_body",
+                new=AsyncMock(return_value={"redirect_uris": ["https://claude.ai/cb"]}),
+            ),
+            patch("litellm.proxy.proxy_server.master_key", "sk-test-salt-for-lit3637"),
         ):
-            result = await register_client(request=mock_request, mcp_server_name=None)
+            response = await register_client(request=mock_request, mcp_server_name=None)
 
-        # Should resolve to the single server and return its name as client_id
-        assert result["client_id"] == "test_oauth"
-        assert "redirect_uris" in result
+        body = json.loads(response.body)
+        assert body["client_id"].startswith("llm_dcrc_")
+        assert body["client_id"] != "test_oauth"
+        assert body["token_endpoint_auth_method"] == "none"
     finally:
         global_mcp_server_manager.registry.clear()
 
 
 @pytest.mark.asyncio
-async def test_register_root_does_not_resolve_private_server_for_external_client():
-    """Root /register must not reveal or use a hidden MCP server."""
-    try:
-        from fastapi import Request
+async def test_register_root_does_not_leak_a_private_server():
+    """Root /register never resolves or reveals a configured server, so a private one cannot
+    leak to an external caller: it always mints the aggregate DCR client instead."""
+    import json
 
-        from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
-            register_client,
-        )
-        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
-            global_mcp_server_manager,
-        )
-    except ImportError:
-        pytest.skip("MCP discoverable endpoints not available")
+    from fastapi import Request
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        register_client,
+    )
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
 
     global_mcp_server_manager.registry.clear()
     oauth2_server = _create_oauth2_server(available_on_public_internet=False)
@@ -3365,17 +3370,19 @@ async def test_register_root_does_not_resolve_private_server_for_external_client
         with (
             patch(
                 "litellm.proxy._experimental.mcp_server.discoverable_endpoints._read_request_body",
-                new=AsyncMock(return_value={}),
+                new=AsyncMock(return_value={"redirect_uris": ["https://claude.ai/cb"]}),
             ),
             patch(
                 "litellm.proxy._experimental.mcp_server.discoverable_endpoints.IPAddressUtils.get_mcp_client_ip",
                 return_value="198.51.100.10",
             ),
+            patch("litellm.proxy.proxy_server.master_key", "sk-test-salt-for-lit3637"),
         ):
-            result = await register_client(request=mock_request, mcp_server_name=None)
+            response = await register_client(request=mock_request, mcp_server_name=None)
 
-        assert result["client_id"] == "dummy_client"
-        assert result["redirect_uris"] == ["https://llm.example.com/callback"]
+        body = json.loads(response.body)
+        assert body["client_id"].startswith("llm_dcrc_")
+        assert "test_oauth" not in body["client_id"]
     finally:
         global_mcp_server_manager.registry.clear()
 
@@ -5155,7 +5162,10 @@ async def test_bridge_refresh_grant_with_non_envelope_is_invalid_grant_before_up
 
 
 def _mint_test_refresh_envelope(
-    server_id="bridge_srv", key_hash="hashed-litellm-key-77", upstream_refresh="UPSTREAM-REFRESH", identity=None,
+    server_id="bridge_srv",
+    key_hash="hashed-litellm-key-77",
+    upstream_refresh="UPSTREAM-REFRESH",
+    identity=None,
     scope=None,
 ):
     """Mint a refresh envelope the way the producer does, for driving the refresh_token grant in tests.
@@ -5178,7 +5188,9 @@ def _mint_test_refresh_envelope(
     keys = envelope_keys_from_master_key(_BRIDGE_MASTER_KEY)
     identity = identity if identity is not None else key_hash_identity(server_id=server_id, key_hash=key_hash)
     sealed = build_bridge_refresh_token_response(
-        identity, RefreshCredential(refresh_token=SecretStr(upstream_refresh), scope=scope), keys,
+        identity,
+        RefreshCredential(refresh_token=SecretStr(upstream_refresh), scope=scope),
+        keys,
         datetime.now(timezone.utc),
     )
     assert isinstance(sealed, SealedEnvelope)
@@ -5413,7 +5425,10 @@ async def test_bridge_refresh_re_requests_the_sealed_scope_when_client_omits_it(
     )
     captured: dict = {}
     response = await _refresh_for_bridge_server(
-        server, refresh_env, {"access_token": "NEW-ACCESS", "token_type": "Bearer", "expires_in": 3600}, None,
+        server,
+        refresh_env,
+        {"access_token": "NEW-ACCESS", "token_type": "Bearer", "expires_in": 3600},
+        None,
         fake_client_out=captured,
     )
 
@@ -5553,7 +5568,9 @@ async def test_bridge_refresh_upstream_invalid_grant_maps_to_invalid_grant():
     error_response = MagicMock()
     error_response.status_code = 400
     error_response.text = '{"error": "invalid_grant", "error_description": "refresh token expired"}'
-    error_response.json = MagicMock(return_value={"error": "invalid_grant", "error_description": "refresh token expired"})
+    error_response.json = MagicMock(
+        return_value={"error": "invalid_grant", "error_description": "refresh token expired"}
+    )
     error_response.raise_for_status = MagicMock(
         side_effect=httpx.HTTPStatusError("bad", request=MagicMock(), response=error_response)
     )
@@ -7183,7 +7200,9 @@ def _upstream_token_response(status_code: int, *, json_body: object = None, text
     return httpx.Response(status_code, text=text_body, request=request)
 
 
-async def _exchange_with_upstream_response(upstream_response, *, server_client_id="web-client.apps.googleusercontent.com"):
+async def _exchange_with_upstream_response(
+    upstream_response, *, server_client_id="web-client.apps.googleusercontent.com"
+):
     """Run the raw (non-bridge) authorization_code exchange against a canned upstream token-endpoint
     response and return what the gateway would hand the client. ``server_client_id=None`` models the
     caller-supplied-credentials flow (no stored client on the server)."""
@@ -7334,9 +7353,7 @@ async def test_token_exchange_bounds_relayed_error_fields():
 async def test_token_exchange_200_without_access_token_is_502_not_keyerror():
     """A 200 whose body has no usable access_token used to KeyError into a 500; the raw arm now
     answers 502 with the same wording as the bridge arm's no_upstream_token rejection."""
-    response = await _exchange_with_upstream_response(
-        _upstream_token_response(200, json_body={"token_type": "Bearer"})
-    )
+    response = await _exchange_with_upstream_response(_upstream_token_response(200, json_body={"token_type": "Bearer"}))
 
     assert response.status_code == 502
     body = json.loads(response.body)
@@ -7357,7 +7374,9 @@ async def test_token_exchange_relays_rejection_when_http_client_raises():
     )
     raising_client = MagicMock()
     raising_client.post = AsyncMock(
-        side_effect=httpx.HTTPStatusError("Client error '401 Unauthorized'", request=rejection.request, response=rejection)
+        side_effect=httpx.HTTPStatusError(
+            "Client error '401 Unauthorized'", request=rejection.request, response=rejection
+        )
     )
 
     from fastapi import Request
@@ -7422,7 +7441,9 @@ async def test_register_relays_rejection_when_http_client_raises():
     )
     raising_client = MagicMock()
     raising_client.post = AsyncMock(
-        side_effect=httpx.HTTPStatusError("Client error '400 Bad Request'", request=rejection.request, response=rejection)
+        side_effect=httpx.HTTPStatusError(
+            "Client error '400 Bad Request'", request=rejection.request, response=rejection
+        )
     )
 
     oauth2_server = _bridge_server(auth_type=MCPAuth.oauth2, dcr_bridge=None)
@@ -7800,9 +7821,7 @@ async def test_hydrate_does_not_overwrite_explicit_config_client_id():
         auth_type=MCPAuth.oauth2,
         client_id="explicit-from-config",
     )
-    store_read = AsyncMock(
-        return_value={"client_id": "stale-store-client", "client_secret": "x", "redirect_uris": []}
-    )
+    store_read = AsyncMock(return_value={"client_id": "stale-store-client", "client_secret": "x", "redirect_uris": []})
     with (
         patch("litellm.proxy.utils.get_prisma_client_or_throw", return_value=MagicMock()),
         patch(
@@ -8019,9 +8038,7 @@ async def test_bare_origin_discovery_resolves_single_server_not_aggregate():
     mock_request.headers = {}
 
     try:
-        authorization_response = _build_oauth_authorization_server_response(
-            request=mock_request, mcp_server_name=None
-        )
+        authorization_response = _build_oauth_authorization_server_response(request=mock_request, mcp_server_name=None)
         resource_response = await _build_oauth_protected_resource_response(
             request=mock_request, mcp_server_name=None, use_standard_pattern=True
         )
@@ -8031,6 +8048,65 @@ async def test_bare_origin_discovery_resolves_single_server_not_aggregate():
         assert resource_response["authorization_servers"] == ["https://llm.example.com/test_oauth"]
     finally:
         global_mcp_server_manager.registry.clear()
+
+
+def test_gateway_dcr_flow_routing_engages_only_for_llm_dcrc_clients(monkeypatch):
+    """The aggregate DCR arms engage for llm_dcrc_ client_ids (register always mints one,
+    authorize/token route into the aggregate flow); a non-gateway client_id keeps the
+    per-server behavior, and /authorize/complete exists but 400s without a valid flow."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import router
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+
+    monkeypatch.setenv("LITELLM_SALT_KEY", "sk-test-salt-for-lit3637")
+    monkeypatch.setattr("litellm.proxy.proxy_server.master_key", "sk-test-salt-for-lit3637", raising=False)
+    global_mcp_server_manager.registry.clear()
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    registered = client.post("/register", json={"redirect_uris": ["https://claude.ai/cb"]})
+    assert registered.status_code == 201
+    assert registered.json()["client_id"].startswith("llm_dcrc_")
+    assert registered.json()["token_endpoint_auth_method"] == "none"
+
+    authorize_params = {
+        "client_id": "llm_dcrc_bogus",
+        "redirect_uri": "https://claude.ai/cb",
+        "response_type": "code",
+        "code_challenge": "c" * 43,
+        "code_challenge_method": "S256",
+    }
+    bogus_client = client.get("/authorize", params=authorize_params)
+    assert bogus_client.status_code == 400
+    assert bogus_client.json()["error"] == "invalid_client"
+
+    no_cookie = client.post("/authorize/complete", data={"flow": "h"})
+    assert no_cookie.status_code == 400
+    assert no_cookie.json()["error"] == "invalid_request"
+
+    token_response = client.post(
+        "/token",
+        data={
+            "grant_type": "authorization_code",
+            "client_id": "llm_dcrc_bogus",
+            "code": "x",
+            "redirect_uri": "https://claude.ai/cb",
+            "code_verifier": "v" * 43,
+        },
+    )
+    assert token_response.status_code == 400
+    assert token_response.json()["error"] == "invalid_grant"
+
+    upstream_shaped = client.post(
+        "/token",
+        data={"grant_type": "authorization_code", "client_id": "regular-upstream-client", "code": "x"},
+    )
+    assert upstream_shaped.status_code == 404
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_gateway_dcr_flow.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_gateway_dcr_flow.py
@@ -1,0 +1,590 @@
+"""Tests for the aggregate gateway DCR flow (register, authorize, complete, token)."""
+
+import hashlib
+import json
+from base64 import urlsafe_b64encode
+from datetime import datetime, timedelta, timezone
+from http.cookies import SimpleCookie
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from starlette.requests import Request
+
+from litellm.caching.caching import DualCache
+from litellm.proxy._experimental.mcp_server.gateway_dcr_flow import (
+    CONNECT_FLOW_COOKIE_PREFIX,
+    GATEWAY_AUTH_CODE_PREFIX,
+    GATEWAY_AUTH_CODE_TTL_SECONDS,
+    GATEWAY_DCR_CLIENT_ID_PREFIX,
+    _GatewayAuthCode,
+    _seal,
+    aggregate_authorize,
+    aggregate_token,
+    complete_connect_flow,
+    is_gateway_dcr_client_id,
+    open_gateway_dcr_client,
+    register_aggregate_client,
+)
+from litellm.proxy._experimental.mcp_server.outbound_credentials.session_credentials import (
+    resolve_session_bearer,
+    session_keys_from_master_key,
+    SessionBearerAdmitted,
+)
+
+MASTER_KEY = "sk-gateway-dcr-flow-tests"
+REDIRECT_URI = "https://claude.ai/api/mcp/auth_callback"
+CODE_VERIFIER = "verifier-" + "v" * 43
+CODE_CHALLENGE = urlsafe_b64encode(hashlib.sha256(CODE_VERIFIER.encode("ascii")).digest()).rstrip(b"=").decode("ascii")
+
+
+@pytest.fixture(autouse=True)
+def _salt_key(monkeypatch):
+    monkeypatch.setenv("LITELLM_SALT_KEY", MASTER_KEY)
+
+
+def _request(path="/authorize", query="", cookies=None, method="GET"):
+    cookie_header = []
+    if cookies:
+        cookie = SimpleCookie()
+        for name, value in cookies.items():
+            cookie[name] = value
+        cookie_header = [(b"cookie", cookie.output(header="", sep="; ").strip().encode())]
+    return Request(
+        {
+            "type": "http",
+            "method": method,
+            "scheme": "https",
+            "path": path,
+            "query_string": query.encode(),
+            "headers": [(b"host", b"llm.example.com"), *cookie_header],
+        }
+    )
+
+
+async def _register(redirect_uris) -> dict:
+    response = await register_aggregate_client(
+        request=_request(path="/register", method="POST"), request_body={"redirect_uris": redirect_uris}
+    )
+    return json.loads(response.body)
+
+
+async def _reload_user_active(user_id: str):
+    return None
+
+
+@pytest.mark.asyncio
+async def test_register_mints_stateless_public_client():
+    body = await _register([REDIRECT_URI])
+    assert body["token_endpoint_auth_method"] == "none"
+    assert "client_secret" not in body
+    assert body["redirect_uris"] == [REDIRECT_URI]
+    assert is_gateway_dcr_client_id(body["client_id"])
+    record = open_gateway_dcr_client(body["client_id"])
+    assert record is not None
+    assert record.redirect_uris == (REDIRECT_URI,)
+
+
+@pytest.mark.asyncio
+async def test_register_allows_loopback_http_for_dev_clients():
+    body = await _register(["http://localhost:6274/oauth/callback"])
+    assert is_gateway_dcr_client_id(body["client_id"])
+
+
+@pytest.mark.parametrize(
+    "code_challenge",
+    ["short", "", "p" * 300, "ünïcode-challenge", "AAAA" * 20],
+)
+def test_pkce_mismatched_challenge_returns_false_never_raises(code_challenge):
+    """A wrong-length or non-ASCII code_challenge must VERIFY FALSE, not raise.
+
+    Pins the reason this compares bytes rather than str: hmac.compare_digest raises TypeError on
+    two str with non-ASCII content, but on bytes of unequal length it simply returns False. A
+    review flagged this as an unhandled 500 on length mismatch; encoding both sides to bytes is
+    exactly what makes that impossible, so the claim is pinned here rather than in a comment."""
+    from litellm.proxy._experimental.mcp_server.gateway_dcr_flow import _pkce_verifier_matches
+
+    assert _pkce_verifier_matches("a" * 43, code_challenge) is False
+
+
+@pytest.mark.asyncio
+async def test_register_allows_allowlisted_native_callback():
+    """Native MCP clients register a private-use scheme, not https. Registration shares
+    the one redirect-URI shape owner with /authorize, so the callback the allowlist
+    already trusts there is registrable here rather than rejected as non-https."""
+    body = await _register(["cursor://anysphere.cursor-mcp/oauth/callback"])
+    assert is_gateway_dcr_client_id(body["client_id"])
+    record = open_gateway_dcr_client(body["client_id"])
+    assert record is not None
+    assert record.redirect_uris == ("cursor://anysphere.cursor-mcp/oauth/callback",)
+
+
+@pytest.mark.asyncio
+async def test_register_rejects_userinfo_spoofed_origin():
+    """``https://claude.ai@attacker.example/cb`` parses with netloc
+    ``claude.ai@attacker.example``, so a naive origin display on the consent screen reads
+    as claude.ai while the code would be delivered to attacker.example. Rejected at
+    registration, which is the only way such a URI could enter a sealed client."""
+    response = await register_aggregate_client(
+        request=_request(path="/register", method="POST"),
+        request_body={"redirect_uris": ["https://claude.ai@attacker.example/callback"]},
+    )
+    assert response.status_code == 400
+    assert json.loads(response.body)["error"] == "invalid_redirect_uri"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "redirect_uris",
+    [
+        [],
+        "not-a-list",
+        ["http://evil.example.com/callback"],
+        ["https://claude.ai/cb#fragment"],
+        ["ftp://claude.ai/cb"],
+        ["https://a.example.com/" + "p" * 300],
+        ["https://a.example.com/1", "https://a.example.com/2", "https://a.example.com/3", "https://a.example.com/4"],
+        [12345],
+    ],
+)
+async def test_register_rejects_bad_redirect_uris(redirect_uris):
+    response = await register_aggregate_client(
+        request=_request(path="/register", method="POST"), request_body={"redirect_uris": redirect_uris}
+    )
+    assert response.status_code == 400
+    assert json.loads(response.body)["error"] in ("invalid_redirect_uri", "invalid_client_metadata")
+
+
+@pytest.mark.asyncio
+async def test_tampered_client_id_does_not_open():
+    body = await _register([REDIRECT_URI])
+    tampered = body["client_id"][:-4] + "AAAA"
+    assert open_gateway_dcr_client(tampered) is None
+    assert open_gateway_dcr_client("llm_dcrc_garbage") is None
+    assert open_gateway_dcr_client("other_prefix") is None
+
+
+def _authorize(
+    client_id, session_user_id, redirect_uri=REDIRECT_URI, challenge=CODE_CHALLENGE, method="S256", response_type="code"
+):
+    return aggregate_authorize(
+        request=_request(query=f"client_id={client_id}"),
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        state="client-state-123",
+        code_challenge=challenge,
+        code_challenge_method=method,
+        response_type=response_type,
+        session_user_id=session_user_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_authorize_validation_failures_never_redirect_to_client():
+    client_id = (await _register([REDIRECT_URI]))["client_id"]
+    for response, expected_error in (
+        (_authorize("llm_dcrc_bogus", "u1"), "invalid_client"),
+        (_authorize(client_id, "u1", redirect_uri="https://attacker.example.com/cb"), "invalid_request"),
+        (_authorize(client_id, "u1", response_type="token"), "unsupported_response_type"),
+        (_authorize(client_id, "u1", challenge=None), "invalid_request"),
+        (_authorize(client_id, "u1", method="plain"), "invalid_request"),
+    ):
+        assert response.status_code == 400
+        assert json.loads(response.body)["error"] == expected_error
+
+
+@pytest.mark.asyncio
+async def test_authorize_without_session_redirects_to_login_with_return_to():
+    client_id = (await _register([REDIRECT_URI]))["client_id"]
+    response = _authorize(client_id, session_user_id=None)
+    assert response.status_code == 303
+    location = response.headers["location"]
+    assert location.startswith("https://llm.example.com/sso/key/generate?return_to=")
+    assert "return_to=%2Fauthorize" in location
+
+
+@pytest.mark.asyncio
+async def test_authorize_with_session_hands_browser_to_connect_page_with_flow_cookie():
+    client_id = (await _register([REDIRECT_URI]))["client_id"]
+    response = _authorize(client_id, session_user_id="u1")
+    assert response.status_code == 303
+    location = urlparse(response.headers["location"])
+    assert location.path == "/ui/chat/integrations"
+    params = parse_qs(location.query)
+    handle = params["connect_flow"][0]
+    assert params["connect_client"] == ["https://claude.ai"]
+    set_cookie = response.headers["set-cookie"]
+    assert f"{CONNECT_FLOW_COOKIE_PREFIX}{handle}" in set_cookie
+    assert "HttpOnly" in set_cookie
+    return handle, set_cookie
+
+
+def _flow_cookie_from(response) -> tuple:
+    location = urlparse(response.headers["location"])
+    handle = parse_qs(location.query)["connect_flow"][0]
+    cookie = SimpleCookie()
+    cookie.load(response.headers["set-cookie"])
+    name = f"{CONNECT_FLOW_COOKIE_PREFIX}{handle}"
+    return handle, {name: cookie[name].value}
+
+
+@pytest.mark.asyncio
+async def test_full_walk_register_authorize_complete_token_and_replay():
+    """The whole front door on one deterministic walk: register -> authorize ->
+    complete -> token, then the security edges on the same artifacts (user mismatch,
+    PKCE mismatch, single-use replay, refresh rotation, cross-client refresh)."""
+    client_id = (await _register([REDIRECT_URI]))["client_id"]
+    authorize_response = _authorize(client_id, session_user_id="u1")
+    handle, cookies = _flow_cookie_from(authorize_response)
+
+    denied = await complete_connect_flow(
+        request=_request("/authorize/complete", cookies=cookies, method="POST"),
+        flow_handle=handle,
+        session_user_id="attacker",
+        cache=DualCache(),
+    )
+    assert denied.status_code == 403
+
+    anonymous = await complete_connect_flow(
+        request=_request("/authorize/complete", cookies=cookies, method="POST"),
+        flow_handle=handle,
+        session_user_id=None,
+        cache=DualCache(),
+    )
+    assert anonymous.status_code == 401
+
+    completed = await complete_connect_flow(
+        request=_request("/authorize/complete", cookies=cookies, method="POST"),
+        flow_handle=handle,
+        session_user_id="u1",
+        cache=DualCache(),
+    )
+    assert completed.status_code == 303
+    redirect = urlparse(completed.headers["location"])
+    assert f"{redirect.scheme}://{redirect.netloc}{redirect.path}" == REDIRECT_URI
+    params = parse_qs(redirect.query)
+    assert params["state"] == ["client-state-123"]
+    code = params["code"][0]
+    assert code.startswith(GATEWAY_AUTH_CODE_PREFIX)
+
+    cache = DualCache()
+
+    async def _token(**overrides):
+        arguments = {
+            "request": _request("/token", method="POST"),
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": REDIRECT_URI,
+            "client_id": client_id,
+            "code_verifier": CODE_VERIFIER,
+            "refresh_token": None,
+            "master_key": MASTER_KEY,
+            "reload_user": _reload_user_active,
+            "cache": cache,
+        }
+        return await aggregate_token(**{**arguments, **overrides})
+
+    wrong_verifier = await _token(code_verifier="wrong-" + "w" * 43)
+    assert json.loads(wrong_verifier.body)["error"] == "invalid_grant"
+
+    wrong_client = await _token(client_id=(await _register([REDIRECT_URI]))["client_id"])
+    assert json.loads(wrong_client.body)["error"] == "invalid_grant"
+
+    token_response = await _token()
+    assert token_response.status_code == 200
+    payload = json.loads(token_response.body)
+    assert payload["token_type"] == "Bearer"
+    assert 0 < payload["expires_in"] <= 3600
+
+    keys = session_keys_from_master_key(MASTER_KEY)
+    admitted = resolve_session_bearer(f"Bearer {payload['access_token']}", keys, datetime.now(timezone.utc))
+    assert isinstance(admitted, SessionBearerAdmitted)
+    assert admitted.principal.user_id == "u1"
+    assert admitted.principal.client_id == client_id
+
+    replay = await _token()
+    assert json.loads(replay.body)["error"] == "invalid_grant"
+
+    refreshed = await _token(grant_type="refresh_token", code=None, refresh_token=payload["refresh_token"])
+    assert refreshed.status_code == 200
+    rotated = json.loads(refreshed.body)
+    assert rotated["refresh_token"] != payload["refresh_token"]
+
+    # Rotation is single-use: replaying the now-consumed refresh token cannot mint a second pair
+    # (a captured token is dead once the legitimate holder has rotated).
+    replayed = await _token(grant_type="refresh_token", code=None, refresh_token=payload["refresh_token"])
+    assert json.loads(replayed.body)["error"] == "invalid_grant"
+    assert "already used" in json.loads(replayed.body).get("error_description", "")
+
+    cross_client = await _token(
+        grant_type="refresh_token",
+        code=None,
+        refresh_token=payload["refresh_token"],
+        client_id=(await _register([REDIRECT_URI]))["client_id"],
+    )
+    assert json.loads(cross_client.body)["error"] == "invalid_grant"
+
+
+@pytest.mark.asyncio
+async def test_complete_rejects_missing_tampered_and_expired_flows():
+    missing = await complete_connect_flow(
+        request=_request("/authorize/complete", method="POST"),
+        flow_handle="nope",
+        session_user_id="u1",
+        cache=DualCache(),
+    )
+    assert missing.status_code == 400
+
+    tampered = await complete_connect_flow(
+        request=_request("/authorize/complete", cookies={f"{CONNECT_FLOW_COOKIE_PREFIX}h1": "garbage"}, method="POST"),
+        flow_handle="h1",
+        session_user_id="u1",
+        cache=DualCache(),
+    )
+    assert tampered.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_token_rejects_expired_code_and_missing_configuration():
+    expired_code = _seal(
+        GATEWAY_AUTH_CODE_PREFIX,
+        _GatewayAuthCode(
+            user_id="u1",
+            client_id="llm_dcrc_x",
+            redirect_uri=REDIRECT_URI,
+            code_challenge=CODE_CHALLENGE,
+            jti="jti-1",
+            iat=int((datetime.now(timezone.utc) - timedelta(seconds=500)).timestamp()),
+            exp=int((datetime.now(timezone.utc) - timedelta(seconds=500 - GATEWAY_AUTH_CODE_TTL_SECONDS)).timestamp()),
+        ),
+    )
+    response = await aggregate_token(
+        request=_request("/token", method="POST"),
+        grant_type="authorization_code",
+        code=expired_code,
+        redirect_uri=REDIRECT_URI,
+        client_id="llm_dcrc_x",
+        code_verifier=CODE_VERIFIER,
+        refresh_token=None,
+        master_key=MASTER_KEY,
+        reload_user=_reload_user_active,
+        cache=DualCache(),
+    )
+    assert json.loads(response.body)["error"] == "invalid_grant"
+
+    no_master_key = await aggregate_token(
+        request=_request("/token", method="POST"),
+        grant_type="authorization_code",
+        code="llm_gcode_x",
+        redirect_uri=REDIRECT_URI,
+        client_id="llm_dcrc_x",
+        code_verifier=CODE_VERIFIER,
+        refresh_token=None,
+        master_key=None,
+        reload_user=_reload_user_active,
+        cache=DualCache(),
+    )
+    assert no_master_key.status_code == 500
+    assert json.loads(no_master_key.body)["error"] == "server_error"
+
+    unsupported = await aggregate_token(
+        request=_request("/token", method="POST"),
+        grant_type="password",
+        code=None,
+        redirect_uri=None,
+        client_id="llm_dcrc_x",
+        code_verifier=None,
+        refresh_token=None,
+        master_key=MASTER_KEY,
+        reload_user=_reload_user_active,
+        cache=DualCache(),
+    )
+    assert json.loads(unsupported.body)["error"] == "unsupported_grant_type"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure,expected_status,expected_error",
+    [
+        ("no_active_key", 400, "invalid_grant"),
+        ("unavailable", 503, "temporarily_unavailable"),
+        ("unresolvable", 500, "server_error"),
+    ],
+)
+async def test_token_gates_on_live_user_revalidation(failure, expected_status, expected_error):
+    client_id = (await _register([REDIRECT_URI]))["client_id"]
+    authorize_response = _authorize(client_id, session_user_id="deactivated-user")
+    handle, cookies = _flow_cookie_from(authorize_response)
+    completed = await complete_connect_flow(
+        request=_request("/authorize/complete", cookies=cookies, method="POST"),
+        flow_handle=handle,
+        session_user_id="deactivated-user",
+        cache=DualCache(),
+    )
+    code = parse_qs(urlparse(completed.headers["location"]).query)["code"][0]
+
+    async def _reload_user_failing(user_id: str):
+        return failure
+
+    response = await aggregate_token(
+        request=_request("/token", method="POST"),
+        grant_type="authorization_code",
+        code=code,
+        redirect_uri=REDIRECT_URI,
+        client_id=client_id,
+        code_verifier=CODE_VERIFIER,
+        refresh_token=None,
+        master_key=MASTER_KEY,
+        reload_user=_reload_user_failing,
+        cache=DualCache(),
+    )
+    assert response.status_code == expected_status
+    assert json.loads(response.body)["error"] == expected_error
+
+
+@pytest.mark.asyncio
+async def test_flow_is_single_use_shared_cache_rejects_second_complete():
+    """A double-submit of the finish step mints only ONE code: the second complete over the
+    same cache fails invalid_request (atomic flow claim), so one sign-in cannot yield two codes."""
+    cache = DualCache()
+    client_id = (await _register([REDIRECT_URI]))["client_id"]
+    handle, cookies = _flow_cookie_from(_authorize(client_id, session_user_id="u1"))
+
+    first = await complete_connect_flow(
+        request=_request("/authorize/complete", cookies=cookies, method="POST"),
+        flow_handle=handle,
+        session_user_id="u1",
+        cache=cache,
+    )
+    assert first.status_code == 303
+    second = await complete_connect_flow(
+        request=_request("/authorize/complete", cookies=cookies, method="POST"),
+        flow_handle=handle,
+        session_user_id="u1",
+        cache=cache,
+    )
+    assert second.status_code == 400
+    assert json.loads(second.body)["error"] == "invalid_request"
+
+
+@pytest.mark.asyncio
+async def test_token_rejects_out_of_range_code_verifier():
+    """RFC 7636: a code_verifier outside 43-128 chars is invalid_request, not a confusing
+    invalid_grant PKCE-mismatch."""
+    for bad in ["short", "x" * 200]:
+        response = await aggregate_token(
+            request=_request("/token", method="POST"),
+            grant_type="authorization_code",
+            code="llm_gcode_whatever",
+            redirect_uri=REDIRECT_URI,
+            client_id="llm_dcrc_x",
+            code_verifier=bad,
+            refresh_token=None,
+            master_key=MASTER_KEY,
+            reload_user=_reload_user_active,
+            cache=DualCache(),
+        )
+        assert response.status_code == 400
+        assert json.loads(response.body)["error"] == "invalid_request"
+
+
+@pytest.mark.asyncio
+async def test_authorize_rejects_over_long_state():
+    client_id = (await _register([REDIRECT_URI]))["client_id"]
+    response = aggregate_authorize(
+        request=_request(query=f"client_id={client_id}"),
+        client_id=client_id,
+        redirect_uri=REDIRECT_URI,
+        state="s" * 2000,
+        code_challenge=CODE_CHALLENGE,
+        code_challenge_method="S256",
+        response_type="code",
+        session_user_id="u1",
+    )
+    assert response.status_code == 400
+    assert json.loads(response.body)["error"] == "invalid_request"
+
+
+@pytest.mark.asyncio
+async def test_non_ascii_code_challenge_fails_grant_not_500():
+    """A non-ASCII code_challenge (unvalidated from the client) must yield a clean
+    invalid_grant, never a TypeError-driven 500 (bytes comparison, not str)."""
+    client_id = (await _register([REDIRECT_URI]))["client_id"]
+    # Seal a code carrying a non-ASCII challenge directly (authorize requires S256 shape,
+    # but the challenge charset is not validated there, so this state is reachable).
+    from datetime import datetime, timezone
+
+    code = _seal(
+        GATEWAY_AUTH_CODE_PREFIX,
+        _GatewayAuthCode(
+            user_id="u1",
+            client_id=client_id,
+            redirect_uri=REDIRECT_URI,
+            code_challenge="challenge-with-€-non-ascii",
+            jti="jti-x",
+            iat=int(datetime.now(timezone.utc).timestamp()),
+            exp=int(datetime.now(timezone.utc).timestamp()) + 120,
+        ),
+    )
+    response = await aggregate_token(
+        request=_request("/token", method="POST"),
+        grant_type="authorization_code",
+        code=code,
+        redirect_uri=REDIRECT_URI,
+        client_id=client_id,
+        code_verifier=CODE_VERIFIER,
+        refresh_token=None,
+        master_key=MASTER_KEY,
+        reload_user=_reload_user_active,
+        cache=DualCache(),
+    )
+    assert response.status_code == 400
+    assert json.loads(response.body)["error"] == "invalid_grant"
+
+
+@pytest.mark.asyncio
+async def test_single_use_guard_in_memory_is_single_use_within_process():
+    """No Redis configured (single-replica): the in-memory increment is authoritative — the first claim
+    wins, a replay of the same id loses."""
+    from litellm.proxy._experimental.mcp_server.gateway_dcr_flow import _SingleUseGuard
+
+    guard = _SingleUseGuard(DualCache())  # redis_cache is None
+    assert await guard.claim("jti-inmem", 60) is True
+    assert await guard.claim("jti-inmem", 60) is False  # replay of the same id
+
+
+@pytest.mark.asyncio
+async def test_single_use_guard_uses_redis_as_sole_authority_when_configured():
+    """With Redis configured it is the SOLE authority: the shared INCR result decides the claim (1 →
+    first caller, >1 → replay), and the per-worker in-memory count is never consulted."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.proxy._experimental.mcp_server.gateway_dcr_flow import _SingleUseGuard
+
+    cache = DualCache()
+    cache.redis_cache = MagicMock()
+    cache.redis_cache.async_increment = AsyncMock(return_value=1)
+    # in-memory must NOT be consulted when Redis is configured — poison it so any fallback is visible.
+    cache.async_increment_cache = AsyncMock(side_effect=AssertionError("must not fall back to in-memory"))
+
+    guard = _SingleUseGuard(cache)
+    assert await guard.claim("jti-redis", 60) is True
+    cache.redis_cache.async_increment = AsyncMock(return_value=2)
+    assert await guard.claim("jti-redis", 60) is False  # Redis says 2 → replay
+
+
+@pytest.mark.asyncio
+async def test_single_use_guard_fails_closed_when_redis_errors():
+    """A Redis fault must fail the claim CLOSED (refuse the id) rather than fall back to the per-worker
+    in-memory count — which would let each replica observe count==1 and replay the one-time id (the
+    Cursor/Veria replay-across-workers finding)."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.proxy._experimental.mcp_server.gateway_dcr_flow import _SingleUseGuard
+
+    cache = DualCache()
+    cache.redis_cache = MagicMock()
+    cache.redis_cache.async_increment = AsyncMock(side_effect=ConnectionError("redis down"))
+    cache.async_increment_cache = AsyncMock(return_value=1)  # would fail OPEN if the guard fell back
+
+    guard = _SingleUseGuard(cache)
+    assert await guard.claim("jti-fault", 60) is False  # fail closed, not a fallback count of 1

--- a/tests/test_litellm/proxy/auth/test_login_utils.py
+++ b/tests/test_litellm/proxy/auth/test_login_utils.py
@@ -176,9 +176,7 @@ async def test_authenticate_user_invalid_credentials():
     mock_prisma_client = MagicMock()
     mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(return_value=None)
 
-    with patch.dict(
-        os.environ, {"UI_USERNAME": ui_username, "UI_PASSWORD": "correct-password"}
-    ):
+    with patch.dict(os.environ, {"UI_USERNAME": ui_username, "UI_PASSWORD": "correct-password"}):
         with pytest.raises(ProxyException) as exc_info:
             await authenticate_user(
                 username=ui_username,
@@ -227,9 +225,7 @@ async def test_authenticate_user_wrong_password():
     )
 
     mock_prisma_client = MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(
-        return_value=mock_user
-    )
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(return_value=mock_user)
 
     with patch.dict(
         os.environ,
@@ -279,9 +275,7 @@ async def test_authenticate_user_email_case_insensitive_login():
         return None
 
     mock_prisma_client = MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(
-        side_effect=mock_find_first
-    )
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(side_effect=mock_find_first)
 
     with patch.dict(
         os.environ,
@@ -334,9 +328,7 @@ async def test_authenticate_user_database_required_for_admin():
     mock_prisma_client = MagicMock()
     mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(return_value=None)
 
-    with patch.dict(
-        os.environ, {"UI_USERNAME": ui_username, "UI_PASSWORD": ui_password}
-    ):
+    with patch.dict(os.environ, {"UI_USERNAME": ui_username, "UI_PASSWORD": ui_password}):
         with patch(
             "litellm.proxy.auth.login_utils.user_update",
             new_callable=AsyncMock,
@@ -429,9 +421,7 @@ def test_authenticate_user_non_ascii_direct_comparison():
     assert result is True
 
     # And correctly returns False for different passwords
-    result = secrets.compare_digest(
-        password.encode("utf-8"), "different£pass".encode("utf-8")
-    )
+    result = secrets.compare_digest(password.encode("utf-8"), "different£pass".encode("utf-8"))
     assert result is False
 
 
@@ -531,9 +521,7 @@ async def test_authenticate_user_database_login_with_non_ascii_password():
         return None
 
     mock_prisma_client = MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(
-        side_effect=mock_find_first
-    )
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(side_effect=mock_find_first)
 
     with patch.dict(
         os.environ,
@@ -559,3 +547,58 @@ async def test_authenticate_user_database_login_with_non_ascii_password():
             assert isinstance(result, LoginResult)
             assert result.user_id == "test-user-123"
             assert result.user_email == user_email
+
+
+class TestEncodeUiSessionJwt:
+    """The UI session cookie must carry a bounded exp so it does not stay
+    signature-valid until the master key rotates, and so the session-cookie readers
+    that require a bounded lifetime (the MCP interactive sign-in) accept it."""
+
+    def _decode(self, token: str) -> dict:
+        import jwt
+
+        return jwt.decode(token, "sk-master-for-tests", algorithms=["HS256"])
+
+    def test_encoded_cookie_carries_bounded_exp(self):
+        import time
+
+        from litellm.proxy.auth.login_utils import encode_ui_session_jwt
+
+        token_object = {"user_id": "u1", "key": "sk-abc", "login_method": "username_password"}
+        with patch("litellm.proxy.auth.login_utils.LITELLM_UI_SESSION_DURATION", "24h"):
+            token = encode_ui_session_jwt(token_object, "sk-master-for-tests")
+        claims = self._decode(token)
+        assert claims["user_id"] == "u1"
+        assert claims["login_method"] == "username_password"
+        remaining = claims["exp"] - int(time.time())
+        assert 23 * 3600 < remaining <= 24 * 3600
+
+    def test_duration_is_honored_from_env(self):
+        import time
+
+        from litellm.proxy.auth.login_utils import encode_ui_session_jwt
+
+        with patch("litellm.proxy.auth.login_utils.LITELLM_UI_SESSION_DURATION", "1h"):
+            token = encode_ui_session_jwt({"user_id": "u1"}, "sk-master-for-tests")
+        remaining = self._decode(token)["exp"] - int(time.time())
+        assert 0 < remaining <= 3600
+
+    def test_cookie_is_accepted_by_the_exp_requiring_session_reader(self):
+        """The regression this change exists for: before it, the UI cookie carried no
+        exp and _user_id_from_session_cookie (require=["exp"]) rejected every real login,
+        so the MCP interactive sign-in could never capture identity. A cookie minted by
+        this helper must now be accepted."""
+        from unittest.mock import MagicMock
+
+        from litellm.proxy._experimental.mcp_server.byok_oauth_endpoints import (
+            _user_id_from_session_cookie,
+        )
+        from litellm.proxy.auth.login_utils import encode_ui_session_jwt
+
+        token_object = {"user_id": "cornell-user", "key": "sk-abc", "login_method": "sso"}
+        with patch("litellm.proxy.auth.login_utils.LITELLM_UI_SESSION_DURATION", "24h"):
+            token = encode_ui_session_jwt(token_object, "sk-master-for-tests")
+        request = MagicMock()
+        request.cookies = {"token": token}
+        with patch("litellm.proxy.proxy_server.master_key", "sk-master-for-tests"):
+            assert _user_id_from_session_cookie(request) == "cornell-user"

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -7763,3 +7763,80 @@ async def test_cli_completion_persists_assertion_under_db_user_id():
 
     retain_mock.assert_awaited_once_with(user_id="cli-user-id", assertion=assertion)
     assert response.status_code == 200
+
+
+class TestSameOriginReturnPath:
+    """The same-origin relative return_to arm added for the MCP gateway DCR authorize
+    round-trip: only strictly relative paths qualify, so login can never redirect the
+    browser off the gateway origin."""
+
+    def test_accepts_relative_paths(self):
+        from litellm.proxy.management_endpoints.ui_sso import _is_same_origin_return_path
+
+        assert _is_same_origin_return_path("/authorize?client_id=llm_dcrc_x&state=s") is True
+        assert _is_same_origin_return_path("/some_server/authorize") is True
+
+    def test_rejects_absolute_protocol_relative_and_backslash_paths(self):
+        from litellm.proxy.management_endpoints.ui_sso import _is_same_origin_return_path
+
+        assert _is_same_origin_return_path("https://evil.example.com/authorize") is False
+        assert _is_same_origin_return_path("//evil.example.com/authorize") is False
+        assert _is_same_origin_return_path("/\\evil.example.com") is False
+        assert _is_same_origin_return_path("javascript:alert(1)") is False
+        assert _is_same_origin_return_path("") is False
+
+
+class TestPersistReturnToCookieSharedHelper:
+    """The single shared return_to helper used by EVERY sign-in branch (SSO / Okta / generic AND the
+    username/password form). It must be best-effort and NEVER raise — a bad return_to can never block
+    sign-in. Regression: the password form previously 400'd because it called _validate_return_to
+    directly (which raises for a non-matching absolute return_to when control_plane_url is set)."""
+
+    @staticmethod
+    def _cookie(resp) -> str:
+        return resp.headers.get("set-cookie", "")
+
+    def test_sets_cookie_for_same_origin_relative_path(self, monkeypatch):
+        from fastapi import Response
+
+        from litellm.proxy.management_endpoints.ui_sso import _persist_return_to_cookie
+
+        monkeypatch.setattr("litellm.proxy.proxy_server.general_settings", {})
+        resp = Response()
+        _persist_return_to_cookie(resp, "/mcp/authorize?client_id=llm_dcrc_abc")
+        assert "litellm_cp_return_to=" in self._cookie(resp)
+
+    def test_bad_absolute_with_control_plane_configured_does_not_raise_and_is_not_stored(self, monkeypatch):
+        """THE regression: a non-matching absolute return_to with control_plane_url set must NOT raise
+        (it did, blocking the login form) and must NOT be stored — sign-in proceeds."""
+        from fastapi import Response
+
+        from litellm.proxy.management_endpoints.ui_sso import _persist_return_to_cookie
+
+        monkeypatch.setattr(
+            "litellm.proxy.proxy_server.general_settings", {"control_plane_url": "https://cp.example.com"}
+        )
+        resp = Response()
+        _persist_return_to_cookie(resp, "https://evil.example.com/steal")  # must not raise
+        assert "litellm_cp_return_to=" not in self._cookie(resp)
+
+    def test_none_return_to_is_a_noop(self):
+        from fastapi import Response
+
+        from litellm.proxy.management_endpoints.ui_sso import _persist_return_to_cookie
+
+        resp = Response()
+        _persist_return_to_cookie(resp, None)
+        assert "litellm_cp_return_to=" not in self._cookie(resp)
+
+    def test_control_plane_matching_absolute_is_stored(self, monkeypatch):
+        from fastapi import Response
+
+        from litellm.proxy.management_endpoints.ui_sso import _persist_return_to_cookie
+
+        monkeypatch.setattr(
+            "litellm.proxy.proxy_server.general_settings", {"control_plane_url": "https://cp.example.com"}
+        )
+        resp = Response()
+        _persist_return_to_cookie(resp, "https://cp.example.com/ui?page=models")
+        assert "litellm_cp_return_to=" in self._cookie(resp)

--- a/tests/test_litellm/proxy/proxy_server/test_routes_login_sso.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_login_sso.py
@@ -49,9 +49,7 @@ def _install_login_mocks(monkeypatch, raise_on_auth: bool = False) -> None:
         }
 
     monkeypatch.setattr("litellm.proxy.auth.login_utils.authenticate_user", _fake_auth)
-    monkeypatch.setattr(
-        "litellm.proxy.auth.login_utils.create_ui_token_object", _fake_token_object
-    )
+    monkeypatch.setattr("litellm.proxy.auth.login_utils.create_ui_token_object", _fake_token_object)
     monkeypatch.setattr(ps, "master_key", "sk-test-master")
     monkeypatch.setattr(ps, "general_settings", {})
     monkeypatch.setattr(ps, "premium_user", False)
@@ -69,9 +67,7 @@ def test_fallback_login_returns_html_form(client, monkeypatch):
     body_lower = response.text.lower()
     shape = {
         "status": response.status_code,
-        "content_type_html": response.headers.get("content-type", "").startswith(
-            "text/html"
-        ),
+        "content_type_html": response.headers.get("content-type", "").startswith("text/html"),
         "has_form": "<form" in body_lower or "username" in body_lower,
     }
     assert shape == {
@@ -88,9 +84,7 @@ def test_fallback_login_returns_html_form_with_ui_username_set(client, monkeypat
     body_lower = response.text.lower()
     shape = {
         "status": response.status_code,
-        "content_type_html": response.headers.get("content-type", "").startswith(
-            "text/html"
-        ),
+        "content_type_html": response.headers.get("content-type", "").startswith("text/html"),
         "has_form_or_username": "<form" in body_lower or "username" in body_lower,
     }
     assert shape == {
@@ -126,11 +120,7 @@ def test_fallback_login_invalid_method_405(client):
     """POST against the GET-only /fallback/login is rejected (error path)."""
     response = client.post("/fallback/login")
     assert response.status_code == 405
-    body = (
-        response.json()
-        if response.headers.get("content-type", "").startswith("application/json")
-        else {}
-    )
+    body = response.json() if response.headers.get("content-type", "").startswith("application/json") else {}
     assert isinstance(body, dict)
 
 
@@ -193,15 +183,15 @@ def test_v2_login_success_returns_token_and_redirect(client, monkeypatch):
         json={"username": "admin", "password": "password"},
     )
     assert response.status_code == 200
-    assert normalize(
-        response.json(), volatile=frozenset({"token", "redirect_url"})
-    ) == {"redirect_url": "<VOLATILE>", "token": "<VOLATILE>"}
+    assert normalize(response.json(), volatile=frozenset({"token", "redirect_url"})) == {
+        "redirect_url": "<VOLATILE>",
+        "token": "<VOLATILE>",
+    }
     body = response.json()
     set_cookie = response.headers.get("set-cookie", "")
     shape = {
         "redirect_url_has_ui": "/ui/" in body.get("redirect_url", ""),
-        "redirect_url_has_login_success": "login=success"
-        in body.get("redirect_url", ""),
+        "redirect_url_has_login_success": "login=success" in body.get("redirect_url", ""),
         "token_in_body": bool(body.get("token")),
         "token_cookie_set": "token=" in set_cookie,
     }
@@ -264,9 +254,7 @@ def test_v3_login_success_returns_code(client, monkeypatch):
     from litellm.proxy import proxy_server as ps
 
     _install_login_mocks(monkeypatch)
-    monkeypatch.setattr(
-        ps, "general_settings", {"control_plane_url": "https://cp.example.invalid"}
-    )
+    monkeypatch.setattr(ps, "general_settings", {"control_plane_url": "https://cp.example.invalid"})
     # Force the local (non-redis) cache path
     monkeypatch.setattr(ps, "redis_usage_cache", None)
     fake_cache = MagicMock()
@@ -301,9 +289,7 @@ def test_v3_login_authenticate_failure_500(client, monkeypatch):
     from litellm.proxy import proxy_server as ps
 
     _install_login_mocks(monkeypatch, raise_on_auth=True)
-    monkeypatch.setattr(
-        ps, "general_settings", {"control_plane_url": "https://cp.example.invalid"}
-    )
+    monkeypatch.setattr(ps, "general_settings", {"control_plane_url": "https://cp.example.invalid"})
 
     response = client.post(
         "/v3/login",
@@ -337,9 +323,7 @@ def test_v3_login_exchange_missing_code_400(client, monkeypatch):
     """Error path: missing 'code' in body -> 400 with 'Missing' message."""
     from litellm.proxy import proxy_server as ps
 
-    monkeypatch.setattr(
-        ps, "general_settings", {"control_plane_url": "https://cp.example.invalid"}
-    )
+    monkeypatch.setattr(ps, "general_settings", {"control_plane_url": "https://cp.example.invalid"})
 
     response = client.post("/v3/login/exchange", json={})
     assert response.status_code == 400
@@ -352,9 +336,7 @@ def test_v3_login_exchange_invalid_code_401(client, monkeypatch):
     """Error path: code that isn't in cache -> 401 'Invalid or expired'."""
     from litellm.proxy import proxy_server as ps
 
-    monkeypatch.setattr(
-        ps, "general_settings", {"control_plane_url": "https://cp.example.invalid"}
-    )
+    monkeypatch.setattr(ps, "general_settings", {"control_plane_url": "https://cp.example.invalid"})
     monkeypatch.setattr(ps, "redis_usage_cache", None)
     fake_cache = MagicMock()
     fake_cache.async_get_cache = AsyncMock(return_value=None)
@@ -372,9 +354,7 @@ def test_v3_login_exchange_success_returns_token_and_redirect(client, monkeypatc
     """Pin: valid code -> JSON {token, redirect_url} + token cookie + cache deleted (single-use)."""
     from litellm.proxy import proxy_server as ps
 
-    monkeypatch.setattr(
-        ps, "general_settings", {"control_plane_url": "https://cp.example.invalid"}
-    )
+    monkeypatch.setattr(ps, "general_settings", {"control_plane_url": "https://cp.example.invalid"})
     monkeypatch.setattr(ps, "redis_usage_cache", None)
 
     cached_payload = {
@@ -388,9 +368,10 @@ def test_v3_login_exchange_success_returns_token_and_redirect(client, monkeypatc
 
     response = client.post("/v3/login/exchange", json={"code": "valid-code"})
     assert response.status_code == 200
-    assert normalize(
-        response.json(), volatile=frozenset({"token", "redirect_url"})
-    ) == {"token": "<VOLATILE>", "redirect_url": "<VOLATILE>"}
+    assert normalize(response.json(), volatile=frozenset({"token", "redirect_url"})) == {
+        "token": "<VOLATILE>",
+        "redirect_url": "<VOLATILE>",
+    }
     body = response.json()
     set_cookie = response.headers.get("set-cookie", "")
     shape = {
@@ -405,3 +386,77 @@ def test_v3_login_exchange_success_returns_token_and_redirect(client, monkeypatc
         "token_cookie_set": True,
         "cache_deleted_once": True,
     }
+
+
+def test_login_form_honors_same_origin_return_to_cookie(client, monkeypatch):
+    """The aggregate DCR connect flow preserves a same-origin return_to in the litellm_cp_return_to
+    cookie; /login must RESUME there after password sign-in instead of dead-ending at the dashboard."""
+    _install_login_mocks(monkeypatch)
+    return_to = "/mcp/authorize?client_id=llm_dcrc_abc&response_type=code"
+    response = client.post(
+        "/login",
+        data={"username": "admin", "password": "password"},
+        cookies={"litellm_cp_return_to": return_to},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    assert response.headers.get("location", "") == return_to  # resumed the connect flow, not the dashboard
+    assert "token=" in response.headers.get("set-cookie", "")
+
+
+def test_login_form_honors_control_plane_return_to_cookie(client, monkeypatch):
+    """/login resumes through the SAME resumer the SSO callback uses, so it honors BOTH shapes
+    _persist_return_to_cookie is willing to store. Honoring only the relative one silently dropped
+    a control-plane return_to and landed the user on the dashboard."""
+    import litellm.proxy.proxy_server as ps
+
+    _install_login_mocks(monkeypatch)
+    monkeypatch.setitem(ps.general_settings, "control_plane_url", "https://cp.example.com")
+    response = client.post(
+        "/login",
+        data={"username": "admin", "password": "password"},
+        cookies={"litellm_cp_return_to": "https://cp.example.com/console"},
+        follow_redirects=False,
+    )
+    location = response.headers.get("location", "")
+    assert response.status_code == 303
+    assert location.startswith("https://cp.example.com/console")
+    # Cross-origin arm hands the JWT off via a one-time code rather than a cookie.
+    assert "code=" in location and "login=success" in location
+    assert "token=" not in response.headers.get("set-cookie", "")
+
+
+def test_login_form_survives_stale_control_plane_return_to(client, monkeypatch):
+    """A stale one-shot cookie must NEVER fail a completed sign-in. The resumer rejects a return_to
+    that no longer matches control_plane_url (a config change between the cookie's write and this
+    read); the user has already authenticated, so land on the dashboard instead of erroring."""
+    import litellm.proxy.proxy_server as ps
+
+    _install_login_mocks(monkeypatch)
+    monkeypatch.setitem(ps.general_settings, "control_plane_url", "https://new-cp.example.com")
+    response = client.post(
+        "/login",
+        data={"username": "admin", "password": "password"},
+        cookies={"litellm_cp_return_to": "https://old-cp.example.com/console"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303, "login must not break on a stale return_to cookie"
+    location = response.headers.get("location", "")
+    assert "old-cp.example.com" not in location
+    assert "/ui/" in location
+
+
+def test_login_form_ignores_open_redirect_return_to(client, monkeypatch):
+    """A non-same-origin return_to (open-redirect attempt) is rejected — /login falls back to the
+    dashboard rather than honoring an absolute/foreign URL."""
+    _install_login_mocks(monkeypatch)
+    response = client.post(
+        "/login",
+        data={"username": "admin", "password": "password"},
+        cookies={"litellm_cp_return_to": "https://evil.example.com/steal"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    location = response.headers.get("location", "")
+    assert "evil.example.com" not in location
+    assert "/ui/" in location  # dashboard fallback

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -127,11 +127,15 @@ def test_login_v2_returns_redirect_url_and_sets_cookie(monkeypatch):
         general_settings={},
         premium_user=False,
     )
-    mock_jwt_encode.assert_called_once_with(
-        {"user_id": "test-user"},
-        "test-master-key",
-        algorithm="HS256",
-    )
+    mock_jwt_encode.assert_called_once()
+    payload, secret = mock_jwt_encode.call_args.args
+    # The UI session token carries a bounded-lifetime `exp` claim (dynamic timestamp), alongside
+    # the user_id; assert its presence rather than an exact expiry value.
+    assert payload["user_id"] == "test-user"
+    assert isinstance(payload.get("exp"), int) and payload["exp"] > 0
+    assert set(payload.keys()) == {"user_id", "exp"}
+    assert secret == "test-master-key"
+    assert mock_jwt_encode.call_args.kwargs == {"algorithm": "HS256"}
 
 
 def test_login_v2_returns_json_on_proxy_exception(monkeypatch):

--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -2972,7 +2972,7 @@
       "count": 1
     },
     "no-nested-ternary": {
-      "count": 7
+      "count": 6
     }
   },
   "src/components/chat/MCPConnectPicker.tsx": {

--- a/ui/litellm-dashboard/src/app/chat/integrations/page.tsx
+++ b/ui/litellm-dashboard/src/app/chat/integrations/page.tsx
@@ -4,6 +4,7 @@ import { Suspense, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useChatShell } from "@/contexts/ChatShellContext";
 import MCPAppsPanel from "@/components/chat/MCPAppsPanel";
+import ConnectFlowBanner from "@/components/chat/ConnectFlowBanner";
 
 // useSearchParams() requires a Suspense boundary for static export.
 function IntegrationsPageContent() {
@@ -11,6 +12,13 @@ function IntegrationsPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const oauthReturn = searchParams.get("mcpOauthReturn");
+  // Set by the gateway DCR authorize when a DCR client sends the user here to
+  // authorize servers before finishing sign-in (see gateway_dcr_flow.py). The
+  // handle keys the sealed per-flow cookie; connect_client is the client origin
+  // for display only. connect_flow is NOT cleaned from the URL: the finish form
+  // needs it, and the sealed cookie (not the URL) is the security boundary.
+  const connectFlow = searchParams.get("connect_flow");
+  const connectClient = searchParams.get("connect_client");
 
   // Clean up the OAuth return param after it's been consumed — real routing means
   // we no longer need it to pick a tab, but it should not linger in the address bar.
@@ -24,7 +32,13 @@ function IntegrationsPageContent() {
 
   return (
     <div className="flex-1 min-h-0 overflow-auto w-full py-8 px-8">
-      <MCPAppsPanel accessToken={accessToken} selectedServers={selectedMCPServers} onChange={setSelectedMCPServers} />
+      {connectFlow && <ConnectFlowBanner flowHandle={connectFlow} clientOrigin={connectClient} />}
+      <MCPAppsPanel
+        accessToken={accessToken}
+        selectedServers={selectedMCPServers}
+        onChange={setSelectedMCPServers}
+        connectMode={!!connectFlow}
+      />
     </div>
   );
 }

--- a/ui/litellm-dashboard/src/components/chat/ConnectFlowBanner.test.tsx
+++ b/ui/litellm-dashboard/src/components/chat/ConnectFlowBanner.test.tsx
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ConnectFlowBanner from "./ConnectFlowBanner";
+
+vi.mock("@/components/networking", () => ({
+  getProxyBaseUrl: () => "https://gateway.example.com",
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  sessionStorage.clear();
+});
+
+describe("ConnectFlowBanner", () => {
+  it("posts the flow handle to the proxy /authorize/complete as a full-page form", () => {
+    const { container } = render(<ConnectFlowBanner flowHandle="flow-handle-123" clientOrigin="https://claude.ai" />);
+
+    const form = container.querySelector("form")!;
+    expect(form.getAttribute("method")).toBe("POST");
+    expect(form.getAttribute("action")).toBe("https://gateway.example.com/authorize/complete");
+
+    const hidden = form.querySelector('input[name="flow"]') as HTMLInputElement;
+    expect(hidden.value).toBe("flow-handle-123");
+    // No token, code, or secret is ever placed in the form; the sealed cookie carries them.
+    expect(form.innerHTML).not.toContain("token");
+  });
+
+  it("shows the client origin so the user knows what they are connecting to", () => {
+    render(<ConnectFlowBanner flowHandle="h" clientOrigin="https://claude.ai" />);
+    expect(screen.getAllByText(/claude\.ai/).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /finish connecting/i })).toBeInTheDocument();
+  });
+
+  it("falls back to a generic label when the client origin is unknown", () => {
+    render(<ConnectFlowBanner flowHandle="h" clientOrigin={null} />);
+    expect(screen.getAllByText(/the application/).length).toBeGreaterThan(0);
+  });
+
+  it("does NOT complete the flow on pagehide (completion requires the explicit button)", () => {
+    // Security regression: an attacker could lure a signed-in victim to their own client's
+    // authorize URL; the victim merely closing the tab must NOT deliver a victim-bound code.
+    // Completion is a deliberate button press, never a side effect of leaving the page.
+    const beaconMock = vi.fn(() => true);
+    vi.stubGlobal("navigator", { ...navigator, sendBeacon: beaconMock });
+    render(<ConnectFlowBanner flowHandle="flow-xyz" clientOrigin="https://claude.ai" />);
+
+    window.dispatchEvent(new Event("pagehide"));
+
+    expect(beaconMock).not.toHaveBeenCalled();
+  });
+});

--- a/ui/litellm-dashboard/src/components/chat/ConnectFlowBanner.tsx
+++ b/ui/litellm-dashboard/src/components/chat/ConnectFlowBanner.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import React from "react";
+import { CheckCircle } from "lucide-react";
+import { getProxyBaseUrl } from "@/components/networking";
+
+interface Props {
+  flowHandle: string;
+  clientOrigin: string | null;
+}
+
+/**
+ * The interlude shown when a DCR client (Claude Desktop, MCP Inspector) sends the user
+ * through the gateway sign-in and lands them on the apps grid to authorize servers. The
+ * grid below authorizes individual servers into the per-user vault; this banner is the
+ * finish step that returns the user to the client.
+ *
+ * Finishing requires the explicit "Finish connecting" button: a native form POST to the proxy's
+ * /authorize/complete, which mints the gateway authorization code and 303-redirects to the DCR
+ * client's own redirect URI (the full-page navigation carries the HttpOnly per-flow cookie and
+ * follows the cross-origin redirect to the client's loopback).
+ *
+ * The button press IS the consent gate and must not be bypassed. An earlier version auto-finished
+ * on tab close via navigator.sendBeacon; that let an attacker who lured a signed-in victim to their
+ * own client's authorize URL harvest a victim-bound code the moment the victim closed the tab
+ * (no click). Merely visiting the authorize URL is attacker-inducible, so completion has to be a
+ * deliberate user action, not a side effect of leaving the page.
+ */
+const ConnectFlowBanner: React.FC<Props> = ({ flowHandle, clientOrigin }) => {
+  const action = `${getProxyBaseUrl()}/authorize/complete`;
+  const clientLabel = clientOrigin ?? "the application";
+
+  return (
+    <div className="mb-6 rounded-lg border border-primary/30 bg-primary/5 px-5 py-4">
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div className="flex items-start gap-3 min-w-0">
+          <CheckCircle className="h-5 w-5 text-primary shrink-0 mt-0.5" />
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-foreground">Connect your MCP servers to {clientLabel}</p>
+            <p className="text-[13px] text-muted-foreground mt-0.5">
+              Authorize the servers you want to use below, then click Finish connecting to return to {clientLabel}.
+            </p>
+          </div>
+        </div>
+        <form method="POST" action={action} className="shrink-0">
+          <input type="hidden" name="flow" value={flowHandle} />
+          <button
+            type="submit"
+            className="h-[38px] rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground hover:bg-primary/90"
+          >
+            Finish connecting
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ConnectFlowBanner;

--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
@@ -13,7 +13,7 @@ import {
   getMCPOAuthUserCredentialStatus,
   listMCPTools,
 } from "../networking";
-import { AUTH_TYPE, MCPServer, MCPTool, handleTransport } from "../mcp_tools/types";
+import { AUTH_TYPE, MCPServer, MCPTool, handleTransport, isUnsupportedOnGatewayConnect } from "../mcp_tools/types";
 import { Logo } from "@/components/molecules/logo/Logo";
 import MessageManager from "@/components/molecules/message_manager";
 import { useUserMcpOAuthFlow } from "@/hooks/useUserMcpOAuthFlow";
@@ -71,6 +71,7 @@ interface Props {
   accessToken: string;
   selectedServers: string[];
   onChange: (servers: string[]) => void;
+  connectMode?: boolean;
 }
 
 const AVATAR_COLORS = [
@@ -96,7 +97,7 @@ type TabKey = "all" | "connected";
 
 const TOOLS_FETCH_CONCURRENCY = 5;
 
-const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange }) => {
+const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange, connectMode }) => {
   const [servers, setServers] = useState<MCPServer[]>([]);
   const [loading, setLoading] = useState(true);
   const [query, setQuery] = useState("");
@@ -106,6 +107,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
   const [toolCounts, setToolCounts] = useState<Record<string, number>>({});
   const [loadingCounts, setLoadingCounts] = useState(false);
   const [oauthConnected, setOauthConnected] = useState<Set<string>>(new Set());
+  const [oauthChecking, setOauthChecking] = useState<Set<string>>(new Set());
 
   const serversRef = useRef<MCPServer[]>([]);
   useEffect(() => {
@@ -148,6 +150,14 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
         }
       } catch {
         // ignore
+      } finally {
+        if (!fetchLoadCancelledRef.current) {
+          setOauthChecking((prev) => {
+            const next = new Set(prev);
+            next.delete(server.server_id);
+            return next;
+          });
+        }
       }
     },
     [accessToken],
@@ -160,8 +170,12 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
       .then(async (serverData) => {
         if (fetchLoadCancelledRef.current) return;
         const list: MCPServer[] = Array.isArray(serverData) ? serverData : serverData?.data ?? [];
+        const oauthServers = list.filter((s) => s.auth_type === AUTH_TYPE.OAUTH2);
         setServers(list);
+        setOauthChecking(new Set(oauthServers.map((s) => s.server_id)));
         setLoading(false);
+
+        oauthServers.forEach((s) => checkOauthCredential(s));
 
         setLoadingCounts(true);
         const chunks = Array.from({ length: Math.ceil(list.length / TOOLS_FETCH_CONCURRENCY) }, (_, i) =>
@@ -172,9 +186,6 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
           await Promise.allSettled(chunk.map((s) => fetchToolCount(s)));
         }
         if (!fetchLoadCancelledRef.current) setLoadingCounts(false);
-
-        const oauthServers = list.filter((s) => s.auth_type === AUTH_TYPE.OAUTH2);
-        oauthServers.forEach((s) => checkOauthCredential(s));
       })
       .catch(() => {
         if (!fetchLoadCancelledRef.current) {
@@ -229,6 +240,36 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
         return next;
       });
     }
+  };
+
+  const renderConnectionIndicator = (server: MCPServer) => {
+    if (connectMode && isUnsupportedOnGatewayConnect(server.auth_type)) {
+      return (
+        <span className="text-[11px] text-muted-foreground shrink-0 whitespace-nowrap">
+          Not supported on this connection
+        </span>
+      );
+    }
+    if (server.auth_type === AUTH_TYPE.OAUTH2) {
+      if (oauthConnected.has(server.server_id)) {
+        return <CheckCircle className="h-3.5 w-3.5 text-emerald-600 shrink-0" />;
+      }
+      if (oauthChecking.has(server.server_id)) {
+        return <Skeleton className="h-6 w-16 shrink-0 rounded-md" />;
+      }
+      return (
+        <OAuth2ConnectButton
+          server={server}
+          accessToken={accessToken}
+          onConnect={(id) => setOauthConnected((prev) => new Set(prev).add(id))}
+          variant="badge"
+        />
+      );
+    }
+    if (selectedServers.includes(nameOf(server))) {
+      return <span className="w-[7px] h-[7px] rounded-full bg-emerald-600 dark:bg-emerald-400 shrink-0" />;
+    }
+    return null;
   };
 
   const { data: detailToolsResult, isLoading: loadingTools } = useQuery({
@@ -390,24 +431,30 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
         <div>
           <div className="flex items-center gap-2 mb-1">
             <h2 className="m-0 text-lg font-semibold text-foreground">MCP Servers</h2>
-            <span className="text-[10px] font-semibold text-primary bg-primary/10 rounded px-1.5 py-0.5 uppercase tracking-wider">
-              Beta
-            </span>
-          </div>
-          <div className="flex items-center gap-3">
-            <p className="m-0 text-[13px] text-muted-foreground">Browse tools, authenticate once, use in chat</p>
-            {loadingCounts ? (
-              <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                <Loader2 className="h-3 w-3 animate-spin" />
-                Loading tools...
+            {!connectMode && (
+              <span className="text-[10px] font-semibold text-primary bg-primary/10 rounded px-1.5 py-0.5 uppercase tracking-wider">
+                Beta
               </span>
-            ) : totalTools > 0 ? (
-              <span className="flex items-center gap-1 text-xs text-muted-foreground">
-                <Wrench className="h-3 w-3" />
-                {totalTools} tool{totalTools !== 1 ? "s" : ""} available
-              </span>
-            ) : null}
+            )}
           </div>
+          {connectMode ? (
+            <p className="m-0 text-[13px] text-muted-foreground">Click a server to see its tools and connect</p>
+          ) : (
+            <div className="flex items-center gap-3">
+              <p className="m-0 text-[13px] text-muted-foreground">Browse tools, authenticate once, use in chat</p>
+              {loadingCounts ? (
+                <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  Loading tools...
+                </span>
+              ) : totalTools > 0 ? (
+                <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                  <Wrench className="h-3 w-3" />
+                  {totalTools} tool{totalTools !== 1 ? "s" : ""} available
+                </span>
+              ) : null}
+            </div>
+          )}
         </div>
         <div className="relative w-[220px]">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
@@ -458,10 +505,10 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
         <div className="grid grid-cols-2 border rounded-lg overflow-hidden">
           {filtered.map((server, idx) => {
             const name = nameOf(server);
-            const isConnected = selectedServers.includes(name);
             const color = getAvatarColor(name);
             const isLeftCol = idx % 2 === 0;
             const count = toolCounts[name];
+            const unsupported = !!connectMode && isUnsupportedOnGatewayConnect(server.auth_type);
 
             return (
               <div
@@ -469,7 +516,9 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
                 onClick={() => setDetailServer(server)}
                 className={`flex items-center gap-3 p-4 bg-card cursor-pointer transition-colors hover:bg-accent/30 min-w-0 ${
                   isLeftCol ? "border-r" : ""
-                } ${Math.floor(idx / 2) < Math.floor((filtered.length - 1) / 2) ? "border-b" : ""}`}
+                } ${Math.floor(idx / 2) < Math.floor((filtered.length - 1) / 2) ? "border-b" : ""} ${
+                  unsupported ? "opacity-50" : ""
+                }`}
               >
                 {server.mcp_info?.logo_url ? (
                   <Logo
@@ -500,22 +549,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
                     ) : null}
                   </div>
                 </div>
-                {server.auth_type === AUTH_TYPE.OAUTH2 ? (
-                  oauthConnected.has(server.server_id) ? (
-                    <CheckCircle className="h-3.5 w-3.5 text-emerald-600 shrink-0" />
-                  ) : (
-                    <OAuth2ConnectButton
-                      server={server}
-                      accessToken={accessToken}
-                      onConnect={(id) => {
-                        setOauthConnected((prev) => new Set(prev).add(id));
-                      }}
-                      variant="badge"
-                    />
-                  )
-                ) : isConnected ? (
-                  <span className="w-[7px] h-[7px] rounded-full bg-emerald-600 dark:bg-emerald-400 shrink-0" />
-                ) : null}
+                {renderConnectionIndicator(server)}
                 <ChevronRight className="h-3 w-3 text-muted-foreground/40 shrink-0" />
               </div>
             );

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.test.tsx
@@ -14,6 +14,7 @@ import {
   preservedDeclaredAppCredentials,
   withoutMintedTokenCredentials,
   credentialAuthClass,
+  isUnsupportedOnGatewayConnect,
 } from "./types";
 
 describe("getOAuthAuthorizationIdentity", () => {
@@ -265,5 +266,25 @@ describe("credentialAuthClass", () => {
     expect(credentialAuthClass(AUTH_TYPE.OAUTH_DELEGATE)).toBe("client_forwarded");
     expect(credentialAuthClass(AUTH_TYPE.OAUTH2)).toBe(AUTH_TYPE.OAUTH2);
     expect(credentialAuthClass(null)).toBeNull();
+  });
+});
+
+describe("isUnsupportedOnGatewayConnect", () => {
+  it("flags the modes that need a caller-supplied upstream token or subject", () => {
+    // client-forwarded: caller presents the upstream Authorization per call
+    expect(isUnsupportedOnGatewayConnect(AUTH_TYPE.TRUE_PASSTHROUGH)).toBe(true);
+    expect(isUnsupportedOnGatewayConnect(AUTH_TYPE.OAUTH_DELEGATE)).toBe(true);
+    // OBO: caller's own IdP token is the exchange subject, which the session bearer is not
+    expect(isUnsupportedOnGatewayConnect(AUTH_TYPE.OAUTH2_TOKEN_EXCHANGE)).toBe(true);
+  });
+
+  it("does not flag modes the gateway can serve from server-side state or interactive vaulting", () => {
+    // interactive authorization_code is the one mode the connect grid vaults per user
+    expect(isUnsupportedOnGatewayConnect(AUTH_TYPE.OAUTH2)).toBe(false);
+    // server-configured credentials need no per-user connect
+    expect(isUnsupportedOnGatewayConnect(AUTH_TYPE.API_KEY)).toBe(false);
+    expect(isUnsupportedOnGatewayConnect(AUTH_TYPE.NONE)).toBe(false);
+    expect(isUnsupportedOnGatewayConnect(null)).toBe(false);
+    expect(isUnsupportedOnGatewayConnect(undefined)).toBe(false);
   });
 });

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
@@ -65,6 +65,15 @@ export const gatewayMintsClientFor = (server: { auth_type?: string | null; dcr_b
   server.auth_type === AUTH_TYPE.TRUE_PASSTHROUGH ||
   (server.auth_type === AUTH_TYPE.OAUTH_DELEGATE && !server.dcr_bridge);
 
+// Auth modes that cannot be used through the gateway aggregate connect flow, where the client holds
+// only an identity-only session bearer and upstream credentials are resolved server-side from the
+// per-user vault. The vault is only populated by interactive authorization_code (oauth2). The
+// client-forwarded modes need the caller to present the upstream Authorization per call, and
+// oauth2_token_exchange (OBO) needs the caller's own IdP token as the subject to exchange; the
+// session bearer is neither, so none of these can complete a tool call on this connection.
+export const isUnsupportedOnGatewayConnect = (authType?: string | null): boolean =>
+  isClientForwardedTokenMode(authType) || authType === AUTH_TYPE.OAUTH2_TOKEN_EXCHANGE;
+
 export const OAUTH_FLOW = {
   INTERACTIVE: "interactive",
   M2M: "m2m",


### PR DESCRIPTION
## Relevant issues

- Admits a keyless SSO user (no virtual key) at the aggregate `/mcp` endpoint from a gateway DCR session bearer, resolving team/org/SCIM/budget authorization fresh on every call.
- Resolves that user's access by asking the SAME resolver virtual keys use, once per grant source (their own grants, plus each team they are a live roster member of), then unioning. Each team source carries its own org, so cross-org ceilings apply per team rather than from the caller's home org.
- Scrubs the session bearer / bridge envelope from every egress path (anchored to the credential shape) so an admission credential can never be forwarded upstream and replayed as the user.

## Changes

- Admission arm at the aggregate `/mcp` scope: session-shaped bearer -> live user reload -> centralized policy gate, gated on an un-forgeable server-only marker so virtual-key and JWT auth are byte-identical.
- Authorization resolves per source through the canonical resolver instead of a parallel model, so sentinel expansion, access groups, tool permissions and toolsets cannot drift from the key path. For a keyless source the org list only ever intersects (a ceiling never becomes a grant) and an unresolvable ceiling denies instead of silently uncapping, on both the server and tool axes.
- Every granting team's per-server `mcp_rpm_limit` binds on the union: admission stamps each roster team's limit map onto the auth (server-only, unforgeable like the marker) and the limiter emits one `mcp_per_team` descriptor per applicable team, so a cross-team user cannot outrun any team's throttle and a team only throttles what it actually granted. A source team counts only while it is a live grantor — roster member, not blocked, and neither the team nor its owning org over budget (enforced via the same `_team_max_budget_check` / `_organization_max_budget_check` owners `common_checks` uses for keys) — decided in one place for grants, tools and throttles together. The manager wrapper honors the same model: the admin-role full-registry short-circuit and the absolute `no_mcp_servers` early-return are key-credential rules that never apply to an admitted subject, and one `operator_open_server_ids` owner feeds both the server union and the admitted tool resolution so open-channel servers (`allow_all_keys`, own BYOM) are default-open for tools rather than listable but uninvokable.
- One owner for redirect-URI hygiene shared by DCR registration and the OAuth endpoints, so allowlisted native callbacks (`cursor://`) register and userinfo-bearing URIs (`https://claude.ai@attacker.example/cb`) are rejected.
- Single-use claims for auth codes, refresh tokens and connect flows resolve the proxy's cross-worker redis cache themselves and fail closed on a Redis fault, instead of degrading to a per-worker count another worker could replay through.
- One shared, never-raising helper persists a safe sign-in `return_to` for every sign-in branch, so the connect flow resumes after login.

**What does NOT change:** virtual-key and JWT authorization take the same paths and the same code as before; the admitted subject is the only caller shape that fans out.

**Things a reviewer will ask about.** Registration deliberately accepts any https client rather than reusing `validate_trusted_redirect_uri`'s same-origin/allowlist policy: public dynamic registration must let a hosted MCP client register, and its controls are mandatory S256 PKCE plus the consent screen. Per-team BUDGET attribution for the union stays deferred on purpose: spend attributes to the user, whose own budget is enforced, and charging one team's shared budget for a server several teams grant has no correct attribution. Rate limits do not have that problem (all applicable descriptors are enforced together), so every granting team's `mcp_rpm_limit` now binds. Client-selected server scoping of the session token is tracked as LIT-4680.

**Operational note: there is no off-switch for the aggregate DCR surface.** The `mcp_gateway_dcr` flag was removed earlier in the stack, so `/register`, `/authorize`, `/token` and the admission arm are always available, and the lazy loader registers them on path match, so they materialize on any proxy that receives a request to those paths whether or not `/mcp` is mounted or any MCP server exists. Exposure is bounded by the flow rather than by configuration: `/register` is stateless and mints no credential (the `client_id` IS the sealed registration), and `/authorize` interposes LiteLLM sign-in, so a token can only be minted by an authenticated LiteLLM user who then completes the deliberate `POST /authorize/complete`. Revocation does not require rotating the master key; because admission reloads the live user on every call, deactivating or deleting the user cuts off outstanding session bearers at the next tool call, and `allowed_ips` / `allowed_routes` still bound the `/mcp` side. Rotating the master key remains the only way to invalidate every outstanding session token at once, since the session keys derive from it

**Operational note: single-use claims need Redis on multi-worker deployments.** The auth-code, refresh-token and connect-flow claims are recorded through the proxy's shared Redis when one is configured, and Redis is then the sole authority, so any Redis fault fails the claim closed instead of degrading to a per-worker count. Two consequences are worth knowing before deploying: a multi-replica proxy with no Redis configured gets the guarantee per worker only, which leaves a replay window across workers, and a Redis outage fails every claim closed, so gateway DCR sign-in and refresh stop working for its duration rather than degrading

Stacked on #33189 (aggregate flow) -> #33188 -> #33182; #33174 is merged.

## Linear ticket

Part of LIT-3637 (PR 4 of the stack: the admission edge that turns a gateway session bearer into a request admitted as the litellm user, closing the loop end to end)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

**Admission edge** — proven live end to end on a real proxy (:4139, Postgres, `--use_v2_migration_resolver`) by walking the full flow to a session token, then presenting it at the aggregate `/mcp` endpoint:

```
session access token: llm_session_eyJhbGciOiJI...

A. session bearer admits at aggregate /mcp (initialize)        -> HTTP 200
B. session bearer lists tools at aggregate /mcp (admitted)     -> HTTP 200
C. tampered session bearer -> 401 invalid_token challenge
   www-authenticate: Bearer error="invalid_token", resource_metadata=".../.well-known/oauth-protected-resource/mcp"
D. refresh token rejected at the tool edge                     -> HTTP 401
E. anonymous aggregate /mcp still challenges (PR 1 intact)     -> HTTP 401
   www-authenticate: Bearer resource_metadata=".../.well-known/oauth-protected-resource/mcp"
```

**Cross-org grant model** — proven live against real Postgres exercising the real `get_org_object` / `get_team_object` / `get_object_permission` resolvers, before/after on the identical seed:

```
org-A: NO ceiling;         team-A (org-A) grants {srv1, srv2}
org-B: ceiling {srv3};     team-B (org-B) grants {srv3, srv4}, srv3 tools capped to {read}
user U: member of team-A AND team-B; primary org = A

pre-fix:   reachable = {srv1, srv2, srv3, srv4}   (srv4 LEAKS — only the user's primary org-A capped)
           srv3 tools = None                      (all tools; org-B's tool ceiling bypassed)
fixed:     reachable = {srv1, srv2, srv3}          (srv4 excluded — org-B's ceiling binds team-B)
           srv3 tools = ['read']                   (org-B's tool ceiling binds)
```

## Type

🆕 New Feature

## Changes

The stack so far lets a DCR client register, sign in, and receive an identity-only session bearer; this PR is the admission edge that accepts that bearer at the aggregate `/mcp` endpoint. A new arm in `process_mcp_request` fires when the request targets the aggregate scope (no server named by `x-mcp-servers` or the path) and the `Authorization` bearer is session-shaped. The aggregate DCR front door is always-on — the earlier `mcp_gateway_dcr` config flag was removed in `refactor(mcp): make the aggregate DCR front door always-on` earlier in the stack — so the arm is gated on request shape, not a setting. It opens the session token, reloads the live litellm user the token references through the SAME `_reload_admitted_user` the bridge user-subject envelope path already uses, and runs the admitted identity through the centralized policy gate, so the user's present team, org, budget, and SCIM state gate the request rather than anything frozen at sign-in. Unlike the bridge arm it injects no per-server credential; the session seals no upstream token, those are vaulted per user and resolved at egress by user id

The token is a reference, not an authorization: the signature proves the user signed in, but authorization is resolved fresh on every call, so deactivating the user or their team takes effect immediately. A session-shaped bearer that is expired, tampered, minted under a different master key, or is a refresh token presented at the tool edge fails closed with the aggregate `invalid_token` challenge from PR 1; a non-session bearer never enters this arm and falls through to the existing oauth2 path unchanged

The aggregate-scope test (no named server, no path target) that PR 1 inlined for the challenge is factored into one `_is_aggregate_mcp_scope` helper now shared by the challenge and this admission arm, so the two cannot drift on what "aggregate" means

**Authorization model (keyless admitted subject).** A keyless admitted user reaches the UNION of MCP servers/tools granted through ANY of their teams, plus their own direct object-permission grants. It is gated on the un-forgeable, server-only `mcp_admitted_user_subject` marker (stripped from every validated input, set only post-construction after crypto + live DB reload), so virtual-key and JWT auth are byte-identical. Because a `team_id`-less subject skips the centralized `common_checks` per-team gates, the union enforces them itself, at the one chokepoint both the server and tool paths share:

- **Per-team org ceilings, cross-org.** Each team's grant — servers AND tools — is capped by THAT team's own organization, not the caller's primary org, so a user who belongs to a team in another org cannot reach servers/tools that org forbids. A team with no `organization_id` falls back to the user's primary org; the user's own direct grants are capped by the user's org.
- **Blocked-team + roster membership**, enforced per unioned team (the team roster is the source of truth, so a stale/foreign `team_id` cannot keep access after removal).
- **Fail-closed for this subject, everywhere.** Tool resolution, the empty/TOCTOU case, and any org-lookup DB fault all deny rather than allow-all; a *missing* org row is treated as "no ceiling" (not a lock-out) — matching how the key path tolerates a deleted org.
- **Egress leak-defense, credential-anchored.** The session bearer / bridge envelope is scrubbed from every egress header context, keyed on the credential SHAPE (not the admission arm), so a session bearer misdirected to a per-server `true_passthrough` path is stripped too — it is never a valid upstream token and can't be captured + replayed as the user.
- **Config.yaml-defined servers (incl. OAuth) resolve identically** — every grant/ceiling lookup goes through the config ∪ DB registry union (id/alias/name), and per-user upstream OAuth tokens are keyed by `(user_id, server_id)` (the config server's DCR client persists via #33768).
- **Deferred (tracked follow-up): per-team/org BUDGET** for the union — the exact sibling of per-team rate limits: a cross-team user's calls attribute to the USER (whose own budget/RPM/TPM `common_checks` DOES enforce), never to a specific team's shared bucket, so there is no correct per-team attribution. Not a bypass of the user's own limits.

## QA runbook

Run a proxy with a master key and a database; walk the flow from the PR below this one to obtain a session `access_token`, then present it as `Authorization: Bearer <token>` to `POST /mcp/`. Confirm initialize and tools/list return 200 (admitted as the user); a tampered token returns 401 with the `error="invalid_token"` challenge; a `refresh_token` presented at `/mcp/` returns 401; and an anonymous `/mcp/` still returns the bare `resource_metadata` challenge. For the cross-org grant model, seed two orgs with different MCP ceilings + a user in a team under each, and confirm each team's servers/tools are capped by that team's own org (see the before/after above)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large auth/authorization surface (MCP admission, multi-team grants, org ceilings, credential scrubbing, DCR token single-use); mistakes could leak cross-org access or forward replayable credentials.
> 
> **Overview**
> Adds the **admission edge** for aggregate `/mcp`: session-shaped `Authorization` bearers are opened via `_admit_gateway_session`, the live user is reloaded, and policy is enforced on every call. Virtual-key and JWT paths are unchanged.
> 
> **Keyless admitted users** (server-only `mcp_admitted_user_subject`, not forgeable from metadata) get MCP access by **unioning grants per source**—own permissions plus each roster-verified team—with **per-team org ceilings** on servers and tools, blocked/over-budget teams excluded, and **fail-closed** org lookup faults for keyless sources. Tool calls can **bill the granting team** via `billing_auth_for_tool_call`; **per-team `mcp_rpm_limit`** descriptors apply across teams.
> 
> **Egress hardening** strips session/bridge-shaped credentials from all outbound header paths so gateway admission tokens cannot be replayed upstream.
> 
> Supporting changes: **`gateway_dcr_flow`** (stateless register, authorize, `POST /authorize/complete`, token with Redis-backed single-use claims), shared redirect-uri hygiene, UI session JWT **`exp`**, unified **`return_to`** after sign-in, and **`OrganizationNotFoundError`** so missing org vs DB outage is distinguishable for org ceilings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffa0dffbc6aa7918a9c2c3a1088aef18d0c2dc63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->






