### PR TITLE
fix(embeddings): accept encoding_format='float' for vertex_ai/gemini embeddings

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3197,6 +3197,12 @@ def get_optional_params_embeddings(
             non_default_params=non_default_params, optional_params={}, kwargs=kwargs
         )
     elif custom_llm_provider == "vertex_ai" or custom_llm_provider == "gemini":
+        # OpenAI SDKs (and litellm's own client) send encoding_format="float"
+        # by default; float lists are exactly what the vertex API returns, so
+        # the param is a no-op — don't reject the provider default. Other
+        # values (e.g. "base64") stay on the unsupported-param path below.
+        if non_default_params.get("encoding_format") == "float":
+            non_default_params.pop("encoding_format")
         supported_params = get_supported_openai_params(
             model=model,
             custom_llm_provider="vertex_ai",

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4710,3 +4710,53 @@ class TestValidateEnvironmentTencent:
         assert "TENCENT_API_KEY" in result["missing_keys"]
 
 
+
+
+class TestVertexEmbeddingEncodingFormat:
+    """vertex_ai/gemini embeddings must accept encoding_format="float" — it's
+    the OpenAI SDK default and float lists are exactly what the vertex API
+    returns. Other values keep the unsupported-param behavior (drop with
+    drop_params, raise otherwise). Issue #33173."""
+
+    def test_encoding_format_float_is_accepted_and_dropped(self):
+        optional_params = litellm.utils.get_optional_params_embeddings(
+            model="gemini-embedding-001",
+            encoding_format="float",
+            custom_llm_provider="vertex_ai",
+        )
+        assert "encoding_format" not in optional_params
+
+    def test_encoding_format_float_accepted_for_gemini_provider(self):
+        optional_params = litellm.utils.get_optional_params_embeddings(
+            model="gemini-embedding-001",
+            encoding_format="float",
+            custom_llm_provider="gemini",
+        )
+        assert "encoding_format" not in optional_params
+
+    def test_encoding_format_base64_still_rejected_without_drop_params(self):
+        with pytest.raises(Exception) as excinfo:
+            litellm.utils.get_optional_params_embeddings(
+                model="gemini-embedding-001",
+                encoding_format="base64",
+                custom_llm_provider="vertex_ai",
+            )
+        assert "encoding_format" in str(excinfo.value)
+
+    def test_encoding_format_base64_dropped_with_drop_params(self):
+        optional_params = litellm.utils.get_optional_params_embeddings(
+            model="gemini-embedding-001",
+            encoding_format="base64",
+            custom_llm_provider="vertex_ai",
+            drop_params=True,
+        )
+        assert "encoding_format" not in optional_params
+
+    def test_dimensions_still_mapped(self):
+        optional_params = litellm.utils.get_optional_params_embeddings(
+            model="gemini-embedding-001",
+            encoding_format="float",
+            dimensions=256,
+            custom_llm_provider="vertex_ai",
+        )
+        assert optional_params.get("outputDimensionality") == 256


### PR DESCRIPTION
## Relevant issues

Fixes #33173

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

**Production observation** (litellm proxy 1.92.0, real vertex_ai `gemini-embedding-2` deployment, real OpenAI-SDK clients): every embedding call from a stock `openai>=1.x` / litellm-client (which send `encoding_format="float"` by default) 400s with

```
litellm.UnsupportedParamsError: vertex_ai does not support parameters: {'encoding_format': 'float'}, for model=gemini-embedding-2. To drop these, set `litellm.drop_params=True` ...
```

Client-side `drop_params` cannot help (the rejection is in the proxy's provider handler); we had to set proxy-wide `litellm_settings.drop_params: true` as a workaround. Pinning the client to litellm `<1.84` (which doesn't send the default) also "fixed" it — confirming the trigger is the SDK-default param, not user code.

**Unit tests** (`TestVertexEmbeddingEncodingFormat` in `tests/test_litellm/test_utils.py`):

Before (base `10d5804b3e`): the three cases sending `encoding_format="float"` FAIL with `UnsupportedParamsError`; the two `base64` cases pass.

After (this PR, `e27b240d94`):

```
$ pytest tests/test_litellm/test_utils.py::TestVertexEmbeddingEncodingFormat -q
5 passed
```

covering: float accepted + dropped as a no-op (vertex_ai and gemini providers), `base64` still rejected without `drop_params`, `base64` still dropped with `drop_params=True` (semantics unchanged), and `dimensions` → `outputDimensionality` mapping untouched.

`ruff format --check` / `ruff check` pass on `litellm/utils.py`.

## Type

🐛 Bug Fix

## Changes

- In `get_optional_params_embeddings`' vertex_ai/gemini branch, pop `encoding_format` when its value is `"float"` before `_check_valid_arg` runs: float lists are exactly what the vertex API returns, so the OpenAI SDK default is a no-op, not an unsupported param.
- Values other than `"float"` (e.g. `"base64"`, which vertex genuinely can't produce) keep the existing unsupported-param behavior — dropped under `drop_params`, raised otherwise. No change to `VertexAITextEmbeddingConfig`'s supported params, so no drop_params regression.
