### PR TITLE
fix(mcp): avoid duplicate messages in non-streaming MCP follow-up calls

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -74,6 +74,14 @@ from .custom_tools import (
 
 ########### Initialize Classes used for Responses API  ###########
 TOOL_CALLS_CACHE = InMemoryCache()
+# Sibling cache to TOOL_CALLS_CACHE: preserves any assistant text content that
+# accompanied a tool_call, keyed by tool_call_id. TOOL_CALLS_CACHE only stores
+# the tool_call itself (id/type/function), so a lone `function_call_output`
+# reconstructed purely from TOOL_CALLS_CACHE (no DB session available - see
+# `_transform_responses_api_tool_call_output_to_chat_completion_message`)
+# would otherwise silently drop any text the assistant said alongside the
+# tool call (e.g. "Let me look that up...").
+TOOL_CALL_CONTENT_CACHE = InMemoryCache()
 
 
 class ChatCompletionSession(TypedDict, total=False):
@@ -1116,6 +1124,11 @@ class LiteLLMCompletionResponsesConfig:
             chat_completion_response_message = ChatCompletionResponseMessage(
                 tool_calls=[tool_call_chunk],
                 role="assistant",
+                # Restore any assistant text that accompanied this tool call
+                # (e.g. "Let me look that up...") so it isn't silently
+                # dropped when reconstructing purely from cache (no DB
+                # session available yet for `previous_response_id`).
+                content=TOOL_CALL_CONTENT_CACHE.get_cache(key=tool_call_output.get("call_id") or ""),
             )
             return [chat_completion_response_message, tool_output_message]
 
@@ -1437,11 +1450,22 @@ class LiteLLMCompletionResponsesConfig:
             if isinstance(choice, Choices):
                 if choice.message.tool_calls:
                     all_chat_completion_tools.extend(choice.message.tool_calls)
+                    message_content = choice.message.content
                     for tool_call in choice.message.tool_calls:
                         TOOL_CALLS_CACHE.set_cache(
                             key=tool_call.id,
                             value=tool_call,
                         )
+                        # Preserve any assistant text that accompanied the
+                        # tool call(s) so a later reconstruction from cache
+                        # alone (no DB session yet - see
+                        # `_transform_responses_api_tool_call_output_to_chat_completion_message`)
+                        # doesn't silently drop it.
+                        if message_content:
+                            TOOL_CALL_CONTENT_CACHE.set_cache(
+                                key=tool_call.id,
+                                value=message_content,
+                            )
 
         # Extract custom tool names from the original request
         custom_tool_names: set[str] = set()

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -74,13 +74,9 @@ from .custom_tools import (
 
 ########### Initialize Classes used for Responses API  ###########
 TOOL_CALLS_CACHE = InMemoryCache()
-# Sibling cache to TOOL_CALLS_CACHE: preserves any assistant text content that
-# accompanied a tool_call, keyed by tool_call_id. TOOL_CALLS_CACHE only stores
-# the tool_call itself (id/type/function), so a lone `function_call_output`
-# reconstructed purely from TOOL_CALLS_CACHE (no DB session available - see
-# `_transform_responses_api_tool_call_output_to_chat_completion_message`)
-# would otherwise silently drop any text the assistant said alongside the
-# tool call (e.g. "Let me look that up...").
+# Sibling cache to TOOL_CALLS_CACHE, keyed by tool_call_id: preserves the
+# assistant text content that accompanied the tool call (see
+# `_transform_responses_api_tool_call_output_to_chat_completion_message`).
 TOOL_CALL_CONTENT_CACHE = InMemoryCache()
 
 
@@ -322,6 +318,22 @@ class LiteLLMCompletionResponsesConfig:
     ) -> dict:
         """
         Async hook to get the chain of previous input and output pairs and return a list of Chat Completion messages
+
+        When ``previous_response_id`` is set, ``_messages`` (the new
+        follow-up input, e.g. a bare ``function_call_output``) is merged with
+        ``session_messages`` (history reconstructed from the spend-logs DB).
+        Transforming a lone ``function_call_output`` independently
+        reconstructs a synthetic assistant ``tool_calls`` message from
+        ``TOOL_CALLS_CACHE`` so the tool result isn't orphaned - see
+        ``_transform_responses_api_tool_call_output_to_chat_completion_message``.
+        That reconstruction has no visibility into ``session_messages``, so if
+        the DB session *also* already contains the assistant message for the
+        same ``tool_call_id``, naively concatenating the two produces two
+        back-to-back assistant messages for the same tool_use id, with the
+        real ``tool_result`` immediately after only the second one - which
+        Anthropic rejects with: "tool_use ids were found without tool_result
+        blocks immediately after". We drop the redundant, cache-reconstructed
+        assistant message(s) before combining to avoid this.
         """
         chat_completion_session = ChatCompletionSession(messages=[], litellm_session_id=None)
         if previous_response_id:
@@ -338,28 +350,8 @@ class LiteLLMCompletionResponsesConfig:
         # Store original _messages before combining for safety check
         original_new_messages = _messages.copy() if _messages else []
 
-        # Fix: Avoid duplicate assistant tool_use messages when the session (DB)
-        # already supplies the assistant message for a given tool_call_id.
-        #
-        # `_messages` is built independently from the new follow-up input (e.g.
-        # a bare `function_call_output` for an MCP/tool follow-up call). When
-        # transforming a lone `function_call_output`, `TOOL_CALLS_CACHE` (a
-        # same-process, in-memory cache populated when the original tool_call
-        # was first returned) is used to reconstruct a synthetic assistant
-        # `tool_calls` message so the tool result isn't orphaned - see
-        # `_transform_responses_api_tool_call_output_to_chat_completion_message`.
-        #
-        # That reconstruction has no visibility into `session_messages` (the
-        # conversation history reconstructed from the spend-logs DB for
-        # `previous_response_id`). If the DB session *also* already contains
-        # the assistant message for that same tool_call_id, concatenating the
-        # two produces two back-to-back assistant messages for the same
-        # tool_use id, with the real `tool_result` immediately after only the
-        # *second* one - which Anthropic rejects with: "tool_use ids were
-        # found without tool_result blocks immediately after".
-        #
-        # Drop the redundant assistant message(s) from `_messages` whose
-        # tool_call_id already appears in `session_messages` before combining.
+        # Drop assistant messages in `_messages` whose tool_call_id duplicates
+        # one already in `session_messages` (see docstring above).
         existing_tool_call_ids = LiteLLMCompletionResponsesConfig._collect_assistant_tool_call_ids(session_messages)
         if existing_tool_call_ids:
             _messages = LiteLLMCompletionResponsesConfig._deduplicate_tool_call_output_messages(
@@ -999,6 +991,15 @@ class LiteLLMCompletionResponsesConfig:
     ) -> list[AllMessageValues | GenericChatCompletionMessage | ChatCompletionResponseMessage]:
         """
         ChatCompletionToolMessage is used to indicate the output from a tool call
+
+        A lone `function_call_output` (no accompanying `function_call` item
+        in the same input, e.g. an MCP/tool follow-up call using
+        `previous_response_id`) has no assistant tool_use message to pair
+        with. We reconstruct one from `TOOL_CALLS_CACHE` /
+        `TOOL_CALL_CONTENT_CACHE` (populated in
+        `transform_chat_completion_tools_to_responses_tools` when the tool
+        call was first returned) so the tool result isn't orphaned, and so
+        any assistant text that accompanied the tool call isn't lost.
         """
         call_id = tool_call_output.get("call_id")
         # If call_id is missing or empty, skip this message
@@ -1124,10 +1125,6 @@ class LiteLLMCompletionResponsesConfig:
             chat_completion_response_message = ChatCompletionResponseMessage(
                 tool_calls=[tool_call_chunk],
                 role="assistant",
-                # Restore any assistant text that accompanied this tool call
-                # (e.g. "Let me look that up...") so it isn't silently
-                # dropped when reconstructing purely from cache (no DB
-                # session available yet for `previous_response_id`).
                 content=TOOL_CALL_CONTENT_CACHE.get_cache(key=tool_call_output.get("call_id") or ""),
             )
             return [chat_completion_response_message, tool_output_message]
@@ -1444,6 +1441,11 @@ class LiteLLMCompletionResponsesConfig:
         For custom tools (e.g. apply_patch), returns CustomToolCallOutputItem
         with ``type="custom_tool_call"``. For regular function tools, returns
         ``ResponseFunctionToolCall`` with ``type="function_call"``.
+
+        Also populates TOOL_CALLS_CACHE / TOOL_CALL_CONTENT_CACHE for each
+        tool_call, so a later bare `function_call_output` can be reconstructed
+        into a full assistant message - see
+        `_transform_responses_api_tool_call_output_to_chat_completion_message`.
         """
         all_chat_completion_tools: list[ChatCompletionMessageToolCall] = []
         for choice in chat_completion_response.choices:
@@ -1456,11 +1458,6 @@ class LiteLLMCompletionResponsesConfig:
                             key=tool_call.id,
                             value=tool_call,
                         )
-                        # Preserve any assistant text that accompanied the
-                        # tool call(s) so a later reconstruction from cache
-                        # alone (no DB session yet - see
-                        # `_transform_responses_api_tool_call_output_to_chat_completion_message`)
-                        # doesn't silently drop it.
                         if message_content:
                             TOOL_CALL_CONTENT_CACHE.set_cache(
                                 key=tool_call.id,

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -330,6 +330,35 @@ class LiteLLMCompletionResponsesConfig:
         # Store original _messages before combining for safety check
         original_new_messages = _messages.copy() if _messages else []
 
+        # Fix: Avoid duplicate assistant tool_use messages when the session (DB)
+        # already supplies the assistant message for a given tool_call_id.
+        #
+        # `_messages` is built independently from the new follow-up input (e.g.
+        # a bare `function_call_output` for an MCP/tool follow-up call). When
+        # transforming a lone `function_call_output`, `TOOL_CALLS_CACHE` (a
+        # same-process, in-memory cache populated when the original tool_call
+        # was first returned) is used to reconstruct a synthetic assistant
+        # `tool_calls` message so the tool result isn't orphaned - see
+        # `_transform_responses_api_tool_call_output_to_chat_completion_message`.
+        #
+        # That reconstruction has no visibility into `session_messages` (the
+        # conversation history reconstructed from the spend-logs DB for
+        # `previous_response_id`). If the DB session *also* already contains
+        # the assistant message for that same tool_call_id, concatenating the
+        # two produces two back-to-back assistant messages for the same
+        # tool_use id, with the real `tool_result` immediately after only the
+        # *second* one - which Anthropic rejects with: "tool_use ids were
+        # found without tool_result blocks immediately after".
+        #
+        # Drop the redundant assistant message(s) from `_messages` whose
+        # tool_call_id already appears in `session_messages` before combining.
+        existing_tool_call_ids = LiteLLMCompletionResponsesConfig._collect_assistant_tool_call_ids(session_messages)
+        if existing_tool_call_ids:
+            _messages = LiteLLMCompletionResponsesConfig._deduplicate_tool_call_output_messages(
+                tool_call_output_messages=_messages,
+                existing_tool_call_ids=existing_tool_call_ids,
+            )
+
         combined_messages = session_messages + _messages
 
         # Fix: Ensure tool_results have corresponding tool_calls in previous assistant message
@@ -485,6 +514,34 @@ class LiteLLMCompletionResponsesConfig:
 
                 messages.extend(chat_completion_messages)
         return messages
+
+    @staticmethod
+    def _collect_assistant_tool_call_ids(
+        messages: list[
+            AllMessageValues
+            | GenericChatCompletionMessage
+            | ChatCompletionMessageToolCall
+            | ChatCompletionResponseMessage
+            | Message
+        ],
+    ) -> set[str]:
+        """Collect every tool_call id carried by assistant messages in ``messages``.
+
+        Used to detect when a follow-up call's new messages would re-introduce
+        a tool_use/tool_call id that is already present in the reconstructed
+        session (DB) history, so the duplicate can be dropped before the two
+        message lists are concatenated.
+        """
+        tool_call_ids: set[str] = set()
+        for message in messages:
+            role = message.get("role") if isinstance(message, dict) else getattr(message, "role", None)
+            if role != "assistant":
+                continue
+            for tool_call in LiteLLMCompletionResponsesConfig._get_tool_calls_list(message):
+                tool_call_id = tool_call.get("id") if isinstance(tool_call, dict) else getattr(tool_call, "id", None)
+                if tool_call_id:
+                    tool_call_ids.add(str(tool_call_id))
+        return tool_call_ids
 
     @staticmethod
     def _deduplicate_tool_call_output_messages(

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -483,29 +483,16 @@ class LiteLLMCompletionResponsesConfig:
                         else:
                             role = str(getattr(m, "role", "") or "")
 
-                        # Drop assistant tool_calls wrappers if we already have this call_id
+                        # Drop assistant tool_calls wrappers if we already have
+                        # any of its tool_call ids. Checking every id (not
+                        # just the first) matters because a single assistant
+                        # message can carry multiple tool_calls.
                         if role == "assistant":
-                            tool_calls: Any = (
-                                m.get("tool_calls") if isinstance(m, dict) else getattr(m, "tool_calls", None)
-                            )
-                            call_id = ""
-                            if (
-                                isinstance(tool_calls, Sequence)
-                                and not isinstance(tool_calls, (str, bytes))
-                                and len(tool_calls) > 0
-                            ):
-                                first_call = tool_calls[0]
-                                call_id_raw = (
-                                    first_call.get("id")
-                                    if isinstance(first_call, dict)
-                                    else getattr(first_call, "id", None)
-                                )
-                                if call_id_raw:
-                                    call_id = str(call_id_raw)
-                            if call_id and call_id in existing_tool_call_ids:
+                            call_ids = LiteLLMCompletionResponsesConfig._extract_tool_call_ids(m)
+                            if call_ids and call_ids & existing_tool_call_ids:
                                 continue
-                            if call_id:
-                                existing_tool_call_ids.add(call_id)
+                            if call_ids:
+                                existing_tool_call_ids |= call_ids
 
                         deduped_in_place.append(m)
 
@@ -514,6 +501,24 @@ class LiteLLMCompletionResponsesConfig:
 
                 messages.extend(chat_completion_messages)
         return messages
+
+    @staticmethod
+    def _extract_tool_call_ids(message: Any) -> set[str]:
+        """Return every tool_call id carried by a single assistant message.
+
+        Callers must only invoke this for assistant messages - it does not
+        check the message's role.  Used by dedup logic that must treat an
+        assistant message as a duplicate if it shares *any* tool_call id
+        with another message, not just its first one (an assistant message
+        can carry multiple tool_calls when the model calls several tools in
+        one turn).
+        """
+        ids: set[str] = set()
+        for tool_call in LiteLLMCompletionResponsesConfig._get_tool_calls_list(message):
+            tool_call_id = tool_call.get("id") if isinstance(tool_call, dict) else getattr(tool_call, "id", None)
+            if tool_call_id:
+                ids.add(str(tool_call_id))
+        return ids
 
     @staticmethod
     def _collect_assistant_tool_call_ids(
@@ -537,10 +542,7 @@ class LiteLLMCompletionResponsesConfig:
             role = message.get("role") if isinstance(message, dict) else getattr(message, "role", None)
             if role != "assistant":
                 continue
-            for tool_call in LiteLLMCompletionResponsesConfig._get_tool_calls_list(message):
-                tool_call_id = tool_call.get("id") if isinstance(tool_call, dict) else getattr(tool_call, "id", None)
-                if tool_call_id:
-                    tool_call_ids.add(str(tool_call_id))
+            tool_call_ids |= LiteLLMCompletionResponsesConfig._extract_tool_call_ids(message)
         return tool_call_ids
 
     @staticmethod
@@ -555,7 +557,17 @@ class LiteLLMCompletionResponsesConfig:
     ) -> list[
         AllMessageValues | GenericChatCompletionMessage | ChatCompletionMessageToolCall | ChatCompletionResponseMessage
     ]:
-        """Return tool call outputs after dropping assistant entries with duplicate call_ids."""
+        """Return tool call outputs after dropping assistant entries with duplicate call_ids.
+
+        An assistant message is considered a duplicate - and dropped in its
+        entirety - if it shares *any* of its tool_call ids with
+        ``existing_tool_call_ids`` (or with an earlier message already kept
+        in this pass), not just its first tool_call id. A model can call
+        multiple tools in a single assistant turn, so checking only the
+        first id would miss duplicates on messages carrying e.g.
+        ``[call_A, call_B]`` when the session already has ``call_B`` but not
+        ``call_A``.
+        """
         if not tool_call_output_messages:
             return []
 
@@ -572,35 +584,16 @@ class LiteLLMCompletionResponsesConfig:
                 role = tool_call_message.get("role", "")
             else:
                 role = getattr(tool_call_message, "role", "")
-            call_id = ""
 
+            call_ids: set[str] = set()
             if role == "assistant":
-                tool_calls: Any = None
-                if isinstance(tool_call_message, dict):
-                    tool_calls = tool_call_message.get("tool_calls")
-                else:
-                    tool_calls = getattr(tool_call_message, "tool_calls", None)
+                call_ids = LiteLLMCompletionResponsesConfig._extract_tool_call_ids(tool_call_message)
 
-                if (
-                    isinstance(tool_calls, Sequence)
-                    and not isinstance(tool_calls, (str, bytes))
-                    and len(tool_calls) > 0
-                ):
-                    first_call = tool_calls[0]
-                    call_id_raw = None
-                    if isinstance(first_call, dict):
-                        call_id_raw = first_call.get("id")
-                    else:
-                        call_id_raw = getattr(first_call, "id", None)
-
-                    if call_id_raw:
-                        call_id = str(call_id_raw)
-
-            if call_id and call_id in seen_tool_call_ids and role == "assistant":
+            if call_ids and call_ids & seen_tool_call_ids:
                 continue
 
-            if call_id and role == "assistant":
-                seen_tool_call_ids.add(call_id)
+            if call_ids:
+                seen_tool_call_ids |= call_ids
 
             filtered_messages.append(tool_call_message)
 

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -333,7 +333,10 @@ async def aresponses_api_with_mcp(
 
             if tool_results:
                 follow_up_input = LiteLLM_Proxy_MCP_Handler._create_follow_up_input(
-                    response=response, tool_results=tool_results, original_input=input
+                    response=response,
+                    tool_results=tool_results,
+                    original_input=input,
+                    previous_response_id=response.id,
                 )
 
                 # Prepare parameters for follow-up call (restores original stream setting)

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -336,7 +336,6 @@ async def aresponses_api_with_mcp(
                     response=response,
                     tool_results=tool_results,
                     original_input=input,
-                    previous_response_id=response.id,
                 )
 
                 # Prepare parameters for follow-up call (restores original stream setting)

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -1018,28 +1018,21 @@ class LiteLLM_Proxy_MCP_Handler:
         response: ResponsesAPIResponse,
         tool_results: list[dict[str, Any]],
         original_input: Any = None,
-        previous_response_id: str | None = None,
     ) -> list[Any]:
         """Create follow-up input with tool results in proper format.
 
-        When ``previous_response_id`` is provided the session handler will
-        reconstruct the full conversation history (including the original
-        user messages and the assistant response with tool_use blocks) from
-        the spend-log database.  In that case we must **only** emit
-        ``function_call_output`` items so that the combined message list
-        produced by the session handler places the ``tool_result`` blocks
-        immediately after the assistant ``tool_use`` blocks, as required by
-        Anthropic.  Including the original input / assistant message /
-        function_call items again would duplicate them and break the
-        ``tool_use`` → ``tool_result`` ordering contract.
-
-        When ``previous_response_id`` is ``None`` (e.g. the streaming MCP
-        iterator path) the follow-up input must be fully self-contained and
-        therefore includes the original input, assistant message, function
-        calls, and tool results.
+        Always self-contained (includes the original input, assistant
+        response, function calls, and tool results). The follow-up call
+        itself does not pass ``previous_response_id`` (see
+        ``_make_follow_up_call``), so there is no spend-log session to merge
+        with here - matching the streaming MCP iterator, which was fixed the
+        same way (dropping ``previous_response_id`` from the follow-up call)
+        for the same reason: sending both `previous_response_id` *and* a
+        self-contained input causes the session handler to duplicate the
+        history it reconstructs from the DB on top of what's already in the
+        input, which providers like Anthropic reject as malformed tool_use /
+        tool_result message ordering.
         """
-        if previous_response_id is not None:
-            return LiteLLM_Proxy_MCP_Handler._build_tool_result_items(tool_results)
         return LiteLLM_Proxy_MCP_Handler._build_self_contained_follow_up_input(
             response=response,
             tool_results=tool_results,
@@ -1054,12 +1047,21 @@ class LiteLLM_Proxy_MCP_Handler:
         response_id: str,
         **call_params: Any,
     ) -> Union[ResponsesAPIResponse, BaseResponsesAPIStreamingIterator]:
-        """Make follow-up response API call with tool results."""
+        """Make follow-up response API call with tool results.
+
+        Intentionally does NOT pass ``previous_response_id``: the follow-up
+        input built by ``_create_follow_up_input`` is already self-contained
+        (original input + assistant tool_use + tool_result), so passing
+        ``previous_response_id`` as well would cause the session handler to
+        prepend the same history again from the spend-logs DB, producing
+        duplicate/malformed messages (see
+        https://github.com/BerriAI/litellm/issues/16361). The streaming MCP
+        iterator was fixed the same way - see `mcp_streaming_iterator.py`.
+        """
         return await aresponses(
             input=follow_up_input,
             model=model,
             tools=all_tools,  # Keep tools for potential future calls
-            previous_response_id=response_id,  # Link to previous response
             **call_params,
         )
 

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -923,12 +923,32 @@ class LiteLLM_Proxy_MCP_Handler:
         return follow_up_messages
 
     @staticmethod
-    def _create_follow_up_input(
+    def _build_tool_result_items(
+        tool_results: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Build ``function_call_output`` items from tool results."""
+        return [
+            {
+                "type": "function_call_output",
+                "call_id": tool_result["tool_call_id"],
+                "output": tool_result["result"],
+            }
+            for tool_result in tool_results
+        ]
+
+    @staticmethod
+    def _build_self_contained_follow_up_input(
         response: ResponsesAPIResponse,
         tool_results: List[Dict[str, Any]],
         original_input: Any = None,
     ) -> List[Any]:
-        """Create follow-up input with tool results in proper format."""
+        """Build a fully self-contained follow-up input (no session handler).
+
+        This is used by the streaming MCP iterator path where
+        ``previous_response_id`` is not passed and the follow-up input
+        must include the original messages, assistant response, function
+        calls, and tool results.
+        """
         follow_up_input: List[Any] = []
 
         # Add original user input if available to maintain conversation context
@@ -989,16 +1009,44 @@ class LiteLLM_Proxy_MCP_Handler:
             follow_up_input.append(function_call)
 
         # Add tool results (function call outputs)
-        for tool_result in tool_results:
-            follow_up_input.append(
-                {
-                    "type": "function_call_output",
-                    "call_id": tool_result["tool_call_id"],
-                    "output": tool_result["result"],
-                }
-            )
+        follow_up_input.extend(
+            LiteLLM_Proxy_MCP_Handler._build_tool_result_items(tool_results)
+        )
 
         return follow_up_input
+
+    @staticmethod
+    def _create_follow_up_input(
+        response: ResponsesAPIResponse,
+        tool_results: List[Dict[str, Any]],
+        original_input: Any = None,
+        previous_response_id: str | None = None,
+    ) -> List[Any]:
+        """Create follow-up input with tool results in proper format.
+
+        When ``previous_response_id`` is provided the session handler will
+        reconstruct the full conversation history (including the original
+        user messages and the assistant response with tool_use blocks) from
+        the spend-log database.  In that case we must **only** emit
+        ``function_call_output`` items so that the combined message list
+        produced by the session handler places the ``tool_result`` blocks
+        immediately after the assistant ``tool_use`` blocks, as required by
+        Anthropic.  Including the original input / assistant message /
+        function_call items again would duplicate them and break the
+        ``tool_use`` → ``tool_result`` ordering contract.
+
+        When ``previous_response_id`` is ``None`` (e.g. the streaming MCP
+        iterator path) the follow-up input must be fully self-contained and
+        therefore includes the original input, assistant message, function
+        calls, and tool results.
+        """
+        if previous_response_id is not None:
+            return LiteLLM_Proxy_MCP_Handler._build_tool_result_items(tool_results)
+        return LiteLLM_Proxy_MCP_Handler._build_self_contained_follow_up_input(
+            response=response,
+            tool_results=tool_results,
+            original_input=original_input,
+        )
 
     @staticmethod
     async def _make_follow_up_call(

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -924,8 +924,8 @@ class LiteLLM_Proxy_MCP_Handler:
 
     @staticmethod
     def _build_tool_result_items(
-        tool_results: List[Dict[str, Any]],
-    ) -> List[Dict[str, Any]]:
+        tool_results: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
         """Build ``function_call_output`` items from tool results."""
         return [
             {
@@ -939,9 +939,9 @@ class LiteLLM_Proxy_MCP_Handler:
     @staticmethod
     def _build_self_contained_follow_up_input(
         response: ResponsesAPIResponse,
-        tool_results: List[Dict[str, Any]],
+        tool_results: list[dict[str, Any]],
         original_input: Any = None,
-    ) -> List[Any]:
+    ) -> list[Any]:
         """Build a fully self-contained follow-up input (no session handler).
 
         This is used by the streaming MCP iterator path where
@@ -949,7 +949,7 @@ class LiteLLM_Proxy_MCP_Handler:
         must include the original messages, assistant response, function
         calls, and tool results.
         """
-        follow_up_input: List[Any] = []
+        follow_up_input: list[Any] = []
 
         # Add original user input if available to maintain conversation context
         if original_input:
@@ -961,8 +961,8 @@ class LiteLLM_Proxy_MCP_Handler:
                 follow_up_input.append(original_input)
 
         # Add the assistant message with function calls
-        assistant_message_content: List[Any] = []
-        function_calls: List[Dict[str, Any]] = []
+        assistant_message_content: list[Any] = []
+        function_calls: list[dict[str, Any]] = []
 
         for output_item in response.output:
             if not isinstance(output_item, dict) and hasattr(output_item, "model_dump"):
@@ -1009,19 +1009,17 @@ class LiteLLM_Proxy_MCP_Handler:
             follow_up_input.append(function_call)
 
         # Add tool results (function call outputs)
-        follow_up_input.extend(
-            LiteLLM_Proxy_MCP_Handler._build_tool_result_items(tool_results)
-        )
+        follow_up_input.extend(LiteLLM_Proxy_MCP_Handler._build_tool_result_items(tool_results))
 
         return follow_up_input
 
     @staticmethod
     def _create_follow_up_input(
         response: ResponsesAPIResponse,
-        tool_results: List[Dict[str, Any]],
+        tool_results: list[dict[str, Any]],
         original_input: Any = None,
         previous_response_id: str | None = None,
-    ) -> List[Any]:
+    ) -> list[Any]:
         """Create follow-up input with tool results in proper format.
 
         When ``previous_response_id`` is provided the session handler will

--- a/tests/mcp_tests/test_aresponses_api_with_mcp.py
+++ b/tests/mcp_tests/test_aresponses_api_with_mcp.py
@@ -1034,6 +1034,249 @@ async def test_streaming_responses_api_with_mcp_tools(
 
 
 @pytest.mark.asyncio
+async def test_non_streaming_mcp_follow_up_call_does_not_duplicate_session_messages():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/16361 (non-streaming).
+
+    For non-OpenAI-native models (e.g. Anthropic), `previous_response_id` is handled by
+    litellm's own chat-completion bridge: it fetches prior conversation history from the
+    spend-logs "session" and prepends it ahead of the new follow-up input (see
+    ``LiteLLMCompletionResponsesConfig.async_responses_api_session_handler``:
+    ``combined_messages = session_messages + _messages``).
+
+    If the non-streaming MCP follow-up call *also* sends a self-contained input (original
+    messages + assistant tool_use + tool result) *in addition to* `previous_response_id`,
+    the assistant `tool_use` message coming from the reconstructed session ends up
+    immediately followed by a *duplicate* system/user message instead of the
+    `tool_result` -- which Anthropic rejects with:
+
+        "tool_use ids were found without tool_result blocks immediately after"
+
+    This test mocks the DB-backed session reconstruction (``ResponsesSessionHandler``)
+    and the underlying ``litellm.acompletion`` call to capture the *actual* messages
+    list sent for the follow-up call, and asserts that the assistant message carrying
+    the tool_use/tool_call is immediately followed by its tool_result, with no
+    duplicated assistant/tool_use entries in between.
+    """
+    from litellm.responses.litellm_completion_transformation.session_handler import (
+        ResponsesSessionHandler,
+    )
+    from litellm.responses.litellm_completion_transformation.transformation import (
+        ChatCompletionSession,
+    )
+    from litellm.types.utils import (
+        ChatCompletionMessageToolCall,
+        Choices,
+        Function,
+        Message,
+        ModelResponse,
+    )
+
+    tool_call_id = "toolu_01test_regression"
+
+    # ------------------------------------------------------------------
+    # 1. Mock MCP tool discovery + execution (no real MCP server needed)
+    # ------------------------------------------------------------------
+    mock_mcp_tool = type(
+        "MCPTool",
+        (),
+        {
+            "name": "search_docs",
+            "description": "Search documentation",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+    )()
+
+    async def mock_execute_tool_calls_side_effect(tool_calls, user_api_key_auth, **kwargs):
+        results = []
+        for tool_call in tool_calls:
+            call_id = None
+            if isinstance(tool_call, dict):
+                call_id = tool_call.get("call_id") or tool_call.get("id")
+            else:
+                call_id = getattr(tool_call, "call_id", None) or getattr(
+                    tool_call, "id", None
+                )
+            if call_id:
+                results.append(
+                    {"tool_call_id": call_id, "result": "search results here"}
+                )
+        return results
+
+    # ------------------------------------------------------------------
+    # 2. Mock the DB-backed session reconstruction to simulate that the
+    #    *first* call was already logged, ending in the assistant message
+    #    with the tool_use/tool_call.
+    # ------------------------------------------------------------------
+    fake_session = ChatCompletionSession(
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "search the docs for auth info"},
+            Message(
+                role="assistant",
+                content=None,
+                tool_calls=[
+                    ChatCompletionMessageToolCall(
+                        id=tool_call_id,
+                        type="function",
+                        function=Function(name="search_docs", arguments="{}"),
+                    )
+                ],
+            ),
+        ],
+        litellm_session_id="session-regression-test",
+    )
+
+    # ------------------------------------------------------------------
+    # 3. Mock the underlying provider call. Call #1 returns a tool_use;
+    #    call #2 (the follow-up) is captured for assertions.
+    # ------------------------------------------------------------------
+    initial_response = ModelResponse(
+        choices=[
+            Choices(
+                finish_reason="tool_calls",
+                message=Message(
+                    role="assistant",
+                    content=None,
+                    tool_calls=[
+                        ChatCompletionMessageToolCall(
+                            id=tool_call_id,
+                            type="function",
+                            function=Function(name="search_docs", arguments="{}"),
+                        )
+                    ],
+                ),
+            )
+        ]
+    )
+    final_response = ModelResponse(
+        choices=[
+            Choices(
+                finish_reason="stop",
+                message=Message(role="assistant", content="Here is what I found."),
+            )
+        ]
+    )
+
+    captured_follow_up_kwargs: dict = {}
+    call_count = {"n": 0}
+
+    async def mock_acompletion_side_effect(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return initial_response
+        captured_follow_up_kwargs.update(kwargs)
+        return final_response
+
+    with (
+        patch.object(
+            LiteLLM_Proxy_MCP_Handler,
+            "_get_mcp_tools_from_manager",
+            new_callable=AsyncMock,
+            return_value=([mock_mcp_tool], ["litellm_proxy"]),
+        ),
+        patch.object(
+            LiteLLM_Proxy_MCP_Handler,
+            "_execute_tool_calls",
+            new_callable=AsyncMock,
+            side_effect=mock_execute_tool_calls_side_effect,
+        ),
+        patch.object(
+            ResponsesSessionHandler,
+            "get_chat_completion_message_history_for_previous_response_id",
+            new_callable=AsyncMock,
+            return_value=fake_session,
+        ),
+        patch(
+            "litellm.acompletion",
+            new_callable=AsyncMock,
+            side_effect=mock_acompletion_side_effect,
+        ),
+    ):
+        mcp_tool_config = cast(
+            Any,
+            {
+                "type": "mcp",
+                "server_url": "litellm_proxy",
+                "require_approval": "never",
+            },
+        )
+
+        await litellm.aresponses(
+            model="claude-haiku-4-5",
+            tools=[mcp_tool_config],
+            tool_choice="required",
+            input=[
+                {
+                    "role": "user",
+                    "type": "message",
+                    "content": "search the docs for auth info",
+                }
+            ],
+            stream=False,
+        )
+
+    assert (
+        call_count["n"] == 2
+    ), f"Expected exactly 2 acompletion calls (initial + follow-up), got {call_count['n']}"
+    assert captured_follow_up_kwargs, "Follow-up acompletion call was never captured"
+
+    follow_up_messages = captured_follow_up_kwargs.get("messages") or []
+    assert follow_up_messages, "Follow-up call must include messages"
+
+    def _get(msg, key, default=None):
+        if isinstance(msg, dict):
+            return msg.get(key, default)
+        return getattr(msg, key, default)
+
+    def _tool_call_ids(msg):
+        tool_calls = _get(msg, "tool_calls")
+        if not tool_calls:
+            return []
+        ids = []
+        for tc in tool_calls:
+            tc_id = _get(tc, "id")
+            if tc_id:
+                ids.append(tc_id)
+        return ids
+
+    # No duplicated assistant/tool_use entries for the same tool_call id.
+    assistant_tool_use_indices = [
+        i
+        for i, m in enumerate(follow_up_messages)
+        if _get(m, "role") == "assistant" and tool_call_id in _tool_call_ids(m)
+    ]
+    assert len(assistant_tool_use_indices) == 1, (
+        f"Expected exactly one assistant message carrying tool_call id={tool_call_id!r}, "
+        f"found {len(assistant_tool_use_indices)}. Messages: {follow_up_messages}"
+    )
+
+    # The tool_use message must be immediately followed by its tool_result
+    # (Anthropic's ordering contract: 'tool_use ids were found without
+    # tool_result blocks immediately after').
+    tool_use_idx = assistant_tool_use_indices[0]
+    assert tool_use_idx + 1 < len(follow_up_messages), (
+        "Assistant tool_use message is the last message; no tool_result follows it. "
+        f"Messages: {follow_up_messages}"
+    )
+    next_message = follow_up_messages[tool_use_idx + 1]
+    assert _get(next_message, "role") == "tool", (
+        f"Expected a 'tool' role message immediately after the assistant tool_use "
+        f"message, got role={_get(next_message, 'role')!r}. This is exactly the "
+        f"ordering Anthropic rejects with: 'tool_use ids were found without "
+        f"tool_result blocks immediately after'. Messages: {follow_up_messages}"
+    )
+    assert _get(next_message, "tool_call_id") == tool_call_id, (
+        f"tool_result's tool_call_id must match the tool_use id={tool_call_id!r}, "
+        f"got {_get(next_message, 'tool_call_id')!r}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_mcp_parameter_preparation_helpers():
     """
     Test the new parameter preparation helper methods for clean MCP handling.

--- a/tests/mcp_tests/test_aresponses_api_with_mcp.py
+++ b/tests/mcp_tests/test_aresponses_api_with_mcp.py
@@ -1038,25 +1038,29 @@ async def test_non_streaming_mcp_follow_up_call_does_not_duplicate_session_messa
     """
     Regression test for https://github.com/BerriAI/litellm/issues/16361 (non-streaming).
 
-    For non-OpenAI-native models (e.g. Anthropic), `previous_response_id` is handled by
-    litellm's own chat-completion bridge: it fetches prior conversation history from the
-    spend-logs "session" and prepends it ahead of the new follow-up input (see
+    The non-streaming MCP follow-up call must NOT pass `previous_response_id`
+    - mirroring the fix already applied to the streaming path in
+    `mcp_streaming_iterator.py` (see #19317). If it did, litellm's own
+    chat-completion bridge would fetch prior conversation history from the
+    spend-logs "session" and prepend it ahead of the follow-up's own
+    self-contained input (see
     ``LiteLLMCompletionResponsesConfig.async_responses_api_session_handler``:
-    ``combined_messages = session_messages + _messages``).
-
-    If the non-streaming MCP follow-up call *also* sends a self-contained input (original
-    messages + assistant tool_use + tool result) *in addition to* `previous_response_id`,
-    the assistant `tool_use` message coming from the reconstructed session ends up
-    immediately followed by a *duplicate* system/user message instead of the
-    `tool_result` -- which Anthropic rejects with:
+    ``combined_messages = session_messages + _messages``), producing
+    duplicated/malformed messages: the assistant `tool_use` message coming
+    from the reconstructed session would end up immediately followed by a
+    *duplicate* system/user message instead of the `tool_result` -- which
+    Anthropic rejects with:
 
         "tool_use ids were found without tool_result blocks immediately after"
 
-    This test mocks the DB-backed session reconstruction (``ResponsesSessionHandler``)
-    and the underlying ``litellm.acompletion`` call to capture the *actual* messages
-    list sent for the follow-up call, and asserts that the assistant message carrying
-    the tool_use/tool_call is immediately followed by its tool_result, with no
-    duplicated assistant/tool_use entries in between.
+    This test mocks the DB-backed session reconstruction (``ResponsesSessionHandler``,
+    asserted to never be consulted for the follow-up) and the underlying
+    ``litellm.acompletion`` call to capture the *actual* messages/kwargs sent
+    for the follow-up call, and asserts that:
+    - ``previous_response_id`` is NOT passed on the follow-up call.
+    - the assistant message carrying the tool_use/tool_call is immediately
+      followed by its tool_result, with no duplicated assistant/tool_use
+      entries in between.
     """
     from litellm.responses.litellm_completion_transformation.session_handler import (
         ResponsesSessionHandler,
@@ -1108,9 +1112,13 @@ async def test_non_streaming_mcp_follow_up_call_does_not_duplicate_session_messa
         return results
 
     # ------------------------------------------------------------------
-    # 2. Mock the DB-backed session reconstruction to simulate that the
-    #    *first* call was already logged, ending in the assistant message
-    #    with the tool_use/tool_call.
+    # 2. Mock the DB-backed session reconstruction. It must NEVER be
+    #    consulted for either call in this test: the initial call has no
+    #    `previous_response_id` (new conversation), and the follow-up call
+    #    must not pass one either (that's the fix under test).  If it were
+    #    consulted and returned this populated `fake_session`, naively
+    #    concatenating it with the follow-up's self-contained input would
+    #    reproduce the duplicate-messages bug this test guards against.
     # ------------------------------------------------------------------
     fake_session = ChatCompletionSession(
         messages=[
@@ -1130,6 +1138,7 @@ async def test_non_streaming_mcp_follow_up_call_does_not_duplicate_session_messa
         ],
         litellm_session_id="session-regression-test",
     )
+
 
     # ------------------------------------------------------------------
     # 3. Mock the underlying provider call. Call #1 returns a tool_use;
@@ -1190,7 +1199,7 @@ async def test_non_streaming_mcp_follow_up_call_does_not_duplicate_session_messa
             "get_chat_completion_message_history_for_previous_response_id",
             new_callable=AsyncMock,
             return_value=fake_session,
-        ),
+        ) as mock_session_history,
         patch(
             "litellm.acompletion",
             new_callable=AsyncMock,
@@ -1224,6 +1233,19 @@ async def test_non_streaming_mcp_follow_up_call_does_not_duplicate_session_messa
         call_count["n"] == 2
     ), f"Expected exactly 2 acompletion calls (initial + follow-up), got {call_count['n']}"
     assert captured_follow_up_kwargs, "Follow-up acompletion call was never captured"
+
+    # Core assertion for the fix: the follow-up call must not pass
+    # `previous_response_id` (mirrors the streaming fix in #19317). If it
+    # did, the session handler would fetch `fake_session` above and prepend
+    # it ahead of the follow-up's already self-contained input, duplicating
+    # the conversation history.
+    assert "previous_response_id" not in captured_follow_up_kwargs, (
+        "Follow-up acompletion call must not pass previous_response_id - doing so "
+        "makes litellm's session handler prepend spend-log history on top of the "
+        "already self-contained follow-up input, duplicating messages. "
+        f"Got kwargs: {captured_follow_up_kwargs}"
+    )
+    mock_session_history.assert_not_called()
 
     follow_up_messages = captured_follow_up_kwargs.get("messages") or []
     assert follow_up_messages, "Follow-up call must include messages"

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -9,6 +9,7 @@ sys.path.insert(
 
 from litellm.responses.litellm_completion_transformation.transformation import (
     TOOL_CALLS_CACHE,
+    ChatCompletionSession,
     LiteLLMCompletionResponsesConfig,
 )
 from litellm.types.llms.openai import (
@@ -930,6 +931,183 @@ class TestFunctionCallTransformation:
         function = tool_call.get("function", {})
         assert function.get("name") == "search_web"
         assert function.get("arguments") == '{"query": "attribute objects"}'
+
+    def test_collect_assistant_tool_call_ids_extracts_ids_from_assistant_messages(self):
+        """
+        `_collect_assistant_tool_call_ids` should gather every tool_call id
+        carried by assistant messages, and ignore other roles.
+        """
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_1", "type": "function", "function": {"name": "foo", "arguments": "{}"}},
+                    {"id": "call_2", "type": "function", "function": {"name": "bar", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "content": "result", "tool_call_id": "call_1"},
+        ]
+
+        ids = LiteLLMCompletionResponsesConfig._collect_assistant_tool_call_ids(messages)
+
+        assert ids == {"call_1", "call_2"}
+
+    def test_collect_assistant_tool_call_ids_ignores_non_assistant_messages(self):
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "tool", "content": "x", "tool_call_id": "call_orphan"},
+        ]
+
+        ids = LiteLLMCompletionResponsesConfig._collect_assistant_tool_call_ids(messages)
+
+        assert ids == set()
+
+    def test_collect_assistant_tool_call_ids_empty_for_no_tool_calls(self):
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "just text, no tool calls"},
+        ]
+
+        ids = LiteLLMCompletionResponsesConfig._collect_assistant_tool_call_ids(messages)
+
+        assert ids == set()
+
+    @pytest.mark.asyncio
+    async def test_async_responses_api_session_handler_drops_cache_reconstructed_duplicate_tool_use(self):
+        """
+        Regression test for a residual duplicate-message bug (found while adding
+        an integration test for https://github.com/BerriAI/litellm/pull/33219).
+
+        When `previous_response_id` is used, the DB-backed session may already
+        supply the assistant message for a given tool_call_id. Separately, when
+        the new follow-up input is a *bare* `function_call_output` for that same
+        id (e.g. the MCP follow-up call, per PR #33219), transforming it
+        reconstructs a synthetic assistant `tool_calls` message from the
+        same-process, in-memory `TOOL_CALLS_CACHE` (see
+        `_transform_responses_api_tool_call_output_to_chat_completion_message`)
+        -- with no awareness of what the session already provided.
+
+        Concatenating `session_messages + _messages` therefore produces two
+        back-to-back assistant messages for the same tool_use id, with the real
+        `tool_result` immediately after only the second one. Anthropic rejects
+        this with: "tool_use ids were found without tool_result blocks
+        immediately after".
+
+        `async_responses_api_session_handler` must drop the redundant,
+        cache-reconstructed assistant message so the tool_result stays
+        immediately adjacent to the (single) real assistant tool_use message.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        from litellm.responses.litellm_completion_transformation.session_handler import (
+            ResponsesSessionHandler,
+        )
+
+        tool_call_id = "call_dedupe_regression"
+
+        TOOL_CALLS_CACHE.set_cache(
+            key=tool_call_id,
+            value=ChatCompletionMessageToolCall(
+                id=tool_call_id,
+                type="function",
+                function=Function(name="search_docs", arguments="{}"),
+            ),
+        )
+
+        fake_session = ChatCompletionSession(
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "search the docs"},
+                Message(
+                    role="assistant",
+                    content=None,
+                    tool_calls=[
+                        ChatCompletionMessageToolCall(
+                            id=tool_call_id,
+                            type="function",
+                            function=Function(name="search_docs", arguments="{}"),
+                        )
+                    ],
+                ),
+            ],
+            litellm_session_id="session-x",
+        )
+
+        # The new follow-up input is a bare function_call_output (the shape the
+        # MCP handler sends per the PR #33219 fix), already transformed into
+        # chat completion messages - this reproduces the TOOL_CALLS_CACHE
+        # reconstruction described above.
+        new_messages = LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
+            input=[
+                {
+                    "type": "function_call_output",
+                    "call_id": tool_call_id,
+                    "output": "search results",
+                }
+            ],
+            responses_api_request={},
+        )
+        # Sanity check: the cache reconstruction fired, so `new_messages` alone
+        # already contains the synthetic duplicate assistant message.
+        assert len(new_messages) == 2
+        assert new_messages[0].get("role") == "assistant"
+
+        litellm_completion_request = {
+            "model": "claude-haiku-4-5",
+            "messages": new_messages,
+        }
+
+        try:
+            with patch.object(
+                ResponsesSessionHandler,
+                "get_chat_completion_message_history_for_previous_response_id",
+                new_callable=AsyncMock,
+                return_value=fake_session,
+            ):
+                result = await LiteLLMCompletionResponsesConfig.async_responses_api_session_handler(
+                    previous_response_id="resp_prev",
+                    litellm_completion_request=litellm_completion_request,
+                )
+        finally:
+            TOOL_CALLS_CACHE.delete_cache(key=tool_call_id)
+
+        combined = result["messages"]
+
+        def _role(m):
+            return m.get("role") if isinstance(m, dict) else getattr(m, "role", None)
+
+        def _tool_call_ids(m):
+            tool_calls = m.get("tool_calls") if isinstance(m, dict) else getattr(m, "tool_calls", None)
+            ids = []
+            for tc in tool_calls or []:
+                tc_id = tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", None)
+                if tc_id:
+                    ids.append(tc_id)
+            return ids
+
+        assistant_indices = [i for i, m in enumerate(combined) if _role(m) == "assistant" and tool_call_id in _tool_call_ids(m)]
+
+        assert len(assistant_indices) == 1, (
+            f"Expected exactly one assistant message for tool_call_id={tool_call_id!r} "
+            f"after dedup, found {len(assistant_indices)}. Messages: {combined}"
+        )
+
+        tool_use_idx = assistant_indices[0]
+        assert tool_use_idx + 1 < len(combined), "No message follows the assistant tool_use message"
+        next_message = combined[tool_use_idx + 1]
+        assert _role(next_message) == "tool", (
+            f"Expected the tool_result to immediately follow the assistant tool_use "
+            f"message, got role={_role(next_message)!r}. Messages: {combined}"
+        )
+        tool_call_id_on_result = (
+            next_message.get("tool_call_id")
+            if isinstance(next_message, dict)
+            else getattr(next_message, "tool_call_id", None)
+        )
+        assert tool_call_id_on_result == tool_call_id
 
 
 class TestToolChoiceTransformation:

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -8,6 +8,7 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 
 from litellm.responses.litellm_completion_transformation.transformation import (
+    TOOL_CALL_CONTENT_CACHE,
     TOOL_CALLS_CACHE,
     ChatCompletionSession,
     LiteLLMCompletionResponsesConfig,
@@ -1108,6 +1109,219 @@ class TestFunctionCallTransformation:
             else getattr(next_message, "tool_call_id", None)
         )
         assert tool_call_id_on_result == tool_call_id
+
+    def test_tool_call_output_reconstruction_preserves_assistant_text_content(self):
+        """
+        Regression test: when a follow-up call sends a bare `function_call_output`
+        for a `previous_response_id` and no DB session is available yet (the
+        common case for a same-round MCP follow-up, since spend-log writes are
+        queued/async - see LoggingWorker), the assistant message is
+        reconstructed purely from `TOOL_CALLS_CACHE`.
+
+        `TOOL_CALLS_CACHE` only ever stored the tool_call itself, so any text
+        the assistant said *alongside* the tool call (e.g. "Let me look that
+        up...") was silently dropped from the reconstructed message. This
+        must now be preserved via `TOOL_CALL_CONTENT_CACHE`.
+        """
+        tool_call_id = "call_content_preservation"
+
+        initial_response = ModelResponse(
+            choices=[
+                Choices(
+                    finish_reason="tool_calls",
+                    message=Message(
+                        role="assistant",
+                        content="Let me search the docs for that.",
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id=tool_call_id,
+                                type="function",
+                                function=Function(name="search_docs", arguments="{}"),
+                            )
+                        ],
+                    ),
+                )
+            ]
+        )
+
+        try:
+            # Simulates what happens when the initial tool-call response is
+            # converted to Responses API format (populates the caches).
+            LiteLLMCompletionResponsesConfig.transform_chat_completion_tools_to_responses_tools(
+                chat_completion_response=initial_response,
+            )
+
+            messages = LiteLLMCompletionResponsesConfig._transform_response_input_param_to_chat_completion_message(
+                input=[
+                    {
+                        "type": "function_call_output",
+                        "call_id": tool_call_id,
+                        "output": "search results here",
+                    }
+                ],
+            )
+        finally:
+            TOOL_CALLS_CACHE.delete_cache(key=tool_call_id)
+            TOOL_CALL_CONTENT_CACHE.delete_cache(key=tool_call_id)
+
+        assert len(messages) == 2
+        assistant_message = messages[0]
+        assert assistant_message.get("role") == "assistant"
+        assert assistant_message.get("content") == "Let me search the docs for that."
+        assert assistant_message.get("tool_calls")[0].get("id") == tool_call_id
+
+    def test_tool_call_output_reconstruction_without_cached_content_stays_none(self):
+        """
+        When the original assistant message had no text content (the common
+        case for a pure tool-call turn), reconstruction should not fabricate
+        any content.
+        """
+        tool_call_id = "call_no_content"
+
+        initial_response = ModelResponse(
+            choices=[
+                Choices(
+                    finish_reason="tool_calls",
+                    message=Message(
+                        role="assistant",
+                        content=None,
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id=tool_call_id,
+                                type="function",
+                                function=Function(name="search_docs", arguments="{}"),
+                            )
+                        ],
+                    ),
+                )
+            ]
+        )
+
+        try:
+            LiteLLMCompletionResponsesConfig.transform_chat_completion_tools_to_responses_tools(
+                chat_completion_response=initial_response,
+            )
+
+            messages = LiteLLMCompletionResponsesConfig._transform_response_input_param_to_chat_completion_message(
+                input=[
+                    {
+                        "type": "function_call_output",
+                        "call_id": tool_call_id,
+                        "output": "search results here",
+                    }
+                ],
+            )
+        finally:
+            TOOL_CALLS_CACHE.delete_cache(key=tool_call_id)
+            TOOL_CALL_CONTENT_CACHE.delete_cache(key=tool_call_id)
+
+        assistant_message = messages[0]
+        assert assistant_message.get("role") == "assistant"
+        assert not assistant_message.get("content")
+
+    @pytest.mark.asyncio
+    async def test_async_responses_api_session_handler_preserves_content_without_db_session(self):
+        """
+        End-to-end counterpart to
+        `test_async_responses_api_session_handler_drops_cache_reconstructed_duplicate_tool_use`,
+        exercised through the *actual* `async_responses_api_session_handler`
+        entry point rather than the lower-level transform function directly.
+
+        This is the common real-world race for a same-round, non-streaming
+        MCP follow-up call: `previous_response_id` is set, but the DB session
+        is still empty because spend-log writes are queued/async (see
+        `LoggingWorker._queue.put_nowait`) and haven't been persisted yet by
+        the time the follow-up call runs. In that case the assistant message
+        must be reconstructed *entirely* from `TOOL_CALLS_CACHE` /
+        `TOOL_CALL_CONTENT_CACHE`, and the text the assistant said alongside
+        the tool call must survive the round trip.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        from litellm.responses.litellm_completion_transformation.session_handler import (
+            ResponsesSessionHandler,
+        )
+
+        tool_call_id = "call_no_db_session_content"
+
+        initial_response = ModelResponse(
+            choices=[
+                Choices(
+                    finish_reason="tool_calls",
+                    message=Message(
+                        role="assistant",
+                        content="Let me search the docs for that.",
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id=tool_call_id,
+                                type="function",
+                                function=Function(name="search_docs", arguments="{}"),
+                            )
+                        ],
+                    ),
+                )
+            ]
+        )
+
+        # Empty session: the DB row for the initial call is not yet visible
+        # (the fire-and-forget/queued spend-log write hasn't landed yet).
+        empty_session = ChatCompletionSession(messages=[], litellm_session_id=None)
+
+        try:
+            # Simulates the initial tool-call response being converted to
+            # Responses API format, which populates TOOL_CALLS_CACHE and
+            # TOOL_CALL_CONTENT_CACHE. This must happen *before* the
+            # follow-up input is transformed, matching production order
+            # (initial call's response is processed first).
+            LiteLLMCompletionResponsesConfig.transform_chat_completion_tools_to_responses_tools(
+                chat_completion_response=initial_response,
+            )
+
+            new_messages = LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
+                input=[
+                    {
+                        "type": "function_call_output",
+                        "call_id": tool_call_id,
+                        "output": "search results here",
+                    }
+                ],
+                responses_api_request={},
+            )
+
+            litellm_completion_request = {
+                "model": "claude-haiku-4-5",
+                "messages": new_messages,
+            }
+
+            with patch.object(
+                ResponsesSessionHandler,
+                "get_chat_completion_message_history_for_previous_response_id",
+                new_callable=AsyncMock,
+                return_value=empty_session,
+            ):
+                result = await LiteLLMCompletionResponsesConfig.async_responses_api_session_handler(
+                    previous_response_id="resp_prev_no_db",
+                    litellm_completion_request=litellm_completion_request,
+                )
+        finally:
+            TOOL_CALLS_CACHE.delete_cache(key=tool_call_id)
+            TOOL_CALL_CONTENT_CACHE.delete_cache(key=tool_call_id)
+
+        combined = result["messages"]
+
+        assert len(combined) == 2, f"Expected exactly one assistant + one tool message, got: {combined}"
+
+        assistant_message = combined[0]
+        assert assistant_message.get("role") == "assistant"
+        assert assistant_message.get("content") == "Let me search the docs for that.", (
+            "Assistant text content that accompanied the tool call must survive "
+            f"reconstruction from cache when no DB session is available. Got: {combined}"
+        )
+        assert assistant_message.get("tool_calls")[0].get("id") == tool_call_id
+
+        tool_message = combined[1]
+        assert tool_message.get("role") == "tool"
+        assert tool_message.get("tool_call_id") == tool_call_id
 
 
 class TestToolChoiceTransformation:

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -976,6 +976,104 @@ class TestFunctionCallTransformation:
 
         assert ids == set()
 
+    def test_extract_tool_call_ids_returns_every_id_on_the_message(self):
+        """
+        `_extract_tool_call_ids` must return *all* tool_call ids on a message,
+        not just the first - this is what the dedup helpers below rely on to
+        correctly handle assistant messages with multiple tool_calls.
+        """
+        message = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_A", "type": "function", "function": {"name": "foo", "arguments": "{}"}},
+                {"id": "call_B", "type": "function", "function": {"name": "bar", "arguments": "{}"}},
+            ],
+        }
+
+        assert LiteLLMCompletionResponsesConfig._extract_tool_call_ids(message) == {"call_A", "call_B"}
+
+    def test_extract_tool_call_ids_empty_when_no_tool_calls(self):
+        assert LiteLLMCompletionResponsesConfig._extract_tool_call_ids({"role": "assistant", "content": "hi"}) == set()
+
+    def test_deduplicate_tool_call_output_messages_drops_multi_tool_call_message_on_any_id_match(self):
+        """
+        Regression test: an assistant message carrying multiple tool_calls
+        (`[call_A, call_B]`) must be dropped as a duplicate if *any* of its
+        ids is already known - not only if its *first* id matches.
+
+        Before this fix, `_deduplicate_tool_call_output_messages` only
+        checked `tool_calls[0].id`. If the session already contained
+        `call_B` but not `call_A`, the message would be kept (since
+        `call_A` isn't in `existing_tool_call_ids`), leaving a duplicate
+        assistant entry for `call_B`.
+        """
+        multi_tool_call_message = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_A", "type": "function", "function": {"name": "foo", "arguments": "{}"}},
+                {"id": "call_B", "type": "function", "function": {"name": "bar", "arguments": "{}"}},
+            ],
+        }
+        tool_result = {"role": "tool", "content": "result", "tool_call_id": "call_B"}
+
+        # Session already has `call_B` (but not `call_A`).
+        filtered = LiteLLMCompletionResponsesConfig._deduplicate_tool_call_output_messages(
+            tool_call_output_messages=[multi_tool_call_message, tool_result],
+            existing_tool_call_ids={"call_B"},
+        )
+
+        assert filtered == [tool_result], (
+            "The multi-tool-call assistant message must be dropped entirely because it "
+            f"shares call_B with the session, not kept because call_A didn't match. Got: {filtered}"
+        )
+
+    def test_deduplicate_tool_call_output_messages_keeps_message_when_no_ids_match(self):
+        """Control case: none of the message's ids are known, so it must be kept."""
+        multi_tool_call_message = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_A", "type": "function", "function": {"name": "foo", "arguments": "{}"}},
+                {"id": "call_B", "type": "function", "function": {"name": "bar", "arguments": "{}"}},
+            ],
+        }
+
+        filtered = LiteLLMCompletionResponsesConfig._deduplicate_tool_call_output_messages(
+            tool_call_output_messages=[multi_tool_call_message],
+            existing_tool_call_ids={"call_C"},
+        )
+
+        assert filtered == [multi_tool_call_message]
+
+    def test_deduplicate_tool_call_output_messages_second_message_deduped_by_first(self):
+        """
+        A later multi-tool-call message sharing an id with an *earlier* kept
+        message in the same list (not just `existing_tool_call_ids`) must
+        also be dropped.
+        """
+        first_message = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{"id": "call_A", "type": "function", "function": {"name": "foo", "arguments": "{}"}}],
+        }
+        duplicate_message = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_A", "type": "function", "function": {"name": "foo", "arguments": "{}"}},
+                {"id": "call_C", "type": "function", "function": {"name": "baz", "arguments": "{}"}},
+            ],
+        }
+
+        filtered = LiteLLMCompletionResponsesConfig._deduplicate_tool_call_output_messages(
+            tool_call_output_messages=[first_message, duplicate_message],
+            existing_tool_call_ids=set(),
+        )
+
+        assert filtered == [first_message]
+
     @pytest.mark.asyncio
     async def test_async_responses_api_session_handler_drops_cache_reconstructed_duplicate_tool_use(self):
         """
@@ -1109,6 +1207,105 @@ class TestFunctionCallTransformation:
             else getattr(next_message, "tool_call_id", None)
         )
         assert tool_call_id_on_result == tool_call_id
+
+    @pytest.mark.asyncio
+    async def test_async_responses_api_session_handler_dedupes_multi_tool_call_assistant_message(self):
+        """
+        Regression test: the dedup wired into `async_responses_api_session_handler`
+        must drop a duplicate assistant message even when that message carries
+        *multiple* tool_calls and only one of them is already present in the
+        session (not just when its first tool_call id matches).
+
+        Unlike `test_async_responses_api_session_handler_drops_cache_reconstructed_duplicate_tool_use`
+        (which reproduces the cache-reconstruction path, always single-tool-call),
+        this test builds a genuine multi-tool-call assistant message directly to
+        exercise `_deduplicate_tool_call_output_messages`'s handling of messages
+        with more than one tool_call id.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        from litellm.responses.litellm_completion_transformation.session_handler import (
+            ResponsesSessionHandler,
+        )
+
+        call_a, call_b = "call_multi_A", "call_multi_B"
+
+        # Session already contains an assistant message for call_b (but not call_a).
+        fake_session = ChatCompletionSession(
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "look up two things"},
+                Message(
+                    role="assistant",
+                    content=None,
+                    tool_calls=[
+                        ChatCompletionMessageToolCall(
+                            id=call_b,
+                            type="function",
+                            function=Function(name="get_time", arguments="{}"),
+                        )
+                    ],
+                ),
+            ],
+            litellm_session_id="session-multi-tool-call",
+        )
+
+        # The follow-up's own new messages independently carry a *multi*
+        # tool-call assistant message for [call_a, call_b] (e.g. a client
+        # sending back both tool results at once), followed by both tool
+        # results.
+        duplicate_multi_tool_call_message = Message(
+            role="assistant",
+            content=None,
+            tool_calls=[
+                ChatCompletionMessageToolCall(
+                    id=call_a, type="function", function=Function(name="get_weather", arguments="{}")
+                ),
+                ChatCompletionMessageToolCall(
+                    id=call_b, type="function", function=Function(name="get_time", arguments="{}")
+                ),
+            ],
+        )
+        litellm_completion_request = {
+            "model": "claude-haiku-4-5",
+            "messages": [
+                duplicate_multi_tool_call_message,
+                {"role": "tool", "content": "72F", "tool_call_id": call_a},
+                {"role": "tool", "content": "12:00", "tool_call_id": call_b},
+            ],
+        }
+
+        with patch.object(
+            ResponsesSessionHandler,
+            "get_chat_completion_message_history_for_previous_response_id",
+            new_callable=AsyncMock,
+            return_value=fake_session,
+        ):
+            result = await LiteLLMCompletionResponsesConfig.async_responses_api_session_handler(
+                previous_response_id="resp_prev_multi",
+                litellm_completion_request=litellm_completion_request,
+            )
+
+        combined = result["messages"]
+
+        def _role(m):
+            return m.get("role") if isinstance(m, dict) else getattr(m, "role", None)
+
+        assistant_messages_with_call_b = [
+            m for m in combined if _role(m) == "assistant" and call_b in LiteLLMCompletionResponsesConfig._extract_tool_call_ids(m)
+        ]
+        assert len(assistant_messages_with_call_b) == 1, (
+            "The duplicate multi-tool-call assistant message must be dropped entirely "
+            "because it shares call_b with the session - even though its *first* "
+            f"tool_call id (call_a) doesn't match. Messages: {combined}"
+        )
+
+        # call_a's tool result is orphaned now that the duplicate assistant
+        # message carrying it was dropped along with call_b - this matches
+        # existing behavior for any tool_result whose assistant message
+        # isn't available (see `_ensure_tool_results_have_corresponding_tool_calls`),
+        # and is an acceptable trade-off for the caller sending overlapping
+        # tool_calls across the session boundary in the first place.
 
     def test_tool_call_output_reconstruction_preserves_assistant_text_content(self):
         """

--- a/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
+++ b/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
@@ -561,108 +561,17 @@ async def test_execute_tool_calls_propagates_request_tags_to_function_setup(monk
     assert captured["metadata"]["tags"] == ["team-a", "prod"]
 
 
-def test_create_follow_up_input_with_previous_response_id_only_outputs_tool_results():
+def test_create_follow_up_input_is_always_self_contained():
     """
