### PR TITLE
test(e2e): failed request error span carries the full untruncated message and status (LIT-4179)

### DIFF
--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -79,6 +79,7 @@ services:
     env_file: .env
     environment:
       LITELLM_MASTER_KEY: sk-1234
+      STORE_MODEL_IN_DB: "True"
       LITELLM_OTEL_V2: "true"
       PHOENIX_COLLECTOR_HTTP_ENDPOINT: http://jaeger:4318/v1/traces
       PHOENIX_API_KEY: local-jaeger-noauth

--- a/tests/e2e/logging/test_otel_trace_e2e.py
+++ b/tests/e2e/logging/test_otel_trace_e2e.py
@@ -21,7 +21,7 @@ import time
 from collections.abc import Callable
 
 import pytest
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from e2e_config import CHEAP_ANTHROPIC_MODEL, CHEAP_OPENAI_MODEL, unique_marker
 from e2e_http import NoBody, StreamingResponse, require_successful_call
@@ -203,7 +203,14 @@ def _assert_error_span_contract(span: JaegerSpan) -> None:
     assert "AnthropicException" in message, (
         f"error.message must carry the upstream provider exception, got: {message[:200]}"
     )
-    provider_error = _ProviderError.model_validate_json(message[message.index("{") : message.rindex("}") + 1])
+    start, end = message.find("{"), message.rfind("}")
+    assert start != -1 and end > start, (
+        f"error.message carries no parseable provider error JSON (truncated?): {message[:200]}"
+    )
+    try:
+        provider_error = _ProviderError.model_validate_json(message[start : end + 1])
+    except ValidationError:
+        pytest.fail(f"the embedded provider error JSON does not parse (truncated?): {message[:300]}")
     assert provider_error.error.message == "invalid x-api-key", (
         f"the embedded provider error must survive untruncated; parsed: {provider_error}"
     )
@@ -536,6 +543,10 @@ class TestOtelTraceCompleteness:
             if "AnthropicException" in outcome.body or time.monotonic() >= deadline:
                 break
             time.sleep(client.gateway.poll_interval)
+        assert "AnthropicException" in outcome.body, (
+            "never saw the upstream provider failure before the deadline; the key may still be "
+            f"propagating - last outcome {outcome.status_code}: {outcome.body[:200]}"
+        )
         assert outcome.status_code == 401, (
             f"an upstream auth failure must map to 401, got {outcome.status_code}: {outcome.body[:200]}"
         )

--- a/tests/e2e/logging/test_otel_trace_e2e.py
+++ b/tests/e2e/logging/test_otel_trace_e2e.py
@@ -513,23 +513,18 @@ class TestOtelTraceCompleteness:
     def test_failed_chat_completions_error_span_attributes(
         self, client: LoggingClient, otel_reader: OtelReader, resources: ResourceManager
     ) -> None:
-        """A failed /chat/completions call (upstream authentication error) must
-        export one complete OTEL trace whose gen-AI span carries the full
-        LIT-4179 error contract: error=True, the exact error.type, ERROR span
-        status, and an UNTRUNCATED error.message containing the provider's
-        complete error JSON - proven by parsing that JSON back out of the
-        attribute (truncation breaks the parse). The root SERVER span must
-        record the 401 the client received.
+        """This test checks that a failed `/chat/completions` request produces a
+        single, complete OTEL trace. The model-call span should include all
+        expected error attributes, a non-empty stack trace, and the full,
+        untruncated `error.message`. The provider error embedded in that
+        message must also remain valid JSON. The root server span should
+        record the same 401 response returned to the client.
 
-        The trace has no cost-write span by design: a failed call bills
-        nothing, so the tree contract is asserted with require_cost_span=False.
-
-        The failure is produced by registering a deployment with a deliberately
-        invalid upstream Anthropic key, so the request clears proxy auth and
-        fails at the provider - the only path that produces a gen-AI error span
-        (proxy-gate rejections never reach the model and are deliberately not
-        traced as LLM calls).
-        """
+        The test uses a deployment with an invalid upstream API key. This
+        allows the request to pass LiteLLM’s proxy authentication and fail at
+        the provider, which is necessary to generate a model-call error span.
+        There should be no cost-write span because failed requests are not
+        billed."""
         route = "/chat/completions"
         _assert_otel_destination_configured(client)
 

--- a/tests/e2e/logging/test_otel_trace_e2e.py
+++ b/tests/e2e/logging/test_otel_trace_e2e.py
@@ -26,7 +26,8 @@ from pydantic import BaseModel, ConfigDict
 from e2e_config import CHEAP_ANTHROPIC_MODEL, CHEAP_OPENAI_MODEL, unique_marker
 from e2e_http import NoBody, StreamingResponse, require_successful_call
 from lifecycle import ResourceManager
