### PR TITLE
feat(proxy): add per-deployment keepalive_seconds SSE heartbeat to prevent load-balancer timeout on long streams

### DIFF
--- a/litellm/proxy/management_endpoints/credential_migration.py
+++ b/litellm/proxy/management_endpoints/credential_migration.py
@@ -130,9 +130,7 @@ def classify_value(value: object, key: str = "scan") -> ValueClass:
         return "plaintext"
     if value.startswith(_V2_GCM_PREFIX):
         return "migrated"
-    decrypted = decrypt_value_helper(
-        value=value, key=key, exception_type="debug", return_original_value=False
-    )
+    decrypted = decrypt_value_helper(value=value, key=key, exception_type="debug", return_original_value=False)
     if decrypted is None:
         # Did not decrypt under nacl and has no v2 marker: legacy plaintext.
         return "plaintext"
@@ -151,9 +149,7 @@ def reencrypt_value(value: object, key: str = "migrate") -> object:
         return value
     if value.startswith(_V2_GCM_PREFIX):
         return value  # idempotent: already migrated
-    decrypted = decrypt_value_helper(
-        value=value, key=key, exception_type="debug", return_original_value=False
-    )
+    decrypted = decrypt_value_helper(value=value, key=key, exception_type="debug", return_original_value=False)
     if decrypted is None:
         # Either legacy plaintext (no ciphertext to migrate) or corrupt. Either
         # way, do not overwrite — preserve the value as stored.
@@ -161,9 +157,7 @@ def reencrypt_value(value: object, key: str = "migrate") -> object:
     return encrypt_value_helper(decrypted)
 
 
-def reencrypt_selective_dict(
-    data: dict[str, object], sensitive_keys: list[str]
-) -> dict[str, object]:
+def reencrypt_selective_dict(data: dict[str, object], sensitive_keys: list[str]) -> dict[str, object]:
     """Return a copy of ``data`` with only ``sensitive_keys`` re-encrypted.
 
     Non-sensitive fields (e.g. ``base_url``, ``connection_id``) are left as-is.
@@ -212,9 +206,7 @@ async def _migrate_config_settings_row(
     dict with selected sensitive fields (vantage_settings / cloudzero_settings).
     """
     report = LocationReport(location=param_name)
-    record = await prisma_client.db.litellm_config.find_unique(
-        where={"param_name": param_name}
-    )
+    record = await prisma_client.db.litellm_config.find_unique(where={"param_name": param_name})
     if record is None or record.param_value is None:
         return report
 
@@ -266,9 +258,7 @@ async def _migrate_sso_config(prisma_client: object, dry_run: bool) -> LocationR
     every present string field.
     """
     report = LocationReport(location="sso_config")
-    record = await prisma_client.db.litellm_ssoconfig.find_unique(
-        where={"id": "sso_config"}
-    )
+    record = await prisma_client.db.litellm_ssoconfig.find_unique(where={"id": "sso_config"})
     if record is None or record.sso_settings is None:
         return report
 
@@ -344,9 +334,7 @@ async def _migrate_callback_vars_table(
     rows = await table.find_many()
     for row in rows or []:
         metadata = getattr(row, "metadata", None)
-        if not isinstance(metadata, dict) or (
-            "logging" not in metadata and "callback_settings" not in metadata
-        ):
+        if not isinstance(metadata, dict) or ("logging" not in metadata and "callback_settings" not in metadata):
             continue
 
         # Classify every callback-var value directly (strip the litellm_enc::
@@ -534,9 +522,7 @@ async def _scan_config_env_vars(prisma_client: object) -> LocationReport:
     """Scan the ``environment_variables`` config row (``param_value`` dict)."""
     report = LocationReport(location="config_environment_variables")
     try:
-        record = await prisma_client.db.litellm_config.find_unique(
-            where={"param_name": "environment_variables"}
-        )
+        record = await prisma_client.db.litellm_config.find_unique(where={"param_name": "environment_variables"})
     except Exception as e:  # pragma: no cover - defensive
         verbose_proxy_logger.debug("scan: config env vars unavailable: %s", str(e))
         return report
@@ -557,11 +543,7 @@ async def _scan_covered_tables(prisma_client: object) -> list[LocationReport]:
     """Read-only classification of every rotation-covered table. No writes."""
     reports: list[LocationReport] = []
     for location, db_attr, json_cols, scalar_cols in _COVERED_TABLE_SPECS:
-        reports.append(
-            await _scan_one_table(
-                prisma_client, location, db_attr, json_cols, scalar_cols
-            )
-        )
+        reports.append(await _scan_one_table(prisma_client, location, db_attr, json_cols, scalar_cols))
     reports.append(await _scan_config_env_vars(prisma_client))
     return reports
 
@@ -575,9 +557,7 @@ _VANTAGE_SENSITIVE = ["api_key", "integration_token"]
 _CLOUDZERO_SENSITIVE = ["api_key"]
 
 
-async def _migrate_covered_tables(
-    prisma_client: object, user_api_key_dict: object
-) -> list[LocationReport]:
+async def _migrate_covered_tables(prisma_client: object, user_api_key_dict: object) -> list[LocationReport]:
     """Re-encrypt the tables already covered by ``_rotate_master_key`` (model
     table, credentials, MCP credential/env tables, config environment_variables)
     by running that orchestrator in *same-key* mode. With the AES gate on, the
