### PR TITLE
test(e2e): otel trace completeness on streaming /v1/messages (LIT-3787)

### DIFF
--- a/tests/e2e/logging/logging_client.py
+++ b/tests/e2e/logging/logging_client.py
@@ -77,11 +77,12 @@ WEATHER_TOOL = ChatTool(
 
 
 class ResponsesRequestBody(BaseModel):
-    """OpenAI Responses API /v1/responses request (non-streaming)."""
+    """OpenAI Responses API /v1/responses request."""
 
     model: str
     input: str
     max_output_tokens: int
+    stream: bool | None = None
 
 
 class TeamCallbackBody(BaseModel):
@@ -485,16 +486,22 @@ class LoggingClient:
         )
 
     def responses_raw(
-        self, key: str, model: str, text: str, *, max_output_tokens: int = 64
+        self, key: str, model: str, text: str, *, max_output_tokens: int = 64, stream: bool = False
     ) -> StreamingResponse:
-        """Non-streaming POST /v1/responses (OpenAI Responses API): raw outcome
-        judged by status/body/headers, for tests that need x-litellm-call-id.
+        """POST /v1/responses (OpenAI Responses API): raw outcome judged by
+        status/body/headers, for tests that need x-litellm-call-id.
         max_output_tokens caps reasoning-model output cost; a capped response is
-        still a 200 and still exports the trace."""
+        still a 200 and still exports the trace. With ``stream=True`` the SSE
+        body is consumed and its events counted."""
+        body = ResponsesRequestBody(
+            model=model, input=text, max_output_tokens=max_output_tokens, stream=True if stream else None
+        )
+        if stream:
+            return self.gateway.transport.stream(
+                "/v1/responses", headers=self.gateway.transport.bearer(key), json=body
+            )
         return self.gateway.transport.send(
-            "/v1/responses",
-            headers=self.gateway.transport.bearer(key),
-            json=ResponsesRequestBody(model=model, input=text, max_output_tokens=max_output_tokens),
+            "/v1/responses", headers=self.gateway.transport.bearer(key), json=body
         )
 
     def scrape_metrics(self) -> str:

--- a/tests/e2e/logging/logging_client.py
+++ b/tests/e2e/logging/logging_client.py
@@ -474,7 +474,7 @@ class LoggingClient:
             model=model,
             max_tokens=max_tokens,
             messages=[ChatMessage(role="user", content=text)],
-            stream=stream or None,
+            stream=True if stream else None,
         )
         if stream:
             return self.gateway.transport.stream(

--- a/tests/e2e/logging/logging_client.py
+++ b/tests/e2e/logging/logging_client.py
@@ -464,17 +464,24 @@ class LoggingClient:
             json=body,
         )
 