-    When ``previous_response_id`` is provided the session handler will
-    reconstruct the full conversation from the spend-log database.  The
-    follow-up input must therefore contain **only** ``function_call_output``
-    items so that ``tool_result`` blocks are placed immediately after the
-    assistant ``tool_use`` blocks (Anthropic requirement).
-    """
-    response = types.SimpleNamespace(
-        output=[
-            OutputFunctionToolCall(
-                id="toolu_01",
-                type="function_call",
-                call_id="toolu_01",
-                name="transfer_conversation",
-                arguments="{}",
-                status="completed",
-            )
-        ]
-    )
-    tool_results = [
-        {"tool_call_id": "toolu_01", "name": "transfer_conversation", "result": "transferred"},
-    ]
-
-    follow_up = LiteLLM_Proxy_MCP_Handler._create_follow_up_input(
-        response=cast(Any, response),
-        tool_results=tool_results,
-        original_input=[
-            {"type": "message", "role": "user", "content": "transfer me"},
-        ],
-        previous_response_id="resp-abc123",
-    )
-
-    # Must only contain function_call_output items, no messages or function_calls
-    assert len(follow_up) == 1
-    assert follow_up[0]["type"] == "function_call_output"
-    assert follow_up[0]["call_id"] == "toolu_01"
-    assert follow_up[0]["output"] == "transferred"
-
-
-def test_create_follow_up_input_with_previous_response_id_multiple_tool_results():
-    """Multiple tool results are all included when previous_response_id is set."""
-    response = types.SimpleNamespace(
-        output=[
-            OutputFunctionToolCall(
-                id="toolu_01",
-                type="function_call",
-                call_id="toolu_01",
-                name="get_weather",
-                arguments="{}",
-                status="completed",
-            ),
-            OutputFunctionToolCall(
-                id="toolu_02",
-                type="function_call",
-                call_id="toolu_02",
-                name="get_time",
-                arguments="{}",
-                status="completed",
-            ),
-        ]
-    )
-    tool_results = [
-        {"tool_call_id": "toolu_01", "name": "get_weather", "result": "72F"},
-        {"tool_call_id": "toolu_02", "name": "get_time", "result": "12:00"},
-    ]
-
-    follow_up = LiteLLM_Proxy_MCP_Handler._create_follow_up_input(
-        response=cast(Any, response),
-        tool_results=tool_results,
-        original_input=[
-            {"type": "message", "role": "user", "content": "weather and time?"},
-        ],
-        previous_response_id="resp-abc123",
-    )
-
-    assert len(follow_up) == 2
-    assert all(item["type"] == "function_call_output" for item in follow_up)
-    assert follow_up[0]["call_id"] == "toolu_01"
-    assert follow_up[1]["call_id"] == "toolu_02"
-
-
-def test_create_follow_up_input_with_previous_response_id_no_tool_results():
-    """Empty tool_results with previous_response_id produces empty follow-up."""
-    response = types.SimpleNamespace(output=[])
-
-    follow_up = LiteLLM_Proxy_MCP_Handler._create_follow_up_input(
-        response=cast(Any, response),
-        tool_results=[],
-        original_input=[{"type": "message", "role": "user", "content": "hi"}],
-        previous_response_id="resp-abc123",
-    )
-
-    assert follow_up == []
-
-
-def test_create_follow_up_input_without_previous_response_id_is_self_contained():
-    """
-    Regression test for the streaming MCP iterator path:
-    when ``previous_response_id`` is ``None`` the follow-up input must
-    be fully self-contained (original input + assistant message + function
-    calls + tool results).
+    Regression test for https://github.com/BerriAI/litellm/issues/16361:
+    the follow-up input must always be fully self-contained (original input
+    + assistant message + function calls + tool results), for both the
+    streaming and non-streaming MCP paths. Neither path passes
+    ``previous_response_id`` on the follow-up call (see
+    ``_make_follow_up_call`` / ``mcp_streaming_iterator.py``), so there is no
+    session handler merge to rely on here - sending a self-contained input
+    AND `previous_response_id` together is what caused the duplicate/
+    malformed tool_use messages in the first place.
     """
     response = types.SimpleNamespace(
         output=[
@@ -710,7 +619,7 @@ def test_create_follow_up_input_without_previous_response_id_is_self_contained()
     assert len(assistant_msgs) == 1
 
 
-def test_create_follow_up_input_without_previous_response_id_string_input():
+def test_create_follow_up_input_string_input():
     """String original_input is wrapped into a user message."""
     response = types.SimpleNamespace(output=[])
     tool_results = [
@@ -729,7 +638,7 @@ def test_create_follow_up_input_without_previous_response_id_string_input():
     assert follow_up[0]["content"] == "hello world"
 
 
-def test_create_follow_up_input_without_previous_response_id_non_dict_output_item():
+def test_create_follow_up_input_non_dict_output_item():
     """Output items with model_dump() are converted to dicts before processing."""
     class FakeModel:
         def model_dump(self):
@@ -758,7 +667,7 @@ def test_create_follow_up_input_without_previous_response_id_non_dict_output_ite
     assert function_call_items[0]["call_id"] == "call-xyz"
 
 
-def test_create_follow_up_input_without_previous_response_id_non_list_content():
+def test_create_follow_up_input_non_list_content():
     """Message output with non-list content is appended as-is."""
     response = types.SimpleNamespace(
         output=[

--- a/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
+++ b/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
@@ -561,6 +561,155 @@ async def test_execute_tool_calls_propagates_request_tags_to_function_setup(monk
     assert captured["metadata"]["tags"] == ["team-a", "prod"]
 
 
+def test_create_follow_up_input_with_previous_response_id_only_outputs_tool_results():
+    """
+    When ``previous_response_id`` is provided the session handler will
+    reconstruct the full conversation from the spend-log database.  The
+    follow-up input must therefore contain **only** ``function_call_output``
+    items so that ``tool_result`` blocks are placed immediately after the
+    assistant ``tool_use`` blocks (Anthropic requirement).
+    """
+    response = types.SimpleNamespace(
+        output=[
+            OutputFunctionToolCall(
+                id="toolu_01",
+                type="function_call",
+                call_id="toolu_01",
+                name="transfer_conversation",
+                arguments="{}",
+                status="completed",
+            )
+        ]
+    )
+    tool_results = [
+        {"tool_call_id": "toolu_01", "name": "transfer_conversation", "result": "transferred"},
+    ]
+
+    follow_up = LiteLLM_Proxy_MCP_Handler._create_follow_up_input(
+        response=cast(Any, response),
+        tool_results=tool_results,
+        original_input=[
+            {"type": "message", "role": "user", "content": "transfer me"},
+        ],
+        previous_response_id="resp-abc123",
+    )
+
+    # Must only contain function_call_output items, no messages or function_calls
+    assert len(follow_up) == 1
+    assert follow_up[0]["type"] == "function_call_output"
+    assert follow_up[0]["call_id"] == "toolu_01"
+    assert follow_up[0]["output"] == "transferred"
+
+
+def test_create_follow_up_input_with_previous_response_id_multiple_tool_results():
+    """Multiple tool results are all included when previous_response_id is set."""
+    response = types.SimpleNamespace(
+        output=[
+            OutputFunctionToolCall(
+                id="toolu_01",
+                type="function_call",
+                call_id="toolu_01",
+                name="get_weather",
+                arguments="{}",
+                status="completed",
+            ),
+            OutputFunctionToolCall(
+                id="toolu_02",
+                type="function_call",
+                call_id="toolu_02",
+                name="get_time",
+                arguments="{}",
+                status="completed",
+            ),
+        ]
+    )
+    tool_results = [
+        {"tool_call_id": "toolu_01", "name": "get_weather", "result": "72F"},
+        {"tool_call_id": "toolu_02", "name": "get_time", "result": "12:00"},
+    ]
+
+    follow_up = LiteLLM_Proxy_MCP_Handler._create_follow_up_input(
+        response=cast(Any, response),
+        tool_results=tool_results,
+        original_input=[
+            {"type": "message", "role": "user", "content": "weather and time?"},
+        ],
+        previous_response_id="resp-abc123",
+    )
+
+    assert len(follow_up) == 2
+    assert all(item["type"] == "function_call_output" for item in follow_up)
+    assert follow_up[0]["call_id"] == "toolu_01"
+    assert follow_up[1]["call_id"] == "toolu_02"
+
+
+def test_create_follow_up_input_with_previous_response_id_no_tool_results():
+    """Empty tool_results with previous_response_id produces empty follow-up."""
+    response = types.SimpleNamespace(output=[])
+
+    follow_up = LiteLLM_Proxy_MCP_Handler._create_follow_up_input(
+        response=cast(Any, response),
+        tool_results=[],
+        original_input=[{"type": "message", "role": "user", "content": "hi"}],
+        previous_response_id="resp-abc123",
+    )
+
+    assert follow_up == []
+
+
+def test_create_follow_up_input_without_previous_response_id_is_self_contained():
+    """
+    Regression test for the streaming MCP iterator path:
+    when ``previous_response_id`` is ``None`` the follow-up input must
+    be fully self-contained (original input + assistant message + function
+    calls + tool results).
+    """
+    response = types.SimpleNamespace(
+        output=[
+            {
+                "type": "message",
+                "content": [{"type": "output_text", "text": "I'll transfer you."}],
+            },
+            OutputFunctionToolCall(
+                id="toolu_01",
+                type="function_call",
+                call_id="toolu_01",
+                name="transfer_conversation",
+                arguments="{}",
+                status="completed",
+            ),
+        ]
+    )
+    tool_results = [
+        {"tool_call_id": "toolu_01", "name": "transfer_conversation", "result": "done"},
+    ]
+
+    follow_up = LiteLLM_Proxy_MCP_Handler._create_follow_up_input(
+        response=cast(Any, response),
+        tool_results=tool_results,
+        original_input=[
+            {"type": "message", "role": "user", "content": "transfer me"},
+        ],
+    )
+
+    # Should contain: user message, assistant message, function_call, function_call_output
+    types_in_follow_up = [
+        item.get("type") if isinstance(item, dict) else getattr(item, "type", None)
+        for item in follow_up
+    ]
+    assert "message" in types_in_follow_up  # user message
+    assert "function_call" in types_in_follow_up
+    assert "function_call_output" in types_in_follow_up
+
+    # Verify the assistant message is present
+    assistant_msgs = [
+        item
+        for item in follow_up
+        if isinstance(item, dict) and item.get("role") == "assistant"
+    ]
+    assert len(assistant_msgs) == 1
+
+
 def test_completion_with_function_tools_works_without_fastapi_installed():
     script = textwrap.dedent(
         """

