### PR TITLE
fix(responses): flatten forced tool_choice for ResponsesAPIResponse

### DIFF
--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -336,9 +336,16 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         if "text" in self.responses_api_request:
             response_created_event_data["text"] = self.responses_api_request["text"]
         if "tool_choice" in self.responses_api_request:
-            # Transform tool_choice from dict format (e.g., {"type": "auto"}) to string format
+            # Normalize tool_choice to the shape ResponsesAPIResponse.tool_choice
+            # accepts (flat {"type": "function", "name": "..."}), not the Chat
+            # Completion nested {"type": "function", "function": {"name": "..."}}
+            # shape that _transform_tool_choice produces for the outbound provider
+            # call. Reusing that Chat-Completion-shaped value here fails Pydantic
+            # validation for any forced named tool call.
             response_created_event_data["tool_choice"] = (
-                LiteLLMCompletionResponsesConfig._transform_tool_choice(self.responses_api_request["tool_choice"])
+                LiteLLMCompletionResponsesConfig._transform_tool_choice_for_responses_api_response(
+                    self.responses_api_request["tool_choice"]
+                )
                 or "auto"
             )
         else:

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -336,12 +336,8 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         if "text" in self.responses_api_request:
             response_created_event_data["text"] = self.responses_api_request["text"]
         if "tool_choice" in self.responses_api_request:
