### PR TITLE
feat(router): resolve auto-router routing plugins from proxy YAML config

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -556,6 +556,7 @@ from litellm.types.router import (
 from litellm.types.router import ModelInfo as RouterModelInfo
 from litellm.types.router import (
     RouterGeneralSettings,
+    RoutingPlugin,
     SearchToolTypedDict,
     updateDeployment,
 )
@@ -3660,6 +3661,39 @@ def _attach_redis_usage_cache(redis_cache: RedisCache, enable_redis_auth_cache: 
     litellm_config_cache.redis_cache = redis_cache
 
 
+def resolve_complexity_router_plugins(
+    model_name: str,
+    complexity_router_config: dict,
+    config_file_path: Optional[str],
+) -> None:
+    """
+    Resolves `complexity_router_config["plugins"]` dotted-path strings to live
+    instances via `get_instance_fn` (the same convention `litellm_settings.callbacks`
+    uses), in place. Raises at config-load time if a path resolves to something that
+    doesn't implement `RoutingPlugin`, rather than deferring to a confusing
+    `AttributeError` on the first request that reaches the plugin pipeline.
+    """
+    plugin_paths = complexity_router_config.get("plugins")
+    if not isinstance(plugin_paths, list):
+        return
+
+    resolved_plugins = [
+        get_instance_fn(value=plugin_path, config_file_path=config_file_path)
+        if isinstance(plugin_path, str)
+        else plugin_path
+        for plugin_path in plugin_paths
+    ]
+    for plugin_path, resolved_plugin in zip(plugin_paths, resolved_plugins):
+        if not isinstance(resolved_plugin, RoutingPlugin):
+            raise ValueError(
+                f"complexity_router_config.plugins entry {plugin_path!r} on model {model_name!r} "
+                f"resolved to {resolved_plugin!r}, which does not implement the RoutingPlugin "
+                "interface (an async `run(context)` method). Fix the referenced module before "
+                "starting the proxy."
+            )
+    complexity_router_config["plugins"] = resolved_plugins
+
+
 class ProxyConfig:
     """
     Abstraction class on top of config loading/updating logic. Gives us one place to control all config updating logic.
@@ -4722,14 +4756,11 @@ class ProxyConfig:
                         model["litellm_params"][k] = get_secret(v)
                 complexity_router_config = model["litellm_params"].get("complexity_router_config")
                 if isinstance(complexity_router_config, dict):
-                    plugin_paths = complexity_router_config.get("plugins")
-                    if isinstance(plugin_paths, list):
-                        complexity_router_config["plugins"] = [
-                            get_instance_fn(value=plugin_path, config_file_path=config_file_path)
-                            if isinstance(plugin_path, str)
-                            else plugin_path
-                            for plugin_path in plugin_paths
-                        ]
+                    resolve_complexity_router_plugins(
+                        model_name=model.get("model_name", ""),
+                        complexity_router_config=complexity_router_config,
+                        config_file_path=config_file_path,
+                    )
                 print(f"\033[32m    {model.get('model_name', '')}\033[0m")  # noqa: T201
                 litellm_model_name = model["litellm_params"]["model"]
                 litellm_model_api_base = model["litellm_params"].get("api_base", None)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4720,6 +4720,16 @@ class ProxyConfig:
                 for k, v in model["litellm_params"].items():
                     if isinstance(v, str) and v.startswith("os.environ/"):
                         model["litellm_params"][k] = get_secret(v)
+                complexity_router_config = model["litellm_params"].get("complexity_router_config")
+                if isinstance(complexity_router_config, dict):
+                    plugin_paths = complexity_router_config.get("plugins")
+                    if isinstance(plugin_paths, list):
+                        complexity_router_config["plugins"] = [
+                            get_instance_fn(value=plugin_path, config_file_path=config_file_path)
+                            if isinstance(plugin_path, str)
+                            else plugin_path
+                            for plugin_path in plugin_paths
+                        ]
                 print(f"\033[32m    {model.get('model_name', '')}\033[0m")  # noqa: T201
                 litellm_model_name = model["litellm_params"]["model"]
                 litellm_model_api_base = model["litellm_params"].get("api_base", None)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3684,7 +3684,13 @@ def resolve_complexity_router_plugins(
         for plugin_path in plugin_paths
     ]
     for plugin_path, resolved_plugin in zip(plugin_paths, resolved_plugins):
-        if not isinstance(resolved_plugin, RoutingPlugin):
+        # `@runtime_checkable` only checks that `run` exists as an attribute, not that
+        # it's a coroutine function -- a synchronous `def run(self, context)` would pass
+        # isinstance() here and only fail at request time with a confusing `TypeError:
+        # object RoutingContext can't be used in 'await' expression`.
+        if not isinstance(resolved_plugin, RoutingPlugin) or not inspect.iscoroutinefunction(
+            getattr(resolved_plugin, "run", None)
+        ):
             raise ValueError(
                 f"complexity_router_config.plugins entry {plugin_path!r} on model {model_name!r} "
                 f"resolved to {resolved_plugin!r}, which does not implement the RoutingPlugin "

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3664,7 +3664,7 @@ def _attach_redis_usage_cache(redis_cache: RedisCache, enable_redis_auth_cache: 
 def resolve_complexity_router_plugins(
     model_name: str,
     complexity_router_config: dict,
-    config_file_path: Optional[str],
+    config_file_path: str | None,
 ) -> None:
     """
     Resolves `complexity_router_config["plugins"]` dotted-path strings to live

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7284,6 +7284,14 @@ class Router:
                     raise e
         return returned_healthy_deployments
 
+    @staticmethod
+    def _json_default_stable_id(value: object) -> str:
+        """json.dumps default= for _generate_model_id: plain str() on an arbitrary
+        object (e.g. a RoutingPlugin instance) falls back to object.__repr__'s
+        `<module.Class object at 0x...>`, so the hash -- and deployment id -- would
+        change every restart. Use the class name instead, stable across restarts."""
+        return f"{type(value).__module__}.{type(value).__qualname__}"
+
     def _generate_model_id(self, model_group: str, litellm_params: dict):
         """
         Helper function to consistently generate the same id for a deployment
@@ -7299,14 +7307,14 @@ class Router:
             if isinstance(k, str):
                 parts.append(k)
             elif isinstance(k, dict):
-                parts.append(json.dumps(k, default=str))
+                parts.append(json.dumps(k, default=self._json_default_stable_id))
             else:
                 parts.append(str(k))
 
             if isinstance(v, str):
                 parts.append(v)
             elif isinstance(v, dict):
-                parts.append(json.dumps(v, default=str))
+                parts.append(json.dumps(v, default=self._json_default_stable_id))
             else:
                 parts.append(str(v))
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7299,14 +7299,14 @@ class Router:
             if isinstance(k, str):
                 parts.append(k)
             elif isinstance(k, dict):
-                parts.append(json.dumps(k))
+                parts.append(json.dumps(k, default=str))
             else:
                 parts.append(str(k))
 
             if isinstance(v, str):
                 parts.append(v)
             elif isinstance(v, dict):
-                parts.append(json.dumps(v))
+                parts.append(json.dumps(v, default=str))
             else:
                 parts.append(str(v))
 

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -492,11 +492,13 @@ class ComplexityRouter(CustomLogger):
             context = await plugin.run(context)
 
         if not context.candidate_models:
-            if self.config.default_model:
-                return self.config.default_model
+            # A plugin narrowing a tier to zero candidates is a policy decision (e.g. no
+            # model this tenant's budget allows) -- falling back to default_model here
+            # (which was never checked against the plugins) would let that policy be
+            # silently bypassed. Raise instead, matching the Router-level plugin
+            # pipeline's own fail-closed behavior for the same situation.
             raise ValueError(
-                f"No candidate models left for tier {tier_key} after routing-plugin filtering, "
-                "and no default_model configured"
+                f"No candidate models left for tier {tier_key} after routing-plugin filtering"
             )
         return self._pick_from_tier_value(context.candidate_models, tier_key)
 

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -985,14 +985,18 @@ class ComplexityRouter(CustomLogger):
 
         if user_message is None:
             verbose_router_logger.debug("ComplexityRouter: No user message found, routing to default model")
-            # No `self.config.default_model or ...` short-circuit here: default_model was
-            # never checked against the plugins, so it would function as an unconditional
-            # escape hatch around whatever policy a plugin enforces. Falls through to
-            # _pick_model_for_tier -> get_model_for_tier, which checks the MEDIUM tier
-            # before default_model -- the same priority every other call site already uses.
-            routed_model = await self._pick_model_for_tier(
-                ComplexityTier.MEDIUM, messages, resolved_messages, request_kwargs
-            )
+            if not self.config.plugins and self.config.default_model:
+                # No plugins configured: preserve the pre-existing default_model-first
+                # priority exactly (changing it would be a silent behavior change for
+                # every non-plugin user, not just a security fix).
+                routed_model = self.config.default_model
+            else:
+                # Plugins configured: default_model must never bypass them, so it's not
+                # checked here at all -- _pick_model_for_tier -> get_model_for_tier still
+                # falls back to it (after the MEDIUM tier) once the plugin pipeline runs.
+                routed_model = await self._pick_model_for_tier(
+                    ComplexityTier.MEDIUM, messages, resolved_messages, request_kwargs
+                )
             return PreRoutingHookResponse(
                 model=routed_model,
                 messages=messages if has_original_messages else None,

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -468,6 +468,38 @@ class ComplexityRouter(CustomLogger):
     def _tier_pools(self) -> dict[str, list[str]]:
         return {tier: (models if isinstance(models, list) else [models]) for tier, models in self.config.tiers.items()}
 
+    async def _pick_model_for_tier(
+        self,
+        tier: ComplexityTier,
+        raw_messages: list[dict[str, Any]] | None,
+        resolved_messages: list[dict[str, Any]] | None,
+        request_kwargs: dict,
+    ) -> str:
+        if not self.config.plugins:
+            return self.get_model_for_tier(tier)
+
+        from litellm.types.router import RoutingContext
+
+        tier_key = tier.value
+        metadata_key = "litellm_metadata" if "litellm_metadata" in request_kwargs else "metadata"
+        context = RoutingContext(
+            raw_messages=raw_messages or [],
+            structured_messages=resolved_messages or [],
+            candidate_models=list(self._tier_pools().get(tier_key, [])),
+            metadata=request_kwargs.get(metadata_key) or {},
+        )
+        for plugin in self.config.plugins:
+            context = await plugin.run(context)
+
+        if not context.candidate_models:
+            if self.config.default_model:
+                return self.config.default_model
+            raise ValueError(
+                f"No candidate models left for tier {tier_key} after routing-plugin filtering, "
+                "and no default_model configured"
+            )
+        return self._pick_from_tier_value(context.candidate_models, tier_key)
+
     def _ensure_adaptive_router(self) -> Any | None:
         if not self.config.adaptive:
             return None
@@ -947,14 +979,17 @@ class ComplexityRouter(CustomLogger):
 
         if user_message is None:
             verbose_router_logger.debug("ComplexityRouter: No user message found, routing to default model")
+            routed_model = self.config.default_model or await self._pick_model_for_tier(
+                ComplexityTier.MEDIUM, messages, resolved_messages, request_kwargs
+            )
             return PreRoutingHookResponse(
-                model=self.config.default_model or self.get_model_for_tier(ComplexityTier.MEDIUM),
+                model=routed_model,
                 messages=messages if has_original_messages else None,
             )
 
         override_tier = await self._resolve_keyword_tier_override(user_message, request_kwargs)
         if override_tier is not None:
-            routed_model = self.get_model_for_tier(override_tier)
+            routed_model = await self._pick_model_for_tier(override_tier, messages, resolved_messages, request_kwargs)
             cause = "semantic_keyword_match" if self.config.semantic_keyword_matching else "literal_keyword_match"
             verbose_router_logger.info(
                 f"ComplexityRouter: routing decision cause={cause}, "
@@ -980,7 +1015,7 @@ class ComplexityRouter(CustomLogger):
                 f"signals={signals}, routed_model={routed_model}"
             )
         else:
-            routed_model = self.get_model_for_tier(tier)
+            routed_model = await self._pick_model_for_tier(tier, messages, resolved_messages, request_kwargs)
             verbose_router_logger.info(
                 f"ComplexityRouter: routing decision cause=complexity_scorer, tier={tier.value}, "
                 f"score={score:.3f}, signals={signals}, routed_model={routed_model}"

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -893,10 +893,16 @@ class ComplexityRouter(CustomLogger):
         When `session_affinity` is enabled and a session_id is resolvable on the request,
         pins the model chosen on the session's first turn and reuses it for every later
         turn, skipping classification entirely. Otherwise delegates to `_classify_and_route`.
+
+        Skipped entirely when `plugins` are configured: reusing a stale pin would bypass
+        the plugin pipeline on every turn after the first, since a pinned model was never
+        re-checked against a policy plugin whose decision can change between turns (e.g. a
+        budget plugin, once the session's spend crosses its cap).
         """
         from litellm.types.router import PreRoutingHookResponse
 
-        session_id = self._get_session_id_from_request_kwargs(request_kwargs) if self.config.session_affinity else None
+        use_session_affinity = self.config.session_affinity and not self.config.plugins
+        session_id = self._get_session_id_from_request_kwargs(request_kwargs) if use_session_affinity else None
         cache_key = self._get_session_affinity_cache_key(session_id, request_kwargs) if session_id is not None else None
 
         if cache_key is not None:

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -497,9 +497,7 @@ class ComplexityRouter(CustomLogger):
             # (which was never checked against the plugins) would let that policy be
             # silently bypassed. Raise instead, matching the Router-level plugin
             # pipeline's own fail-closed behavior for the same situation.
-            raise ValueError(
-                f"No candidate models left for tier {tier_key} after routing-plugin filtering"
-            )
+            raise ValueError(f"No candidate models left for tier {tier_key} after routing-plugin filtering")
         return self._pick_from_tier_value(context.candidate_models, tier_key)
 
     def _ensure_adaptive_router(self) -> Any | None:

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -985,7 +985,12 @@ class ComplexityRouter(CustomLogger):
 
         if user_message is None:
             verbose_router_logger.debug("ComplexityRouter: No user message found, routing to default model")
-            routed_model = self.config.default_model or await self._pick_model_for_tier(
+            # No `self.config.default_model or ...` short-circuit here: default_model was
+            # never checked against the plugins, so it would function as an unconditional
+            # escape hatch around whatever policy a plugin enforces. Falls through to
+            # _pick_model_for_tier -> get_model_for_tier, which checks the MEDIUM tier
+            # before default_model -- the same priority every other call site already uses.
+            routed_model = await self._pick_model_for_tier(
                 ComplexityTier.MEDIUM, messages, resolved_messages, request_kwargs
             )
             return PreRoutingHookResponse(

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -10,7 +10,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from litellm.types.router import AdaptiveRouterWeights
+from litellm.types.router import AdaptiveRouterWeights, RoutingPlugin
 
 
 class ComplexityTier(str, Enum):
@@ -375,7 +375,12 @@ class ComplexityRouterConfig(BaseModel):
         description="TTL for the session affinity pin; refreshed on every cache hit",
     )
 
-    model_config = ConfigDict(extra="allow")  # Allow additional fields
+    plugins: list[RoutingPlugin] | None = Field(
+        default=None,
+        description="RoutingPlugin instances that narrow the classified tier's candidate models before selection",
+    )
+
+    model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)  # Allow additional fields
 
     @field_validator("tiers", mode="before")
     @classmethod
@@ -419,6 +424,15 @@ class ComplexityRouterConfig(BaseModel):
             raise ValueError("embedding_model is required when semantic_keyword_matching is enabled")
         if not self.keyword_tier_rules:
             raise ValueError("keyword_tier_rules must be non-empty when semantic_keyword_matching is enabled")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_plugins_adaptive_combo(self) -> "ComplexityRouterConfig":
+        if self.plugins and self.adaptive:
+            raise ValueError(
+                "plugins and adaptive=True cannot both be set: adaptive's bandit selection doesn't yet "
+                "consume plugin-narrowed candidate pools. Disable adaptive or remove plugins."
+            )
         return self
 
 

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Literal, Optional, Tuple, Union, get_type_hi
 
 import httpx
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
-from typing_extensions import Protocol, Required, TypedDict
+from typing_extensions import Protocol, Required, TypedDict, runtime_checkable
 
 from litellm._uuid import uuid
 
@@ -852,6 +852,7 @@ class RoutingContext(BaseModel):
     signals: dict[str, Any] = Field(default_factory=dict)
 
 
+@runtime_checkable
 class RoutingPlugin(Protocol):
     """Interface a custom routing plugin must implement to run in `Router(plugins=[...])`."""
 

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -21,6 +21,7 @@ from litellm.proxy.proxy_server import (
     _is_remote_module_url,
     _scrub_db_overlay_remote_module_loads,
     _scrub_guardrail_inner,
+    resolve_complexity_router_plugins,
 )
 
 from .conftest import normalize
@@ -110,6 +111,54 @@ def test__scrub_db_overlay_remote_module_loads_strips_lists_and_strs():
 def test__scrub_db_overlay_remote_module_loads_invalid_non_dict_returns_input():
     # Non-dict input bypasses scrubbing entirely.
     assert _scrub_db_overlay_remote_module_loads("litellm_settings", "raw") == "raw"
+
+
+# ---------------------------------------------------------------------------
+# resolve_complexity_router_plugins
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_complexity_router_plugins_no_plugins_key_is_a_noop():
+    config: Dict[str, Any] = {"tiers": {"SIMPLE": "gpt-4o-mini"}}
+    resolve_complexity_router_plugins(
+        model_name="smart-router", complexity_router_config=config, config_file_path=None
+    )
+    assert config == {"tiers": {"SIMPLE": "gpt-4o-mini"}}
+
+
+def test_resolve_complexity_router_plugins_resolves_dotted_path_to_live_instance(tmp_path):
+    plugin_file = tmp_path / "my_plugin.py"
+    plugin_file.write_text(
+        "class _Plugin:\n"
+        "    async def run(self, context):\n"
+        "        return context\n"
+        "\n"
+        "my_plugin_instance = _Plugin()\n"
+    )
+    config: Dict[str, Any] = {"plugins": ["my_plugin.my_plugin_instance"]}
+
+    resolve_complexity_router_plugins(
+        model_name="smart-router",
+        complexity_router_config=config,
+        config_file_path=str(tmp_path / "config.yaml"),
+    )
+
+    assert len(config["plugins"]) == 1
+    assert hasattr(config["plugins"][0], "run")
+    assert type(config["plugins"][0]).__name__ == "_Plugin"
+
+
+def test_resolve_complexity_router_plugins_rejects_non_routing_plugin_object(tmp_path):
+    plugin_file = tmp_path / "bad_plugin.py"
+    plugin_file.write_text("not_a_plugin = object()\n")
+    config: Dict[str, Any] = {"plugins": ["bad_plugin.not_a_plugin"]}
+
+    with pytest.raises(ValueError, match="does not implement the RoutingPlugin interface"):
+        resolve_complexity_router_plugins(
+            model_name="smart-router",
+            complexity_router_config=config,
+            config_file_path=str(tmp_path / "config.yaml"),
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -161,6 +161,30 @@ def test_resolve_complexity_router_plugins_rejects_non_routing_plugin_object(tmp
         )
 
 
+def test_resolve_complexity_router_plugins_rejects_synchronous_run_method(tmp_path):
+    """Regression: @runtime_checkable only checks that `run` exists as an attribute,
+    not that it's a coroutine function. A plugin with a synchronous `run` passes a bare
+    isinstance() check and would only fail at request time with a confusing
+    `TypeError: object RoutingContext can't be used in 'await' expression`. Reported
+    by Greptile on PR #33251."""
+    plugin_file = tmp_path / "sync_plugin.py"
+    plugin_file.write_text(
+        "class _SyncPlugin:\n"
+        "    def run(self, context):\n"
+        "        return context\n"
+        "\n"
+        "sync_plugin_instance = _SyncPlugin()\n"
+    )
+    config: Dict[str, Any] = {"plugins": ["sync_plugin.sync_plugin_instance"]}
+
+    with pytest.raises(ValueError, match="does not implement the RoutingPlugin interface"):
+        resolve_complexity_router_plugins(
+            model_name="smart-router",
+            complexity_router_config=config,
+            config_file_path=str(tmp_path / "config.yaml"),
+        )
+
+
 # ---------------------------------------------------------------------------
 # ProxyConfig.__init__
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -2700,3 +2700,152 @@ class TestSessionAffinity:
             spy_aclassify.assert_not_called()
         assert second.model == "cheap"
         assert request_kwargs_2["metadata"]["adaptive_router_chosen_model"] == "cheap"
+
+
+class _DummyPlugin:
+    async def run(self, context):
+        return context
+
+
+class TestRoutingPlugins:
+    """Test the `complexity_router_config.plugins` field: narrows the classified
+    tier's candidate pool before a model is picked. Discussion:
+    https://github.com/BerriAI/litellm/discussions/32168"""
+
+    @pytest.mark.asyncio
+    async def test_plugin_narrows_tier_candidates(self, mock_router_instance):
+        class ExcludeGpt4oMini:
+            async def run(self, context):
+                context.candidate_models = [m for m in context.candidate_models if m != "gpt-4o-mini"]
+                return context
+
+        router = ComplexityRouter(
+            model_name="test-complexity-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "tiers": {"SIMPLE": ["gpt-4o-mini", "gpt-4o-nano"]},
+                "plugins": [ExcludeGpt4oMini()],
+            },
+        )
+        result = await router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert result is not None
+        assert result.model == "gpt-4o-nano"
+
+    @pytest.mark.asyncio
+    async def test_plugin_narrowing_to_zero_falls_back_to_default_model(self, mock_router_instance):
+        class BlockEverything:
+            async def run(self, context):
+                context.candidate_models = []
+                return context
+
+        router = ComplexityRouter(
+            model_name="test-complexity-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "tiers": {"SIMPLE": "gpt-4o-mini"},
+                "default_model": "gpt-4o-fallback",
+                "plugins": [BlockEverything()],
+            },
+        )
+        result = await router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert result is not None
+        assert result.model == "gpt-4o-fallback"
+
+    @pytest.mark.asyncio
+    async def test_plugin_narrowing_to_zero_without_default_model_raises(self, mock_router_instance):
+        class BlockEverything:
+            async def run(self, context):
+                context.candidate_models = []
+                return context
+
+        router = ComplexityRouter(
+            model_name="test-complexity-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "tiers": {"SIMPLE": "gpt-4o-mini"},
+                "plugins": [BlockEverything()],
+            },
+        )
+        with pytest.raises(ValueError, match="No candidate models left for tier"):
+            await router.async_pre_routing_hook(
+                model="test-model",
+                request_kwargs={},
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+    @pytest.mark.asyncio
+    async def test_plugin_receives_metadata_from_request_kwargs(self, mock_router_instance):
+        captured = {}
+
+        class CaptureMetadata:
+            async def run(self, context):
+                captured.update(context.metadata)
+                return context
+
+        router = ComplexityRouter(
+            model_name="test-complexity-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "tiers": {"SIMPLE": "gpt-4o-mini"},
+                "plugins": [CaptureMetadata()],
+            },
+        )
+        await router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={"metadata": {"tenant": "acme-corp"}},
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert captured.get("tenant") == "acme-corp"
+
+    @pytest.mark.asyncio
+    async def test_plugin_applies_to_keyword_tier_override(self, mock_router_instance):
+        """A policy plugin must not be bypassable via the keyword_tier_rules override path."""
+
+        class ExcludeGpt4oMini:
+            async def run(self, context):
+                context.candidate_models = [m for m in context.candidate_models if m != "gpt-4o-mini"]
+                return context
+
+        router = ComplexityRouter(
+            model_name="test-complexity-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "tiers": {"SIMPLE": ["gpt-4o-mini", "gpt-4o-nano"]},
+                "keyword_tier_rules": [{"keywords": ["hello"], "tier": "SIMPLE"}],
+                "plugins": [ExcludeGpt4oMini()],
+            },
+        )
+        result = await router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=[{"role": "user", "content": "hello there"}],
+        )
+        assert result is not None
+        assert result.model == "gpt-4o-nano"
+
+    def test_plugins_and_adaptive_together_raises(self):
+        with pytest.raises(ValidationError, match="plugins and adaptive=True cannot both be set"):
+            ComplexityRouterConfig(
+                tiers={"SIMPLE": ["gpt-4o-mini"]},
+                adaptive=True,
+                plugins=[_DummyPlugin()],
+            )
+
+    @pytest.mark.asyncio
+    async def test_no_plugins_configured_is_unaffected(self, complexity_router):
+        """Regression guard: a ComplexityRouter with no `plugins` configured behaves exactly as before."""
+        result = await complexity_router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=[{"role": "user", "content": "Hello!"}],
+        )
+        assert result is not None
+        assert result.model == "gpt-4o-mini"

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -2736,7 +2736,12 @@ class TestRoutingPlugins:
         assert result.model == "gpt-4o-nano"
 
     @pytest.mark.asyncio
