### PR TITLE
feat(router): add per-deployment allowed_fails_policy and cooldown_time override support

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -1605,6 +1605,7 @@ async def update_team(
     - allowed_passthrough_routes: Optional[List[str]] - List of allowed pass through routes for the team.
     - model_rpm_limit: Optional[Dict[str, int]] - The RPM (Requests Per Minute) limit per model for this team. Example: {"gpt-4": 100, "gpt-3.5-turbo": 200}
     - model_tpm_limit: Optional[Dict[str, int]] - The TPM (Tokens Per Minute) limit per model for this team. Example: {"gpt-4": 10000, "gpt-3.5-turbo": 20000}
+    - mcp_rpm_limit: Optional[Dict[str, int]] - Per-MCP-server RPM limit for this team, keyed by MCP server name (alias if set, else the configured name). Example: {"github": 100, "slack": 200}. Applied across all keys for this team.
     Example - update team TPM Limit
     - allowed_vector_store_indexes: Optional[List[dict]] - List of allowed vector store indexes for the key. Example - [{"index_name": "my-index", "index_permissions": ["write", "read"]}]. If specified, the key will only be able to use these specific vector store indexes. Create index, using `/v1/indexes` endpoint.
     - secret_manager_settings: Optional[dict] - Secret manager settings for the team. [Docs](https://docs.litellm.ai/docs/secret_managers/overview)

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -10999,6 +10999,26 @@ class Router:
             and allowed_fails_policy.BadRequestErrorAllowedFails is not None
         ):
             return allowed_fails_policy.BadRequestErrorAllowedFails
+        if (
+            isinstance(exception, litellm.InternalServerError)
+            and allowed_fails_policy.InternalServerErrorAllowedFails is not None
+        ):
+            return allowed_fails_policy.InternalServerErrorAllowedFails
+        if (
+            isinstance(exception, litellm.ServiceUnavailableError)
+            and allowed_fails_policy.ServiceUnavailableErrorAllowedFails is not None
+        ):
+            return allowed_fails_policy.ServiceUnavailableErrorAllowedFails
+        if (
+            isinstance(exception, litellm.BadGatewayError)
+            and allowed_fails_policy.BadGatewayErrorAllowedFails is not None
+        ):
+            return allowed_fails_policy.BadGatewayErrorAllowedFails
+        if (
+            isinstance(exception, litellm.NotFoundError)
+            and allowed_fails_policy.NotFoundErrorAllowedFails is not None
+        ):
+            return allowed_fails_policy.NotFoundErrorAllowedFails
 
     def _initialize_alerting(self):
         from litellm.integrations.SlackAlerting.slack_alerting import SlackAlerting

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -11014,10 +11014,7 @@ class Router:
             and allowed_fails_policy.BadGatewayErrorAllowedFails is not None
         ):
             return allowed_fails_policy.BadGatewayErrorAllowedFails
-        if (
-            isinstance(exception, litellm.NotFoundError)
-            and allowed_fails_policy.NotFoundErrorAllowedFails is not None
-        ):
+        if isinstance(exception, litellm.NotFoundError) and allowed_fails_policy.NotFoundErrorAllowedFails is not None:
             return allowed_fails_policy.NotFoundErrorAllowedFails
 
     def _initialize_alerting(self):

--- a/litellm/router_utils/cooldown_cache.py
+++ b/litellm/router_utils/cooldown_cache.py
@@ -100,6 +100,30 @@ class CooldownCache:
     def get_cooldown_cache_key(model_id: str) -> str:
         return "deployment:" + model_id + ":cooldown"
 
+    def _corrected_active_cooldown(
+        self,
+        key: str,
+        result: dict,
+        current_time: float,
+    ) -> Optional[CooldownCacheValue]:
+        """
+        Return a CooldownCacheValue if the cooldown is still active, or None if it has expired.
+
+        Also corrects the in-memory TTL when DualCache promotes a Redis entry using the
+        default 600s TTL instead of the true remaining cooldown time.
+        """
+        cooldown_cache_value = CooldownCacheValue(**result)  # type: ignore
+        remaining = (cooldown_cache_value["timestamp"] + cooldown_cache_value["cooldown_time"]) - current_time
+        if remaining <= 0:
+            self.cache.in_memory_cache.delete_cache(key)
+            return None
+        current_expiry = self.cache.in_memory_cache.ttl_dict.get(key)
+        if current_expiry is not None and current_expiry > current_time + remaining + 5:
+            corrected_ttl = min(remaining, 60.0)
+            self.cache.in_memory_cache.delete_cache(key)
+            self.cache.in_memory_cache.set_cache(key, result, ttl=corrected_ttl)
+        return cooldown_cache_value
+
     async def async_get_active_cooldowns(
         self, model_ids: List[str], parent_otel_span: Optional[Span]
     ) -> List[Tuple[str, CooldownCacheValue]]:
@@ -117,11 +141,13 @@ class CooldownCache:
         if results is None or all(v is None for v in results):
             return active_cooldowns
 
-        # Process the results
+        current_time = time.time()
         for model_id, result in zip(model_ids, results):
             if result and isinstance(result, dict):
-                cooldown_cache_value = CooldownCacheValue(**result)  # type: ignore
-                active_cooldowns.append((model_id, cooldown_cache_value))
+                key = CooldownCache.get_cooldown_cache_key(model_id)
+                cooldown_cache_value = self._corrected_active_cooldown(key, result, current_time)
+                if cooldown_cache_value is not None:
+                    active_cooldowns.append((model_id, cooldown_cache_value))
 
         return active_cooldowns
 
@@ -134,11 +160,13 @@ class CooldownCache:
         results = self.cache.batch_get_cache(keys=keys, parent_otel_span=parent_otel_span) or []
 
         active_cooldowns = []
-        # Process the results
+        current_time = time.time()
         for model_id, result in zip(model_ids, results):
             if result and isinstance(result, dict):
-                cooldown_cache_value = CooldownCacheValue(**result)  # type: ignore
-                active_cooldowns.append((model_id, cooldown_cache_value))
+                key = CooldownCache.get_cooldown_cache_key(model_id)
+                cooldown_cache_value = self._corrected_active_cooldown(key, result, current_time)
+                if cooldown_cache_value is not None:
+                    active_cooldowns.append((model_id, cooldown_cache_value))
 
         return active_cooldowns
 

--- a/litellm/router_utils/cooldown_handlers.py
+++ b/litellm/router_utils/cooldown_handlers.py
@@ -37,6 +37,79 @@ else:
     Span = Any
 
 
