### PR TITLE
fix(e2e): bound spend-log snapshots to a /spend/logs/v2 window

### DIFF
--- a/tests/e2e/batches/test_batches_e2e.py
+++ b/tests/e2e/batches/test_batches_e2e.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import time
+from datetime import datetime, timedelta, timezone
 from typing import Callable
 
 import pytest
@@ -49,7 +50,7 @@ from e2e_http import (
     unwrap,
 )
 from lifecycle import ResourceManager
-from models import KeyGenerateBody, SpendLogRow, SpendLogsParams
+from models import KeyGenerateBody, SpendLogRow
 
 pytestmark = pytest.mark.e2e
 
@@ -349,6 +350,10 @@ def test_rate_limited_batch_create_leaves_no_unattributed_spend_row(
     the file-read path fires while the batch itself is not blocked.
     ``resources.key()`` cannot set limits, so the key is minted on the gateway
     directly and its delete deferred.
+
+    Snapshots read /spend/logs/v2 over a bounded window around the test instead
+    of the unpaginated /spend/logs whole-table read, which grows with the
+    environment and OOMed the e2e runner on stage.
     """
     user_id = f"e2e-batch-rl-{unique_marker()}"
     key = client.gateway.generate_key(
@@ -356,8 +361,13 @@ def test_rate_limited_batch_create_leaves_no_unattributed_spend_row(
     )
     resources.defer(lambda: client.gateway.delete_key(key))
 
+    window_start = datetime.now(timezone.utc) - timedelta(hours=1)
+    window_end = window_start + timedelta(hours=2)
     before = frozenset(
-        row.request_id for row in unattributed_rows(client.gateway.spend_logs(SpendLogsParams()))
+        row.request_id
+        for row in unattributed_rows(
+            client.gateway.spend_logs_window(start=window_start, end=window_end)
+        )
     )
 
     file = unwrap(
@@ -379,7 +389,9 @@ def test_rate_limited_batch_create_leaves_no_unattributed_spend_row(
 
     new_orphans = [
         row
-        for row in unattributed_rows(client.gateway.spend_logs(SpendLogsParams()))
+        for row in unattributed_rows(
+            client.gateway.spend_logs_window(start=window_start, end=window_end)
+        )
         if row.request_id not in before
     ]
     assert not new_orphans, (

--- a/tests/e2e/e2e_gateway.py
+++ b/tests/e2e/e2e_gateway.py
@@ -12,6 +12,7 @@ import time
 import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 
 from e2e_http import (
     NoBody,
@@ -50,6 +51,8 @@ from models import (
     OcrResponse,
     SpendLogRow,
     SpendLogs,
+    SpendLogsPage,
+    SpendLogsPageParams,
     SpendLogsParams,
 )
 from e2e_config import (
@@ -254,6 +257,28 @@ class Gateway:
                 return logs.root
             case _:
                 return []
+
+    def spend_logs_window(self, *, start: datetime, end: datetime) -> list[SpendLogRow]:
+        def fetch(page: int) -> SpendLogsPage:
+            return unwrap(
+                self.transport.get(
+                    "/spend/logs/v2",
+                    headers=self.transport.master,
+                    params=SpendLogsPageParams(
+                        start_date=start.strftime("%Y-%m-%d %H:%M:%S"),
+                        end_date=end.strftime("%Y-%m-%d %H:%M:%S"),
+                        page=page,
+                        page_size=100,
+                    ),
+                    response_type=SpendLogsPage,
+                )
+            )
+
+        first = fetch(1)
+        return [
+            *first.data,
+            *(row for page in range(2, first.total_pages + 1) for row in fetch(page).data),
+        ]
 
     def poll_logs_for_key(
         self, key: str, *, min_rows: int = 1, predicate: RowsPredicate | None = None

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, RootModel
+from pydantic import BaseModel, ConfigDict, RootModel, model_validator
 
 # ---------- keys ----------
 
@@ -254,6 +254,16 @@ class SpendLogs(RootModel[list[SpendLogRow]]):
 class SpendLogsParams(BaseModel):
     request_id: str | None = None
     api_key: str | None = None
+
+    @model_validator(mode="after")
+    def require_filter(self) -> SpendLogsParams:
+        if self.request_id is None and self.api_key is None:
+            raise ValueError(
+                "unfiltered /spend/logs returns the entire spend table and OOMs the "
+                "runner on long-lived environments; filter by request_id or api_key, "
+                "or use Gateway.spend_logs_window for a bounded /spend/logs/v2 read"
+            )
+        return self
 
 
 class SpendLogsPageParams(BaseModel):

--- a/tests/e2e/test_e2e_gateway.py
+++ b/tests/e2e/test_e2e_gateway.py
@@ -1,17 +1,23 @@
 """Unit coverage for the Gateway model-management surface (create_model /
-delete_model).
+delete_model) and the bounded spend read-back (spend_logs_window).
 
 The batches conftest and several llm_translation tests register deployments at
 runtime through gateway.create_model; when that method went missing, every batch
 test errored at fixture setup (AttributeError) before a single request reached
 the proxy. This pins the surface with a typed fake Transport so a rename or
 signature drift fails here instead of in a live stage run.
