### PR TITLE
fix(s3): sanitize slashes in response-id-derived object key file name

### DIFF
--- a/litellm/integrations/s3.py
+++ b/litellm/integrations/s3.py
@@ -161,8 +161,13 @@ def get_s3_object_key(
     start_time: datetime,
     s3_file_name: str,
 ) -> str:
+    sanitized_s3_file_name = s3_file_name.replace("/", "_")
     s3_object_key = (
-        (s3_path.rstrip("/") + "/" if s3_path else "") + prefix + start_time.strftime("%Y-%m-%d") + "/" + s3_file_name
+        (s3_path.rstrip("/") + "/" if s3_path else "")
+        + prefix
+        + start_time.strftime("%Y-%m-%d")
+        + "/"
+        + sanitized_s3_file_name
     )  # we need the s3 key to include the time, so we log cache hits too
     s3_object_key += ".json"
     return s3_object_key

--- a/tests/test_litellm/integrations/test_s3_v2.py
+++ b/tests/test_litellm/integrations/test_s3_v2.py
@@ -1125,6 +1125,47 @@ async def test_combined_prefix_reflects_in_s3_object_key():
     assert "myteam/apikey/" in key, f"Expected both prefixes in key: {key}"
 
 
+def test_s3_object_key_sanitizes_slashes_in_file_name():
+    """Response ids containing slashes (e.g. bedrock batch job ARNs) must not
+    create nested S3 folders; only path/prefix/date slashes are separators."""
+    from litellm.integrations.s3 import get_s3_object_key
+
+    start_time = datetime(2026, 2, 11, 0, 35, 18, 391582)
+    file_name = "time-00-35-18-391582_arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/gl18r6skk9yy"
+
+    key = get_s3_object_key(
+        s3_path="LiteLLMAPPLogs",
+        prefix="myteam/",
+        start_time=start_time,
+        s3_file_name=file_name,
+    )
+
+    assert key == (
+        "LiteLLMAPPLogs/myteam/2026-02-11/"
+        "time-00-35-18-391582_arn:aws:bedrock:us-east-1:123456789012:model-invocation-job_gl18r6skk9yy.json"
+    )
+
+
+def test_create_s3_batch_logging_element_flat_key_for_arn_response_id():
+    """End-to-end through the s3_v2 element builder: an ARN response id must
+    yield a flat file directly under the date segment."""
+    logger = S3Logger(s3_use_team_prefix=False, s3_use_key_prefix=False)
+    payload = StandardLoggingPayload(
+        id="arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/gl18r6skk9yy",
+        metadata={},
+        messages=[],
+    )
+
+    start_time = datetime(2026, 2, 11, 0, 35, 18, 391582)
+    result = logger.create_s3_batch_logging_element(start_time, payload)
+
+    assert result is not None
+    date_segment = "2026-02-11/"
+    file_segment = result.s3_object_key.split(date_segment, 1)[1]
+    assert "/" not in file_segment, f"Expected flat file under date segment, got: {result.s3_object_key}"
+    assert file_segment.endswith("model-invocation-job_gl18r6skk9yy.json")
+
+
 # --------------------------------------------------------------
 # params_source / s3_callback_params_override (audit-log decoupling)
 # --------------------------------------------------------------


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-1891

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Bedrock batch operations use the model invocation job ARN as the response id, and reproducing that end to end needs a live `model-invocation-job` in an AWS account, so the repro instead runs a real proxy with the `s3_v2` callback pointed at a local MinIO and a local OpenAI-compatible stub whose only job is to return a response id with the exact ARN shape the bedrock batch handler emits (`id=job_arn`, see `litellm/llms/bedrock/batches/handler.py` and `transformation.py`). Everything downstream of the response id, which is the entire code path this PR touches (`get_logging_id` -> `get_s3_object_key` -> S3 PUT), is fully live: real proxy on a Postgres-backed instance, real SigV4-signed uploads to a real S3-compatible store

