### PR TITLE
fix(mcp): persist discovered OAuth endpoints and keep last known good on failed re-discovery

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -1133,7 +1133,6 @@ async def _persist_dcr_client_registration(
                 credentials=credentials,
                 oauth2_flow="authorization_code",
                 **({"token_url": mcp_server.token_url} if mcp_server.token_url else {}),
-                **({"authorization_url": mcp_server.authorization_url} if mcp_server.authorization_url else {}),
             ),
             touched_by="mcp_oauth_dcr",
         )

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -1133,6 +1133,7 @@ async def _persist_dcr_client_registration(
                 credentials=credentials,
                 oauth2_flow="authorization_code",
                 **({"token_url": mcp_server.token_url} if mcp_server.token_url else {}),
+                **({"authorization_url": mcp_server.authorization_url} if mcp_server.authorization_url else {}),
             ),
             touched_by="mcp_oauth_dcr",
         )

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -193,7 +193,11 @@ def _carry_forward_resolved_oauth_endpoints(new_server: MCPServer, previous_serv
     during re-discovery downgrades a working server (``authorization_url`` set) to a broken one
     (``None``, /authorize 400s) with no configuration change. Mirrors the ``short_prefix``
     carry-forward. Skipped when the server's ``url`` or ``auth_type`` changed, since the previous
-    endpoints may then belong to a different upstream.
+    endpoints may then belong to a different upstream. ``registration_url`` IS carried here even
+    though ``_persist_discovered_oauth_endpoints`` refuses to write it to the row: carrying only
+    restores the same in-memory value the previous build already ran with, while persisting it
+    would flip ``_dcr_bridge_relays_client_registration`` (which keys off the stored column) for
+    dcr_bridge servers that never had one configured.
     """
     if previous_server is None:
         return
@@ -3099,7 +3103,7 @@ class MCPServerManager:
 
             return metadata
         except Exception as exc:  # pragma: no cover - network/transient issues
-            verbose_logger.warning("MCP OAuth discovery failed for %s: %s", server_url, exc)
+            verbose_logger.debug("MCP OAuth discovery failed for %s: %s", server_url, exc)
             return None
 
     def _parse_www_authenticate_header(self, header_value: Optional[str]) -> tuple[Optional[str], Optional[list[str]]]:

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -186,6 +186,29 @@ _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES: tuple[MCPAuth, ...] = (
 )
 
 
+def _carry_forward_resolved_oauth_endpoints(new_server: MCPServer, previous_server: MCPServer | None) -> None:
+    """Keep the last known good OAuth endpoints when a rebuild's re-discovery comes back empty.
+
+    A rebuild wholesale-replaces the registry entry, so without this a transient upstream outage
+    during re-discovery downgrades a working server (``authorization_url`` set) to a broken one
+    (``None``, /authorize 400s) with no configuration change. Mirrors the ``short_prefix``
+    carry-forward. Skipped when the server's ``url`` or ``auth_type`` changed, since the previous
+    endpoints may then belong to a different upstream.
+    """
+    if previous_server is None:
+        return
+    if previous_server.url != new_server.url or previous_server.auth_type != new_server.auth_type:
+        return
+    if new_server.authorization_url is None and previous_server.authorization_url:
+        new_server.authorization_url = previous_server.authorization_url
+    if new_server.token_url is None and previous_server.token_url:
+        new_server.token_url = previous_server.token_url
+    if new_server.registration_url is None and previous_server.registration_url:
+        new_server.registration_url = previous_server.registration_url
+    if not new_server.scopes and previous_server.scopes:
+        new_server.scopes = previous_server.scopes
+
+
 def invalidate_user_env_vars_cache(user_id: str, server_id: str) -> None:
     """Drop a cached entry after the user stores or clears their env var values
     so the next request reads the fresh value instead of a stale one."""
@@ -1343,6 +1366,7 @@ class MCPServerManager:
         *,
         credentials_are_encrypted: bool = True,
         env_vars_are_encrypted: Optional[bool] = None,
+        persist_discovered_endpoints: bool = True,
     ) -> MCPServer:
         _mcp_info: MCPInfo = mcp_server.mcp_info or {}
         env_dict = _deserialize_json_dict(getattr(mcp_server, "env", None))
@@ -1436,6 +1460,13 @@ class MCPServerManager:
             if needs_discovery
             else None
         )
+        if needs_discovery and mcp_oauth_metadata is None:
+            verbose_logger.warning(
+                "MCP OAuth discovery yielded no metadata for server %s (%s); "
+                "OAuth endpoints stay unresolved until a rebuild succeeds",
+                mcp_server.server_id,
+                server_url,
+            )
 
         resolved_scopes = scopes or (mcp_oauth_metadata.scopes if mcp_oauth_metadata else None)
 
@@ -1506,12 +1537,21 @@ class MCPServerManager:
             max_concurrent_requests=getattr(mcp_server, "max_concurrent_requests", None),
         )
         _warn_internal_delegate_pkce_if_applicable(new_server, source="database")
-        await self._persist_discovered_obo_token_url(
-            server_id=mcp_server.server_id,
-            auth_type=auth_type,
-            existing_token_url=mcp_server.token_url,
-            discovered_token_url=new_server.token_url,
-        )
+        if persist_discovered_endpoints:
+            await self._persist_discovered_obo_token_url(
+                server_id=mcp_server.server_id,
+                auth_type=auth_type,
+                existing_token_url=mcp_server.token_url,
+                discovered_token_url=new_server.token_url,
+            )
+            await self._persist_discovered_oauth_endpoints(
+                server_id=mcp_server.server_id,
+                auth_type=auth_type,
+                existing_authorization_url=mcp_server.authorization_url,
+                existing_token_url=mcp_server.token_url,
+                existing_scopes=scopes,
+                metadata=mcp_oauth_metadata,
+            )
         return new_server
 
     async def _persist_discovered_obo_token_url(
@@ -1548,6 +1588,69 @@ class MCPServerManager:
             verbose_logger.debug("Persisted discovered OBO token_url for MCP server %s", server_id)
         except Exception as exc:  # noqa: BLE001 - best-effort; a failed write re-discovers next build
             verbose_logger.warning("Failed to persist discovered OBO token_url for MCP server %s: %s", server_id, exc)
+
+    async def _persist_discovered_oauth_endpoints(
+        self,
+        *,
+        server_id: str,
+        auth_type: MCPAuthType | None,
+        existing_authorization_url: str | None,
+        existing_token_url: str | None,
+        existing_scopes: list[str] | None,
+        metadata: MCPOAuthMetadata | None,
+    ) -> None:
+        """Write freshly discovered OAuth endpoints back onto the DB row.
+
+        Same rationale as ``_persist_discovered_obo_token_url`` but for the interactive oauth2
+        family: discovered ``authorization_url``/``token_url``/``scopes`` otherwise live only on
+        the in-memory registry entry, which is rebuilt on every client connect (the DCR reuse path
+        calls ``update_server``) and on every post-write DB reload, so one failed re-discovery
+        serves 400 "authorization url is not set" from /authorize until a later rebuild succeeds.
+        Only fills row fields that are currently empty, never persists origin-fallback guesses
+        (RFC 9728/8414-advertised metadata only), and deliberately skips ``registration_url``
+        because ``_dcr_bridge_relays_client_registration`` keys off that column. Best-effort: a
+        failed write re-discovers on the next build. Scopes go through ``update_mcp_server`` so
+        they merge into the credentials blob without touching the stored client credentials.
+        """
+        if auth_type not in _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES:
+            return
+        if metadata is None or metadata.from_origin_fallback:
+            return
+        authorization_url_update = (
+            {"authorization_url": metadata.authorization_url}
+            if metadata.authorization_url and not existing_authorization_url
+            else {}
+        )
+        token_url_update = {"token_url": metadata.token_url} if metadata.token_url and not existing_token_url else {}
+        scopes_update = {"credentials": {"scopes": metadata.scopes}} if metadata.scopes and not existing_scopes else {}
+        updates: dict[str, object] = {**authorization_url_update, **token_url_update, **scopes_update}
+        if not updates:
+            return
+        from litellm.proxy._experimental.mcp_server.db import (  # noqa: PLC0415  # db.py imports this module at load
+            update_mcp_server,
+        )
+        from litellm.proxy._types import UpdateMCPServerRequest  # noqa: PLC0415  # heavy module; import at call time
+        from litellm.proxy.proxy_server import prisma_client  # noqa: PLC0415  # runtime value, set after startup
+
+        if prisma_client is None:
+            return
+        try:
+            await update_mcp_server(
+                prisma_client=prisma_client,
+                data=UpdateMCPServerRequest.model_validate({"server_id": server_id, **updates}),
+                touched_by="mcp_oauth_discovery",
+            )
+            verbose_logger.info(
+                "Persisted discovered OAuth endpoints for MCP server %s: %s",
+                server_id,
+                sorted(updates),
+            )
+        except Exception as exc:  # noqa: BLE001 - best-effort; a failed write re-discovers next build
+            verbose_logger.warning(
+                "Failed to persist discovered OAuth endpoints for MCP server %s: %s",
+                server_id,
+                exc,
+            )
 
     async def _maybe_register_openapi_tools(self, server: MCPServer, *, initialize_mapping: bool = True):
         """Register OpenAPI tools if the server has a spec_path configured."""
@@ -1607,6 +1710,10 @@ class MCPServerManager:
                 existing_prefix = self.registry[mcp_server.server_id].short_prefix
                 if existing_prefix and not new_server.short_prefix:
                     new_server.short_prefix = existing_prefix
+                _carry_forward_resolved_oauth_endpoints(
+                    new_server=new_server,
+                    previous_server=self.registry[mcp_server.server_id],
+                )
                 self._assign_unique_short_prefix(new_server)
                 self.registry[mcp_server.server_id] = new_server
                 await self._maybe_register_openapi_tools(new_server)
@@ -2969,16 +3076,20 @@ class MCPServerManager:
                 ) = await self._attempt_well_known_discovery(server_url)
 
             metadata = None
+            used_origin_fallback = False
             if allow_origin_fallback and not authorization_servers:
                 try:
                     parsed_url = urlparse(server_url)
                     if parsed_url.scheme and parsed_url.netloc:
                         authorization_servers = [f"{parsed_url.scheme}://{parsed_url.netloc}"]
+                        used_origin_fallback = True
                 except Exception:
                     authorization_servers = []
 
             if authorization_servers:
                 metadata = await self._fetch_authorization_server_metadata(authorization_servers, server_url)
+                if metadata is not None and used_origin_fallback:
+                    metadata.from_origin_fallback = True
 
             preferred_scopes = scopes or resource_scopes
             if metadata is None and preferred_scopes:
@@ -2988,7 +3099,7 @@ class MCPServerManager:
 
             return metadata
         except Exception as exc:  # pragma: no cover - network/transient issues
-            verbose_logger.debug("MCP OAuth discovery failed for %s: %s", server_url, exc)
+            verbose_logger.warning("MCP OAuth discovery failed for %s: %s", server_url, exc)
             return None
 
     def _parse_www_authenticate_header(self, header_value: Optional[str]) -> tuple[Optional[str], Optional[list[str]]]:
@@ -4489,6 +4600,7 @@ class MCPServerManager:
                 # (if any) so the prefix is stable across reloads.
                 if existing_server is not None and existing_server.short_prefix:
                     new_server.short_prefix = existing_server.short_prefix
+                _carry_forward_resolved_oauth_endpoints(new_server=new_server, previous_server=existing_server)
                 new_registry[server.server_id] = new_server
             except Exception as e:
                 verbose_logger.exception(

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -1475,6 +1475,7 @@ if MCP_AVAILABLE:
             temporary_server = await global_mcp_server_manager.build_mcp_server_from_table(
                 temp_record,
                 credentials_are_encrypted=False,
+                persist_discovered_endpoints=False,
             )
             _cache_temporary_mcp_server(
                 temporary_server,

--- a/litellm/types/mcp_server/mcp_server_manager.py
+++ b/litellm/types/mcp_server/mcp_server_manager.py
@@ -20,6 +20,10 @@ class MCPOAuthMetadata(BaseModel):
     authorization_url: Optional[str] = None
     token_url: Optional[str] = None
     registration_url: Optional[str] = None
+    from_origin_fallback: bool = False
+    """True when the metadata came from guessing the resource origin as its authorization
+    server rather than from an RFC 9728/8414-advertised document. Guessed endpoints are
+    usable in memory but must never be persisted as configuration."""
 
 
 class MCPServer(BaseModel):

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -657,6 +657,7 @@ async def test_register_client_persists_dcr_client_identity():
     update_data = mock_update.call_args.kwargs["data"]
     assert update_data.server_id == "remote_server"
     assert update_data.token_url == "https://provider.example/oauth/token"
+    assert update_data.authorization_url == "https://provider.example/oauth/authorize"
     assert update_data.credentials["client_id"] == "generated-client"
     assert update_data.credentials["client_secret"] == "generated-secret"
     assert update_data.credentials["token_endpoint_auth_method"] == "client_secret_basic"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -657,7 +657,7 @@ async def test_register_client_persists_dcr_client_identity():
     update_data = mock_update.call_args.kwargs["data"]
     assert update_data.server_id == "remote_server"
     assert update_data.token_url == "https://provider.example/oauth/token"
-    assert update_data.authorization_url == "https://provider.example/oauth/authorize"
+    assert "authorization_url" not in update_data.fields_set()
     assert update_data.credentials["client_id"] == "generated-client"
     assert update_data.credentials["client_secret"] == "generated-secret"
     assert update_data.credentials["token_endpoint_auth_method"] == "client_secret_basic"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -1040,7 +1040,7 @@ class TestMCPServerManager:
             updated_at=datetime.now(),
         )
 
-        metadata = SimpleNamespace(
+        metadata = MCPOAuthMetadata(
             authorization_url="https://idp.example.com/authorize",
             token_url="https://idp.example.com/token",
             registration_url="https://idp.example.com/register",
@@ -2125,6 +2125,7 @@ class TestMCPServerManager:
         )
         assert result is mock_metadata
         assert result.scopes == ["api://some-scope/.default"]
+        assert result.from_origin_fallback is False
 
     @pytest.mark.asyncio
     async def test_fetch_single_authorization_server_metadata_supports_azure_issuer_path(
@@ -2247,6 +2248,7 @@ class TestMCPServerManager:
         mock_fetch_auth.assert_awaited_once_with(["https://example.com"], server_url)
         assert result is mock_metadata
         assert result.scopes == ["read"]
+        assert result.from_origin_fallback is True
 
     @pytest.mark.asyncio
     async def test_load_servers_from_config_overrides_discovery_metadata(self):
@@ -4820,6 +4822,276 @@ class TestMCPServerTimestamps:
             )
 
         update_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_build_mcp_server_from_table_persists_discovered_oauth_endpoints(self):
+        """A DB-backed oauth2 server with no configured endpoints discovers them and must write
+        authorization_url, token_url, and scopes back to the row; otherwise the resolved values
+        live only in memory and one failed re-discovery serves 400 "authorization url is not set"
+        from /authorize. registration_url must never be persisted because
+        _dcr_bridge_relays_client_registration keys off that column."""
+        manager = MCPServerManager()
+
+        async def fake_discovery(server_url: str, *, allow_origin_fallback: bool = True):
+            assert allow_origin_fallback is True
+            return MCPOAuthMetadata(
+                scopes=["mcp.read", "mcp.write"],
+                authorization_url="https://idp.example.com/authorize",
+                token_url="https://idp.example.com/token",
+                registration_url="https://idp.example.com/register",
+            )
+
+        manager._descovery_metadata = fake_discovery  # type: ignore[attr-defined]
+
+        record = LiteLLM_MCPServerTable(
+            server_id="oauth-persist-1",
+            server_name="oauth_persist",
+            url="https://example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2,
+            oauth2_flow="authorization_code",
+            credentials={"client_id": "cid", "client_secret": "csec"},
+        )
+
+        update_mcp_server_mock = AsyncMock()
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.db.update_mcp_server",
+                new=update_mcp_server_mock,
+            ),
+            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        ):
+            server = await manager.build_mcp_server_from_table(record, credentials_are_encrypted=False)
+
+        assert server.authorization_url == "https://idp.example.com/authorize"
+        update_mcp_server_mock.assert_awaited_once()
+        persisted = update_mcp_server_mock.call_args.kwargs["data"]
+        assert persisted.server_id == "oauth-persist-1"
+        assert persisted.authorization_url == "https://idp.example.com/authorize"
+        assert persisted.token_url == "https://idp.example.com/token"
+        assert persisted.credentials == {"scopes": ["mcp.read", "mcp.write"]}
+        assert "registration_url" not in persisted.fields_set()
+        assert update_mcp_server_mock.call_args.kwargs["touched_by"] == "mcp_oauth_discovery"
+
+    @pytest.mark.asyncio
+    async def test_persist_discovered_oauth_endpoints_guards(self):
+        """The write-back must no-op for non-discovery auth types, empty discovery, origin-fallback
+        guesses (never harden an inferred authorization server into configuration), and rows whose
+        fields are all already populated."""
+        manager = MCPServerManager()
+        advertised = MCPOAuthMetadata(
+            scopes=["s1"],
+            authorization_url="https://idp.example.com/authorize",
+            token_url="https://idp.example.com/token",
+        )
+
+        update_mcp_server_mock = AsyncMock()
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.db.update_mcp_server",
+                new=update_mcp_server_mock,
+            ),
+            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        ):
+            await manager._persist_discovered_oauth_endpoints(
+                server_id="s",
+                auth_type=MCPAuth.api_key,
+                existing_authorization_url=None,
+                existing_token_url=None,
+                existing_scopes=None,
+                metadata=advertised,
+            )
+            await manager._persist_discovered_oauth_endpoints(
+                server_id="s",
+                auth_type=MCPAuth.oauth2,
+                existing_authorization_url=None,
+                existing_token_url=None,
+                existing_scopes=None,
+                metadata=None,
+            )
+            await manager._persist_discovered_oauth_endpoints(
+                server_id="s",
+                auth_type=MCPAuth.oauth2,
+                existing_authorization_url=None,
+                existing_token_url=None,
+                existing_scopes=None,
+                metadata=advertised.model_copy(update={"from_origin_fallback": True}),
+            )
+            await manager._persist_discovered_oauth_endpoints(
+                server_id="s",
+                auth_type=MCPAuth.oauth2,
+                existing_authorization_url="https://configured.example.com/authorize",
+                existing_token_url="https://configured.example.com/token",
+                existing_scopes=["configured"],
+                metadata=advertised,
+            )
+
+        update_mcp_server_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_persist_discovered_oauth_endpoints_only_fills_empty_fields(self):
+        """A row that already has token_url keeps it; only the missing authorization_url and
+        scopes are written, so admin-typed values always win over discovery."""
+        manager = MCPServerManager()
+
+        update_mcp_server_mock = AsyncMock()
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.db.update_mcp_server",
+                new=update_mcp_server_mock,
+            ),
+            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        ):
+            await manager._persist_discovered_oauth_endpoints(
+                server_id="s",
+                auth_type=MCPAuth.oauth2,
+                existing_authorization_url=None,
+                existing_token_url="https://configured.example.com/token",
+                existing_scopes=None,
+                metadata=MCPOAuthMetadata(
+                    scopes=["s1"],
+                    authorization_url="https://idp.example.com/authorize",
+                    token_url="https://idp.example.com/token",
+                ),
+            )
+
+        update_mcp_server_mock.assert_awaited_once()
+        persisted = update_mcp_server_mock.call_args.kwargs["data"]
+        assert persisted.authorization_url == "https://idp.example.com/authorize"
+        assert persisted.credentials == {"scopes": ["s1"]}
+        assert "token_url" not in persisted.fields_set()
+
+    @pytest.mark.asyncio
+    async def test_build_mcp_server_from_table_skips_persistence_for_temporary_servers(self):
+        """The session endpoint builds temporary servers whose server_id has no DB row; with
+        persist_discovered_endpoints=False neither the oauth2 nor the OBO write-back may fire."""
+        manager = MCPServerManager()
+
+        async def fake_discovery(server_url: str, *, allow_origin_fallback: bool = True):
+            return MCPOAuthMetadata(
+                scopes=["s1"],
+                authorization_url="https://idp.example.com/authorize",
+                token_url="https://idp.example.com/token",
+            )
+
+        manager._descovery_metadata = fake_discovery  # type: ignore[attr-defined]
+
+        update_mcp_server_mock = AsyncMock()
+        obo_update_mock = AsyncMock()
+        repo_instance = MagicMock()
+        repo_instance.table.update = obo_update_mock
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.db.update_mcp_server",
+                new=update_mcp_server_mock,
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.MCPServerRepository",
+                return_value=repo_instance,
+            ),
+            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        ):
+            oauth2_record = LiteLLM_MCPServerTable(
+                server_id="temp-oauth-1",
+                server_name="temp_oauth",
+                url="https://example.com/mcp",
+                transport=MCPTransport.http,
+                auth_type=MCPAuth.oauth2,
+                oauth2_flow="authorization_code",
+                credentials={"client_id": "cid", "client_secret": "csec"},
+            )
+            obo_record = LiteLLM_MCPServerTable(
+                server_id="temp-obo-1",
+                server_name="temp_obo",
+                url="https://example.com/mcp",
+                transport=MCPTransport.http,
+                auth_type=MCPAuth.oauth2_token_exchange,
+                credentials={"client_id": "cid", "client_secret": "csec"},
+            )
+            built_oauth2 = await manager.build_mcp_server_from_table(
+                oauth2_record, credentials_are_encrypted=False, persist_discovered_endpoints=False
+            )
+            await manager.build_mcp_server_from_table(
+                obo_record, credentials_are_encrypted=False, persist_discovered_endpoints=False
+            )
+
+        assert built_oauth2.authorization_url == "https://idp.example.com/authorize"
+        update_mcp_server_mock.assert_not_awaited()
+        obo_update_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_update_server_carries_forward_last_known_good_oauth_endpoints(self):
+        """A rebuild whose re-discovery fails must not downgrade a working registry entry: the
+        previous entry's resolved endpoints and scopes carry forward instead of being replaced
+        with None (which turns every /authorize into a 400 with no configuration change)."""
+        manager = MCPServerManager()
+        manager.registry["lkg-1"] = MCPServer(
+            server_id="lkg-1",
+            name="lkg_server",
+            server_name="lkg_server",
+            url="https://example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2,
+            authorization_url="https://idp.example.com/authorize",
+            token_url="https://idp.example.com/token",
+            registration_url="https://idp.example.com/register",
+            scopes=["mcp.read"],
+        )
+
+        manager._descovery_metadata = AsyncMock(return_value=None)  # type: ignore[attr-defined]
+
+        record = LiteLLM_MCPServerTable(
+            server_id="lkg-1",
+            server_name="lkg_server",
+            url="https://example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2,
+            oauth2_flow="authorization_code",
+            credentials={"client_id": "cid", "client_secret": "csec"},
+        )
+
+        with patch("litellm.proxy.proxy_server.prisma_client", None):
+            await manager.update_server(record)
+
+        rebuilt = manager.registry["lkg-1"]
+        assert rebuilt.authorization_url == "https://idp.example.com/authorize"
+        assert rebuilt.token_url == "https://idp.example.com/token"
+        assert rebuilt.registration_url == "https://idp.example.com/register"
+        assert rebuilt.scopes == ["mcp.read"]
+
+    def test_carry_forward_skips_when_url_or_auth_type_changed(self):
+        """Stale endpoints from a different upstream or auth mode must not carry forward."""
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            _carry_forward_resolved_oauth_endpoints,
+        )
+
+        def make_server(url: str, auth_type: MCPAuth, authorization_url: Optional[str]) -> MCPServer:
+            return MCPServer(
+                server_id="s1",
+                name="s1",
+                url=url,
+                transport=MCPTransport.http,
+                auth_type=auth_type,
+                authorization_url=authorization_url,
+            )
+
+        previous = make_server("https://old.example.com/mcp", MCPAuth.oauth2, "https://idp.example.com/authorize")
+
+        url_changed = make_server("https://new.example.com/mcp", MCPAuth.oauth2, None)
+        _carry_forward_resolved_oauth_endpoints(new_server=url_changed, previous_server=previous)
+        assert url_changed.authorization_url is None
+
+        auth_changed = make_server("https://old.example.com/mcp", MCPAuth.true_passthrough, None)
+        _carry_forward_resolved_oauth_endpoints(new_server=auth_changed, previous_server=previous)
+        assert auth_changed.authorization_url is None
+
+        same = make_server("https://old.example.com/mcp", MCPAuth.oauth2, None)
+        _carry_forward_resolved_oauth_endpoints(new_server=same, previous_server=previous)
+        assert same.authorization_url == "https://idp.example.com/authorize"
+
+        explicit = make_server("https://old.example.com/mcp", MCPAuth.oauth2, "https://configured.example.com/auth")
+        _carry_forward_resolved_oauth_endpoints(new_server=explicit, previous_server=previous)
+        assert explicit.authorization_url == "https://configured.example.com/auth"
 
     def test_build_mcp_server_table_preserves_timestamps(self):
         """_build_mcp_server_table must use the MCPServer's stored timestamps, not datetime.now()."""


### PR DESCRIPTION
## Relevant issues

Live-diagnosed on a sandbox gateway: interactive MCP OAuth servers intermittently return 400 "MCP server authorization url is not set" from /{server}/authorize with no configuration change, then start working again on their own

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup: local proxy on :4000 backed by Postgres, plus a stub upstream MCP server and OAuth authorization server on one origin (localhost:9321) serving the real RFC 9728 -> RFC 8414 discovery chain (401 with WWW-Authenticate resource_metadata, protected resource metadata, authorization server metadata) with a kill switch that turns every endpoint into a 500 to simulate a transient upstream outage

Repro on unfixed code (staging tip 477ef3a7e2). Create an oauth2 authorization_code server with admin-supplied client credentials and no URLs typed in, so everything depends on discovery

```
$ curl -sX POST http://localhost:4000/v1/mcp/server -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"server_name": "rig_oauth_server", "url": "http://localhost:9321/mcp", "transport": "http",
         "auth_type": "oauth2", "oauth2_flow": "authorization_code",
         "credentials": {"client_id": "my-manual-client", "client_secret": "my-manual-secret"}}'

# the row never stores the discovered endpoints
$ docker exec pg psql -U postgres -tc 'SELECT server_name, authorization_url, token_url FROM "LiteLLM_MCPServerTable";'
 rig_oauth_server |                   |

# in-memory discovery worked, so authorize redirects to the real IdP
$ curl -s -o /dev/null -w "%{http_code} -> %{redirect_url}\n" "http://localhost:4000/rig_oauth_server/authorize?redirect_uri=http%3A%2F%2Flocalhost%3A8945%2Fcallback&client_id=test-client&state=abc123"
307 -> http://localhost:9321/idp/authorize?client_id=my-manual-client&...&scope=mcp.read+mcp.write

# simulate a transient upstream outage, then any row write (a no-op admin edit here) forces a rebuild
$ touch rig_down
$ curl -sX PUT http://localhost:4000/v1/mcp/server -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"server_id": "67ffbbe4-...", "description": "noop touch"}' -o /dev/null -w "edit: %{http_code}\n"
edit: 202

$ curl -s -w "\nHTTP %{http_code}\n" "http://localhost:4000/rig_oauth_server/authorize?redirect_uri=http%3A%2F%2Flocalhost%3A8945%2Fcallback&client_id=test-client&state=abc123"
{"detail":"MCP server authorization url is not set"}
HTTP 400

# upstream comes back, another no-op edit, and it works again with zero configuration change
$ rm rig_down && curl -sX PUT ... -d '{"server_id": "67ffbbe4-...", "description": "noop touch 2"}' && curl -s -o /dev/null -w "%{http_code} -> %{redirect_url}\n" ".../rig_oauth_server/authorize?..."
307 -> http://localhost:9321/idp/authorize?client_id=my-manual-client&...

# the only trace of the outage was at DEBUG level
[92m14:51:05 - LiteLLM:DEBUG[0m: mcp_server_manager.py:3126 - Failed to fetch authorization metadata from http://localhost:9321/...: Server error '500 Internal Server Error' ...
```

Verify on fixed code. Restarting the proxy backfills the same pre-existing row on the first successful rebuild

```
$ docker exec pg psql -U postgres -tc "SELECT authorization_url, token_url, updated_by FROM \"LiteLLM_MCPServerTable\" WHERE server_name='rig_oauth_server';"
 http://localhost:9321/idp/authorize | http://localhost:9321/idp/token | mcp_oauth_discovery

# scopes merged into the credentials blob, stored client credentials untouched
credentials keys: ['client_id', 'client_secret', 'scopes'] | scopes: ['mcp.read', 'mcp.write']

# the exact repro sequence (outage + no-op edit + rebuild) now keeps working
$ touch rig_down && curl -sX PUT ... -d '{"server_id": "67ffbbe4-...", "description": "noop touch 3"}'
$ curl -s -o /dev/null -w "%{http_code} -> %{redirect_url}\n" ".../rig_oauth_server/authorize?..."
307 -> http://localhost:9321/idp/authorize?client_id=my-manual-client&...&scope=mcp.read+mcp.write
```

Origin-fallback and last-known-good, on a second server where the stub advertises no protected resource metadata so discovery only succeeds by guessing the origin as the authorization server

```
# authorize works off the in-memory guess
$ curl -s -o /dev/null -w "%{http_code} -> %{redirect_url}\n" ".../rig_fallback_server/authorize?..."
307 -> http://localhost:9321/idp/authorize?client_id=fb-client&...

# but the guessed endpoints are never persisted as configuration
$ docker exec pg psql -U postgres -tc "SELECT COALESCE(authorization_url,'NULL'), COALESCE(token_url,'NULL') FROM \"LiteLLM_MCPServerTable\" WHERE server_name='rig_fallback_server';"
 NULL     | NULL

# full outage plus a rebuild: the last known good endpoints carry forward instead of downgrading to None
$ touch rig_down && curl -sX PUT ... -d '{"server_id": "c4edcdc4-...", "description": "noop"}'
$ curl -s -o /dev/null -w "%{http_code} -> %{redirect_url}\n" ".../rig_fallback_server/authorize?..."
307 -> http://localhost:9321/idp/authorize?client_id=fb-client&...

# and the failure is now visible
[92m15:05:37 - LiteLLM:WARNING[0m: mcp_server_manager.py:1464 - MCP OAuth discovery yielded no metadata for server c4edcdc4-... (http://localhost:9321/mcp); OAuth endpoints stay unresolved until a rebuild succeeds
```

## Type

🐛 Bug Fix

## Changes

MCP servers with auth_type oauth2, true_passthrough, or oauth_delegate resolve their upstream OAuth endpoints (authorization_url, token_url, scopes) through RFC 9728 -> RFC 8414 discovery at registry build time, but the resolved values only ever lived on the in-memory registry entry; the DB row keeps NULL. That entry is rebuilt far more often than it looks: every /register that reuses a persisted DCR client calls update_server, and any row write bumps updated_at, which defeats the reuse cache in reload_servers_from_database (the 30s scheduler job), so each rebuild re-runs discovery over the network. A rebuild whose discovery attempt fails (timeout, upstream blip, rate limiting) replaces a working authorization_url with None, and every /{server}/authorize returns 400 "MCP server authorization url is not set" until a later rebuild happens to succeed. With multiple pods each rolling their own discovery, the same server works or 400s depending on which pod serves the request. Failures were logged at DEBUG, so the flapping looked random

`build_mcp_server_from_table` now writes discovered authorization_url, token_url, and scopes back onto the row after a successful discovery, extending the existing `_persist_discovered_obo_token_url` precedent (whose docstring describes this exact failure mode for the token-exchange arm) to the interactive oauth2 family. It only fills row fields that are currently empty so admin-typed values always win, goes through `update_mcp_server` so scopes merge into the credentials blob without touching the stored client credentials, never persists origin-fallback guesses (RFC 9728/8414-advertised metadata only, tracked by a new `from_origin_fallback` flag on `MCPOAuthMetadata`), and deliberately skips registration_url because `_dcr_bridge_relays_client_registration` keys off that column. Once the row has authorization_url, needs_discovery is False and rebuilds stop hitting the network entirely; rows that predate the fix backfill automatically on their first successful rebuild after deploy

The DCR registration persist deliberately does not write authorization_url (a regression test asserts it stays absent from the persist payload): the build-path hook is the single authorization_url writer, so the origin-fallback guard cannot be bypassed. The old asymmetry (token_url persisted while authorization_url never was, both values from the same authorization server metadata document) produced the diagnostic signature of this bug, /token working while /authorize 400d, and is closed by the build-path hook

A rebuild whose re-discovery returns nothing carries forward the previous registry entry's resolved endpoints and scopes, mirroring the existing short_prefix carry-forward and skipped when url or auth_type changed. This protects rows that predate the fix and is the standard stale-on-failure behavior for OAuth metadata (compare Microsoft.IdentityModel's ConfigurationManager, which keeps the last known good configuration when a metadata refresh fails)

