### PR TITLE
test(e2e): otel trace completeness on streaming /v1/responses (LIT-3787)

### DIFF
--- a/tests/e2e/logging/logging_client.py
+++ b/tests/e2e/logging/logging_client.py
@@ -77,11 +77,12 @@ WEATHER_TOOL = ChatTool(
 
 
 class ResponsesRequestBody(BaseModel):
-    """OpenAI Responses API /v1/responses request (non-streaming)."""
+    """OpenAI Responses API /v1/responses request."""
 
     model: str
     input: str
     max_output_tokens: int
+    stream: bool | None = None
 
 
 class TeamCallbackBody(BaseModel):
@@ -485,16 +486,22 @@ class LoggingClient:
         )
 
     def responses_raw(
-        self, key: str, model: str, text: str, *, max_output_tokens: int = 64
+        self, key: str, model: str, text: str, *, max_output_tokens: int = 64, stream: bool = False
     ) -> StreamingResponse:
-        """Non-streaming POST /v1/responses (OpenAI Responses API): raw outcome
-        judged by status/body/headers, for tests that need x-litellm-call-id.
+        """POST /v1/responses (OpenAI Responses API): raw outcome judged by
+        status/body/headers, for tests that need x-litellm-call-id.
         max_output_tokens caps reasoning-model output cost; a capped response is
-        still a 200 and still exports the trace."""
+        still a 200 and still exports the trace. With ``stream=True`` the SSE
+        body is consumed and its events counted."""
+        body = ResponsesRequestBody(
+            model=model, input=text, max_output_tokens=max_output_tokens, stream=stream or None
+        )
+        if stream:
+            return self.gateway.transport.stream(
+                "/v1/responses", headers=self.gateway.transport.bearer(key), json=body
+            )
         return self.gateway.transport.send(
-            "/v1/responses",
-            headers=self.gateway.transport.bearer(key),
-            json=ResponsesRequestBody(model=model, input=text, max_output_tokens=max_output_tokens),
+            "/v1/responses", headers=self.gateway.transport.bearer(key), json=body
         )
 
     def scrape_metrics(self) -> str:

--- a/tests/e2e/logging/logging_client.py
+++ b/tests/e2e/logging/logging_client.py
@@ -494,7 +494,7 @@ class LoggingClient:
         still a 200 and still exports the trace. With ``stream=True`` the SSE
         body is consumed and its events counted."""
         body = ResponsesRequestBody(
-            model=model, input=text, max_output_tokens=max_output_tokens, stream=stream or None
+            model=model, input=text, max_output_tokens=max_output_tokens, stream=True if stream else None
         )
         if stream:
             return self.gateway.transport.stream(

--- a/tests/e2e/logging/test_otel_trace_e2e.py
+++ b/tests/e2e/logging/test_otel_trace_e2e.py
@@ -151,7 +151,7 @@ def _assert_complete_trace(
 
 def _settled_names(*, route: str, genai_span: str, require_cost_span: bool = True) -> set[str]:
     names = {f"POST {route}", f"auth {route}", genai_span}
-    return names | {COST_SPAN} if require_cost_span else names
+    return (names | {COST_SPAN}) if require_cost_span else names
 
 
 def _tag(span: JaegerSpan, key: str) -> str | int | float | bool | None:

--- a/tests/e2e/logging/test_otel_trace_e2e.py
+++ b/tests/e2e/logging/test_otel_trace_e2e.py
@@ -96,7 +96,9 @@ def _chain_reaches(span_id: str, root_id: str, trace: JaegerTrace) -> bool:
     return False
 
 
-def _assert_complete_trace(hits: list[JaegerTrace], *, route: str, genai_span: str) -> None:
+def _assert_complete_trace(
+    hits: list[JaegerTrace], *, route: str, genai_span: str, require_cost_span: bool = True
+) -> None:
     """The enforced behavior: the destination holds exactly one trace for the
     call, rooted at the SERVER span, with auth/db/cost children and the gen-AI
     span all connected into that one tree - no dangling parent references."""
@@ -135,7 +137,8 @@ def _assert_complete_trace(hits: list[JaegerTrace], *, route: str, genai_span: s
     assert any(name.startswith(DB_SPAN_PREFIX) for name in names), (
         f"no db ('{DB_SPAN_PREFIX}*') span in the trace; spans: {names}"
     )
-    assert COST_SPAN in names, f"cost write span {COST_SPAN!r} missing; spans: {names}"
+    if require_cost_span:
+        assert COST_SPAN in names, f"cost write span {COST_SPAN!r} missing; spans: {names}"
 
     genai = next((span for span in trace.spans if span.operation_name == genai_span), None)
     assert genai is not None, f"gen-AI span {genai_span!r} missing; spans: {names}"
@@ -146,8 +149,9 @@ def _assert_complete_trace(hits: list[JaegerTrace], *, route: str, genai_span: s
     )
 
 
-def _settled_names(*, route: str, genai_span: str) -> set[str]:
-    return {f"POST {route}", f"auth {route}", COST_SPAN, genai_span}
+def _settled_names(*, route: str, genai_span: str, require_cost_span: bool = True) -> set[str]:
+    names = {f"POST {route}", f"auth {route}", genai_span}
+    return names | {COST_SPAN} if require_cost_span else names
 
 
 def _tag(span: JaegerSpan, key: str) -> str | int | float | bool | None:
@@ -361,4 +365,54 @@ class TestOtelTraceCompleteness:
         assert _tag(genai_spans[0], "litellm.request.streaming") is True, (
             "the gen-AI span must record litellm.request.streaming=true; its absence means "
             "the stream flag was dropped before the model call"
+        )
+
+    @pytest.mark.covers("logging.otel.stream.exports_metric", exercised_on=["responses"])
+    def test_responses_stream_exports_complete_trace(
+        self, client: LoggingClient, otel_reader: OtelReader, resources: ResourceManager
+    ) -> None:
+        """One successful STREAMED /v1/responses call must export ONE complete
+        OTEL trace: a single root SERVER span with auth/db/cost children and
+        the gen-AI CLIENT span connected back to the root, plus the stream
+        actually delivering events and exactly ONE gen-AI span for the call.
+
+        Two knowingly relaxed assertions on this surface, both verified against
+        live traces and both tracked in LIT-4428: the responses route
+        does not stamp litellm.request.streaming on the gen-AI span, and the
+        spend write for a streamed responses call records spend correctly but
+        emits no batch_write_to_db cost span (streamed chat/messages and
+        non-streamed responses all emit it). Streaming is instead proven from
+        the response side (event-stream content type, chunks consumed). When
+        the product closes either gap, tighten this test to match the sibling
+        assertions.
+        """
+        route = "/v1/responses"
+        _assert_otel_destination_configured(client)
+
+        key = client.key_with_alias(
+            f"otel-stream-responses-{unique_marker()}", models=[CHEAP_OPENAI_MODEL]
+        )
+        resources.defer(lambda: client.delete_key(key))
+
+        marker = unique_marker()
+        outcome = _first_ok(
+            client,
+            lambda: client.responses_raw(key, CHEAP_OPENAI_MODEL, f"reply with one word {marker}", stream=True),
+        )
+        assert outcome.call_id is not None, "success response must carry x-litellm-call-id"
+        assert outcome.is_streaming, f"response must be an event stream, got content-type {outcome.content_type!r}"
+        assert outcome.chunks > 0, "the stream must deliver at least one event"
+
+        genai_span = f"chat {CHEAP_OPENAI_MODEL}"
+        hits = otel_reader.poll_traces_for_call(
+            call_id=outcome.call_id,
+            settled_names=_settled_names(route=route, genai_span=genai_span, require_cost_span=False),
+            settled_prefixes={DB_SPAN_PREFIX},
+        )
+        _assert_complete_trace(hits, route=route, genai_span=genai_span, require_cost_span=False)
+
+        genai_spans = [span for span in hits[0].spans if span.operation_name == genai_span]
+        assert len(genai_spans) == 1, (
+            f"a streamed call must produce exactly ONE gen-AI span, got {len(genai_spans)}; "
+            f"spans: {hits[0].span_names()}"
         )


### PR DESCRIPTION
## Relevant issues

Related: LIT-4428 (product gap found while writing this test)

## Linear ticket

https://linear.app/litellm-ai/issue/LIT-3787 (streaming follow-up; top of the streaming stack)
https://linear.app/litellm-ai/issue/LIT-4428 (tracks the two assertions this test knowingly relaxes)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Stacked on the streaming /v1/messages PR; merge that first. Same infra, no new services. Run on 2026-07-14, proxies from source at exact refs. Outputs verbatim.

Provider disclosure: the OpenAI org behind the .env key is currently out of quota (insufficient_quota arrives inside the stream after an HTTP 200, since streaming commits the status before upstream completes), so verification ran with `E2E_CHEAP_OPENAI_MODEL=gemini-2.5-flash` (the constant is env-overridable by design). The route under test is unchanged; the expected span name derives from the constant.

1. Evidence-first, and it found a product gap. A successful streamed /v1/responses call records spend correctly, but its trace never receives the cost-write span, and the gen-AI span carries no litellm.request.streaming tag (streamed chat/messages and non-streamed responses all have both):

   ```
   recent gemini spend rows: 3
     2026-07-14T19:24:16 spend=0.0001529 tokens=77 call_type='aresponses'
     2026-07-14T19:21:58 spend=0.0001523 tokens=75 call_type='aresponses'
     2026-07-14T19:21:25 spend=8.43e-05 tokens=39 call_type='aresponses'
   traces containing a 'batch_write_to_db _PROXY_track_cost_callback' span (30m window, responses-only traffic): 0
   ```

   Filed as LIT-4428. This test therefore relaxes exactly those two assertions on this surface (documented in the docstring with the ticket id); everything else in the completeness contract is asserted, and the sibling streamed chat/messages tests keep the strict versions. Tighten when LIT-4428 lands.

2. Pass on current code (compose stack):

   ```
   $ LITELLM_PROXY_URL=http://localhost:4000 E2E_CHEAP_OPENAI_MODEL=gemini-2.5-flash uv run pytest \
       "logging/test_otel_trace_e2e.py::TestOtelTraceCompleteness::test_responses_stream_exports_complete_trace" -v
   ============================== 1 passed in 6.21s ===============================
   ```

3. Fail-before-fix at **1bd603d1ac** (parent of #30590): on that ref a streamed responses call exports nothing tagged to the destination at all, so the test fails at its first trace assertion (an even earlier break than the orphan the non-streaming tests catch):

   ```
   $ LITELLM_PROXY_URL=http://localhost:4611 E2E_OTEL_QUERY_URL=http://localhost:16690 \
       E2E_CHEAP_OPENAI_MODEL=gemini-2.5-flash uv run pytest "...::test_responses_stream_exports_complete_trace"
   E  AssertionError: no trace for this call arrived at the destination within the deadline
      (nothing tagged with its call id was found)
   ======================== 1 failed in 121.51s (0:02:01) =========================
   ```

4. Static gates: `make lint-e2e-basedpyright` -> 0 errors; `coverage_registry.collector --strict` passes.

## Type

✅ Test

## Changes

Third surface of the `logging.otel.stream.exports_metric` row: streamed `/v1/responses`.

- `logging/test_otel_trace_e2e.py`: adds `test_responses_stream_exports_complete_trace` (shared completeness contract + streamed-response checks + exactly one gen-AI span). `_assert_complete_trace`/`_settled_names` gain a `require_cost_span` flag so this surface can skip the cost-span requirement while the siblings keep it strict; the docstring names LIT-4428 as the tracked reason.
- `logging/logging_client.py`: `responses_raw` gains a `stream` mode; `ResponsesRequestBody` gains an optional `stream` field.

## Behavior changes

None; test-only changes under tests/e2e.

## QA runbook

- tests/e2e/logging/test_otel_trace_e2e.py::TestOtelTraceCompleteness::test_responses_stream_exports_complete_trace - one successful streamed Responses API call shows up at the OTEL destination as one connected trace tree with a single model-call span
  - [ ] GET /health/readiness/details with the master key and confirm `OpenTelemetryV2` appears in `success_callbacks`
  - [ ] POST /key/generate with `{"models":["gemini-2.5-flash"],"key_alias":"otel-stream-responses-<uniq>"}` and save the returned key (gemini-2.5-flash via `E2E_CHEAP_OPENAI_MODEL` while the OpenAI org quota is exhausted; default is gpt-5.5)
  - [ ] `curl -N` POST /v1/responses with `"stream": true`, `max_output_tokens: 64`, and a unique phrase; retry the first call on 401 for a few seconds; confirm `content-type: text/event-stream`, that events ending in `response.completed` arrive (an in-stream `"type":"error"` event means the upstream failed despite the 200), and note the `x-litellm-call-id` header
  - [ ] In Jaeger (http://localhost:16686, service `litellm`), search by tag `litellm.call_id=<that id>` and wait for the trace (spans flush in batches)
  - [ ] Confirm exactly ONE trace holds the call-id
  - [ ] Confirm a single root span `POST /v1/responses` (kind server) and no span referencing a parent missing from the trace
  - [ ] Confirm the children: `auth /v1/responses` and a `postgres ...` span (the cost-write span is knowingly absent on this surface; see LIT-4428)
  - [ ] Confirm exactly ONE `chat <model>` span (kind client) and that its parent chain reaches the root
  - [ ] POST /key/delete to clean up

Final attestation: "I agree this test is testing what the writer wanted to test."