-    async def test_plugin_narrowing_to_zero_falls_back_to_default_model(self, mock_router_instance):
+    async def test_plugin_narrowing_to_zero_raises_even_with_default_model_configured(self, mock_router_instance):
+        """Regression: default_model must never be used as an escape hatch around a
+        plugin's narrowing decision -- it was never checked against the plugins, so
+        falling back to it would let a tenant/budget policy be silently bypassed.
+        Reported by Veria AI on PR #33251."""
+
         class BlockEverything:
             async def run(self, context):
                 context.candidate_models = []
@@ -2751,13 +2756,12 @@ class TestRoutingPlugins:
                 "plugins": [BlockEverything()],
             },
         )
-        result = await router.async_pre_routing_hook(
-            model="test-model",
-            request_kwargs={},
-            messages=[{"role": "user", "content": "hi"}],
-        )
-        assert result is not None
-        assert result.model == "gpt-4o-fallback"
+        with pytest.raises(ValueError, match="No candidate models left for tier"):
+            await router.async_pre_routing_hook(
+                model="test-model",
+                request_kwargs={},
+                messages=[{"role": "user", "content": "hi"}],
+            )
 
     @pytest.mark.asyncio
     async def test_plugin_narrowing_to_zero_without_default_model_raises(self, mock_router_instance):