-            # Normalize tool_choice to the shape ResponsesAPIResponse.tool_choice
-            # accepts (flat {"type": "function", "name": "..."}), not the Chat
-            # Completion nested {"type": "function", "function": {"name": "..."}}
-            # shape that _transform_tool_choice produces for the outbound provider
-            # call. Reusing that Chat-Completion-shaped value here fails Pydantic
-            # validation for any forced named tool call.
+            # Use the Responses-API-shaped value here, not _transform_tool_choice's
+            # Chat Completion shape, or forced named tool calls fail Pydantic validation.
             response_created_event_data["tool_choice"] = (
                 LiteLLMCompletionResponsesConfig._transform_tool_choice_for_responses_api_response(
                     self.responses_api_request["tool_choice"]

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -186,26 +186,33 @@ class LiteLLMCompletionResponsesConfig:
         ``{"type": "function", "name": "..."}``, not Chat Completion's
         nested ``{"type": "function", "function": {"name": "..."}}``.
 
+        Delegates to ``_transform_tool_choice`` first to normalize any
+        Cursor-IDE-style dict input (e.g. {"type": "tool"}, {"type":
+        "function"} without a name) into a string or the Chat Completion
+        nested shape, then rewrites only the nested-function case into the
+        flat Responses API shape.
+
         Handles:
         - String values: "auto", "none", "required" -> pass through as-is
+        - Dict with type only (Cursor IDE format), normalized the same way
+          as _transform_tool_choice: {"type": "auto"/"none"/"required"/
+          "tool"/"any"} -> the corresponding string
         - Chat Completion nested function format:
             - {"type": "function", "function": {"name": "..."}} -> {"type": "function", "name": "..."}
         - Already-flat Responses API format: pass through as-is
         """
-        if tool_choice is None:
-            return None
+        normalized = LiteLLMCompletionResponsesConfig._transform_tool_choice(tool_choice)
 
-        if isinstance(tool_choice, str):
-            return tool_choice
+        if normalized is None or isinstance(normalized, str):
+            return normalized
 
-        if isinstance(tool_choice, dict):
-            if tool_choice.get("type") == "function":
-                function_name = tool_choice.get("function", {}).get("name") or tool_choice.get("name")
-                if function_name:
-                    return {"type": "function", "name": function_name}
+        if isinstance(normalized, dict) and normalized.get("type") == "function":
+            function_name = normalized.get("function", {}).get("name") or normalized.get("name")
+            if function_name:
+                return {"type": "function", "name": function_name}
 
         # Return as-is for unknown formats
-        return tool_choice
+        return normalized
 
     @staticmethod
     def _should_drop_derived_web_search_options(model: str, custom_llm_provider: str | None) -> bool:

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -171,35 +171,11 @@ class LiteLLMCompletionResponsesConfig:
         tool_choice: Any,
     ) -> str | dict[str, Any] | None:
         """
-        Transform tool_choice into the shape the Responses API's own
-        ``ResponsesAPIResponse.tool_choice`` field accepts.
-
-        This is the inverse of ``_transform_tool_choice``: that function
-        converts an incoming Responses-API-shaped tool_choice into Chat
-        Completion format so it can be sent to the provider. But the
-        streaming iterator also needs a tool_choice value to echo back on
-        the synthetic ``response.created``/``response.in_progress`` events,
-        and those events are validated against the Responses API schema, not
-        the Chat Completion one. Reusing the Chat-Completion-shaped value
-        there fails validation for a forced named tool call, since OpenAI's
-        Responses API ``ToolChoiceFunctionParam`` is the flat
-        ``{"type": "function", "name": "..."}``, not Chat Completion's
-        nested ``{"type": "function", "function": {"name": "..."}}``.
-
-        Delegates to ``_transform_tool_choice`` first to normalize any
-        Cursor-IDE-style dict input (e.g. {"type": "tool"}, {"type":
-        "function"} without a name) into a string or the Chat Completion
-        nested shape, then rewrites only the nested-function case into the
-        flat Responses API shape.
-
-        Handles:
-        - String values: "auto", "none", "required" -> pass through as-is
-        - Dict with type only (Cursor IDE format), normalized the same way
-          as _transform_tool_choice: {"type": "auto"/"none"/"required"/
-          "tool"/"any"} -> the corresponding string
-        - Chat Completion nested function format:
-            - {"type": "function", "function": {"name": "..."}} -> {"type": "function", "name": "..."}
-        - Already-flat Responses API format: pass through as-is
+        Inverse of ``_transform_tool_choice``: normalizes tool_choice into the
+        shape ``ResponsesAPIResponse.tool_choice`` accepts (flat
+        ``{"type": "function", "name": "..."}``), not Chat Completion's nested
+        ``{"type": "function", "function": {"name": "..."}}``, which fails
+        Pydantic validation on this field.
         """
         normalized = LiteLLMCompletionResponsesConfig._transform_tool_choice(tool_choice)
 

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -167,6 +167,47 @@ class LiteLLMCompletionResponsesConfig:
         return tool_choice
 
     @staticmethod
+    def _transform_tool_choice_for_responses_api_response(
+        tool_choice: Any,
+    ) -> str | dict[str, Any] | None:
+        """
+        Transform tool_choice into the shape the Responses API's own
+        ``ResponsesAPIResponse.tool_choice`` field accepts.
+
+        This is the inverse of ``_transform_tool_choice``: that function
+        converts an incoming Responses-API-shaped tool_choice into Chat
+        Completion format so it can be sent to the provider. But the
+        streaming iterator also needs a tool_choice value to echo back on
+        the synthetic ``response.created``/``response.in_progress`` events,
+        and those events are validated against the Responses API schema, not
+        the Chat Completion one. Reusing the Chat-Completion-shaped value
+        there fails validation for a forced named tool call, since OpenAI's
+        Responses API ``ToolChoiceFunctionParam`` is the flat
+        ``{"type": "function", "name": "..."}``, not Chat Completion's
+        nested ``{"type": "function", "function": {"name": "..."}}``.
+
+        Handles:
+        - String values: "auto", "none", "required" -> pass through as-is
+        - Chat Completion nested function format:
+            - {"type": "function", "function": {"name": "..."}} -> {"type": "function", "name": "..."}
+        - Already-flat Responses API format: pass through as-is
+        """
+        if tool_choice is None:
+            return None
+
+        if isinstance(tool_choice, str):
+            return tool_choice
+
+        if isinstance(tool_choice, dict):
+            if tool_choice.get("type") == "function":
+                function_name = tool_choice.get("function", {}).get("name") or tool_choice.get("name")
+                if function_name:
+                    return {"type": "function", "name": function_name}
+
+        # Return as-is for unknown formats
+        return tool_choice
+
+    @staticmethod
     def _should_drop_derived_web_search_options(model: str, custom_llm_provider: str | None) -> bool:
         """
         A Responses ``web_search`` built-in tool is derived into a ``web_search_options`` param.
@@ -1617,7 +1658,10 @@ class LiteLLMCompletionResponsesConfig:
             ),
             parallel_tool_calls=getattr(chat_completion_response, "parallel_tool_calls", False),
             temperature=getattr(chat_completion_response, "temperature", 0),
-            tool_choice=getattr(chat_completion_response, "tool_choice", "auto"),
+            tool_choice=LiteLLMCompletionResponsesConfig._transform_tool_choice_for_responses_api_response(
+                getattr(chat_completion_response, "tool_choice", "auto")
+            )
+            or "auto",
             tools=getattr(chat_completion_response, "tools", []),
             top_p=getattr(chat_completion_response, "top_p", None),
             max_output_tokens=getattr(chat_completion_response, "max_output_tokens", None),

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -168,7 +168,7 @@ class LiteLLMCompletionResponsesConfig:
 
     @staticmethod
     def _transform_tool_choice_for_responses_api_response(
-        tool_choice: Any,
+        tool_choice: str | dict[str, Any] | None,
     ) -> str | dict[str, Any] | None:
         """
         Inverse of ``_transform_tool_choice``: normalizes tool_choice into the

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -5,7 +5,7 @@ Handles transforming from Responses API -> LiteLLM completion  (Chat Completion 
 import json
 import re
 from collections.abc import Sequence
-from typing import Any, Literal, cast
+from typing import Any, Literal, Mapping, cast
 
 from openai.types.responses import ResponseFunctionToolCall
 from openai.types.responses.response_create_params import ResponseInputParam
@@ -168,8 +168,8 @@ class LiteLLMCompletionResponsesConfig:
 
     @staticmethod
     def _transform_tool_choice_for_responses_api_response(
-        tool_choice: str | dict[str, Any] | None,
-    ) -> str | dict[str, Any] | None:
+        tool_choice: str | Mapping[str, Any] | None,
+    ) -> str | Mapping[str, Any] | None:
         """
         Inverse of ``_transform_tool_choice``: normalizes tool_choice into the
         shape ``ResponsesAPIResponse.tool_choice`` accepts (flat

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -2845,6 +2845,52 @@ class TestToolChoiceForResponsesAPIResponse:
     def test_transform_tool_choice_for_responses_api_response_none(self):
         assert LiteLLMCompletionResponsesConfig._transform_tool_choice_for_responses_api_response(None) is None
 
+    def test_transform_tool_choice_for_responses_api_response_normalizes_cursor_ide_dict_modes(self):
+        """
+        Cursor IDE dict modes like {"type": "tool"} or {"type": "function"} without a
+        name must still be normalized to a valid Literal string, not passed through
+        unchanged - regression for a review finding on the initial fix, which only
+        handled the named-function case and let these fall through to "return as-is",
+        failing ResponsesAPIResponse's Pydantic validation just like the original bug.
+        """
+        cases = {
+            "auto": "auto",
+            "none": "none",
+            "required": "required",
+            "tool": "required",
+            "any": "required",
+            "function": "required",  # "function" type with no name - same as "tool"
+        }
+        for type_value, expected in cases.items():
+            result = LiteLLMCompletionResponsesConfig._transform_tool_choice_for_responses_api_response(
+                {"type": type_value}
+            )
+            assert result == expected, f"type={type_value!r} expected {expected!r}, got {result!r}"
+
+    def test_transform_tool_choice_for_responses_api_response_cursor_ide_dict_modes_do_not_crash_validation(self):
+        """
+        Every Cursor-IDE-style dict mode must produce a value ResponsesAPIResponse
+        actually accepts, not just a normalized-looking one.
+        """
+        import time
+
+        from litellm.types.llms.openai import ResponsesAPIResponse
+
+        for type_value in ("auto", "none", "required", "tool", "any", "function"):
+            normalized = LiteLLMCompletionResponsesConfig._transform_tool_choice_for_responses_api_response(
+                {"type": type_value}
+            )
+            ResponsesAPIResponse(
+                id="resp_1",
+                created_at=int(time.time()),
+                model="x",
+                object="response",
+                output=[],
+                parallel_tool_calls=True,
+                tool_choice=normalized,
+                tools=[],
+            )
+
     def test_streaming_response_created_event_does_not_crash_on_forced_tool_choice(self):
         """
         Regression test for the exact crash: building the synthetic

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -2811,3 +2811,99 @@ def test_function_call_tool_id_falls_back_to_unique_id_for_degenerate_call_id():
         id="fc_2", call_id="call_tokyo", name="get_weather", arguments="{}"
     )
     assert convert(openai)["id"] == "call_tokyo"
+
+
+class TestToolChoiceForResponsesAPIResponse:
+    """
+    Forcing a named tool call (e.g. {"type": "function", "function": {"name": "..."}},
+    the Chat Completion shape) crashed ResponsesAPIResponse's Pydantic validation
+    (one error per member of the tool_choice union), since that field only accepts
+    strings or the flat Responses API shape ({"type": "function", "name": "..."}).
+    Reproduced on Bedrock/Anthropic models, which route through this litellm_completion
+    bridge for the Responses API (OpenAI/Azure models use a native Responses API path
+    and never hit this code).
+    """
+
+    def test_transform_tool_choice_for_responses_api_response_rewrites_chat_completion_shape(self):
+        result = LiteLLMCompletionResponsesConfig._transform_tool_choice_for_responses_api_response(
+            {"type": "function", "function": {"name": "delivery_gpt_web_search_tool"}}
+        )
+        assert result == {"type": "function", "name": "delivery_gpt_web_search_tool"}
+
+    def test_transform_tool_choice_for_responses_api_response_passes_through_flat_shape(self):
+        result = LiteLLMCompletionResponsesConfig._transform_tool_choice_for_responses_api_response(
+            {"type": "function", "name": "delivery_gpt_web_search_tool"}
+        )
+        assert result == {"type": "function", "name": "delivery_gpt_web_search_tool"}
+
+    def test_transform_tool_choice_for_responses_api_response_passes_through_strings(self):
+        for value in ("auto", "none", "required"):
+            assert (
+                LiteLLMCompletionResponsesConfig._transform_tool_choice_for_responses_api_response(value) == value
+            )
+
+    def test_transform_tool_choice_for_responses_api_response_none(self):
+        assert LiteLLMCompletionResponsesConfig._transform_tool_choice_for_responses_api_response(None) is None
+
+    def test_streaming_response_created_event_does_not_crash_on_forced_tool_choice(self):
+        """
+        Regression test for the exact crash: building the synthetic
+        response.created event with a Chat-Completion-shaped forced tool_choice
+        in responses_api_request must not raise a Pydantic ValidationError.
+        """
+        from unittest.mock import Mock
+
+        import litellm
+        from litellm.responses.litellm_completion_transformation.streaming_iterator import (
+            LiteLLMCompletionStreamingIterator,
+        )
+
+        mock_stream_wrapper = Mock(spec=litellm.CustomStreamWrapper)
+        mock_stream_wrapper.logging_obj = Mock()
+
+        iterator = LiteLLMCompletionStreamingIterator(
+            model="anthropic/claude-opus-4-6",
+            litellm_custom_stream_wrapper=mock_stream_wrapper,
+            request_input="test",
+            responses_api_request={
+                "tool_choice": {"type": "function", "function": {"name": "delivery_gpt_web_search_tool"}},
+            },
+            custom_llm_provider="anthropic",
+        )
+
+        event = iterator.create_response_created_event()
+
+        assert event.response.tool_choice == {"type": "function", "name": "delivery_gpt_web_search_tool"}
+
+    def test_non_streaming_response_does_not_crash_on_forced_tool_choice(self):
+        """
+        Regression test for the non-streaming path: transforming a Chat
+        Completion response whose tool_choice is the Chat-Completion-nested
+        shape into a ResponsesAPIResponse must not raise a Pydantic ValidationError.
+        """
+        chat_completion_response = ModelResponse(
+            id="chatcmpl-test",
+            created=1234567890,
+            model="anthropic/claude-opus-4-6",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="tool_calls",
+                    index=0,
+                    message=Message(content="", role="assistant"),
+                )
+            ],
+            usage=Usage(prompt_tokens=10, completion_tokens=1, total_tokens=11),
+        )
+        chat_completion_response.tool_choice = {
+            "type": "function",
+            "function": {"name": "delivery_gpt_web_search_tool"},
+        }
+
+        result = LiteLLMCompletionResponsesConfig.transform_chat_completion_response_to_responses_api_response(
+            request_input="test",
+            responses_api_request={},
+            chat_completion_response=chat_completion_response,
+        )
+
+        assert result.tool_choice == {"type": "function", "name": "delivery_gpt_web_search_tool"}


### PR DESCRIPTION
## Relevant issues
https://github.com/BerriAI/litellm/issues/33689

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Reproduced end-to-end against a live Anthropic Claude model through the proxy's `/v1/responses` endpoint with a forced named tool call and `stream: true`. Anthropic is used rather than Bedrock because it is cheaper and exercises the identical code path: neither has a `responses_api_provider_config`, so both fall back to the `litellm_completion` bridge where the bug lives. The crash is on the synthetic `response.created` event that the streaming bridge builds, so streaming is required to hit it

Proxy started with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug`. Identical request on both commits:

```bash
curl -sN -X POST http://localhost:4000/v1/responses \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "anthropic-opus-4-8",
    "stream": true,
    "input": "Search the web for the latest LiteLLM release and summarize it in one sentence",
    "tools": [{"type": "function", "name": "web_search", "description": "Search the web", "parameters": {"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]}}],
    "tool_choice": {"type": "function", "name": "web_search"}
  }'
```

Before the fix, commit `b200d664ee` (parent of this branch): HTTP 500, the stream never starts

```
HTTP 500
{"error":{"message":"12 validation errors for ResponsesAPIResponse\ntool_choice.literal['none','auto','required']\n  Input should be 'none', 'auto' or 'required' [type=literal_error, input_value={'type': 'function', 'fun... {'name': 'web_search'}}, input_type=dict]\n ... \ntool_choice.ToolChoiceFunctionParam.name\n  Field required [type=missing, input_value={'type': 'function', 'fun... {'name': 'web_search'}}, input_type=dict]\n ... \ntool_choice.ToolChoiceShellParam.type\n  Input should be 'shell' [type=literal_error, input_value='function', input_type=str]","type":"None","param":"None","code":"500"}}
```

The `input_value` is the nested Chat Completion shape `{'type': 'function', 'function': {'name': 'web_search'}}` leaking into a field that only accepts the flat Responses API shape

After the fix, commit `50fa768b2c` (this branch HEAD): HTTP 200, the first SSE event is a well-formed `response.created` carrying the flat shape, and the stream proceeds normally

```
HTTP 200
data: {"type":"response.created","response":{"id":"resp_Q1j0AP...","model":"claude-opus-4-8","object":"response","output":[],"parallel_tool_calls":true,"tool_choice":{"name":"web_search","type":"function"},"tools":[{"name":"web_search",...}],"status":"in_progress","store":true},"model":"anthropic-opus-4-8"}

data: {"type":"response.in_progress", ... "tool_choice":{"name":"web_search","type":"function"} ...}

data: {"type":"response.output_item.added", ...}
data: {"type":"response.output_text.delta", "delta":"I can't actually search", ...}
...
```

## Type

🐛 Bug Fix

## Changes

`ResponsesAPIResponse.tool_choice` crashed with 13 Pydantic validation errors whenever a caller forced a named tool call through the `litellm_completion` Responses API bridge. That field only accepts strings (`none`/`auto`/`required`) or the flat Responses API shape `{"type": "function", "name": "..."}`, and the bridge was populating it with Chat Completion's nested `{"type": "function", "function": {"name": "..."}}` shape instead

It reproduces on Bedrock and Anthropic models rather than OpenAI or Azure, which made it look model-specific, but it is really provider-routing-specific: OpenAI, Azure, and xAI get native Responses API handling that never touches this bridge, while Bedrock and Anthropic have no `responses_api_provider_config` and always fall back to it. Any forced named tool call against any Claude variant on Bedrock hits it identically

The root cause is that both the streaming `_default_response_created_event_data` and the non-streaming `transform_chat_completion_response_to_responses_api_response` reused the value from `_transform_tool_choice`, which correctly builds the outbound provider request in Chat Completion shape, to also populate the inbound `ResponsesAPIResponse.tool_choice` field, which needs the Responses API shape

This adds `_transform_tool_choice_for_responses_api_response`, which rewrites the Chat Completion nested shape to the flat Responses API shape and passes strings and already-flat dicts through untouched, then wires it into both call sites. `_transform_tool_choice` stays exactly as it was for the outbound request

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
