### PR TITLE
fix(router): evict strategy-router registries in upsert/delete_deployment (DB-sync path)

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7847,7 +7847,7 @@ class Router:
             len(config.available_models),
         )
 
-    def _remove_deployment_from_strategy_registries(self, model_name: str, litellm_model: Optional[str]) -> None:
+    def _remove_deployment_from_strategy_registries(self, model_name: str, litellm_model: str | None) -> None:
         """
         Drop a model_name's strategy-router registration (auto / complexity /
         adaptive / quality) when its deployment is removed from the router.

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7870,11 +7870,24 @@ class Router:
         upsert/delete cycle leaks one hook (and a deleted router's hook keeps
         firing forever).
         """
-        if not (litellm_model or "").startswith("auto_router/"):
+        litellm_model = litellm_model or ""
+        if not litellm_model.startswith("auto_router/"):
             return
-        self.auto_routers.pop(model_name, None)
-        self.complexity_routers.pop(model_name, None)
-        self.quality_routers.pop(model_name, None)
+
+        # scope the pop to the removed deployment's OWN strategy registry —
+        # model_names are only unique per registry, so a complexity router and
+        # a quality router may legally share a name; deleting one must not
+        # evict the other.
+        if litellm_model.startswith("auto_router/complexity_router"):
+            self.complexity_routers.pop(model_name, None)
+            return
+        if litellm_model.startswith("auto_router/quality_router"):
+            self.quality_routers.pop(model_name, None)
+            return
+        if not litellm_model.startswith("auto_router/adaptive_router"):
+            # plain auto_router/<name> (semantic router)
+            self.auto_routers.pop(model_name, None)
+            return
 
         adaptive_router = self.adaptive_routers.pop(model_name, None)
         if adaptive_router is not None:

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7847,7 +7847,7 @@ class Router:
             len(config.available_models),
         )
 
-    def _remove_deployment_from_strategy_registries(self, model_name: str) -> None:
+    def _remove_deployment_from_strategy_registries(self, model_name: str, litellm_model: Optional[str]) -> None:
         """
         Drop a model_name's strategy-router registration (auto / complexity /
         adaptive / quality) when its deployment is removed from the router.
@@ -7860,15 +7860,38 @@ class Router:
         `/v1/models` & `/model/info`, and the stale registry object keeps
         serving requests with its old config. See issue #33168.
 
-        Safe for regular deployments: they are never in these registries, so
-        the pops are no-ops. Strategy deployments are unique per model_name
-        (the init functions enforce this), so popping by name cannot orphan a
-        sibling deployment.
+        `litellm_model` is the removed deployment's `litellm_params.model`;
+        registries are only touched when it carries the `auto_router/` prefix.
+        This guards against a REGULAR deployment that merely shares a strategy
+        router's public model_name evicting the strategy router when deleted.
+
+        For adaptive routers, the deployment's `AdaptiveRouterPostCallHook` is
+        also removed from the global callback lists — otherwise every
+        upsert/delete cycle leaks one hook (and a deleted router's hook keeps
+        firing forever).
         """
+        if not (litellm_model or "").startswith("auto_router/"):
+            return
         self.auto_routers.pop(model_name, None)
         self.complexity_routers.pop(model_name, None)
-        self.adaptive_routers.pop(model_name, None)
         self.quality_routers.pop(model_name, None)