+
+spend_logs_window exists because the unpaginated /spend/logs whole-table read
+grew past the e2e runner's memory limit on stage and OOMKilled every run; these
+tests pin its /spend/logs/v2 pagination and that SpendLogsParams can no longer
+express the unfiltered read.
 """
 
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from batches.batch_client import BatchClient
 from e2e_gateway import Gateway
@@ -30,6 +36,9 @@ from models import (
     ModelNewBody,
     ModelNewResponse,
     ModelsListResponse,
+    SpendLogsPage,
+    SpendLogsPageParams,
+    SpendLogsParams,
 )
 
 
@@ -46,6 +55,8 @@ class _RecordingTransport:
     servable_after_gets: int = 0
     models_error: UnknownApiError | None = None
     model_gets: int = 0
+    spend_total: int = 0
+    spend_gets: list[SpendLogsPageParams] = field(default_factory=list)
     _created: list[str] = field(default_factory=list)
 
     def post[R: BaseModel](
@@ -90,6 +101,22 @@ class _RecordingTransport:
             visible = self._created if self.model_gets > self.servable_after_gets else []
             return Success(
                 data=response_type.model_validate({"data": [{"id": name} for name in visible]})
+            )
+        if path == "/spend/logs/v2" and response_type is SpendLogsPage:
+            assert isinstance(params, SpendLogsPageParams)
+            self.spend_gets.append(params)
+            offset = (params.page - 1) * params.page_size
+            count = min(params.page_size, max(self.spend_total - offset, 0))
+            return Success(
+                data=response_type.model_validate(
+                    {
+                        "data": [{"request_id": f"req-{offset + i}"} for i in range(count)],
+                        "total": self.spend_total,
+                        "page": params.page,
+                        "page_size": params.page_size,
+                        "total_pages": (self.spend_total + params.page_size - 1) // params.page_size,
+                    }
+                )
             )
         raise AssertionError(f"unexpected get: {path}")
 
@@ -202,3 +229,45 @@ def test_gateway_delete_model_posts_the_model_id() -> None:
     assert path == "/model/delete"
     assert isinstance(body, ModelDeleteBody)
     assert body.id == "registered-id"
+
+
+WINDOW_START = datetime(2026, 7, 14, 12, 0, 0, tzinfo=timezone.utc)
+WINDOW_END = datetime(2026, 7, 14, 14, 0, 0, tzinfo=timezone.utc)
+
+
+def test_gateway_spend_logs_window_pages_through_every_row_in_the_window() -> None:
+    transport = _RecordingTransport(spend_total=250)
+    gateway = Gateway(transport=transport)
+
+    rows = gateway.spend_logs_window(start=WINDOW_START, end=WINDOW_END)
+
+    assert len(rows) == 250
+    assert len({row.request_id for row in rows}) == 250
+    assert [params.page for params in transport.spend_gets] == [1, 2, 3]
+    assert all(params.start_date == "2026-07-14 12:00:00" for params in transport.spend_gets)
+    assert all(params.end_date == "2026-07-14 14:00:00" for params in transport.spend_gets)
+
+
+def test_gateway_spend_logs_window_stops_at_an_exact_page_boundary() -> None:
+    transport = _RecordingTransport(spend_total=200)
+    gateway = Gateway(transport=transport)
+
+    rows = gateway.spend_logs_window(start=WINDOW_START, end=WINDOW_END)
+
+    assert len(rows) == 200
+    assert [params.page for params in transport.spend_gets] == [1, 2]
+
+
+def test_gateway_spend_logs_window_returns_empty_for_an_empty_window() -> None:
+    transport = _RecordingTransport(spend_total=0)
+    gateway = Gateway(transport=transport)
+
+    rows = gateway.spend_logs_window(start=WINDOW_START, end=WINDOW_END)
+
+    assert rows == []
+    assert [params.page for params in transport.spend_gets] == [1]
+
+
+def test_spend_logs_params_rejects_the_unfiltered_whole_table_read() -> None:
+    with pytest.raises(ValidationError, match="spend_logs_window"):
+        SpendLogsParams()


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before (captured 2026-07-14 against the live stage cluster, tree at 2166608eb8): every scheduled e2e run dies at 9% progress when `test_rate_limited_batch_create_leaves_no_unattributed_spend_row` starts. The runner pod is OOMKilled at its 512Mi limit, and the kill time matches the last Loki log line of the run to the second

```
$ kubectl get pods -n litellm
NAME                                          READY   STATUS      RESTARTS   AGE
litellm-e2e-1-0-0-main-20260714181949-lpnfs   0/1     OOMKilled   0          61m

$ kubectl describe pod litellm-e2e-1-0-0-main-20260714181949-lpnfs -n litellm
    State:          Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Finished:     Tue, 14 Jul 2026 11:24:44 -0700
    Limits:
      memory:  512Mi
```

The trigger is the snapshot read the test used: an unfiltered `GET /spend/logs` falls into that endpoint's deprecated find_all branch and serializes the entire spend table, which only grows on a long-lived environment. Measured through a port-forward to the stage control plane

```
$ curl -s -o /dev/null -w "bytes: %{size_download}  time: %{time_total}s  http: %{http_code}\n" \
    "http://localhost:14001/spend/logs" -H "Authorization: Bearer $MASTER_KEY"
bytes: 58123001  time: 13.411745s  http: 200
```

Parsing a 58MB JSON body inside a 512Mi pod is what kills the runner, twice per test (before and after snapshots)

After (8a5ffab1ca): the same snapshot reads a two hour window of `/spend/logs/v2`, paged at 100 rows per page

```
$ curl -s -o /dev/null -w "bytes: %{size_download}  time: %{time_total}s  http: %{http_code}\n" \
    -G "http://localhost:14001/spend/logs/v2" \
    --data-urlencode "start_date=<now minus 1h>" --data-urlencode "end_date=<now plus 1h>" \
    --data-urlencode "page=1" --data-urlencode "page_size=100" \
    -H "Authorization: Bearer $MASTER_KEY"
bytes: 5580  time: 0.288140s  http: 200
```

Running the changed test at 8a5ffab1ca against the live stage gateway gets through the previously fatal snapshot in under a second and proceeds to the real OpenAI batch create. That create currently returns 400 `billing_hard_limit_reached` because the stage OpenAI org has exhausted its billing budget; the same limit has been failing the four `test_batch_lifecycle[openai-*]` cases since the 06:44 UTC run on 07-14 and needs a budget bump on the OpenAI account, independent of this PR

## Type

🐛 Bug Fix
✅ Test

## Changes

`Gateway.spend_logs_window(start=, end=)` in tests/e2e/e2e_gateway.py pages `/spend/logs/v2` over an explicit date window, walking the response's total_pages at 100 rows per page. The rate-limited batch spend test in tests/e2e/batches/test_batches_e2e.py now takes its before and after unattributed-row snapshots over a bounded window (one hour back, one hour forward) instead of the whole table

`SpendLogsParams` in tests/e2e/models.py now rejects construction with neither request_id nor api_key, so the filterless whole-table read fails deterministically on any environment instead of OOMing only once the table grows past the runner's memory limit. New tests in tests/e2e/test_e2e_gateway.py pin the pager (multi page walk, exact page boundary, empty window) through the existing typed fake transport, and pin the validator

## QA runbook

- tests/e2e/batches/test_batches_e2e.py::test_rate_limited_batch_create_leaves_no_unattributed_spend_row - creating a batch on an rpm/tpm-limited key leaves no spend row with an empty api_key, with snapshots read from a bounded /spend/logs/v2 window (needs OPENAI_API_KEY with batch access and available billing budget; the suite registers the openai-batch deployment via /model/new)
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"models": [], "tpm_limit": 1000000, "rpm_limit": 1000, "user_id": "qa-batch-rl"}'
  - [ ] Snapshot orphans before: curl -G "http://localhost:4000/spend/logs/v2" --data-urlencode "start_date=<now minus 1h, YYYY-MM-DD HH:MM:SS>" --data-urlencode "end_date=<now plus 1h>" --data-urlencode "page=1" --data-urlencode "page_size=100" -H "Authorization: Bearer sk-1234" and note the request_ids of rows whose api_key is empty, walking all total_pages pages if total exceeds 100
  - [ ] Upload a batch input with the limited key: curl -X POST http://localhost:4000/v1/files -H "Authorization: Bearer <limited key>" -F purpose=batch -F model=openai-batch -F file=@input.jsonl where input.jsonl holds one gpt-4o-mini /v1/chat/completions line
  - [ ] Create the batch: curl -X POST http://localhost:4000/v1/batches -H "Authorization: Bearer <limited key>" -d '{"input_file_id": "<file id>", "endpoint": "/v1/chat/completions", "completion_window": "24h"}' and expect 200 with a non-terminal batch status
  - [ ] Poll curl -G "http://localhost:4000/spend/logs" --data-urlencode "api_key=<limited key>" -H "Authorization: Bearer sk-1234" until the key's spend row lands, then re-run the windowed v2 query from step 2 and expect no new rows with an empty api_key
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
