### PR TITLE
fix(mcp): hide upstream mcp server urls and auth details in public mcp hub

### DIFF
--- a/litellm/proxy/public_endpoints/public_endpoints.py
+++ b/litellm/proxy/public_endpoints/public_endpoints.py
@@ -20,7 +20,7 @@ from litellm.proxy._types import (
 from litellm.proxy.utils import get_custom_url
 from litellm.repositories.table_repositories import ClaudeCodePluginRepository
 from litellm.types.agents import AgentCard
-from litellm.types.mcp import MCPPublicServer
+from litellm.types.mcp import MCPPublicServer, MCPPublicServerInfo
 from litellm.types.proxy.management_endpoints.model_management_endpoints import (
     ModelGroupInfoProxy,
 )
@@ -237,7 +237,16 @@ async def get_mcp_servers():
     public_mcp_servers = global_mcp_server_manager.get_public_mcp_servers()
     return [
         MCPPublicServer(
-            **server.model_dump(),
+            server_id=server.server_id,
+            name=server.name,
+            alias=server.alias,
+            server_name=server.server_name,
+            transport=server.transport,
+            mcp_info=(
+                MCPPublicServerInfo(description=server.mcp_info["description"])
+                if server.mcp_info and server.mcp_info.get("description")
+                else None
+            ),
         )
         for server in public_mcp_servers
     ]

--- a/litellm/types/mcp.py
+++ b/litellm/types/mcp.py
@@ -70,6 +70,10 @@ MCPAuthType = Optional[
 ]
 
 
+class MCPPublicServerInfo(BaseModel):
+    description: Optional[str] = None
+
+
 class MCPPublicServer(BaseModel):
     """
     Safe params for public MCP servers
@@ -80,9 +84,7 @@ class MCPPublicServer(BaseModel):
     alias: Optional[str] = None
     server_name: Optional[str] = None
     transport: MCPTransportType
-    spec_path: Optional[str] = None
-    auth_type: Optional[MCPAuthType] = None
-    mcp_info: Optional[Dict[str, Any]] = None
+    mcp_info: Optional[MCPPublicServerInfo] = None
 
 
 # OAuth 2.0 token-endpoint client authentication method (RFC 6749 section 2.3.1).

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -875,12 +875,16 @@ def test_public_mcp_hub_does_not_expose_upstream_url():
     client = TestClient(app)
 
     secret_url = "https://internal-only.example.com/mcp"
+    secret_mcp_info_url = "https://internal-only.example.com/metadata"
+    public_description = "Public server description"
     server = MCPServer(
         server_id="listed",
         name="listed",
         server_name="listed",
         url=secret_url,
         transport=MCPTransport.http,
+        auth_type="api_key",
+        mcp_info={"description": public_description, "upstream_url": secret_mcp_info_url},
         available_on_public_internet=True,
     )
 
@@ -899,6 +903,9 @@ def test_public_mcp_hub_does_not_expose_upstream_url():
     assert response.status_code == 200
     data = response.json()
     assert [item["server_id"] for item in data] == ["listed"]
+    assert data[0]["mcp_info"] == {"description": public_description}
     assert all("url" not in item for item in data)
+    assert all("auth_type" not in item for item in data)
     assert secret_url not in response.text
+    assert secret_mcp_info_url not in response.text
     app.dependency_overrides.clear()

--- a/ui/litellm-dashboard/src/components/PublicModelHubTableColumns.tsx
+++ b/ui/litellm-dashboard/src/components/PublicModelHubTableColumns.tsx
@@ -61,14 +61,9 @@ export interface MCPServerData {
   alias?: string | null;
   server_name: string;
   transport: string;
-  spec_path?: string | null;
-  auth_type: string;
-  mcp_info: {
-    server_name: string;
+  mcp_info?: {
     description?: string;
-    mcp_server_cost_info?: any;
-  };
-  [key: string]: any;
+  } | null;
 }
 
 const formatCapabilityName = (key: string) =>
@@ -453,18 +448,6 @@ export const getPublicMCPHubColumns = ({ onServerClick }: PublicMCPHubColumnsDep
       <Badge variant="secondary" className="font-mono font-normal uppercase">
         {row.original.transport}
       </Badge>
-    ),
-  },
-  {
-    id: "auth_type",
-    accessorKey: "auth_type",
-    meta: { title: "Auth Type", skeleton: "badge" },
-    header: ({ column }) => <DataTableSortHeader column={column} title="Auth Type" />,
-    size: 110,
-    enableSorting: true,
-    sortingFn: "alphanumeric",
-    cell: ({ row }) => (
-      <StatusBadge tone={row.original.auth_type === "none" ? "neutral" : "success"} label={row.original.auth_type} />
     ),
   },
 ];

--- a/ui/litellm-dashboard/src/components/public_model_hub.test.tsx
+++ b/ui/litellm-dashboard/src/components/public_model_hub.test.tsx
@@ -156,10 +156,8 @@ const mockMcpServer: MCPServerData = {
   server_id: "server-1",
   name: "exa_test",
   server_name: "exa_test",
-  url: PUBLIC_SERVER_URL,
   transport: "http",
-  auth_type: "none",
-  mcp_info: { server_name: "exa_test", description: "Fast, intelligent web search and web crawling" },
+  mcp_info: { description: "Public server description" },
 };
 
 function PublicMcpTestTable({ data }: { data: MCPServerData[] }) {
@@ -194,36 +192,62 @@ describe("publicMCPHubColumns", () => {
   it("keeps the non-sensitive columns", () => {
     render(<PublicMcpTestTable data={[mockMcpServer]} />);
     expect(screen.getByText("Server Name")).toBeInTheDocument();
+    expect(screen.getByText("Description")).toBeInTheDocument();
     expect(screen.getByText("Transport")).toBeInTheDocument();
-    expect(screen.getByText("Auth Type")).toBeInTheDocument();
   });
 
-  it("does not expose a URL column header", () => {
+  it("does not expose URL or auth type column headers", () => {
     render(<PublicMcpTestTable data={[mockMcpServer]} />);
     expect(screen.queryByText("URL")).not.toBeInTheDocument();
     const columns = getPublicMCPHubColumns({ onServerClick: vi.fn() });
     expect(columns.some((c) => c.header === "URL" || c.meta?.title === "URL")).toBe(false);
+    expect(screen.queryByText("Auth Type")).not.toBeInTheDocument();
+    expect(columns.some((c) => c.header === "Auth Type" || c.meta?.title === "Auth Type")).toBe(false);
   });
 
-  it("does not render the server url anywhere in the table", () => {
-    render(<PublicMcpTestTable data={[mockMcpServer]} />);
+  it("does not render private response fields in the table", () => {
+    const serverWithPrivateData = {
+      ...mockMcpServer,
+      url: PUBLIC_SERVER_URL,
+      auth_type: "api_key",
+      mcp_info: {
+        description: "Public server description",
+        upstream_url: "https://internal.example.com/mcp",
+      },
+    };
+
+    render(<PublicMcpTestTable data={[serverWithPrivateData]} />);
     expect(screen.queryByText(PUBLIC_SERVER_URL)).not.toBeInTheDocument();
+    expect(screen.queryByText("api_key")).not.toBeInTheDocument();
+    expect(screen.queryByText("https://internal.example.com/mcp")).not.toBeInTheDocument();
   });
 });
 
 describe("public hub MCP details modal", () => {
-  it("does not show the upstream url when a server is opened", async () => {
+  it("only shows the LiteLLM proxy endpoint when a server is opened", async () => {
     const networkingModule = await import("./networking");
-    vi.mocked(networkingModule.mcpHubPublicServersCall).mockResolvedValue([mockMcpServer]);
+    vi.mocked(networkingModule.mcpHubPublicServersCall).mockResolvedValue([
+      {
+        ...mockMcpServer,
+        url: PUBLIC_SERVER_URL,
+        auth_type: "api_key",
+        mcp_info: {
+          description: "Public server description",
+          upstream_url: "https://internal.example.com/mcp",
+        },
+      },
+    ]);
 
     render(<PublicModelHub />);
 
     fireEvent.click(await screen.findByRole("tab", { name: /MCP Hub/i }));
     fireEvent.click(await screen.findByRole("button", { name: "exa_test" }));
 
-    // "Server Overview" only exists inside the opened MCP details modal,
-    // so finding it proves the modal rendered and the url assertion is not vacuous.
     await screen.findByText("Server Overview");
+    expect(screen.getAllByText("Public server description")).not.toHaveLength(0);
     expect(screen.queryByText(PUBLIC_SERVER_URL)).not.toBeInTheDocument();
+    expect(screen.queryByText("api_key")).not.toBeInTheDocument();
+    expect(screen.queryByText("https://internal.example.com/mcp")).not.toBeInTheDocument();
+    expect(screen.getByText((content) => content.includes("/exa_test/mcp"))).toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/components/public_model_hub.tsx
+++ b/ui/litellm-dashboard/src/components/public_model_hub.tsx
@@ -1411,28 +1411,12 @@ print(response.model_dump(mode='json', exclude_none=True))`;
                       <Text>{selectedMcpServer.alias}</Text>
                     </div>
                   )}
-                  <div>
-                    <Text className="font-medium">Auth Type:</Text>
-                    <Tag color={selectedMcpServer.auth_type === "none" ? "gray" : "green"}>
-                      {selectedMcpServer.auth_type}
-                    </Tag>
-                  </div>
                   <div className="col-span-2">
                     <Text className="font-medium">Description:</Text>
                     <Text>{selectedMcpServer.mcp_info?.description || "-"}</Text>
                   </div>
                 </div>
               </div>
-
-              {/* Additional Info */}
-              {selectedMcpServer.mcp_info && Object.keys(selectedMcpServer.mcp_info).length > 0 && (
-                <div>
-                  <Text className="text-lg font-semibold mb-4">Additional Information</Text>
-                  <div className="bg-gray-50 p-4 rounded-lg">
-                    <pre className="text-xs overflow-x-auto">{JSON.stringify(selectedMcpServer.mcp_info, null, 2)}</pre>
-                  </div>
-                </div>
-              )}
 
               {/* Usage Example */}
               <div>

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -27302,25 +27302,23 @@ export interface components {
         MCPPublicServer: {
             /** Alias */
             alias?: string | null;
-            /** Auth Type */
-            auth_type?: ("none" | "api_key" | "bearer_token" | "basic" | "authorization" | "oauth2" | "aws_sigv4" | "token" | "oauth2_token_exchange" | "oauth2_id_jag" | "true_passthrough" | "oauth_delegate") | null;
-            /** Mcp Info */
-            mcp_info?: {
-                [key: string]: unknown;
-            } | null;
+            mcp_info?: components["schemas"]["MCPPublicServerInfo"] | null;
             /** Name */
             name: string;
             /** Server Id */
             server_id: string;
             /** Server Name */
             server_name?: string | null;
-            /** Spec Path */
-            spec_path?: string | null;
             /**
              * Transport
              * @enum {string}
              */
             transport: "sse" | "http" | "stdio";
+        };
+        /** MCPPublicServerInfo */
+        MCPPublicServerInfo: {
+            /** Description */
+            description?: string | null;
         };
         /**
          * MCPSemanticFilterSettings


### PR DESCRIPTION
## Relevant issues

Fixes #30472

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->
<img width="1409" height="531" alt="Screenshot 2026-07-14 at 16 33 48" src="https://github.com/user-attachments/assets/b9c4d104-a40e-444d-9b1f-a009d018e8a4" />


## Type
🐛 Bug Fix

## Changes

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->
N/A

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