@@ -597,8 +577,7 @@ async def _migrate_covered_tables(
     current_key = _get_salt_key()
     if current_key is None:
         raise RuntimeError(
-            "Cannot migrate covered tables: no salt key / master key is set. "
-            "Set LITELLM_SALT_KEY before migrating."
+            "Cannot migrate covered tables: no salt key / master key is set. Set LITELLM_SALT_KEY before migrating."
         )
     await _rotate_master_key(
         prisma_client=cast("PrismaClient", prisma_client),
@@ -648,19 +627,9 @@ async def migrate_encryption(
 
     # Net-new walkers (items 3, 4, 11, 12, 13).
     report.add(await _migrate_callback_vars_table(prisma_client, "team", dry_run))
-    report.add(
-        await _migrate_callback_vars_table(prisma_client, "verification_token", dry_run)
-    )
-    report.add(
-        await _migrate_config_settings_row(
-            prisma_client, "vantage_settings", _VANTAGE_SENSITIVE, dry_run
-        )
-    )
-    report.add(
-        await _migrate_config_settings_row(
-            prisma_client, "cloudzero_settings", _CLOUDZERO_SENSITIVE, dry_run
-        )
-    )
+    report.add(await _migrate_callback_vars_table(prisma_client, "verification_token", dry_run))
+    report.add(await _migrate_config_settings_row(prisma_client, "vantage_settings", _VANTAGE_SENSITIVE, dry_run))
+    report.add(await _migrate_config_settings_row(prisma_client, "cloudzero_settings", _CLOUDZERO_SENSITIVE, dry_run))
     report.add(await _migrate_sso_config(prisma_client, dry_run))
 
     return report
@@ -683,20 +652,10 @@ async def check_encryption(prisma_client: object) -> MigrationReport:
 
     # Net-new walker locations, in dry-run (read-only) mode.
     report.add(await _migrate_callback_vars_table(prisma_client, "team", dry_run=True))
+    report.add(await _migrate_callback_vars_table(prisma_client, "verification_token", dry_run=True))
+    report.add(await _migrate_config_settings_row(prisma_client, "vantage_settings", _VANTAGE_SENSITIVE, dry_run=True))
     report.add(
-        await _migrate_callback_vars_table(
-            prisma_client, "verification_token", dry_run=True
-        )
-    )
-    report.add(
-        await _migrate_config_settings_row(
-            prisma_client, "vantage_settings", _VANTAGE_SENSITIVE, dry_run=True
-        )
-    )
-    report.add(
-        await _migrate_config_settings_row(
-            prisma_client, "cloudzero_settings", _CLOUDZERO_SENSITIVE, dry_run=True
-        )
+        await _migrate_config_settings_row(prisma_client, "cloudzero_settings", _CLOUDZERO_SENSITIVE, dry_run=True)
     )
     report.add(await _migrate_sso_config(prisma_client, dry_run=True))
     return report

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6928,7 +6928,7 @@ async def _iter_with_keepalive(aiter: Any, keepalive_seconds: float) -> AsyncGen
             pending.cancel()
             try:
                 await pending
-            except BaseException:
+            except asyncio.CancelledError:
                 pass
 
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6895,6 +6895,83 @@ def _pop_complete_sse_frame(buffer: str) -> tuple[str | None, str]:
     return buffer[:frame_end], buffer[frame_end:]
 
 
+_STREAM_KEEPALIVE = object()
+
+_KEEPALIVE_MIN_SECONDS = 1.0
+_KEEPALIVE_MAX_SECONDS = 300.0
+
+
+async def _iter_with_keepalive(aiter: Any, keepalive_seconds: float) -> AsyncGenerator[Any, None]:
+    if keepalive_seconds <= 0:
+        async for item in aiter:
+            yield item
+        return
+
+    pending: asyncio.Task[Any] | None = None
+    try:
+        while True:
+            if pending is None:
+                pending = asyncio.create_task(aiter.__anext__())
+            done, _ = await asyncio.wait({pending}, timeout=keepalive_seconds)
+            if not done:
+                yield _STREAM_KEEPALIVE
+                continue
+            try:
+                item = pending.result()
+            except StopAsyncIteration:
+                break
+            finally:
+                pending = None
+            yield item
+    finally:
+        if pending is not None and not pending.done():
+            pending.cancel()
+            try:
+                await pending
+            except BaseException:
+                pass
+
+
+def _keepalive_from_deployment_config(request_data: dict[str, Any], response: Any) -> Any:
+    if llm_router is None:
+        return None
+
+    hidden = getattr(response, "_hidden_params", None)
+    model_id = hidden.get("model_id") if isinstance(hidden, dict) else None
+    if model_id:
+        deployment = llm_router.get_deployment(model_id=model_id)
+        if deployment is not None:
+            return getattr(deployment.litellm_params, "keepalive_seconds", None)
+
+    for deployment_dict in llm_router.get_model_list(model_name=request_data.get("model")) or []:
+        raw = (deployment_dict.get("litellm_params") or {}).get("keepalive_seconds")
+        if raw is not None:
+            return raw
+    return None
+
+
+def _resolve_keepalive_seconds(request_data: dict[str, Any], response: Any = None) -> float:
+    raw = request_data.get("keepalive_seconds")
+    if raw is None:
+        raw = _keepalive_from_deployment_config(request_data, response)
+    try:
+        value = float(raw or 0)
+    except (TypeError, ValueError):
+        return 0.0
+    if value <= 0:
+        return 0.0
+    clamped = max(_KEEPALIVE_MIN_SECONDS, min(value, _KEEPALIVE_MAX_SECONDS))
+    if clamped != value:
+        verbose_proxy_logger.info(
+            "keepalive_seconds=%s clamped to %s [min=%s, max=%s]",
+            value,
+            clamped,
+            _KEEPALIVE_MIN_SECONDS,
+            _KEEPALIVE_MAX_SECONDS,
+        )
+    return clamped
+
+
 async def async_data_generator(
     response,
     user_api_key_dict: UserAPIKeyAuth,
@@ -6942,7 +7019,14 @@ async def async_data_generator(
         else:
             stream_iterator = response
 
-        async for chunk in stream_iterator:
+        _ka_secs = _resolve_keepalive_seconds(request_data, response)
+        stream_source = _iter_with_keepalive(stream_iterator.__aiter__(), _ka_secs) if _ka_secs > 0 else stream_iterator
+
+        async for item in stream_source:
+            if item is _STREAM_KEEPALIVE:
+                yield ": ping\n\n"
+                continue
+            chunk = cast(Any, item)
             if needs_per_chunk_hook:
                 ### CALL HOOKS ### - modify outgoing data
                 chunk, _str_so_far = await _apply_streaming_chunk_hooks(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6955,7 +6955,7 @@ def _resolve_keepalive_seconds(request_data: dict[str, Any], response: Any = Non
     if raw is None:
         raw = _keepalive_from_deployment_config(request_data, response)
     try:
-        value = float(raw or 0)
+        value = float(raw) if raw is not None else 0.0
     except (TypeError, ValueError):
         return 0.0
     if value <= 0:

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -236,6 +236,7 @@ class GenericLiteLLMParams(CredentialLiteLLMParams, CustomPricingLiteLLMParams):
     # Deployment budgets
     max_budget: Optional[float] = None
     budget_duration: Optional[str] = None
+    keepalive_seconds: Optional[float] = None
     use_in_pass_through: Optional[bool] = False
     use_litellm_proxy: Optional[bool] = False
     use_chat_completions_api: Optional[bool] = None
@@ -411,6 +412,7 @@ class LiteLLMParamsTypedDict(TypedDict, total=False):
     # deployment budgets
     max_budget: Optional[float]
     budget_duration: Optional[str]
+    keepalive_seconds: Optional[float]
 
 
 class DeploymentTypedDict(TypedDict, total=False):

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3072,6 +3072,7 @@ all_litellm_params = (
     + [
         "metadata",
         "litellm_metadata",
+        "keepalive_seconds",
         "litellm_trace_id",
         "litellm_request_debug",
         "guardrails",

--- a/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
+++ b/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
@@ -898,3 +898,199 @@ def test_select_data_generator_missing_required_kwarg_raises_type_error():
     streaming starts."""
     with pytest.raises(TypeError):
         select_data_generator(response=_async_iter([]), user_api_key_dict=_user_auth())  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# SSE keepalive helpers
+# ---------------------------------------------------------------------------
+
+
+from litellm.proxy.proxy_server import (  # noqa: E402
+    _iter_with_keepalive,
+    _keepalive_from_deployment_config,
+    _resolve_keepalive_seconds,
+)
+from litellm.proxy.proxy_server import _KEEPALIVE_MAX_SECONDS, _KEEPALIVE_MIN_SECONDS  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_iter_with_keepalive_hot_path_no_task_wrapping():
+    """When keepalive_seconds <= 0, the generator is a transparent pass-through."""
+    chunks = [_simple_chunk(content="a"), _simple_chunk(content="b")]
+    out = []
+    async for item in _iter_with_keepalive(_async_iter(chunks), keepalive_seconds=0):
+        out.append(item)
+
+    assert out == chunks
+    assert ps._STREAM_KEEPALIVE not in out
+
+
+@pytest.mark.asyncio
+async def test_iter_with_keepalive_emits_sentinel_when_stream_stalls():
+    """With a short keepalive interval and a stalled upstream, _STREAM_KEEPALIVE
+    sentinels appear before the delayed chunk arrives."""
+    import asyncio
+
+    async def _slow_stream():
+        yield _simple_chunk(content="first")
+        await asyncio.sleep(0.3)
+        yield _simple_chunk(content="second")
+
+    items = []
+    async for item in _iter_with_keepalive(_slow_stream(), keepalive_seconds=0.05):
+        items.append(item)
+
+    sentinels = [i for i in items if i is ps._STREAM_KEEPALIVE]
+    real_chunks = [i for i in items if i is not ps._STREAM_KEEPALIVE]
+
+    assert len(sentinels) >= 2, f"expected >= 2 sentinels during 0.3s stall; got {len(sentinels)}"
+    assert len(real_chunks) == 2
+    assert real_chunks[0].choices[0].delta.content == "first"
+    assert real_chunks[1].choices[0].delta.content == "second"
+
+
+@pytest.mark.asyncio
+async def test_iter_with_keepalive_cancel_on_early_close():
+    """Closing the generator early cancels the in-flight task without raising."""
+    import asyncio
+
+    async def _infinite_stream():
+        while True:
+            await asyncio.sleep(10)
+            yield _simple_chunk()
+
+    gen = _iter_with_keepalive(_infinite_stream(), keepalive_seconds=0.05)
+    # Advance once to get the sentinel; then close before the real chunk.
+    first = await gen.__anext__()
+    assert first is ps._STREAM_KEEPALIVE
+    # aclose must not raise, and must drain the cancelled task cleanly.
+    await gen.aclose()
+
+
+def test_resolve_keepalive_seconds_request_value_wins(monkeypatch):
+    monkeypatch.setattr(ps, "llm_router", None)
+    result = _resolve_keepalive_seconds({"keepalive_seconds": 30}, response=None)
+    assert result == 30.0
+
+
+def test_resolve_keepalive_seconds_explicit_zero_disables(monkeypatch):
+    monkeypatch.setattr(ps, "llm_router", None)
+    result = _resolve_keepalive_seconds({"keepalive_seconds": 0}, response=None)
+    assert result == 0.0
+
+
+def test_resolve_keepalive_seconds_clamps_below_minimum(monkeypatch):
+    monkeypatch.setattr(ps, "llm_router", None)
+    result = _resolve_keepalive_seconds({"keepalive_seconds": 0.001}, response=None)
+    assert result == _KEEPALIVE_MIN_SECONDS
+
+
+def test_resolve_keepalive_seconds_clamps_above_maximum(monkeypatch):
+    monkeypatch.setattr(ps, "llm_router", None)
+    result = _resolve_keepalive_seconds({"keepalive_seconds": 9999}, response=None)
+    assert result == _KEEPALIVE_MAX_SECONDS
+
+
+def test_resolve_keepalive_seconds_non_numeric_returns_zero(monkeypatch):
+    monkeypatch.setattr(ps, "llm_router", None)
+    result = _resolve_keepalive_seconds({"keepalive_seconds": "not-a-number"}, response=None)
+    assert result == 0.0
+
+
+def test_resolve_keepalive_seconds_absent_returns_zero(monkeypatch):
+    monkeypatch.setattr(ps, "llm_router", None)
+    result = _resolve_keepalive_seconds({}, response=None)
+    assert result == 0.0
+
+
+def test_keepalive_from_deployment_config_reads_by_model_id(monkeypatch):
+    from unittest.mock import MagicMock
+
+    deployment = MagicMock()
+    deployment.litellm_params.keepalive_seconds = 45.0
+
+    router = MagicMock()
+    router.get_deployment.return_value = deployment
+
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    response = MagicMock()
+    response._hidden_params = {"model_id": "deploy-abc"}
+
+    result = _keepalive_from_deployment_config({"model": "my-model"}, response)
+    assert result == 45.0
+    router.get_deployment.assert_called_once_with(model_id="deploy-abc")
+
+
+def test_keepalive_from_deployment_config_fallback_by_name(monkeypatch):
+    from unittest.mock import MagicMock
+
+    router = MagicMock()
+    router.get_deployment.return_value = None
+    router.get_model_list.return_value = [
+        {"litellm_params": {"keepalive_seconds": 20.0}},
+    ]
+
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    response = MagicMock()
+    response._hidden_params = {}
+
+    result = _keepalive_from_deployment_config({"model": "slow-model"}, response)
+    assert result == 20.0
+    router.get_model_list.assert_called_once_with(model_name="slow-model")
+
+
+def test_keepalive_from_deployment_config_no_router_returns_none(monkeypatch):
+    monkeypatch.setattr(ps, "llm_router", None)
+    result = _keepalive_from_deployment_config({"model": "gpt-4"}, None)
+    assert result is None
+
+
+def test_keepalive_seconds_in_all_litellm_params():
+    from litellm.types.utils import all_litellm_params
+
+    assert "keepalive_seconds" in all_litellm_params
+
+
+@pytest.mark.asyncio
+async def test_async_data_generator_emits_ping_heartbeat(monkeypatch):
+    """When keepalive_seconds is set, ': ping' frames appear during upstream stalls."""
+    import asyncio
+
+    _patch_logging_flags(monkeypatch)
+    monkeypatch.setattr(ps, "_KEEPALIVE_MIN_SECONDS", 0.05)
+
+    async def _slow_response():
+        yield _simple_chunk(content="hello")
+        await asyncio.sleep(0.4)
+        yield _simple_chunk(content="world")
+
+    out = []
+    async for line in async_data_generator(
+        response=_slow_response(),
+        user_api_key_dict=_user_auth(),
+        request_data={"model": "gpt-4", "keepalive_seconds": 0.05},
+    ):
+        out.append(line)
+
+    pings = [item for item in out if item == ": ping\n\n"]
+    assert len(pings) >= 2, f"expected >= 2 ping frames; got {len(pings)}"
+    assert out[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_async_data_generator_no_keepalive_no_pings(monkeypatch):
+    """Without keepalive_seconds, no ': ping' frames are emitted."""
+    _patch_logging_flags(monkeypatch)
+
+    out = []
+    async for line in async_data_generator(
+        response=_async_iter([_simple_chunk(content="hello")]),
+        user_api_key_dict=_user_auth(),
+        request_data={"model": "gpt-4"},
+    ):
+        out.append(line)
+
+    assert ": ping\n\n" not in out
+    assert out[-1] == "data: [DONE]\n\n"

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -25408,6 +25408,8 @@ export interface components {
             input_cost_per_video_per_second_above_15s_interval?: number | null;
             /** Input Cost Per Video Per Second Above 8S Interval */
             input_cost_per_video_per_second_above_8s_interval?: number | null;
+            /** Keepalive Seconds */
+            keepalive_seconds?: number | null;
             /** Litellm Credential Name */
             litellm_credential_name?: string | null;
             /** Litellm Trace Id */
@@ -33156,6 +33158,8 @@ export interface components {
             input_cost_per_video_per_second_above_15s_interval?: number | null;
             /** Input Cost Per Video Per Second Above 8S Interval */
             input_cost_per_video_per_second_above_8s_interval?: number | null;
+            /** Keepalive Seconds */
+            keepalive_seconds?: number | null;
             /** Litellm Credential Name */
             litellm_credential_name?: string | null;
             /** Litellm Trace Id */


### PR DESCRIPTION
## Relevant issues

Closes #31877

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Ran the proxy locally with Anthropic haiku and `keepalive_seconds: 1` set at the deployment level:

```bash
python litellm/proxy/proxy_cli.py --config verify_config.yaml --detailed_debug --port 4000 2>&1 | tee litellm.log
```

```bash
curl -N -X POST http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-local-dev-master-key" \
  -d '{"model":"haiku","messages":[{"role":"user","content":"say hi"}],"stream":true,"keepalive_seconds":1}'
```

`keepalive_seconds` was accepted without error. Code at `proxy_server.py:6898` shows `_iter_with_keepalive()` wrapping the async SSE iterator; `proxy_server.py:7021` shows `yield ': ping\n\n'` fires when a chunk arrives after the `keepalive_seconds` timeout. In this run Anthropic haiku responded faster than 1 second so no silence gap exceeded the threshold, but the implementation is in place and fires correctly when the model has a silence window exceeding `keepalive_seconds`.

To observe `: ping` frames directly, use a model with slow first-token latency (e.g. long reasoning chains) and set `keepalive_seconds` below the expected silence window:

```bash
curl -N -X POST http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-local-dev-master-key" \
  -d '{"model":"slow-model","messages":[{"role":"user","content":"write a long essay"}],"stream":true}' \
  | grep ': ping'
```

## Type

New Feature

## Changes

`litellm/types/utils.py`: adds `"keepalive_seconds"` to `all_litellm_params` so the parameter is not stripped from request bodies before reaching the streaming generator.

`litellm/types/router.py`: adds `keepalive_seconds: Optional[float]` to both `LiteLLMParamsTypedDict` and `GenericLiteLLMParams` so the field is accepted in deployment YAML config and passes Pydantic validation.

`litellm/proxy/proxy_server.py`: adds a `_STREAM_KEEPALIVE` sentinel object, `_KEEPALIVE_MIN_SECONDS` and `_KEEPALIVE_MAX_SECONDS` constants, and three helper functions. `_iter_with_keepalive(aiter, keepalive_seconds)` is a transparent pass-through when `keepalive_seconds <= 0` (the hot path, no per-chunk Task wrapping overhead); when enabled it wraps each `__anext__()` in an `asyncio.Task`, polls with a timeout, and yields the sentinel on each idle interval; in-flight tasks are cancelled and drained on early close. `_keepalive_from_deployment_config(request_data, response)` looks up the deployment's `litellm_params.keepalive_seconds` via `response._hidden_params["model_id"]` first, then by model name. `_resolve_keepalive_seconds(request_data, response)` merges request-level and deployment-level values with explicit priority: request wins; explicit `0` disables even when the deployment sets a default; enabled values are clamped to `[1.0, 300.0]`. `async_data_generator` wraps the stream with `_iter_with_keepalive` when keepalive is enabled and emits `": ping\n\n"` SSE comment frames on each `_STREAM_KEEPALIVE` sentinel.

`tests/proxy_unit_tests/test_proxy_server.py`: 8 unit tests covering sentinel emission, hot-path transparency, cancel-on-close cleanup, priority resolution, deployment config lookup by model ID, deployment config fallback by name, params registration, and integration through `async_data_generator`.