### PR TITLE
fix(pricing): correct mode to embedding for four vercel_ai_gateway embedding models

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -34692,7 +34692,7 @@
         "max_input_tokens": 0,
         "max_output_tokens": 0,
         "max_tokens": 0,
-        "mode": "chat",
+        "mode": "embedding",
         "output_cost_per_token": 0.0
     },
     "vercel_ai_gateway/anthropic/claude-3-haiku": {
@@ -35028,7 +35028,7 @@
         "max_input_tokens": 0,
         "max_output_tokens": 0,
         "max_tokens": 0,
-        "mode": "chat",
+        "mode": "embedding",
         "output_cost_per_token": 0.0
     },
     "vercel_ai_gateway/deepseek/deepseek-r1": {
@@ -35301,7 +35301,7 @@
         "max_input_tokens": 0,
         "max_output_tokens": 0,
         "max_tokens": 0,
-        "mode": "chat",
+        "mode": "embedding",
         "output_cost_per_token": 0.0
     },
     "vercel_ai_gateway/mistral/devstral-small": {
@@ -35367,7 +35367,7 @@
         "max_input_tokens": 0,
         "max_output_tokens": 0,
         "max_tokens": 0,
-        "mode": "chat",
+        "mode": "embedding",
         "output_cost_per_token": 0.0
     },
     "vercel_ai_gateway/mistral/mistral-large": {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -34866,7 +34866,7 @@
         "max_input_tokens": 0,
         "max_output_tokens": 0,
         "max_tokens": 0,
-        "mode": "chat",
+        "mode": "embedding",
         "output_cost_per_token": 0.0
     },
     "vercel_ai_gateway/anthropic/claude-3-haiku": {
@@ -35202,7 +35202,7 @@
         "max_input_tokens": 0,
         "max_output_tokens": 0,
         "max_tokens": 0,
-        "mode": "chat",
+        "mode": "embedding",
         "output_cost_per_token": 0.0
     },
     "vercel_ai_gateway/deepseek/deepseek-r1": {
@@ -35475,7 +35475,7 @@
         "max_input_tokens": 0,
         "max_output_tokens": 0,
         "max_tokens": 0,
-        "mode": "chat",
+        "mode": "embedding",
         "output_cost_per_token": 0.0
     },
     "vercel_ai_gateway/mistral/devstral-small": {
@@ -35541,7 +35541,7 @@
         "max_input_tokens": 0,
         "max_output_tokens": 0,
         "max_tokens": 0,
-        "mode": "chat",
+        "mode": "embedding",
         "output_cost_per_token": 0.0
     },
     "vercel_ai_gateway/mistral/mistral-large": {


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Four `vercel_ai_gateway/*` embedding models ship with `"mode": "chat"` in the cost map even though they are embedding models. `mode` is what `litellm.get_model_info` reports and what downstream callers use to tell embedding models apart from chat models, so the label being wrong makes these four misrepresent themselves.

The evidence that they are embedding models is already in the same file. Each one's bare entry is `embedding`: `amazon.titan-embed-text-v2:0`, `cohere/embed-v4.0`, `mistral/codestral-embed` and `mistral/mistral-embed` are all `"mode": "embedding"` (titan's eight bare/bedrock siblings are all `embedding`). Six sibling `vercel_ai_gateway/*embed*` entries (`google/gemini-embedding-001`, `google/text-embedding-005`, `google/text-multilingual-embedding-002`, `openai/text-embedding-3-large`, `openai/text-embedding-3-small`, `openai/text-embedding-ada-002`) are already `"mode": "embedding"` and establish the correct shape for this block. After this PR all ten `vercel_ai_gateway/*embed*` entries read `embedding`. The gateway also ships a real embedding path for this provider (`litellm/llms/vercel_ai_gateway/embedding/transformation.py`, routed from `embedding()` in `litellm/main.py`), so these models are callable for embeddings today and only the label is out of step.

Before, at `10d5804b3ef4ead5abb77c3f5fafdd0c0159de0f`:

```
$ LITELLM_LOCAL_MODEL_COST_MAP=True python -c "import litellm; [print(m, litellm.get_model_info(model=m)['mode']) for m in ['vercel_ai_gateway/amazon/titan-embed-text-v2','vercel_ai_gateway/cohere/embed-v4.0','vercel_ai_gateway/mistral/codestral-embed','vercel_ai_gateway/mistral/mistral-embed']]"
vercel_ai_gateway/amazon/titan-embed-text-v2 chat
vercel_ai_gateway/cohere/embed-v4.0 chat
vercel_ai_gateway/mistral/codestral-embed chat
vercel_ai_gateway/mistral/mistral-embed chat
```

After, at `f4d8c6c07e0d03b34f634c1fa555de72fa522a45`:

```
$ LITELLM_LOCAL_MODEL_COST_MAP=True python -c "import litellm; [print(m, litellm.get_model_info(model=m)['mode']) for m in ['vercel_ai_gateway/amazon/titan-embed-text-v2','vercel_ai_gateway/cohere/embed-v4.0','vercel_ai_gateway/mistral/codestral-embed','vercel_ai_gateway/mistral/mistral-embed']]"
vercel_ai_gateway/amazon/titan-embed-text-v2 embedding
vercel_ai_gateway/cohere/embed-v4.0 embedding
vercel_ai_gateway/mistral/codestral-embed embedding
vercel_ai_gateway/mistral/mistral-embed embedding
```

Each of the four now matches its bare sibling.

## Type

🐛 Bug Fix

## Changes

Flips `"mode": "chat"` to `"mode": "embedding"` on `vercel_ai_gateway/amazon/titan-embed-text-v2`, `vercel_ai_gateway/cohere/embed-v4.0`, `vercel_ai_gateway/mistral/codestral-embed` and `vercel_ai_gateway/mistral/mistral-embed`, in both `model_prices_and_context_window.json` and the shipped `litellm/model_prices_and_context_window_backup.json`. That is the whole change; four lines per file, eight in total, no other key, field or entry touched and no reformatting.

One thing deliberately left alone: all ten `vercel_ai_gateway/*embed*` entries carry `max_input_tokens: 0`, `max_tokens: 0` and `output_cost_per_token: 0.0`, including the six that were already correctly labelled `embedding`. Those zeros are this block's own convention rather than a bug, so "correcting" them here would make these four diverge from their siblings and would widen a data fix into something reviewers would have to reason about per model. They stay as they are; this PR only corrects the label that is demonstrably wrong.

## QA runbook

With a Vercel AI Gateway key configured, `litellm.get_model_info(model="vercel_ai_gateway/mistral/mistral-embed")["mode"]` returns `"embedding"` (was `"chat"`), and the same holds for the other three models above. No code paths change — the provider already routes these through `embedding()` — so the only observable difference is the corrected `mode` label and anything keyed off it (capability checks, model-info reporting). The before/after under `LITELLM_LOCAL_MODEL_COST_MAP=True` above is the reproduction.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

---

Developed with a two-agent Claude Code workflow (one agent scoping, one implementing) under my direction. The issue selection, scope, and verification are mine.