### PR TITLE
fix(bedrock): drop toolSpec.strict for Claude Sonnet 5 on Converse

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -1759,6 +1759,7 @@
         "prompt_cache_min_tokens": 2048
     },
     "anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.5e-06,
         "cache_creation_input_token_cost_above_1hr": 4e-06,
         "cache_read_input_token_cost": 2e-07,
@@ -1795,6 +1796,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "global.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.5e-06,
         "cache_creation_input_token_cost_above_1hr": 4e-06,
         "cache_read_input_token_cost": 2e-07,
@@ -1831,6 +1833,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "us.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.75e-06,
         "cache_creation_input_token_cost_above_1hr": 4.4e-06,
         "cache_read_input_token_cost": 2.2e-07,
@@ -1867,6 +1870,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "eu.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.75e-06,
         "cache_creation_input_token_cost_above_1hr": 4.4e-06,
         "cache_read_input_token_cost": 2.2e-07,
@@ -1903,6 +1907,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "au.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.75e-06,
         "cache_creation_input_token_cost_above_1hr": 4.4e-06,
         "cache_read_input_token_cost": 2.2e-07,
@@ -1939,6 +1944,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "jp.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.75e-06,
         "cache_creation_input_token_cost_above_1hr": 4.4e-06,
         "cache_read_input_token_cost": 2.2e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -1759,6 +1759,7 @@
         "prompt_cache_min_tokens": 2048
     },
     "anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.5e-06,
         "cache_creation_input_token_cost_above_1hr": 4e-06,
         "cache_read_input_token_cost": 2e-07,
@@ -1795,6 +1796,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "global.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.5e-06,
         "cache_creation_input_token_cost_above_1hr": 4e-06,
         "cache_read_input_token_cost": 2e-07,
@@ -1831,6 +1833,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "us.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.75e-06,
         "cache_creation_input_token_cost_above_1hr": 4.4e-06,
         "cache_read_input_token_cost": 2.2e-07,
@@ -1867,6 +1870,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "eu.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.75e-06,
         "cache_creation_input_token_cost_above_1hr": 4.4e-06,
         "cache_read_input_token_cost": 2.2e-07,
@@ -1903,6 +1907,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "au.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.75e-06,
         "cache_creation_input_token_cost_above_1hr": 4.4e-06,
         "cache_read_input_token_cost": 2.2e-07,
@@ -1939,6 +1944,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "jp.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.75e-06,
         "cache_creation_input_token_cost_above_1hr": 4.4e-06,
         "cache_read_input_token_cost": 2.2e-07,

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py
@@ -1,9 +1,9 @@
 """Regression tests for Bedrock Converse ``toolSpec.strict`` forwarding.
 
-Bedrock Converse routes Claude Opus 4.7/4.8 and Claude Sonnet 4 through an
-Anthropic-compatible validator that rejects ``toolSpec.strict`` even though
-Anthropic's native API accepts ``strict`` as a top-level tool field. See
-BerriAI/litellm#31582.
+Bedrock Converse routes Claude Opus 4.7/4.8, Claude Sonnet 4 and Claude
+Sonnet 5 through an Anthropic-compatible validator that rejects
+``toolSpec.strict`` even though Anthropic's native API accepts ``strict``
+as a top-level tool field. See BerriAI/litellm#31582.
 """
 
 import pytest
@@ -48,12 +48,18 @@ _STRICT_TOOL = [
         "bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0",
         "bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0",
         "bedrock/apac.anthropic.claude-sonnet-4-20250514-v1:0",
+        "anthropic.claude-sonnet-5",
+        "bedrock/global.anthropic.claude-sonnet-5",
+        "bedrock/us.anthropic.claude-sonnet-5",
+        "bedrock/eu.anthropic.claude-sonnet-5",
+        "bedrock/au.anthropic.claude-sonnet-5",
+        "bedrock/jp.anthropic.claude-sonnet-5",
     ],
 )
 def test_bedrock_tools_pt_strict_dropped_for_strict_unsupported_models(
     model_id: str,
 ) -> None:
-    """Opus 4.7/4.8 and Sonnet 4 reject toolSpec.strict and additionalProperties."""
+    """Opus 4.7/4.8, Sonnet 4 and Sonnet 5 reject toolSpec.strict and additionalProperties."""
     result = _bedrock_tools_pt(_STRICT_TOOL, model=model_id)
     tool_spec = result[0]["toolSpec"]
     assert (
@@ -129,6 +135,11 @@ def test_bedrock_converse_supports_strict_tools_helper() -> None:
         )
         is False
     )
+    assert bedrock_converse_supports_strict_tools("anthropic.claude-sonnet-5") is False
+    assert (
+        bedrock_converse_supports_strict_tools("bedrock/us.anthropic.claude-sonnet-5")
+        is False
+    )
 
 
 @pytest.mark.parametrize(
@@ -143,6 +154,12 @@ def test_bedrock_converse_supports_strict_tools_helper() -> None:
         "us.anthropic.claude-sonnet-4-20250514-v1:0",
         "eu.anthropic.claude-sonnet-4-20250514-v1:0",
         "apac.anthropic.claude-sonnet-4-20250514-v1:0",
+        "anthropic.claude-sonnet-5",
+        "global.anthropic.claude-sonnet-5",
+        "us.anthropic.claude-sonnet-5",
+        "eu.anthropic.claude-sonnet-5",
+        "au.anthropic.claude-sonnet-5",
+        "jp.anthropic.claude-sonnet-5",
     ],
 )
 def test_strict_tools_flag_set_in_model_cost_map(cost_map_key: str) -> None:


### PR DESCRIPTION
## Relevant issues

Fixes #33193

## Linear ticket
Resolves LIT-4261

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

Note on CI: after retargeting to litellm_oss_daily_2026_07_20 and rebasing, `auth-and-jwt` and `Block fork dependency changes` pass. The only red check is `osv-scan`, which flags two freshly published advisories in UI dev dependencies (`brace-expansion`, GHSA-3jxr-9vmj-r5cp and `js-yaml`, GHSA-52cp-r559-cp3m in `ui/litellm-dashboard/package-lock.json`); it fails the same way on sibling PRs #34083, #34067 and #34034, and fork PRs are not allowed to modify lockfiles per the `Block fork dependency changes` policy, so the bump has to happen in the canonical repository

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The branch was later rebased onto litellm_oss_daily_2026_07_20 to satisfy the uv.lock parity check; the proof runs below were captured at the pre-rebase commits referenced in each section (`10d5804b3e` before, `2eee00e0f8` after) and the rebased head `c2e887b2a2` carries the identical diff

Real Bedrock calls against `us.anthropic.claude-sonnet-5` in us-east-1, proxy started with `LITELLM_LOCAL_MODEL_COST_MAP=True` so the local cost map (where this fix lives) is used instead of the remote one. Config:

```yaml
model_list:
  - model_name: claude-sonnet
    litellm_params:
      model: bedrock/us.anthropic.claude-sonnet-5
      aws_region_name: us-east-1

general_settings:
  master_key: sk-1234
```

Before, at base commit `10d5804b3e` (litellm_oss_daily_2026_07_13). Tool definition contains `strict` and Bedrock rejects the request:

```bash
$ curl -sS http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{
    "model": "claude-sonnet",
    "messages": [{"role": "user", "content": "what is the weather in Prague? use the tool"}],
    "max_tokens": 100,
    "tools": [{"type": "function", "function": {"name": "get_weather", "description": "Get the weather for a city", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}, "strict": true}}]
  }'

{"error":{"message":"litellm.BadRequestError: BedrockException - {\"message\":\"The model returned the following errors: tools.0.custom.strict: Extra inputs are not permitted\"}. Received Model Group=claude-sonnet\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
```

Before, same commit `10d5804b3e`, `/v1/responses` with no `strict` anywhere in the request; the Responses to ChatCompletions bridge inserts the field itself, so this endpoint is broken for this model with no client-side workaround:

```bash
$ curl -sS http://localhost:4000/v1/responses \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{
    "model": "claude-sonnet",
    "input": "what is the weather in Prague? use the tool",
    "tools": [{"type": "function", "name": "get_weather", "description": "Get the weather for a city", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}]
  }'

{"error":{"message":"litellm.BadRequestError: BedrockException - {\"message\":\"The model returned the following errors: tools.0.custom.strict: Extra inputs are not permitted\"}. Received Model Group=claude-sonnet\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
```

After, at fix commit `2eee00e0f8`, identical chat completions request now returns a real tool call:

```bash
{"id":"chatcmpl-8284e712-b85d-4ae0-b5d1-7528f6538703","created":1784022777,"model":"claude-sonnet","object":"chat.completion","choices":[{"finish_reason":"tool_calls","index":0,"message":{"content":"","role":"assistant","tool_calls":[{"index":0,"function":{"arguments":"{\"city\": \"Prague\"}","name":"get_weather"},"id":"tooluse_kUJAnoxDYhw0MVoHDlYqRT","type":"function"}]}}],"usage":{"completion_tokens":50,"prompt_tokens":444,"total_tokens":494,...}}
```

After, same commit `2eee00e0f8`, identical `/v1/responses` request also succeeds; output contains the function call (response id and message item trimmed for brevity):

```bash
{"id":"resp_...","created_at":1784022840,"model":"claude-sonnet","object":"response","output":[{"type":"message",...},{"type":"function_call","name":"get_weather","arguments":"{\"city\": \"Prague\"}",...}],...}
```

Control checks from the same proxy: the chat completions request without the `strict` key succeeds on both commits, and `strict` is still forwarded for models that accept it (covered by the `test_bedrock_tools_pt_strict_kept_for_other_anthropic` cases)

## Type

🐛 Bug Fix

## Changes

Same shape as the #31582 fix for Opus 4.7/4.8. Bedrock routes Claude Sonnet 5 through the Anthropic-compatible validator that rejects `toolSpec.strict`, but the six Sonnet 5 entries (`anthropic.claude-sonnet-5` plus `global.`/`us.`/`eu.`/`au.`/`jp.` inference profiles) never got the `bedrock_converse_supports_strict_tools: false` flag, so the gate in `bedrock_converse_supports_strict_tools()` fell back to its forward-by-default behavior for Anthropic models and every tool call carrying `strict` 400'd

This PR sets `bedrock_converse_supports_strict_tools: false` on those six entries in both `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json`, and extends the existing regression test file `tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py` with the Sonnet 5 cases (13 new parametrized cases across `_bedrock_tools_pt`, the `bedrock_converse_supports_strict_tools` helper and the cost map flag check). The new cases fail on the base commit and pass with the fix; the full file is 40 passed