The temporary session endpoint (POST /server/oauth/session) builds registry entries whose server_id has no DB row; it now passes `persist_discovered_endpoints=False` so neither this write-back nor the OBO one attempts a write for it. Discovery that yields no metadata now logs at WARNING with the server id

## QA runbook

Create an oauth2 authorization_code MCP server with your own client_id/client_secret and leave Authorization URL, Token URL, and Scopes blank. After the server loads, check the DB row: authorization_url and token_url columns should be populated and updated_by should read mcp_oauth_discovery, with scopes inside the credentials JSON. Take the upstream IdP offline (or block egress), edit the server description to force a rebuild, and confirm /{server}/authorize still 307-redirects to the upstream authorize URL instead of returning 400. Confirm an admin-typed Authorization URL is never overwritten by discovery. For the guess guard, point a server at an upstream that serves authorization server metadata at its origin but no protected resource metadata, and confirm the row's URL columns stay NULL while /authorize still works

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches interactive OAuth authorize flows and DB writes for MCP server rows; guards limit overwrites and skip temporary servers, but mis-persisted endpoints could still affect multi-pod behavior until corrected.
> 
> **Overview**
> Fixes intermittent **400 "MCP server authorization url is not set"** on `/{server}/authorize` when registry rebuilds re-run OAuth discovery and a transient failure clears in-memory endpoints that were never stored on the DB row.
> 
> **Persist discovery:** After a successful RFC 9728/8414 discovery in `build_mcp_server_from_table`, empty row fields get `authorization_url`, `token_url`, and scopes (via `update_mcp_server`, `touched_by=mcp_oauth_discovery`). Only empty fields are filled; **`registration_url` is never persisted**; metadata tagged **`from_origin_fallback`** is excluded from writes. **`persist_discovered_endpoints=False`** skips DB writes for temporary session servers.
> 
> **Resilience:** `_carry_forward_resolved_oauth_endpoints` copies the previous registry entry’s OAuth URLs/scopes when re-discovery returns nothing (unless `url`/`auth_type` changed). Failed discovery logs at **WARNING**.
> 
> `MCPOAuthMetadata.from_origin_fallback` marks origin-guess discovery so it stays in-memory only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0d5df21dae230892c7758c2b26e7cd2b043ae67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

