### PR TITLE
fix(get_llm_provider): resolve bedrock_mantle models when custom_llm_provider=bedrock is set

### DIFF
--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -176,6 +176,9 @@ def get_llm_provider(
 
         model, custom_llm_provider = handle_anthropic_text_model_custom_llm_provider(model, custom_llm_provider)
 
+        if custom_llm_provider == "bedrock" and model.startswith("bedrock_mantle/"):
+            custom_llm_provider = "bedrock_mantle"
+
         if custom_llm_provider and (
             model.split("/")[0] != custom_llm_provider
         ):  # handle scenario where model="azure/*" and custom_llm_provider="azure"

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -578,6 +578,44 @@ class TestBedrockMantleProviderResolution:
         assert provider == "bedrock_mantle"
         assert model == "openai.gpt-oss-20b"
 
+    def test_explicit_bedrock_provider_reconciled_to_mantle(self):
+        model, provider, _, _ = litellm.get_llm_provider(
+            "bedrock_mantle/openai.gpt-5.5", custom_llm_provider="bedrock"
+        )
+        assert provider == "bedrock_mantle"
+        assert model == "openai.gpt-5.5"
+
+    def test_explicit_bedrock_provider_keeps_native_bedrock_models(self):
+        model, provider, _, _ = litellm.get_llm_provider(
+            "anthropic.claude-3-5-sonnet-20240620-v1:0",
+            custom_llm_provider="bedrock",
+        )
+        assert provider == "bedrock"
+        assert model == "anthropic.claude-3-5-sonnet-20240620-v1:0"
+
+    def test_completion_with_explicit_bedrock_provider_supports_tools(
+        self, local_cost_map
+    ):
+        response = litellm.completion(
+            model="bedrock_mantle/openai.gpt-5.5",
+            custom_llm_provider="bedrock",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+            tool_choice="auto",
+            parallel_tool_calls=False,
+            reasoning_effort="low",
+            mock_response="ok",
+        )
+        assert response.choices[0].message.content == "ok"
+
 
 class TestBedrockMantlePricing:
     """Tests that verify Bedrock Mantle uses correct AWS Bedrock pricing, not OpenAI pricing."""


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on localhost:4000 hitting the real Bedrock Mantle API in us-east-2 over SigV4 (real tokens, real $), started with `python litellm/proxy/proxy_cli.py --config /tmp/mantle_repro.yaml --port 4000` and this config, which mirrors what the Admin UI stores when the model was added with provider "Amazon Bedrock" selected

```yaml
model_list:
  - model_name: gpt-5.5
    litellm_params:
      model: bedrock_mantle/openai.gpt-5.5
      custom_llm_provider: bedrock
      aws_region_name: us-east-2

general_settings:
  master_key: sk-1234
```

The same request was sent before and after the fix

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-5.5",
    "messages": [{"role": "user", "content": "What is the weather in Tokyo? Use the tool."}],
    "tools": [{"type": "function", "function": {"name": "get_weather", "description": "Get current weather for a city", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}}],
    "tool_choice": "auto",
    "parallel_tool_calls": false,
    "reasoning_effort": "low"
  }' | python3 -m json.tool
```

Before, captured at 10d5804b3e (the parent of this PR's commit)

```json
{
    "error": {
        "message": "litellm.UnsupportedParamsError: bedrock does not support parameters: ['tools', 'tool_choice', 'parallel_tool_calls', 'reasoning_effort'], for model=bedrock_mantle/openai.gpt-5.5. To drop these, set `litellm.drop_params=True` or for proxy:\n\n`litellm_settings:\n drop_params: true`\n. \n If you want to use these params dynamically send allowed_openai_params=['tools', 'tool_choice', 'parallel_tool_calls', 'reasoning_effort'] in your request.. Received Model Group=gpt-5.5\nAvailable Model Group Fallbacks=None",
        "type": "None",
        "param": null,
        "code": "400"
    }
}
```

After, captured at d54c320c9d

```json
{
    "id": "chatcmpl-c673f057-4858-4bfe-a57b-a7b5b05408e0",
    "created": 1784041016,
    "model": "gpt-5.5",
    "object": "chat.completion",
    "choices": [
        {
            "finish_reason": "tool_calls",
            "index": 0,
            "message": {
                "role": "assistant",
                "tool_calls": [
                    {
                        "index": 0,
                        "function": {
                            "arguments": "{\"city\":\"Tokyo\"}",
                            "name": "get_weather"
                        },
                        "id": "fc_6e3a54a99d4a5382b012e19b70d2ab2f",
                        "type": "function"
                    }
                ],
                "content": null
            }
        }
    ],
    "usage": {
        "completion_tokens": 18,
        "prompt_tokens": 132,
        "total_tokens": 150,
        "completion_tokens_details": {
            "reasoning_tokens": 0
        },
        "prompt_tokens_details": {
            "cached_tokens": 0
        }
    }
}
```

## Type

🐛 Bug Fix

## Changes

When a deployment sets `custom_llm_provider: bedrock` together with a `bedrock_mantle/` prefixed model, `get_llm_provider` honors the explicit provider, so the model string keeps its `bedrock_mantle/` routing prefix and the request is validated against bedrock's supported params. `get_optional_params` then rejects `tools`, `tool_choice`, `parallel_tool_calls` and `reasoning_effort` with an `UnsupportedParamsError` even though the underlying Mantle model supports all of them. This combination is easy to hit in practice: it is exactly what gets stored when a model is added through the Admin UI with "Amazon Bedrock" selected as the provider while the model name is entered with its `bedrock_mantle/` prefix

The fix reconciles the pair in `get_llm_provider` the same way `cohere`/`cohere_chat` and `anthropic`/`anthropic_text` are already reconciled there: an explicit `bedrock` provider with a `bedrock_mantle/` prefixed model resolves to `bedrock_mantle`, after which the existing prefix handling strips the prefix and derives the Mantle api_base as usual. This cannot misfire on real Bedrock model identifiers because none of them begin with `bedrock_mantle/` (foundation model ids use dots, and inference profile references are ARNs); a guard test pins that native bedrock resolution is unchanged

Regression tests live in `tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py::TestBedrockMantleProviderResolution`. The two new resolution tests fail without the fix and pass with it, and the completion-level test reproduces the exact params from the original failure