@@ -2883,4 +2887,3 @@ class TestRoutingPlugins:
         assert first.model == "gpt-4o-mini"
         assert second.model == "gpt-4o-mini"
         assert spy.call_count == 2
-        assert result.model == "gpt-4o-mini"

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -2848,4 +2848,39 @@ class TestRoutingPlugins:
             messages=[{"role": "user", "content": "Hello!"}],
         )
         assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_session_affinity_pin_shortcut_disabled_when_plugins_configured(self, mock_router_instance):
+        """Regression: the session_affinity cache-pin shortcut returned a stale pinned
+        model without ever re-running it through plugins, so a policy plugin's decision
+        (e.g. a budget cap crossed mid-session) was only ever enforced on a session's
+        first turn. With plugins configured, every turn must go through
+        _classify_and_route (and therefore the plugin pipeline) again."""
+        mock_router_instance.cache = DualCache()
+
+        class AllowAll:
+            async def run(self, context):
+                return context
+
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "tiers": {"SIMPLE": ["gpt-4o-mini"]},
+                "session_affinity": True,
+                "plugins": [AllowAll()],
+            },
+        )
+        request_kwargs = {"metadata": {"session_id": "session-1"}}
+
+        with patch.object(router, "_classify_and_route", wraps=router._classify_and_route) as spy:
+            first = await router.async_pre_routing_hook(
+                model="test-model", request_kwargs=request_kwargs, messages=[{"role": "user", "content": "hi"}]
+            )
+            second = await router.async_pre_routing_hook(
+                model="test-model", request_kwargs=request_kwargs, messages=[{"role": "user", "content": "hi again"}]
+            )
+        assert first.model == "gpt-4o-mini"
+        assert second.model == "gpt-4o-mini"
+        assert spy.call_count == 2
         assert result.model == "gpt-4o-mini"

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -2867,6 +2867,34 @@ class TestRoutingPlugins:
         assert result is not None
         assert result.model == "gpt-4o-nano"
 
