### PR TITLE
test(bedrock): make agentcore invocation tests hermetic after AWS MMDSv2 enforcement

### DIFF
--- a/tests/llm_translation/test_bedrock_agentcore.py
+++ b/tests/llm_translation/test_bedrock_agentcore.py
@@ -2,6 +2,7 @@
 Test Bedrock AgentCore integration
 """
 
+import json
 import os
 import sys
 from dotenv import load_dotenv
@@ -11,61 +12,130 @@ load_dotenv()
 sys.path.insert(0, os.path.abspath("../.."))
 
 import litellm
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import pytest
 import httpx
 
+AGENTCORE_TEST_MODEL = "bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/hosted_agent_test-MockedRt"
+
+FAKE_AWS_CREDS = {
+    "aws_access_key_id": "fake-access-key-id",
+    "aws_secret_access_key": "fake-secret-access-key",
+    "aws_region_name": "us-west-2",
+}
+
+AGENTCORE_ANSWER = "Machine learning is pattern matching at scale."
+
+AGENTCORE_SSE_BODY = (
+    'data: {"event":{"contentBlockDelta":{"delta":{"text":"Machine learning is "}}}}\n\n'
+    'data: {"event":{"contentBlockDelta":{"delta":{"text":"pattern matching at scale."}}}}\n\n'
+    'data: {"event":{"metadata":{"usage":{"inputTokens":12,"outputTokens":9,"totalTokens":21}}}}\n\n'
+    'data: {"message":{"role":"assistant","content":[{"text":"Machine learning is pattern matching at scale."}]}}\n'
+)
+
+
+def _json_invocation_response() -> Mock:
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.json.return_value = {
+        "result": {"role": "assistant", "content": [{"text": AGENTCORE_ANSWER}]}
+    }
+    return mock_response
+
+
+def _sse_invocation_response() -> Mock:
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "text/event-stream"}
+    mock_response.text = AGENTCORE_SSE_BODY
+    return mock_response
+
+
+class _FakeAsyncByteStream(httpx.AsyncByteStream):
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    async def __aiter__(self):
+        yield self._payload
+
 
 @pytest.mark.parametrize(
-    "model",
-    [
-        "bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/hosted_agent_13sf6-cALnp38iZD",  # non-streaming invocation
-        "bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/hosted_agent_r9jvp-3ySZuRHjLC",  # streaming invocation
-    ],
+    "mock_response_factory,expected_total_tokens",
+    [(_json_invocation_response, None), (_sse_invocation_response, 21)],
+    ids=["json_invocation", "sse_invocation"],
 )
-def test_bedrock_agentcore_basic(model):
+def test_bedrock_agentcore_basic(mock_response_factory, expected_total_tokens, monkeypatch):
     """