+
+        adaptive_router = self.adaptive_routers.pop(model_name, None)
+        if adaptive_router is not None:
+            from litellm.router_strategy.adaptive_router.hooks import (
+                AdaptiveRouterPostCallHook,
+            )
+
+            for _cb_list in (
+                litellm.callbacks,
+                litellm.success_callback,
+                litellm.failure_callback,
+                litellm._async_success_callback,
+                litellm._async_failure_callback,
+            ):
+                for _cb in list(_cb_list):
+                    if isinstance(_cb, AdaptiveRouterPostCallHook) and _cb.adaptive_router is adaptive_router:
+                        litellm.logging_callback_manager.remove_callback_from_all_lists(_cb)
 
     def _is_quality_router_deployment(self, litellm_params: LiteLLM_Params) -> bool:
         """
@@ -8416,10 +8439,24 @@ class Router:
                         # of dying on the init functions' "already exists"
                         # check (which silently delists the model under
                         # ignore_invalid_deployments). See issue #33168.
-                        self._remove_deployment_from_strategy_registries(model_name=_deployment_on_router.model_name)
+                        self._remove_deployment_from_strategy_registries(
+                            model_name=_deployment_on_router.model_name,
+                            litellm_model=_deployment_on_router.litellm_params.model,
+                        )
 
             # if the model_id is not in router
-            self.add_deployment(deployment=deployment)
+            added = self.add_deployment(deployment=deployment)
+            # adaptive-router init is deferred out of _add_deployment (it needs
+            # the finalized model_list), so an upserted adaptive deployment must
+            # be re-registered here — its previous registration (and post-call
+            # hook) were removed above, and without this the deployment would
+            # stop routing until the next full set_model_list().
+            if (
+                added is not None
+                and self._is_adaptive_router_deployment(litellm_params=deployment.litellm_params)
+                and deployment.model_name not in self.adaptive_routers
+            ):
+                self.init_adaptive_router_deployment(deployment=deployment)
             return deployment
         except Exception as e:
             if self.ignore_invalid_deployments:
@@ -8453,11 +8490,22 @@ class Router:
                 # de-register any strategy router tied to this deployment —
                 # otherwise it keeps serving the deleted model as a ghost and
                 # blocks any future re-add under the same name (issue #33168)
-                _removed_model_name = (
-                    item.get("model_name") if isinstance(item, dict) else getattr(item, "model_name", None)
-                )
+                if isinstance(item, dict):
+                    _removed_model_name = item.get("model_name")
+                    _removed_lp = item.get("litellm_params") or {}
+                    _removed_litellm_model = (
+                        _removed_lp.get("model")
+                        if isinstance(_removed_lp, dict)
+                        else getattr(_removed_lp, "model", None)
+                    )
+                else:
+                    _removed_model_name = getattr(item, "model_name", None)
+                    _removed_litellm_model = getattr(getattr(item, "litellm_params", None), "model", None)
                 if _removed_model_name:
-                    self._remove_deployment_from_strategy_registries(model_name=_removed_model_name)
+                    self._remove_deployment_from_strategy_registries(
+                        model_name=_removed_model_name,
+                        litellm_model=_removed_litellm_model,
+                    )
                 _budget_limiter = self._get_router_deployment_budget_limiter()
                 if _budget_limiter is not None:
                     _budget_limiter.unregister_deployment_budget(model_id=id)

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7847,6 +7847,29 @@ class Router:
             len(config.available_models),
         )
 
+    def _remove_deployment_from_strategy_registries(self, model_name: str) -> None:
+        """
+        Drop a model_name's strategy-router registration (auto / complexity /
+        adaptive / quality) when its deployment is removed from the router.
+
+        Every `init_*_router_deployment` raises "already exists" when the
+        model_name is still registered, so a removal path that cleans
+        `model_list` but not these registries makes the deployment
+        un-re-addable: the re-add dies before `_add_model_to_list_and_index_map`
+        (swallowed under `ignore_invalid_deployments`), the row disappears from
+        `/v1/models` & `/model/info`, and the stale registry object keeps
+        serving requests with its old config. See issue #33168.
+
+        Safe for regular deployments: they are never in these registries, so
+        the pops are no-ops. Strategy deployments are unique per model_name
+        (the init functions enforce this), so popping by name cannot orphan a
+        sibling deployment.
+        """
+        self.auto_routers.pop(model_name, None)
+        self.complexity_routers.pop(model_name, None)
+        self.adaptive_routers.pop(model_name, None)
+        self.quality_routers.pop(model_name, None)
+
     def _is_quality_router_deployment(self, litellm_params: LiteLLM_Params) -> bool:
         """
         Check if the deployment is a quality-router deployment.
