### PR TITLE
feat(litellm_proxy): forward tags and session_id to downstream LiteLLM proxy in cascaded topology

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -386,6 +386,7 @@ budget_duration: Optional[str] = (
 )
 default_soft_budget: float = DEFAULT_SOFT_BUDGET  # by default all litellm proxy keys have a soft budget of 50.0
 forward_traceparent_to_llm_provider: bool = False
+forward_proxy_metadata: bool = False
 
 
 _current_cost = 0.0  # private variable, used if max budget is set

--- a/litellm/llms/litellm_proxy/chat/transformation.py
+++ b/litellm/llms/litellm_proxy/chat/transformation.py
@@ -135,7 +135,7 @@ class LiteLLMProxyChatConfig(OpenAIGPTConfig):
             if requester_metadata is not None:
                 forwarded = {k: v for k, v in requester_metadata.items() if k in self.FORWARDED_METADATA_FIELDS}
                 if forwarded:
-                    request_body["metadata"] = forwarded
+                    request_body["metadata"] = {**(request_body.get("metadata") or {}), **forwarded}
 
         litellm_session_id = litellm_params.get("litellm_session_id")
         if litellm_session_id is not None:

--- a/litellm/llms/litellm_proxy/chat/transformation.py
+++ b/litellm/llms/litellm_proxy/chat/transformation.py
@@ -111,6 +111,40 @@ class LiteLLMProxyChatConfig(OpenAIGPTConfig):
 
         return model, custom_llm_provider, api_key, api_base
 
+    # Fields from requester_metadata that should be forwarded to the downstream proxy.
+    # Allowlist approach: requester_metadata also contains internal pipeline slots
+    # (user_api_key_* echoes, guardrails config) that must never be forwarded.
+    FORWARDED_METADATA_FIELDS: frozenset[str] = frozenset({"tags"})
+
+    def _build_forwarded_request_body(
+        self,
+        model: str,
+        messages: list["AllMessageValues"],
+        optional_params: dict,
+        litellm_params: dict,
+    ) -> dict:
+        request_body: dict = {
+            "model": model,
+            "messages": messages,
+            **optional_params,
+        }
+
+        metadata = litellm_params.get("metadata")
+        if metadata is not None:
+            requester_metadata = metadata.get("requester_metadata")
+            if requester_metadata is not None:
+                forwarded = {k: v for k, v in requester_metadata.items() if k in self.FORWARDED_METADATA_FIELDS}
+                if forwarded:
+                    request_body["metadata"] = forwarded
+
+        litellm_session_id = litellm_params.get("litellm_session_id")
+        if litellm_session_id is not None:
+            extra_body: dict = request_body.get("extra_body") or {}
+            if "litellm_session_id" not in extra_body:
+                request_body["extra_body"] = {**extra_body, "litellm_session_id": litellm_session_id}
+
+        return request_body
+
     def transform_request(
         self,
         model: str,
@@ -119,12 +153,12 @@ class LiteLLMProxyChatConfig(OpenAIGPTConfig):
         litellm_params: dict,
         headers: dict,
     ) -> dict:
-        # don't transform the request
-        return {
-            "model": model,
-            "messages": messages,
-            **optional_params,
-        }
+        return self._build_forwarded_request_body(
+            model=model,
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params=litellm_params,
+        )
 
     async def async_transform_request(
         self,
@@ -134,9 +168,9 @@ class LiteLLMProxyChatConfig(OpenAIGPTConfig):
         litellm_params: dict,
         headers: dict,
     ) -> dict:
-        # don't transform the request
-        return {
-            "model": model,
-            "messages": messages,
-            **optional_params,
-        }
+        return self._build_forwarded_request_body(
+            model=model,
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params=litellm_params,
+        )

--- a/litellm/llms/litellm_proxy/chat/transformation.py
+++ b/litellm/llms/litellm_proxy/chat/transformation.py
@@ -129,6 +129,11 @@ class LiteLLMProxyChatConfig(OpenAIGPTConfig):
             **optional_params,
         }
 
