### PR TITLE
fix(streaming_chunk_builder): emit streamed tool calls with a missing id

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -299,7 +299,7 @@ class ChunkProcessor:
         # Convert the map to a list of tool calls
         for index in sorted(tool_call_map.keys()):
             tool_call_data = tool_call_map[index]
-            if tool_call_data["id"] and tool_call_data["name"]:
+            if tool_call_data["name"]:
                 combined_arguments = "".join(tool_call_data["arguments"]) or "{}"
 
                 # Build function - provider_specific_fields should be on tool_call level, not function level
@@ -310,7 +310,7 @@ class ChunkProcessor:
 
                 # Prepare params for ChatCompletionMessageToolCall
                 tool_call_params = {
-                    "id": tool_call_data["id"],
+                    "id": tool_call_data["id"] or None,
                     "function": function,
                     "type": tool_call_data["type"] or "function",
                 }

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -956,3 +956,56 @@ def test_stream_chunk_builder_propagates_vertex_ai_metadata_from_dict_chunks():
     assert response.model_dump()["vertex_ai_grounding_metadata"] == [
         {"webSearchQueries": ["test query"]}
     ]
+
+
+@pytest.mark.parametrize("tool_call_id", ["", None])
+def test_get_combined_tool_content_missing_id(tool_call_id):
+    chunks = [
+        ModelResponseStream(
+            id="chatcmpl-8478099a-3724-42c7-9194-88d97ffd254b",
+            created=1744771912,
+            model="llama-3.3-70b-versatile",
+            object="chat.completion.chunk",
+            system_fingerprint=None,
+            choices=[
+                StreamingChoices(
+                    finish_reason=None,
+                    index=0,
+                    delta=Delta(
+                        provider_specific_fields=None,
+                        content=None,
+                        role="assistant",
+                        function_call=None,
+                        tool_calls=[
+                            ChatCompletionDeltaToolCall(
+                                id=tool_call_id,
+                                function=Function(
+                                    arguments='{"location": "San Francisco", "unit": "imperial"}',
+                                    name="get_current_weather",
+                                ),
+                                type="function",
+                                index=0,
+                            )
+                        ],
+                        audio=None,
+                    ),
+                    logprobs=None,
+                )
+            ],
+            provider_specific_fields=None,
+            stream_options=None,
+        ),
+    ]
+    chunk_processor = ChunkProcessor(chunks=chunks)
+
+    tool_calls_list = chunk_processor.get_combined_tool_content(chunks)
+
+    assert len(tool_calls_list) == 1
+    assert tool_calls_list[0].function.name == "get_current_weather"
+    assert tool_calls_list[0].function.arguments == '{"location": "San Francisco", "unit": "imperial"}'
+    assert isinstance(tool_calls_list[0].id, str) and len(tool_calls_list[0].id) > 0
+
+    response = stream_chunk_builder(chunks=chunks, messages=[{"role": "user", "content": "whats the weather"}])
+    assert response.choices[0].message.tool_calls is not None
+    assert len(response.choices[0].message.tool_calls) == 1
+    assert response.choices[0].message.tool_calls[0].function.name == "get_current_weather"


### PR DESCRIPTION
## Relevant issues

<!-- e.g., "Fixes #000" -->

This is core streaming reassembly and shares lineage with the tool-call reconstruction issues tracked around #25208, but it is a distinct root cause and I did not open a separate tracking issue for it

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected -->

`ChunkProcessor.get_combined_tool_content` in `litellm/litellm_core_utils/streaming_chunk_builder_utils.py` walks the streamed tool-call deltas into a per-index map and then emits each entry only if `tool_call_data["id"] and tool_call_data["name"]`. The map is seeded with `"id": None` and the id is overwritten only when a truthy id arrives, so a provider that streams a valid function name and complete arguments while omitting the id (empty string or absent) leaves the id falsy and the entire tool call is dropped. Both `ChatCompletionDeltaToolCall.id` (litellm/types/utils.py) and `ChatCompletionToolCallChunk.id` (litellm/types/llms/openai.py) are typed `Optional[str]`, and `ChatCompletionMessageToolCall.__init__` already synthesizes a UUID when the id is `None`, so the guard was stricter than the contract the surrounding types promise. Because this assembled list is written to `message.tool_calls` in `litellm/main.py` for the non-streaming reconstruction used by logging and cost calculation, the tool invocation was silently lost from those records

I was not able to attach a real paid provider run here because the empty/missing tool-call id pattern comes from OpenAI-compatible backends (vLLM, llama.cpp-style servers, custom `openai/` base_url endpoints) rather than the major hosted APIs, and I did not have such an endpoint to point a live proxy at. To make the before/after reproducible without mocks in the library code path, here is a deterministic replay through the public `litellm.stream_chunk_builder` entrypoint using the exact chunk shape a provider emits, captured at both commits

Before, at base commit `10d5804b3ef4ead5abb77c3f5fafdd0c0159de0f`

```
python - <<'PY'
import litellm
from litellm.types.utils import ModelResponseStream, StreamingChoices, Delta, ChatCompletionDeltaToolCall, Function
chunk = ModelResponseStream(model="my-openai-compatible-model", object="chat.completion.chunk", choices=[StreamingChoices(index=0, delta=Delta(role="assistant", tool_calls=[ChatCompletionDeltaToolCall(id="", function=Function(name="get_current_weather", arguments='{"location": "San Francisco"}'), type="function", index=0)]))])
resp = litellm.stream_chunk_builder(chunks=[chunk], messages=[{"role": "user", "content": "whats the weather"}])
print("tool_calls:", resp.choices[0].message.tool_calls)
PY
tool_calls: None
```

After, at fix commit `ac041335427c041e59745216c1a185db8c130150`, the same script prints one reconstructed tool call with a synthesized id

```
tool_calls: [ChatCompletionMessageToolCall(function=Function(arguments='{"location": "San Francisco"}', name='get_current_weather'), id='…uuid…', type='function')]
```

For a fully e2e check against a live proxy, point `dev_config.yaml` at any OpenAI-compatible server that omits ids on streamed tool deltas, run the proxy on localhost:4000, and curl `/v1/chat/completions` with `"stream": false` and a tool that forces a call; before this change `choices[0].message.tool_calls` is dropped, after it is present with a synthesized id

## Type

🐛 Bug Fix

## Changes

Two changes in `ChunkProcessor.get_combined_tool_content`. The emit guard now requires only the function name, since the name is the sole field needed to reconstruct a call and the id types are `Optional[str]` throughout the delta contract. When building the params, a falsy stored id is coerced to `None` so the empty-string case reaches the existing UUID synthesis in `ChatCompletionMessageToolCall.__init__` rather than being passed through verbatim. Tool calls that already carry a provider-issued id and name are emitted unchanged, and entries that still lack a name are skipped exactly as before

One behavior note worth calling out is that tool calls which were previously dropped now surface with a synthesized UUID id. Any consumer that assumed assembled tool_calls always carry provider-issued ids will now occasionally see a synthetic one, which matches the documented `ChatCompletionMessageToolCall` contract and is preferable to silently losing the invocation from the logging and cost paths

Tests live in the mapped file `tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py`. I added `test_get_combined_tool_content_missing_id`, parametrized over an empty-string id and a `None` id, which builds a single-chunk stream carrying a valid function name and arguments, asserts the call survives reassembly with a non-empty synthesized id, and also drives it through the public `stream_chunk_builder` path so `choices[0].message.tool_calls` is verified end to end. The pre-existing valid-id test is untouched. On the base commit both parametrized cases fail with an empty result list; with the fix the file reports 18 passing