+_EXCEPTION_POLICY_FIELDS: tuple[tuple[type, str], ...] = (
+    (litellm.BadRequestError, "BadRequestErrorAllowedFails"),
+    (litellm.AuthenticationError, "AuthenticationErrorAllowedFails"),
+    (litellm.Timeout, "TimeoutErrorAllowedFails"),
+    (litellm.RateLimitError, "RateLimitErrorAllowedFails"),
+    (litellm.ContentPolicyViolationError, "ContentPolicyViolationErrorAllowedFails"),
+    (litellm.InternalServerError, "InternalServerErrorAllowedFails"),
+    (litellm.ServiceUnavailableError, "ServiceUnavailableErrorAllowedFails"),
+    (litellm.BadGatewayError, "BadGatewayErrorAllowedFails"),
+    (litellm.NotFoundError, "NotFoundErrorAllowedFails"),
+)
+
+
+def _get_deployment_cooldown_policy(
+    litellm_router_instance: LitellmRouter,
+    deployment: str,
+) -> tuple[Optional[dict[str, int]], Optional[int]]:
+    """Return (allowed_fails_policy, allowed_fails) from deployment model_info, or (None, None)."""
+    dep = litellm_router_instance.get_model_info(id=deployment)
+    if dep is None:
+        return None, None
+    mi: dict[str, Any] = dep.get("model_info") or {}
+    raw = mi.get("allowed_fails_policy")
+    policy: Optional[dict[str, int]] = raw if isinstance(raw, dict) else None
+    allowed: Optional[int] = mi.get("allowed_fails")
+    return policy, allowed
+
+
+def _resolve_allowed_fails_from_policy(
+    policy: Optional[dict[str, int]],
+    exception: Any,
+) -> Optional[int]:
+    """Match *exception* against *policy* and return the configured allowed-fail count, or None."""
+    if policy is None:
+        return None
+    for exc_type, field in _EXCEPTION_POLICY_FIELDS:
+        if isinstance(exception, exc_type):
+            return policy.get(field)
+    return None
+
+
+def _should_cooldown_based_on_deployment_policy(
+    litellm_router_instance: LitellmRouter,
+    deployment: str,
+    original_exception: Any,
+    dep_policy: Optional[dict[str, int]],
+    dep_allowed_fails: Optional[int],
+) -> bool:
+    """Resolve deployment-level allowed-fails and delegate to the shared counting logic."""
+    allowed_fails_from_policy = _resolve_allowed_fails_from_policy(dep_policy, original_exception)
+    if allowed_fails_from_policy is not None:
+        allowed_fails_override: int = allowed_fails_from_policy
+        cache_key_suffix: str = type(original_exception).__name__
+    else:
+        allowed_fails_override = dep_allowed_fails if dep_allowed_fails is not None else 0
+        cache_key_suffix = "generic"
+
+    model_info = litellm_router_instance.get_model_info(id=deployment)
+    cooldown_time_override: Optional[float] = None
+    if model_info is not None:
+        litellm_params = model_info.get("litellm_params") or {}
+        cooldown_time_override = litellm_params.get("cooldown_time")
+
+    return should_cooldown_based_on_allowed_fails_policy(
+        litellm_router_instance=litellm_router_instance,
+        deployment=deployment,
+        original_exception=original_exception,
+        allowed_fails_override=allowed_fails_override,
+        cooldown_time_override=cooldown_time_override,
+        cache_key_suffix=cache_key_suffix,
+    )
+
+
 def _is_cooldown_required(
     litellm_router_instance: LitellmRouter,
     model_id: str,
@@ -172,6 +245,17 @@ def _should_cooldown_deployment(
 
     - v1 logic (Legacy): if allowed fails or allowed fail policy set, coolsdown if num fails in this minute > allowed fails
     """
+    ## CHECK DEPLOYMENT-LEVEL POLICY FIRST (overrides router-level)
+    dep_policy, dep_allowed_fails = _get_deployment_cooldown_policy(litellm_router_instance, deployment)
+    if dep_policy is not None or dep_allowed_fails is not None:
+        return _should_cooldown_based_on_deployment_policy(
+            litellm_router_instance,
+            deployment,
+            original_exception,
+            dep_policy,
+            dep_allowed_fails,
+        )
+
     ## BASE CASE - single deployment
     model_group = litellm_router_instance.get_model_group(id=deployment)
     is_single_deployment_model_group = False
@@ -364,29 +448,43 @@ def should_cooldown_based_on_allowed_fails_policy(
     litellm_router_instance: LitellmRouter,
     deployment: str,
     original_exception: Any,
+    allowed_fails_override: Optional[int] = None,
+    cooldown_time_override: Optional[float] = None,
+    cache_key_suffix: Optional[str] = None,
 ) -> bool:
     """
     Check if fails are within the allowed limit and update the number of fails.
+
+    When *allowed_fails_override* / *cooldown_time_override* are supplied they
+    take precedence over the router-level values (used by deployment-level overrides).
+
+    When *cache_key_suffix* is supplied the fail counter is keyed as
+    ``{deployment}:{cache_key_suffix}`` so that different exception types are
+    tracked independently per deployment.
 
     Returns:
     - True if fails exceed the allowed limit (should cooldown)
     - False if fails are within the allowed limit (should not cooldown)
     """
-    allowed_fails = (
-        litellm_router_instance.get_allowed_fails_from_policy(
-            exception=original_exception,
+    if allowed_fails_override is not None:
+        allowed_fails = allowed_fails_override
+    else:
+        allowed_fails = (
+            litellm_router_instance.get_allowed_fails_from_policy(
+                exception=original_exception,
+            )
+            or litellm_router_instance.allowed_fails
         )
-        or litellm_router_instance.allowed_fails
-    )
-    cooldown_time = litellm_router_instance.cooldown_time or DEFAULT_COOLDOWN_TIME_SECONDS
+    cooldown_time = cooldown_time_override or litellm_router_instance.cooldown_time or DEFAULT_COOLDOWN_TIME_SECONDS
 
-    current_fails = litellm_router_instance.failed_calls.get_cache(key=deployment) or 0
+    cache_key = f"{deployment}:{cache_key_suffix}" if cache_key_suffix else deployment
+    current_fails = litellm_router_instance.failed_calls.get_cache(key=cache_key) or 0
     updated_fails = current_fails + 1
 
     if updated_fails > allowed_fails:
         return True
     else:
-        litellm_router_instance.failed_calls.set_cache(key=deployment, value=updated_fails, ttl=cooldown_time)
+        litellm_router_instance.failed_calls.set_cache(key=cache_key, value=updated_fails, ttl=cooldown_time)
 
     return False
 

--- a/litellm/router_utils/cooldown_handlers.py
+++ b/litellm/router_utils/cooldown_handlers.py
@@ -475,7 +475,11 @@ def should_cooldown_based_on_allowed_fails_policy(
             )
             or litellm_router_instance.allowed_fails
         )
-    cooldown_time = cooldown_time_override or litellm_router_instance.cooldown_time or DEFAULT_COOLDOWN_TIME_SECONDS
+    cooldown_time = (
+        cooldown_time_override
+        if cooldown_time_override is not None
+        else (litellm_router_instance.cooldown_time or DEFAULT_COOLDOWN_TIME_SECONDS)
+    )
 
     cache_key = f"{deployment}:{cache_key_suffix}" if cache_key_suffix else deployment
     current_fails = litellm_router_instance.failed_calls.get_cache(key=cache_key) or 0

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -8,6 +8,7 @@ from litellm.router_utils.add_retry_fallback_headers import (
     add_fallback_headers_to_response,
     get_fallback_error_info,
 )
+from litellm.router_utils.cooldown_handlers import _set_cooldown_deployments
 from litellm.types.router import LiteLLMParamsTypedDict
 
 if TYPE_CHECKING:
@@ -16,6 +17,50 @@ if TYPE_CHECKING:
     LitellmRouter = _Router
 else:
     LitellmRouter = Any
+
+
+def _trigger_cooldown_for_failed_deployment(
+    litellm_router: LitellmRouter,
+    kwargs: dict,
+    exception: Exception,
+) -> None:
+    """
+    Trigger cooldown for a failed fallback deployment.
+
+    In the fallback path the normal failure-callback cooldown is skipped because the
+    Logging object sets has_logged_async_failure=True after the first failure and
+    blocks all subsequent failure callbacks. This helper ensures every failed
+    fallback deployment is evaluated for cooldown regardless.
+    """
+    try:
+        metadata = kwargs.get("litellm_metadata") or kwargs.get("metadata") or {}
+        model_info = metadata.get("model_info") or {}
+        deployment_id: Optional[str] = model_info.get("id") if isinstance(model_info, dict) else None
+
+        if deployment_id is None:
+            verbose_router_logger.debug("Cannot trigger cooldown for fallback: no deployment_id in metadata")
+            return
+
+        exception_status: Union[str, int] = getattr(exception, "status_code", "")
+
+        time_to_cooldown = litellm_router.cooldown_time
+        deployment_dict = litellm_router.get_model_info(id=deployment_id)
+        if deployment_dict is not None:
+            deployment_cooldown = (deployment_dict.get("litellm_params") or {}).get("cooldown_time")
+            if deployment_cooldown is not None and deployment_cooldown >= 0:
+                time_to_cooldown = deployment_cooldown
+
+        _set_cooldown_deployments(
+            litellm_router_instance=litellm_router,
+            exception_status=exception_status,
+            original_exception=exception,
+            deployment=deployment_id,
+            time_to_cooldown=time_to_cooldown,
+        )
+
+        verbose_router_logger.debug(f"Triggered cooldown for fallback deployment {deployment_id}")
+    except Exception as e:  # noqa: BLE001
+        verbose_router_logger.debug(f"Error triggering cooldown for fallback deployment: {e}")
 
 
 def _check_stripped_model_group(model_group: str, fallback_key: str) -> bool:
@@ -160,6 +205,11 @@ async def run_async_fallback(
                 original_model_group=original_model_group,
                 kwargs=kwargs,
                 original_exception=original_exception,
+            )
+            _trigger_cooldown_for_failed_deployment(
+                litellm_router=litellm_router,
+                kwargs=kwargs,
+                exception=e,
             )
     raise error_from_fallbacks
 

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -33,7 +33,7 @@ def _trigger_cooldown_for_failed_deployment(
     fallback deployment is evaluated for cooldown regardless.
     """
     try:
-        metadata = kwargs.get("litellm_metadata") or kwargs.get("metadata") or {}
+        metadata = kwargs.get("litellm_metadata") or {}
         model_info = metadata.get("model_info") or {}
         deployment_id: Optional[str] = model_info.get("id") if isinstance(model_info, dict) else None
 
@@ -206,11 +206,13 @@ async def run_async_fallback(
                 kwargs=kwargs,
                 original_exception=original_exception,
             )
-            _trigger_cooldown_for_failed_deployment(
-                litellm_router=litellm_router,
-                kwargs=kwargs,
-                exception=e,
-            )
+            logging_obj = kwargs.get("litellm_logging_obj")
+            if getattr(logging_obj, "has_logged_async_failure", False):
+                _trigger_cooldown_for_failed_deployment(
+                    litellm_router=litellm_router,
+                    kwargs=kwargs,
+                    exception=e,
+                )
     raise error_from_fallbacks
 
 

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -35,13 +35,13 @@ def _trigger_cooldown_for_failed_deployment(
     try:
         metadata = kwargs.get("litellm_metadata") or {}
         model_info = metadata.get("model_info") or {}
-        deployment_id: Optional[str] = model_info.get("id") if isinstance(model_info, dict) else None
+        deployment_id: str | None = model_info.get("id") if isinstance(model_info, dict) else None
 
         if deployment_id is None:
             verbose_router_logger.debug("Cannot trigger cooldown for fallback: no deployment_id in metadata")
             return
 
-        exception_status: Union[str, int] = getattr(exception, "status_code", "")
+        exception_status: str | int = getattr(exception, "status_code", "")
 
         time_to_cooldown = litellm_router.cooldown_time
         deployment_dict = litellm_router.get_model_info(id=deployment_id)

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -412,6 +412,9 @@ class LiteLLMParamsTypedDict(TypedDict, total=False):
     max_budget: Optional[float]
     budget_duration: Optional[str]
 
+    # per-deployment cooldown override
+    cooldown_time: Optional[float]
+
 
 class DeploymentTypedDict(TypedDict, total=False):
     model_name: Required[str]
@@ -510,6 +513,9 @@ class AllowedFailsPolicy(BaseModel):
     RateLimitErrorAllowedFails: Optional[int] = None
     ContentPolicyViolationErrorAllowedFails: Optional[int] = None
     InternalServerErrorAllowedFails: Optional[int] = None
+    ServiceUnavailableErrorAllowedFails: Optional[int] = None
+    BadGatewayErrorAllowedFails: Optional[int] = None
+    NotFoundErrorAllowedFails: Optional[int] = None
 
 
 class AlertingConfig(BaseModel):

--- a/tests/router_unit_tests/test_router_cooldown_per_deployment.py
+++ b/tests/router_unit_tests/test_router_cooldown_per_deployment.py
@@ -447,3 +447,38 @@ class TestNewAllowedFailsPolicyFields:
         assert policy.ServiceUnavailableErrorAllowedFails == 3
         assert policy.BadGatewayErrorAllowedFails == 2
         assert policy.NotFoundErrorAllowedFails == 1
+
+
+class TestRouterLevelGetAllowedFailsFromPolicy:
+    """Router.get_allowed_fails_from_policy must handle all AllowedFailsPolicy fields."""
+
+    def _make_router(self, **policy_kwargs):
+        return Router(
+            model_list=[{"model_name": "gpt-4", "litellm_params": {"model": "gpt-4", "api_key": "fake"}}],
+            allowed_fails_policy=AllowedFailsPolicy(**policy_kwargs),
+        )
+
+    def test_internal_server_error_returned(self):
+        router = self._make_router(InternalServerErrorAllowedFails=7)
+        exc = litellm.InternalServerError("500 error", "openai", "gpt-4")
+        assert router.get_allowed_fails_from_policy(exc) == 7
+
+    def test_service_unavailable_error_returned(self):
+        router = self._make_router(ServiceUnavailableErrorAllowedFails=4)
+        exc = litellm.ServiceUnavailableError("503 error", "openai", "gpt-4")
+        assert router.get_allowed_fails_from_policy(exc) == 4
+
+    def test_bad_gateway_error_returned(self):
+        router = self._make_router(BadGatewayErrorAllowedFails=2)
+        exc = litellm.BadGatewayError("502 error", "openai", "gpt-4")
+        assert router.get_allowed_fails_from_policy(exc) == 2
+
+    def test_not_found_error_returned(self):
+        router = self._make_router(NotFoundErrorAllowedFails=1)
+        exc = litellm.NotFoundError("404 error", "openai", "gpt-4")
+        assert router.get_allowed_fails_from_policy(exc) == 1
+
+    def test_unmatched_exception_returns_none(self):
+        router = self._make_router(InternalServerErrorAllowedFails=5)
+        exc = litellm.RateLimitError("429", "openai", "gpt-4")
+        assert router.get_allowed_fails_from_policy(exc) is None

--- a/tests/router_unit_tests/test_router_cooldown_per_deployment.py
+++ b/tests/router_unit_tests/test_router_cooldown_per_deployment.py
@@ -1,0 +1,449 @@
+"""
+Tests for per-deployment cooldown policy overrides, DualCache TTL correction,
+and fallback-path cooldown gap fix.
+"""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import litellm
+from litellm import Router
+from litellm.caching.dual_cache import DualCache
+from litellm.caching.in_memory_cache import InMemoryCache
+from litellm.router_utils.cooldown_cache import CooldownCache, CooldownCacheValue
+from litellm.router_utils.cooldown_handlers import (
+    _get_deployment_cooldown_policy,
+    _resolve_allowed_fails_from_policy,
+    _should_cooldown_deployment,
+    should_cooldown_based_on_allowed_fails_policy,
+)
+from litellm.router_utils.fallback_event_handlers import _trigger_cooldown_for_failed_deployment
+from litellm.types.router import AllowedFailsPolicy
+
+
+def _make_router(model_list: list, **kwargs) -> Router:
+    return Router(model_list=model_list, **kwargs)
+
+
+class TestDeploymentLevelAllowedFails:
+    def test_deployment_level_allowed_fails_overrides_router_level(self):
+        """
+        A deployment with model_info.allowed_fails=0 must enter cooldown after 1
+        failure even when the router-level allowed_fails=10.
+        """
+        router = _make_router(
+            model_list=[
+                {
+                    "model_name": "gpt-4",
+                    "litellm_params": {"model": "openai/gpt-4"},
+                    "model_info": {
+                        "id": "primary",
+                        "allowed_fails": 0,
+                    },
+                },
+                {
+                    "model_name": "gpt-4",
+                    "litellm_params": {"model": "openai/gpt-4"},
+                    "model_info": {"id": "secondary"},
+                },
+            ],
+            allowed_fails=10,
+        )
+
+        _exception = litellm.RateLimitError("Rate limit", "openai", "gpt-4")
+        should_cooldown = _should_cooldown_deployment(
+            litellm_router_instance=router,
+            deployment="primary",
+            exception_status=429,
+            original_exception=_exception,
+        )
+
+        assert should_cooldown is True, "Deployment-level allowed_fails=0 should force cooldown after first failure"
+
+    def test_deployment_level_allowed_fails_does_not_affect_other_deployments(self):
+        """
+        A deployment without model_info.allowed_fails must still use the router-level
+        allowed_fails and not be pulled into cooldown prematurely.
+        """
+        router = _make_router(
+            model_list=[
+                {
+                    "model_name": "gpt-4",
+                    "litellm_params": {"model": "openai/gpt-4"},
+                    "model_info": {
+                        "id": "primary",
+                        "allowed_fails": 0,
+                    },
+                },
+                {
+                    "model_name": "gpt-4",
+                    "litellm_params": {"model": "openai/gpt-4"},
+                    "model_info": {"id": "secondary"},
+                },
+            ],
+            allowed_fails=10,
+        )
+
+        _exception = litellm.RateLimitError("Rate limit", "openai", "gpt-4")
+        should_cooldown = _should_cooldown_deployment(
+            litellm_router_instance=router,
+            deployment="secondary",
+            exception_status=429,
+            original_exception=_exception,
+        )
+
+        assert should_cooldown is False, (
+            "secondary has no deployment-level policy; with allowed_fails=10 it should not cool down on first failure"
+        )
+
+
+class TestDeploymentLevelAllowedFailsPolicyByExceptionType:
+    def test_rate_limit_error_triggers_cooldown_with_zero_threshold(self):
+        """
+        RateLimitErrorAllowedFails=0 must trigger cooldown after 1 RateLimitError
+        even when allowed_fails=5 for other exception types.
+        """
+        router = _make_router(
+            model_list=[
+                {
+                    "model_name": "gpt-4",
+                    "litellm_params": {"model": "openai/gpt-4"},
+                    "model_info": {
+                        "id": "primary",
+                        "allowed_fails_policy": {
+                            "RateLimitErrorAllowedFails": 0,
+                            "InternalServerErrorAllowedFails": 5,
+                        },
+                    },
+                },
+            ],
+            allowed_fails=10,
+        )
+
+        rate_limit_exc = litellm.RateLimitError("Rate limit", "openai", "gpt-4")
+        should_cooldown = _should_cooldown_deployment(
+            litellm_router_instance=router,
+            deployment="primary",
+            exception_status=429,
+            original_exception=rate_limit_exc,
+        )
+
+        assert should_cooldown is True, "RateLimitErrorAllowedFails=0 must trigger cooldown on first rate limit error"
+
+    def test_internal_server_error_respects_per_exception_threshold(self):
+        """
+        InternalServerErrorAllowedFails=5 must allow 5 InternalServerErrors before cooldown.
+        """
+        router = _make_router(
+            model_list=[
+                {
+                    "model_name": "gpt-4",
+                    "litellm_params": {"model": "openai/gpt-4"},
+                    "model_info": {
+                        "id": "primary",
+                        "allowed_fails_policy": {
+                            "RateLimitErrorAllowedFails": 0,
+                            "InternalServerErrorAllowedFails": 5,
+                        },
+                    },
+                },
+            ],
+            allowed_fails=10,
+        )
+
+        ise = litellm.InternalServerError("Internal error", "openai", "gpt-4")
+
+        for _ in range(5):
+            should_cooldown = _should_cooldown_deployment(
+                litellm_router_instance=router,
+                deployment="primary",
+                exception_status=500,
+                original_exception=ise,
+            )
+            assert should_cooldown is False, "Should not cooldown within the allowed_fails threshold"
+
+        should_cooldown = _should_cooldown_deployment(
+            litellm_router_instance=router,
+            deployment="primary",
+            exception_status=500,
+            original_exception=ise,
+        )
+        assert should_cooldown is True, "Should cooldown after exceeding InternalServerErrorAllowedFails=5"
+
+
+class TestExceptionTypeCountersTrackedIndependently:
+    def test_cache_key_suffix_separates_exception_type_counters(self):
+        """
+        When cache_key_suffix is provided, fail counters for different exception types
+        must be independent; RateLimitError fails must not bleed into generic counters.
+        """
+        router = _make_router(
+            model_list=[
+                {
+                    "model_name": "gpt-4",
+                    "litellm_params": {"model": "openai/gpt-4"},
+                    "model_info": {"id": "primary"},
+                },
+            ],
+            allowed_fails=10,
+        )
+
+        rate_limit_exc = litellm.RateLimitError("Rate limit", "openai", "gpt-4")
+        ise = litellm.InternalServerError("Internal error", "openai", "gpt-4")
+
+        for _ in range(3):
+            should_cooldown_based_on_allowed_fails_policy(
+                litellm_router_instance=router,
+                deployment="primary",
+                original_exception=rate_limit_exc,
+                allowed_fails_override=5,
+                cache_key_suffix="RateLimitError",
+            )
+
+        rl_counter = router.failed_calls.get_cache(key="primary:RateLimitError") or 0
+        generic_counter = router.failed_calls.get_cache(key="primary:generic") or 0
+
+        assert rl_counter == 3, "RateLimitError counter should be 3"
+        assert generic_counter == 0, "generic counter must be untouched by RateLimitError increments"
+
+        should_cooldown_based_on_allowed_fails_policy(
+            litellm_router_instance=router,
+            deployment="primary",
+            original_exception=ise,
+            allowed_fails_override=5,
+            cache_key_suffix="generic",
+        )
+
+        generic_counter_after = router.failed_calls.get_cache(key="primary:generic") or 0
+        rl_counter_after = router.failed_calls.get_cache(key="primary:RateLimitError") or 0
+
+        assert generic_counter_after == 1, "generic counter should now be 1"
+        assert rl_counter_after == 3, "RateLimitError counter must remain unchanged after InternalServerError"
+
+
+class TestCooldownCacheTTLCorrection:
+    def _make_cooldown_cache(self) -> CooldownCache:
+        in_memory = InMemoryCache()
+        dual_cache = DualCache(in_memory_cache=in_memory)
+        return CooldownCache(cache=dual_cache, default_cooldown_time=60.0)
+
+    def test_expired_entry_evicted_and_not_returned(self):
+        """
+        An entry with timestamp+cooldown_time in the past must be evicted from
+        in-memory cache and excluded from the active cooldown list.
+        """
+        cc = self._make_cooldown_cache()
+        model_id = "expired-deployment"
+        key = CooldownCache.get_cooldown_cache_key(model_id)
+
+        expired_value: CooldownCacheValue = {
+            "exception_received": "Rate limit",
+            "status_code": "429",
+            "timestamp": time.time() - 120.0,
+            "cooldown_time": 60.0,
+        }
+        cc.cache.in_memory_cache.set_cache(key, expired_value, ttl=600)
+
+        active = cc.get_active_cooldowns(model_ids=[model_id], parent_otel_span=None)
+
+        assert active == [], "Expired cooldown entry must not appear in active cooldowns"
+        assert cc.cache.in_memory_cache.get_cache(key) is None, "Expired entry must be evicted from in-memory cache"
+
+    def test_active_entry_is_returned(self):
+        """
+        An entry whose cooldown window has not elapsed must appear in the active list.
+        """
+        cc = self._make_cooldown_cache()
+        model_id = "active-deployment"
+        key = CooldownCache.get_cooldown_cache_key(model_id)
+
+        active_value: CooldownCacheValue = {
+            "exception_received": "Rate limit",
+            "status_code": "429",
+            "timestamp": time.time(),
+            "cooldown_time": 60.0,
+        }
+        cc.cache.in_memory_cache.set_cache(key, active_value, ttl=60)
+
+        active = cc.get_active_cooldowns(model_ids=[model_id], parent_otel_span=None)
+
+        assert len(active) == 1
+        assert active[0][0] == model_id
+
+    def test_ttl_corrected_when_in_memory_expiry_far_exceeds_remaining(self):
+        """
+        When DualCache backfills from Redis using the default 600s TTL, the in-memory
+        TTL must be corrected to min(remaining, 60) seconds.
+        """
+        cc = self._make_cooldown_cache()
+        model_id = "backfilled-deployment"
+        key = CooldownCache.get_cooldown_cache_key(model_id)
+
+        remaining = 30.0
+        value: CooldownCacheValue = {
+            "exception_received": "Rate limit",
+            "status_code": "429",
+            "timestamp": time.time() - (60.0 - remaining),
+            "cooldown_time": 60.0,
+        }
+        cc.cache.in_memory_cache.set_cache(key, value, ttl=600)
+
+        before_expiry = cc.cache.in_memory_cache.ttl_dict.get(key)
+        assert before_expiry is not None
+
+        cc.get_active_cooldowns(model_ids=[model_id], parent_otel_span=None)
+
+        after_expiry = cc.cache.in_memory_cache.ttl_dict.get(key)
+        assert after_expiry is not None
+        corrected_remaining = after_expiry - time.time()
+        assert corrected_remaining <= 60.0, "Corrected TTL must not exceed 60s"
+        assert corrected_remaining > 0, "Corrected TTL must be positive (cooldown still active)"
+
+    @pytest.mark.asyncio
+    async def test_async_expired_entry_evicted(self):
+        """
+        Async path must also evict expired entries.
+        """
+        cc = self._make_cooldown_cache()
+        model_id = "async-expired"
+        key = CooldownCache.get_cooldown_cache_key(model_id)
+
+        expired_value: CooldownCacheValue = {
+            "exception_received": "Rate limit",
+            "status_code": "429",
+            "timestamp": time.time() - 120.0,
+            "cooldown_time": 60.0,
+        }
+        cc.cache.in_memory_cache.set_cache(key, expired_value, ttl=600)
+
+        active = await cc.async_get_active_cooldowns(model_ids=[model_id], parent_otel_span=None)
+
+        assert active == [], "Expired entry must not appear in async active cooldowns"
+        assert cc.cache.in_memory_cache.get_cache(key) is None
+
+
+class TestFallbackDeploymentCooldown:
+    def test_trigger_cooldown_for_failed_deployment_calls_set_cooldown(self):
+        """
+        _trigger_cooldown_for_failed_deployment must call _set_cooldown_deployments
+        with the deployment ID extracted from kwargs metadata.
+        """
+        mock_router = MagicMock()
+        mock_router.cooldown_time = 60.0
+        mock_router.get_model_info.return_value = None
+
+        kwargs = {
+            "litellm_metadata": {
+                "model_info": {"id": "fallback-deployment"},
+            }
+        }
+        exc = litellm.RateLimitError("Rate limit", "openai", "gpt-4")
+
+        with patch("litellm.router_utils.fallback_event_handlers._set_cooldown_deployments") as mock_set_cooldown:
+            _trigger_cooldown_for_failed_deployment(
+                litellm_router=mock_router,
+                kwargs=kwargs,
+                exception=exc,
+            )
+
+            mock_set_cooldown.assert_called_once()
+            call_kwargs = mock_set_cooldown.call_args[1]
+            assert call_kwargs["deployment"] == "fallback-deployment"
+            assert call_kwargs["original_exception"] is exc
+
+    def test_trigger_cooldown_no_op_when_deployment_id_missing(self):
+        """
+        _trigger_cooldown_for_failed_deployment must not raise and must skip
+        _set_cooldown_deployments when deployment_id is absent from metadata.
+        """
+        mock_router = MagicMock()
+
+        with patch("litellm.router_utils.fallback_event_handlers._set_cooldown_deployments") as mock_set_cooldown:
+            _trigger_cooldown_for_failed_deployment(
+                litellm_router=mock_router,
+                kwargs={},
+                exception=RuntimeError("no metadata"),
+            )
+
+            mock_set_cooldown.assert_not_called()
+
+    def test_trigger_cooldown_uses_deployment_cooldown_time_override(self):
+        """
+        When the deployment has a litellm_params.cooldown_time, that value must be
+        passed as time_to_cooldown rather than the router-level cooldown_time.
+        """
+        mock_router = MagicMock()
+        mock_router.cooldown_time = 300.0
+        mock_router.get_model_info.return_value = {"litellm_params": {"cooldown_time": 30.0}}
+
+        kwargs = {
+            "litellm_metadata": {
+                "model_info": {"id": "fallback-deployment"},
+            }
+        }
+        exc = litellm.RateLimitError("Rate limit", "openai", "gpt-4")
+
+        with patch("litellm.router_utils.fallback_event_handlers._set_cooldown_deployments") as mock_set_cooldown:
+            _trigger_cooldown_for_failed_deployment(
+                litellm_router=mock_router,
+                kwargs=kwargs,
+                exception=exc,
+            )
+
+            call_kwargs = mock_set_cooldown.call_args[1]
+            assert call_kwargs["time_to_cooldown"] == 30.0, (
+                "Deployment-level cooldown_time must override router-level value"
+            )
+
+
+class TestNewAllowedFailsPolicyFields:
+    def test_service_unavailable_error_matched_by_policy(self):
+        """
+        ServiceUnavailableError must be matched against ServiceUnavailableErrorAllowedFails.
+        """
+        policy = {"ServiceUnavailableErrorAllowedFails": 0}
+        exc = litellm.ServiceUnavailableError("Service unavailable", "openai", "gpt-4")
+        result = _resolve_allowed_fails_from_policy(policy=policy, exception=exc)
+        assert result == 0
+
+    def test_bad_gateway_error_matched_by_policy(self):
+        """
+        BadGatewayError must be matched against BadGatewayErrorAllowedFails.
+        """
+        policy = {"BadGatewayErrorAllowedFails": 2}
+        exc = litellm.BadGatewayError("Bad gateway", "openai", "gpt-4")
+        result = _resolve_allowed_fails_from_policy(policy=policy, exception=exc)
+        assert result == 2
+
+    def test_not_found_error_matched_by_policy(self):
+        """
+        NotFoundError must be matched against NotFoundErrorAllowedFails.
+        """
+        policy = {"NotFoundErrorAllowedFails": 1}
+        exc = litellm.NotFoundError("Not found", "openai", "gpt-4")
+        result = _resolve_allowed_fails_from_policy(policy=policy, exception=exc)
+        assert result == 1
+
+    def test_unknown_exception_type_returns_none(self):
+        """
+        An exception type not in the policy mapping must return None.
+        """
+        policy = {"RateLimitErrorAllowedFails": 0}
+        exc = ValueError("unexpected error")
+        result = _resolve_allowed_fails_from_policy(policy=policy, exception=exc)
+        assert result is None
+
+    def test_allowed_fails_policy_model_accepts_new_fields(self):
+        """
+        AllowedFailsPolicy Pydantic model must accept the three new fields.
+        """
+        policy = AllowedFailsPolicy(
+            ServiceUnavailableErrorAllowedFails=3,
+            BadGatewayErrorAllowedFails=2,
+            NotFoundErrorAllowedFails=1,
+        )
+        assert policy.ServiceUnavailableErrorAllowedFails == 3
+        assert policy.BadGatewayErrorAllowedFails == 2
+        assert policy.NotFoundErrorAllowedFails == 1

--- a/tests/test_litellm/interactions/test_openapi_compliance.py
+++ b/tests/test_litellm/interactions/test_openapi_compliance.py
@@ -194,6 +194,7 @@ class TestResponseCompliance:
             "cancelled",
             "incomplete",
             "budget_exceeded",
+            "queued",
         ]
         assert status_prop["enum"] == expected_statuses
         print(f"✓ Status enum values: {expected_statuses}")

--- a/tests/test_litellm/router_utils/test_cooldown_cache.py
+++ b/tests/test_litellm/router_utils/test_cooldown_cache.py
@@ -4,6 +4,7 @@ Unit tests for CooldownCache exception masking functionality
 
 import os
 import sys
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -255,3 +256,66 @@ class TestCooldownCacheExceptionMasking:
         # Should show first 50 characters, then all asterisks
         expected = "A" * 50 + "*" * 50
         assert masked == expected
+
+
+class TestCorrectedActiveCooldown:
+    def _make_cooldown_cache(self) -> CooldownCache:
+        in_memory = InMemoryCache()
+        dual_cache = DualCache(in_memory_cache=in_memory)
+        return CooldownCache(cache=dual_cache, default_cooldown_time=60.0)
+
+    def _entry(self, timestamp: float, cooldown_time: float) -> CooldownCacheValue:
+        return CooldownCacheValue(
+            exception_received="Rate limit",
+            status_code="429",
+            timestamp=timestamp,
+            cooldown_time=cooldown_time,
+        )
+
+    def test_expired_entry_returns_none_and_evicts(self):
+        cc = self._make_cooldown_cache()
+        key = "deployment:expired-dep:cooldown"
+        entry = self._entry(timestamp=time.time() - 120.0, cooldown_time=60.0)
+        cc.cache.in_memory_cache.set_cache(key, dict(entry), ttl=600)
+
+        result = cc._corrected_active_cooldown(key, dict(entry), current_time=time.time())
+
+        assert result is None
+        assert cc.cache.in_memory_cache.get_cache(key) is None
+
+    def test_active_entry_within_window_returns_value(self):
+        cc = self._make_cooldown_cache()
+        key = "deployment:active-dep:cooldown"
+        entry = self._entry(timestamp=time.time(), cooldown_time=60.0)
+        cc.cache.in_memory_cache.set_cache(key, dict(entry), ttl=60)
+
+        result = cc._corrected_active_cooldown(key, dict(entry), current_time=time.time())
+
+        assert result is not None
+        assert result["status_code"] == "429"
+
+    def test_inflated_ttl_is_corrected(self):
+        cc = self._make_cooldown_cache()
+        key = "deployment:backfilled-dep:cooldown"
+        remaining = 30.0
+        entry = self._entry(timestamp=time.time() - (60.0 - remaining), cooldown_time=60.0)
+        cc.cache.in_memory_cache.set_cache(key, dict(entry), ttl=600)
+
+        result = cc._corrected_active_cooldown(key, dict(entry), current_time=time.time())
+
+        assert result is not None
+        corrected_expiry = cc.cache.in_memory_cache.ttl_dict.get(key)
+        assert corrected_expiry is not None
+        assert corrected_expiry - time.time() <= 60.0
+
+    def test_normal_ttl_not_modified(self):
+        cc = self._make_cooldown_cache()
+        key = "deployment:normal-dep:cooldown"
+        entry = self._entry(timestamp=time.time(), cooldown_time=60.0)
+        cc.cache.in_memory_cache.set_cache(key, dict(entry), ttl=60)
+        original_expiry = cc.cache.in_memory_cache.ttl_dict.get(key)
+
+        cc._corrected_active_cooldown(key, dict(entry), current_time=time.time())
+
+        after_expiry = cc.cache.in_memory_cache.ttl_dict.get(key)
+        assert after_expiry == original_expiry

--- a/tests/test_litellm/router_utils/test_cooldown_handlers.py
+++ b/tests/test_litellm/router_utils/test_cooldown_handlers.py
@@ -5,6 +5,7 @@ from litellm.router_utils.cooldown_handlers import (
     _get_deployment_cooldown_policy,
     _resolve_allowed_fails_from_policy,
     _should_cooldown_based_on_deployment_policy,
+    should_cooldown_based_on_allowed_fails_policy,
 )
 
 
@@ -172,3 +173,33 @@ class TestShouldCooldownBasedOnDeploymentPolicy:
 
         call_kwargs = mock_sc.call_args[1]
         assert call_kwargs["cooldown_time_override"] is None
+
+
+class TestShouldCooldownBasedOnAllowedFailsPolicy:
+    def _make_router(self, cooldown_time: float = 60.0) -> MagicMock:
+        router = MagicMock()
+        router.cooldown_time = cooldown_time
+        router.allowed_fails = 0
+        router.allowed_fails_policy = None
+        router.get_allowed_fails_from_policy.return_value = None
+        router.failed_calls.get_cache.return_value = None
+        return router
+
+    def test_cooldown_time_override_zero_is_not_falsy(self):
+        """cooldown_time_override=0 must be honored; it must not fall through to the router-level value."""
+        router = self._make_router(cooldown_time=60.0)
+        exc = litellm.RateLimitError("429", "openai", "gpt-4")
+
+        should_cooldown_based_on_allowed_fails_policy(
+            litellm_router_instance=router,
+            deployment="dep-1",
+            original_exception=exc,
+            allowed_fails_override=5,
+            cooldown_time_override=0.0,
+        )
+
+        set_cache_call = router.failed_calls.set_cache.call_args
+        assert set_cache_call is not None
+        assert set_cache_call[1]["ttl"] == 0.0, (
+            "cooldown_time_override=0 should be used as TTL, not the router-level 60.0"
+        )

--- a/tests/test_litellm/router_utils/test_cooldown_handlers.py
+++ b/tests/test_litellm/router_utils/test_cooldown_handlers.py
@@ -1,0 +1,174 @@
+from unittest.mock import MagicMock, patch
+
+import litellm
+from litellm.router_utils.cooldown_handlers import (
+    _get_deployment_cooldown_policy,
+    _resolve_allowed_fails_from_policy,
+    _should_cooldown_based_on_deployment_policy,
+)
+
+
+class TestGetDeploymentCooldownPolicy:
+    def _make_router(self, deployment_id: str, model_info: dict | None = None):
+        router = MagicMock()
+        if model_info is None:
+            router.get_model_info.return_value = None
+        else:
+            router.get_model_info.return_value = {"model_info": model_info}
+        return router
+
+    def test_deployment_not_found_returns_none_none(self):
+        router = self._make_router("dep-1")
+        policy, allowed = _get_deployment_cooldown_policy(router, "dep-1")
+        assert policy is None
+        assert allowed is None
+
+    def test_no_model_info_returns_none_none(self):
+        router = MagicMock()
+        router.get_model_info.return_value = {"model_info": {}}
+        policy, allowed = _get_deployment_cooldown_policy(router, "dep-1")
+        assert policy is None
+        assert allowed is None
+
+    def test_returns_policy_dict_and_allowed_fails(self):
+        router = self._make_router(
+            "dep-1",
+            {"allowed_fails_policy": {"RateLimitErrorAllowedFails": 2}, "allowed_fails": 3},
+        )
+        policy, allowed = _get_deployment_cooldown_policy(router, "dep-1")
+        assert policy == {"RateLimitErrorAllowedFails": 2}
+        assert allowed == 3
+
+    def test_non_dict_policy_treated_as_none(self):
+        router = self._make_router("dep-1", {"allowed_fails_policy": "invalid", "allowed_fails": 5})
+        policy, allowed = _get_deployment_cooldown_policy(router, "dep-1")
+        assert policy is None
+        assert allowed == 5
+
+    def test_allowed_fails_only(self):
+        router = self._make_router("dep-1", {"allowed_fails": 1})
+        policy, allowed = _get_deployment_cooldown_policy(router, "dep-1")
+        assert policy is None
+        assert allowed == 1
+
+
+class TestResolveAllowedFailsFromPolicy:
+    def test_none_policy_returns_none(self):
+        exc = litellm.RateLimitError("429", "openai", "gpt-4")
+        assert _resolve_allowed_fails_from_policy(None, exc) is None
+
+    def test_matching_rate_limit_error(self):
+        policy = {"RateLimitErrorAllowedFails": 3}
+        exc = litellm.RateLimitError("429", "openai", "gpt-4")
+        assert _resolve_allowed_fails_from_policy(policy, exc) == 3
+
+    def test_matching_internal_server_error(self):
+        policy = {"InternalServerErrorAllowedFails": 5}
+        exc = litellm.InternalServerError("500", "openai", "gpt-4")
+        assert _resolve_allowed_fails_from_policy(policy, exc) == 5
+
+    def test_matching_service_unavailable_error(self):
+        policy = {"ServiceUnavailableErrorAllowedFails": 4}
+        exc = litellm.ServiceUnavailableError("503", "openai", "gpt-4")
+        assert _resolve_allowed_fails_from_policy(policy, exc) == 4
+
+    def test_matching_bad_gateway_error(self):
+        policy = {"BadGatewayErrorAllowedFails": 2}
+        exc = litellm.BadGatewayError("502", "openai", "gpt-4")
+        assert _resolve_allowed_fails_from_policy(policy, exc) == 2
+
+    def test_matching_not_found_error(self):
+        policy = {"NotFoundErrorAllowedFails": 1}
+        exc = litellm.NotFoundError("404", "openai", "gpt-4")
+        assert _resolve_allowed_fails_from_policy(policy, exc) == 1
+
+    def test_unmatched_exception_returns_none(self):
+        policy = {"RateLimitErrorAllowedFails": 3}
+        exc = litellm.InternalServerError("500", "openai", "gpt-4")
+        assert _resolve_allowed_fails_from_policy(policy, exc) is None
+
+    def test_field_absent_from_policy_returns_none(self):
+        policy: dict[str, int] = {}
+        exc = litellm.InternalServerError("500", "openai", "gpt-4")
+        assert _resolve_allowed_fails_from_policy(policy, exc) is None
+
+
+class TestShouldCooldownBasedOnDeploymentPolicy:
+    def _make_router(self, model_info: dict | None = None):
+        router = MagicMock()
+        if model_info is None:
+            router.get_model_info.return_value = None
+        else:
+            router.get_model_info.return_value = model_info
+        return router
+
+    def test_policy_match_uses_exception_type_as_cache_key_suffix(self):
+        policy = {"RateLimitErrorAllowedFails": 0}
+        exc = litellm.RateLimitError("429", "openai", "gpt-4")
+        router = self._make_router({"litellm_params": {}, "model_info": {}})
+
+        with patch(
+            "litellm.router_utils.cooldown_handlers.should_cooldown_based_on_allowed_fails_policy"
+        ) as mock_sc:
+            mock_sc.return_value = True
+            result = _should_cooldown_based_on_deployment_policy(router, "dep-1", exc, policy, None)
+
+        assert result is True
+        call_kwargs = mock_sc.call_args[1]
+        assert call_kwargs["allowed_fails_override"] == 0
+        assert call_kwargs["cache_key_suffix"] == "RateLimitError"
+
+    def test_no_policy_match_uses_dep_allowed_fails_and_generic_suffix(self):
+        policy: dict[str, int] = {}
+        exc = litellm.InternalServerError("500", "openai", "gpt-4")
+        router = self._make_router({"litellm_params": {}, "model_info": {}})
+
+        with patch(
+            "litellm.router_utils.cooldown_handlers.should_cooldown_based_on_allowed_fails_policy"
+        ) as mock_sc:
+            mock_sc.return_value = False
+            result = _should_cooldown_based_on_deployment_policy(router, "dep-1", exc, policy, dep_allowed_fails=3)
+
+        assert result is False
+        call_kwargs = mock_sc.call_args[1]
+        assert call_kwargs["allowed_fails_override"] == 3
+        assert call_kwargs["cache_key_suffix"] == "generic"
+
+    def test_no_policy_and_no_dep_allowed_fails_defaults_to_zero(self):
+        exc = litellm.InternalServerError("500", "openai", "gpt-4")
+        router = self._make_router({"litellm_params": {}, "model_info": {}})
+
+        with patch(
+            "litellm.router_utils.cooldown_handlers.should_cooldown_based_on_allowed_fails_policy"
+        ) as mock_sc:
+            mock_sc.return_value = True
+            _should_cooldown_based_on_deployment_policy(router, "dep-1", exc, None, None)
+
+        call_kwargs = mock_sc.call_args[1]
+        assert call_kwargs["allowed_fails_override"] == 0
+
+    def test_cooldown_time_from_litellm_params_passed_through(self):
+        exc = litellm.RateLimitError("429", "openai", "gpt-4")
+        router = self._make_router({"litellm_params": {"cooldown_time": 120.0}, "model_info": {}})
+
+        with patch(
+            "litellm.router_utils.cooldown_handlers.should_cooldown_based_on_allowed_fails_policy"
+        ) as mock_sc:
+            mock_sc.return_value = True
+            _should_cooldown_based_on_deployment_policy(router, "dep-1", exc, None, None)
+
+        call_kwargs = mock_sc.call_args[1]
+        assert call_kwargs["cooldown_time_override"] == 120.0
+
+    def test_model_info_none_passes_none_cooldown_time(self):
+        exc = litellm.RateLimitError("429", "openai", "gpt-4")
+        router = self._make_router(None)
+
+        with patch(
+            "litellm.router_utils.cooldown_handlers.should_cooldown_based_on_allowed_fails_policy"
+        ) as mock_sc:
+            mock_sc.return_value = False
+            _should_cooldown_based_on_deployment_policy(router, "dep-1", exc, None, None)
+
+        call_kwargs = mock_sc.call_args[1]
+        assert call_kwargs["cooldown_time_override"] is None

--- a/tests/test_litellm/router_utils/test_fallback_event_handlers.py
+++ b/tests/test_litellm/router_utils/test_fallback_event_handlers.py
@@ -1,8 +1,10 @@
 import json
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from litellm.router_utils.fallback_event_handlers import (
+    _trigger_cooldown_for_failed_deployment,
     get_fallback_model_group,
     run_async_fallback,
 )
@@ -140,6 +142,138 @@ async def test_run_async_fallback_skips_original_model_group():
     )
 
     assert response._hidden_params["additional_headers"]["x-litellm-attempted-fallbacks"] == 1
+
+
+def test_trigger_cooldown_calls_set_cooldown_when_deployment_id_present():
+    router = MagicMock()
+    router.cooldown_time = 60
+    router.get_model_info.return_value = None
+
+    exc = RuntimeError("upstream error")
+    exc.status_code = 429
+
+    kwargs = {"litellm_metadata": {"model_info": {"id": "deployment-abc"}}}
+
+    with patch(
+        "litellm.router_utils.fallback_event_handlers._set_cooldown_deployments"
+    ) as mock_set:
+        _trigger_cooldown_for_failed_deployment(
+            litellm_router=router, kwargs=kwargs, exception=exc
+        )
+
+    mock_set.assert_called_once()
+    _, call_kwargs = mock_set.call_args
+    assert call_kwargs["deployment"] == "deployment-abc"
+    assert call_kwargs["exception_status"] == 429
+
+
+def test_trigger_cooldown_skips_when_no_deployment_id():
+    router = MagicMock()
+    kwargs = {"litellm_metadata": {}}
+
+    with patch(
+        "litellm.router_utils.fallback_event_handlers._set_cooldown_deployments"
+    ) as mock_set:
+        _trigger_cooldown_for_failed_deployment(
+            litellm_router=router, kwargs=kwargs, exception=RuntimeError("err")
+        )
+
+    mock_set.assert_not_called()
+
+
+def test_trigger_cooldown_uses_litellm_metadata_only_not_metadata():
+    router = MagicMock()
+    router.cooldown_time = 60
+    router.get_model_info.return_value = None
+
+    exc = RuntimeError("err")
+    # metadata (user-supplied) should be ignored; litellm_metadata is absent -> no cooldown
+    kwargs = {"metadata": {"model_info": {"id": "injected-id"}}}
+
+    with patch(
+        "litellm.router_utils.fallback_event_handlers._set_cooldown_deployments"
+    ) as mock_set:
+        _trigger_cooldown_for_failed_deployment(
+            litellm_router=router, kwargs=kwargs, exception=exc
+        )
+
+    mock_set.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_async_fallback_triggers_cooldown_when_logging_obj_has_logged():
+    router = MagicMock()
+    router.cooldown_time = 60
+    router.get_model_info.return_value = None
+    router.log_retry = MagicMock(side_effect=lambda kwargs, e: kwargs)
+
+    exc = RuntimeError("fallback failed")
+
+    async def _always_fail(*args, **kwargs):
+        raise exc
+
+    router.async_function_with_fallbacks = _always_fail
+
+    logging_obj = MagicMock()
+    logging_obj.has_logged_async_failure = True
+
+    kwargs = {
+        "litellm_metadata": {"model_info": {"id": "dep-xyz"}},
+        "litellm_logging_obj": logging_obj,
+    }
+
+    with patch(
+        "litellm.router_utils.fallback_event_handlers._set_cooldown_deployments"
+    ) as mock_set:
+        with pytest.raises(RuntimeError):
+            await run_async_fallback(
+                litellm_router=router,
+                fallback_model_group=["fallback-model"],
+                original_model_group="primary-model",
+                original_exception=RuntimeError("original"),
+                max_fallbacks=3,
+                fallback_depth=0,
+                **kwargs,
+            )
+
+    mock_set.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_run_async_fallback_skips_cooldown_when_logging_obj_not_logged():
+    router = MagicMock()
+    router.log_retry = MagicMock(side_effect=lambda kwargs, e: kwargs)
+
+    exc = RuntimeError("fallback failed")
+
+    async def _always_fail(*args, **kwargs):
+        raise exc
+
+    router.async_function_with_fallbacks = _always_fail
+
+    logging_obj = MagicMock()
+    logging_obj.has_logged_async_failure = False
+
+    kwargs = {
+        "litellm_metadata": {"model_info": {"id": "dep-xyz"}},
+        "litellm_logging_obj": logging_obj,
+    }
+
+    with patch(
+        "litellm.router_utils.fallback_event_handlers._set_cooldown_deployments"
+    ) as mock_set:
+        with pytest.raises(RuntimeError):
+            await run_async_fallback(
+                litellm_router=router,
+                fallback_model_group=["fallback-model"],
+                original_model_group="primary-model",
+                original_exception=RuntimeError("original"),
+                max_fallbacks=3,
+                fallback_depth=0,
+                **kwargs,
+            )
+
+    mock_set.assert_not_called()
 
 
 def test_get_fallback_model_group_does_not_mutate_fallbacks():

--- a/tests/test_litellm/router_utils/test_fallback_event_handlers.py
+++ b/tests/test_litellm/router_utils/test_fallback_event_handlers.py
@@ -181,6 +181,44 @@ def test_trigger_cooldown_skips_when_no_deployment_id():
     mock_set.assert_not_called()
 
 
+def test_trigger_cooldown_uses_deployment_cooldown_time_when_present():
+    router = MagicMock()
+    router.cooldown_time = 60
+    router.get_model_info.return_value = {"litellm_params": {"cooldown_time": 30}}
+
+    exc = RuntimeError("upstream error")
+    exc.status_code = 429
+
+    kwargs = {"litellm_metadata": {"model_info": {"id": "deployment-abc"}}}
+
+    with patch(
+        "litellm.router_utils.fallback_event_handlers._set_cooldown_deployments"
+    ) as mock_set:
+        _trigger_cooldown_for_failed_deployment(
+            litellm_router=router, kwargs=kwargs, exception=exc
+        )
+
+    _, call_kwargs = mock_set.call_args
+    assert call_kwargs["time_to_cooldown"] == 30
+
+
+def test_trigger_cooldown_silently_catches_exceptions():
+    router = MagicMock()
+    router.cooldown_time = 60
+    router.get_model_info.return_value = None
+
+    exc = RuntimeError("upstream error")
+    kwargs = {"litellm_metadata": {"model_info": {"id": "deployment-abc"}}}
+
+    with patch(
+        "litellm.router_utils.fallback_event_handlers._set_cooldown_deployments",
+        side_effect=RuntimeError("cooldown error"),
+    ):
+        _trigger_cooldown_for_failed_deployment(
+            litellm_router=router, kwargs=kwargs, exception=exc
+        )
+
+
 def test_trigger_cooldown_uses_litellm_metadata_only_not_metadata():
     router = MagicMock()
     router.cooldown_time = 60

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -5304,3 +5304,44 @@ class TestRouterRequestTimeoutPropagation:
             )
             == 60
         )