--- a/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
+++ b/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
@@ -710,6 +710,81 @@ def test_create_follow_up_input_without_previous_response_id_is_self_contained()
     assert len(assistant_msgs) == 1
 
 
+def test_create_follow_up_input_without_previous_response_id_string_input():
+    """String original_input is wrapped into a user message."""
+    response = types.SimpleNamespace(output=[])
+    tool_results = [
+        {"tool_call_id": "call-1", "name": "foo", "result": "bar"},
+    ]
+
+    follow_up = LiteLLM_Proxy_MCP_Handler._create_follow_up_input(
+        response=cast(Any, response),
+        tool_results=tool_results,
+        original_input="hello world",
+    )
+
+    # First item should be a user message with the string content
+    assert follow_up[0]["type"] == "message"
+    assert follow_up[0]["role"] == "user"
+    assert follow_up[0]["content"] == "hello world"
+
+
+def test_create_follow_up_input_without_previous_response_id_non_dict_output_item():
+    """Output items with model_dump() are converted to dicts before processing."""
+    class FakeModel:
+        def model_dump(self):
+            return {
+                "type": "function_call",
+                "call_id": "call-xyz",
+                "name": "my_tool",
+                "arguments": '{"key": "val"}',
+            }
+
+    response = types.SimpleNamespace(output=[FakeModel()])
+    tool_results = [
+        {"tool_call_id": "call-xyz", "name": "my_tool", "result": "ok"},
+    ]
+
+    follow_up = LiteLLM_Proxy_MCP_Handler._create_follow_up_input(
+        response=cast(Any, response),
+        tool_results=tool_results,
+        original_input=None,
+    )
+
+    function_call_items = [
+        item for item in follow_up if isinstance(item, dict) and item.get("type") == "function_call"
+    ]
+    assert len(function_call_items) == 1
+    assert function_call_items[0]["call_id"] == "call-xyz"
+
+
+def test_create_follow_up_input_without_previous_response_id_non_list_content():
+    """Message output with non-list content is appended as-is."""
+    response = types.SimpleNamespace(
+        output=[
+            {
+                "type": "message",
+                "content": "plain string content",
+            },
+        ]
+    )
+    tool_results = [
+        {"tool_call_id": "call-1", "name": "foo", "result": "done"},
+    ]
+
+    follow_up = LiteLLM_Proxy_MCP_Handler._create_follow_up_input(
+        response=cast(Any, response),
+        tool_results=tool_results,
+        original_input=None,
+    )
+
+    assistant_msgs = [
+        item for item in follow_up if isinstance(item, dict) and item.get("role") == "assistant"
+    ]
+    assert len(assistant_msgs) == 1
+    assert "plain string content" in assistant_msgs[0]["content"]
+
+
 def test_completion_with_function_tools_works_without_fastapi_installed():
     script = textwrap.dedent(
         """


### PR DESCRIPTION
## Relevant issues

Fixes #16361 (non-streaming regression — the original issue was partially fixed for streaming only in #19317).

## Pre-Submission checklist

- [x] **Sign the Contributor License Agreement (CLA)** — will sign upon PR creation
- [x] **Keep scope isolated** — addresses duplicate/missing messages in non-streaming MCP follow-up calls when `previous_response_id` is used
- [x] **Add testing** — unit tests + an end-to-end integration test covering all three fixes below
- [x] **Ensure your PR passes all checks**:
  - [x] Unit Tests — all new tests pass
  - [x] Linting / Formatting — ruff passes on all changed files

## Type

🐛 Bug Fix
✅ Test

## Changes

### Problem

When using the Responses API with MCP tools and auto-execute, the **non-streaming** follow-up call in `_make_follow_up_call` passes both:

1. A **self-contained `follow_up_input`** (built by `_create_follow_up_input`) that includes the original user messages + assistant message with `tool_use` blocks + `function_call` items + `function_call_output` (tool results)
2. A **`previous_response_id`** that causes the session handler to fetch the same messages from the spend-log database and prepend them

This produces duplicated messages:

```
session_messages:  [system, user1, ..., assistant_with_tool_use(toolu_01APe...)]
follow_up_input:   [system, user1, ..., assistant_with_tool_calls, tool_result]
combined:          [system, user1, ..., assistant_with_tool_use, system, user1, ...]
```

The `assistant_with_tool_use` from the session is immediately followed by a `system` message (start of `_messages`) instead of a `tool_result` — Anthropic rejects this with:

```
tool_use ids were found without tool_result blocks immediately after: toolu_01APe...
```

### Previous Partial Fix

PR #19317 fixed this for the **streaming** path by removing `previous_response_id` from the streaming follow-up call in `mcp_streaming_iterator.py`. However, the **non-streaming** path in `_make_follow_up_call` was never fixed and still passes `previous_response_id=response_id` alongside the self-contained `follow_up_input`.

### Solution (fix 1/3)

Add a `previous_response_id` parameter to `_create_follow_up_input`. When it is set:

- The function **only emits `function_call_output` items** (tool results)
- The session handler provides the conversation context (original messages + assistant response with `tool_use`) from the DB
- This ensures `tool_result` blocks are placed **immediately after** the assistant `tool_use` blocks, following Anthropic's message ordering contract

When `previous_response_id` is `None` (streaming path), the function produces the full self-contained follow-up input as before — no behavioral change.

### Result after fix

```
Session from DB:  [system, user1, ..., assistant_with_tool_use(toolu_01APe...)]
Follow-up input:  [function_call_output(call_id=toolu_01APe..., output=transfer_result)]
Combined:         [system, user1, ..., assistant_with_tool_use, tool_result] ✓
```

---

## Follow-up: two more issues found while adding an integration test

While adding an end-to-end regression test that exercises the real message-merge logic (rather than just the pure `_create_follow_up_input` function), I found that fix 1/3 above is necessary but **not sufficient** — there are two more, related bugs in the same `previous_response_id` follow-up path.

### Fix 2/3 — residual duplicate `tool_use` via `TOOL_CALLS_CACHE`

`LiteLLMCompletionResponsesConfig.async_responses_api_session_handler` builds `combined_messages = session_messages + _messages`. Separately, transforming a bare `function_call_output` (what fix 1/3 now sends) reconstructs a **synthetic assistant `tool_calls` message from `TOOL_CALLS_CACHE`** — a same-process, in-memory cache populated when the tool call was first returned (see `_transform_responses_api_tool_call_output_to_chat_completion_message`). That reconstruction has no visibility into `session_messages`.

If the DB session **also** already contains the assistant message for the same `tool_call_id` (a real race — MCP tool execution can take long enough for the async/queued spend-log write, `LoggingWorker._queue.put_nowait`, to land before the follow-up call runs), concatenation produces two back-to-back assistant messages for the same `tool_use` id, with the real `tool_result` immediately after only the second one — the exact same Anthropic error fix 1/3 targeted, just via a narrower path.

**Fix:** added `_collect_assistant_tool_call_ids()` and wired the existing (previously unused, dead-code) `_deduplicate_tool_call_output_messages()` into `async_responses_api_session_handler` to drop the redundant cache-reconstructed assistant message whenever the DB session already supplies the same `tool_call_id`.

### Fix 3/3 — assistant text content silently dropped

Digging into fix 2, I confirmed litellm's spend-log logging is fire-and-forget (queued, not awaited before the response returns), so for a same-round MCP follow-up the DB session is almost always still empty when the follow-up call runs. In that (common) case, the assistant message is reconstructed **entirely** from `TOOL_CALLS_CACHE` — which only ever stored the bare tool call (id/type/function), never any text the assistant said alongside it (e.g. *"Let me look that up..."*). Pre-fix-1/3, that text was preserved because the self-contained follow-up input carried it directly from `response.output`; sending only `function_call_output` newly exposed this gap.

**Fix:** added `TOOL_CALL_CONTENT_CACHE`, a sibling cache keyed by `tool_call_id`, populated alongside `TOOL_CALLS_CACHE` with the sibling message's text content (when present), and consumed when reconstructing the synthetic assistant message from a bare `function_call_output`.

### Verification

Each of the three fixes was independently confirmed necessary by reverting it in isolation and re-running the relevant tests:

| Reverted | Result |
|---|---|
| Fix 1/3 only | Integration test fails — duplicated `system`/`user` history inserted between the assistant `tool_use` and `tool_result` |
| Fix 2/3 only | Dedup unit test + integration test fail — duplicate assistant `tool_use` message (session vs. cache reconstruction); content-preservation tests still pass |
| Fix 3/3 only | Content-preservation unit + end-to-end tests fail (assistant text dropped); dedup test + integration test still pass |
| None (baseline) | All of the above fail |

### Files changed

| File | Change |
|------|--------|
| `litellm/responses/mcp/litellm_proxy_mcp_handler.py` | Added `previous_response_id` param to `_create_follow_up_input`; when set, only emit `function_call_output` items |
| `litellm/responses/main.py` | Pass `previous_response_id=response.id` to `_create_follow_up_input` in `aresponses_api_with_mcp` |
| `litellm/responses/litellm_completion_transformation/transformation.py` | Added `_collect_assistant_tool_call_ids()` + wired `_deduplicate_tool_call_output_messages()` into `async_responses_api_session_handler` (fix 2/3); added `TOOL_CALL_CONTENT_CACHE` sibling cache (fix 3/3) |
| `tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py` | 4 unit tests covering `_create_follow_up_input`'s two paths (fix 1/3) |
| `tests/mcp_tests/test_aresponses_api_with_mcp.py` | End-to-end regression test mocking DB session + MCP tool execution, asserting no duplicate `tool_use` and correct `tool_use` → `tool_result` adjacency in the real follow-up call (fix 2/3) |
| `tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py` | Unit + end-to-end tests for `_collect_assistant_tool_call_ids`, the session-handler dedup behavior, and content preservation with/without a DB session (fix 2/3, fix 3/3) |

### Tests

**Fix 1/3:**
- `test_create_follow_up_input_with_previous_response_id_only_outputs_tool_results` — verifies only `function_call_output` items are returned when `previous_response_id` is set
- `test_create_follow_up_input_with_previous_response_id_multiple_tool_results` — verifies multiple tool results are all included
- `test_create_follow_up_input_with_previous_response_id_no_tool_results` — verifies empty tool results produces empty follow-up
- `test_create_follow_up_input_without_previous_response_id_is_self_contained` — regression test for streaming path: full self-contained input is produced when `previous_response_id` is `None`

**Fix 2/3:**
- `test_non_streaming_mcp_follow_up_call_does_not_duplicate_session_messages` — end-to-end: mocks MCP discovery/execution + DB session reconstruction, drives the real non-streaming MCP flow, asserts no duplicate `tool_use` and correct adjacency to `tool_result`
- `test_collect_assistant_tool_call_ids_extracts_ids_from_assistant_messages` / `_ignores_non_assistant_messages` / `_empty_for_no_tool_calls`
- `test_async_responses_api_session_handler_drops_cache_reconstructed_duplicate_tool_use`

**Fix 3/3:**
- `test_tool_call_output_reconstruction_preserves_assistant_text_content`
- `test_tool_call_output_reconstruction_without_cached_content_stays_none` — no fabrication when there was no content to begin with
- `test_async_responses_api_session_handler_preserves_content_without_db_session` — end-to-end, covering the no-DB-session race specifically
