### PR TITLE
fix(anthropic-adapter): drop empty content_block_delta events

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -458,11 +458,14 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
 
                     # 3. If the trigger chunk carries delta content, queue it
                     # so the first delta of the new block is not silently dropped.
-                    if self._trigger_delta_has_content(processed_chunk):
+                    if self._delta_has_content(processed_chunk):
                         self.chunk_queue.append(processed_chunk)
 
                     self.sent_content_block_finish = False
                     return self.chunk_queue.popleft()
+
+                if processed_chunk["type"] == "content_block_delta" and not self._delta_has_content(processed_chunk):
+                    continue
 
                 if processed_chunk["type"] == "message_delta" and self.sent_content_block_finish is False:
                     # Queue both the content_block_stop and the message_delta
@@ -670,12 +673,17 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
 
                         # 3. If the trigger chunk carries delta content, queue it
                         # so the first delta of the new block is not silently dropped.
-                        if self._trigger_delta_has_content(processed_chunk):
+                        if self._delta_has_content(processed_chunk):
                             self.chunk_queue.append(processed_chunk)
 
                         # Reset state for new block
                         self.sent_content_block_finish = False
                         return self.chunk_queue.popleft()
+
+                    if processed_chunk["type"] == "content_block_delta" and not self._delta_has_content(
+                        processed_chunk
+                    ):
+                        continue
 
                     if processed_chunk["type"] == "message_delta" and self.sent_content_block_finish is False:
                         # Queue both the content_block_stop and the holding chunk
@@ -808,15 +816,22 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
         self.current_content_block_index += 1
 
     @staticmethod
-    def _trigger_delta_has_content(processed_chunk: Dict[str, Any]) -> bool:
-        """Return True if a translated trigger chunk carries a non-empty
-        ``content_block_delta`` payload that must be re-emitted after a
-        block transition.
+    def _delta_has_content(processed_chunk: Dict[str, Any]) -> bool:
+        """Return True if a translated chunk carries a non-empty
+        ``content_block_delta`` payload.
 
-        When an upstream chunk both *triggers* a new content block (its type
-        differs from the active block) and *carries* delta content, that
-        content belongs to the new block. The synthesized
-        ``content_block_start`` only ever carries an empty body — see
+        Gates every ``content_block_delta`` emission. An empty delta carries
+        no information, and the translate fallback types empty deltas as
+        ``text_delta`` regardless of the active block's type — emitting one
+        into an open ``thinking`` block (e.g. Bedrock Converse sends an empty
+        reasoning delta mid-block) crashes strict Anthropic SDK clients with
+        "Content block is not a text block".
+
+        Also gates re-emission after a block transition: when an upstream
+        chunk both *triggers* a new content block (its type differs from the
+        active block) and *carries* delta content, that content belongs to
+        the new block. The synthesized ``content_block_start`` only ever
+        carries an empty body — see
         ``_translate_streaming_openai_chunk_to_anthropic_content_block``,
         which returns an empty ``TextBlock``/``ToolUseBlock``/thinking block —
         so the trigger chunk's delta must be re-queued or the first token of

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -13,7 +13,10 @@ from typing import (
     List,
     Literal,
     Optional,
+    get_args,
 )
+
+from typing_extensions import assert_never
 
 from litellm._logging import verbose_logger
 from litellm._uuid import uuid
@@ -21,6 +24,7 @@ from litellm.types.llms.anthropic import (
     AppliedEdit,
     CompactionBlock,
     ContextManagementResponse,
+    StreamingContentBlockDeltaType,
     UsageDelta,
     UsageIteration,
 )
@@ -28,6 +32,23 @@ from litellm.types.utils import AdapterCompletionStreamWrapper
 
 if TYPE_CHECKING:
     from litellm.types.utils import ModelResponseStream
+
+
+_STREAMING_DELTA_TYPES = frozenset(get_args(StreamingContentBlockDeltaType))
+
+
+def _delta_payload_field(delta_type: StreamingContentBlockDeltaType) -> str:
+    match delta_type:
+        case "text_delta":
+            return "text"
+        case "input_json_delta":
+            return "partial_json"
+        case "thinking_delta":
+            return "thinking"
+        case "signature_delta":
+            return "signature"
+        case _:
+            assert_never(delta_type)
 
 
 class _CombinedChunkSplitter:
@@ -837,6 +858,12 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
         so the trigger chunk's delta must be re-queued or the first token of
         the new block (the first non-empty text/thinking delta, or bundled
         tool arguments) is silently dropped.
+
+        Delta types outside ``StreamingContentBlockDeltaType`` — the closed
+        set the translate layer can produce — are treated as empty. The
+        per-type payload lookup is exhaustively matched against that set in
+        ``_delta_payload_field``, so extending the translate layer with a new
+        delta type fails type-checking here until it is handled.
         """
         if processed_chunk.get("type") != "content_block_delta":
             return False
@@ -844,15 +871,9 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
         if not isinstance(delta, dict):
             return False
         delta_type = delta.get("type")
-        if delta_type == "text_delta":
-            return bool(delta.get("text"))
-        if delta_type == "input_json_delta":
-            return bool(delta.get("partial_json"))
-        if delta_type == "thinking_delta":
-            return bool(delta.get("thinking"))
-        if delta_type == "signature_delta":
-            return bool(delta.get("signature"))
-        return False
+        if delta_type not in _STREAMING_DELTA_TYPES:
+            return False
+        return bool(delta.get(_delta_payload_field(delta_type)))
 
     def _should_start_new_content_block(self, chunk: "ModelResponseStream") -> bool:
         """

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -104,6 +104,7 @@ from litellm.types.llms.anthropic import (
     ContextManagementResponse,
     MessageBlockDelta,
     MessageDelta,
+    StreamingContentBlockDeltaType,
     UsageDelta,
     UsageIteration,
 )