Config used (`s3_callback_params` pointing at MinIO on `localhost:9020`, one `bedrock-batch-sim` deployment pointing at the stub):

```yaml
litellm_settings:
  success_callback: ["s3_v2"]
  s3_callback_params:
    s3_bucket_name: litellm-logs
    s3_region_name: us-east-1
    s3_endpoint_url: http://localhost:9020
    s3_path: LiteLLMAPPLogs
```

Before (captured at base commit `edd3bce0ec`):

```
$ curl -sS http://localhost:4019/v1/chat/completions \
    -H "Authorization: Bearer sk-1891-master" -H "Content-Type: application/json" \
    -d '{"model":"bedrock-batch-sim","messages":[{"role":"user","content":"hi"}]}' | jq .id
"arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/gl18r6skk9yy"

# S3 listing with Delimiter="/" under the date prefix
files directly under the date prefix: []
nested folders under the date prefix: ['LiteLLMAPPLogs/2026-07-14/time-13-53-57-911051_arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/']
```

The log landed at `LiteLLMAPPLogs/2026-07-14/time-13-53-57-911051_arn:aws:bedrock:us-east-1:123456789012:model-invocation-job/gl18r6skk9yy.json`, i.e. an unintended `model-invocation-job/` folder and zero flat files under the date directory

After (captured at `4e4f8853cf`, same request against a fresh bucket):

```
all keys: ['LiteLLMAPPLogs/2026-07-14/time-14-05-08-581195_arn:aws:bedrock:us-east-1:123456789012:model-invocation-job_gl18r6skk9yy.json']
flat files under date prefix: ['LiteLLMAPPLogs/2026-07-14/time-14-05-08-581195_arn:aws:bedrock:us-east-1:123456789012:model-invocation-job_gl18r6skk9yy.json']
nested folders under date prefix: []
```

The object is also retrievable by the sanitized key and the payload inside still carries the raw ARN id untouched; only the storage key is sanitized

## Type

🐛 Bug Fix

## Changes

`get_s3_object_key()` in `litellm/integrations/s3.py` now replaces `/` with `_` in the file-name segment before joining it into the object key. The path components that are supposed to contain slashes (`s3_path`, team and key alias prefixes, the date directory) are untouched

This one function is the choke point for all three S3 key producers: the legacy `s3` logger, `s3_v2`, and the cold-storage object key generated in `litellm_core_utils/litellm_logging.py`. Cold-storage read-back uses the key stored at write time (it is never re-derived from the response id), so writes and reads stay consistent and rows written before this fix keep resolving through their stored keys

The existing `sanitize_cloud_object_component` helper was considered and rejected: it applies `posixpath.basename()` first, which would collapse an ARN-derived file name to just the trailing job id and change keys for ids that contain no slash at all. The minimal replace keeps every slash-free id byte-identical to before, which the regression test asserts exactly

Two regression tests are added to `tests/test_litellm/integrations/test_s3_v2.py` (there is no mapped `test_s3.py`, and this file already exercises `get_s3_object_key`): a direct assertion on the produced key for an ARN file name, and an end-to-end check through `create_s3_batch_logging_element` that the segment after the date prefix contains no `/`. Both fail on the unfixed code and pass with the fix

## Behavior changes

S3 and cold-storage object keys for response ids that contain `/` (bedrock batch job ARNs) change from a nested layout to a flat file with `_` substituted, which is the fix this ticket asks for. Ids without slashes produce byte-identical keys, so no other key changes. Objects written before this fix remain retrievable because cold-storage lookups use the stored key

The same slash-in-id defect class exists in separate copies out of this PR's scope: the GCS bucket logger (which also re-derives names on read-back, so it needs a coordinated write/read fix), the Azure blob storage logger, and the `Content-Disposition` download filename built from the raw payload id in both s3 loggers. Tracked in LIT-4431

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
