### PR TITLE
fix(pricing): replace nonexistent apac.amazon.nova-2-lite-v1:0 with jp.amazon.nova-2-lite-v1:0

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -394,7 +394,7 @@
         "supports_video_input": true,
         "supports_vision": true
     },
-    "apac.amazon.nova-2-lite-v1:0": {
+    "jp.amazon.nova-2-lite-v1:0": {
         "cache_read_input_token_cost": 8.25e-08,
         "input_cost_per_token": 3.3e-07,
         "litellm_provider": "bedrock_converse",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -394,7 +394,7 @@
         "supports_video_input": true,
         "supports_vision": true
     },
-    "apac.amazon.nova-2-lite-v1:0": {
+    "jp.amazon.nova-2-lite-v1:0": {
         "cache_read_input_token_cost": 8.25e-08,
         "input_cost_per_token": 3.3e-07,
         "litellm_provider": "bedrock_converse",


### PR DESCRIPTION
## Relevant issues

Fixes #33211

## Pre-Submission checklist

- [ ] I have added meaningful tests (data-only fix in the pricing maps; no code paths changed)
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Per the [AWS model card for Amazon Nova 2 Lite](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-2-lite.html), the documented geo inference IDs are `us.`, `eu.` and `jp.` (plus `global.`) — there is no APAC geo tier for this model, and Bedrock rejects `apac.amazon.nova-2-lite-v1:0` with `"The provided model identifier is invalid."`

Before (at b200d66):

```
$ LITELLM_LOCAL_MODEL_COST_MAP=True python -c "
import litellm
print('apac.amazon.nova-2-lite-v1:0' in litellm.model_cost)
print('jp.amazon.nova-2-lite-v1:0' in litellm.model_cost)"
True
False
```

After (at e9ded7a):

```
$ LITELLM_LOCAL_MODEL_COST_MAP=True python -c "
import litellm
from litellm import get_model_info
print('apac.amazon.nova-2-lite-v1:0' in litellm.model_cost)
print('jp.amazon.nova-2-lite-v1:0' in litellm.model_cost)
i = get_model_info('bedrock/jp.amazon.nova-2-lite-v1:0')
print(i['input_cost_per_token'], i['output_cost_per_token'])"
False
True
3.3e-07 2.75e-06
```

## Type

🐛 Bug Fix

## Changes

Pure key rename in `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json`: `apac.amazon.nova-2-lite-v1:0` → `jp.amazon.nova-2-lite-v1:0`. Pricing values are unchanged (identical to the `us.`/`eu.` geo entries, which carry the same +10% premium over in-region). The `jp` prefix is already in `get_bedrock_invoke_provider`'s supported region prefixes, so no code change is needed.