+    @pytest.mark.asyncio
+    async def test_no_user_message_prefers_default_model_over_medium_tier_without_plugins(
+        self, mock_router_instance
+    ):
+        """Regression: without plugins configured, the no-user-message path must keep its
+        pre-existing default_model-first priority over the MEDIUM tier exactly as before --
+        closing the plugin-bypass gap must not silently flip model selection for the (much
+        larger) population of users who don't use plugins at all. Flagged by Greptile on
+        PR #33251 after the plugin-bypass fix changed this priority unconditionally."""
+        router = ComplexityRouter(
+            model_name="test-complexity-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "tiers": {"MEDIUM": ["gpt-4o-medium-tier"]},
+                "default_model": "gpt-4o-configured-default",
+            },
+        )
+        result = await router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=[
+                {"role": "system", "content": "You are helpful."},
+                {"role": "assistant", "content": "Hello!"},
+            ],
+        )
+        assert result is not None
+        assert result.model == "gpt-4o-configured-default"
+
     def test_plugins_and_adaptive_together_raises(self):
         with pytest.raises(ValidationError, match="plugins and adaptive=True cannot both be set"):
             ComplexityRouterConfig(

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -2835,6 +2835,38 @@ class TestRoutingPlugins:
         assert result is not None
         assert result.model == "gpt-4o-nano"
 
+    @pytest.mark.asyncio
+    async def test_plugin_applies_to_no_user_message_default_tier_path(self, mock_router_instance):
+        """Regression: `self.config.default_model or await self._pick_model_for_tier(...)`
+        short-circuited on a truthy default_model, so the no-user-message path never ran
+        the plugin pipeline at all when default_model was configured. A policy plugin
+        must not be bypassable via this path either. Reported by Veria AI on PR #33251."""
+
+        class ExcludeDefaultModel:
+            async def run(self, context):
+                context.candidate_models = [m for m in context.candidate_models if m != "gpt-4o-default"]
+                return context
+
+        router = ComplexityRouter(
+            model_name="test-complexity-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "tiers": {"MEDIUM": ["gpt-4o-default", "gpt-4o-nano"]},
+                "default_model": "gpt-4o-default",
+                "plugins": [ExcludeDefaultModel()],
+            },
+        )
+        result = await router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=[
+                {"role": "system", "content": "You are helpful."},
+                {"role": "assistant", "content": "Hello!"},
+            ],
+        )
+        assert result is not None
+        assert result.model == "gpt-4o-nano"
+
     def test_plugins_and_adaptive_together_raises(self):
         with pytest.raises(ValidationError, match="plugins and adaptive=True cannot both be set"):
             ComplexityRouterConfig(

--- a/tests/test_litellm/router_strategy/test_router_routing_plugins.py
+++ b/tests/test_litellm/router_strategy/test_router_routing_plugins.py
@@ -218,3 +218,36 @@ def test_filter_by_routing_plugin_candidates_narrows_and_raises_when_empty():
             healthy_deployments=healthy_deployments,
             request_kwargs={"metadata": {"_routing_plugin_candidate_models": ["nonexistent/model"]}},
         )