+
+
+class TestGetAllowedFailsFromPolicy:
+    def _make_router(self, **policy_kwargs) -> litellm.Router:
+        from litellm.types.router import AllowedFailsPolicy
+
+        return litellm.Router(
+            model_list=[{"model_name": "gpt-4", "litellm_params": {"model": "gpt-4", "api_key": "fake"}}],
+            allowed_fails_policy=AllowedFailsPolicy(**policy_kwargs),
+        )
+
+    def test_no_policy_returns_none(self):
+        router = litellm.Router(
+            model_list=[{"model_name": "gpt-4", "litellm_params": {"model": "gpt-4", "api_key": "fake"}}],
+        )
+        assert router.get_allowed_fails_from_policy(litellm.RateLimitError("429", "openai", "gpt-4")) is None
+
+    def test_internal_server_error_allowed_fails(self):
+        router = self._make_router(InternalServerErrorAllowedFails=7)
+        exc = litellm.InternalServerError("500", "openai", "gpt-4")
+        assert router.get_allowed_fails_from_policy(exc) == 7
+
+    def test_service_unavailable_error_allowed_fails(self):
+        router = self._make_router(ServiceUnavailableErrorAllowedFails=4)
+        exc = litellm.ServiceUnavailableError("503", "openai", "gpt-4")
+        assert router.get_allowed_fails_from_policy(exc) == 4
+
+    def test_bad_gateway_error_allowed_fails(self):
+        router = self._make_router(BadGatewayErrorAllowedFails=2)
+        exc = litellm.BadGatewayError("502", "openai", "gpt-4")
+        assert router.get_allowed_fails_from_policy(exc) == 2
+
+    def test_not_found_error_allowed_fails(self):
+        router = self._make_router(NotFoundErrorAllowedFails=1)
+        exc = litellm.NotFoundError("404", "openai", "gpt-4")
+        assert router.get_allowed_fails_from_policy(exc) == 1
+
+    def test_unmatched_exception_returns_none(self):
+        router = self._make_router(InternalServerErrorAllowedFails=5)
+        exc = litellm.RateLimitError("429", "openai", "gpt-4")
+        assert router.get_allowed_fails_from_policy(exc) is None

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -13740,6 +13740,7 @@ export interface paths {
          *     - allowed_passthrough_routes: Optional[List[str]] - List of allowed pass through routes for the team.
          *     - model_rpm_limit: Optional[Dict[str, int]] - The RPM (Requests Per Minute) limit per model for this team. Example: {"gpt-4": 100, "gpt-3.5-turbo": 200}
          *     - model_tpm_limit: Optional[Dict[str, int]] - The TPM (Tokens Per Minute) limit per model for this team. Example: {"gpt-4": 10000, "gpt-3.5-turbo": 20000}
+         *     - mcp_rpm_limit: Optional[Dict[str, int]] - Per-MCP-server RPM limit for this team, keyed by MCP server name (alias if set, else the configured name). Example: {"github": 100, "slack": 200}. Applied across all keys for this team.
          *     Example - update team TPM Limit
          *     - allowed_vector_store_indexes: Optional[List[dict]] - List of allowed vector store indexes for the key. Example - [{"index_name": "my-index", "index_permissions": ["write", "read"]}]. If specified, the key will only be able to use these specific vector store indexes. Create index, using `/v1/indexes` endpoint.
          *     - secret_manager_settings: Optional[dict] - Secret manager settings for the team. [Docs](https://docs.litellm.ai/docs/secret_managers/overview)


### PR DESCRIPTION
## Relevant issues

Closes #31876

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Ran the proxy locally with a `strict-model` deployment (intentionally bad API key, `model_info.allowed_fails: 1`, `cooldown_time: 60`) and a fallback to Anthropic haiku:

```bash
python litellm/proxy/proxy_cli.py --config verify_config.yaml --detailed_debug --port 4000 2>&1 | tee litellm.log
```

```bash
curl -X POST http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-local-dev-master-key" \
  -d '{"model":"strict-model","messages":[{"role":"user","content":"say hi"}]}'
# 200 OK response from fallback good-model
```

Router read `model_info: {'allowed_fails': 1, 'cooldown_time': 60}` from the deployment config. Log showed `cooldown_handlers.py:350: Attempting to add deployment-bad to cooldown list` after the first authentication failure. Fallback fired immediately to the working deployment. Per-deployment cooldown override confirmed applied, overriding the router-level default.

## Type

New Feature

## Changes

`litellm/types/router.py`: adds `ServiceUnavailableErrorAllowedFails`, `BadGatewayErrorAllowedFails`, and `NotFoundErrorAllowedFails` to `AllowedFailsPolicy`; adds a `cooldown_time` field to `LiteLLMParamsTypedDict` so per-deployment cooldown windows can be set in YAML config.

`litellm/router_utils/cooldown_handlers.py`: adds `_EXCEPTION_POLICY_FIELDS` (a tuple mapping exception types to policy field names), `_get_deployment_cooldown_policy`, `_resolve_allowed_fails_from_policy`, and `_should_cooldown_based_on_deployment_policy` helper functions; adds a precedence check at the top of `_should_cooldown_deployment` so deployment-level `model_info.allowed_fails` and `model_info.allowed_fails_policy` win over router-level settings; extends `should_cooldown_based_on_allowed_fails_policy` with `allowed_fails_override`, `cooldown_time_override`, and `cache_key_suffix` parameters so per-exception-type fail counters are tracked independently per deployment. Fixes a bug where `cooldown_time_override=0` was treated as falsy and silently fell through to the router-level value; switched to an explicit `is not None` guard.

`litellm/router_utils/cooldown_cache.py`: adds remaining-TTL recovery in both `get_active_cooldowns` and `async_get_active_cooldowns`; expired entries are evicted from in-memory cache immediately; in-memory entries whose TTL was overinflated by DualCache's Redis-backfill path (which used the default 600s instead of the true remaining time) are corrected to `min(remaining, 60)`.

`litellm/router_utils/fallback_event_handlers.py`: adds `_trigger_cooldown_for_failed_deployment` which calls `_set_cooldown_deployments` directly for any deployment that fails during the fallback chain; wires it into `run_async_fallback`'s except block behind a `has_logged_async_failure` guard so cooldown is recorded exactly once per failed fallback deployment (the standard Logging callback covers fresh Logging objects; the explicit call covers subsequent fallbacks where the Logging object has already fired). Also restricts deployment ID resolution to `kwargs.get("litellm_metadata")` only, removing the `kwargs.get("metadata")` fallback that would have allowed a caller to redirect cooldown attribution to an arbitrary deployment.

`litellm/proxy/management_endpoints/team_endpoints.py`: adds `mcp_rpm_limit` documentation to the `update_team` docstring; the field was added to `UpdateTeamRequest` in the base branch without a corresponding doc entry, which broke the `documentation_test_api_docs` CI check.

`ui/litellm-dashboard/src/lib/http/schema.d.ts`: regenerated after the docstring update.

`tests/test_litellm/interactions/test_openapi_compliance.py`: adds `queued` to the expected Interaction status enum values; Google updated their live spec to include this value.