### PR TITLE
fix(auth): scope the JWT enterprise gate to actual JWTs

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1191,13 +1191,15 @@ async def _user_api_key_auth_builder(
             return await handle_oauth2_proxy_request(request=request)
 
         if general_settings.get("enable_jwt_auth", False) is True:
-            from litellm.proxy.proxy_server import premium_user
-
-            if premium_user is not True:
-                raise ValueError(f"JWT Auth is an enterprise only feature. {CommonProxyErrors.not_premium_user.value}")
             is_jwt = jwt_handler.is_jwt(token=api_key)
             verbose_proxy_logger.debug("is_jwt: %s", is_jwt)
             if is_jwt:
+                from litellm.proxy.proxy_server import premium_user
+
+                if premium_user is not True:
+                    raise ValueError(
+                        f"JWT Auth is an enterprise only feature. {CommonProxyErrors.not_premium_user.value}"
+                    )
                 # Try JWT-to-Virtual-Key mapping first to avoid
                 # unnecessary DB queries in auth_builder
                 do_standard_jwt_auth = True

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -3993,6 +3993,80 @@ async def test_non_admin_cli_session_token_reaches_production_auth_path(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_cli_session_token_authenticates_when_jwt_auth_enabled_without_license(monkeypatch):
+    """A lite login token is an encrypted (non-JWT) session blob. With
+    enable_jwt_auth on and no enterprise license (premium_user False), the JWT
+    premium gate used to fire for every request before the token was decoded, so
+    the CLI token 401'd with 'JWT Auth is an enterprise only feature' and was
+    never decrypted. The gate must apply only to actual JWTs; a non-JWT session
+    token has to keep authenticating on its own path regardless of license."""
+    monkeypatch.delenv("EXPERIMENTAL_UI_LOGIN", raising=False)
+    cli_token = _mint_cli_session_token(monkeypatch)
+
+    jwt_handler = MagicMock()
+    jwt_handler.is_jwt = JWTHandler.is_jwt
+    jwt_handler.litellm_jwtauth = LiteLLM_JWTAuth()
+
+    mock_request = MagicMock()
+    mock_request.url.path = "/v1/messages"
+    mock_request.method = "POST"
+    mock_request.headers = {"authorization": f"Bearer {cli_token}"}
+    mock_request.query_params = {}
+
+    with (
+        patch("litellm.proxy.proxy_server.general_settings", {"enable_jwt_auth": True}),
+        patch("litellm.proxy.proxy_server.premium_user", False),
+        patch("litellm.proxy.proxy_server.jwt_handler", jwt_handler),
+        patch("litellm.proxy.proxy_server.master_key", "sk-master"),
+        patch("litellm.proxy.proxy_server.prisma_client", None),
+    ):
+        result = await user_api_key_auth(
+            request=mock_request,
+            api_key=f"Bearer {cli_token}",
+        )
+
+    assert result.user_id == "cli-admin"
+    assert result.team_id == "cli-team"
+    assert result.token is not None and result.token.startswith("cli-session-")
+
+
+@pytest.mark.asyncio
+async def test_real_jwt_still_requires_license_when_jwt_auth_enabled(monkeypatch):
+    """Guard for the reorder above: the enterprise gate must still reject an
+    actual JWT when there is no license. Moving the premium check inside the
+    is_jwt branch must not open JWT auth to non-premium deployments."""
+    monkeypatch.delenv("EXPERIMENTAL_UI_LOGIN", raising=False)
+    monkeypatch.setenv("LITELLM_SALT_KEY", "sk-salt-cli-test")
+
+    jwt_token = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyMSJ9.sig"
+    jwt_handler = MagicMock()
+    jwt_handler.is_jwt = JWTHandler.is_jwt
+    jwt_handler.litellm_jwtauth = LiteLLM_JWTAuth()
+
+    mock_request = MagicMock()
+    mock_request.url.path = "/v1/messages"
+    mock_request.method = "POST"
+    mock_request.headers = {"authorization": f"Bearer {jwt_token}"}
+    mock_request.query_params = {}
+
+    with (
+        patch("litellm.proxy.proxy_server.general_settings", {"enable_jwt_auth": True}),
+        patch("litellm.proxy.proxy_server.premium_user", False),
+        patch("litellm.proxy.proxy_server.jwt_handler", jwt_handler),
+        patch("litellm.proxy.proxy_server.master_key", "sk-master"),
+        patch("litellm.proxy.proxy_server.prisma_client", None),
+    ):
+        with pytest.raises(Exception) as exc_info:
+            await user_api_key_auth(
+                request=mock_request,
+                api_key=f"Bearer {jwt_token}",
+            )
+
+    message = str(getattr(exc_info.value, "message", exc_info.value))
+    assert "enterprise only feature" in message
+
+
+@pytest.mark.asyncio
 async def test_auth_path_caches_team_object_under_canonical_team_id_key():
     """Regression for LIT-4000: the auth builder must cache the team object under
     the canonical ``team_id:{id}`` key that ``get_team_object`` and


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Config for all runs (the failing setup a customer hits): `general_settings.enable_jwt_auth: True` with **no** `LITELLM_LICENSE`, so `premium_user` resolves to `False`. The CLI session token below is the exact blob `lite login` stores (minted server-side with `ExperimentalUIJWTToken.get_cli_jwt_auth_token`, since the browser SSO step is not scriptable); it is not a JWT, it is an encrypted `UserAPIKeyAuth` session token.

**Before the fix** (working tree at the pre-fix state, same as `litellm_internal_staging` for these lines). The JWT enterprise gate fires for every credential, so even the master key 401s and the token is never decoded:

```
$ curl -s -X POST http://localhost:4000/team/new -H "Authorization: Bearer sk-1234" -d '{"team_alias":"x"}'
{"error":{"message":"Authentication Error, JWT Auth is an enterprise only feature. You must be a LiteLLM Enterprise user to use this feature...","type":"auth_error","code":"401"}}
```

**After the fix** (commit `a3d8de40b3`). Non-JWT credentials authenticate; a real JWT is still rejected:

```
# master key
$ curl -s -o /dev/null -w "%{http_code}\n" http://localhost:4000/models -H "Authorization: Bearer sk-1234"
200

# lite login session token -> real Anthropic call
$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:4000/chat/completions \
    -H "Authorization: Bearer <cli-session-token>" -H "Content-Type: application/json" \
    -d '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"say ok"}]}'
{ ... "usage":{"completion_tokens":24,"prompt_tokens":8,"total_tokens":32}, ... }
HTTP 200

# an actual JWT (header.payload.sig) is STILL gated -> enterprise feature unchanged
$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:4000/chat/completions \
    -H "Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyMSJ9.sig" -H "Content-Type: application/json" \
    -d '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"hi"}]}'
{"error":{"message":"...JWT Auth is an enterprise only feature...","type":"auth_error","code":"401"}}
HTTP 401
```

The non-admin (`internal_user`) session token was verified the same way and also returns 200 with a real Anthropic response, with spend attributed to its `user_id` / `team_id`.

## Type

🐛 Bug Fix

## Changes

`enable_jwt_auth` is an enterprise feature, so when it is on and the deployment is not licensed (`premium_user` is `False`), the builder raised `"JWT Auth is an enterprise only feature"` for the request. The check ran before the token type was known, so it rejected every credential, including the proxy master key, `sk-` virtual keys, and the encrypted CLI/UI SSO session token that `lite login` issues. The token was never decoded, and `lite login` plus `lite claude` (whose pre-launch `/v1/models` probe hits the same path) failed with a 401 on any deployment that turned JWT auth on without a license.

The fix moves the premium check inside the `is_jwt` branch in `_user_api_key_auth_builder`, so it gates only actual JWTs. Non-JWT credentials fall through to their existing auth paths (master key, virtual-key lookup, session-token decrypt) regardless of license, while a real JWT under a non-premium deployment is still rejected, so the enterprise gate is unchanged for the feature it protects. `is_jwt` is a pure structural check (`len(token.split(".")) == 3`), so the encrypted session blob never enters the JWT path.

Regression coverage in `test_user_api_key_auth.py`: `test_cli_session_token_authenticates_when_jwt_auth_enabled_without_license` fails on the old ordering and passes now, and `test_real_jwt_still_requires_license_when_jwt_auth_enabled` locks in that a genuine JWT is still gated.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