+
+
+def test_json_default_stable_id_is_stable_across_instances():
+    """_generate_model_id's json.dumps `default=` fallback must not embed an object's
+    memory address (e.g. plain str() on an object with no custom __repr__ falls back
+    to object.__repr__'s `<module.Class object at 0x...>`) -- that would make the
+    deployment id churn on every process restart for any deployment whose
+    litellm_params contain a live plugin instance."""
+    router = Router(model_list=_smart_router_model_list())
+
+    assert router._json_default_stable_id(LanguageDetector()) == router._json_default_stable_id(LanguageDetector())
+    assert router._json_default_stable_id(LanguageDetector()) != router._json_default_stable_id(TenantPolicy())
+
+
+def test_generate_model_id_is_stable_when_litellm_params_contain_a_plugin_instance():
+    """End-to-end: a deployment id built from litellm_params containing a routing
+    plugin instance (e.g. complexity_router_config.plugins) must be identical across
+    separate calls, not just non-crashing."""
+    router = Router(model_list=_smart_router_model_list())
+    litellm_params = {
+        "model": "auto_router/complexity_router",
+        "complexity_router_config": {"plugins": [LanguageDetector()]},
+    }
+
+    id1 = router._generate_model_id("smart-router", litellm_params)
+    id2 = router._generate_model_id(
+        "smart-router",
+        {
+            "model": "auto_router/complexity_router",
+            "complexity_router_config": {"plugins": [LanguageDetector()]},
+        },
+    )
+    assert id1 == id2