-    Test AgentCore invocation parameterized by model
+    Test AgentCore invocation parameterized by the response shape the runtime returns
     """
-    litellm._turn_on_debug()
-    response = litellm.completion(
-        model=model,
-        messages=[
-            {"role": "user", "content": "Explain machine learning in simple terms"}
-        ],
-    )
-    print("response from agentcore=", response.model_dump_json(indent=4))
-    # Assert that the message content has a response with some length
-    assert response.choices[0].message.content
-    assert len(response.choices[0].message.content) > 0
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+    client = HTTPHandler()
+    with patch.object(client, "post", return_value=mock_response_factory()) as mock_post:
+        response = litellm.completion(
+            model=AGENTCORE_TEST_MODEL,
+            messages=[
+                {"role": "user", "content": "Explain machine learning in simple terms"}
+            ],
+            client=client,
+            **FAKE_AWS_CREDS,
+        )
+
+    mock_post.assert_called_once()
+    request_body = json.loads(mock_post.call_args.kwargs["data"])
+    assert request_body == {"prompt": "Explain machine learning in simple terms"}
+    assert "AWS4-HMAC-SHA256" in mock_post.call_args.kwargs["headers"]["Authorization"]
+    assert response.choices[0].message.content == AGENTCORE_ANSWER
+    assert response.choices[0].finish_reason == "stop"
+    if expected_total_tokens is None:
+        assert response.usage.total_tokens > 0
+    else:
+        assert response.usage.total_tokens == expected_total_tokens
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "model",
-    [
-        "bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/hosted_agent_13sf6-cALnp38iZD",  # streaming invocation
-    ],
-)
-async def test_bedrock_agentcore_with_streaming(model):
+async def test_bedrock_agentcore_with_streaming(monkeypatch):
     """
     Test AgentCore with streaming
     """
-    print("running streming test for model=", model)
-    # litellm._turn_on_debug()
-    response = await litellm.acompletion(
-        model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/hosted_agent_r9jvp-3ySZuRHjLC",
-        messages=[
-            {
-                "role": "user",
-                "content": "Explain machine learning in simple terms",
-            }
-        ],
-        stream=True,
-    )
+    from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 
-    async for chunk in response:
-        print("chunk=", chunk)
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+    client = AsyncHTTPHandler()
+    streaming_response = httpx.Response(
+        status_code=200,
+        headers={"content-type": "text/event-stream"},
+        stream=_FakeAsyncByteStream(AGENTCORE_SSE_BODY.encode()),
+        request=httpx.Request("POST", "https://bedrock-agentcore.us-west-2.amazonaws.com"),
+    )
+    with patch.object(
+        client, "post", new=AsyncMock(return_value=streaming_response)
+    ) as mock_post:
+        response = await litellm.acompletion(
+            model=AGENTCORE_TEST_MODEL,
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Explain machine learning in simple terms",
+                }
+            ],
+            stream=True,
+            client=client,
+            **FAKE_AWS_CREDS,
+        )
+        chunks = [chunk async for chunk in response]
+
+    mock_post.assert_called_once()
+    assert mock_post.call_args.kwargs["stream"] is True
+    streamed_content = "".join(
+        chunk.choices[0].delta.content or "" for chunk in chunks if chunk.choices
+    )
+    assert streamed_content == AGENTCORE_ANSWER
+    assert any(
+        chunk.choices[0].finish_reason == "stop" for chunk in chunks if chunk.choices
+    )
 
 
 def test_bedrock_agentcore_with_custom_params():
@@ -336,15 +406,14 @@ def test_bedrock_agentcore_with_all_parameters():
         assert request_data["prompt"] == "Complete test"
 
 
-def test_bedrock_agentcore_without_api_key_uses_sigv4():
+def test_bedrock_agentcore_without_api_key_uses_sigv4(monkeypatch):
     """
     Test that AgentCore uses AWS SigV4 signing when api_key is not provided
     """
-    import json
-
-    litellm._turn_on_debug()
     from litellm.llms.custom_httpx.http_handler import HTTPHandler
 
+    litellm._turn_on_debug()
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
     client = HTTPHandler()
 
     with patch.object(client, "post", return_value=MagicMock()) as mock_post:
@@ -357,9 +426,9 @@ def test_bedrock_agentcore_without_api_key_uses_sigv4():
                         "content": "Test SigV4",
                     }
                 ],
-                # No api_key provided - should use SigV4
                 runtimeSessionId="sigv4-test-session",
                 client=client,
+                **FAKE_AWS_CREDS,
             )
         except Exception as e:
             print(f"Error: {e}")
@@ -368,18 +437,14 @@ def test_bedrock_agentcore_without_api_key_uses_sigv4():
         call_kwargs = mock_post.call_args.kwargs
         print(f"mock_post.call_args.kwargs: {call_kwargs}")
 
-        # Verify headers - should have AWS SigV4 headers, not Bearer token
         assert "headers" in call_kwargs
         headers = call_kwargs["headers"]
         print(f"Headers: {headers}")
 
-        # Should NOT have Bearer Authorization when using SigV4
-        if "Authorization" in headers:
-            assert not headers["Authorization"].startswith("Bearer ")
-            # Should have AWS4-HMAC-SHA256 signature
-            assert "AWS4-HMAC-SHA256" in headers["Authorization"]
+        assert "Authorization" in headers
+        assert not headers["Authorization"].startswith("Bearer ")
+        assert "AWS4-HMAC-SHA256" in headers["Authorization"]
 
-        # Session ID should still be present
         assert "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id" in headers
         assert (
             headers["X-Amzn-Bedrock-AgentCore-Runtime-Session-Id"]


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before, captured at `ce3bf2d839` (PR #33274): [job 2089381](https://app.circleci.com/pipelines/github/BerriAI/litellm/87638/workflows/bd72a6b3-d08b-416c-8d62-af15a5d18897/jobs/2089381) fails `llm_translation_testing` on the three `test_bedrock_agentcore` live tests, all raising

```
litellm.exceptions.BadRequestError: litellm.BadRequestError: BedrockException - b'{"fieldList":null,"message":"This runtime is not MMDSv2-enabled and can no longer be invoked. Enable MMDSv2 by calling UpdateAgentRuntime with requireMMDSV2=True in metadataConfiguration.","reason":null}'
```

This reproduces on every pipeline since 2026-07-14 17:44 UTC regardless of branch content (last green job 2087374 started 17:39 UTC, first red job 2087496 started 17:44 UTC; pipelines 87598 through 87638 all show the identical three failures). AWS now rejects invocations of AgentCore runtimes that do not have MMDSv2 enabled ([AWS docs](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-troubleshooting.html)) and both hosted agent runtimes these tests invoke predate that requirement, so they are disabled server-side and no live invocation of them can succeed from any commit until they are updated in AWS

The after proof, captured at `87de8fd5cc`, is therefore the `llm_translation_testing` check on this PR going green ([job 2089721](https://circleci.com/gh/BerriAI/litellm/2089721), success) while the same check is red on every other pipeline since 17:44 UTC. Full RCA with the first-red/last-green bisect and the runtime re-enable runbook: [RCA - AWS MMDSv2 enforcement bricked the AgentCore CI runtimes](https://app.notion.com/p/39d43b8acdab813bb83dc375b341499f)

## Type

✅ Test

## Changes

AWS began enforcing MMDSv2 on Bedrock AgentCore runtimes, which turned the three tests in `tests/llm_translation/test_bedrock_agentcore.py` that live-invoke two hand-provisioned runtimes in the CI account into deterministic failures on every pipeline, blocking all PRs on a required check

This PR rewrites those three tests as mocked invocations that pin the same contract the live calls exercised: the request payload shape (`{"prompt": ...}`), SigV4 signing of the request, JSON and SSE response parsing on the sync completion path (including usage extraction from SSE metadata versus the token-counter fallback for JSON bodies), and SSE chunk assembly plus stop signaling on the async streaming path

It also makes `test_bedrock_agentcore_without_api_key_uses_sigv4` deterministic. It previously took the Bearer path whenever `AWS_BEARER_TOKEN_BEDROCK` was set in the runner environment and its Authorization assertions sat inside an `if`, so it silently asserted nothing; it now clears that env var, passes static test credentials, and asserts the SigV4 signature unconditionally

Update: MMDSv2 has since been enabled on both runtimes via `aws bedrock-agentcore-control update-agent-runtime` and real litellm invocations of each (non-streaming and streaming) verified working again, so live coverage can be restored in a follow-up, ideally as a nightly/e2e job rather than a PR-gating check so provider-side lifecycle events cannot block merges again; details in the RCA linked above

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
