### PR TITLE
feat(ui): connect-flow interlude banner on the MCP apps grid for gateway DCR sign-in

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -1797,7 +1797,7 @@
   },
   "src/components/chat/MCPAppsPanel.tsx": {
     "no-nested-ternary": {
-      "count": 7
+      "count": 6
     }
   },
   "src/components/chat/MCPConnectPicker.tsx": {

--- a/ui/litellm-dashboard/src/app/chat/integrations/page.tsx
+++ b/ui/litellm-dashboard/src/app/chat/integrations/page.tsx
@@ -33,7 +33,12 @@ function IntegrationsPageContent() {
   return (
     <div className="flex-1 min-h-0 overflow-auto w-full py-8 px-8">
       {connectFlow && <ConnectFlowBanner flowHandle={connectFlow} clientOrigin={connectClient} />}
-      <MCPAppsPanel accessToken={accessToken} selectedServers={selectedMCPServers} onChange={setSelectedMCPServers} />
+      <MCPAppsPanel
+        accessToken={accessToken}
+        selectedServers={selectedMCPServers}
+        onChange={setSelectedMCPServers}
+        connectMode={!!connectFlow}
+      />
     </div>
   );
 }

--- a/ui/litellm-dashboard/src/app/chat/integrations/page.tsx
+++ b/ui/litellm-dashboard/src/app/chat/integrations/page.tsx
@@ -4,6 +4,7 @@ import { Suspense, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useChatShell } from "@/contexts/ChatShellContext";
 import MCPAppsPanel from "@/components/chat/MCPAppsPanel";
+import ConnectFlowBanner from "@/components/chat/ConnectFlowBanner";
 
 // useSearchParams() requires a Suspense boundary for static export.
 function IntegrationsPageContent() {
@@ -11,6 +12,13 @@ function IntegrationsPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const oauthReturn = searchParams.get("mcpOauthReturn");
+  // Set by the gateway DCR authorize when a DCR client sends the user here to
+  // authorize servers before finishing sign-in (see gateway_dcr_flow.py). The
+  // handle keys the sealed per-flow cookie; connect_client is the client origin
+  // for display only. connect_flow is NOT cleaned from the URL: the finish form
+  // needs it, and the sealed cookie (not the URL) is the security boundary.
+  const connectFlow = searchParams.get("connect_flow");
+  const connectClient = searchParams.get("connect_client");
 
   // Clean up the OAuth return param after it's been consumed — real routing means
   // we no longer need it to pick a tab, but it should not linger in the address bar.
@@ -24,6 +32,7 @@ function IntegrationsPageContent() {
 
   return (
     <div className="flex-1 min-h-0 overflow-auto w-full py-8 px-8">
+      {connectFlow && <ConnectFlowBanner flowHandle={connectFlow} clientOrigin={connectClient} />}
       <MCPAppsPanel accessToken={accessToken} selectedServers={selectedMCPServers} onChange={setSelectedMCPServers} />
     </div>
   );

--- a/ui/litellm-dashboard/src/components/chat/ConnectFlowBanner.test.tsx
+++ b/ui/litellm-dashboard/src/components/chat/ConnectFlowBanner.test.tsx
@@ -1,10 +1,16 @@
-import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
 import ConnectFlowBanner from "./ConnectFlowBanner";
+import { PERSERVER_CONNECTING_KEY } from "@/hooks/mcpOAuthUtils";
 
 vi.mock("@/components/networking", () => ({
   getProxyBaseUrl: () => "https://gateway.example.com",
 }));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  sessionStorage.clear();
+});
 
 describe("ConnectFlowBanner", () => {
   it("posts the flow handle to the proxy /authorize/complete as a full-page form", () => {
@@ -29,5 +35,42 @@ describe("ConnectFlowBanner", () => {
   it("falls back to a generic label when the client origin is unknown", () => {
     render(<ConnectFlowBanner flowHandle="h" clientOrigin={null} />);
     expect(screen.getAllByText(/the application/).length).toBeGreaterThan(0);
+  });
+
+  it("best-effort auto-finishes on pagehide (closing the tab)", () => {
+    const beaconMock = vi.fn(() => true);
+    vi.stubGlobal("navigator", { ...navigator, sendBeacon: beaconMock });
+    render(<ConnectFlowBanner flowHandle="flow-xyz" clientOrigin="https://claude.ai" />);
+
+    window.dispatchEvent(new Event("pagehide"));
+
+    expect(beaconMock).toHaveBeenCalledTimes(1);
+    const [url, body] = beaconMock.mock.calls[0] as unknown as [string, URLSearchParams];
+    expect(url).toBe("https://gateway.example.com/authorize/complete");
+    expect(body.toString()).toContain("flow=flow-xyz");
+  });
+
+  it("does NOT auto-finish while a per-server connect is navigating away", () => {
+    const beaconMock = vi.fn(() => true);
+    vi.stubGlobal("navigator", { ...navigator, sendBeacon: beaconMock });
+    render(<ConnectFlowBanner flowHandle="flow-xyz" clientOrigin="https://claude.ai" />);
+
+    // the per-server connect flow sets this right before it navigates to the upstream IdP
+    sessionStorage.setItem(PERSERVER_CONNECTING_KEY, "1");
+    window.dispatchEvent(new Event("pagehide"));
+
+    expect(beaconMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT double-fire the auto-finish after the button was pressed", () => {
+    const beaconMock = vi.fn(() => true);
+    vi.stubGlobal("navigator", { ...navigator, sendBeacon: beaconMock });
+    const { container } = render(<ConnectFlowBanner flowHandle="flow-xyz" clientOrigin="https://claude.ai" />);
+
+    // jsdom does not submit forms; fire the form's submit so onSubmit marks it finished
+    fireEvent.submit(container.querySelector("form")!);
+    window.dispatchEvent(new Event("pagehide"));
+
+    expect(beaconMock).not.toHaveBeenCalled();
   });
 });

--- a/ui/litellm-dashboard/src/components/chat/ConnectFlowBanner.test.tsx
+++ b/ui/litellm-dashboard/src/components/chat/ConnectFlowBanner.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ConnectFlowBanner from "./ConnectFlowBanner";
+
+vi.mock("@/components/networking", () => ({
+  getProxyBaseUrl: () => "https://gateway.example.com",
+}));
+
+describe("ConnectFlowBanner", () => {
+  it("posts the flow handle to the proxy /authorize/complete as a full-page form", () => {
+    const { container } = render(<ConnectFlowBanner flowHandle="flow-handle-123" clientOrigin="https://claude.ai" />);
+
+    const form = container.querySelector("form")!;
+    expect(form.getAttribute("method")).toBe("POST");
+    expect(form.getAttribute("action")).toBe("https://gateway.example.com/authorize/complete");
+
+    const hidden = form.querySelector('input[name="flow"]') as HTMLInputElement;
+    expect(hidden.value).toBe("flow-handle-123");
+    // No token, code, or secret is ever placed in the form; the sealed cookie carries them.
+    expect(form.innerHTML).not.toContain("token");
+  });
+
+  it("shows the client origin so the user knows what they are connecting to", () => {
+    render(<ConnectFlowBanner flowHandle="h" clientOrigin="https://claude.ai" />);
+    expect(screen.getAllByText(/claude\.ai/).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /finish connecting/i })).toBeInTheDocument();
+  });
+
+  it("falls back to a generic label when the client origin is unknown", () => {
+    render(<ConnectFlowBanner flowHandle="h" clientOrigin={null} />);
+    expect(screen.getAllByText(/the application/).length).toBeGreaterThan(0);
+  });
+});

--- a/ui/litellm-dashboard/src/components/chat/ConnectFlowBanner.tsx
+++ b/ui/litellm-dashboard/src/components/chat/ConnectFlowBanner.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import React from "react";
+import { CheckCircle } from "lucide-react";
+import { getProxyBaseUrl } from "@/components/networking";
+
+interface Props {
+  flowHandle: string;
+  clientOrigin: string | null;
+}
+
+/**
+ * The interlude shown when a DCR client (Claude Desktop, MCP Inspector) sends the user
+ * through the gateway sign-in and lands them on the apps grid to authorize servers. The
+ * grid below authorizes individual servers into the per-user vault; this banner is the
+ * deliberate finish step.
+ *
+ * "Finish connecting" is a native form POST to the proxy's /authorize/complete, not a
+ * fetch: the endpoint 303-redirects the browser back to the DCR client's own redirect URI
+ * with the gateway authorization code, and only a full-page navigation carries the
+ * HttpOnly per-flow cookie and follows that cross-origin redirect. The flow handle is the
+ * only field; the sealed flow cookie set at /authorize holds everything else.
+ */
+const ConnectFlowBanner: React.FC<Props> = ({ flowHandle, clientOrigin }) => {
+  const action = `${getProxyBaseUrl()}/authorize/complete`;
+  const clientLabel = clientOrigin ?? "the application";
+
+  return (
+    <div className="mb-6 rounded-lg border border-primary/30 bg-primary/5 px-5 py-4">
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div className="flex items-start gap-3 min-w-0">
+          <CheckCircle className="h-5 w-5 text-primary shrink-0 mt-0.5" />
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-foreground">Connect your MCP servers to {clientLabel}</p>
+            <p className="text-[13px] text-muted-foreground mt-0.5">
+              Authorize the servers you want to use below. When you are ready, finish connecting and you will be
+              returned to {clientLabel}.
+            </p>
+          </div>
+        </div>
+        <form method="POST" action={action} className="shrink-0">
+          <input type="hidden" name="flow" value={flowHandle} />
+          <button
+            type="submit"
+            className="h-[38px] rounded-md bg-primary px-4 text-sm font-semibold text-primary-foreground hover:bg-primary/90"
+          >
+            Finish connecting
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ConnectFlowBanner;

--- a/ui/litellm-dashboard/src/components/chat/ConnectFlowBanner.tsx
+++ b/ui/litellm-dashboard/src/components/chat/ConnectFlowBanner.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { CheckCircle } from "lucide-react";
 import { getProxyBaseUrl } from "@/components/networking";
+import { PERSERVER_CONNECTING_KEY } from "@/hooks/mcpOAuthUtils";
 
 interface Props {
   flowHandle: string;
@@ -13,17 +14,38 @@ interface Props {
  * The interlude shown when a DCR client (Claude Desktop, MCP Inspector) sends the user
  * through the gateway sign-in and lands them on the apps grid to authorize servers. The
  * grid below authorizes individual servers into the per-user vault; this banner is the
- * deliberate finish step.
+ * finish step that returns the user to the client.
  *
- * "Finish connecting" is a native form POST to the proxy's /authorize/complete, not a
- * fetch: the endpoint 303-redirects the browser back to the DCR client's own redirect URI
- * with the gateway authorization code, and only a full-page navigation carries the
- * HttpOnly per-flow cookie and follows that cross-origin redirect. The flow handle is the
- * only field; the sealed flow cookie set at /authorize holds everything else.
+ * Finishing happens two ways, both hitting the proxy's /authorize/complete, which mints the
+ * gateway authorization code and 303-redirects to the DCR client's own redirect URI:
+ *  - The explicit "Finish connecting" button is a native form POST, so the full-page
+ *    navigation carries the HttpOnly per-flow cookie and follows the cross-origin redirect
+ *    to the client's loopback. This is the reliable path.
+ *  - Closing (or navigating away from) the tab fires a best-effort navigator.sendBeacon to the
+ *    same endpoint. The browser follows the 303 to the client's loopback, so in most browsers
+ *    the code still reaches the client without an explicit click. This is a convenience, not a
+ *    consent gate: consent already happened at sign-in, so returning the user is safe. It is
+ *    skipped while a per-server connect is navigating away (that is not leaving the flow),
+ *    and after the button was pressed (which already delivers the code).
  */
 const ConnectFlowBanner: React.FC<Props> = ({ flowHandle, clientOrigin }) => {
   const action = `${getProxyBaseUrl()}/authorize/complete`;
   const clientLabel = clientOrigin ?? "the application";
+  const finishedRef = useRef(false);
+
+  useEffect(() => {
+    sessionStorage.removeItem(PERSERVER_CONNECTING_KEY);
+
+    const autoFinishOnLeave = () => {
+      if (finishedRef.current) return;
+      if (sessionStorage.getItem(PERSERVER_CONNECTING_KEY) === "1") return;
+      if (typeof navigator.sendBeacon === "function") {
+        navigator.sendBeacon(action, new URLSearchParams({ flow: flowHandle }));
+      }
+    };
+    window.addEventListener("pagehide", autoFinishOnLeave);
+    return () => window.removeEventListener("pagehide", autoFinishOnLeave);
+  }, [action, flowHandle]);
 
   return (
     <div className="mb-6 rounded-lg border border-primary/30 bg-primary/5 px-5 py-4">
@@ -33,12 +55,12 @@ const ConnectFlowBanner: React.FC<Props> = ({ flowHandle, clientOrigin }) => {
           <div className="min-w-0">
             <p className="text-sm font-semibold text-foreground">Connect your MCP servers to {clientLabel}</p>
             <p className="text-[13px] text-muted-foreground mt-0.5">
-              Authorize the servers you want to use below. When you are ready, finish connecting and you will be
-              returned to {clientLabel}.
+              Authorize the servers you want to use below, then finish connecting to return to {clientLabel}. Closing
+              this tab finishes for you.
             </p>
           </div>
         </div>
-        <form method="POST" action={action} className="shrink-0">
+        <form method="POST" action={action} className="shrink-0" onSubmit={() => (finishedRef.current = true)}>
           <input type="hidden" name="flow" value={flowHandle} />
           <button
             type="submit"

--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
@@ -13,7 +13,7 @@ import {
   getMCPOAuthUserCredentialStatus,
   listMCPTools,
 } from "../networking";
-import { AUTH_TYPE, MCPServer, MCPTool, handleTransport } from "../mcp_tools/types";
+import { AUTH_TYPE, MCPServer, MCPTool, handleTransport, isUnsupportedOnGatewayConnect } from "../mcp_tools/types";
 import MessageManager from "@/components/molecules/message_manager";
 import { useUserMcpOAuthFlow } from "@/hooks/useUserMcpOAuthFlow";
 
@@ -242,6 +242,13 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
   };
 
   const renderConnectionIndicator = (server: MCPServer) => {
+    if (connectMode && isUnsupportedOnGatewayConnect(server.auth_type)) {
+      return (
+        <span className="text-[11px] text-muted-foreground shrink-0 whitespace-nowrap">
+          Not supported on this connection
+        </span>
+      );
+    }
     if (server.auth_type === AUTH_TYPE.OAUTH2) {
       if (oauthConnected.has(server.server_id)) {
         return <CheckCircle className="h-3.5 w-3.5 text-emerald-600 shrink-0" />;
@@ -507,6 +514,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
             const color = getAvatarColor(name);
             const isLeftCol = idx % 2 === 0;
             const count = toolCounts[name];
+            const unsupported = !!connectMode && isUnsupportedOnGatewayConnect(server.auth_type);
 
             return (
               <div
@@ -514,7 +522,9 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
                 onClick={() => setDetailServer(server)}
                 className={`flex items-center gap-3 p-4 bg-card cursor-pointer transition-colors hover:bg-accent/30 min-w-0 ${
                   isLeftCol ? "border-r" : ""
-                } ${Math.floor(idx / 2) < Math.floor((filtered.length - 1) / 2) ? "border-b" : ""}`}
+                } ${Math.floor(idx / 2) < Math.floor((filtered.length - 1) / 2) ? "border-b" : ""} ${
+                  unsupported ? "opacity-50" : ""
+                }`}
               >
                 {server.mcp_info?.logo_url ? (
                   <img

--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
@@ -70,6 +70,7 @@ interface Props {
   accessToken: string;
   selectedServers: string[];
   onChange: (servers: string[]) => void;
+  connectMode?: boolean;
 }
 
 const AVATAR_COLORS = [
@@ -95,7 +96,7 @@ type TabKey = "all" | "connected";
 
 const TOOLS_FETCH_CONCURRENCY = 5;
 
-const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange }) => {
+const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange, connectMode }) => {
   const [servers, setServers] = useState<MCPServer[]>([]);
   const [loading, setLoading] = useState(true);
   const [query, setQuery] = useState("");
@@ -105,6 +106,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
   const [toolCounts, setToolCounts] = useState<Record<string, number>>({});
   const [loadingCounts, setLoadingCounts] = useState(false);
   const [oauthConnected, setOauthConnected] = useState<Set<string>>(new Set());
+  const [oauthChecking, setOauthChecking] = useState<Set<string>>(new Set());
 
   const serversRef = useRef<MCPServer[]>([]);
   useEffect(() => {
@@ -147,6 +149,14 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
         }
       } catch {
         // ignore
+      } finally {
+        if (!fetchLoadCancelledRef.current) {
+          setOauthChecking((prev) => {
+            const next = new Set(prev);
+            next.delete(server.server_id);
+            return next;
+          });
+        }
       }
     },
     [accessToken],
@@ -159,8 +169,12 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
       .then(async (serverData) => {
         if (fetchLoadCancelledRef.current) return;
         const list: MCPServer[] = Array.isArray(serverData) ? serverData : serverData?.data ?? [];
+        const oauthServers = list.filter((s) => s.auth_type === AUTH_TYPE.OAUTH2);
         setServers(list);
+        setOauthChecking(new Set(oauthServers.map((s) => s.server_id)));
         setLoading(false);
+
+        oauthServers.forEach((s) => checkOauthCredential(s));
 
         setLoadingCounts(true);
         const chunks = Array.from({ length: Math.ceil(list.length / TOOLS_FETCH_CONCURRENCY) }, (_, i) =>
@@ -171,9 +185,6 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
           await Promise.allSettled(chunk.map((s) => fetchToolCount(s)));
         }
         if (!fetchLoadCancelledRef.current) setLoadingCounts(false);
-
-        const oauthServers = list.filter((s) => s.auth_type === AUTH_TYPE.OAUTH2);
-        oauthServers.forEach((s) => checkOauthCredential(s));
       })
       .catch(() => {
         if (!fetchLoadCancelledRef.current) {
@@ -228,6 +239,29 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
         return next;
       });
     }
+  };
+
+  const renderConnectionIndicator = (server: MCPServer) => {
+    if (server.auth_type === AUTH_TYPE.OAUTH2) {
+      if (oauthConnected.has(server.server_id)) {
+        return <CheckCircle className="h-3.5 w-3.5 text-emerald-600 shrink-0" />;
+      }
+      if (oauthChecking.has(server.server_id)) {
+        return <Skeleton className="h-6 w-16 shrink-0 rounded-md" />;
+      }
+      return (
+        <OAuth2ConnectButton
+          server={server}
+          accessToken={accessToken}
+          onConnect={(id) => setOauthConnected((prev) => new Set(prev).add(id))}
+          variant="badge"
+        />
+      );
+    }
+    if (selectedServers.includes(nameOf(server))) {
+      return <span className="w-[7px] h-[7px] rounded-full bg-emerald-600 dark:bg-emerald-400 shrink-0" />;
+    }
+    return null;
   };
 
   const { data: detailToolsResult, isLoading: loadingTools } = useQuery({
@@ -396,24 +430,30 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
         <div>
           <div className="flex items-center gap-2 mb-1">
             <h2 className="m-0 text-lg font-semibold text-foreground">MCP Servers</h2>
-            <span className="text-[10px] font-semibold text-primary bg-primary/10 rounded px-1.5 py-0.5 uppercase tracking-wider">
-              Beta
-            </span>
-          </div>
-          <div className="flex items-center gap-3">
-            <p className="m-0 text-[13px] text-muted-foreground">Browse tools, authenticate once, use in chat</p>
-            {loadingCounts ? (
-              <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                <Loader2 className="h-3 w-3 animate-spin" />
-                Loading tools...
+            {!connectMode && (
+              <span className="text-[10px] font-semibold text-primary bg-primary/10 rounded px-1.5 py-0.5 uppercase tracking-wider">
+                Beta
               </span>
-            ) : totalTools > 0 ? (
-              <span className="flex items-center gap-1 text-xs text-muted-foreground">
-                <Wrench className="h-3 w-3" />
-                {totalTools} tool{totalTools !== 1 ? "s" : ""} available
-              </span>
-            ) : null}
+            )}
           </div>
+          {connectMode ? (
+            <p className="m-0 text-[13px] text-muted-foreground">Click a server to see its tools and connect</p>
+          ) : (
+            <div className="flex items-center gap-3">
+              <p className="m-0 text-[13px] text-muted-foreground">Browse tools, authenticate once, use in chat</p>
+              {loadingCounts ? (
+                <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  Loading tools...
+                </span>
+              ) : totalTools > 0 ? (
+                <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                  <Wrench className="h-3 w-3" />
+                  {totalTools} tool{totalTools !== 1 ? "s" : ""} available
+                </span>
+              ) : null}
+            </div>
+          )}
         </div>
         <div className="relative w-[220px]">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
@@ -464,7 +504,6 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
         <div className="grid grid-cols-2 border rounded-lg overflow-hidden">
           {filtered.map((server, idx) => {
             const name = nameOf(server);
-            const isConnected = selectedServers.includes(name);
             const color = getAvatarColor(name);
             const isLeftCol = idx % 2 === 0;
             const count = toolCounts[name];
@@ -513,22 +552,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
                     ) : null}
                   </div>
                 </div>
-                {server.auth_type === AUTH_TYPE.OAUTH2 ? (
-                  oauthConnected.has(server.server_id) ? (
-                    <CheckCircle className="h-3.5 w-3.5 text-emerald-600 shrink-0" />
-                  ) : (
-                    <OAuth2ConnectButton
-                      server={server}
-                      accessToken={accessToken}
-                      onConnect={(id) => {
-                        setOauthConnected((prev) => new Set(prev).add(id));
-                      }}
-                      variant="badge"
-                    />
-                  )
-                ) : isConnected ? (
-                  <span className="w-[7px] h-[7px] rounded-full bg-emerald-600 dark:bg-emerald-400 shrink-0" />
-                ) : null}
+                {renderConnectionIndicator(server)}
                 <ChevronRight className="h-3 w-3 text-muted-foreground/40 shrink-0" />
               </div>
             );

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.test.tsx
@@ -13,6 +13,7 @@ import {
   preservedDeclaredAppCredentials,
   withoutMintedTokenCredentials,
   credentialAuthClass,
+  isUnsupportedOnGatewayConnect,
 } from "./types";
 
 describe("getOAuthAuthorizationIdentity", () => {
@@ -229,5 +230,25 @@ describe("credentialAuthClass", () => {
     expect(credentialAuthClass(AUTH_TYPE.OAUTH_DELEGATE)).toBe("client_forwarded");
     expect(credentialAuthClass(AUTH_TYPE.OAUTH2)).toBe(AUTH_TYPE.OAUTH2);
     expect(credentialAuthClass(null)).toBeNull();
+  });
+});
+
+describe("isUnsupportedOnGatewayConnect", () => {
+  it("flags the modes that need a caller-supplied upstream token or subject", () => {
+    // client-forwarded: caller presents the upstream Authorization per call
+    expect(isUnsupportedOnGatewayConnect(AUTH_TYPE.TRUE_PASSTHROUGH)).toBe(true);
+    expect(isUnsupportedOnGatewayConnect(AUTH_TYPE.OAUTH_DELEGATE)).toBe(true);
+    // OBO: caller's own IdP token is the exchange subject, which the session bearer is not
+    expect(isUnsupportedOnGatewayConnect(AUTH_TYPE.OAUTH2_TOKEN_EXCHANGE)).toBe(true);
+  });
+
+  it("does not flag modes the gateway can serve from server-side state or interactive vaulting", () => {
+    // interactive authorization_code is the one mode the connect grid vaults per user
+    expect(isUnsupportedOnGatewayConnect(AUTH_TYPE.OAUTH2)).toBe(false);
+    // server-configured credentials need no per-user connect
+    expect(isUnsupportedOnGatewayConnect(AUTH_TYPE.API_KEY)).toBe(false);
+    expect(isUnsupportedOnGatewayConnect(AUTH_TYPE.NONE)).toBe(false);
+    expect(isUnsupportedOnGatewayConnect(null)).toBe(false);
+    expect(isUnsupportedOnGatewayConnect(undefined)).toBe(false);
   });
 });

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
@@ -52,6 +52,15 @@ export const AUTH_TYPE = {
 export const isClientForwardedTokenMode = (authType?: string | null): boolean =>
   authType === AUTH_TYPE.TRUE_PASSTHROUGH || authType === AUTH_TYPE.OAUTH_DELEGATE;
 
+// Auth modes that cannot be used through the gateway aggregate connect flow, where the client holds
+// only an identity-only session bearer and upstream credentials are resolved server-side from the
+// per-user vault. The vault is only populated by interactive authorization_code (oauth2). The
+// client-forwarded modes need the caller to present the upstream Authorization per call, and
+// oauth2_token_exchange (OBO) needs the caller's own IdP token as the subject to exchange; the
+// session bearer is neither, so none of these can complete a tool call on this connection.
+export const isUnsupportedOnGatewayConnect = (authType?: string | null): boolean =>
+  isClientForwardedTokenMode(authType) || authType === AUTH_TYPE.OAUTH2_TOKEN_EXCHANGE;
+
 export const OAUTH_FLOW = {
   INTERACTIVE: "interactive",
   M2M: "m2m",

--- a/ui/litellm-dashboard/src/hooks/mcpOAuthUtils.ts
+++ b/ui/litellm-dashboard/src/hooks/mcpOAuthUtils.ts
@@ -17,6 +17,14 @@ import { getProxyBaseUrl, serverRootPath } from "@/components/networking";
 export const TOOLS_OAUTH_UI_STATE_KEY = "litellm-mcp-oauth-tools-state";
 
 /**
+ * sessionStorage flag set by useUserMcpOAuthFlow right before it navigates the whole page
+ * to the upstream IdP to authorize one server. ConnectFlowBanner's auto-finish-on-close
+ * handler skips while this is set, so authorizing a server is not mistaken for the user
+ * leaving the gateway DCR connect flow.
+ */
+export const PERSERVER_CONNECTING_KEY = "litellm-mcp-perserver-connecting";
+
+/**
  * Build the OAuth callback URL for the current UI deployment.
  *
  * In the browser, derive the `/ui` prefix from the current pathname so the

--- a/ui/litellm-dashboard/src/hooks/useUserMcpOAuthFlow.tsx
+++ b/ui/litellm-dashboard/src/hooks/useUserMcpOAuthFlow.tsx
@@ -23,7 +23,7 @@ import NotificationsManager from "@/components/molecules/notifications_manager";
 import { extractErrorMessage } from "@/utils/errorUtils";
 import { generateCodeChallenge, generateCodeVerifier } from "@/utils/pkce";
 import { getSecureItem, setSecureItem } from "@/utils/secureStorage";
-import { buildCallbackUrl, clearStorage } from "./mcpOAuthUtils";
+import { buildCallbackUrl, clearStorage, PERSERVER_CONNECTING_KEY } from "./mcpOAuthUtils";
 
 export type UserMcpOAuthStatus = "idle" | "authorizing" | "exchanging" | "success" | "error";
 
@@ -135,6 +135,7 @@ export const useUserMcpOAuthFlow = ({
       returnUrl.searchParams.set("mcpOauthReturn", "apps");
       setStorage(RETURN_URL_KEY, returnUrl.toString());
 
+      sessionStorage.setItem(PERSERVER_CONNECTING_KEY, "1");
       window.location.href = authorizeUrl;
     } catch (err) {
       const msg = extractErrorMessage(err);


### PR DESCRIPTION
## Relevant issues

Stacked on #33191 (multi-team union) -> #33190 -> #33189 -> #33188 -> #33182 -> #33174. The base of this PR is `litellm_lit3637_team_union`; review and merge after those

## Linear ticket

Part of LIT-3637 (PR 5 of the stack: the magic-URL interlude that turns the apps grid into the finish step of the gateway DCR sign-in)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a UI-only change. To see it end to end against a live proxy (aggregate gateway DCR is on by default, no flag):

1. Start the proxy and the dashboard dev server (`npm run dev` in `ui/litellm-dashboard`, served on port 3000)
2. Drive a DCR client (or the curl walk from PR #33189) up to the authorize step, which 303-redirects the browser to `http://localhost:4000/ui/chat/integrations?connect_flow=<handle>&connect_client=https://claude.ai`
3. Open that URL in a browser where you are signed into LiteLLM; confirm the blue interlude banner appears above the apps grid, reading "Connect your MCP servers to https://claude.ai", and that the grid shows only the server cards with no Beta badge, chat subtitle, or tool-count summary
4. Confirm each already-authorized OAuth2 server shows Connected immediately without first flashing a Connect button, and servers still needing authorization show their Connect button
5. Authorize any servers you need with the per-card Connect buttons (they vault tokens per user); confirm authorizing one navigates you out and back without the banner auto-finishing behind you
6. Either click "Finish connecting" or just close the tab; confirm the browser reaches `/authorize/complete` (a form POST for the button, a sendBeacon for the close) and the client receives the gateway authorization code at its redirect URI, completing sign-in

The unit tests assert the finish action is a full-page form POST carrying only the flow handle (no token, code, or secret), that closing the tab fires a sendBeacon to the same endpoint, that the beacon is suppressed while a per-server authorize is in flight and after the button was pressed, that the client origin is shown, and that it falls back to a generic label when the origin is absent

## Type

🆕 New Feature

## Changes

The gateway DCR authorize (PR #33189) sends a signed-in user to `/ui/chat/integrations?connect_flow=<handle>` to authorize servers before finishing sign-in. This adds the interlude that page needs: when `connect_flow` is present, a `ConnectFlowBanner` renders above the apps grid, naming the client the user is connecting to and offering a single finish action

In this connect context the grid drops its chat-oriented chrome so it reads as "authorize your servers" rather than a chat feature: the `connectMode` prop hides the Beta badge, the "browse tools, authenticate once, use in chat" subtitle, and the tool-count summary, leaving just the server cards you click into to see tools and connect. With no `connect_flow` param the page is byte-identical to today, so the normal browse-and-connect experience is untouched

Finish happens two ways. The explicit "Finish connecting" button is a native HTML form POST to the proxy's `/authorize/complete`, not a fetch: that endpoint 303-redirects the browser back to the DCR client's own redirect URI with the gateway authorization code, and only a full-page navigation carries the HttpOnly per-flow cookie and follows that redirect. Closing or navigating away from the tab now also best-effort finishes, via `navigator.sendBeacon` to the same endpoint, so the code still reaches the client's loopback without an explicit click and the browser follows the 303 the same way. This is a convenience, not a consent gate, since consent already happened at sign-in. It is skipped while a per-server authorize is navigating the page away (tracked by a short-lived sessionStorage flag) and after the button was pressed, so it never fires mid-authorize or double-delivers the code. The form and the beacon both carry only the opaque flow handle; everything sensitive lives in the sealed cookie the authorize step set

Authorized servers used to flash their Connect button for about a second before flipping to Connected, because the per-user credential checks only ran after the whole tool-count fetch had finished. The credential checks now fire in parallel with the tool-count load, and each OAuth card shows a skeleton in its button slot until its own status resolves, so the connect/connected state never flips under the user. Batching the status into the `/v1/mcp/server` response is a separate backend/schema optimization still left out to keep this change UI-only

## QA runbook

Follow the numbered steps above. Also confirm that visiting `/ui/chat/integrations` with no `connect_flow` param shows no banner, keeps the Beta badge and tool-count chrome, and behaves exactly as before

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
