### PR TITLE
feat(ptu): surface ptu_flat_cost via /team/daily/activity response

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1628,3 +1628,9 @@ ADVISOR_TOOL_DESCRIPTION: str = (
     "want to verify your reasoning, or face a complex decision. "
     "Describe your question or challenge clearly in the 'question' field."
 )
+
+# PTU reservation rollup writes rows to LiteLLM_DailyTeamSpend with this
+# sentinel api_key so PTU flat cost stays distinguishable from real per-request
+# spend under the table's composite unique constraint.
+PTU_SENTINEL_API_KEY: str = "__ptu_reservation__"
+PTU_ROLLUP_JOB_ID: str = "ptu_reservation_rollup_job"

--- a/litellm/proxy/management_endpoints/common_daily_activity.py
+++ b/litellm/proxy/management_endpoints/common_daily_activity.py
@@ -6,6 +6,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple, U
 from fastapi import HTTPException, status
 
 from litellm._logging import verbose_proxy_logger
+from litellm.constants import PTU_SENTINEL_API_KEY
 from litellm.proxy._types import CommonProxyErrors
 from litellm.proxy.utils import PrismaClient
 from litellm.repositories.table_repositories import DeletedVerificationTokenRepository
@@ -44,6 +45,7 @@ def update_metrics(existing_metrics: SpendMetrics, record: Any) -> SpendMetrics:
     prompt_tokens = record.prompt_tokens or 0
     completion_tokens = record.completion_tokens or 0
     existing_metrics.spend += record.spend or 0.0
+    existing_metrics.flat_cost += getattr(record, "ptu_flat_cost", None) or 0.0
     existing_metrics.prompt_tokens += prompt_tokens
     existing_metrics.completion_tokens += completion_tokens
     existing_metrics.total_tokens += prompt_tokens + completion_tokens
@@ -98,7 +100,15 @@ def update_breakdown_metrics(
     entity_id_field: Optional[str] = None,
     entity_metadata_field: Optional[Dict[str, dict]] = None,
 ) -> BreakdownMetrics:
-    """Updates breakdown metrics for a single record using the existing update_metrics function"""
+    """Updates breakdown metrics for a single record using the existing update_metrics function.
+
+    PTU sentinel rows (``api_key == PTU_SENTINEL_API_KEY``) contribute their
+    ``ptu_flat_cost`` to every parent breakdown (per-model, per-provider,
+    per-endpoint, per-entity, per-day totals) but never appear as a row in
+    any ``api_keys`` / ``api_key_breakdown`` map — the sentinel string is not
+    a real key alias.
+    """
+    is_ptu_sentinel = record.api_key == PTU_SENTINEL_API_KEY
 
     # Update model breakdown
     if record.model and record.model not in breakdown.models:
@@ -110,18 +120,19 @@ def update_breakdown_metrics(
         breakdown.models[record.model].metrics = update_metrics(breakdown.models[record.model].metrics, record)
 
         # Update API key breakdown for this model
-        if record.api_key not in breakdown.models[record.model].api_key_breakdown:
-            breakdown.models[record.model].api_key_breakdown[record.api_key] = KeyMetricWithMetadata(
-                metrics=SpendMetrics(),
-                metadata=KeyMetadata(
-                    key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
-                    team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
-                ),
+        if not is_ptu_sentinel:
+            if record.api_key not in breakdown.models[record.model].api_key_breakdown:
+                breakdown.models[record.model].api_key_breakdown[record.api_key] = KeyMetricWithMetadata(
+                    metrics=SpendMetrics(),
+                    metadata=KeyMetadata(
+                        key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
+                        team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
+                    ),
+                )
+            breakdown.models[record.model].api_key_breakdown[record.api_key].metrics = update_metrics(
+                breakdown.models[record.model].api_key_breakdown[record.api_key].metrics,
+                record,
             )
-        breakdown.models[record.model].api_key_breakdown[record.api_key].metrics = update_metrics(
-            breakdown.models[record.model].api_key_breakdown[record.api_key].metrics,
-            record,
-        )
 
     # Update model group breakdown
     if record.model_group and record.model_group not in breakdown.model_groups:
@@ -135,18 +146,19 @@ def update_breakdown_metrics(
         )
 
         # Update API key breakdown for this model
-        if record.api_key not in breakdown.model_groups[record.model_group].api_key_breakdown:
-            breakdown.model_groups[record.model_group].api_key_breakdown[record.api_key] = KeyMetricWithMetadata(
-                metrics=SpendMetrics(),
-                metadata=KeyMetadata(
-                    key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
-                    team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
-                ),
+        if not is_ptu_sentinel:
+            if record.api_key not in breakdown.model_groups[record.model_group].api_key_breakdown:
+                breakdown.model_groups[record.model_group].api_key_breakdown[record.api_key] = KeyMetricWithMetadata(
+                    metrics=SpendMetrics(),
+                    metadata=KeyMetadata(
+                        key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
+                        team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
+                    ),
+                )
+            breakdown.model_groups[record.model_group].api_key_breakdown[record.api_key].metrics = update_metrics(
+                breakdown.model_groups[record.model_group].api_key_breakdown[record.api_key].metrics,
+                record,
             )
-        breakdown.model_groups[record.model_group].api_key_breakdown[record.api_key].metrics = update_metrics(
-            breakdown.model_groups[record.model_group].api_key_breakdown[record.api_key].metrics,
-            record,
-        )
 
     if record.mcp_namespaced_tool_name:
         if record.mcp_namespaced_tool_name not in breakdown.mcp_servers:
@@ -159,23 +171,24 @@ def update_breakdown_metrics(
         )
 
         # Update API key breakdown for this MCP server
-        if record.api_key not in breakdown.mcp_servers[record.mcp_namespaced_tool_name].api_key_breakdown:
-            breakdown.mcp_servers[record.mcp_namespaced_tool_name].api_key_breakdown[record.api_key] = (
-                KeyMetricWithMetadata(
-                    metrics=SpendMetrics(),
-                    metadata=KeyMetadata(
-                        key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
-                        team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
-                    ),
+        if not is_ptu_sentinel:
+            if record.api_key not in breakdown.mcp_servers[record.mcp_namespaced_tool_name].api_key_breakdown:
+                breakdown.mcp_servers[record.mcp_namespaced_tool_name].api_key_breakdown[record.api_key] = (
+                    KeyMetricWithMetadata(
+                        metrics=SpendMetrics(),
+                        metadata=KeyMetadata(
+                            key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
+                            team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
+                        ),
+                    )
                 )
-            )
 
-        breakdown.mcp_servers[record.mcp_namespaced_tool_name].api_key_breakdown[
-            record.api_key
-        ].metrics = update_metrics(
-            breakdown.mcp_servers[record.mcp_namespaced_tool_name].api_key_breakdown[record.api_key].metrics,
-            record,
-        )
+            breakdown.mcp_servers[record.mcp_namespaced_tool_name].api_key_breakdown[
+                record.api_key
+            ].metrics = update_metrics(
+                breakdown.mcp_servers[record.mcp_namespaced_tool_name].api_key_breakdown[record.api_key].metrics,
+                record,
+            )
 
     # Update provider breakdown
     provider = record.custom_llm_provider or "unknown"
@@ -187,18 +200,19 @@ def update_breakdown_metrics(
     breakdown.providers[provider].metrics = update_metrics(breakdown.providers[provider].metrics, record)
 
     # Update API key breakdown for this provider
-    if record.api_key not in breakdown.providers[provider].api_key_breakdown:
-        breakdown.providers[provider].api_key_breakdown[record.api_key] = KeyMetricWithMetadata(
-            metrics=SpendMetrics(),
-            metadata=KeyMetadata(
-                key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
-                team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
-            ),
+    if not is_ptu_sentinel:
+        if record.api_key not in breakdown.providers[provider].api_key_breakdown:
+            breakdown.providers[provider].api_key_breakdown[record.api_key] = KeyMetricWithMetadata(
+                metrics=SpendMetrics(),
+                metadata=KeyMetadata(
+                    key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
+                    team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
+                ),
+            )
+        breakdown.providers[provider].api_key_breakdown[record.api_key].metrics = update_metrics(
+            breakdown.providers[provider].api_key_breakdown[record.api_key].metrics,
+            record,
         )
-    breakdown.providers[provider].api_key_breakdown[record.api_key].metrics = update_metrics(
-        breakdown.providers[provider].api_key_breakdown[record.api_key].metrics,
-        record,
-    )
 
     # Update endpoint breakdown
     if record.endpoint:
@@ -212,29 +226,31 @@ def update_breakdown_metrics(
         )
 
         # Update API key breakdown for this endpoint
-        if record.api_key not in breakdown.endpoints[record.endpoint].api_key_breakdown:
-            breakdown.endpoints[record.endpoint].api_key_breakdown[record.api_key] = KeyMetricWithMetadata(
+        if not is_ptu_sentinel:
+            if record.api_key not in breakdown.endpoints[record.endpoint].api_key_breakdown:
+                breakdown.endpoints[record.endpoint].api_key_breakdown[record.api_key] = KeyMetricWithMetadata(
+                    metrics=SpendMetrics(),
+                    metadata=KeyMetadata(
+                        key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
+                        team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
+                    ),
+                )
+            breakdown.endpoints[record.endpoint].api_key_breakdown[record.api_key].metrics = update_metrics(
+                breakdown.endpoints[record.endpoint].api_key_breakdown[record.api_key].metrics,
+                record,
+            )
+
+    # Update api key breakdown
+    if not is_ptu_sentinel:
+        if record.api_key not in breakdown.api_keys:
+            breakdown.api_keys[record.api_key] = KeyMetricWithMetadata(
                 metrics=SpendMetrics(),
                 metadata=KeyMetadata(
                     key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
                     team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
-                ),
+                ),  # Add any api_key-specific metadata here
             )
-        breakdown.endpoints[record.endpoint].api_key_breakdown[record.api_key].metrics = update_metrics(
-            breakdown.endpoints[record.endpoint].api_key_breakdown[record.api_key].metrics,
-            record,
-        )
-
-    # Update api key breakdown
-    if record.api_key not in breakdown.api_keys:
-        breakdown.api_keys[record.api_key] = KeyMetricWithMetadata(
-            metrics=SpendMetrics(),
-            metadata=KeyMetadata(
-                key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
-                team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
-            ),  # Add any api_key-specific metadata here
-        )
-    breakdown.api_keys[record.api_key].metrics = update_metrics(breakdown.api_keys[record.api_key].metrics, record)
+        breakdown.api_keys[record.api_key].metrics = update_metrics(breakdown.api_keys[record.api_key].metrics, record)
 
     # Update entity-specific metrics if entity_id_field is provided
     if entity_id_field:
@@ -248,18 +264,19 @@ def update_breakdown_metrics(
         breakdown.entities[entity_value].metrics = update_metrics(breakdown.entities[entity_value].metrics, record)
 
         # Update API key breakdown for this entity
-        if record.api_key not in breakdown.entities[entity_value].api_key_breakdown:
-            breakdown.entities[entity_value].api_key_breakdown[record.api_key] = KeyMetricWithMetadata(
-                metrics=SpendMetrics(),
-                metadata=KeyMetadata(
-                    key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
-                    team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
-                ),
+        if not is_ptu_sentinel:
+            if record.api_key not in breakdown.entities[entity_value].api_key_breakdown:
+                breakdown.entities[entity_value].api_key_breakdown[record.api_key] = KeyMetricWithMetadata(
+                    metrics=SpendMetrics(),
+                    metadata=KeyMetadata(
+                        key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
+                        team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
+                    ),
+                )
+            breakdown.entities[entity_value].api_key_breakdown[record.api_key].metrics = update_metrics(
+                breakdown.entities[entity_value].api_key_breakdown[record.api_key].metrics,
+                record,
             )
-        breakdown.entities[entity_value].api_key_breakdown[record.api_key].metrics = update_metrics(
-            breakdown.entities[entity_value].api_key_breakdown[record.api_key].metrics,
-            record,
-        )
 
     return breakdown
 
@@ -401,6 +418,14 @@ def _build_aggregated_sql_query(
     if pg_table is None:
         raise ValueError(f"Unknown table name: {table_name}")
 
+    # Only LiteLLM_DailyTeamSpend carries ptu_flat_cost today. Other daily tables
+    # emit a constant zero so the response shape (SpendMetrics.flat_cost) stays
+    # uniform for every entity.
+    has_ptu_flat_cost = table_name == "litellm_dailyteamspend"
+    ptu_flat_cost_select = (
+        "SUM(ptu_flat_cost)::float AS ptu_flat_cost" if has_ptu_flat_cost else "0::float AS ptu_flat_cost"
+    )
+
     adjusted_start, adjusted_end = _adjust_dates_for_timezone(start_date, end_date, timezone_offset_minutes)
 
     sql_conditions: List[str] = []
@@ -469,6 +494,7 @@ def _build_aggregated_sql_query(
                      custom_llm_provider, mcp_namespaced_tool_name,
                      endpoint) AS group_level,
             SUM(spend)::float AS spend,
+            {ptu_flat_cost_select},
             SUM(prompt_tokens)::bigint AS prompt_tokens,
             SUM(completion_tokens)::bigint AS completion_tokens,
             SUM(cache_read_input_tokens)::bigint AS cache_read_input_tokens,
@@ -560,7 +586,9 @@ async def _aggregate_spend_records(
     The per-row loop is offloaded to a worker thread via asyncio.to_thread so
     a large result set doesn't peg the event loop.
     """
-    api_keys: Set[str] = {record.api_key for record in records if record.api_key}
+    api_keys: Set[str] = {
+        record.api_key for record in records if record.api_key and record.api_key != PTU_SENTINEL_API_KEY
+    }
 
     api_key_metadata: Dict[str, Dict[str, Any]] = {}
     if api_keys:
@@ -607,6 +635,7 @@ def _record_to_spend_metrics(record: Any) -> SpendMetrics:
     completion_tokens = record.completion_tokens or 0
     return SpendMetrics(
         spend=record.spend or 0.0,
+        flat_cost=getattr(record, "ptu_flat_cost", None) or 0.0,
         prompt_tokens=prompt_tokens,
         completion_tokens=completion_tokens,
         total_tokens=prompt_tokens + completion_tokens,
@@ -669,6 +698,10 @@ def _aggregate_grouping_sets_records_sync(
     for record in records:
         level = record.group_level
         metrics = _record_to_spend_metrics(record)
+        # Sentinel PTU rows contribute to grand-total / per-day / per-model /
+        # per-provider / per-endpoint buckets, but must never appear in any
+        # api_key or api_key_breakdown map.
+        real_api_key = record.api_key and record.api_key != PTU_SENTINEL_API_KEY
 
         if level == _GROUP_GRAND_TOTAL:
             total_metrics = metrics
@@ -681,7 +714,7 @@ def _aggregate_grouping_sets_records_sync(
         breakdown = ensure_date(record.date)["breakdown"]
 
         if level == _GROUP_DATE_API_KEY:
-            if record.api_key:
+            if real_api_key:
                 breakdown.api_keys[record.api_key] = KeyMetricWithMetadata(
                     metrics=metrics,
                     metadata=_key_metadata(api_key_metadata, record.api_key),
@@ -690,13 +723,13 @@ def _aggregate_grouping_sets_records_sync(
             if record.model:
                 assign_metric_with_metadata(breakdown.models, record.model, metrics)
         elif level == _GROUP_DATE_MODEL_API_KEY:
-            if record.model and record.api_key:
+            if record.model and real_api_key:
                 assign_api_key_breakdown(breakdown.models, record.model, record.api_key, metrics)
         elif level == _GROUP_DATE_MODEL_GROUP:
             if record.model_group:
                 assign_metric_with_metadata(breakdown.model_groups, record.model_group, metrics)
         elif level == _GROUP_DATE_MODEL_GROUP_API_KEY:
-            if record.model_group and record.api_key:
+            if record.model_group and real_api_key:
                 assign_api_key_breakdown(
                     breakdown.model_groups,
                     record.model_group,
@@ -707,14 +740,14 @@ def _aggregate_grouping_sets_records_sync(
             provider = record.custom_llm_provider or "unknown"
             assign_metric_with_metadata(breakdown.providers, provider, metrics)
         elif level == _GROUP_DATE_PROVIDER_API_KEY:
-            if record.api_key:
+            if real_api_key:
                 provider = record.custom_llm_provider or "unknown"
                 assign_api_key_breakdown(breakdown.providers, provider, record.api_key, metrics)
         elif level == _GROUP_DATE_MCP:
             if record.mcp_namespaced_tool_name:
                 assign_metric_with_metadata(breakdown.mcp_servers, record.mcp_namespaced_tool_name, metrics)
         elif level == _GROUP_DATE_MCP_API_KEY:
-            if record.mcp_namespaced_tool_name and record.api_key:
+            if record.mcp_namespaced_tool_name and real_api_key:
                 assign_api_key_breakdown(
                     breakdown.mcp_servers,
                     record.mcp_namespaced_tool_name,
@@ -725,7 +758,7 @@ def _aggregate_grouping_sets_records_sync(
             if record.endpoint:
                 assign_metric_with_metadata(breakdown.endpoints, record.endpoint, metrics)
         elif level == _GROUP_DATE_ENDPOINT_API_KEY:
-            if record.endpoint and record.api_key:
+            if record.endpoint and real_api_key:
                 assign_api_key_breakdown(breakdown.endpoints, record.endpoint, record.api_key, metrics)
 
     results = [
@@ -747,7 +780,7 @@ async def _aggregate_grouping_sets_records(
     records: List[Any],
 ) -> Dict[str, Any]:
     """Async wrapper: fetch api_key_metadata, then dispatch on a worker thread."""
-    api_keys: Set[str] = {r.api_key for r in records if r.api_key}
+    api_keys: Set[str] = {r.api_key for r in records if r.api_key and r.api_key != PTU_SENTINEL_API_KEY}
 
     api_key_metadata: Dict[str, Dict[str, Any]] = {}
     if api_keys:
@@ -854,6 +887,7 @@ async def get_daily_activity(
             results=aggregated["results"],
             metadata=DailySpendMetadata(
                 total_spend=metadata_metrics.spend,
+                total_flat_cost=metadata_metrics.flat_cost,
                 total_prompt_tokens=metadata_metrics.prompt_tokens,
                 total_completion_tokens=metadata_metrics.completion_tokens,
                 total_tokens=metadata_metrics.total_tokens,
@@ -940,6 +974,7 @@ async def get_daily_activity_aggregated(
             results=aggregated["results"],
             metadata=DailySpendMetadata(
                 total_spend=aggregated["totals"].spend,
+                total_flat_cost=aggregated["totals"].flat_cost,
                 total_prompt_tokens=aggregated["totals"].prompt_tokens,
                 total_completion_tokens=aggregated["totals"].completion_tokens,
                 total_tokens=aggregated["totals"].total_tokens,

--- a/litellm/proxy/spend_tracking/ptu_reservation_rollup.py
+++ b/litellm/proxy/spend_tracking/ptu_reservation_rollup.py
@@ -12,10 +12,8 @@ from datetime import date, datetime, time, timedelta, timezone
 from typing import Any
 
 from litellm._logging import verbose_proxy_logger
+from litellm.constants import PTU_ROLLUP_JOB_ID, PTU_SENTINEL_API_KEY
 from litellm.repositories.ptu_reservation_repository import PTUReservationRepository
-
-PTU_SENTINEL_API_KEY = "__ptu_reservation__"
-PTU_ROLLUP_JOB_ID = "ptu_reservation_rollup_job"
 
 
 @dataclass(frozen=True, slots=True)

--- a/litellm/types/proxy/management_endpoints/common_daily_activity.py
+++ b/litellm/types/proxy/management_endpoints/common_daily_activity.py
@@ -18,6 +18,7 @@ class GroupByDimension(str, Enum):
 
 class SpendMetrics(BaseModel):
     spend: float = Field(default=0.0)
+    flat_cost: float = Field(default=0.0)
     prompt_tokens: int = Field(default=0)
     completion_tokens: int = Field(default=0)
     cache_read_input_tokens: int = Field(default=0)
@@ -71,6 +72,7 @@ class DailySpendData(BaseModel):
 
 class DailySpendMetadata(BaseModel):
     total_spend: float = Field(default=0.0)
+    total_flat_cost: float = Field(default=0.0)
     total_prompt_tokens: int = Field(default=0)
     total_completion_tokens: int = Field(default=0)
     total_tokens: int = Field(default=0)

--- a/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
@@ -936,3 +936,300 @@ def test_update_metrics_handles_none_values():
     assert metrics.failed_requests == 0
     assert metrics.cache_read_input_tokens == 0
     assert metrics.cache_creation_input_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# Stage 3: ptu_flat_cost surfacing on team daily activity read path
+# ---------------------------------------------------------------------------
+
+from litellm.constants import PTU_SENTINEL_API_KEY  # noqa: E402
+from litellm.proxy.management_endpoints.common_daily_activity import (  # noqa: E402
+    update_breakdown_metrics,
+)
+from litellm.types.proxy.management_endpoints.common_daily_activity import (  # noqa: E402
+    BreakdownMetrics,
+)
+
+
+def _team_row(
+    *,
+    date="2026-08-01",
+    api_key="sk-real",
+    model="gpt-4",
+    model_group=None,
+    custom_llm_provider="azure",
+    endpoint=None,
+    mcp_namespaced_tool_name=None,
+    spend=0.0,
+    ptu_flat_cost=0.0,
+    prompt_tokens=0,
+    completion_tokens=0,
+    cache_read_input_tokens=0,
+    cache_creation_input_tokens=0,
+    api_requests=0,
+    successful_requests=0,
+    failed_requests=0,
+    team_id="team_x",
+):
+    return SimpleNamespace(
+        date=date,
+        api_key=api_key,
+        model=model,
+        model_group=model_group,
+        custom_llm_provider=custom_llm_provider,
+        endpoint=endpoint,
+        mcp_namespaced_tool_name=mcp_namespaced_tool_name,
+        spend=spend,
+        ptu_flat_cost=ptu_flat_cost,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        cache_read_input_tokens=cache_read_input_tokens,
+        cache_creation_input_tokens=cache_creation_input_tokens,
+        api_requests=api_requests,
+        successful_requests=successful_requests,
+        failed_requests=failed_requests,
+        team_id=team_id,
+    )
+
+
+def test_spend_metrics_flat_cost_defaults_zero():
+    assert SpendMetrics().flat_cost == 0.0
+
+
+def test_update_metrics_adds_ptu_flat_cost():
+    metrics = SpendMetrics()
+    update_metrics(metrics, _team_row(ptu_flat_cost=6.45))
+    update_metrics(metrics, _team_row(ptu_flat_cost=3.55))
+    assert metrics.flat_cost == pytest.approx(10.0)
+
+
+def test_update_metrics_ignores_missing_ptu_flat_cost_attr():
+    """User/org/tag daily rows don't carry ptu_flat_cost — must not raise."""
+    row_without_field = SimpleNamespace(
+        spend=1.0,
+        prompt_tokens=0,
+        completion_tokens=0,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+        api_requests=0,
+        successful_requests=0,
+        failed_requests=0,
+    )
+    metrics = SpendMetrics()
+    update_metrics(metrics, row_without_field)
+    assert metrics.spend == pytest.approx(1.0)
+    assert metrics.flat_cost == 0.0
+
+
+def test_update_metrics_treats_none_ptu_flat_cost_as_zero():
+    row = _team_row(ptu_flat_cost=None)
+    metrics = SpendMetrics()
+    update_metrics(metrics, row)
+    assert metrics.flat_cost == 0.0
+
+
+def test_record_to_spend_metrics_reads_ptu_flat_cost():
+    row = _team_row(ptu_flat_cost=42.0)
+    m = _record_to_spend_metrics(row)
+    assert m.flat_cost == pytest.approx(42.0)
+
+
+def test_record_to_spend_metrics_defaults_ptu_flat_cost_when_absent():
+    row_without = SimpleNamespace(
+        spend=1.0,
+        prompt_tokens=0,
+        completion_tokens=0,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+        api_requests=0,
+        successful_requests=0,
+        failed_requests=0,
+    )
+    m = _record_to_spend_metrics(row_without)
+    assert m.flat_cost == 0.0
+
+
+def test_sentinel_row_skipped_from_top_level_api_keys_breakdown():
+    breakdown = BreakdownMetrics()
+    sentinel_row = _team_row(
+        api_key=PTU_SENTINEL_API_KEY,
+        ptu_flat_cost=6.45,
+        custom_llm_provider=None,
+    )
+    update_breakdown_metrics(breakdown, sentinel_row, {}, {}, {})
+    assert PTU_SENTINEL_API_KEY not in breakdown.api_keys
+    assert breakdown.api_keys == {}
+
+
+def test_sentinel_row_contributes_to_model_breakdown_flat_cost():
+    breakdown = BreakdownMetrics()
+    sentinel_row = _team_row(
+        api_key=PTU_SENTINEL_API_KEY,
+        model="gpt-4",
+        ptu_flat_cost=6.45,
+    )
+    update_breakdown_metrics(breakdown, sentinel_row, {}, {}, {})
+    assert "gpt-4" in breakdown.models
+    assert breakdown.models["gpt-4"].metrics.flat_cost == pytest.approx(6.45)
+    # And it must not leak into api_key_breakdown under the model
+    assert PTU_SENTINEL_API_KEY not in breakdown.models["gpt-4"].api_key_breakdown
+
+
+def test_real_key_and_sentinel_row_share_a_model_bucket():
+    breakdown = BreakdownMetrics()
+    real_row = _team_row(api_key="sk-real", model="gpt-4", spend=1.5)
+    sentinel_row = _team_row(api_key=PTU_SENTINEL_API_KEY, model="gpt-4", ptu_flat_cost=6.45)
+    update_breakdown_metrics(breakdown, real_row, {}, {}, {})
+    update_breakdown_metrics(breakdown, sentinel_row, {}, {}, {})
+
+    model_bucket = breakdown.models["gpt-4"]
+    assert model_bucket.metrics.spend == pytest.approx(1.5)
+    assert model_bucket.metrics.flat_cost == pytest.approx(6.45)
+
+    # api_keys only surfaces the real key
+    assert list(breakdown.api_keys.keys()) == ["sk-real"]
+    # and the api_key_breakdown under the model also only holds the real key
+    assert list(model_bucket.api_key_breakdown.keys()) == ["sk-real"]
+
+
+def test_sentinel_row_contributes_to_provider_and_endpoint_breakdowns():
+    breakdown = BreakdownMetrics()
+    sentinel_row = _team_row(
+        api_key=PTU_SENTINEL_API_KEY,
+        model="gpt-4",
+        custom_llm_provider="azure",
+        endpoint="/v1/chat/completions",
+        ptu_flat_cost=6.45,
+    )
+    update_breakdown_metrics(breakdown, sentinel_row, {}, {}, {})
+    assert breakdown.providers["azure"].metrics.flat_cost == pytest.approx(6.45)
+    assert PTU_SENTINEL_API_KEY not in breakdown.providers["azure"].api_key_breakdown
+    assert breakdown.endpoints["/v1/chat/completions"].metrics.flat_cost == pytest.approx(6.45)
+    assert PTU_SENTINEL_API_KEY not in breakdown.endpoints["/v1/chat/completions"].api_key_breakdown
+
+
+def test_sentinel_row_contributes_to_entity_breakdown():
+    breakdown = BreakdownMetrics()
+    sentinel_row = _team_row(
+        api_key=PTU_SENTINEL_API_KEY,
+        team_id="team_x",
+        ptu_flat_cost=6.45,
+    )
+    update_breakdown_metrics(
+        breakdown,
+        sentinel_row,
+        {},
+        {},
+        {},
+        entity_id_field="team_id",
+    )
+    assert breakdown.entities["team_x"].metrics.flat_cost == pytest.approx(6.45)
+    assert PTU_SENTINEL_API_KEY not in breakdown.entities["team_x"].api_key_breakdown
+
+
+def test_get_api_key_metadata_excludes_sentinel_from_lookup():
+    """The sentinel api_key is not a real hashed token; skip the Prisma lookup for it."""
+    from litellm.proxy.management_endpoints.common_daily_activity import (
+        _aggregate_spend_records,
+    )
+    import asyncio
+
+    mock_prisma = MagicMock()
+    mock_vt_table = MagicMock()
+    mock_vt_table.find_many = AsyncMock(return_value=[])
+    mock_deleted_table = MagicMock()
+    mock_deleted_table.find_many = AsyncMock(return_value=[])
+    mock_prisma.db = MagicMock()
+    mock_prisma.db.litellm_verificationtoken = mock_vt_table
+    mock_prisma.db.litellm_deletedverificationtoken = mock_deleted_table
+
+    real_row = _team_row(api_key="sk-real")
+    sentinel_row = _team_row(api_key=PTU_SENTINEL_API_KEY, ptu_flat_cost=6.45)
+
+    asyncio.run(
+        _aggregate_spend_records(
+            prisma_client=mock_prisma,
+            records=[real_row, sentinel_row],
+            entity_id_field="team_id",
+            entity_metadata_field=None,
+        )
+    )
+
+    mock_vt_table.find_many.assert_called_once()
+    where = mock_vt_table.find_many.await_args.kwargs["where"]
+    queried = set(where["token"]["in"])
+    assert "sk-real" in queried
+    assert PTU_SENTINEL_API_KEY not in queried
+
+
+def test_build_aggregated_sql_query_selects_ptu_flat_cost_only_for_team_table():
+    sql_team, _ = _build_aggregated_sql_query(
+        table_name="litellm_dailyteamspend",
+        entity_id_field="team_id",
+        entity_id=None,
+        start_date="2026-08-01",
+        end_date="2026-08-31",
+        model=None,
+        api_key=None,
+    )
+    assert "SUM(ptu_flat_cost)::float AS ptu_flat_cost" in sql_team
+
+    sql_user, _ = _build_aggregated_sql_query(
+        table_name="litellm_dailyuserspend",
+        entity_id_field="user_id",
+        entity_id=None,
+        start_date="2026-08-01",
+        end_date="2026-08-31",
+        model=None,
+        api_key=None,
+    )
+    assert "SUM(ptu_flat_cost)" not in sql_user
+    assert "0::float AS ptu_flat_cost" in sql_user
+
+
+@pytest.mark.asyncio
+async def test_get_daily_activity_returns_total_flat_cost_for_team():
+    """End-to-end: seed team daily rows (one real + one sentinel), assert response shape."""
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+
+    mock_table = MagicMock()
+    mock_table.count = AsyncMock(return_value=2)
+    mock_table.find_many = AsyncMock(
+        return_value=[
+            _team_row(api_key="sk-real", spend=1.5, ptu_flat_cost=0.0),
+            _team_row(api_key=PTU_SENTINEL_API_KEY, spend=0.0, ptu_flat_cost=6.45),
+        ]
+    )
+    mock_prisma.db.litellm_dailyteamspend = mock_table
+
+    mock_vt_table = MagicMock()
+    mock_vt_table.find_many = AsyncMock(return_value=[])
+    mock_prisma.db.litellm_verificationtoken = mock_vt_table
+    mock_deleted_table = MagicMock()
+    mock_deleted_table.find_many = AsyncMock(return_value=[])
+    mock_prisma.db.litellm_deletedverificationtoken = mock_deleted_table
+
+    result = await get_daily_activity(
+        prisma_client=mock_prisma,
+        table_name="litellm_dailyteamspend",
+        entity_id_field="team_id",
+        entity_id=None,
+        entity_metadata_field=None,
+        start_date="2026-08-01",
+        end_date="2026-08-01",
+        model=None,
+        api_key=None,
+        page=1,
+        page_size=10,
+    )
+
+    assert result.metadata.total_spend == pytest.approx(1.5)
+    assert result.metadata.total_flat_cost == pytest.approx(6.45)
+    assert len(result.results) == 1
+    day = result.results[0]
+    assert day.metrics.spend == pytest.approx(1.5)
+    assert day.metrics.flat_cost == pytest.approx(6.45)
+    # api_keys breakdown must not contain the sentinel
+    assert PTU_SENTINEL_API_KEY not in day.breakdown.api_keys
+    assert "sk-real" in day.breakdown.api_keys

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -23333,6 +23333,11 @@ export interface components {
              */
             total_failed_requests: number;
             /**
+             * Total Flat Cost
+             * @default 0
+             */
+            total_flat_cost: number;
+            /**
              * Total Pages
              * @default 1
              */
@@ -31022,6 +31027,11 @@ export interface components {
              * @default 0
              */
             failed_requests: number;
+            /**
+             * Flat Cost
+             * @default 0
+             */
+            flat_cost: number;
             /**
              * Prompt Tokens
              * @default 0


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-1697 (stage 3 of 5)

Stacks on #33137. Merge that first.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Prereq: stages 1 and 2 already applied and a reservation seeded. Enable flag, run a real Azure gpt-4 request as a real team key so we have per-request spend on the same team+model+day, and run the backfill for that day.

```
$ MASTER_KEY=sk-1234
$ TEAM=<real team id>
$ curl -s -X POST http://localhost:4000/config/general_settings \
    -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"enable_ptu_cost_attribution": true}' > /dev/null

# real request
$ curl -s -X POST http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer $TEAM_KEY" -H "Content-Type: application/json" \
    -d '{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}' > /dev/null

# ensure a PTU sentinel row lands for the same day
$ .venv/bin/python scripts/ptu_reservation_backfill.py --date 2026-07-14
[2026-07-14] reservations=1 rows_written=1

# Response now includes flat_cost + total_flat_cost
$ curl -s "http://localhost:4000/team/daily/activity?team_ids=$TEAM&start_date=2026-07-14&end_date=2026-07-14&page_size=10" \
    -H "Authorization: Bearer $MASTER_KEY" | jq '{
      total_spend: .metadata.total_spend,
      total_flat_cost: .metadata.total_flat_cost,
      day_spend: .results[0].metrics.spend,
      day_flat_cost: .results[0].metrics.flat_cost,
      api_keys_in_breakdown: (.results[0].breakdown.api_keys | keys),
      model_flat_cost: .results[0].breakdown.models["gpt-4"].metrics.flat_cost
    }'
{
  "total_spend": 0.0135,
  "total_flat_cost": 6.4516,
  "day_spend": 0.0135,
  "day_flat_cost": 6.4516,
  "api_keys_in_breakdown": ["sk-abc123..."],       # sentinel is NOT here
  "model_flat_cost": 6.4516                        # sentinel DID contribute
}

# Confirm sentinel row is included when a caller explicitly filters for it
$ curl -s "http://localhost:4000/team/daily/activity?team_ids=$TEAM&start_date=2026-07-14&end_date=2026-07-14&api_key=__ptu_reservation__&page_size=10" \
    -H "Authorization: Bearer $MASTER_KEY" | jq '.metadata.total_flat_cost'
6.4516

# Non-team daily-activity endpoints unaffected — flat_cost stays 0
$ curl -s "http://localhost:4000/user/daily/activity?user_ids=<me>&start_date=2026-07-14&end_date=2026-07-14" \
    -H "Authorization: Bearer $MASTER_KEY" | jq '{total_spend: .metadata.total_spend, total_flat_cost: .metadata.total_flat_cost}'
{"total_spend": 0.0135, "total_flat_cost": 0}
```

Aggregated variant (`?aggregated=true`) shows the same fields in `metadata` because both paths run through the same shared response construction; also verified.

## Type

New Feature

## Changes

Extends the shared daily-activity read path so team daily activity surfaces prorated PTU flat cost alongside per-request spend. All changes are additive to the response shape; consumers that don't know about `flat_cost` / `total_flat_cost` see them as zero-valued defaults and behave exactly as before.

**Response shape.** `SpendMetrics` gains a `flat_cost: float = 0.0` peer of `spend`. `DailySpendMetadata` gains `total_flat_cost: float = 0.0` peer of `total_spend`. Peer of, not folded into: an auditor asking "why does this team show $206 total for a day with two requests" needs the components independently. The UI in stage 4 will compute the display total by summing the two.

**Row-level aggregation.** `update_metrics` and `_record_to_spend_metrics` read `ptu_flat_cost` via `getattr(record, "ptu_flat_cost", None) or 0.0`, so rows from `LiteLLM_DailyUserSpend` / `LiteLLM_DailyOrganizationSpend` / `LiteLLM_DailyTagSpend` / `LiteLLM_DailyAgentSpend` / `LiteLLM_DailyEndUserSpend` (which don't have that column) pass through with `flat_cost=0.0`. No table-shape check needed at the row level.

**Grouping-sets SQL query.** `_build_aggregated_sql_query` now conditionally emits `SUM(ptu_flat_cost)::float AS ptu_flat_cost` when the table is `litellm_dailyteamspend`, and `0::float AS ptu_flat_cost` otherwise. Every daily-* table's query returns the same column shape so `_record_to_spend_metrics` doesn't need to branch on entity.

**Sentinel filtering.** The rollup in stage 2 writes rows with `api_key = "__ptu_reservation__"`. Those rows must contribute their `ptu_flat_cost` to every parent bucket (per-day totals, per-model, per-provider, per-endpoint, per-entity) but never appear in any `api_keys` / `api_key_breakdown` map — the sentinel string is not a real key alias.

Two aggregator changes enforce that invariant:

- `update_breakdown_metrics` (paginated path): sets `is_ptu_sentinel = record.api_key == PTU_SENTINEL_API_KEY` at the top and guards every `api_key` / `api_key_breakdown` write on it. Parent buckets (models, providers, mcp_servers, endpoints, entities) still receive the row via `update_metrics`, so `flat_cost` accumulates there.
- `_aggregate_grouping_sets_records_sync` (aggregated path): computes `real_api_key = record.api_key and record.api_key != PTU_SENTINEL_API_KEY` per row and gates each `*_API_KEY` grouping-level dispatch on it. The `_GROUP_DATE`, `_GROUP_DATE_MODEL`, `_GROUP_DATE_PROVIDER`, etc. levels are unaffected — sentinel rows contribute normally.

`get_api_key_metadata` also skips the sentinel when building the set of tokens to look up, so we don't issue a wasted Prisma query for `"__ptu_reservation__"`.

**Constant relocation.** `PTU_SENTINEL_API_KEY` and `PTU_ROLLUP_JOB_ID` moved from `litellm/proxy/spend_tracking/ptu_reservation_rollup.py` to `litellm/constants.py`. The rollup module re-exports both from the top so external callers continue to work. This addresses the Greptile P2 finding on #33137.

## Deviation from the admin-entity pattern

None new in this stage. Stage 1's rationale for skipping `/update` still applies; stage 3 doesn't add or remove endpoints.

## Behavior changes

- **`SpendMetrics` and `DailySpendMetadata` grow two fields.** Additive. Any consumer that deserializes the response body ignores unknown fields, and any consumer that reads specific fields keeps working.
- **`GET /team/daily/activity` responses now carry `flat_cost` and `total_flat_cost`.** Zero-valued if the feature flag is off, zero-valued for teams with no reservations, non-zero for teams whose rollup has landed rows.
- **`GET /user/daily/activity`, `/organization/daily/activity`, `/customer/daily/activity`, `/tag/daily/activity`, `/agent/daily/activity`, `/enduser/daily/activity`, `/mcp_server/daily/activity`:** each gains the fields too, but always zero — none of those daily tables carry PTU flat cost. Kept identical response shape across entities so downstream consumers don't need per-entity branches.
- **api_key filter semantics:** a client filtering `api_key=<real token>` naturally excludes sentinel PTU rows because the sentinel value doesn't equal any real hashed token. A client explicitly passing `api_key=__ptu_reservation__` sees only PTU rows (undocumented but harmless; useful for FinOps auditors).
- No change to `LiteLLM_TeamTable.spend`, budget enforcement, per-request spend hot path, or any Prometheus metric.
- No new writes: this PR only threads existing columns into the response. The rollup still writes only what stage 2 wrote.

## Files changed

- `litellm/constants.py`: `PTU_SENTINEL_API_KEY` and `PTU_ROLLUP_JOB_ID` constants
- `litellm/proxy/spend_tracking/ptu_reservation_rollup.py`: re-exports constants from `litellm.constants`
- `litellm/types/proxy/management_endpoints/common_daily_activity.py`: `flat_cost` on `SpendMetrics`, `total_flat_cost` on `DailySpendMetadata`
- `litellm/proxy/management_endpoints/common_daily_activity.py`:
  - `update_metrics` and `_record_to_spend_metrics` read `ptu_flat_cost`
  - `update_breakdown_metrics` guards all `api_key` writes on sentinel
  - `_build_aggregated_sql_query` emits `SUM(ptu_flat_cost)` for team, `0::float` for others
  - `_aggregate_grouping_sets_records_sync` gates `*_API_KEY` levels on sentinel
  - `get_daily_activity` and `get_daily_activity_aggregated` populate `total_flat_cost` on the response
  - `_aggregate_spend_records` and `_aggregate_grouping_sets_records` skip sentinel in `get_api_key_metadata` lookup
- `ui/litellm-dashboard/src/lib/http/schema.d.ts`: regenerated (10 lines added for the two new fields)
- `tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py`: 15 new tests

## Tests

15 new tests covering:

- `SpendMetrics.flat_cost` defaults to 0.0
- `update_metrics` accumulates `ptu_flat_cost`; handles missing attr (user/org/tag rows); handles None
- `_record_to_spend_metrics` reads `ptu_flat_cost`; defaults to 0.0 when absent
- Sentinel row is skipped from top-level `api_keys` breakdown but shows up in `models`, `providers`, `endpoints`, `entities` breakdowns with correct `flat_cost`
- Real key + sentinel share a model bucket; only the real key appears in `api_key_breakdown` under that model
- `get_api_key_metadata` lookup excludes sentinel from the Prisma `.find_many` `IN` clause
- SQL builder emits `SUM(ptu_flat_cost)` for team table only, `0::float` for user/org/etc.
- End-to-end `get_daily_activity` on team table with mixed real + sentinel rows returns correct `total_spend`, `total_flat_cost`, per-day `flat_cost`, sentinel-free `api_keys` breakdown

```
$ .venv/bin/python -m pytest tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py -q
47 passed
$ .venv/bin/python -m pytest tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py \
    tests/test_litellm/proxy/management_endpoints/test_ptu_reservation_endpoints.py \
    tests/test_litellm/proxy/spend_tracking/test_ptu_reservation_rollup.py \
    tests/test_scripts/ \
    tests/test_litellm/proxy/test_component_allowlists.py -q
114 passed
```

Mutation checks (locally, not permanent):
- Removing the `ptu_flat_cost` accumulation in `update_metrics` fails 6 tests
- Setting `is_ptu_sentinel = False` unconditionally fails 6 tests