@@ -1423,7 +1424,7 @@ class LiteLLMAnthropicMessagesAdapter:
     def _translate_streaming_openai_chunk_to_anthropic(
         self, choices: List[Union[OpenAIStreamingChoice, StreamingChoices]]
     ) -> Tuple[
-        Literal["text_delta", "input_json_delta", "thinking_delta", "signature_delta"],
+        StreamingContentBlockDeltaType,
         Union[
             ContentTextBlockDelta,
             ContentJsonBlockDelta,

--- a/litellm/types/llms/anthropic.py
+++ b/litellm/types/llms/anthropic.py
@@ -439,6 +439,9 @@ class ContentThinkingSignatureBlockDelta(TypedDict):
     signature: str
 
 
+StreamingContentBlockDeltaType = Literal["text_delta", "input_json_delta", "thinking_delta", "signature_delta"]
+
+
 class ContentBlockDelta(TypedDict):
     type: Literal["content_block_delta"]
     index: int

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_first_delta.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_first_delta.py
@@ -12,6 +12,13 @@ silently dropped — e.g. text resuming after a tool call started from the secon
 token ("The weather is nice." was lost, "Hi" rendered as ""). Bundled
 ``input_json_delta`` tool arguments were already preserved and must stay
 preserved, and empty trigger deltas must not produce spurious events.
+
+Also covers the inverse regression: a chunk whose translated delta carries no
+payload must not be emitted at all. The translate fallback types empty deltas
+as ``text_delta`` regardless of the active block, so an empty reasoning delta
+mid-thinking-block (Bedrock Converse sends these) used to emit ``text_delta``
+into an open ``thinking`` block, crashing Anthropic SDK clients (Claude Code)
+with "Content block is not a text block".
 """
 
 import os
@@ -49,6 +56,13 @@ def _make_chunk(delta: Delta, finish_reason: Optional[str] = None) -> MagicMock:
     chunk.usage = None
     chunk._hidden_params = {}
     return chunk
+
+
+def _thinking_chunk(thinking: str, signature: str = "") -> MagicMock:
+    block = {"type": "thinking", "thinking": thinking}
+    if signature:
+        block["signature"] = signature
+    return _make_chunk(Delta(content=None, thinking_blocks=[block]))
 
 
 def _tool_chunk(
@@ -107,6 +121,47 @@ def _input_json_deltas(events: List[dict]) -> List[str]:
         if e.get("type") == "content_block_delta"
         and e["delta"].get("type") == "input_json_delta"
     ]
+
+
+def _thinking_deltas(events: List[dict]) -> List[str]:
+    return [
+        e["delta"]["thinking"]
+        for e in events
+        if e.get("type") == "content_block_delta"
+        and e["delta"].get("type") == "thinking_delta"
+    ]
+
+
+def _signature_deltas(events: List[dict]) -> List[str]:
+    return [
+        e["delta"]["signature"]
+        for e in events
+        if e.get("type") == "content_block_delta"
+        and e["delta"].get("type") == "signature_delta"
+    ]
+
+
+_DELTA_TYPES_PER_BLOCK_TYPE = {
+    "text": {"text_delta"},
+    "thinking": {"thinking_delta", "signature_delta"},
+    "tool_use": {"input_json_delta"},
+}
+
+
+def _assert_deltas_match_their_block_type(events: List[dict]) -> None:
+    """Enforce the invariant the Anthropic SDK enforces client-side: every
+    ``content_block_delta`` must be of a type valid for the block opened by
+    the most recent ``content_block_start`` at the same index.
+    """
+    block_types = {}
+    for event in events:
+        if event.get("type") == "content_block_start":
+            block_types[event["index"]] = event["content_block"]["type"]
+        if event.get("type") == "content_block_delta":
+            block_type = block_types[event["index"]]
+            assert event["delta"]["type"] in _DELTA_TYPES_PER_BLOCK_TYPE[block_type], (
+                f"{event['delta']['type']} emitted into a {block_type} block: {event}"
+            )
 
 
 def test_held_stop_reason_usage_merge_preserves_openai_cache_token_details():
@@ -332,11 +387,70 @@ def test_bundled_tool_args_on_transition_still_preserved_sync():
         ({"type": "content_block_delta", "delta": None}, False),
     ],
 )
-def test_trigger_delta_has_content_branches(processed_chunk, expected):
-    """Directly exercise the re-emit predicate across all delta types and the
+def test_delta_has_content_branches(processed_chunk, expected):
+    """Directly exercise the emission predicate across all delta types and the
     empty/malformed guards, so the helper's behavior is pinned independently of
     upstream chunk-translation details.
     """
-    assert (
-        AnthropicStreamWrapper._trigger_delta_has_content(processed_chunk) is expected
+    assert AnthropicStreamWrapper._delta_has_content(processed_chunk) is expected
+
+
+def _empty_reasoning_delta_mid_thinking_chunks() -> List[MagicMock]:
+    return [
+        _thinking_chunk("Let me think"),
+        _thinking_chunk(""),
+        _thinking_chunk("", signature="sig123"),
+        _make_chunk(Delta(content="Hello")),
+        _make_chunk(Delta(content=None), finish_reason="stop"),
+    ]
+
+
+def _assert_empty_reasoning_delta_suppressed(events: List[dict]) -> None:
+    _assert_deltas_match_their_block_type(events)
+    assert _thinking_deltas(events) == ["Let me think"]
+    assert _signature_deltas(events) == ["sig123"]
+    assert _text_deltas(events) == ["Hello"]
+
+
+def test_empty_reasoning_delta_mid_thinking_block_is_suppressed_sync():
+    """Bedrock Converse repro: an empty reasoning delta arriving inside an open
+    thinking block used to be emitted as ``text_delta {"text": ""}`` at the
+    thinking block's index (no block transition), which crashes Claude Code's
+    Anthropic SDK with "Content block is not a text block". It must be dropped,
+    while the surrounding thinking/signature/text deltas all still flow.
+    """
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=iter(_empty_reasoning_delta_mid_thinking_chunks()),
+        model="claude-x",
     )
+    _assert_empty_reasoning_delta_suppressed(_drain_sync(wrapper))
+
+
+@pytest.mark.asyncio
+async def test_empty_reasoning_delta_mid_thinking_block_is_suppressed_async():
+    """Async twin of the Bedrock Converse repro — the proxy serves the async
+    iterator, so the skip must exist on that path too.
+    """
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=_AsyncStream(_empty_reasoning_delta_mid_thinking_chunks()),
+        model="claude-x",
+    )
+    _assert_empty_reasoning_delta_suppressed(await _drain_async(wrapper))
+
+
+def test_empty_content_chunk_mid_text_block_is_suppressed_sync():
+    """An empty-content chunk arriving mid-text-block (no transition) used to
+    emit a pointless ``text_delta {"text": ""}``; it must be dropped without
+    affecting the surrounding text deltas.
+    """
+    chunks = [
+        _make_chunk(Delta(content="Hi")),
+        _make_chunk(Delta(content="")),
+        _make_chunk(Delta(content=" there")),
+        _make_chunk(Delta(content=None), finish_reason="stop"),
+    ]
+    wrapper = AnthropicStreamWrapper(completion_stream=iter(chunks), model="claude-x")
+    events = _drain_sync(wrapper)
+
+    assert _text_deltas(events) == ["Hi", " there"]
+    _assert_deltas_match_their_block_type(events)


### PR DESCRIPTION
## Relevant issues

Fixes #29441

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Fully e2e against real Bedrock: a live proxy serving `bedrock/converse/us.anthropic.claude-haiku-4-5-20251001-v1:0` on `/v1/messages`, driven by the real Claude Code CLI (v2.1.210), no mocks. The prompt forces a thinking-then-tool-use stream, which is what makes Bedrock emit the empty reasoning delta mid-thinking-block

Proxy under test (same command for both runs, only the checked-out commit differs):

```bash
python litellm/proxy/proxy_cli.py --config qa_bedrock_converse_config.yaml --port 41873
```

```yaml
model_list:
  - model_name: claude-haiku-4-5-bedrock-converse
    litellm_params:
      model: bedrock/converse/us.anthropic.claude-haiku-4-5-20251001-v1:0
      aws_region_name: us-east-1

general_settings:
  master_key: sk-1234
```

Repro command (run 5 times per side):

```bash
for i in 1 2 3 4 5; do
  env -u ANTHROPIC_API_KEY ANTHROPIC_BASE_URL=http://localhost:41873 ANTHROPIC_AUTH_TOKEN=sk-1234 \
    claude --print --output-format stream-json --verbose \
    --allowed-tools 'Bash(echo pong)' --permission-mode dontAsk \
    --model claude-haiku-4-5-bedrock-converse \
    'Use the Bash tool to run the command `echo pong` and report what it printed.' > run-$i.jsonl 2>&1
  grep '"type":"result"' run-$i.jsonl | jq -r '"run '$i': \(.subtype): \(.result)"'
done
```

Before, at commit b2202cb1aa586e9b8bfe211f0b45ce8c99607a5c (current litellm_internal_staging, this PR's merge base), 5 out of 5 runs crash client-side:

```
run 1: success: API Error: Content block is not a text block
run 2: success: API Error: Content block is not a text block
run 3: success: API Error: Content block is not a text block
run 4: success: API Error: Content block is not a text block
run 5: success: API Error: Content block is not a text block
```

After, at commit bf3a1f47dd1ea0a13137ca9c689d433f74a09330 (this PR's head), 5 out of 5 runs complete:

```
run 1: success: The command printed `pong`
run 2: success: The command printed `pong`
run 3: success: The command printed `pong`
run 4: success: It printed `pong`
run 5: success: It printed `pong`
```

Every after run still streamed a thinking block and a Bash tool_use (verified with `grep -c '"type":"thinking"'` and `grep -c '"name":"Bash"'` on the stream-json output: 1 each per run), so the passing runs exercise the exact code path that used to crash

## Type

🐛 Bug Fix

## Changes

When the proxy serves `/v1/messages` backed by a chat-completions provider, `AnthropicStreamWrapper` translates each upstream chunk twice: once to decide the active content block type and once to produce the delta. A Bedrock Converse chunk carrying an empty reasoning delta (`thinking_blocks=[{"type": "thinking", "thinking": ""}]`, observed mid-thinking-block in real Converse streams) classifies as `thinking` in the first translation, so no block transition happens, but accumulates nothing in the second and falls through its fallback, which types every empty delta as `text_delta`. The client then receives `content_block_delta {"type": "text_delta", "text": ""}` at the open thinking block's index, and strict Anthropic SDK clients (Claude Code, the official TS/Python SDKs) abort the stream with "Content block is not a text block"

The fix makes the wrapper never emit a payload-less `content_block_delta`: the existing `_trigger_delta_has_content` re-emission guard is generalized to `_delta_has_content` and now also gates the mid-block emission path in both `__next__` and `__anext__`. An empty delta carries no information, so dropping it is safe for every client; this also removes the pointless `text_delta {"text": ""}` previously emitted for empty-content chunks mid-text-block

Regression tests extend `tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_first_delta.py` with an invariant checker that mirrors what the Anthropic SDK enforces client-side (every `content_block_delta` type must be valid for the block opened at its index) and cover the exact Converse sequence (thinking delta, empty reasoning delta, signature delta, text, finish) on both the sync and async paths, plus the empty-content-mid-text case. All three fail before the fix and pass after; the 517 existing tests under `tests/test_litellm/llms/anthropic/experimental_pass_through/` still pass

A follow-up commit addresses the review note about unknown delta types being silently dropped by the gate: the closed set of delta types the translate layer can produce is extracted into a shared `StreamingContentBlockDeltaType` alias (used in the translate function's return type), and the gate resolves each type's payload field through an exhaustive `match` ending in `assert_never`. Extending the translate layer with a fifth delta type now fails basedpyright at the gate (verified by temporarily adding `citations_delta` to the alias: `Literal['citations_delta'] is not assignable to type 'Never'`) instead of the new deltas being silently suppressed mid-block

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

## Behavior changes

### Removed / renamed
- None

### Silent regressions to watch
- On `/v1/messages` backed by a chat-completions provider, the proxy no longer emits payload-less `content_block_delta` events; this includes the previously harmless `text_delta {"text": ""}` sent for empty-content chunks mid-text-block. Accumulated content is identical; only a client counting raw SSE delta events would observe fewer events

### Migration for existing customers
- None required

### Regression tests
- `tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_first_delta.py::test_empty_reasoning_delta_mid_thinking_block_is_suppressed_sync` and `::test_empty_reasoning_delta_mid_thinking_block_is_suppressed_async` pin the suppressed empty reasoning delta inside an open thinking block
- `::test_empty_content_chunk_mid_text_block_is_suppressed_sync` pins the dropped empty text delta mid-text-block

## Follow-up

The adjacent pre-existing gap (a payload-less chunk on the `reasoning_content` path can still trigger a spurious block transition via the `text` classification fallback; well-formed stream, but the client accumulates an empty text block the Anthropic API rejects on the next turn) is out of scope here and tracked in LIT-4435

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live Anthropic SSE streaming translation used by the proxy `/v1/messages` path; scope is narrow (empty-delta filtering) but incorrect gating could drop real tokens or alter block transitions.
> 
> **Overview**
> Fixes **#29441** by changing how `AnthropicStreamWrapper` emits translated streaming events on the `/v1/messages` pass-through path.
> 
> **`AnthropicStreamWrapper`** now **skips** any `content_block_delta` whose payload is empty on both sync (`__next__`) and async (`__anext__`) paths, not only when re-queuing deltas after a block transition. Empty upstream chunks (e.g. Bedrock Converse empty reasoning inside an open **thinking** block) used to fall through translation as `text_delta` and break strict Anthropic clients with *"Content block is not a text block"*.
> 
> The re-emit guard is renamed to **`_delta_has_content`** and centralizes checks via shared **`StreamingContentBlockDeltaType`** and an exhaustive **`_delta_payload_field`** `match` (`assert_never`), so new delta types must be handled explicitly instead of being treated as empty.
> 
> **Tests** add SDK-style block/delta type invariants plus sync/async coverage for suppressed empty reasoning mid-thinking and empty text mid-text-block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf3a1f47dd1ea0a13137ca9c689d433f74a09330. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
