### PR TITLE
fix(pricing): add undated azure aliases for gpt-audio-mini and gpt-realtime-mini

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -4868,6 +4868,7 @@
         "supports_vision": false
     },
     "azure/gpt-audio-mini": {
+        "deprecation_date": "2027-04-06",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "azure",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -5121,7 +5121,7 @@
         "max_input_tokens": 32000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_audio_token": 2e-05,
         "output_cost_per_token": 2.4e-06,
         "supported_endpoints": [

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -4867,6 +4867,37 @@
         "supports_tool_choice": true,
         "supports_vision": false
     },
+    "azure/gpt-audio-mini": {
+        "input_cost_per_audio_token": 1e-05,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "azure",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2.4e-06,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": false,
+        "supports_reasoning": false,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
     "azure/gpt-audio-mini-2025-10-06": {
         "deprecation_date": "2027-04-06",
         "input_cost_per_audio_token": 1e-05,
@@ -5061,6 +5092,38 @@
         "mode": "realtime",
         "output_cost_per_audio_token": 6.4e-05,
         "output_cost_per_token": 1.6e-05,
+        "supported_endpoints": [
+            "/v1/realtime"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
+    "azure/gpt-realtime-mini": {
+        "cache_creation_input_audio_token_cost": 3e-07,
+        "cache_read_input_token_cost": 6e-08,
+        "input_cost_per_audio_token": 1e-05,
+        "input_cost_per_image": 8e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "azure",
+        "max_input_tokens": 32000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2.4e-06,
         "supported_endpoints": [
             "/v1/realtime"
         ],

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -4804,6 +4804,37 @@
         "supports_tool_choice": true,
         "supports_vision": false
     },
+    "azure/gpt-audio-mini": {
+        "input_cost_per_audio_token": 1e-05,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "azure",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2.4e-06,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": false,
+        "supports_reasoning": false,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
     "azure/gpt-audio-mini-2025-10-06": {
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,
@@ -4993,6 +5024,38 @@
         "mode": "realtime",
         "output_cost_per_audio_token": 6.4e-05,
         "output_cost_per_token": 1.6e-05,
+        "supported_endpoints": [
+            "/v1/realtime"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
+    "azure/gpt-realtime-mini": {
+        "cache_creation_input_audio_token_cost": 3e-07,
+        "cache_read_input_token_cost": 6e-08,
+        "input_cost_per_audio_token": 1e-05,
+        "input_cost_per_image": 8e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "azure",
+        "max_input_tokens": 32000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2.4e-06,
         "supported_endpoints": [
             "/v1/realtime"
         ],

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -5053,7 +5053,7 @@
         "max_input_tokens": 32000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_audio_token": 2e-05,
         "output_cost_per_token": 2.4e-06,
         "supported_endpoints": [

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4868,6 +4868,7 @@
         "supports_vision": false
     },
     "azure/gpt-audio-mini": {
+        "deprecation_date": "2027-04-06",
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,
         "litellm_provider": "azure",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5121,7 +5121,7 @@
         "max_input_tokens": 32000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_audio_token": 2e-05,
         "output_cost_per_token": 2.4e-06,
         "supported_endpoints": [

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4867,6 +4867,37 @@
         "supports_tool_choice": true,
         "supports_vision": false
     },
+    "azure/gpt-audio-mini": {
+        "input_cost_per_audio_token": 1e-05,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "azure",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2.4e-06,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": false,
+        "supports_reasoning": false,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
     "azure/gpt-audio-mini-2025-10-06": {
         "deprecation_date": "2027-04-06",
         "input_cost_per_audio_token": 1e-05,
@@ -5061,6 +5092,38 @@
         "mode": "realtime",
         "output_cost_per_audio_token": 6.4e-05,
         "output_cost_per_token": 1.6e-05,
+        "supported_endpoints": [
+            "/v1/realtime"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
+    "azure/gpt-realtime-mini": {
+        "cache_creation_input_audio_token_cost": 3e-07,
+        "cache_read_input_token_cost": 6e-08,
+        "input_cost_per_audio_token": 1e-05,
+        "input_cost_per_image": 8e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "azure",
+        "max_input_tokens": 32000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2.4e-06,
         "supported_endpoints": [
             "/v1/realtime"
         ],

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4804,6 +4804,37 @@
         "supports_tool_choice": true,
         "supports_vision": false
     },
+    "azure/gpt-audio-mini": {
+        "input_cost_per_audio_token": 1e-05,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "azure",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2.4e-06,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": false,
+        "supports_reasoning": false,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
     "azure/gpt-audio-mini-2025-10-06": {
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,
@@ -4993,6 +5024,38 @@
         "mode": "realtime",
         "output_cost_per_audio_token": 6.4e-05,
         "output_cost_per_token": 1.6e-05,
+        "supported_endpoints": [
+            "/v1/realtime"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
+    "azure/gpt-realtime-mini": {
+        "cache_creation_input_audio_token_cost": 3e-07,
+        "cache_read_input_token_cost": 6e-08,
+        "input_cost_per_audio_token": 1e-05,
+        "input_cost_per_image": 8e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "azure",
+        "max_input_tokens": 32000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2.4e-06,
         "supported_endpoints": [
             "/v1/realtime"
         ],

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5053,7 +5053,7 @@
         "max_input_tokens": 32000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
-        "mode": "chat",
+        "mode": "realtime",
         "output_cost_per_audio_token": 2e-05,
         "output_cost_per_token": 2.4e-06,
         "supported_endpoints": [

--- a/tests/test_litellm/test_azure_audio_price_aliases.py
+++ b/tests/test_litellm/test_azure_audio_price_aliases.py
@@ -46,3 +46,22 @@ def test_undated_azure_audio_alias_matches_dated_entry(undated, dated):
 
     assert undated_info.get("litellm_provider") == "azure"
     assert undated_info.get("mode") == dated_info.get("mode")
+
+
+@pytest.mark.parametrize(
+    "undated, dated",
+    [
+        ("azure/gpt-audio-mini", "azure/gpt-audio-mini-2025-10-06"),
+        ("azure/gpt-realtime-mini", "azure/gpt-realtime-mini-2025-10-06"),
+    ],
+)
+def test_undated_azure_audio_alias_is_exact_mirror(undated, dated):
+    """The undated alias must be a byte-for-byte mirror of its dated entry —
+    covers every field (incl. realtime-specific cache/audio cost keys) so any
+    future drift between the pair is caught, not just the core COST_FIELDS."""
+    model_map = litellm.model_cost
+    assert undated in model_map, f"{undated} missing from model cost map"
+    assert model_map[undated] == model_map[dated], (
+        f"{undated} must exactly mirror {dated}; "
+        f"diff keys: {[k for k in set(model_map[undated]) | set(model_map[dated]) if model_map[undated].get(k) != model_map[dated].get(k)]}"
+    )

--- a/tests/test_litellm/test_azure_audio_price_aliases.py
+++ b/tests/test_litellm/test_azure_audio_price_aliases.py
@@ -1,0 +1,48 @@
+"""Undated azure aliases for the audio models must exist and match their dated
+variants — Azure deployments are commonly created against the undated model
+name, and `base_model: azure/gpt-audio-mini` previously resolved to nothing
+(text tokens billed at $0). Issue #33170."""
+
+import pytest
+
+import litellm
+
+
+@pytest.fixture(autouse=True)
+def _use_local_model_cost_map(monkeypatch):
+    original_model_cost = litellm.model_cost
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    try:
+        yield
+    finally:
+        litellm.model_cost = original_model_cost
+
+
+COST_FIELDS = (
+    "input_cost_per_token",
+    "output_cost_per_token",
+    "input_cost_per_audio_token",
+    "output_cost_per_audio_token",
+)
+
+
+@pytest.mark.parametrize(
+    "undated, dated",
+    [
+        ("azure/gpt-audio-mini", "azure/gpt-audio-mini-2025-10-06"),
+        ("azure/gpt-realtime-mini", "azure/gpt-realtime-mini-2025-10-06"),
+    ],
+)
+def test_undated_azure_audio_alias_matches_dated_entry(undated, dated):
+    undated_info = litellm.get_model_info(undated)
+    dated_info = litellm.get_model_info(dated)
+
+    for field in COST_FIELDS:
+        assert undated_info.get(field) == dated_info.get(field), field
+        # the production symptom was text tokens billed at $0 — make sure the
+        # alias carries real, non-zero prices
+        assert (undated_info.get(field) or 0) > 0, f"{undated}.{field} must be non-zero"
+
+    assert undated_info.get("litellm_provider") == "azure"
+    assert undated_info.get("mode") == dated_info.get("mode")


### PR DESCRIPTION
## Relevant issues

Fixes #33170

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

**Production observation** (litellm proxy 1.92.0 on Azure, real Azure `gpt-audio-mini` deployment, real audio-modality completions): with no undated `azure/gpt-audio-mini` map key, spend logs and the `x-litellm-response-cost` header billed **text tokens at $0** while audio tokens billed correctly. We verified by putting the correct prices in `litellm_params` custom pricing on the deployment row — after which the cost header matched the hand-computed text+audio math exactly ($0.60/M in, $2.40/M out — the same numbers as the dated `azure/gpt-audio-mini-2025-10-06` entry this PR mirrors).

Map state before (base `10d5804b3e`):

```
$ jq 'has("azure/gpt-audio-mini"), has("azure/gpt-realtime-mini")' model_prices_and_context_window.json
false
false
$ jq -r 'keys[] | select(test("^azure/gpt-(audio|realtime)-mini"))' model_prices_and_context_window.json
azure/gpt-audio-mini-2025-10-06
azure/gpt-realtime-mini-2025-10-06
```

After (`2f906a3415`):

```
$ pytest tests/test_litellm/test_azure_audio_price_aliases.py -q
2 passed
# on base: 2 failed (ValueError: This model isn't mapped yet)
```

The new test resolves both undated names through `litellm.get_model_info` (local cost map fixture, same pattern as `test_cloudflare_workers_ai_model_metadata.py`) and asserts every cost field matches the dated entry and is non-zero.

**Note on the second commit:** running the repo's own `ci_cd/check_files_match.py` sync tool surfaced pre-existing drift on the daily branch (9 entries in the root map missing from the packaged backup — `gemini-3-pro-image`, `zai/glm-5.1`, etc.). That sync is kept as a separate `chore:` commit so the alias fix itself stays a clean 63-line-per-file addition. Happy to drop that commit if you'd rather take the drift separately.

## Type

🐛 Bug Fix

## Changes

- Add `azure/gpt-audio-mini` and `azure/gpt-realtime-mini` to `model_prices_and_context_window.json` (and the packaged backup), each an exact mirror of its `-2025-10-06` dated entry — same relationship as the undated openai `gpt-audio-mini` / `gpt-realtime-mini` entries.
- Parametrized test asserting the undated aliases resolve and match the dated entries with non-zero costs.
