### PR TITLE
feat(ui): left-anchor the Create Key and Create Team CTAs

### DIFF
--- a/ui/litellm-dashboard/src/components/Teams.test.tsx
+++ b/ui/litellm-dashboard/src/components/Teams.test.tsx
@@ -436,6 +436,33 @@ describe("Teams - premium props", () => {
   });
 });
 
+describe("Teams - Create Team CTA is grouped with the tabs on the left", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseOrganizations.mockReturnValue({ data: [] });
+  });
+
+  it("renders the Create Team button inside the tab bar, ahead of the tabs", () => {
+    const { container } = renderWithQueryClient(<Teams accessToken="test-token" userID="user-123" userRole="Admin" />);
+
+    const createButton = screen.getByTestId("create-team-button");
+    const tabNav = container.querySelector(".ant-tabs-nav");
+
+    // The CTA lives in the tab bar's left slot, not the standalone page header.
+    expect(tabNav).not.toBeNull();
+    expect(tabNav!.contains(createButton)).toBe(true);
+
+    // It reads as the left end of the cluster: it precedes the first tab in DOM order.
+    const firstTab = screen.getByRole("tab", { name: "Your Teams" });
+    expect(createButton.compareDocumentPosition(firstTab) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("omits the Create Team CTA for a role that cannot manage teams", () => {
+    renderWithQueryClient(<Teams accessToken="test-token" userID="user-123" userRole="Admin Viewer" />);
+    expect(screen.queryByTestId("create-team-button")).not.toBeInTheDocument();
+  });
+});
+
 describe("Teams - Default Team Settings tab visibility", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/ui/litellm-dashboard/src/components/Teams.tsx
+++ b/ui/litellm-dashboard/src/components/Teams.tsx
@@ -564,18 +564,23 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
               icon={<Users className="size-5" />}
               title="Teams"
               subtitle="Manage teams, members, and their access to models and budgets"
-              actions={
-                canCreateOrManageTeams(userRole, userID, organizations) ? (
+            />
+          </div>
+
+          <Tabs
+            items={tabItems}
+            tabBarExtraContent={{
+              left: canCreateOrManageTeams(userRole, userID, organizations) ? (
+                <div className="flex items-center gap-4 pr-4">
                   <UIButton onClick={() => setIsTeamModalVisible(true)} data-testid="create-team-button">
                     <Plus className="size-4" />
                     Create Team
                   </UIButton>
-                ) : undefined
-              }
-            />
-          </div>
-
-          <Tabs items={tabItems} />
+                  <div className="h-6 w-px bg-gray-200" />
+                </div>
+              ) : undefined,
+            }}
+          />
         </>
       )}
 

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
@@ -174,10 +174,19 @@ it("should render VirtualKeysTable component", () => {
   expect(screen.getByText("Test Key Alias")).toBeInTheDocument();
 });
 
-it("renders the page header with the create-key action slot", () => {
+it("left-anchors the create-key CTA below the title, between the header and the table toolbar", () => {
   renderWithProviders(<VirtualKeysTable headerActions={<button>Create New Key</button>} />);
-  expect(screen.getByRole("heading", { name: "Virtual Keys" })).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: "Create New Key" })).toBeInTheDocument();
+
+  const heading = screen.getByRole("heading", { name: "Virtual Keys" });
+  const ctas = screen.getAllByRole("button", { name: "Create New Key" });
+  expect(ctas).toHaveLength(1);
+  const cta = ctas[0];
+  const search = screen.getByPlaceholderText(/Search by key alias/);
+
+  // The CTA follows the title row...
+  expect(heading.compareDocumentPosition(cta) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  // ...and precedes the table's search toolbar, so it sits in its own row above the table.
+  expect(cta.compareDocumentPosition(search) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 });
 
 it("should display key information correctly", async () => {

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
@@ -162,8 +162,8 @@ export function VirtualKeysTable({ headerActions }: VirtualKeysTableProps) {
         icon={<KeyRound className="size-5" />}
         title="Virtual Keys"
         subtitle="Every key that authenticates requests to the gateway."
-        actions={headerActions}
       />
+      {headerActions}
       <DataTable
         data={keyList}
         columns={columns}


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both changes are UI-only. To audit against a live proxy, run the dashboard dev server (`npm run dev` in `ui/litellm-dashboard`) pointed at a proxy and open the two pages

Keys (http://localhost:3000/ui/?page=api-keys): the "+ Create New Key" button now sits on its own row, left-anchored below the "Virtual Keys" title and above the search toolbar, instead of in the header's top-right corner

Teams (http://localhost:3000/ui/?page=teams): the "Create Team" button now sits to the left of a vertical rule, followed by the "Your Teams / Available Teams / Default Team Settings" tabs, all on one row below the title

Before/after screenshots to follow

## Type

🆕 New Feature

## Changes

Moves the create-resource call to action for both the Keys and Teams tables from the page header's right-side action slot to the left, matching the updated design

On Teams, the "Create Team" button is rendered in the tab bar's left slot via antd's `tabBarExtraContent`, separated from the tabs by a vertical rule so the button and tabs read as a single left-anchored cluster. On Keys, which has no tabs, the "Create New Key" button anchors left on its own row beneath the title. The shared `PageHeader` component is left untouched so no other page that uses it is affected

Existing behavior is preserved; both buttons keep their `data-testid` hooks and click handlers, and the create modals open as before. New regression tests pin the positions, so the Teams test asserts the button now lives inside the tab bar ahead of the first tab and the Keys test asserts the CTA renders once between the title and the search toolbar

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
