### PR TITLE
fix(bedrock_mantle): hoist Codex additional_tools input items to top-level tools

### DIFF
--- a/litellm/llms/bedrock_mantle/responses/transformation.py
+++ b/litellm/llms/bedrock_mantle/responses/transformation.py
@@ -25,7 +25,10 @@ from litellm.llms.bedrock_mantle.common_utils import (
 )
 from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
 from litellm.secret_managers.main import get_secret_str
-from litellm.types.llms.openai import ResponsesAPIOptionalRequestParams
+from litellm.types.llms.openai import (
+    ResponseInputParam,
+    ResponsesAPIOptionalRequestParams,
+)
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 
@@ -41,6 +44,8 @@ _BASE_SUFFIXES_TO_STRIP = (
 
 # Per Bedrock Mantle Responses API validation errors.
 _BEDROCK_MANTLE_SUPPORTED_RESPONSE_TOOL_TYPES = frozenset({"function", "mcp", "custom", "namespace", "tool_search"})
+
+_CODEX_ADDITIONAL_TOOLS_INPUT_ITEM_TYPE = "additional_tools"
 
 
 class BedrockMantleResponsesAPIConfig(BedrockMantleAuthMixin, OpenAIResponsesAPIConfig):
@@ -115,6 +120,64 @@ class BedrockMantleResponsesAPIConfig(BedrockMantleAuthMixin, OpenAIResponsesAPI
             )
 
         return kept
+
+    def transform_responses_api_request(
+        self,
+        model: str,
+        input: "str | ResponseInputParam",
+        response_api_optional_request_params: dict,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+    ) -> dict:
+        remaining_input, hoisted_tools = self._hoist_codex_additional_tools(input)
+        request_params = (
+            {
+                **response_api_optional_request_params,
+                "tools": [
+                    *(response_api_optional_request_params.get("tools") or []),
+                    *hoisted_tools,
+                ],
+            }
+            if hoisted_tools
+            else response_api_optional_request_params
+        )
+        return super().transform_responses_api_request(
+            model=model,
+            input=remaining_input,
+            response_api_optional_request_params=request_params,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
+
+    @staticmethod
+    def _is_codex_additional_tools_item(item: Any) -> bool:
+        return isinstance(item, dict) and item.get("type") == _CODEX_ADDITIONAL_TOOLS_INPUT_ITEM_TYPE
+
+    @staticmethod
+    def _tools_of_additional_tools_item(item: "dict[str, Any]") -> "list[Any]":
+        tools = item.get("tools")
+        return tools if isinstance(tools, list) else []
+
+    @classmethod
+    def _hoist_codex_additional_tools(
+        cls,
+        input: "str | ResponseInputParam",
+    ) -> "tuple[str | ResponseInputParam, list[Any]]":
+        """Codex's "responses lite" wire mode ships tool definitions inside
+        `input` as {"type": "additional_tools", "role": "developer",
+        "tools": [...]} items. api.openai.com accepts that item type; Mantle
+        rejects the whole request with 400 "Invalid 'input': value did not
+        match any expected variant" but accepts the same tools at the top
+        level, so move them there and strip the items from `input`.
+        """
+        if not isinstance(input, list):
+            return input, []
+        additional_tools_items = [item for item in input if cls._is_codex_additional_tools_item(item)]
+        if not additional_tools_items:
+            return input, []
+        remaining_input = [item for item in input if not cls._is_codex_additional_tools_item(item)]
+        hoisted_tools = [tool for item in additional_tools_items for tool in cls._tools_of_additional_tools_item(item)]
+        return remaining_input, cls._filter_unsupported_tools(hoisted_tools)
 
     def map_openai_params(
         self,

--- a/litellm/llms/bedrock_mantle/responses/transformation.py
+++ b/litellm/llms/bedrock_mantle/responses/transformation.py
@@ -177,6 +177,12 @@ class BedrockMantleResponsesAPIConfig(BedrockMantleAuthMixin, OpenAIResponsesAPI
             return input, []
         remaining_input = [item for item in input if not cls._is_codex_additional_tools_item(item)]
         hoisted_tools = [tool for item in additional_tools_items for tool in cls._tools_of_additional_tools_item(item)]
+        verbose_logger.debug(
+            "Bedrock Mantle Responses API: hoisting %d tool(s) out of %d 'additional_tools' input item(s) "
+            "into the top-level tools param (Mantle rejects that input item type).",
+            len(hoisted_tools),
+            len(additional_tools_items),
+        )
         return remaining_input, cls._filter_unsupported_tools(hoisted_tools)
 
     def map_openai_params(

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
@@ -373,6 +373,129 @@ class TestBedrockMantleResponsesTools:
         assert "web_search" in str(mock_warning.call_args)
 
 
+class TestBedrockMantleCodexAdditionalTools:
+    """Codex CLI's "responses lite" wire mode ships tool definitions inside
+    `input` as {"type": "additional_tools", "role": "developer", "tools": [...]}
+    items instead of the top-level `tools` param. api.openai.com accepts that
+    item; Mantle 400s the whole request with "Invalid 'input': value did not
+    match any expected variant" but accepts the same tools at the top level
+    (verified against bedrock-mantle.us-east-2.api.aws with openai.gpt-5.6-sol),
+    so the config must hoist them."""
+
+    _USER_MESSAGE = {
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": "Say hi in one word."}],
+    }
+    _DEVELOPER_MESSAGE = {
+        "type": "message",
+        "role": "developer",
+        "content": [{"type": "input_text", "text": "You are Codex."}],
+    }
+    _CODEX_TOOLS = [
+        {"type": "custom", "name": "exec", "format": {"type": "grammar", "syntax": "lark", "definition": "start: X"}},
+        {"type": "function", "name": "wait", "parameters": {"type": "object"}},
+        {"type": "namespace", "name": "collaboration", "tools": [{"type": "function", "name": "spawn_agent"}]},
+    ]
+
+    def _transform(self, input, params=None):
+        cfg = BedrockMantleResponsesAPIConfig()
+        return cfg.transform_responses_api_request(
+            model="openai.gpt-5.6-sol",
+            input=input,
+            response_api_optional_request_params=params if params is not None else {},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+    def test_additional_tools_item_hoisted_to_top_level_tools(self):
+        body = self._transform(
+            input=[
+                {"type": "additional_tools", "role": "developer", "tools": self._CODEX_TOOLS},
+                self._DEVELOPER_MESSAGE,
+                self._USER_MESSAGE,
+            ]
+        )
+        assert body["input"] == [self._DEVELOPER_MESSAGE, self._USER_MESSAGE]
+        assert body["tools"] == self._CODEX_TOOLS
+
+    def test_hoisted_tools_append_after_existing_tools(self):
+        existing_tool = {"type": "function", "name": "preexisting"}
+        body = self._transform(
+            input=[
+                {"type": "additional_tools", "role": "developer", "tools": self._CODEX_TOOLS},
+                self._USER_MESSAGE,
+            ],
+            params={"tools": [existing_tool]},
+        )
+        assert body["tools"] == [existing_tool, *self._CODEX_TOOLS]
+
+    def test_unsupported_hoisted_tool_types_are_dropped(self):
+        body = self._transform(
+            input=[
+                {
+                    "type": "additional_tools",
+                    "role": "developer",
+                    "tools": [
+                        {"type": "web_search"},
+                        {"type": "function", "name": "wait"},
+                    ],
+                },
+                self._USER_MESSAGE,
+            ]
+        )
+        assert body["tools"] == [{"type": "function", "name": "wait"}]
+
+    def test_item_stripped_even_when_no_hoisted_tool_survives(self):
+        body = self._transform(
+            input=[
+                {"type": "additional_tools", "role": "developer", "tools": [{"type": "web_search"}]},
+                self._USER_MESSAGE,
+            ]
+        )
+        assert body["input"] == [self._USER_MESSAGE]
+        assert "tools" not in body
+
+    def test_multiple_additional_tools_items_merge_in_order(self):
+        first = {"type": "function", "name": "first"}
+        second = {"type": "function", "name": "second"}
+        body = self._transform(
+            input=[
+                {"type": "additional_tools", "role": "developer", "tools": [first]},
+                self._USER_MESSAGE,
+                {"type": "additional_tools", "role": "developer", "tools": [second]},
+            ]
+        )
+        assert body["input"] == [self._USER_MESSAGE]
+        assert body["tools"] == [first, second]
+
+    def test_string_input_passes_through(self):
+        body = self._transform(input="hello")
+        assert body["input"] == "hello"
+        assert "tools" not in body
+
+    def test_input_without_additional_tools_is_unchanged(self):
+        codex_agentic_items = [
+            self._USER_MESSAGE,
+            {"type": "reasoning", "summary": [], "encrypted_content": "gAAAA=="},
+            {"type": "function_call", "name": "wait", "arguments": "{}", "call_id": "call_1"},
+            {"type": "function_call_output", "call_id": "call_1", "output": "done"},
+        ]
+        body = self._transform(input=list(codex_agentic_items))
+        assert body["input"] == codex_agentic_items
+        assert "tools" not in body
+
+    def test_malformed_additional_tools_item_without_tools_list_is_stripped(self):
+        body = self._transform(
+            input=[
+                {"type": "additional_tools", "role": "developer"},
+                self._USER_MESSAGE,
+            ]
+        )
+        assert body["input"] == [self._USER_MESSAGE]
+        assert "tools" not in body
+
+
 class TestBedrockMantleResponsesRegistry:
     def test_registry_returns_config_for_gpt_5_5(self, local_cost_map):
         # gpt-5.x advertises /v1/responses in supported_endpoints (capability)

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
@@ -495,6 +495,21 @@ class TestBedrockMantleCodexAdditionalTools:
         assert body["input"] == [self._USER_MESSAGE]
         assert "tools" not in body
 
+    def test_hoist_is_logged_at_debug_level(self):
+        from unittest.mock import patch
+
+        with patch(
+            "litellm.llms.bedrock_mantle.responses.transformation.verbose_logger.debug"
+        ) as mock_debug:
+            self._transform(
+                input=[
+                    {"type": "additional_tools", "role": "developer", "tools": self._CODEX_TOOLS},
+                    self._USER_MESSAGE,
+                ]
+            )
+        assert mock_debug.call_count == 1
+        assert "additional_tools" in str(mock_debug.call_args)
+
 
 class TestBedrockMantleResponsesRegistry:
     def test_registry_returns_config_for_gpt_5_5(self, local_cost_map):


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup: proxy on localhost:4000 hitting the real Bedrock Mantle endpoint in us-east-2 (SigV4 from the ambient AWS credentials, real $). gpt-5.6 is not in the price map yet, so mode and wire path are declared via model_info, the same way a proxy admin sets them in the Admin UI

```yaml
model_list:
  - model_name: gpt-5.6-sol
    litellm_params:
      model: bedrock_mantle/openai.gpt-5.6-sol
      aws_region_name: us-east-2
    model_info:
      mode: responses
      use_openai_responses_path: true

general_settings:
  master_key: sk-1234
```

Before, at the PR base 10d5804b3e, a Responses request shaped the way Codex CLI 0.144.x sends it (tool definitions inside `input` as an `additional_tools` item) fails:

```bash
curl -sS http://localhost:4000/v1/responses \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-5.6-sol",
    "input": [
      {"type": "additional_tools", "role": "developer", "tools": [
        {"type": "function", "name": "wait", "description": "Waits on a yielded exec cell.", "strict": false,
         "parameters": {"type": "object", "properties": {"cell_id": {"type": "string"}}, "required": ["cell_id"], "additionalProperties": false}}
      ]},
      {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Say hi in one word."}]}
    ]
  }' -w "\nHTTP %{http_code}\n"
```

```text
{"error":{"message":"litellm.APIConnectionError: Bedrock_mantleException - {\"error\":{\"code\":\"validation_error\",\"message\":\"invalid request body: Invalid 'input': value did not match any expected variant\",\"param\":null,\"type\":\"invalid_request_error\"}}. Received Model Group=gpt-5.6-sol\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"500"}}
HTTP 500
```

After, at 20398d905c, the exact same curl succeeds:

```text
HTTP 200
status: completed | error: None
assistant said: ['Hi!']
usage: 56
```

End to end with the real client at 20398d905c: Codex CLI 0.144.4 pointed at the proxy (`wire_api = "responses"`, `base_url = "http://127.0.0.1:4000/v1"`, model gpt-5.6-sol) completes a full agentic task. The run made 5 /v1/responses calls (the first turn plus tool-call turns that replay reasoning, custom_tool_call and function_call_output items) and every one returned 200

```text
$ codex exec --skip-git-repo-check --sandbox workspace-write "Create a file named proof.txt containing exactly 'mantle fix works', then run 'wc -c proof.txt' and report the byte count."
...
Created `proof.txt` exactly as requested. Byte count: **16**.
diff --git a/proof.txt b/proof.txt
new file mode 100644
--- /dev/null
+++ b/proof.txt
@@ -0,0 +1 @@
+mantle fix works

tokens used
10,003

$ cat proof.txt
mantle fix works

$ grep -o 'POST /v1/responses HTTP/1.1" [0-9]*' litellm.log | sort | uniq -c
   5 POST /v1/responses HTTP/1.1" 200
```

Before the fix, the same Codex CLI setup failed on the first request of every session with the HTTP 500 above and retried forever

## Type

🐛 Bug Fix

## Changes

Codex CLI 0.144.x uses a "responses lite" wire format for the gpt-5.5 and gpt-5.6 model families: instructions move into developer messages and the tool definitions move out of the top-level `tools` param into `input` as a `{"type": "additional_tools", "role": "developer", "tools": [...]}` item. api.openai.com accepts that item type; Bedrock Mantle's request parser rejects the whole request with 400 `invalid request body: Invalid 'input': value did not match any expected variant`, which litellm surfaces as a 500 APIConnectionError. The result is that Codex CLI cannot talk to any `bedrock_mantle/` Responses model through the proxy

Testing against the live endpoint (bedrock-mantle.us-east-2.api.aws, openai.gpt-5.6-sol) shows Mantle accepts the very same tool definitions when they are sent in the top-level `tools` param. `BedrockMantleResponsesAPIConfig.transform_responses_api_request` therefore now strips `additional_tools` items from `input` and merges their tools into the top-level `tools` param, running them through the existing unsupported-tool-type filter. Requests that carry no such item are passed through unchanged, and the item is stripped even when none of its tools survive the filter, since Mantle would otherwise 400 on the item itself

Unit tests cover the hoist (item stripped, tools merged after any existing tools, multiple items merged in order), the filter interaction, the malformed-item and string-input edge cases, and a pass-through case built from the item types Codex replays on later turns

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