@@ -8387,6 +8410,13 @@ class Router:
                         self._invalidate_model_group_info_cache()
                         self._invalidate_access_groups_cache()
                         self._update_deployment_indices_after_removal(model_id=deployment_id, removal_idx=removal_idx)
+                        # de-register any strategy router (auto/complexity/
+                        # adaptive/quality) tied to the removed deployment, so
+                        # the add_deployment below can re-register it instead
+                        # of dying on the init functions' "already exists"
+                        # check (which silently delists the model under
+                        # ignore_invalid_deployments). See issue #33168.
+                        self._remove_deployment_from_strategy_registries(model_name=_deployment_on_router.model_name)
 
             # if the model_id is not in router
             self.add_deployment(deployment=deployment)
@@ -8420,6 +8450,14 @@ class Router:
                 self._invalidate_model_group_info_cache()
                 self._invalidate_access_groups_cache()
                 self._update_deployment_indices_after_removal(model_id=id, removal_idx=deployment_idx)
+                # de-register any strategy router tied to this deployment —
+                # otherwise it keeps serving the deleted model as a ghost and
+                # blocks any future re-add under the same name (issue #33168)
+                _removed_model_name = (
+                    item.get("model_name") if isinstance(item, dict) else getattr(item, "model_name", None)
+                )
+                if _removed_model_name:
+                    self._remove_deployment_from_strategy_registries(model_name=_removed_model_name)
                 _budget_limiter = self._get_router_deployment_budget_limiter()
                 if _budget_limiter is not None:
                     _budget_limiter.unregister_deployment_budget(model_id=id)

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7847,7 +7847,12 @@ class Router:
             len(config.available_models),
         )
 
-    def _remove_deployment_from_strategy_registries(self, model_name: str, litellm_model: str | None) -> None:
+    def _remove_deployment_from_strategy_registries(
+        self,
+        model_name: str,
+        litellm_model: str | None,
+        tags: tuple[str, ...] | None = None,
+    ) -> None:
         """
         Drop a model_name's strategy-router registration (auto / complexity /
         adaptive / quality) when its deployment is removed from the router.
@@ -7869,32 +7874,55 @@ class Router:
         also removed from the global callback lists — otherwise every
         upsert/delete cycle leaks one hook (and a deleted router's hook keeps
         firing forever).
+
+        `tags` scopes the eviction to the removed deployment's own
+        `(model_name, tags)` registration — registries hold a LIST of
+        tag-scoped strategies per name, and a differently-tagged sibling
+        sharing the name must survive. Pass `None` to evict every entry under
+        the name (used when the removed row's tags cannot be recovered).
         """
         litellm_model = litellm_model or ""
         if not litellm_model.startswith("auto_router/"):
             return
 
-        # scope the pop to the removed deployment's OWN strategy registry —
-        # model_names are only unique per registry, so a complexity router and
-        # a quality router may legally share a name; deleting one must not
-        # evict the other.
+        # scope the eviction to the removed deployment's OWN strategy
+        # registry — model_names are only unique per registry, so a
+        # complexity router and a quality router may legally share a name;
+        # deleting one must not evict the other.
         if litellm_model.startswith("auto_router/complexity_router"):
-            self.complexity_routers.pop(model_name, None)
-            return
-        if litellm_model.startswith("auto_router/quality_router"):
-            self.quality_routers.pop(model_name, None)
-            return
-        if not litellm_model.startswith("auto_router/adaptive_router"):
+            registry: dict = self.complexity_routers
+        elif litellm_model.startswith("auto_router/quality_router"):
+            registry = self.quality_routers
+        elif litellm_model.startswith("auto_router/adaptive_router"):
+            registry = self.adaptive_routers
+        else:
             # plain auto_router/<name> (semantic router)
-            self.auto_routers.pop(model_name, None)
-            return
+            registry = self.auto_routers
 