### PR DESCRIPTION
## Relevant issues

Discussion: https://github.com/BerriAI/litellm/discussions/32168

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

`make pre-commit` could not complete in the environment this PR was built in: `uv sync` fails building `grpcio==1.78.0` (no wheel for macOS x86_64 at that pin) before it reaches basedpyright, and the dashboard node_modules aren't provisioned either, both unrelated to this diff. `ruff check .` passes clean against the changed files. CI runs in a correctly provisioned environment so its lint job is the authoritative check here.

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Commit under test: `8d5e033929`

`Router(plugins=[...])` (merged separately, discussion #32168) only accepted pre-instantiated plugin objects through the Python constructor, and narrowed candidates from the outer model alias rather than the auto-router's real tier pool, so it was unusable through proxy config and a no-op for `auto_router/complexity_router` deployments even from Python. This PR adds `complexity_router_config.plugins`, a list of dotted-path strings resolved the same way `litellm_settings.callbacks` already is, and wires the resolved plugins into the tier pool that `get_model_for_tier` actually picks from.

Config used below (`complexity_router_config.tiers.COMPLEX: [gpt-4o, gpt-4o-mini]`, `default_model: gpt-4o-mini`), with a `CostCeilingPlugin` that drops any candidate whose real per-token input cost exceeds `0.000001` (`gpt-4o-mini` = `1.5e-07`, `gpt-4o` = `2.5e-06`, from `litellm/model_prices_and_context_window_backup.json`). All requests below are real `openai/gpt-4o` and `openai/gpt-4o-mini` calls against the live proxy, billed against a real OpenAI key; the routed model is read off `x-litellm-response-cost` since gpt-4o-mini's cost (`9.45e-06`) and gpt-4o's cost (`0.0001575`) are only reachable by one deployment each here.

Before, `config.yaml` (no `plugins` key in `complexity_router_config`):

```yaml
model_list:
  - model_name: smart-router
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_config:
        tiers:
          SIMPLE: ["gpt-4o-mini"]
          MEDIUM: ["gpt-4o-mini"]
          COMPLEX: ["gpt-4o", "gpt-4o-mini"]
          REASONING: ["gpt-4o", "gpt-4o-mini"]
        default_model: gpt-4o-mini
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY
      max_tokens: 5
  - model_name: gpt-4o
    litellm_params:
      model: openai/gpt-4o
      api_key: os.environ/OPENAI_API_KEY
      max_tokens: 5

general_settings:
  master_key: sk-1234
```

8 identical COMPLEX-tier requests against that config:

```
$ for i in $(seq 1 8); do
  curl -s -i http://localhost:4114/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "smart-router", "messages": [{"role": "user", "content": "Design a distributed microservice architecture with Kubernetes orchestration, implementing proper authentication, encryption, and database optimization for high throughput. Think step by step about the performance implications and scalability requirements."}]}' \
  | grep -i "^x-litellm-response-cost:"
done

x-litellm-response-cost: 0.0001575
x-litellm-response-cost: 9.45e-06
x-litellm-response-cost: 9.45e-06
x-litellm-response-cost: 0.0001575
x-litellm-response-cost: 0.0001575
x-litellm-response-cost: 9.45e-06
x-litellm-response-cost: 0.0001575
x-litellm-response-cost: 0.0001575
```

gpt-4o (over the would-be ceiling) gets picked 5 of 8 times, as expected from an unfiltered pool.

After, `config.yaml` (same config plus `complexity_router_config.plugins`):

```yaml
model_list:
  - model_name: smart-router
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_config:
        tiers:
          SIMPLE: ["gpt-4o-mini"]
          MEDIUM: ["gpt-4o-mini"]
          COMPLEX: ["gpt-4o", "gpt-4o-mini"]
          REASONING: ["gpt-4o", "gpt-4o-mini"]
        default_model: gpt-4o-mini
        plugins:
          - plugins.cost_ceiling_plugin.cost_ceiling_plugin
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY
      max_tokens: 5
  - model_name: gpt-4o
    litellm_params:
      model: openai/gpt-4o
      api_key: os.environ/OPENAI_API_KEY
      max_tokens: 5

general_settings:
  master_key: sk-1234
```

`plugins.cost_ceiling_plugin.cost_ceiling_plugin` is a dotted path resolved relative to `config.yaml`'s own directory, i.e. a sibling `plugins/cost_ceiling_plugin.py` file.

5 identical COMPLEX-tier requests against that config:

```
$ for i in $(seq 1 5); do
  curl -s -i http://localhost:4113/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "smart-router", "messages": [{"role": "user", "content": "Design a distributed microservice architecture with Kubernetes orchestration, implementing proper authentication, encryption, and database optimization for high throughput. Think step by step about the performance implications and scalability requirements."}]}' \
  | grep -i "^x-litellm-response-cost:"
done

x-litellm-response-cost: 9.45e-06
x-litellm-response-cost: 9.45e-06
x-litellm-response-cost: 9.45e-06
x-litellm-response-cost: 9.45e-06
x-litellm-response-cost: 9.45e-06
```

gpt-4o never gets picked once the plugin is configured; every request lands on gpt-4o-mini, the only candidate the plugin leaves in the tier pool.

`plugins/cost_ceiling_plugin.py` used for both runs:

```python
class CostCeilingPlugin:
    def __init__(self, max_cost_per_token: float, cost_by_model: dict):
        self.max_cost_per_token = max_cost_per_token
        self.cost_by_model = cost_by_model

    async def run(self, context):
        context.candidate_models = [
            m for m in context.candidate_models if self.cost_by_model.get(m, 0.0) <= self.max_cost_per_token
        ]
        context.signals["cost-ceiling-plugin"] = {"max_cost_per_token": self.max_cost_per_token}
        return context


cost_ceiling_plugin = CostCeilingPlugin(
    max_cost_per_token=0.000001,
    cost_by_model={"gpt-4o-mini": 1.5e-07, "gpt-4o": 2.5e-06},
)
```

## Type

🆕 New Feature
🐛 Bug Fix

## Changes

`complexity_router_config` gains a `plugins: list[str] | None` field (dotted-path refs, e.g. `mypackage.mymodule.my_plugin_instance`). The proxy config loader resolves each path through the existing `get_instance_fn` (same helper `litellm_settings.callbacks` and custom guardrails already use) before `Router.__init__` runs, so `ComplexityRouterConfig.plugins` ends up holding live `RoutingPlugin` instances.

`ComplexityRouter._pick_model_for_tier` builds a `RoutingContext` scoped to the classified tier's actual candidate pool (not the outer `auto_router/complexity_router` alias), runs the configured plugins in order, and picks from whatever candidates survive. It's wired into all three model-pick sites inside `_classify_and_route` (the weighted-scoring path, the `keyword_tier_rules` override path, and the no-user-message default-tier path) so a policy plugin can't be bypassed by any of those paths. A tier narrowed to zero candidates raises rather than falling back to `default_model`, since `default_model` was never checked against the plugins and would otherwise function as an unconditional escape hatch around whatever policy a plugin enforces. `adaptive=True` combined with `plugins` raises at config-validation time, since the bandit selector in `_soft_floor_pick` doesn't consume plugin-narrowed pools yet.

Also fixes `Router._generate_model_id`, which builds a deployment id by `json.dumps`-ing every `litellm_params` value; it crashed with `TypeError: Object ... is not JSON serializable` the moment a resolved plugin instance landed inside `complexity_router_config`. Uses `json.dumps(v, default=...)` with a fallback that returns the value's fully-qualified class name. (An earlier revision of this PR used `default=str`, which Greptile correctly flagged: `str()` on an arbitrary object falls back to `object.__repr__`'s `<module.Class object at 0x...>`, embedding the memory address and making the deployment id change on every hot-reload for any deployment with `plugins` configured. Fixed in a follow-up commit.)

Three policy-bypass gaps flagged by Veria AI's security review, all fixed in follow-up commits: the `session_affinity` cache-pin shortcut returned a session's first-turn model on every later turn without ever re-running it through the plugin pipeline, so a plugin's decision (e.g. a budget cap crossed mid-session) was only enforced on turn one -- the pin shortcut is now disabled whenever `plugins` are configured. The no-user-message path used `self.config.default_model or await self._pick_model_for_tier(...)`, and Python's `or` short-circuits on a truthy `default_model` -- the plugin pipeline never ran at all whenever `default_model` was configured; that short-circuit is removed, falling through to the same tier-then-default_model resolution every other call site already uses. Separately, `get_instance_fn` accepts any dotted path and returns whatever object it finds there, so a misconfigured `plugins` entry passed proxy startup silently and only surfaced as a confusing `AttributeError` on the first request that reached the plugin pipeline -- extracted the resolution logic into `resolve_complexity_router_plugins()` with an `isinstance(..., RoutingPlugin)` check that now fails proxy startup immediately with a clear error instead.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