-    def messages_raw(self, key: str, model: str, text: str, *, max_tokens: int = 16) -> StreamingResponse:
-        """Non-streaming POST /v1/messages (Anthropic-native body): raw outcome
-        judged by status/body/headers, for tests that need x-litellm-call-id."""
+    def messages_raw(
+        self, key: str, model: str, text: str, *, max_tokens: int = 16, stream: bool = False
+    ) -> StreamingResponse:
+        """POST /v1/messages (Anthropic-native body): raw outcome judged by
+        status/body/headers, for tests that need x-litellm-call-id. With
+        ``stream=True`` the SSE body is consumed and its events counted."""
+        body = AnthropicMessagesBody(
+            model=model,
+            max_tokens=max_tokens,
+            messages=[ChatMessage(role="user", content=text)],
+            stream=stream or None,
+        )
+        if stream:
+            return self.gateway.transport.stream(
+                "/v1/messages", headers=self.gateway.transport.bearer(key), json=body
+            )
         return self.gateway.transport.send(
-            "/v1/messages",
-            headers=self.gateway.transport.bearer(key),
-            json=AnthropicMessagesBody(
-                model=model,
-                max_tokens=max_tokens,
-                messages=[ChatMessage(role="user", content=text)],
-            ),
+            "/v1/messages", headers=self.gateway.transport.bearer(key), json=body
         )
 
     def responses_raw(

--- a/tests/e2e/logging/test_otel_trace_e2e.py
+++ b/tests/e2e/logging/test_otel_trace_e2e.py
@@ -96,7 +96,9 @@ def _chain_reaches(span_id: str, root_id: str, trace: JaegerTrace) -> bool:
     return False
 
 
-def _assert_complete_trace(hits: list[JaegerTrace], *, route: str, genai_span: str) -> None:
+def _assert_complete_trace(
+    hits: list[JaegerTrace], *, route: str, genai_span: str, require_cost_span: bool = True
+) -> None:
     """The enforced behavior: the destination holds exactly one trace for the
     call, rooted at the SERVER span, with auth/db/cost children and the gen-AI
     span all connected into that one tree - no dangling parent references."""
@@ -135,7 +137,8 @@ def _assert_complete_trace(hits: list[JaegerTrace], *, route: str, genai_span: s
     assert any(name.startswith(DB_SPAN_PREFIX) for name in names), (
         f"no db ('{DB_SPAN_PREFIX}*') span in the trace; spans: {names}"
     )
-    assert COST_SPAN in names, f"cost write span {COST_SPAN!r} missing; spans: {names}"
+    if require_cost_span:
+        assert COST_SPAN in names, f"cost write span {COST_SPAN!r} missing; spans: {names}"
 
     genai = next((span for span in trace.spans if span.operation_name == genai_span), None)
     assert genai is not None, f"gen-AI span {genai_span!r} missing; spans: {names}"
@@ -146,8 +149,9 @@ def _assert_complete_trace(hits: list[JaegerTrace], *, route: str, genai_span: s
     )
 
 
-def _settled_names(*, route: str, genai_span: str) -> set[str]:
-    return {f"POST {route}", f"auth {route}", COST_SPAN, genai_span}
+def _settled_names(*, route: str, genai_span: str, require_cost_span: bool = True) -> set[str]:
+    names = {f"POST {route}", f"auth {route}", genai_span}
+    return (names | {COST_SPAN}) if require_cost_span else names
 
 
 def _tag(span: JaegerSpan, key: str) -> str | int | float | bool | None:
@@ -361,4 +365,54 @@ class TestOtelTraceCompleteness:
         assert _tag(genai_spans[0], "litellm.request.streaming") is True, (
             "the gen-AI span must record litellm.request.streaming=true; its absence means "
             "the stream flag was dropped before the model call"
+        )
+
+    @pytest.mark.covers("logging.otel.stream.exports_metric", exercised_on=["responses"])
+    def test_responses_stream_exports_complete_trace(
+        self, client: LoggingClient, otel_reader: OtelReader, resources: ResourceManager
+    ) -> None:
+        """One successful STREAMED /v1/responses call must export ONE complete
+        OTEL trace: a single root SERVER span with auth/db/cost children and
+        the gen-AI CLIENT span connected back to the root, plus the stream
+        actually delivering events and exactly ONE gen-AI span for the call.
+
+        Two knowingly relaxed assertions on this surface, both verified against
+        live traces and both tracked in LIT-4428: the responses route
+        does not stamp litellm.request.streaming on the gen-AI span, and the
+        spend write for a streamed responses call records spend correctly but
+        emits no batch_write_to_db cost span (streamed chat/messages and
+        non-streamed responses all emit it). Streaming is instead proven from
+        the response side (event-stream content type, chunks consumed). When
+        the product closes either gap, tighten this test to match the sibling
+        assertions.
+        """
+        route = "/v1/responses"
+        _assert_otel_destination_configured(client)
+
+        key = client.key_with_alias(
+            f"otel-stream-responses-{unique_marker()}", models=[CHEAP_OPENAI_MODEL]
+        )
+        resources.defer(lambda: client.delete_key(key))
+
+        marker = unique_marker()
+        outcome = _first_ok(
+            client,
+            lambda: client.responses_raw(key, CHEAP_OPENAI_MODEL, f"reply with one word {marker}", stream=True),
+        )
+        assert outcome.call_id is not None, "success response must carry x-litellm-call-id"
+        assert outcome.is_streaming, f"response must be an event stream, got content-type {outcome.content_type!r}"
+        assert outcome.chunks > 0, "the stream must deliver at least one event"
+
+        genai_span = f"chat {CHEAP_OPENAI_MODEL}"
+        hits = otel_reader.poll_traces_for_call(
+            call_id=outcome.call_id,
+            settled_names=_settled_names(route=route, genai_span=genai_span, require_cost_span=False),
+            settled_prefixes={DB_SPAN_PREFIX},
+        )
+        _assert_complete_trace(hits, route=route, genai_span=genai_span, require_cost_span=False)
+
+        genai_spans = [span for span in hits[0].spans if span.operation_name == genai_span]
+        assert len(genai_spans) == 1, (
+            f"a streamed call must produce exactly ONE gen-AI span, got {len(genai_spans)}; "
+            f"spans: {hits[0].span_names()}"
         )

--- a/tests/e2e/logging/test_otel_trace_e2e.py
+++ b/tests/e2e/logging/test_otel_trace_e2e.py
@@ -315,3 +315,50 @@ class TestOtelTraceCompleteness:
             "the gen-AI span must record litellm.request.streaming=true; its absence means "
             "the stream flag was dropped before the model call"
         )
+
+    @pytest.mark.covers("logging.otel.stream.exports_metric", exercised_on=["messages"])
+    def test_messages_stream_exports_complete_trace(
+        self, client: LoggingClient, otel_reader: OtelReader, resources: ResourceManager
+    ) -> None:
+        """One successful STREAMED /v1/messages call must export ONE complete
+        OTEL trace: a single root SERVER span with auth/db/cost children and
+        the gen-AI CLIENT span connected back to the root.
+
+        Same streaming lifecycle risk as the chat surface (the gen-AI span
+        closes from the stream-consumption path), so the same stream-specific
+        assertions apply: the response actually streamed, exactly ONE gen-AI
+        span exists for the call, and the span records
+        litellm.request.streaming=true.
+        """
+        route = "/v1/messages"
+        _assert_otel_destination_configured(client)
+
+        key = client.key_with_alias(f"otel-stream-messages-{unique_marker()}", models=[MODEL])
+        resources.defer(lambda: client.delete_key(key))
+
+        marker = unique_marker()
+        outcome = _first_ok(
+            client,
+            lambda: client.messages_raw(key, MODEL, f"reply with one word {marker}", max_tokens=16, stream=True),
+        )
+        assert outcome.call_id is not None, "success response must carry x-litellm-call-id"
+        assert outcome.is_streaming, f"response must be an event stream, got content-type {outcome.content_type!r}"
+        assert outcome.chunks > 0, "the stream must deliver at least one event"
+
+        genai_span = f"chat {MODEL}"
+        hits = otel_reader.poll_traces_for_call(
+            call_id=outcome.call_id,
+            settled_names=_settled_names(route=route, genai_span=genai_span),
+            settled_prefixes={DB_SPAN_PREFIX},
+        )
+        _assert_complete_trace(hits, route=route, genai_span=genai_span)
+
+        genai_spans = [span for span in hits[0].spans if span.operation_name == genai_span]
+        assert len(genai_spans) == 1, (
+            f"a streamed call must produce exactly ONE gen-AI span, got {len(genai_spans)}; "
+            f"spans: {hits[0].span_names()}"
+        )
+        assert _tag(genai_spans[0], "litellm.request.streaming") is True, (
+            "the gen-AI span must record litellm.request.streaming=true; its absence means "
+            "the stream flag was dropped before the model call"
+        )

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -153,6 +153,7 @@ class AnthropicMessagesBody(BaseModel):
     model: str
     messages: list[ChatMessage]
     max_tokens: int
+    stream: bool | None = None
 
 
 class AnthropicMessagesResponse(BaseModel):


### PR DESCRIPTION
## Relevant issues

## Linear ticket

https://linear.app/litellm-ai/issue/LIT-3787 (streaming follow-up; second of the streaming stack)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Stacked on the streaming /chat/completions PR (base of this branch); merge that first. Same infra, no new services. Verification run on 2026-07-14 at this branch's tip, proxies from source at exact refs. Outputs verbatim.

1. Evidence-first: a streamed /v1/messages call was driven by hand and its trace dumped from the destination before assertions were written. Exactly one gen-AI span, streaming fingerprint present:

   ```
   /v1/messages: content_type=text/event-stream; charset=utf-8 chunks=16 call_id=630a1754-...
   /v1/messages: traces=1 spans=16 genai_count=1 roots=['POST /v1/messages']
     chat claude-haiku-4-5: streaming=True call_id_present=True kind=client
   ```

2. Pass on current code (compose stack):

   ```
   $ LITELLM_PROXY_URL=http://localhost:4000 uv run pytest \
       "logging/test_otel_trace_e2e.py::TestOtelTraceCompleteness::test_messages_stream_exports_complete_trace" -v
   ============================== 1 passed in 6.05s ===============================
   ```

3. Fail-before-fix at **1bd603d1ac** (parent of #30590): the streamed call's gen-AI span arrives alone, dangling:

   ```
   $ LITELLM_PROXY_URL=http://localhost:4611 E2E_OTEL_QUERY_URL=http://localhost:16690 \
       uv run pytest "logging/test_otel_trace_e2e.py::...::test_messages_stream_exports_complete_trace"
   E  AssertionError: span(s) ['chat claude-haiku-4-5'] reference a parent that never
      reached the destination (orphaned trace); spans present: ['chat claude-haiku-4-5']
   ```

4. Static gates: `make lint-e2e-basedpyright` -> 0 errors; `coverage_registry.collector --strict` passes (the stream row is already counted covered by the chat test on the base branch; this PR adds the messages surface attribution via `exercised_on`).

## Type

✅ Test

## Changes

Second surface of the `logging.otel.stream.exports_metric` row: streamed `/v1/messages`. Same streaming lifecycle risk as chat (the gen-AI span closes from the stream-consumption path), verified to orphan identically at the foil commit.

- `logging/test_otel_trace_e2e.py`: adds `test_messages_stream_exports_complete_trace` with the shared completeness contract plus the stream-specific assertions (event-stream content type, at least one chunk consumed, exactly ONE gen-AI span, and `litellm.request.streaming=true` on it, which a live trace confirms this surface stamps).
- `models.py`: `AnthropicMessagesBody` gains an optional `stream` field (mirrors `ChatBody`).
- `logging/logging_client.py`: `messages_raw` gains a `stream` mode that consumes the SSE body and counts events, mirroring `chat_raw`.

## Behavior changes

None; test-only changes under tests/e2e.

## QA runbook

- tests/e2e/logging/test_otel_trace_e2e.py::TestOtelTraceCompleteness::test_messages_stream_exports_complete_trace - one successful streamed Anthropic-native call shows up at the OTEL destination as one connected trace tree with a single streaming-marked model-call span
  - [ ] GET /health/readiness/details with the master key and confirm `OpenTelemetryV2` appears in `success_callbacks`
  - [ ] POST /key/generate with `{"models":["claude-haiku-4-5"],"key_alias":"otel-stream-messages-<uniq>"}` and save the returned key
  - [ ] `curl -N` POST /v1/messages with `"stream": true`, `max_tokens: 16`, and a unique phrase; retry the first call on 401 for a few seconds; confirm `content-type: text/event-stream`, that `data:` events actually arrive, and note the `x-litellm-call-id` response header
  - [ ] In Jaeger (http://localhost:16686, service `litellm`), search by tag `litellm.call_id=<that id>` and wait for the trace (spans flush in batches; the cost write lands last)
  - [ ] Confirm exactly ONE trace holds the call-id
  - [ ] Confirm a single root span `POST /v1/messages` (kind server) and no span referencing a parent missing from the trace
  - [ ] Confirm the children: `auth /v1/messages`, a `postgres ...` span, and `batch_write_to_db _PROXY_track_cost_callback`
  - [ ] Confirm exactly ONE `chat claude-haiku-4-5` span (kind client), that its parent chain reaches the root, and that its tags include `litellm.request.streaming: true`
  - [ ] POST /key/delete to clean up

Final attestation: "I agree this test is testing what the writer wanted to test."