+        import litellm
+
+        if not litellm.forward_proxy_metadata:
+            return request_body
+
         metadata = litellm_params.get("metadata")
         if metadata is not None:
             requester_metadata = metadata.get("requester_metadata")

--- a/tests/test_litellm/llms/litellm_proxy/chat/test_litellm_proxy_chat_transformation.py
+++ b/tests/test_litellm/llms/litellm_proxy/chat/test_litellm_proxy_chat_transformation.py
@@ -6,6 +6,40 @@ import pytest
 import litellm
 from litellm.llms.litellm_proxy.chat.transformation import LiteLLMProxyChatConfig
 
+MESSAGES = [{"role": "user", "content": "Hello"}]
+
+
+def _sync_transform(
+    config: LiteLLMProxyChatConfig,
+    model: str = "gpt-4o",
+    messages: list = MESSAGES,
+    optional_params: Optional[dict] = None,
+    litellm_params: Optional[dict] = None,
+) -> dict:
+    return config.transform_request(
+        model=model,
+        messages=messages,
+        optional_params=optional_params or {},
+        litellm_params=litellm_params or {},
+        headers={},
+    )
+
+
+async def _async_transform(
+    config: LiteLLMProxyChatConfig,
+    model: str = "gpt-4o",
+    messages: list = MESSAGES,
+    optional_params: Optional[dict] = None,
+    litellm_params: Optional[dict] = None,
+) -> dict:
+    return await config.async_transform_request(
+        model=model,
+        messages=messages,
+        optional_params=optional_params or {},
+        litellm_params=litellm_params or {},
+        headers={},
+    )
+
 
 def test_litellm_proxy_chat_transformation():
     """
@@ -35,8 +69,126 @@ def test_litellm_proxy_chat_transformation():
 def test_litellm_gateway_from_sdk_with_user_param():
     from litellm.llms.litellm_proxy.chat.transformation import LiteLLMProxyChatConfig
 
-    supported_params = LiteLLMProxyChatConfig().get_supported_openai_params(
-        "openai/gpt-4o"
-    )
+    supported_params = LiteLLMProxyChatConfig().get_supported_openai_params("openai/gpt-4o")
     print(f"supported_params: {supported_params}")
     assert "user" in supported_params
+
+
+# --- tags forwarding from requester_metadata ---
+
+
+def test_tags_forwarded_from_requester_metadata():
+    config = LiteLLMProxyChatConfig()
+    litellm_params = {"metadata": {"requester_metadata": {"tags": ["project-x", "cost-center-42"]}}}
+    body = _sync_transform(config, litellm_params=litellm_params)
+    assert body["metadata"] == {"tags": ["project-x", "cost-center-42"]}
+
+
+def test_non_allowlisted_fields_not_forwarded():
+    config = LiteLLMProxyChatConfig()
+    litellm_params = {
+        "metadata": {
+            "requester_metadata": {
+                "tags": ["ok"],
+                "user_api_key_hash": "secret",
+                "guardrails_config": {"block": True},
+                "spend_logs_metadata": {"internal": True},
+            }
+        }
+    }
+    body = _sync_transform(config, litellm_params=litellm_params)
+    assert body["metadata"] == {"tags": ["ok"]}
+    assert "user_api_key_hash" not in body["metadata"]
+    assert "guardrails_config" not in body["metadata"]
+    assert "spend_logs_metadata" not in body["metadata"]
+
+
+def test_no_metadata_key_when_no_allowlisted_fields():
+    config = LiteLLMProxyChatConfig()
+    litellm_params = {"metadata": {"requester_metadata": {"user_api_key_hash": "secret"}}}
+    body = _sync_transform(config, litellm_params=litellm_params)
+    assert "metadata" not in body
+
+
+def test_no_metadata_key_when_requester_metadata_absent():
+    config = LiteLLMProxyChatConfig()
+    litellm_params = {"metadata": {"other_key": "value"}}
+    body = _sync_transform(config, litellm_params=litellm_params)
+    assert "metadata" not in body
+
+
+def test_no_metadata_key_when_metadata_absent():
+    config = LiteLLMProxyChatConfig()
+    body = _sync_transform(config, litellm_params={})
+    assert "metadata" not in body
+
+
+# --- litellm_session_id forwarding ---
+
+
+def test_session_id_injected_into_extra_body():
+    config = LiteLLMProxyChatConfig()
+    litellm_params = {"litellm_session_id": "session-abc-123"}
+    body = _sync_transform(config, litellm_params=litellm_params)
+    assert body["extra_body"]["litellm_session_id"] == "session-abc-123"
+
+
+def test_session_id_does_not_overwrite_existing_extra_body_value():
+    config = LiteLLMProxyChatConfig()
+    litellm_params = {"litellm_session_id": "upstream-session"}
+    optional_params = {"extra_body": {"litellm_session_id": "caller-set-session"}}
+    body = _sync_transform(config, optional_params=optional_params, litellm_params=litellm_params)
+    assert body["extra_body"]["litellm_session_id"] == "caller-set-session"
+
+
+def test_session_id_absent_when_not_in_litellm_params():
+    config = LiteLLMProxyChatConfig()
+    body = _sync_transform(config, litellm_params={})
+    assert "extra_body" not in body or "litellm_session_id" not in body.get("extra_body", {})
+
+
+# --- combined tags + session_id ---
+
+
+def test_tags_and_session_id_both_forwarded():
+    config = LiteLLMProxyChatConfig()
+    litellm_params = {
+        "metadata": {"requester_metadata": {"tags": ["sprint-3"]}},
+        "litellm_session_id": "session-xyz",
+    }
+    body = _sync_transform(config, litellm_params=litellm_params)
+    assert body["metadata"] == {"tags": ["sprint-3"]}
+    assert body["extra_body"]["litellm_session_id"] == "session-xyz"
+
+
+# --- base fields regression ---
+
+
+def test_optional_params_passed_through():
+    config = LiteLLMProxyChatConfig()
+    body = _sync_transform(config, optional_params={"temperature": 0.7, "max_tokens": 100})
+    assert body["temperature"] == 0.7
+    assert body["max_tokens"] == 100
+
+
+# --- async path matches sync ---
+
+
+@pytest.mark.asyncio
+async def test_async_matches_sync_for_tags_and_session():
+    config = LiteLLMProxyChatConfig()
+    litellm_params = {
+        "metadata": {"requester_metadata": {"tags": ["async-test"]}},
+        "litellm_session_id": "async-session-999",
+    }
+    sync_body = _sync_transform(config, litellm_params=litellm_params)
+    async_body = await _async_transform(config, litellm_params=litellm_params)
+    assert sync_body == async_body
+
+
+@pytest.mark.asyncio
+async def test_async_no_metadata_when_empty():
+    config = LiteLLMProxyChatConfig()
+    async_body = await _async_transform(config, litellm_params={})
+    assert "metadata" not in async_body
+    assert "extra_body" not in async_body

--- a/tests/test_litellm/llms/litellm_proxy/chat/test_litellm_proxy_chat_transformation.py
+++ b/tests/test_litellm/llms/litellm_proxy/chat/test_litellm_proxy_chat_transformation.py
@@ -171,6 +171,20 @@ def test_optional_params_passed_through():
     assert body["max_tokens"] == 100
 
 
+def test_forwarded_metadata_merges_with_existing_optional_params_metadata():
+    """Forwarded tags must be merged with any metadata already in optional_params, not overwrite it."""
+    config = LiteLLMProxyChatConfig()
+    body = _sync_transform(
+        config,
+        optional_params={"metadata": {"caller_id": "svc-a", "region": "us-east-1"}},
+        litellm_params={"metadata": {"requester_metadata": {"tags": ["billing-team"]}}},
+    )
+    meta = body["metadata"]
+    assert meta.get("tags") == ["billing-team"], "forwarded tags must be present"
+    assert meta.get("caller_id") == "svc-a", "pre-existing metadata fields must be preserved"
+    assert meta.get("region") == "us-east-1", "pre-existing metadata fields must be preserved"
+
+
 # --- async path matches sync ---
 
 

--- a/tests/test_litellm/llms/litellm_proxy/chat/test_litellm_proxy_chat_transformation.py
+++ b/tests/test_litellm/llms/litellm_proxy/chat/test_litellm_proxy_chat_transformation.py
@@ -77,14 +77,16 @@ def test_litellm_gateway_from_sdk_with_user_param():
 # --- tags forwarding from requester_metadata ---
 
 
-def test_tags_forwarded_from_requester_metadata():
+def test_tags_forwarded_from_requester_metadata(monkeypatch):
+    monkeypatch.setattr(litellm, "forward_proxy_metadata", True)
     config = LiteLLMProxyChatConfig()
     litellm_params = {"metadata": {"requester_metadata": {"tags": ["project-x", "cost-center-42"]}}}
     body = _sync_transform(config, litellm_params=litellm_params)
     assert body["metadata"] == {"tags": ["project-x", "cost-center-42"]}
 
 
-def test_non_allowlisted_fields_not_forwarded():
+def test_non_allowlisted_fields_not_forwarded(monkeypatch):
+    monkeypatch.setattr(litellm, "forward_proxy_metadata", True)
     config = LiteLLMProxyChatConfig()
     litellm_params = {
         "metadata": {
@@ -126,14 +128,16 @@ def test_no_metadata_key_when_metadata_absent():
 # --- litellm_session_id forwarding ---
 
 
-def test_session_id_injected_into_extra_body():
+def test_session_id_injected_into_extra_body(monkeypatch):
+    monkeypatch.setattr(litellm, "forward_proxy_metadata", True)
     config = LiteLLMProxyChatConfig()
     litellm_params = {"litellm_session_id": "session-abc-123"}
     body = _sync_transform(config, litellm_params=litellm_params)
     assert body["extra_body"]["litellm_session_id"] == "session-abc-123"
 
 
-def test_session_id_does_not_overwrite_existing_extra_body_value():
+def test_session_id_does_not_overwrite_existing_extra_body_value(monkeypatch):
+    monkeypatch.setattr(litellm, "forward_proxy_metadata", True)
     config = LiteLLMProxyChatConfig()
     litellm_params = {"litellm_session_id": "upstream-session"}
     optional_params = {"extra_body": {"litellm_session_id": "caller-set-session"}}
@@ -150,7 +154,8 @@ def test_session_id_absent_when_not_in_litellm_params():
 # --- combined tags + session_id ---
 
 
-def test_tags_and_session_id_both_forwarded():
+def test_tags_and_session_id_both_forwarded(monkeypatch):
+    monkeypatch.setattr(litellm, "forward_proxy_metadata", True)
     config = LiteLLMProxyChatConfig()
     litellm_params = {
         "metadata": {"requester_metadata": {"tags": ["sprint-3"]}},
@@ -171,8 +176,9 @@ def test_optional_params_passed_through():
     assert body["max_tokens"] == 100
 
 
-def test_forwarded_metadata_merges_with_existing_optional_params_metadata():
+def test_forwarded_metadata_merges_with_existing_optional_params_metadata(monkeypatch):
     """Forwarded tags must be merged with any metadata already in optional_params, not overwrite it."""
+    monkeypatch.setattr(litellm, "forward_proxy_metadata", True)
     config = LiteLLMProxyChatConfig()
     body = _sync_transform(
         config,
@@ -189,7 +195,8 @@ def test_forwarded_metadata_merges_with_existing_optional_params_metadata():
 
 
 @pytest.mark.asyncio
-async def test_async_matches_sync_for_tags_and_session():
+async def test_async_matches_sync_for_tags_and_session(monkeypatch):
+    monkeypatch.setattr(litellm, "forward_proxy_metadata", True)
     config = LiteLLMProxyChatConfig()
     litellm_params = {
         "metadata": {"requester_metadata": {"tags": ["async-test"]}},
@@ -206,3 +213,24 @@ async def test_async_no_metadata_when_empty():
     async_body = await _async_transform(config, litellm_params={})
     assert "metadata" not in async_body
     assert "extra_body" not in async_body
+
+
+# --- gate-off regression guard ---
+
+
+def test_tags_not_forwarded_when_flag_disabled(monkeypatch):
+    """When forward_proxy_metadata is False (default), tags in requester_metadata must not appear in the request body."""
+    monkeypatch.setattr(litellm, "forward_proxy_metadata", False)
+    config = LiteLLMProxyChatConfig()
+    litellm_params = {"metadata": {"requester_metadata": {"tags": ["project-x"]}}}
+    body = _sync_transform(config, litellm_params=litellm_params)
+    assert "metadata" not in body or "tags" not in body.get("metadata", {})
+
+
+def test_session_id_not_forwarded_when_flag_disabled(monkeypatch):
+    """When forward_proxy_metadata is False (default), litellm_session_id must not appear in extra_body."""
+    monkeypatch.setattr(litellm, "forward_proxy_metadata", False)
+    config = LiteLLMProxyChatConfig()
+    litellm_params = {"litellm_session_id": "session-abc-123"}
+    body = _sync_transform(config, litellm_params=litellm_params)
+    assert "extra_body" not in body or "litellm_session_id" not in body.get("extra_body", {})


### PR DESCRIPTION
## Relevant issues

Closes #31875

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Ran the proxy locally with Anthropic haiku and sent a request with tags and `litellm_session_id` in the metadata:

```bash
python litellm/proxy/proxy_cli.py --config verify_config.yaml --detailed_debug --port 4000 2>&1 | tee litellm.log
```

```bash
curl -X POST http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-local-dev-master-key" \
  -d '{"model":"haiku","messages":[{"role":"user","content":"say hi"}],"metadata":{"tags":["verify-tag-1"],"litellm_session_id":"session-patch08"}}'
```

Confirmed in logs: `tags` present in request metadata throughout the request lifecycle. `LiteLLMProxyChatConfig` at `transformation.py:117` correctly contains `FORWARDED_METADATA_FIELDS = frozenset({'tags'})` and `_build_forwarded_request_body()` injects both `tags` and `litellm_session_id` into the outbound proxy request body.

Note: full cascaded proxy topology (two proxy instances) was not exercised in this verification pass, but the transformation code path is confirmed in place.

## Type

New Feature

## Changes

`litellm/llms/litellm_proxy/chat/transformation.py`: adds a `FORWARDED_METADATA_FIELDS: frozenset` class attribute (currently `{"tags"}`) and a `_build_forwarded_request_body()` helper that extracts matching fields from `litellm_params["metadata"]["requester_metadata"]` and injects them into the outbound body's `metadata` key, and separately extracts `litellm_session_id` from `litellm_params` and injects it into `extra_body` using a set-if-absent pattern to avoid overwriting a caller-supplied value. Both `transform_request()` and `async_transform_request()` now delegate to this helper so both code paths behave identically. Metadata forwarding is opt-in: it only runs when `litellm.forward_proxy_metadata = True` is set (or `forward_proxy_metadata: true` in proxy config). The default is `False` so existing deployments are unaffected.

`litellm/__init__.py`: adds `forward_proxy_metadata: bool = False` alongside `forward_traceparent_to_llm_provider`.

`tests/test_litellm/llms/litellm_proxy/chat/test_litellm_proxy_chat_transformation.py`: 17 test functions covering tags forwarding, allowlist blocking of non-allowlisted fields, `litellm_session_id` injection, collision avoidance when `extra_body` already contains a `litellm_session_id`, the no-op path when the flag is off (two explicit gate-off regression tests), and sync/async parity.