-        adaptive_router = self.adaptive_routers.pop(model_name, None)
-        if adaptive_router is not None:
+        entries = registry.get(model_name)
+        if not entries:
+            return
+        if tags is None:
+            removed = list(entries)
+            remaining = []
+        else:
+            removed = [entry for entry in entries if entry.tags == tags]
+            remaining = [entry for entry in entries if entry.tags != tags]
+            if not removed:
+                # the removed deployment's (model_name, tags) pair isn't
+                # registered, so a re-add can't collide — leave siblings alone
+                return
+        if remaining:
+            registry[model_name] = remaining
+        else:
+            registry.pop(model_name, None)
+
+        if registry is self.adaptive_routers:
             from litellm.router_strategy.adaptive_router.hooks import (
                 AdaptiveRouterPostCallHook,
             )
 
+            removed_strategy_ids = {id(entry.strategy) for entry in removed}
             for _cb_list in (
                 litellm.callbacks,
                 litellm.success_callback,
@@ -7903,7 +7931,7 @@ class Router:
                 litellm._async_failure_callback,
             ):
                 for _cb in list(_cb_list):
-                    if isinstance(_cb, AdaptiveRouterPostCallHook) and _cb.adaptive_router is adaptive_router:
+                    if isinstance(_cb, AdaptiveRouterPostCallHook) and id(_cb.adaptive_router) in removed_strategy_ids:
                         litellm.logging_callback_manager.remove_callback_from_all_lists(_cb)
 
     def _is_quality_router_deployment(self, litellm_params: LiteLLM_Params) -> bool:
@@ -8455,6 +8483,7 @@ class Router:
                         self._remove_deployment_from_strategy_registries(
                             model_name=_deployment_on_router.model_name,
                             litellm_model=_deployment_on_router.litellm_params.model,
+                            tags=self._deployment_tags(_deployment_on_router),
                         )
 
             # if the model_id is not in router
@@ -8467,7 +8496,9 @@ class Router:
             if (
                 added is not None
                 and self._is_adaptive_router_deployment(litellm_params=deployment.litellm_params)
-                and deployment.model_name not in self.adaptive_routers
+                and not self._has_registered_strategy(
+                    self.adaptive_routers, deployment.model_name, self._deployment_tags(deployment)
+                )
             ):
                 self.init_adaptive_router_deployment(deployment=deployment)
             return deployment
@@ -8511,13 +8542,18 @@ class Router:
                         if isinstance(_removed_lp, dict)
                         else getattr(_removed_lp, "model", None)
                     )
+                    _removed_tags = (
+                        _removed_lp.get("tags") if isinstance(_removed_lp, dict) else getattr(_removed_lp, "tags", None)
+                    )
                 else:
                     _removed_model_name = getattr(item, "model_name", None)
                     _removed_litellm_model = getattr(getattr(item, "litellm_params", None), "model", None)
+                    _removed_tags = getattr(getattr(item, "litellm_params", None), "tags", None)
                 if _removed_model_name:
                     self._remove_deployment_from_strategy_registries(
                         model_name=_removed_model_name,
                         litellm_model=_removed_litellm_model,
+                        tags=tuple(_removed_tags or ()),
                     )
                 _budget_limiter = self._get_router_deployment_budget_limiter()
                 if _budget_limiter is not None:

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -6020,22 +6020,77 @@ class TestStrategyRegistryCleanupGuards:
             ]
         )
 
+    def test_deleting_one_strategy_does_not_evict_same_named_other_strategy(self):
+        """model_names are only unique per registry — a complexity router and a
+        quality router may share a name; deleting one must not evict the other."""
+        router = litellm.Router(
+            model_list=[
+                {
+                    "model_name": "backing-model",
+                    "litellm_params": {"model": "gpt-4o-mini", "api_key": "fake-key"},
+                }
+            ]
+        )
+        from litellm.types.router import Deployment, LiteLLM_Params
+
+        tiers = {
+            "SIMPLE": "backing-model",
+            "MEDIUM": "backing-model",
+            "COMPLEX": "backing-model",
+            "REASONING": "backing-model",
+        }
+        router.add_deployment(
+            Deployment(
+                model_name="dual-name",
+                litellm_params=LiteLLM_Params(
+                    model="auto_router/complexity_router",
+                    complexity_router_config={"tiers": tiers},
+                    complexity_router_default_model="backing-model",
+                ),
+                model_info={"id": "dual-complexity-row"},
+            )
+        )
+        router.add_deployment(
+            Deployment(
+                model_name="dual-name",
+                litellm_params=LiteLLM_Params(
+                    model="auto_router/quality_router",
+                    quality_router_config={
+                        "quality_tiers": {"default": "backing-model"},
+                        "default_model": "backing-model",
+                    },
+                ),
+                model_info={"id": "dual-quality-row"},
+            )
+        )
+        assert "dual-name" in router.complexity_routers
+        assert "dual-name" in router.quality_routers
+
+        router.delete_deployment(id="dual-complexity-row")
+
+        assert "dual-name" not in router.complexity_routers
+        assert "dual-name" in router.quality_routers, (
+            "deleting the complexity router must not evict the same-named quality router"
+        )
+
     def test_adaptive_router_delete_retires_post_call_hook(self):
