### PR TITLE
fix(proxy): never log raw virtual keys in key insertion debug output

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -42,7 +42,7 @@ from litellm.proxy._experimental.mcp_server.db import (
     rotate_mcp_user_env_vars_master_key,
 )
 from litellm.proxy._types import *
-from litellm.proxy._types import LiteLLM_VerificationToken
+from litellm.proxy._types import LiteLLM_VerificationToken, hash_token
 from litellm.proxy.auth.auth_checks import (
     _delete_cache_key_object,
     can_team_access_model,
@@ -3777,7 +3777,10 @@ async def generate_key_helper_fn(
                 return user_data
 
             ## CREATE KEY
-            verbose_proxy_logger.debug("prisma_client: Creating Key= %s", key_data)
+            verbose_proxy_logger.debug(
+                "prisma_client: Creating Key= %s",
+                {**key_data, "token": hash_token(token=token)},
+            )
             create_key_response = await prisma_client.insert_data(data=key_data, table_name="key")
 
             key_data["token_id"] = getattr(create_key_response, "token", None)

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3594,7 +3594,7 @@ class PrismaClient:
         try:
             verbose_proxy_logger.debug(
                 "PrismaClient: insert_data: %s",
-                {**data, "token": self.hash_token(token=data["token"])} if "token" in data else data,
+                {**data, "token": self.hash_token(token=data["token"])} if data.get("token") is not None else data,
             )
             if table_name == "key":
                 token = data["token"]

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3592,7 +3592,10 @@ class PrismaClient:
         """
         start_time = time.time()
         try:
-            verbose_proxy_logger.debug("PrismaClient: insert_data: %s", data)
+            verbose_proxy_logger.debug(
+                "PrismaClient: insert_data: %s",
+                {**data, "token": self.hash_token(token=data["token"])} if "token" in data else data,
+            )
             if table_name == "key":
                 token = data["token"]
                 hashed_token = self.hash_token(token=token)

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -530,6 +530,56 @@ async def test_key_generation_with_object_permission(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_generate_key_debug_log_never_contains_raw_token(monkeypatch, caplog):
+    """Regression for LIT-4356: /key/generate must never emit the raw virtual key
+    to a logger, even for short keys that bypass the regex-based
+    SecretRedactionFilter."""
+    import hashlib
+    import logging
+
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.jsonify_object = lambda data: data
+    mock_prisma_client.db = MagicMock()
+
+    async def _insert_data_side_effect(*args, **kwargs):
+        if kwargs.get("table_name") == "user":
+            return MagicMock(models=[], spend=0)
+        return MagicMock(
+            token="hashed_token_456",
+            litellm_budget_table=None,
+            object_permission=None,
+        )
+
+    mock_prisma_client.insert_data = AsyncMock(side_effect=_insert_data_side_effect)
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.key_management_endpoints.get_ui_settings_cached",
+        AsyncMock(return_value={}),
+    )
+
+    from litellm.proxy._types import GenerateKeyRequest, LitellmUserRoles
+    from litellm.proxy.auth.user_api_key_auth import UserAPIKeyAuth
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        generate_key_fn,
+    )
+
+    raw_key = "sk-short-secret"
+    with caplog.at_level(logging.DEBUG, logger="LiteLLM Proxy"):
+        await generate_key_fn(
+            data=GenerateKeyRequest(key=raw_key),
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+                api_key="sk-1234",
+                user_id="user-1",
+            ),
+        )
+
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert raw_key not in log_text
+    assert hashlib.sha256(raw_key.encode()).hexdigest() in log_text
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "field,request_kwargs,expected_in_error",
     [

--- a/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_writes.py
+++ b/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_writes.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -101,6 +102,23 @@ async def test_insert_data_user_organization_fk_raises_400(
     raised = excinfo.value
     assert "Foreign Key Constraint failed" in raised.detail["error"]
     assert raised.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_insert_data_debug_log_hashes_token(
+    prisma_client: PrismaClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Regression for LIT-4356: the raw virtual key must never reach a logger,
+    even for short/nonstandard key formats that bypass the regex-based
+    SecretRedactionFilter."""
+    token = "sk-short-secret"
+    expected_hash = hashlib.sha256(token.encode()).hexdigest()
+    prisma_client.db.litellm_verificationtoken.upsert = AsyncMock(return_value=SimpleNamespace(token=expected_hash))
+    with caplog.at_level(logging.DEBUG, logger="LiteLLM Proxy"):
+        await prisma_client.insert_data(data={"token": token, "key_alias": "redaction-repro"}, table_name="key")
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert token not in log_text
+    assert expected_hash in log_text
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_writes.py
+++ b/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_writes.py
@@ -122,6 +122,18 @@ async def test_insert_data_debug_log_hashes_token(
 
 
 @pytest.mark.asyncio
+async def test_insert_data_debug_log_tolerates_none_token(
+    prisma_client: PrismaClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A None token must not crash the redacting debug log added for LIT-4356."""
+    prisma_client.db.litellm_usertable.upsert = AsyncMock(return_value=SimpleNamespace(user_id="u1"))
+    with caplog.at_level(logging.DEBUG, logger="LiteLLM Proxy"):
+        result = await prisma_client.insert_data(data={"user_id": "u1", "token": None}, table_name="user")
+    assert result.user_id == "u1"
+    assert any("insert_data" in record.getMessage() for record in caplog.records)
+
+
+@pytest.mark.asyncio
 async def test_insert_data_logs_and_raises_generic_error(
     prisma_client: PrismaClient,
 ) -> None:


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4356

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Repro setup for both runs: proxy started against a fresh Postgres with `--detailed_debug` and the full output tee'd to a log file, then a virtual key is generated with a deliberately short custom value so it cannot match the `sk-[A-Za-z0-9\-_]{20,}` pattern the log-level `SecretRedactionFilter` relies on

```bash
uv run litellm --config config.yaml --port 4356 --detailed_debug 2>&1 | tee litellm.log

curl -sS http://localhost:4356/key/generate \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"key":"sk-short-secret","key_alias":"redaction-repro"}'
```

Before (unfixed, captured at `939117bb8d`): the raw key appears in the debug output at both sites

```
grep -Fn 'sk-short-secret' litellm.log | grep -i 'insert_data\|Creating Key'
257:13:22:33 - LiteLLM Proxy:DEBUG: key_management_endpoints.py:3780 - prisma_client: Creating Key= {'token': 'sk-short-secret', 'key_alias': 'redaction-repro', ...}
258:13:22:33 - LiteLLM Proxy:DEBUG: utils.py:3595 - PrismaClient: insert_data: {'token': 'sk-short-secret', 'key_alias': 'redaction-repro', ...}
```

After (fixed, captured at `429ee1d2cb`): the same flow with key `sk-short-secret3` leaves zero occurrences of the raw key anywhere in the full debug log; both lines now show the SHA-256 hash, which is the same value the DB stores as `token_id`

```
$ curl -sS http://localhost:4356/key/generate -H "Authorization: Bearer sk-1234" \
    -H "Content-Type: application/json" -d '{"key":"sk-short-secret3","key_alias":"redaction-after"}'
{"key": "sk-short-secret3", "key_alias": "redaction-after", "token_id": "de8912021302e482b16ee193ab07cac5d2bf1ff7015144925be0b8357bb39e9b", ...}

$ grep -Fc 'sk-short-secret3' litellm.log
0

$ grep -Fn 'de8912021302e482b16ee193ab07cac5d2bf1ff7015144925be0b8357bb39e9b' litellm.log | grep -i 'insert_data\|Creating Key'
107:13:40:25 - LiteLLM Proxy:DEBUG: key_management_endpoints.py:3780 - prisma_client: Creating Key= {'token': 'de8912021302e482b16ee193ab07cac5d2bf1ff7015144925be0b8357bb39e9b', 'key_alias': 'redaction-after', ...}
108:13:40:25 - LiteLLM Proxy:DEBUG: utils.py:3595 - PrismaClient: insert_data: {'token': 'de8912021302e482b16ee193ab07cac5d2bf1ff7015144925be0b8357bb39e9b', 'key_alias': 'redaction-after', ...}
```

The generated key still works end to end against a real provider (costs real $)

```
$ curl -sS http://localhost:4356/v1/chat/completions \
    -H "Authorization: Bearer sk-short-secret3" -H "Content-Type: application/json" \
    -d '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"Say OK"}]}'
{"content": "OK", "id": "chatcmpl-1fcddedb-3b21-4c8b-bd8e-f30902b5e16c", ...}
```

Keys created via `/user/new` and auto-generated keys from `/key/generate` were also exercised on the fixed build; neither leaves a raw key in the log

## Type

🐛 Bug Fix

## Changes

When debug logging is enabled, the key insertion path logged the complete key data dict before the token was hashed, at two sites: `generate_key_helper_fn` ("prisma_client: Creating Key=") and `PrismaClient.insert_data` ("PrismaClient: insert_data:"). Every key creation entrypoint funnels through both (`/key/generate`, service account keys, `/user/new`), so any raw virtual key could land in retained or exported debug logs. The log-level `SecretRedactionFilter` only catches keys matching `sk-` followed by 20 or more characters, so short or nonstandard custom key values sailed through

Both log statements now replace the `token` value with its SHA-256 hash before the dict reaches the logger. The hash is exactly what the DB stores (`token_id`), so the log line keeps its diagnostic value for correlating with the `LiteLLM_VerificationToken` row, and it is not a usable credential since `user_api_key_auth` rejects bearer tokens that do not start with `sk-` precisely to prevent token hashes from being used. The redaction is structural (never pass the raw value to the logger) rather than pattern based, so it holds for any key format

Regression tests extend the existing mapped test files and were mutation checked: both fail on the unfixed code and pass with the fix. `update_data`, `/key/update`, and `/key/regenerate` were audited and already hash before logging; no other raw key sink exists in the insertion path

Follow-up commit 72ad739968 hardens the redacting log guard to tolerate a None token value (Greptile finding; no current caller passes one) and pins that with a test

### Behavior changes

Debug log output only: the `token` field in the two messages above now shows the hashed token instead of the raw key. No API response, return value, exception, or DB write changes. Callers inserting rows without a `token` field (user, team, config, spend) log exactly as before

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Debug-log-only redaction with no API, DB, or auth behavior changes; reduces credential exposure in logs.
> 
> **Overview**
> **Fixes a secret leak in proxy debug logs** when virtual keys are created: two debug lines (`generate_key_helper_fn` “Creating Key=” and `PrismaClient.insert_data`) previously logged the full `key_data` dict while `token` was still the raw key. Regex-based `SecretRedactionFilter` misses short or nonstandard custom keys, so those values could end up in retained `--detailed_debug` output.
> 
> Both log sites now **structurally replace `token` with its SHA-256 hash** (same as stored `token_id`) before the dict is passed to the logger. `insert_data` only redacts when `token` is present; **`None` tokens** still log without crashing.
> 
> Regression tests assert raw keys never appear in DEBUG output for `/key/generate` and `PrismaClient.insert_data`, including the `None` token case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72ad739968c5d219db50d2322826c0cddc0e7935. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->