### PR TITLE
chore(deps): pin httplib2 and setuptools transitive floors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -264,6 +264,8 @@ constraint-dependencies = [
     "aiohttp>=3.14.1,<4.0",
     "packaging>=24.0",
     "soupsieve>=2.8.4",
+    "httplib2>=0.32.0",
+    "setuptools>=83.0.0",
 ]
 override-dependencies = [
     # a2a-sdk 1.x requires packaging>=24.0; lunary 1.4.x still caps at <24.0.

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-11T16:28:34.575803Z"
+exclude-newer = "2026-07-11T16:57:33.067258Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -20,7 +20,9 @@ members = [
 ]
 constraints = [
     { name = "aiohttp", specifier = ">=3.14.1,<4.0" },
+    { name = "httplib2", specifier = ">=0.32.0" },
     { name = "packaging", specifier = ">=24.0" },
+    { name = "setuptools", specifier = ">=83.0.0" },
     { name = "soupsieve", specifier = ">=2.8.4" },
     { name = "tornado", specifier = ">=6.5.6" },
 ]
@@ -2504,14 +2506,14 @@ wheels = [
 
 [[package]]
 name = "httplib2"
-version = "0.31.2"
+version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyparsing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/f5/ccf58de92d61e3ad921119668f54ed36ca1d0cf5dcc5c1657dfb164fd78b/httplib2-0.32.0.tar.gz", hash = "sha256:48a0ef30a42db65d8f3399045e1d09ab0ba66e3b9efc360d07f80ea55d286025", size = 254283, upload-time = "2026-06-26T10:13:56.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a0/550eec327e5f5c7b732531c489f5307efec41f047b0d703bd4ca1e5ad2db/httplib2-0.32.0-py3-none-any.whl", hash = "sha256:dc6705cacdf3fb0a2aba7629fa33c90fd93e30035db0c157325826be177e4816", size = 93148, upload-time = "2026-06-26T10:13:54.985Z" },
 ]
 
 [[package]]
@@ -7003,11 +7005,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

There is nothing unit-testable here; a floor pin is enforced by the resolver, and the existing install/test jobs in CI exercise the resolved versions. Verification is the resolution and import evidence below

## Screenshots / Proof of Fix

This is a dependency-constraint change with no runtime behavior delta, so there is no proxy call to demo; the proof is that resolution moves the two transitive deps to their latest maintenance releases and the runtime still imports cleanly. Captured at commit `ddf1676896`

`uv lock` moves exactly the two packages:

```
$ uv lock
Resolved 417 packages in 665ms
Updated httplib2 v0.31.2 -> v0.32.0
Updated setuptools v82.0.1 -> v83.0.0
```

Import smoke against the updated lock:

```
$ .venv/bin/python -c "import setuptools, grpc_tools, litellm; print('setuptools', setuptools.__version__)"
setuptools 83.0.0

$ uv run --isolated --no-project --with "httplib2==0.32.0" \
    python -c "import httplib2; print('httplib2', httplib2.__version__); httplib2.Http()"
httplib2 0.32.0
```

`import litellm` succeeds, and a default install does not pull either package in; both arrive only through optional integrations

## Type

🚄 Infrastructure

## Changes

Two floor pins are added to the existing `[tool.uv]` `constraint-dependencies` list in `pyproject.toml`, alongside the current `tornado`, `aiohttp`, and `soupsieve` floors: `httplib2>=0.32.0` (was resolving to 0.31.2) and `setuptools>=83.0.0` (was resolving to 82.0.1). This keeps two transitive dependencies on their latest maintenance releases as ordinary dependency hygiene

Both packages are transitive-only. httplib2 comes in through `google-api-python-client` and `google-auth-httplib2`, which both cap `httplib2<1.0.0,>=0.19.0`, so 0.32.0 is in range. setuptools comes in through `grpcio-tools`, `lunary`, and `nvidia-riva-client`, all lower-bound only, so 83.0.0 is in range as well. Because every requirer already allows the newer version, `uv lock` moves only these two packages and nothing else drifts; `exclude-newer` already covers both releases (httplib2 0.32.0 and setuptools 83.0.0 predate the window). setuptools is a major bump, but it is only a runtime dependency of those optional integrations (grpc tooling, lunary observability, the nvidia-riva STT extra), so a default proxy or SDK install is unaffected