+        baseline = self._count_adaptive_hooks()  # tolerate hooks leaked by other tests
         router = self._adaptive_router()
         assert "adaptive-test-router" in router.adaptive_routers
-        assert self._count_adaptive_hooks() == 1
+        assert self._count_adaptive_hooks() == baseline + 1
 
         router.delete_deployment(id="adaptive-row")
 
         assert "adaptive-test-router" not in router.adaptive_routers
-        assert self._count_adaptive_hooks() == 0, "deleted adaptive router's hook must be retired"
+        assert self._count_adaptive_hooks() == baseline, "deleted adaptive router's hook must be retired"
 
     def test_adaptive_router_upsert_applies_new_config_without_leaking_hooks(self):
         from litellm.types.router import Deployment, LiteLLM_Params
 
+        baseline = self._count_adaptive_hooks()  # tolerate hooks leaked by other tests
         router = self._adaptive_router()
         original = router.adaptive_routers["adaptive-test-router"]
-        assert self._count_adaptive_hooks() == 1
+        assert self._count_adaptive_hooks() == baseline + 1
 
         router.upsert_deployment(
             Deployment(
@@ -6055,6 +6110,6 @@ class TestStrategyRegistryCleanupGuards:
         assert router.adaptive_routers["adaptive-test-router"] is not original, (
             "upsert must rebuild the adaptive router with the new config"
         )
-        assert self._count_adaptive_hooks() == 1, (
+        assert self._count_adaptive_hooks() == baseline + 1, (
             "exactly one hook must remain after upsert (old retired, new registered)"
         )

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -5806,3 +5806,80 @@ def test_get_configured_token_limits_coerces_numeric_strings():
     )
 
     assert router.get_configured_token_limits("quoted-limits-model") == (32000, 8000)
+
+
+class TestStrategyRegistryCleanupOnRemoval:
+    """upsert_deployment / delete_deployment must de-register strategy routers
+    (auto/complexity/adaptive/quality) for the removed deployment — otherwise
+    the re-add dies on the init functions' "already exists" check and the
+    model silently disappears from every listing while the stale registry
+    object keeps routing. Issue #33168."""
+
+    def _make_router(self):
+        return litellm.Router(
+            model_list=[
+                {
+                    "model_name": "gpt-4o-mini",
+                    "litellm_params": {"model": "gpt-4o-mini", "api_key": "fake-key"},
+                }
+            ]
+        )
+
+    def _complexity_deployment(self, simple_tier: str = "gpt-4o-mini"):
+        from litellm.types.router import Deployment, LiteLLM_Params
+
+        return Deployment(
+            model_name="test-auto-latest",
+            litellm_params=LiteLLM_Params(
+                model="auto_router/complexity_router",
+                complexity_router_config={
+                    "tiers": {
+                        "SIMPLE": simple_tier,
+                        "MEDIUM": simple_tier,
+                        "COMPLEX": simple_tier,
+                        "REASONING": simple_tier,
+                    }
+                },
+                complexity_router_default_model=simple_tier,
+            ),
+            model_info={"id": "complexity-registry-test-id"},
+        )
+
+    def test_upsert_updated_complexity_router_stays_listed(self):
+        router = self._make_router()
+        router.add_deployment(self._complexity_deployment())
+        assert "test-auto-latest" in router.get_model_names()
+        assert "test-auto-latest" in router.complexity_routers
+
+        # change the config -> upsert removes + re-adds the deployment
+        router.upsert_deployment(self._complexity_deployment(simple_tier="gpt-4o"))
+
+        assert "test-auto-latest" in router.get_model_names()
+        assert (
+            router.complexity_routers["test-auto-latest"].config.tiers["SIMPLE"]
+            == "gpt-4o"
+        )
+
+    def test_delete_complexity_router_clears_registry_and_allows_re_add(self):
+        router = self._make_router()
+        deployment = self._complexity_deployment()
+        router.add_deployment(deployment)
+
+        router.delete_deployment(id="complexity-registry-test-id")
+
+        # ghost registration must be gone once the deployment is deleted
+        assert "test-auto-latest" not in router.complexity_routers
+
+        # and the same name must be re-addable + listed again
+        router.add_deployment(deployment)
+        assert "test-auto-latest" in router.get_model_names()
+        assert "test-auto-latest" in router.complexity_routers
+
+    def test_delete_regular_deployment_untouched_by_registry_cleanup(self):
+        router = self._make_router()
+        model_id = router.get_model_ids()[0]
+
+        deleted = router.delete_deployment(id=model_id)
+
+        assert deleted is not None
+        assert "gpt-4o-mini" not in router.get_model_names()

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -5883,3 +5883,178 @@ class TestStrategyRegistryCleanupOnRemoval:
 
         assert deleted is not None
         assert "gpt-4o-mini" not in router.get_model_names()
+
+
+class TestStrategyRegistryCleanupGuards:
+    """Guards on _remove_deployment_from_strategy_registries: only strategy
+    deployments (litellm_params.model starting with auto_router/) may evict a
+    registry entry, and adaptive-router removal must also retire the
+    deployment's AdaptiveRouterPostCallHook. Issue #33168 follow-ups."""
+
+    def test_direct_call_is_noop_for_non_strategy_model(self):
+        router = litellm.Router(
+            model_list=[
+                {
+                    "model_name": "backing-model",
+                    "litellm_params": {"model": "gpt-4o-mini", "api_key": "fake-key"},
+                }
+            ]
+        )
+        from litellm.types.router import Deployment, LiteLLM_Params
+
+        router.add_deployment(
+            Deployment(
+                model_name="shared-name",
+                litellm_params=LiteLLM_Params(
+                    model="auto_router/complexity_router",
+                    complexity_router_config={
+                        "tiers": {
+                            "SIMPLE": "backing-model",
+                            "MEDIUM": "backing-model",
+                            "COMPLEX": "backing-model",
+                            "REASONING": "backing-model",
+                        }
+                    },
+                    complexity_router_default_model="backing-model",
+                ),
+                model_info={"id": "strategy-row-id"},
+            )
+        )
+        assert "shared-name" in router.complexity_routers
+
+        # a NON-strategy litellm_model must not evict the registry entry
+        router._remove_deployment_from_strategy_registries(
+            model_name="shared-name", litellm_model="azure/gpt-4o"
+        )
+        assert "shared-name" in router.complexity_routers
+
+        # a strategy litellm_model does
+        router._remove_deployment_from_strategy_registries(
+            model_name="shared-name", litellm_model="auto_router/complexity_router"
+        )
+        assert "shared-name" not in router.complexity_routers
+
+    def test_deleting_regular_deployment_with_colliding_name_keeps_strategy_router(self):
+        """A regular deployment that merely SHARES a strategy router's public
+        model_name must not evict the strategy router when deleted."""
+        from litellm.types.router import Deployment, LiteLLM_Params
+
+        router = litellm.Router(
+            model_list=[
+                {
+                    "model_name": "backing-model",
+                    "litellm_params": {"model": "gpt-4o-mini", "api_key": "fake-key"},
+                }
+            ]
+        )
+        router.add_deployment(
+            Deployment(
+                model_name="collide-auto-latest",
+                litellm_params=LiteLLM_Params(
+                    model="auto_router/complexity_router",
+                    complexity_router_config={
+                        "tiers": {
+                            "SIMPLE": "backing-model",
+                            "MEDIUM": "backing-model",
+                            "COMPLEX": "backing-model",
+                            "REASONING": "backing-model",
+                        }
+                    },
+                    complexity_router_default_model="backing-model",
+                ),
+                model_info={"id": "strategy-row"},
+            )
+        )
+        # regular deployment under the SAME public name (different tenant/id)
+        router.add_deployment(
+            Deployment(
+                model_name="collide-auto-latest",
+                litellm_params=LiteLLM_Params(model="gpt-4o-mini", api_key="fake-key"),
+                model_info={"id": "regular-row"},
+            )
+        )
+
+        router.delete_deployment(id="regular-row")
+
+        assert "collide-auto-latest" in router.complexity_routers, (
+            "deleting a regular deployment with a colliding name must not evict "
+            "the strategy router registration"
+        )
+
+    @staticmethod
+    def _count_adaptive_hooks():
+        from litellm.router_strategy.adaptive_router.hooks import (
+            AdaptiveRouterPostCallHook,
+        )
+
+        seen = set()
+        for cb_list in (
+            litellm.callbacks,
+            litellm.success_callback,
+            litellm.failure_callback,
+            litellm._async_success_callback,
+            litellm._async_failure_callback,
+        ):
+            for cb in cb_list:
+                if isinstance(cb, AdaptiveRouterPostCallHook):
+                    seen.add(id(cb))
+        return len(seen)
+
+    def _adaptive_router(self):
+        # adaptive-router init is deferred to set_model_list, so the deployment
+        # must be part of the Router's initial model_list
+        return litellm.Router(
+            model_list=[
+                {
+                    "model_name": "fast",
+                    "litellm_params": {"model": "gpt-4o-mini", "api_key": "fake-key"},
+                },
+                {
+                    "model_name": "adaptive-test-router",
+                    "litellm_params": {
+                        "model": "auto_router/adaptive_router",
+                        "adaptive_router_config": {"available_models": ["fast"]},
+                    },
+                    "model_info": {"id": "adaptive-row"},
+                },
+            ]
+        )
+
+    def test_adaptive_router_delete_retires_post_call_hook(self):
+        router = self._adaptive_router()
+        assert "adaptive-test-router" in router.adaptive_routers
+        assert self._count_adaptive_hooks() == 1
+
+        router.delete_deployment(id="adaptive-row")
+
+        assert "adaptive-test-router" not in router.adaptive_routers
+        assert self._count_adaptive_hooks() == 0, "deleted adaptive router's hook must be retired"
+
+    def test_adaptive_router_upsert_applies_new_config_without_leaking_hooks(self):
+        from litellm.types.router import Deployment, LiteLLM_Params
+
+        router = self._adaptive_router()
+        original = router.adaptive_routers["adaptive-test-router"]
+        assert self._count_adaptive_hooks() == 1
+
+        router.upsert_deployment(
+            Deployment(
+                model_name="adaptive-test-router",
+                litellm_params=LiteLLM_Params(
+                    model="auto_router/adaptive_router",
+                    adaptive_router_config={"available_models": ["fast"], "explore_rate": 0.5},
+                ),
+                model_info={"id": "adaptive-row"},
+            )
+        )
+
+        assert "adaptive-test-router" in router.get_model_names()
+        assert "adaptive-test-router" in router.adaptive_routers, (
+            "upserted adaptive deployment must still have a registered router"
+        )
+        assert router.adaptive_routers["adaptive-test-router"] is not original, (
+            "upsert must rebuild the adaptive router with the new config"
+        )
+        assert self._count_adaptive_hooks() == 1, (
+            "exactly one hook must remain after upsert (old retired, new registered)"
+        )

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -5855,10 +5855,9 @@ class TestStrategyRegistryCleanupOnRemoval:
         router.upsert_deployment(self._complexity_deployment(simple_tier="gpt-4o"))
 
         assert "test-auto-latest" in router.get_model_names()
-        assert (
-            router.complexity_routers["test-auto-latest"].config.tiers["SIMPLE"]
-            == "gpt-4o"
-        )
+        registered = router.complexity_routers["test-auto-latest"]
+        assert len(registered) == 1, "upsert must replace the registration, not accumulate"
+        assert registered[0].strategy.config.tiers["SIMPLE"] == "gpt-4o"
 
     def test_delete_complexity_router_clears_registry_and_allows_re_add(self):
         router = self._make_router()
@@ -6089,7 +6088,7 @@ class TestStrategyRegistryCleanupGuards:
 
         baseline = self._count_adaptive_hooks()  # tolerate hooks leaked by other tests
         router = self._adaptive_router()
-        original = router.adaptive_routers["adaptive-test-router"]
+        original = router.adaptive_routers["adaptive-test-router"][0].strategy
         assert self._count_adaptive_hooks() == baseline + 1
 
         router.upsert_deployment(
@@ -6107,7 +6106,7 @@ class TestStrategyRegistryCleanupGuards:
         assert "adaptive-test-router" in router.adaptive_routers, (
             "upserted adaptive deployment must still have a registered router"
         )
-        assert router.adaptive_routers["adaptive-test-router"] is not original, (
+        assert router.adaptive_routers["adaptive-test-router"][0].strategy is not original, (
             "upsert must rebuild the adaptive router with the new config"
         )
         assert self._count_adaptive_hooks() == baseline + 1, (


### PR DESCRIPTION
## What this fixes

Closes the **remaining registry-eviction gap in the router-layer removal paths** (`Router.upsert_deployment` / `Router.delete_deployment`) — the paths used by the proxy's **periodic DB sync**, which the endpoint-layer eviction shipped in 9521276 / 02137b2 (≥ 1.93.0rc1) doesn't reach.

Relates to #33168 (leaving open until the sync path is covered; also #20558, #13236).

## Why the endpoint-layer fix isn't enough

`model_management_endpoints.py` evicts the strategy registry **only on the replica that serves the PATCH/delete request**. Every other replica picks the change up via the 30s DB sync, which goes through `Router.upsert_deployment`:

1. `upsert_deployment` pops the row from `model_list`…
2. …then `add_deployment` → `init_*_router_deployment` raises **"already exists"** (the registry was never cleaned on this replica),
3. the error is swallowed under `ignore_invalid_deployments` → the row is **delisted from `/v1/models` / `/model/info` on that replica** while the stale registry object keeps serving the old config.

So on any **multi-replica** deployment, updating an auto-router still delists it everywhere except the replica that handled the request. (This is why we currently run our proxies pinned to a single replica.) `delete_deployment` has the same gap: the registry entry survives and keeps serving as a ghost, and blocks re-adds under the same name.

## What the PR does

- `_remove_deployment_from_strategy_registries()`: evicts the removed deployment's registration from its **own** strategy registry (auto / complexity / adaptive / quality), scoped to the `(model_name, tags)` pair — tag-scoped siblings sharing the name survive (v2 `TaggedPreRoutingStrategy` list shape). Guarded on the `auto_router/` prefix so deleting a regular deployment that shares a strategy router's public name can't evict it.
- `upsert_deployment` / `delete_deployment` call it after removing the row, so the re-add re-registers instead of dying.
- Adaptive routers: the removed strategy's `AdaptiveRouterPostCallHook` is retired from the global callback lists (otherwise each upsert/delete cycle leaks one hook that keeps firing), and upsert re-inits the adaptive router (its init is deferred out of `_add_deployment`).

## Tests

8 unit tests in `tests/test_litellm/test_router.py` (`TestStrategyRegistryCleanupOnRemoval`, `TestStrategyRegistryCleanupGuards`) — all in-memory, no network: upsert keeps the model listed and applies the new config; delete clears the registry and allows re-add; ghost routing stops; same-name cross-registry siblings and tag-scoped siblings survive; adaptive hooks don't leak.

Rebased 2026-07-22 onto `litellm_oss_daily_2026_07_20` and adapted to the Auto Router v2 tag-scoped registries.
