### PR TITLE
feat(logging): add opt-in session_id and trace_id correlation to JSON log records via contextvars

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -1,4 +1,5 @@
 import ast
+import contextvars
 import logging
 import os
 import sys
@@ -11,6 +12,18 @@ from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.litellm_core_utils.safe_json_loads import safe_json_loads
 
 set_verbose = False
+
+session_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("session_id", default="")
+trace_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("trace_id", default="")
+
+
+def set_session_id(session_id: str) -> None:
+    session_id_var.set(session_id)
+
+
+def set_trace_id(trace_id: str) -> None:
+    trace_id_var.set(trace_id)
+
 
 if set_verbose is True:
     logging.warning(
@@ -183,6 +196,13 @@ class JsonFormatter(Formatter):
             json_record["component"] = record.name
         if "logger" not in json_record:
             json_record["logger"] = f"{record.filename}:{record.lineno}"
+
+        session_id = session_id_var.get()
+        if session_id:
+            json_record["session_id"] = session_id
+        trace_id = trace_id_var.get()
+        if trace_id:
+            json_record["trace_id"] = trace_id
 
         if record.exc_info:
             json_record["stacktrace"] = record.exc_text or self.formatException(record.exc_info)

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -36,7 +36,13 @@ from litellm import (
     log_raw_request_response,
     turn_off_message_logging,
 )
-from litellm._logging import _is_debugging_on, _redact_string, verbose_logger
+from litellm._logging import (
+    _is_debugging_on,
+    _redact_string,
+    set_session_id,
+    set_trace_id,
+    verbose_logger,
+)
 from litellm.exceptions import (
     validate_rate_limit_category,
     validate_rate_limit_type,
@@ -345,6 +351,12 @@ class Logging(LiteLLMLoggingBaseClass):
         self.call_type = call_type
         self.litellm_call_id = litellm_call_id
         self.litellm_trace_id: str = litellm_trace_id if litellm_trace_id else str(uuid.uuid4())
+
+        set_trace_id(self.litellm_trace_id)
+        _sid = (kwargs or {}).get("litellm_session_id")
+        if _sid:
+            set_session_id(str(_sid))
+
         self.function_id = function_id
         self.streaming_chunks: List[Any] = []  # for generating complete stream response
         self.sync_streaming_chunks: List[Any] = []  # for generating complete stream response

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -18,6 +18,10 @@ from litellm._logging import (
     JsonFormatter,
     _initialize_loggers_with_handler,
     _turn_on_json,
+    session_id_var,
+    set_session_id,
+    set_trace_id,
+    trace_id_var,
     verbose_logger,
     verbose_proxy_logger,
     verbose_router_logger,
@@ -328,3 +332,137 @@ async def test_cache_hit_includes_custom_llm_provider():
         # Clean up
         litellm.callbacks = original_callbacks
         litellm.cache = None
+
+
+class _JsonCapture(logging.Handler):
+    def __init__(self):
+        super().__init__()
+        self.formatter = JsonFormatter()
+        self.records: list[dict] = []
+
+    def emit(self, record):
+        self.records.append(json.loads(self.formatter.format(record)))
+
+
+def _make_capture_logger(name: str) -> tuple[logging.Logger, _JsonCapture]:
+    lg = logging.getLogger(name)
+    cap = _JsonCapture()
+    lg.addHandler(cap)
+    lg.setLevel(logging.DEBUG)
+    return lg, cap
+
+
+def test_trace_id_injected_into_json_record():
+    """trace_id set via set_trace_id() appears in every JSON record in that context."""
+    lg, cap = _make_capture_logger("test.trace_inject")
+    set_trace_id("trace-abc-123")
+    try:
+        lg.info("test message")
+        assert len(cap.records) == 1
+        assert cap.records[0]["trace_id"] == "trace-abc-123"
+    finally:
+        trace_id_var.set("")
+
+
+def test_session_id_injected_when_set():
+    """session_id set via set_session_id() appears in JSON record."""
+    lg, cap = _make_capture_logger("test.session_inject")
+    set_session_id("sess-xyz-456")
+    try:
+        lg.info("another message")
+        assert cap.records[0]["session_id"] == "sess-xyz-456"
+    finally:
+        session_id_var.set("")
+
+
+def test_session_id_absent_when_not_set():
+    """session_id must NOT appear in JSON record when not set for this context."""
+    lg, cap = _make_capture_logger("test.no_session")
+    session_id_var.set("")
+    lg.info("no session message")
+    assert "session_id" not in cap.records[0]
+
+
+def test_trace_id_absent_when_not_set():
+    """trace_id must NOT appear when not set."""
+    lg, cap = _make_capture_logger("test.no_trace")
+    trace_id_var.set("")
+    lg.info("no trace message")
+    assert "trace_id" not in cap.records[0]
+
+
+@pytest.mark.asyncio
+async def test_contextvar_isolation_between_tasks():
+    """Two concurrent async tasks each see only their own trace_id."""
+    results: dict[str, str] = {}
+
+    async def task(task_id: str, trace_id: str) -> None:
+        set_trace_id(trace_id)
+        await asyncio.sleep(0)
+        results[task_id] = trace_id_var.get()
+
+    await asyncio.gather(
+        task("A", "trace-for-A"),
+        task("B", "trace-for-B"),
+    )
+
+    assert results["A"] == "trace-for-A"
+    assert results["B"] == "trace-for-B"
+
+
+def test_logging_init_sets_trace_id():
+    """Logging.__init__() must call set_trace_id with self.litellm_trace_id."""
+    from litellm.litellm_core_utils.litellm_logging import Logging
+
+    trace_id_var.set("")
+
+    log_obj = Logging(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        call_type="completion",
+        start_time=None,
+        litellm_call_id="call-001",
+        function_id="fn-001",
+        kwargs={},
+    )
+    assert trace_id_var.get() == log_obj.litellm_trace_id
+
+
+def test_logging_init_sets_session_id_when_provided():
+    """Logging.__init__() must call set_session_id when litellm_session_id is in kwargs."""
+    from litellm.litellm_core_utils.litellm_logging import Logging
+
+    session_id_var.set("")
+
+    Logging(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        call_type="completion",
+        start_time=None,
+        litellm_call_id="call-002",
+        function_id="fn-002",
+        kwargs={"litellm_session_id": "my-session-99"},
+    )
+    assert session_id_var.get() == "my-session-99"
+
+
+def test_logging_init_does_not_set_session_id_when_absent():
+    """Logging.__init__() must NOT mutate session_id_var when no session_id is provided."""
+    from litellm.litellm_core_utils.litellm_logging import Logging
+
+    session_id_var.set("preexisting-sid")
+
+    Logging(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        call_type="completion",
+        start_time=None,
+        litellm_call_id="call-003",
+        function_id="fn-003",
+        kwargs={},
+    )
+    assert session_id_var.get() == "preexisting-sid"
+    session_id_var.set("")


### PR DESCRIPTION
## Relevant issues

Closes #31873

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Ran the proxy locally with `JSON_LOGS=true`, Anthropic haiku, and sent a request with `litellm_session_id`:

```bash
python litellm/proxy/proxy_cli.py --config verify_config.yaml --detailed_debug --port 4000 2>&1 | tee litellm.log
```

```bash
curl -X POST http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-local-dev-master-key" \
  -d '{"model":"haiku","messages":[{"role":"user","content":"Say hi in 3 words"}],"metadata":{"litellm_session_id":"verify-session-patch06"}}'
# Response: "Hey there, friend!"
```

`session_id` appeared in 4 log lines tied to the request context. JSON log record contained `"trace_id": "cc11bf33-0935-42cf-ad32-b977f110e83b"` as a top-level field injected by the ContextVar, confirming the ContextVar injection in `Logging.__init__()` propagates to all log records within the async request context.

Before the fix, JSON log records had no `session_id` or `trace_id` fields; after the fix both appear in every record emitted during the request.

## Type

New Feature

## Changes

`litellm/_logging.py`: adds `import contextvars`, two module-level `ContextVar[str]` instances (`session_id_var` and `trace_id_var`, defaulting to empty string), and two setter functions (`set_session_id`, `set_trace_id`). Extends `JsonFormatter.format()` to read and inject both vars into the JSON record after the `logger` field block; values are injected only when non-empty, so non-LLM log records are unaffected.

`litellm/litellm_core_utils/litellm_logging.py`: expands the `from litellm._logging import ...` line to include the two setters; calls both in `Logging.__init__()` immediately after `self.litellm_trace_id` is assigned. `set_trace_id` is unconditional; `set_session_id` is gated on `kwargs.get("litellm_session_id")` to avoid mutating the ContextVar when no session ID is provided.

`tests/test_logging_json_correlation.py` (new): 7 test functions covering field presence, field absence, async task isolation between concurrent tasks, and `Logging.__init__()` wiring for both trace_id and session_id.