### PR TITLE
fix(sso): stop enforcing UI session budget on CLI login tokens

### DIFF
--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2071,12 +2071,8 @@ async def cli_poll_key(
         key_id: The CLI login session ID
         team_id: Optional team ID to assign to the JWT. If provided, must be one of user's teams.
     """
-    from litellm.proxy.auth.auth_checks import (
-        ExperimentalUIJWTToken,
-        get_team_object,
-        get_user_object,
-    )
-    from litellm.proxy.proxy_server import prisma_client, user_api_key_cache
+    from litellm.proxy.auth.auth_checks import ExperimentalUIJWTToken
+    from litellm.proxy.proxy_server import user_api_key_cache
 
     try:
         flow = _get_cli_sso_flow_or_raise(login_id=key_id, cache=user_api_key_cache)
@@ -2146,43 +2142,11 @@ async def cli_poll_key(
                 models=session_data.get("models", []),
             )
 
-            try:
-                user_db_obj = await get_user_object(
-                    user_id=user_id,
-                    prisma_client=prisma_client,
-                    user_api_key_cache=user_api_key_cache,
-                    user_id_upsert=False,
-                )
-            except ValueError as e:
-                verbose_proxy_logger.debug(f"CLI poll: user lookup failed, proceeding without user budget: {e}")
-                user_db_obj = None
-            user_budget = user_db_obj.max_budget if user_db_obj is not None else None
-
-            team_budget: Optional[float] = None
-            team_budget_resolved = False
-            if team_id is not None:
-                try:
-                    team_obj = await get_team_object(
-                        team_id=team_id,
-                        prisma_client=prisma_client,
-                        user_api_key_cache=user_api_key_cache,
-                    )
-                    team_budget = team_obj.max_budget
-                    team_budget_resolved = True
-                except Exception:
-                    pass
-
-            session_max_budget = (
-                litellm.max_ui_session_budget
-                if user_budget is None and (team_id is None or (team_budget_resolved and team_budget is None))
-                else None
-            )
-
             jwt_token = ExperimentalUIJWTToken.get_cli_jwt_auth_token(
                 user_info=user_info,
                 team_id=team_id,
                 team_alias=team_alias,
-                max_budget=session_max_budget,
+                max_budget=None,
             )
 
             # Delete cache entry (single-use)

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3092,9 +3092,11 @@ class TestCLIKeyRegenerationFlow:
         assert mock_get_jwt.call_args.kwargs["max_budget"] is None
 
     @pytest.mark.asyncio
-    async def test_cli_poll_key_caps_session_when_user_and_team_have_no_budget(self):
-        """With no user and no team budget, the session falls back to max_ui_session_budget."""
-        from litellm.proxy._types import LiteLLM_TeamTableCachedObj, LiteLLM_UserTable
+    async def test_cli_poll_key_does_not_cap_session_even_without_user_or_team_budget(self):
+        """Regression: a CLI session token must not inherit the UI chat-pane budget
+        (max_ui_session_budget). Even when the user and team have no budget of their
+        own, the minted token carries max_budget=None and is governed only by the
+        real user/team budgets at request time."""
         from litellm.proxy.management_endpoints.ui_sso import (
             _hash_cli_sso_secret,
             cli_poll_key,
@@ -3108,14 +3110,6 @@ class TestCLIKeyRegenerationFlow:
             "models": ["gpt-4"],
             "user_email": "unbudgeted@example.com",
         }
-        mock_user_info = LiteLLM_UserTable(
-            user_id="unbudgeted-user",
-            user_role="internal_user",
-            teams=["team-x"],
-            models=["gpt-4"],
-            max_budget=None,
-        )
-        mock_team = LiteLLM_TeamTableCachedObj(team_id="team-x", max_budget=None)
         mock_cache = MagicMock()
         mock_cache.get_cache.return_value = {
             "poll_secret_hash": _hash_cli_sso_secret("poll-secret"),
@@ -3127,19 +3121,10 @@ class TestCLIKeyRegenerationFlow:
 
         with (
             patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
-            patch("litellm.proxy.proxy_server.prisma_client"),
             patch(
                 "litellm.proxy.auth.auth_checks.ExperimentalUIJWTToken.get_cli_jwt_auth_token",
                 return_value=mock_jwt_token,
             ) as mock_get_jwt,
-            patch(
-                "litellm.proxy.auth.auth_checks.get_user_object",
-                new=AsyncMock(return_value=mock_user_info),
-            ),
-            patch(
-                "litellm.proxy.auth.auth_checks.get_team_object",
-                new=AsyncMock(return_value=mock_team),
-            ),
         ):
             result = await cli_poll_key(
                 key_id="cli-session-unbudgeted",
@@ -3149,9 +3134,7 @@ class TestCLIKeyRegenerationFlow:
 
         assert result["status"] == "ready"
         mock_get_jwt.assert_called_once()
-        assert (
-            mock_get_jwt.call_args.kwargs["max_budget"] == litellm.max_ui_session_budget
-        )
+        assert mock_get_jwt.call_args.kwargs["max_budget"] is None
 
 
 class TestGetAppRolesFromIdToken:


### PR DESCRIPTION
## Relevant issues

Before
<img width="907" height="467" alt="Screenshot 2026-07-14 at 5 54 33 PM" src="https://github.com/user-attachments/assets/910b7346-98a6-4d58-ab8b-2bef137a152d" />
r ticket

After

<img width="907" height="835" alt="Screenshot 2026-07-14 at 5 57 50 PM" src="https://github.com/user-attachments/assets/5d64b166-0b35-4176-b4e5-8210fdcb277e" />

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

**Before:** a `lite login` token 429s with a budget nobody set, capped at the UI chat-pane default:

```
Error Code: 429
Message: Budget has been exceeded! Key=cli-session-k7p02zP6KaB0W1GW4c9S8Q Current cost: 2.2054275, Max budget: 0.25
```

**After** (proxy running this branch): the CLI session token minted by `cli_poll_key` carries no budget cap, and it authenticates and serves normally. The token is decrypted here to show the field, then used against a real Anthropic model:

```
# what cli_poll_key now stamps on the token
$ python - <<'PY'
from litellm.proxy.auth.auth_checks import ExperimentalUIJWTToken
from litellm.proxy.common_utils.encrypt_decrypt_utils import decrypt_value_helper
from litellm.proxy._types import LiteLLM_UserTable
import json
tok = ExperimentalUIJWTToken.get_cli_jwt_auth_token(
    LiteLLM_UserTable(user_id="budget-demo", user_role="internal_user", models=[]),
    team_id=None, team_alias=None, max_budget=None,   # cli_poll_key now passes None
)
print("DECODED max_budget =", json.loads(decrypt_value_helper(tok, key="ui_hash_key")).get("max_budget"))
PY
DECODED max_budget = None

$ curl -s -o /dev/null -w "HTTP %{http_code}\n" -X POST http://localhost:4000/chat/completions \
    -H "Authorization: Bearer <cli-session-token>" -H "Content-Type: application/json" \
    -d '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"hi"}]}'
HTTP 200
```

The user's and team's real budgets are still enforced independently at request time (the token carries `user_id`/`team_id`), so removing this token-level cap does not remove budget enforcement for accounts that have one.

## Type

🐛 Bug Fix

## Changes

`cli_poll_key` (`ui_sso.py`) stamped the minted CLI session token with `litellm.max_ui_session_budget` ($0.25) as a fallback whenever the user and team had no budget of their own. That cap was designed for the Admin UI "Test Key" chat pane, and the CLI reused the same session-token machinery, so a CLI credential inherited a playground-sized budget that is baked into the encrypted token at login time (so it can't be raised without re-running `lite login`). Under real CLI/agent use it trips almost immediately.

The cap was also redundant. The session token already carries `user_id` and `team_id`, so the real user and team budgets are enforced independently on the auth path. This passes `max_budget=None` when minting the CLI token, so the token is governed only by those real budgets, and removes the now-dead user/team budget lookups. The UI login token path (`get_experimental_ui_login_jwt_auth_token`), which legitimately caps the low-trust test-chat pane, is left untouched.

Intended behavior change: a CLI token for a user/team with no budget is now bounded only by real budgets (or a proxy-global `litellm.max_budget`), exactly like a normal virtual key with no budget. The accidental $0.25 net for no-budget users is gone; the correct control is an actual user/team budget.

Test: `test_cli_poll_key_does_not_cap_session_even_without_user_or_team_budget` asserts the minted token carries `max_budget=None` even when both the user and team have no budget. It fails on the old code (which passed `max_ui_session_budget`) and passes now; verified by reverting the one-line change and watching it go red.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
