### PR TITLE
refactor(ui): migrate tags table onto shared DataTable

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -1161,11 +1161,6 @@
       "count": 1
     }
   },
-  "src/app/(dashboard)/tag-management/_components/TagTable.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/app/(dashboard)/tag-management/_components/components/CreateTagModal.tsx": {
     "no-restricted-imports": {
       "count": 1

--- a/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/TagTable.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/TagTable.test.tsx
@@ -1,8 +1,11 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import { formatCellDate } from "@/components/shared/table_cells";
-import TagTable from "./TagTable";
 import { Tag } from "@/components/tag_management/types";
+
+import TagTable from "./TagTable";
 
 describe("TagTable", () => {
   const mockOnEdit = vi.fn();
@@ -41,28 +44,28 @@ describe("TagTable", () => {
     vi.clearAllMocks();
   });
 
-  it("should render", () => {
+  it("should render every column header", () => {
     render(<TagTable {...defaultProps} />);
-    expect(screen.getByText("Tag Name")).toBeInTheDocument();
-    expect(screen.getByText("Description")).toBeInTheDocument();
-    expect(screen.getByText("Allowed Models")).toBeInTheDocument();
-    expect(screen.getByText("Created")).toBeInTheDocument();
-    expect(screen.getByText("Actions")).toBeInTheDocument();
+    for (const header of ["Tag Name", "Description", "Allowed Models", "Created"]) {
+      expect(screen.getByText(header)).toBeInTheDocument();
+    }
   });
 
-  it("should display no tags found message when data is empty", () => {
+  it("should display the empty state when data is empty", () => {
     render(<TagTable {...defaultProps} />);
-    expect(screen.getByText("No tags found")).toBeInTheDocument();
+    expect(screen.getByText("No tags yet")).toBeInTheDocument();
   });
 
-  it("should display tag name", () => {
+  it("should display tag name and description", () => {
     render(<TagTable {...defaultProps} data={[mockTag]} />);
     expect(screen.getByText("test-tag")).toBeInTheDocument();
+    expect(screen.getByText("Test description")).toBeInTheDocument();
   });
 
-  it("should display tag description", () => {
+  it("should display model names from model_info", () => {
     render(<TagTable {...defaultProps} data={[mockTag]} />);
-    expect(screen.getByText("Test description")).toBeInTheDocument();
+    expect(screen.getByText("GPT-4")).toBeInTheDocument();
+    expect(screen.getByText("Claude-3")).toBeInTheDocument();
   });
 
   it("should display All Models badge when models array is empty", () => {
@@ -80,30 +83,56 @@ describe("TagTable", () => {
     expect(screen.getByText(formattedDate)).toBeInTheDocument();
   });
 
-  it("should call onSelectTag when tag name is clicked", () => {
+  it("should sort by created date descending by default", () => {
+    const olderTag: Tag = { ...mockTag, name: "older-tag", created_at: "2023-01-01T00:00:00Z" };
+    const newerTag: Tag = { ...mockTag, name: "newer-tag", created_at: "2025-01-01T00:00:00Z" };
+    render(<TagTable {...defaultProps} data={[olderTag, newerTag]} />);
+    const rows = screen.getAllByRole("row").slice(1);
+    expect(within(rows[0]).getByText("newer-tag")).toBeInTheDocument();
+    expect(within(rows[1]).getByText("older-tag")).toBeInTheDocument();
+  });
+
+  it("should call onSelectTag when tag name is clicked", async () => {
+    const user = userEvent.setup();
     render(<TagTable {...defaultProps} data={[mockTag]} />);
-    fireEvent.click(screen.getByRole("button", { name: "test-tag" }));
+    await user.click(screen.getByRole("button", { name: "test-tag" }));
     expect(mockOnSelectTag).toHaveBeenCalledWith("test-tag");
   });
 
   it("should render tag name as non-clickable for dynamic spend tags", () => {
     render(<TagTable {...defaultProps} data={[mockDynamicSpendTag]} />);
     expect(screen.queryByRole("button", { name: "dynamic-spend-tag" })).not.toBeInTheDocument();
-    fireEvent.click(screen.getByText("dynamic-spend-tag"));
+    expect(screen.getByText("dynamic-spend-tag")).toBeInTheDocument();
     expect(mockOnSelectTag).not.toHaveBeenCalled();
   });
 
-  it("should disable edit icon for dynamic spend tags", () => {
-    render(<TagTable {...defaultProps} data={[mockDynamicSpendTag]} />);
-    const editIcon = screen.getByLabelText("Edit tag (disabled)");
-    expect(editIcon).toBeInTheDocument();
-    expect(editIcon).toHaveClass("cursor-not-allowed");
+  it("should edit a tag through the actions menu", async () => {
+    const user = userEvent.setup();
+    render(<TagTable {...defaultProps} data={[mockTag]} />);
+    await user.click(screen.getByTestId("tag-actions-test-tag"));
+    await user.click(await screen.findByTestId("tag-action-edit"));
+    expect(mockOnEdit).toHaveBeenCalledWith(mockTag);
   });
 
-  it("should disable delete icon for dynamic spend tags", () => {
+  it("should delete a tag through the actions menu", async () => {
+    const user = userEvent.setup();
+    render(<TagTable {...defaultProps} data={[mockTag]} />);
+    await user.click(screen.getByTestId("tag-actions-test-tag"));
+    await user.click(await screen.findByTestId("tag-action-delete"));
+    expect(mockOnDelete).toHaveBeenCalledWith("test-tag");
+  });
+
+  it("should disable edit and delete for dynamic spend tags", async () => {
+    const user = userEvent.setup();
     render(<TagTable {...defaultProps} data={[mockDynamicSpendTag]} />);
-    const deleteIcon = screen.getByLabelText("Delete tag (disabled)");
-    expect(deleteIcon).toBeInTheDocument();
-    expect(deleteIcon).toHaveClass("cursor-not-allowed");
+    await user.click(screen.getByTestId("tag-actions-dynamic-spend-tag"));
+
+    const editItem = await screen.findByTestId("tag-action-edit");
+    const deleteItem = await screen.findByTestId("tag-action-delete");
+
+    expect(editItem).toHaveAttribute("data-disabled");
+    expect(deleteItem).toHaveAttribute("data-disabled");
+    expect(mockOnEdit).not.toHaveBeenCalled();
+    expect(mockOnDelete).not.toHaveBeenCalled();
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/TagTable.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/TagTable.test.tsx
@@ -143,6 +143,10 @@ describe("TagTable", () => {
 
     expect(editItem).toHaveAttribute("data-disabled");
     expect(deleteItem).toHaveAttribute("data-disabled");
+
+    await user.click(editItem);
+    await user.click(deleteItem);
+
     expect(mockOnEdit).not.toHaveBeenCalled();
     expect(mockOnDelete).not.toHaveBeenCalled();
   });

--- a/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/TagTable.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/TagTable.test.tsx
@@ -99,11 +99,22 @@ describe("TagTable", () => {
     expect(mockOnSelectTag).toHaveBeenCalledWith("test-tag");
   });
 
-  it("should render tag name as non-clickable for dynamic spend tags", () => {
+  it("should render tag name as non-clickable and muted for dynamic spend tags", () => {
     render(<TagTable {...defaultProps} data={[mockDynamicSpendTag]} />);
     expect(screen.queryByRole("button", { name: "dynamic-spend-tag" })).not.toBeInTheDocument();
-    expect(screen.getByText("dynamic-spend-tag")).toBeInTheDocument();
+    expect(screen.getByText("dynamic-spend-tag")).toHaveClass("text-muted-foreground");
     expect(mockOnSelectTag).not.toHaveBeenCalled();
+  });
+
+  it("should truncate long tag names and descriptions", () => {
+    const longTag: Tag = {
+      ...mockTag,
+      name: "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15) Firefox/152.0",
+      description: "A very long description that would otherwise stretch the column far beyond what users need to see",
+    };
+    render(<TagTable {...defaultProps} data={[longTag]} />);
+    expect(screen.getByText(longTag.name)).toHaveClass("truncate", "text-primary");
+    expect(screen.getByText(longTag.description as string)).toHaveClass("truncate", "max-w-72");
   });
 
   it("should edit a tag through the actions menu", async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/TagTable.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/TagTable.tsx
@@ -1,227 +1,54 @@
-import { ChevronDownIcon, ChevronUpIcon, PencilAltIcon, SwitchVerticalIcon, TrashIcon } from "@heroicons/react/outline";
-import {
-  ColumnDef,
-  flexRender,
-  getCoreRowModel,
-  getSortedRowModel,
-  SortingState,
-  useReactTable,
-} from "@tanstack/react-table";
-import { Badge, Icon, Table, TableBody, TableCell, TableHead, TableHeaderCell, TableRow, Text } from "@tremor/react";
-import { Tooltip } from "antd";
-import React from "react";
-import { DateCell, IdCell } from "@/components/shared/table_cells";
+"use client";
+
+import { SortingState } from "@tanstack/react-table";
+import { Inbox } from "lucide-react";
+import React, { useMemo, useState } from "react";
+
+import { DataTable } from "@/components/shared/DataTable";
 import { Tag } from "@/components/tag_management/types";
+
+import { getTagTableColumns } from "./tagTableColumns";
 
 interface TagTableProps {
   data: Tag[];
   onEdit: (tag: Tag) => void;
   onDelete: (tagName: string) => void;
   onSelectTag: (tagName: string) => void;
+  isLoading?: boolean;
 }
 
-const DYNAMIC_SPEND_TAG_DESCRIPTION =
-  "This is just a spend tag that was passed dynamically in a request. It does not control any LLM models.";
+const DEFAULT_SORTING: SortingState = [{ id: "created_at", desc: true }];
 
-const TagTable: React.FC<TagTableProps> = ({ data, onEdit, onDelete, onSelectTag }) => {
-  const [sorting, setSorting] = React.useState<SortingState>([{ id: "created_at", desc: true }]);
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center gap-1 py-6">
+      <div className="mb-1 flex size-10 items-center justify-center rounded-lg bg-muted">
+        <Inbox className="size-5 text-muted-foreground" />
+      </div>
+      <div className="text-sm font-medium text-foreground">No tags yet</div>
+      <div className="text-sm text-muted-foreground">Create a tag to start routing and restricting model usage.</div>
+    </div>
+  );
+}
 
-  const columns: ColumnDef<Tag>[] = [
-    {
-      header: "Tag Name",
-      accessorKey: "name",
-      cell: ({ row }) => {
-        const tag = row.original;
-        const isDynamicSpendTag = tag.description === DYNAMIC_SPEND_TAG_DESCRIPTION;
-        return (
-          <div className="overflow-hidden">
-            <IdCell
-              value={tag.name}
-              truncate={false}
-              onClick={onSelectTag}
-              disabled={isDynamicSpendTag}
-              tooltip={
-                isDynamicSpendTag ? "You cannot view the information of a dynamically generated spend tag" : tag.name
-              }
-            />
-          </div>
-        );
-      },
-    },
-    {
-      header: "Description",
-      accessorKey: "description",
-      cell: ({ row }) => {
-        const tag = row.original;
-        return (
-          <Tooltip title={tag.description}>
-            <span className="text-xs">{tag.description || "-"}</span>
-          </Tooltip>
-        );
-      },
-    },
-    {
-      header: "Allowed Models",
-      accessorKey: "models",
-      cell: ({ row }) => {
-        const tag = row.original;
-        return (
-          <div style={{ display: "flex", flexDirection: "column" }}>
-            {tag?.models?.length === 0 ? (
-              <Badge size="xs" className="mb-1" color="red">
-                All Models
-              </Badge>
-            ) : (
-              tag?.models?.map((modelId) => (
-                <Badge key={modelId} size="xs" className="mb-1" color="blue">
-                  <Tooltip title={`ID: ${modelId}`}>
-                    <Text>{tag.model_info?.[modelId] || modelId}</Text>
-                  </Tooltip>
-                </Badge>
-              ))
-            )}
-          </div>
-        );
-      },
-    },
-    {
-      header: "Created",
-      accessorKey: "created_at",
-      sortingFn: "datetime",
-      cell: ({ row }) => <DateCell value={row.original.created_at} precision="date" />,
-    },
-    {
-      id: "actions",
-      header: "Actions",
-      cell: ({ row }) => {
-        const tag = row.original;
-        const isDynamicSpendTag = tag.description === DYNAMIC_SPEND_TAG_DESCRIPTION;
-        return (
-          <div className="flex space-x-2">
-            {isDynamicSpendTag ? (
-              <Tooltip title="Dynamically generated spend tags cannot be edited">
-                <Icon
-                  icon={PencilAltIcon}
-                  size="sm"
-                  className="opacity-50 cursor-not-allowed"
-                  aria-label="Edit tag (disabled)"
-                />
-              </Tooltip>
-            ) : (
-              <Tooltip title="Edit tag">
-                <Icon
-                  icon={PencilAltIcon}
-                  size="sm"
-                  onClick={() => onEdit(tag)}
-                  className="cursor-pointer hover:text-blue-500"
-                />
-              </Tooltip>
-            )}
-            {isDynamicSpendTag ? (
-              <Tooltip title="Dynamically generated spend tags cannot be deleted">
-                <Icon
-                  icon={TrashIcon}
-                  size="sm"
-                  className="opacity-50 cursor-not-allowed"
-                  aria-label="Delete tag (disabled)"
-                />
-              </Tooltip>
-            ) : (
-              <Tooltip title="Delete tag">
-                <Icon
-                  icon={TrashIcon}
-                  size="sm"
-                  onClick={() => onDelete(tag.name)}
-                  className="cursor-pointer hover:text-red-500"
-                />
-              </Tooltip>
-            )}
-          </div>
-        );
-      },
-    },
-  ];
+const TagTable: React.FC<TagTableProps> = ({ data, onEdit, onDelete, onSelectTag, isLoading = false }) => {
+  const [sorting, setSorting] = useState<SortingState>(DEFAULT_SORTING);
 
-  const table = useReactTable({
-    data,
-    columns,
-    state: {
-      sorting,
-    },
-    onSortingChange: setSorting,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    enableSorting: true,
-  });
+  const columns = useMemo(() => getTagTableColumns({ onSelectTag, onEdit, onDelete }), [onSelectTag, onEdit, onDelete]);
 
   return (
-    <div className="rounded-lg custom-border relative">
-      <div className="overflow-x-auto">
-        <Table className="[&_td]:py-0.5 [&_th]:py-1">
-          <TableHead>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => (
-                  <TableHeaderCell
-                    key={header.id}
-                    className={`py-1 h-8 ${
-                      header.id === "actions" ? "sticky right-0 bg-white shadow-[-4px_0_8px_-6px_rgba(0,0,0,0.1)]" : ""
-                    }`}
-                    onClick={header.column.getToggleSortingHandler()}
-                  >
-                    <div className="flex items-center justify-between gap-2">
-                      <div className="flex items-center">
-                        {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
-                      </div>
-                      {header.id !== "actions" && (
-                        <div className="w-4">
-                          {header.column.getIsSorted() ? (
-                            {
-                              asc: <ChevronUpIcon className="h-4 w-4 text-blue-500" />,
-                              desc: <ChevronDownIcon className="h-4 w-4 text-blue-500" />,
-                            }[header.column.getIsSorted() as string]
-                          ) : (
-                            <SwitchVerticalIcon className="h-4 w-4 text-gray-400" />
-                          )}
-                        </div>
-                      )}
-                    </div>
-                  </TableHeaderCell>
-                ))}
-              </TableRow>
-            ))}
-          </TableHead>
-          <TableBody>
-            {table.getRowModel().rows.length > 0 ? (
-              table.getRowModel().rows.map((row) => (
-                <TableRow key={row.id} className="h-8">
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell
-                      key={cell.id}
-                      className={`py-0.5 max-h-8 overflow-hidden text-ellipsis whitespace-nowrap ${
-                        cell.column.id === "actions"
-                          ? "sticky right-0 bg-white shadow-[-4px_0_8px_-6px_rgba(0,0,0,0.1)]"
-                          : ""
-                      }`}
-                    >
-                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))
-            ) : (
-              <TableRow>
-                <TableCell colSpan={columns.length} className="h-8 text-center">
-                  <div className="text-center text-gray-500">
-                    <p>No tags found</p>
-                  </div>
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
-      </div>
-    </div>
+    <DataTable
+      data={data}
+      columns={columns}
+      getRowId={(tag, index) => tag.name || String(index)}
+      sortingMode="client"
+      sorting={sorting}
+      onSortingChange={setSorting}
+      isLoading={isLoading}
+      loadingMessage="Loading tags…"
+      noDataMessage={<EmptyState />}
+      size="compact"
+    />
   );
 };
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/index.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/index.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { tagListCall } from "@/components/networking";
+
+import TagManagement from "./index";
+
+vi.mock("@/components/networking", () => ({
+  tagListCall: vi.fn(),
+  tagCreateCall: vi.fn(),
+  tagDeleteCall: vi.fn(),
+  modelInfoCall: vi.fn(),
+}));
+
+vi.mock("./TagTable", () => ({
+  __esModule: true,
+  default: ({ isLoading }: { isLoading?: boolean }) => (
+    <div data-testid="tag-table">{isLoading ? "table-loading" : "table-loaded"}</div>
+  ),
+}));
+
+vi.mock("./tag_info", () => ({
+  __esModule: true,
+  default: () => <div>Mock Tag Info View</div>,
+}));
+
+vi.mock("./components/CreateTagModal", () => ({
+  __esModule: true,
+  default: () => <div>Mock Create Tag Modal</div>,
+}));
+
+const mockTagListCall = vi.mocked(tagListCall);
+
+describe("TagManagement loading state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should resolve the loading state when accessToken is null instead of showing the skeleton forever", async () => {
+    render(<TagManagement accessToken={null} userID={null} userRole={null} />);
+    expect(await screen.findByText("table-loaded")).toBeInTheDocument();
+    expect(mockTagListCall).not.toHaveBeenCalled();
+  });
+
+  it("should show the loading state until the tag fetch settles", async () => {
+    let resolveFetch: (value: Record<string, never>) => void = () => {};
+    mockTagListCall.mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+    render(<TagManagement accessToken="sk-test" userID="user-1" userRole="Admin" />);
+    expect(screen.getByText("table-loading")).toBeInTheDocument();
+
+    resolveFetch({});
+    expect(await screen.findByText("table-loaded")).toBeInTheDocument();
+    expect(mockTagListCall).toHaveBeenCalledWith("sk-test");
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/index.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/index.tsx
@@ -37,7 +37,10 @@ const TagManagement: React.FC<TagProps> = ({ accessToken, userID, userRole }) =>
   const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);
 
   const fetchTags = async () => {
-    if (!accessToken) return;
+    if (!accessToken) {
+      setIsLoadingTags(false);
+      return;
+    }
     try {
       const response = await tagListCall(accessToken);
       setTags(Object.values(response));

--- a/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/index.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/index.tsx
@@ -27,6 +27,7 @@ interface TagProps {
 
 const TagManagement: React.FC<TagProps> = ({ accessToken, userID, userRole }) => {
   const [tags, setTags] = useState<Tag[]>([]);
+  const [isLoadingTags, setIsLoadingTags] = useState(true);
   const [isCreateModalVisible, setIsCreateModalVisible] = useState(false);
   const [selectedTagId, setSelectedTagId] = useState<string | null>(null);
   const [editTag, setEditTag] = useState<boolean>(false);
@@ -43,6 +44,8 @@ const TagManagement: React.FC<TagProps> = ({ accessToken, userID, userRole }) =>
     } catch (error) {
       console.error("Error fetching tags:", error);
       NotificationsManager.fromBackend("Error fetching tags: " + error);
+    } finally {
+      setIsLoadingTags(false);
     }
   };
 
@@ -163,6 +166,7 @@ const TagManagement: React.FC<TagProps> = ({ accessToken, userID, userRole }) =>
             <Col numColSpan={1}>
               <TagTable
                 data={tags}
+                isLoading={isLoadingTags}
                 onEdit={(tag) => {
                   setSelectedTagId(tag.name);
                   setEditTag(true);

--- a/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/tagTableColumns.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/tagTableColumns.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { ColumnDef } from "@tanstack/react-table";
+import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+
+import { DataTableSortHeader } from "@/components/shared/DataTable";
+import { CellTooltip, DateCell, IdentityCell } from "@/components/shared/table_cells";
+import { Tag } from "@/components/tag_management/types";
+import { Badge } from "@/components/ui/badge";
+import { buttonVariants } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/cva.config";
+
+export const DYNAMIC_SPEND_TAG_DESCRIPTION =
+  "This is just a spend tag that was passed dynamically in a request. It does not control any LLM models.";
+
+const isDynamicSpendTag = (tag: Tag) => tag.description === DYNAMIC_SPEND_TAG_DESCRIPTION;
+
+function TagNameCell({ tag, onSelectTag }: { tag: Tag; onSelectTag: (tagName: string) => void }) {
+  if (isDynamicSpendTag(tag)) {
+    return (
+      <CellTooltip
+        content="You cannot view the information of a dynamically generated spend tag"
+        trigger={<span className="block truncate font-mono text-xs">{tag.name}</span>}
+      />
+    );
+  }
+  return (
+    <IdentityCell
+      title={tag.name}
+      titleClassName="font-mono text-xs font-normal"
+      onClick={() => onSelectTag(tag.name)}
+    />
+  );
+}
+
+function TagModelsCell({ tag }: { tag: Tag }) {
+  const models = tag.models ?? [];
+  if (models.length === 0) {
+    return <Badge variant="secondary">All Models</Badge>;
+  }
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {models.map((modelId) => (
+        <CellTooltip
+          key={modelId}
+          content={`ID: ${modelId}`}
+          trigger={
+            <Badge variant="outline" className="cursor-default">
+              {tag.model_info?.[modelId] || modelId}
+            </Badge>
+          }
+        />
+      ))}
+    </div>
+  );
+}
+
+interface TagRowActionsProps {
+  tag: Tag;
+  onEdit: (tag: Tag) => void;
+  onDelete: (tagName: string) => void;
+}
+
+function TagRowActions({ tag, onEdit, onDelete }: TagRowActionsProps) {
+  const isDynamic = isDynamicSpendTag(tag);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        aria-label="Open tag actions"
+        data-testid={`tag-actions-${tag.name}`}
+        className={cn(buttonVariants({ variant: "ghost", size: "icon-sm" }), "text-muted-foreground")}
+      >
+        <MoreHorizontal className="size-4" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuItem
+          disabled={isDynamic}
+          data-testid="tag-action-edit"
+          title={isDynamic ? "Dynamically generated spend tags cannot be edited" : undefined}
+          onClick={() => onEdit(tag)}
+        >
+          <Pencil />
+          Edit
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          variant="destructive"
+          disabled={isDynamic}
+          data-testid="tag-action-delete"
+          title={isDynamic ? "Dynamically generated spend tags cannot be deleted" : undefined}
+          onClick={() => onDelete(tag.name)}
+        >
+          <Trash2 />
+          Delete
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+interface TagTableColumnsDeps {
+  onSelectTag: (tagName: string) => void;
+  onEdit: (tag: Tag) => void;
+  onDelete: (tagName: string) => void;
+}
+
+export const getTagTableColumns = ({ onSelectTag, onEdit, onDelete }: TagTableColumnsDeps): ColumnDef<Tag>[] => [
+  {
+    id: "name",
+    accessorKey: "name",
+    meta: { title: "Tag Name" },
+    header: ({ column }) => <DataTableSortHeader column={column} title="Tag Name" />,
+    size: 260,
+    enableSorting: true,
+    cell: ({ row }) => <TagNameCell tag={row.original} onSelectTag={onSelectTag} />,
+  },
+  {
+    id: "description",
+    accessorKey: "description",
+    meta: { title: "Description" },
+    header: "Description",
+    size: 300,
+    enableSorting: false,
+    cell: ({ row }) => {
+      const description = row.original.description;
+      return (
+        <span className="block truncate text-sm text-muted-foreground" title={description}>
+          {description || "-"}
+        </span>
+      );
+    },
+  },
+  {
+    id: "models",
+    meta: { title: "Allowed Models", skeleton: "chips" },
+    header: "Allowed Models",
+    size: 240,
+    enableSorting: false,
+    cell: ({ row }) => <TagModelsCell tag={row.original} />,
+  },
+  {
+    id: "created_at",
+    accessorKey: "created_at",
+    sortingFn: "datetime",
+    meta: { title: "Created" },
+    header: ({ column }) => <DataTableSortHeader column={column} title="Created" />,
+    size: 150,
+    enableSorting: true,
+    cell: ({ row }) => <DateCell value={row.original.created_at} precision="date" />,
+  },
+  {
+    id: "actions",
+    meta: { className: "text-right", headerClassName: "text-right" },
+    header: () => <span className="sr-only">Actions</span>,
+    size: 64,
+    enableSorting: false,
+    enableHiding: false,
+    cell: ({ row }) => (
+      <div className="flex justify-end">
+        <TagRowActions tag={row.original} onEdit={onEdit} onDelete={onDelete} />
+      </div>
+    ),
+  },
+];

--- a/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/tagTableColumns.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/tagTableColumns.tsx
@@ -26,14 +26,15 @@ function TagNameCell({ tag, onSelectTag }: { tag: Tag; onSelectTag: (tagName: st
     return (
       <CellTooltip
         content="You cannot view the information of a dynamically generated spend tag"
-        trigger={<span className="block truncate font-mono text-xs">{tag.name}</span>}
+        trigger={<span className="block max-w-60 truncate font-mono text-xs text-muted-foreground">{tag.name}</span>}
       />
     );
   }
   return (
     <IdentityCell
       title={tag.name}
-      titleClassName="font-mono text-xs font-normal"
+      titleClassName="font-mono text-xs font-normal text-primary"
+      className="max-w-60"
       onClick={() => onSelectTag(tag.name)}
     />
   );
@@ -130,7 +131,7 @@ export const getTagTableColumns = ({ onSelectTag, onEdit, onDelete }: TagTableCo
     cell: ({ row }) => {
       const description = row.original.description;
       return (
-        <span className="block truncate text-sm text-muted-foreground" title={description}>
+        <span className="block max-w-72 truncate text-sm text-muted-foreground" title={description}>
           {description || "-"}
         </span>
       );


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Verified against a live proxy (worktree proxy on :4001 with a Postgres DB holding 60 tags, 4 of them regular DB tags and the rest dynamic spend tags) through the dashboard dev server at commit 07deb66218. To reproduce:

1. Run the proxy and `npm run dev` in `ui/litellm-dashboard`, then open http://localhost:3000/tag-management/
2. Loaded state: compact rows, monospace tag names, muted description, "All Models" / per-model badges, Created dates, default sort Created descending, sort toggles on the Tag Name and Created headers only
3. Loading state: reload with the network throttled; skeleton rows match the loaded row height, with chip-shaped placeholders under Allowed Models
4. Empty state: on a proxy with no tags, the table shows the inbox icon with "No tags yet" and "Create a tag to start routing and restricting model usage."
5. Row actions: the trailing overflow menu on a regular tag shows Edit and Delete enabled; Edit opens the tag detail in edit mode and Delete opens the existing confirm modal. On a dynamic spend tag both items render disabled with an explanatory tooltip, and the tag name is not clickable
6. Clicking a regular tag name opens the read-only tag detail view

Screenshots to be attached below

## Type

🧹 Refactoring

## Changes

Migrates the Tag Management table off its hand-rolled TanStack + tremor renderer onto the shared `DataTable` component and cell library, following the same split as the guardrails migration (#33303): a thin `TagTable.tsx` container in client-sort mode plus a new `tagTableColumns.tsx` with the column defs

Behavior is preserved: same columns (Tag Name, Description, Allowed Models, Created, actions), default sort Created descending, dynamic spend tags remain non-clickable and their edit/delete actions disabled with the same tooltips, model badges still resolve display names from `model_info` with the model id in a tooltip, and detail view / modals stay in the parent. The per-row edit and delete icons move into a trailing overflow dropdown matching Teams and Guardrails, and the empty state adopts the shared design copy

Following review feedback, long tag names and descriptions now truncate with an ellipsis (capped cell widths, full description still available on hover) instead of stretching the table, and non-clickable dynamic spend tag names render muted while clickable names use the primary color, so the disabled state is visually distinct

The parent now passes `isLoading` from the initial fetch so the table shows the shared loading skeleton instead of flashing the empty state; when `accessToken` is null the fetch guard resolves the loading flag so the table falls back to the empty state (matching pre-PR behavior) rather than showing the skeleton indefinitely, pinned by a new parent-level test. The rewritten file's stale `no-restricted-imports` entry is pruned from `eslint-suppressions.json`, and the unit tests are rewritten for the new structure, including a regression test pinning the default sort order and the disabled-actions gating for dynamic spend tags

<img width="1595" height="586" alt="image" src="https://github.com/user-attachments/assets/8022169e-93d5-4b2e-ab9d-de9c0ed78abd" />



