### PR TITLE
fix(anthropic): drop non-1 temperature when downgrading adaptive thinking

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -364,6 +364,8 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
 
         if capped_thinking is not None:
             optional_params["thinking"] = capped_thinking
+            if capped_thinking.get("type") == "enabled" and optional_params.get("temperature") != 1:
+                optional_params.pop("temperature", None)
         else:
             verbose_logger.warning(DROP_UNSUPPORTED_ADAPTIVE_EFFORT_WARNING, model)
             optional_params.pop("thinking", None)

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_effort.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_effort.py
@@ -45,6 +45,32 @@ def test_effort_translated_to_legacy_thinking_for_haiku_4_5():
     assert "output_config" not in result
 
 
+def test_non_1_temperature_dropped_for_legacy_thinking_on_haiku_4_5():
+    result = _transform(
+        "claude-haiku-4-5",
+        {**_claude_code_payload(effort="medium"), "temperature": 0},
+    )
+
+    assert result["thinking"] == {
+        "type": "enabled",
+        "budget_tokens": DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
+    }
+    assert "temperature" not in result
+
+
+def test_temperature_1_preserved_for_legacy_thinking_on_haiku_4_5():
+    result = _transform(
+        "claude-haiku-4-5",
+        {**_claude_code_payload(effort="medium"), "temperature": 1},
+    )
+
+    assert result["thinking"] == {
+        "type": "enabled",
+        "budget_tokens": DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
+    }
+    assert result["temperature"] == 1
+
+
 def test_effort_high_maps_to_high_budget_for_sonnet_4_5():
     result = _transform("claude-sonnet-4-5", _claude_code_payload(effort="high"))
 
@@ -61,6 +87,17 @@ def test_adaptive_effort_passes_through_untouched_for_4_6():
 
     assert result["thinking"] == {"type": "adaptive"}
     assert result["output_config"] == {"effort": "high"}
+
+
+def test_non_1_temperature_preserved_for_adaptive_thinking_on_4_6():
+    result = _transform(
+        "claude-sonnet-4-6",
+        {**_claude_code_payload(effort="high"), "temperature": 0},
+    )
+
+    assert result["thinking"] == {"type": "adaptive"}
+    assert result["output_config"] == {"effort": "high"}
+    assert result["temperature"] == 0
 
 
 def test_thinking_and_effort_dropped_for_non_reasoning_model():


### PR DESCRIPTION
## Summary
When adaptive thinking is downgraded to legacy extended thinking for pre-4.6 Anthropic models, drop a non-1 temperature so the request is not rejected by Anthropic.

## Changes
- In `_translate_adaptive_effort_for_non_adaptive_model`, after setting legacy `thinking.type=enabled`, remove `temperature` when it is present and not `1`
- Leave temperature untouched for adaptive-capable models and when thinking is dropped entirely
- Add regression tests for Haiku 4.5 (drop/preserve) and Sonnet 4.6 (preserve temperature with adaptive)

## Verification
- Focused tests in `tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_effort.py`

## Backwards compatibility
No public API changes. Only strips an invalid temperature combination after adaptive-to-legacy translation.

Fixes #33203
