### PR TITLE
fix(openai): bridge gpt-5.6+ with tools to /v1/responses even without reasoning_effort

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1014,8 +1014,10 @@ def responses_api_bridge_check(
         and model_info.get("mode") != "responses"
         and OpenAIGPT5Config.is_model_gpt_5_model(model)
         and not OpenAIGPT5Config.is_model_gpt_5_search_model(model)
-        and reasoning_effort is not None
-        and (reasoning_summary is not None or (OpenAIGPT5Config.is_model_gpt_5_4_plus_model(model) and tools))
+        and (
+            (reasoning_effort is not None and reasoning_summary is not None)
+            or (OpenAIGPT5Config.is_model_gpt_5_4_plus_model(model) and tools)
+        )
     ):
         model_info["mode"] = "responses"
         model = model.replace("responses/", "")

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1006,7 +1006,8 @@ def responses_api_bridge_check(
     # ``reasoningSummary`` in ``extra_body``) must be bridged; Chat Completions rejects
     # those keys.
     #
-    # - gpt-5.4+: tools + reasoning_effort (original) or any reasoning-summary alias.
+    # - # - gpt-5.4+: tools alone (OpenAI applies reasoning_effort server-side, making
+    #   /v1/chat/completions reject tool calls for this family) or reasoning-summary alias.
     # - Older GPT-5 names (e.g. ``gpt-5``, ``gpt-5.1``): bridge only when a reasoning
     #   summary alias is present with ``reasoning_effort`` (tools alone stay on chat).
     if (

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1006,7 +1006,7 @@ def responses_api_bridge_check(
     # ``reasoningSummary`` in ``extra_body``) must be bridged; Chat Completions rejects
     # those keys.
     #
-    # - # - gpt-5.4+: tools alone (OpenAI applies reasoning_effort server-side, making
+    # - gpt-5.4+: tools alone (OpenAI applies reasoning_effort server-side, making
     #   /v1/chat/completions reject tool calls for this family) or reasoning-summary alias.
     # - Older GPT-5 names (e.g. ``gpt-5``, ``gpt-5.1``): bridge only when a reasoning
     #   summary alias is present with ``reasoning_effort`` (tools alone stay on chat).

--- a/tests/test_litellm/test_gpt56_bridge.py
+++ b/tests/test_litellm/test_gpt56_bridge.py
@@ -7,3 +7,10 @@ def test_gpt56_tools_bridged_to_responses_without_reasoning_effort():
     for model in ["gpt-5.6-sol", "gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6"]:
         model_info, _ = responses_api_bridge_check(model=model, custom_llm_provider="openai", tools=tools, reasoning_effort=None)
         assert model_info.get("mode") == "responses", f"{model} with tools should bridge to responses even without reasoning_effort"
+
+def test_older_gpt5_with_tools_not_bridged_without_reasoning_effort():
+    """gpt-5, gpt-5.1, gpt-5.3 with tools should NOT bridge without reasoning_effort."""
+    tools = [{"type": "function", "function": {"name": "get_weather", "description": "test", "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}}}]
+    for model in ["gpt-5", "gpt-5.1", "gpt-5.3"]:
+        model_info, _ = responses_api_bridge_check(model=model, custom_llm_provider="openai", tools=tools, reasoning_effort=None)
+        assert model_info.get("mode") != "responses", f"{model} with tools but no reasoning_effort should NOT bridge"

--- a/tests/test_litellm/test_gpt56_bridge.py
+++ b/tests/test_litellm/test_gpt56_bridge.py
@@ -1,0 +1,9 @@
+"""Regression test for https://github.com/BerriAI/litellm/issues/33221"""
+from litellm.main import responses_api_bridge_check
+
+
+def test_gpt56_tools_bridged_to_responses_without_reasoning_effort():
+    tools = [{"type": "function", "function": {"name": "get_weather", "description": "Get weather", "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}}}]
+    for model in ["gpt-5.6-sol", "gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6"]:
+        model_info, _ = responses_api_bridge_check(model=model, custom_llm_provider="openai", tools=tools, reasoning_effort=None)
+        assert model_info.get("mode") == "responses", f"{model} with tools should bridge to responses even without reasoning_effort"


### PR DESCRIPTION
## Problem
gpt-5.6 family models (gpt-5.6-sol, gpt-5.6-luna, gpt-5.6-terra) fail with:

> Function tools with reasoning_effort are not supported for gpt-5.6-sol in /v1/chat/completions

when function tools are passed without explicitly setting `reasoning_effort`. OpenAI applies a default reasoning_effort server-side for this model family, which makes tools incompatible with `/v1/chat/completions`.

## Root cause
`responses_api_bridge_check` in `main.py` only bridged to `/v1/responses` when `reasoning_effort is not None`. For gpt-5.4+ models with tools, the bridge should fire unconditionally since the model family requires `/v1/responses` for tool calls regardless of whether the caller sets `reasoning_effort`.

## Fix
Removed the `reasoning_effort is not None` gate from the gpt-5.4+ + tools path. The condition now bridges when:
- `reasoning_effort` + `reasoning_summary` are both explicitly set (original behavior for older models), OR  
- model is gpt-5.4+ AND tools are present (new, unconditional for this family)

## Test
Added `tests/test_litellm/test_gpt56_bridge.py` covering all four gpt-5.6 variants.

Fixes #33221