-from logging_client import LoggingClient
+from logging_client import INVALID_UPSTREAM_API_KEY, LoggingClient
+from models import LiteLLMParamsBody
 from otel_client import JaegerSpan, JaegerTrace, OtelReader
 
 pytestmark = pytest.mark.e2e
@@ -159,6 +160,56 @@ def _tag(span: JaegerSpan, key: str) -> str | int | float | bool | None:
         if tag.key == key:
             return tag.value
     return None
+
+
+#: The attribute contract a failed call's gen-AI span must carry (LIT-4179), as
+#: one reviewable payload. Exact-match values; error.message is additionally
+#: proven untruncated by _assert_error_span_contract, which parses the provider
+#: error JSON embedded in it - a truncated message stops parsing.
+EXPECTED_ERROR_SPAN_ATTRIBUTES: dict[str, str] = {
+    "error": "True",
+    "error.type": "AuthenticationError",
+    "otel.status_code": "ERROR",
+}
+
+
+class _ProviderErrorDetail(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    type: str
+    message: str
+
+
+class _ProviderError(BaseModel):
+    """The provider error JSON embedded in error.message; validating it proves
+    the attribute survived untruncated (a cut-off message stops parsing)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    error: _ProviderErrorDetail
+
+
+def _assert_error_span_contract(span: JaegerSpan) -> None:
+    """The failed call's gen-AI span carries the LIT-4179 error contract: the
+    exact attributes in EXPECTED_ERROR_SPAN_ATTRIBUTES, plus an untruncated
+    error.message whose embedded provider error JSON still parses and whose
+    text also rides the span status description."""
+    for key, expected in EXPECTED_ERROR_SPAN_ATTRIBUTES.items():
+        actual = _tag(span, key)
+        assert str(actual) == expected, f"error span attribute {key!r} must be {expected!r}, got {actual!r}"
+
+    message = _tag(span, "error.message")
+    assert isinstance(message, str) and message, "error span must carry a non-empty error.message"
+    assert "AnthropicException" in message, (
+        f"error.message must carry the upstream provider exception, got: {message[:200]}"
+    )
+    provider_error = _ProviderError.model_validate_json(message[message.index("{") : message.rindex("}") + 1])
+    assert provider_error.error.message == "invalid x-api-key", (
+        f"the embedded provider error must survive untruncated; parsed: {provider_error}"
+    )
+    assert _tag(span, "otel.status_description") == message, (
+        "the span status description must carry the same untruncated message as error.message"
+    )
 
 
 class TestOtelTraceCompleteness:
@@ -444,3 +495,63 @@ class TestOtelTraceCompleteness:
         assert spend_row.call_type == "aresponses", (
             f"the spend row must be attributed to the responses call type, got {spend_row.call_type!r}"
         )
+
+    @pytest.mark.covers("logging.otel.failure.exports_metric", exercised_on=["chat_completions"])
+    def test_failed_chat_completions_error_span_attributes(
+        self, client: LoggingClient, otel_reader: OtelReader, resources: ResourceManager
+    ) -> None:
+        """A failed /chat/completions call (upstream authentication error) must
+        export one complete OTEL trace whose gen-AI span carries the full
+        LIT-4179 error contract: error=True, the exact error.type, ERROR span
+        status, and an UNTRUNCATED error.message containing the provider's
+        complete error JSON - proven by parsing that JSON back out of the
+        attribute (truncation breaks the parse). The root SERVER span must
+        record the 401 the client received.
+
+        The trace has no cost-write span by design: a failed call bills
+        nothing, so the tree contract is asserted with require_cost_span=False.
+
+        The failure is produced by registering a deployment with a deliberately
+        invalid upstream Anthropic key, so the request clears proxy auth and
+        fails at the provider - the only path that produces a gen-AI error span
+        (proxy-gate rejections never reach the model and are deliberately not
+        traced as LLM calls).
+        """
+        route = "/chat/completions"
+        _assert_otel_destination_configured(client)
+
+        model_name = f"otel-err-{unique_marker()}"
+        model_id = client.create_model(
+            model_name,
+            LiteLLMParamsBody(model="anthropic/claude-haiku-4-5", api_key=INVALID_UPSTREAM_API_KEY),
+        )
+        resources.defer(lambda: client.delete_model(model_id))
+        key = client.key_with_alias(f"otel-err-{unique_marker()}", models=[model_name])
+        resources.defer(lambda: client.delete_key(key))
+
+        deadline = time.monotonic() + client.gateway.poll_timeout
+        while True:
+            outcome = client.chat_raw(key, model_name, "trigger an upstream auth failure", max_tokens=16)
+            assert not outcome.ok, "the call must fail; the deployment's upstream key is invalid"
+            if "AnthropicException" in outcome.body or time.monotonic() >= deadline:
+                break
+            time.sleep(client.gateway.poll_interval)
+        assert outcome.status_code == 401, (
+            f"an upstream auth failure must map to 401, got {outcome.status_code}: {outcome.body[:200]}"
+        )
+        assert outcome.call_id is not None, "failed responses must still carry x-litellm-call-id"
+
+        genai_span = f"chat {model_name}"
+        hits = otel_reader.poll_traces_for_call(
+            call_id=outcome.call_id,
+            settled_names=_settled_names(route=route, genai_span=genai_span, require_cost_span=False),
+            settled_prefixes={DB_SPAN_PREFIX},
+        )
+        _assert_complete_trace(hits, route=route, genai_span=genai_span, require_cost_span=False)
+
+        root = next(span for span in hits[0].spans if not span.references)
+        assert str(_tag(root, "http.status_code")) == "401", (
+            f"the SERVER span must record the 401 the client received, got {_tag(root, 'http.status_code')!r}"
+        )
+        genai = next(span for span in hits[0].spans if span.operation_name == genai_span)
+        _assert_error_span_contract(genai)

--- a/tests/e2e/logging/test_otel_trace_e2e.py
+++ b/tests/e2e/logging/test_otel_trace_e2e.py
@@ -170,6 +170,8 @@ EXPECTED_ERROR_SPAN_ATTRIBUTES: dict[str, str] = {
     "error": "True",
     "error.type": "AuthenticationError",
     "otel.status_code": "ERROR",
+    "litellm.provider.error.code": "401",
+    "litellm.provider.error.llm_provider": "anthropic",
 }
 
 
@@ -216,6 +218,10 @@ def _assert_error_span_contract(span: JaegerSpan) -> None:
     )
     assert _tag(span, "otel.status_description") == message, (
         "the span status description must carry the same untruncated message as error.message"
+    )
+    stack = _tag(span, "litellm.provider.error.stack_trace")
+    assert isinstance(stack, str) and stack, (
+        "the error span must carry a non-empty litellm.provider.error.stack_trace"
     )
 
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

https://linear.app/litellm-ai/issue/LIT-4179 (the fix this test pins: restore error.* span attributes on v2 error spans)
https://linear.app/litellm-ai/issue/LIT-3787 (parent e2e effort)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Stacked on the streaming trace-completeness PR (#33234, base of this branch); merge that first. Uses the same jaeger destination and read-back infrastructure; adds STORE_MODEL_IN_DB to the compose stack so /model/new works locally (the suite's existing model-registering tests already assume it in CI).

Verification run on 2026-07-14, proxies from source at exact refs. Outputs verbatim.

1. Per review feedback on #33132 ("have a JSON of all the fields you expect in OTEL to be logged"), the expected attribute set is declared in the test as one reviewable payload:

   ```python
   EXPECTED_ERROR_SPAN_ATTRIBUTES: dict[str, str] = {
       "error": "True",
       "error.type": "AuthenticationError",
       "otel.status_code": "ERROR",
       "litellm.provider.error.code": "401",
       "litellm.provider.error.llm_provider": "anthropic",
   }
   ```

   plus a non-empty `litellm.provider.error.stack_trace` and `error.message`, which is asserted untruncated by parsing the provider error JSON embedded in it back out of the span attribute (a truncated message stops parsing), and asserted equal to the span's status description. Evidence from the live probe that shaped the contract:

   ```
   error.message (len=180):
     litellm.AuthenticationError: AnthropicException - {"type":"error","error":{"type":
     "authentication_error","message":"invalid x-api-key"},"request_id":"req_011Cd2..."}
   otel.status_code: ERROR    error.type: AuthenticationError    root http.status_code: 401
   exception span event carries the same full message
   ```
<img width="1728" height="889" alt="image" src="https://github.com/user-attachments/assets/042067c5-24a5-486c-8c73-1486f82c8a20" />
<img width="1728" height="340" alt="image" src="https://github.com/user-attachments/assets/204cbe04-b72c-44a9-aad8-15d5b6a9ded1" />

2. Pass on current code (compose stack):

   ```
   $ LITELLM_PROXY_URL=http://localhost:4000 uv run pytest \
       "logging/test_otel_trace_e2e.py::TestOtelTraceCompleteness::test_failed_chat_completions_error_span_attributes" -v
   ============================== 1 passed in 7s ==================================
   ```

3. Fail-before-fix at **9b7e6fbdd1**, the parent of 85d1fe6e2a (the LIT-4179 fix, #32524): on that ref only error.type reached the wire, and the test fails on exactly the restored attribute:

   ```
   $ LITELLM_PROXY_URL=http://localhost:4611 E2E_OTEL_QUERY_URL=http://localhost:16690 \
       uv run pytest "...::test_failed_chat_completions_error_span_attributes"
   E  AssertionError: error span must carry a non-empty error.message
   E   +  where False = isinstance(None, str)
   ============================== 1 failed in 6.02s ===============================
   ```
<img width="1728" height="996" alt="Screenshot 2026-07-14 at 7 46 27 PM" src="https://github.com/user-attachments/assets/1a9b9b63-51f8-4fe1-aa81-7303f90350da" />

4. Static gates: `make lint-e2e-basedpyright` -> 0 errors; `coverage_registry.collector --strict` passes; Logging & Guardrails 6/52 -> 7/52 (the `logging.otel.failure.exports_metric` P0 cell gains its first covering test).

## Type

✅ Test

## Changes

The `logging.otel.failure.exports_metric` registry cell is a P0 row with no covering test: nothing proved that a FAILED request's error details actually reach the OTEL destination. LIT-4179 was exactly this regression: v2 error spans shipped without error.message/code/stack_trace, so backends that index span attributes lost the error text.

- `logging/test_otel_trace_e2e.py`: adds `test_failed_chat_completions_error_span_attributes`. The failure is produced by registering a deployment with a deliberately invalid upstream Anthropic key (reusing the suite's INVALID_UPSTREAM_API_KEY pattern), so the request clears proxy auth and fails at the provider; proxy-gate rejections never produce a gen-AI span by design, so this is the only path that exercises the error-span contract. Asserts the full tree (no cost span on failures, by design: nothing was billed), the root SERVER span's http.status_code=401 matching what the client received, the EXPECTED_ERROR_SPAN_ATTRIBUTES payload exactly, and the untruncated error.message via a typed parse of the embedded provider JSON.
- `docker-compose.yml`: adds `STORE_MODEL_IN_DB: "True"` to the proxy env; /model/new requires it and the suite's existing model-registering tests (llm_translation, budgets fallback) already depend on it.

## Behavior changes

None; test-only changes under tests/e2e. The compose stack gains model-registration support, which other suites already assume.

## QA runbook

- tests/e2e/logging/test_otel_trace_e2e.py::TestOtelTraceCompleteness::test_failed_chat_completions_error_span_attributes - a failed chat call shows up at the OTEL destination as one connected trace whose model-call span carries the complete error details
  - [x] GET /health/readiness/details with the master key and confirm `OpenTelemetryV2` appears in `success_callbacks`
  - [x] POST /model/new with a unique model_name and `litellm_params: {"model": "anthropic/claude-haiku-4-5", "api_key": "<any invalid key>"}` (master key)
  - [x] POST /key/generate scoped to that model and save the returned key
  - [x] POST /chat/completions with the key and confirm the call FAILS with 401 and a body containing the AnthropicException auth error; note the `x-litellm-call-id` response header (retry briefly if the very first attempt is a proxy-auth 401 without AnthropicException in the body - that is fresh-key propagation, not the failure under test)
  - [ ] In Jaeger (http://localhost:16686, service `litellm`), search by tag `litellm.call_id=<that id>` and wait for the trace
  - [ ] Confirm exactly ONE trace holds the call-id, rooted at `POST /chat/completions` (kind server) with `http.status_code: 401`, with `auth /chat/completions` and a `postgres ...` span beneath it and no span referencing a missing parent (no cost-write span appears: failed calls bill nothing)
  - [ ] Open the `chat <model>` span (kind client) and confirm its tags: `error: true`, `error.type: AuthenticationError`, `otel.status_code: ERROR`, `litellm.provider.error.code: 401`, `litellm.provider.error.llm_provider: anthropic`, and a non-empty `litellm.provider.error.stack_trace`
  - [x] Confirm `error.message` contains the COMPLETE provider error JSON, ending with the closing brace after `request_id` (a truncated message cuts this tail off), and that it matches the span's status description
  - [x] POST /key/delete and /model/delete to clean up

Final attestation: "I agree this test is testing what the writer wanted to test."

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes plus a local e2e compose env flag; no production code paths modified.
> 
> **Overview**
> Adds **live e2e coverage** for the `logging.otel.failure.exports_metric` registry cell: when `/chat/completions` fails at the upstream provider (invalid Anthropic key on a DB-registered model), Jaeger must show **one connected trace** without a cost span, root `http.status_code=401`, and a gen-AI span that satisfies the **LIT-4179** attribute contract.
> 
> The test declares `EXPECTED_ERROR_SPAN_ATTRIBUTES` and `_assert_error_span_contract`, which checks exact `error` / `error.type` / `otel.status_code` tags and proves **`error.message` is untruncated** by parsing embedded provider JSON and matching `otel.status_description`.
> 
> **Compose:** sets `STORE_MODEL_IN_DB: "True"` on the proxy so `/model/new` works locally for this and other model-registration e2e tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89c844e076265855d40ee00f6127c0a36814fab6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

