### PR TITLE
fix(github_copilot): honor explicit api_key

### DIFF
--- a/litellm/llms/github_copilot/chat/transformation.py
+++ b/litellm/llms/github_copilot/chat/transformation.py
@@ -43,7 +43,7 @@ class GithubCopilotConfig(OpenAIConfig):
             or DEFAULT_GITHUB_COPILOT_API_BASE
         )
         try:
-            dynamic_api_key = self.authenticator.get_api_key()
+            dynamic_api_key = api_key or self.authenticator.get_api_key()
         except GetAPIKeyError as e:
             raise AuthenticationError(
                 model=model,

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -2380,9 +2380,8 @@ def _complete_custom_openai(
             get_copilot_default_headers,
         )
 
-        copilot_auth = Authenticator()
         copilot_api_key = (
-            dynamic_api_key if isinstance(dynamic_api_key, str) and dynamic_api_key else copilot_auth.get_api_key()
+            dynamic_api_key if isinstance(dynamic_api_key, str) and dynamic_api_key else Authenticator().get_api_key()
         )
         copilot_headers = get_copilot_default_headers(copilot_api_key)
         if extra_headers:

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -2347,6 +2347,8 @@ def _complete_custom_openai(
     stream = ctx.stream
     timeout = ctx.timeout
 
+    dynamic_api_key = api_key
+
     api_base = (
         api_base  # for deepinfra/perplexity/anyscale/groq/friendliai we check in get_llm_provider and pass in the api base from there
         or litellm.api_base
@@ -2379,7 +2381,9 @@ def _complete_custom_openai(
         )
 
         copilot_auth = Authenticator()
-        copilot_api_key = api_key if isinstance(api_key, str) and api_key else copilot_auth.get_api_key()
+        copilot_api_key = (
+            dynamic_api_key if isinstance(dynamic_api_key, str) and dynamic_api_key else copilot_auth.get_api_key()
+        )
         copilot_headers = get_copilot_default_headers(copilot_api_key)
         if extra_headers:
             copilot_headers.update(extra_headers)

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -2379,7 +2379,7 @@ def _complete_custom_openai(
         )
 
         copilot_auth = Authenticator()
-        copilot_api_key = copilot_auth.get_api_key()
+        copilot_api_key = api_key if isinstance(api_key, str) and api_key else copilot_auth.get_api_key()
         copilot_headers = get_copilot_default_headers(copilot_api_key)
         if extra_headers:
             copilot_headers.update(extra_headers)

--- a/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
@@ -31,6 +31,14 @@ from litellm.llms.github_copilot.common_utils import (
 )
 
 
+def _get_invoked_completion_kwargs(mock_class_completion, mock_instance_completion):
+    invoked = [m for m in (mock_class_completion, mock_instance_completion) if m.called]
+    assert len(invoked) == 1
+    invoked[0].assert_called_once()
+    _, kwargs = invoked[0].call_args
+    return kwargs
+
+
 def test_github_copilot_config_get_openai_compatible_provider_info():
     """Test the GitHub Copilot configuration provider info retrieval."""
 
@@ -41,9 +49,7 @@ def test_github_copilot_config_get_openai_compatible_provider_info():
     config.authenticator = MagicMock()
     config.authenticator.get_api_key.return_value = mock_api_key
     # Test with dynamic endpoint
-    config.authenticator.get_api_base.return_value = (
-        "https://api.enterprise.githubcopilot.com"
-    )
+    config.authenticator.get_api_base.return_value = "https://api.enterprise.githubcopilot.com"
 
     # Test with default values
     model = "github_copilot/gpt-4"
@@ -105,9 +111,7 @@ def test_github_copilot_config_get_openai_compatible_provider_info_explicit_api_
 
     config = GithubCopilotConfig()
     config.authenticator = MagicMock()
-    config.authenticator.get_api_base.return_value = (
-        "https://api.enterprise.githubcopilot.com"
-    )
+    config.authenticator.get_api_base.return_value = "https://api.enterprise.githubcopilot.com"
 
     explicit_api_key = "gh.explicit-account-key-456"
     (
@@ -124,8 +128,6 @@ def test_github_copilot_config_get_openai_compatible_provider_info_explicit_api_
     assert dynamic_api_key == explicit_api_key
     config.authenticator.get_api_key.assert_not_called()
 
-    # Even if the account's own Authenticator is completely broken, an
-    # explicit api_key must still get through rather than raising.
     config.authenticator.get_api_key.side_effect = GetAPIKeyError(
         message="Failed to get API key",
         status_code=401,
@@ -186,11 +188,7 @@ def test_completion_github_copilot_mock_response(
 
     assert mock_get_api_key.call_count >= 1
 
-    # Exactly one of the two patched targets should have been used.
-    invoked = [m for m in (mock_class_completion, mock_instance_completion) if m.called]
-    assert len(invoked) == 1
-    invoked[0].assert_called_once()
-    _, kwargs = invoked[0].call_args
+    kwargs = _get_invoked_completion_kwargs(mock_class_completion, mock_instance_completion)
 
     assert "headers" in kwargs
     assert kwargs.get("model") == "gpt-4"
@@ -232,14 +230,43 @@ def test_completion_github_copilot_explicit_api_key_bypasses_authenticator(
 
     assert response is not None
 
-    invoked = [m for m in (mock_class_completion, mock_instance_completion) if m.called]
-    assert len(invoked) == 1
-    _, kwargs = invoked[0].call_args
+    kwargs = _get_invoked_completion_kwargs(mock_class_completion, mock_instance_completion)
     assert kwargs["api_key"] == explicit_api_key
-    assert (
-        kwargs["optional_params"]["extra_headers"]["Authorization"]
-        == f"Bearer {explicit_api_key}"
+    assert kwargs["optional_params"]["extra_headers"]["Authorization"] == f"Bearer {explicit_api_key}"
+
+
+@patch("litellm.llms.github_copilot.authenticator.Authenticator.get_api_key")
+@patch("litellm.main.openai_chat_completions.completion")
+@patch("litellm.llms.openai.openai.OpenAIChatCompletion.completion")
+def test_completion_github_copilot_without_api_key_uses_authenticator_not_global_openai_key(
+    mock_class_completion, mock_instance_completion, mock_get_api_key, monkeypatch
+):
+    """A global OpenAI key must not be treated as an explicit Copilot api_key."""
+
+    monkeypatch.delenv("EXPERIMENTAL_OPENAI_BASE_LLM_HTTP_HANDLER", raising=False)
+    monkeypatch.setattr(litellm, "api_key", "sk-global-openai-key")
+    monkeypatch.setattr(litellm, "openai_key", None)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    copilot_api_key = "gh.authenticator-account-key-123"
+    mock_get_api_key.return_value = copilot_api_key
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = "Hello from the authenticator account!"
+    mock_class_completion.return_value = mock_response
+    mock_instance_completion.return_value = mock_response
+
+    response = completion(
+        model="github_copilot/gpt-4",
+        messages=[{"role": "user", "content": "Hello, who are you?"}],
     )
+
+    assert response is not None
+
+    kwargs = _get_invoked_completion_kwargs(mock_class_completion, mock_instance_completion)
+    assert kwargs["api_key"] == copilot_api_key
+    assert kwargs["optional_params"]["extra_headers"]["Authorization"] == f"Bearer {copilot_api_key}"
 
 
 def test_transform_messages_disable_copilot_system_to_assistant(monkeypatch):
@@ -257,25 +284,19 @@ def test_transform_messages_disable_copilot_system_to_assistant(monkeypatch):
             {"role": "system", "content": "System message."},
             {"role": "user", "content": "User message."},
         ]
-        out = config._transform_messages(
-            [m.copy() for m in messages], model="github_copilot/gpt-4"
-        )
+        out = config._transform_messages([m.copy() for m in messages], model="github_copilot/gpt-4")
         assert out[0]["role"] == "assistant"
         assert out[1]["role"] == "user"
 
         # Case 2: Flag is True (conversion does not happen)
         litellm.disable_copilot_system_to_assistant = True
-        out = config._transform_messages(
-            [m.copy() for m in messages], model="github_copilot/gpt-4"
-        )
+        out = config._transform_messages([m.copy() for m in messages], model="github_copilot/gpt-4")
         assert out[0]["role"] == "system"
         assert out[1]["role"] == "user"
 
         # Case 3: Flag is False again (conversion happens)
         litellm.disable_copilot_system_to_assistant = False
-        out = config._transform_messages(
-            [m.copy() for m in messages], model="github_copilot/gpt-4"
-        )
+        out = config._transform_messages([m.copy() for m in messages], model="github_copilot/gpt-4")
         assert out[0]["role"] == "assistant"
         assert out[1]["role"] == "user"
     finally:
@@ -480,9 +501,7 @@ def test_get_supported_openai_params_claude_model():
     assert "reasoning_effort" in supported_params
 
     # Test Claude 3-7 model supports thinking and reasoning_effort parameters
-    supported_params_claude37 = config.get_supported_openai_params(
-        "claude-3-7-sonnet-20250219"
-    )
+    supported_params_claude37 = config.get_supported_openai_params("claude-3-7-sonnet-20250219")
     assert "thinking" in supported_params_claude37
     assert "reasoning_effort" in supported_params_claude37
 
@@ -509,16 +528,12 @@ def test_get_supported_openai_params_case_insensitive():
     config = GithubCopilotConfig()
 
     # Test uppercase Claude 4 model with full model name
-    supported_params_upper = config.get_supported_openai_params(
-        "CLAUDE-SONNET-4-20250514"
-    )
+    supported_params_upper = config.get_supported_openai_params("CLAUDE-SONNET-4-20250514")
     assert "thinking" in supported_params_upper
     assert "reasoning_effort" in supported_params_upper
 
     # Test mixed case Claude 3-7 model (has extended thinking) with full model name
-    supported_params_mixed = config.get_supported_openai_params(
-        "Claude-3-7-Sonnet-20250219"
-    )
+    supported_params_mixed = config.get_supported_openai_params("Claude-3-7-Sonnet-20250219")
     assert "thinking" in supported_params_mixed
     assert "reasoning_effort" in supported_params_mixed
 
@@ -852,13 +867,8 @@ class TestGithubCopilotTransformResponse:
         assert result.choices[0].message.tool_calls is not None
         assert len(result.choices[0].message.tool_calls) == 1
         assert result.choices[0].message.tool_calls[0]["id"] == "toolu_01ABC"
-        assert (
-            result.choices[0].message.tool_calls[0]["function"]["name"] == "get_weather"
-        )
-        assert (
-            '"Boston, MA"'
-            in result.choices[0].message.tool_calls[0]["function"]["arguments"]
-        )
+        assert result.choices[0].message.tool_calls[0]["function"]["name"] == "get_weather"
+        assert '"Boston, MA"' in result.choices[0].message.tool_calls[0]["function"]["arguments"]
 
     def test_transform_response_anthropic_native_multiple_text_blocks(self):
         """All text blocks must be concatenated, not only the first."""
@@ -1026,12 +1036,8 @@ class TestGithubCopilotTransformParsedResponseDict:
 
 
 @patch("litellm.llms.openai.openai.OpenAIChatCompletion._get_openai_client")
-@patch(
-    "litellm.llms.openai.openai.OpenAIChatCompletion.make_sync_openai_chat_completion_request"
-)
-def test_openai_handler_repairs_github_copilot_empty_choices(
-    mock_request, mock_get_client
-):
+@patch("litellm.llms.openai.openai.OpenAIChatCompletion.make_sync_openai_chat_completion_request")
+def test_openai_handler_repairs_github_copilot_empty_choices(mock_request, mock_get_client):
     """
     The OpenAI SDK handler calls convert_to_model_response_object directly on the
     SDK's parsed output, bypassing transform_response. convert raises APIError on

--- a/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/test_github_copilot_transformation.py
@@ -93,6 +93,56 @@ def test_github_copilot_config_get_openai_compatible_provider_info():
     assert "Failed to get API key" in str(excinfo.value)
 
 
+def test_github_copilot_config_get_openai_compatible_provider_info_explicit_api_key():
+    """An explicit api_key must be honored instead of the account's own Authenticator.
+
+    This lets multiple GitHub Copilot accounts be run behind a single LiteLLM
+    instance (one deployment per account, each with its own api_key), the same
+    way api_base is already overridable. Before this behavior existed, a
+    deployment's explicit api_key was silently ignored in favor of whichever
+    account GITHUB_COPILOT_TOKEN_DIR pointed at.
+    """
+
+    config = GithubCopilotConfig()
+    config.authenticator = MagicMock()
+    config.authenticator.get_api_base.return_value = (
+        "https://api.enterprise.githubcopilot.com"
+    )
+
+    explicit_api_key = "gh.explicit-account-key-456"
+    (
+        _,
+        dynamic_api_key,
+        _,
+    ) = config._get_openai_compatible_provider_info(
+        model="github_copilot/gpt-4",
+        api_base=None,
+        api_key=explicit_api_key,
+        custom_llm_provider="github_copilot",
+    )
+
+    assert dynamic_api_key == explicit_api_key
+    config.authenticator.get_api_key.assert_not_called()
+
+    # Even if the account's own Authenticator is completely broken, an
+    # explicit api_key must still get through rather than raising.
+    config.authenticator.get_api_key.side_effect = GetAPIKeyError(
+        message="Failed to get API key",
+        status_code=401,
+    )
+    (
+        _,
+        dynamic_api_key,
+        _,
+    ) = config._get_openai_compatible_provider_info(
+        model="github_copilot/gpt-4",
+        api_base=None,
+        api_key=explicit_api_key,
+        custom_llm_provider="github_copilot",
+    )
+    assert dynamic_api_key == explicit_api_key
+
+
 @patch("litellm.llms.github_copilot.authenticator.Authenticator.get_api_key")
 @patch("litellm.main.openai_chat_completions.completion")
 @patch("litellm.llms.openai.openai.OpenAIChatCompletion.completion")
@@ -145,6 +195,51 @@ def test_completion_github_copilot_mock_response(
     assert "headers" in kwargs
     assert kwargs.get("model") == "gpt-4"
     assert kwargs.get("messages") == messages
+
+
+@patch("litellm.llms.github_copilot.authenticator.Authenticator.get_api_key")
+@patch("litellm.main.openai_chat_completions.completion")
+@patch("litellm.llms.openai.openai.OpenAIChatCompletion.completion")
+def test_completion_github_copilot_explicit_api_key_bypasses_authenticator(
+    mock_class_completion, mock_instance_completion, mock_get_api_key, monkeypatch
+):
+    """An explicit api_key on the completion call must reach the outgoing
+    Authorization header even if the account's own Authenticator is
+    completely broken. This is what lets a second GitHub Copilot account's
+    deployment keep working even if the first account's Authenticator fails.
+    """
+
+    monkeypatch.delenv("EXPERIMENTAL_OPENAI_BASE_LLM_HTTP_HANDLER", raising=False)
+
+    mock_get_api_key.side_effect = GetAPIKeyError(
+        message="Failed to get API key",
+        status_code=401,
+    )
+
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = "Hello from the second account!"
+    mock_class_completion.return_value = mock_response
+    mock_instance_completion.return_value = mock_response
+
+    explicit_api_key = "gh.second-account-key-789"
+
+    response = completion(
+        model="github_copilot/gpt-4",
+        messages=[{"role": "user", "content": "Hello, who are you?"}],
+        api_key=explicit_api_key,
+    )
+
+    assert response is not None
+
+    invoked = [m for m in (mock_class_completion, mock_instance_completion) if m.called]
+    assert len(invoked) == 1
+    _, kwargs = invoked[0].call_args
+    assert kwargs["api_key"] == explicit_api_key
+    assert (
+        kwargs["optional_params"]["extra_headers"]["Authorization"]
+        == f"Bearer {explicit_api_key}"
+    )
 
 
 def test_transform_messages_disable_copilot_system_to_assistant(monkeypatch):


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Before this change, `github_copilot` ignored an explicit `api_key` in the chat-completion request header path and used the local Copilot `Authenticator` instead. That made `api_key` behave differently from `api_base`, which was already overridable

Before fix, commit `10d5804b3ef4ead5abb77c3f5fafdd0c0159de0f`: an invalid explicit key is ignored and the local authenticator succeeds

```bash
GITHUB_COPILOT_TOKEN_DIR=/tmp/primary_account uv run python3 -c "
import litellm
resp = litellm.completion(
    model='github_copilot/claude-haiku-4.5',
    api_key='definitely-garbage-should-be-rejected',
    messages=[{'role': 'user', 'content': 'reply with just: BEFORE_FIX_BUG_CONFIRMED'}],
    max_tokens=10,
)
print(resp.choices[0].message.content)
"
```

Output:

```text
BEFORE_FIX_BUG_CONFIRMED
```

After fix, commit `fd65df1097f40cf1c935eb4f8fd3f26f4532feaf`: the same invalid explicit key is sent to GitHub Copilot and rejected instead of falling back to the local authenticator

```bash
GITHUB_COPILOT_TOKEN_DIR=/tmp/primary_account uv run python3 -c "
import litellm
litellm.completion(
    model='github_copilot/claude-haiku-4.5',
    api_key='definitely-garbage-should-be-rejected',
    messages=[{'role': 'user', 'content': 'ok'}],
    max_tokens=10,
)
"
```

Output:

```text
litellm.BadRequestError: Github_copilotException - bad request: Authorization header is badly formatted
```

Also verified that when no explicit `api_key` is provided, the existing local Copilot authenticator path is preserved. A unit regression now covers this case with a global OpenAI key set, so `litellm.api_key` is not accidentally treated as a GitHub Copilot token

## Type

Bug Fix
Test

## Changes

This makes GitHub Copilot honor explicitly configured `api_key` values in both places that resolve provider credentials: `GithubCopilotConfig._get_openai_compatible_provider_info` and the `github_copilot` header setup in `_complete_custom_openai`

The default path is unchanged when no explicit key is passed: Copilot still uses `Authenticator().get_api_key()`. The completion path now preserves the originally supplied key before generic OpenAI fallback fills in `litellm.api_key`, `litellm.openai_key`, or `OPENAI_API_KEY`, so unrelated OpenAI credentials are not sent as Copilot tokens

Tests cover explicit key precedence, broken-authenticator bypass when an explicit key exists, and authenticator fallback when no explicit key exists
