### PR TITLE
fix(mcp): discover missing OAuth scopes and token_url when authorization_url is set manually

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1447,8 +1447,9 @@ class MCPServerManager:
 
         auth_type = cast(MCPAuthType, mcp_server.auth_type)
         server_url = mcp_server.url
+        has_all_upstream_oauth_fields = bool(mcp_server.authorization_url and mcp_server.token_url and scopes)
         needs_discovery = bool(server_url) and (
-            (auth_type in _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES and not mcp_server.authorization_url)
+            (auth_type in _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES and not has_all_upstream_oauth_fields)
             or self._obo_needs_endpoint_discovery(
                 auth_type,
                 mcp_server.token_exchange_endpoint
@@ -1467,7 +1468,7 @@ class MCPServerManager:
         if needs_discovery and mcp_oauth_metadata is None:
             verbose_logger.warning(
                 "MCP OAuth discovery yielded no metadata for server %s (%s); "
-                "OAuth endpoints stay unresolved until a rebuild succeeds",
+                "OAuth endpoints/scopes stay unresolved until a rebuild succeeds",
                 mcp_server.server_id,
                 server_url,
             )

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -186,6 +186,21 @@ _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES: tuple[MCPAuth, ...] = (
 )
 
 
+def _blank_to_none(value: str | None) -> str | None:
+    """Collapse an absent, empty, or whitespace-only string to ``None``.
+
+    OAuth endpoint fields are consumed by truthiness-based merges (``row or discovered``) and by the
+    corroboration gate. A whitespace-only value is truthy to ``or`` but is not a usable endpoint, so
+    without this the merge would keep the blank value for redirects while the gate treats it as
+    unpinned and backfills the other fields, yielding a broken half-discovered config. Normalizing
+    the pinned fields once, at each build entry point, gives every downstream consumer a single
+    notion of "blank" so those code paths cannot disagree.
+    """
+    if not isinstance(value, str):
+        return None
+    return value.strip() or None
+
+
 def _normalized_authorize_endpoint(url: str) -> str:
     """Compare authorize endpoints on scheme, host, and path only. The default port is elided and
     the host is lowercased so ``https://IDP.example.com:443/authorize/`` and
@@ -1120,12 +1135,15 @@ class MCPServerManager:
             )
 
             auth_type = server_config.get("auth_type", None)
+            manual_authorization_url = _blank_to_none(server_config.get("authorization_url"))
+            manual_token_url = _blank_to_none(server_config.get("token_url"))
+            manual_registration_url = _blank_to_none(server_config.get("registration_url"))
             if server_url and (
                 auth_type in _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES
                 or self._obo_needs_endpoint_discovery(
                     auth_type,
                     server_config.get("token_exchange_endpoint"),
-                    server_config.get("token_url"),
+                    manual_token_url,
                 )
             ):
                 mcp_oauth_metadata = await self._descovery_metadata(
@@ -1138,7 +1156,7 @@ class MCPServerManager:
             gated_oauth_metadata = (
                 _restrict_discovery_to_corroborated_authorization_server(
                     mcp_oauth_metadata,
-                    server_config.get("authorization_url"),
+                    manual_authorization_url,
                     server_name or server_id,
                     bool(server_config.get("dcr_bridge")),
                 )
@@ -1152,13 +1170,11 @@ class MCPServerManager:
             resolved_scopes = self._extract_scopes(server_config.get("scopes")) or (
                 gated_oauth_metadata.scopes if gated_oauth_metadata else None
             )
-            resolved_authorization_url = server_config.get("authorization_url") or (
+            resolved_authorization_url = manual_authorization_url or (
                 gated_oauth_metadata.authorization_url if gated_oauth_metadata else None
             )
-            resolved_token_url = server_config.get("token_url") or (
-                gated_oauth_metadata.token_url if gated_oauth_metadata else None
-            )
-            resolved_registration_url = server_config.get("registration_url") or (
+            resolved_token_url = manual_token_url or (gated_oauth_metadata.token_url if gated_oauth_metadata else None)
+            resolved_registration_url = manual_registration_url or (
                 gated_oauth_metadata.registration_url if gated_oauth_metadata else None
             )
 
@@ -1552,14 +1568,17 @@ class MCPServerManager:
 
         auth_type = cast(MCPAuthType, mcp_server.auth_type)
         server_url = mcp_server.url
-        has_all_upstream_oauth_fields = bool(mcp_server.authorization_url and mcp_server.token_url and scopes)
+        manual_authorization_url = _blank_to_none(mcp_server.authorization_url)
+        manual_token_url = _blank_to_none(mcp_server.token_url)
+        manual_registration_url = _blank_to_none(mcp_server.registration_url)
+        has_all_upstream_oauth_fields = bool(manual_authorization_url and manual_token_url and scopes)
         needs_discovery = bool(server_url) and (
             (auth_type in _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES and not has_all_upstream_oauth_fields)
             or self._obo_needs_endpoint_discovery(
                 auth_type,
                 mcp_server.token_exchange_endpoint
                 or (credentials_dict.get("token_exchange_endpoint") if credentials_dict else None),
-                mcp_server.token_url,
+                manual_token_url,
             )
         )
         mcp_oauth_metadata = (
@@ -1580,7 +1599,7 @@ class MCPServerManager:
         gated_oauth_metadata = (
             _restrict_discovery_to_corroborated_authorization_server(
                 mcp_oauth_metadata,
-                mcp_server.authorization_url,
+                manual_authorization_url,
                 mcp_server.server_id,
                 bool(getattr(mcp_server, "dcr_bridge", None)),
             )
@@ -1608,9 +1627,9 @@ class MCPServerManager:
             client_secret=client_secret_value or getattr(mcp_server, "client_secret", None),
             oauth2_flow=self._explicit_oauth2_flow(getattr(mcp_server, "oauth2_flow", None)),
             scopes=resolved_scopes,
-            authorization_url=mcp_server.authorization_url or getattr(gated_oauth_metadata, "authorization_url", None),
-            token_url=mcp_server.token_url or getattr(gated_oauth_metadata, "token_url", None),
-            registration_url=mcp_server.registration_url or getattr(gated_oauth_metadata, "registration_url", None),
+            authorization_url=manual_authorization_url or getattr(gated_oauth_metadata, "authorization_url", None),
+            token_url=manual_token_url or getattr(gated_oauth_metadata, "token_url", None),
+            registration_url=manual_registration_url or getattr(gated_oauth_metadata, "registration_url", None),
             token_endpoint_auth_method=(
                 credentials_dict.get("token_endpoint_auth_method") if credentials_dict else None
             ),
@@ -1661,14 +1680,14 @@ class MCPServerManager:
             await self._persist_discovered_obo_token_url(
                 server_id=mcp_server.server_id,
                 auth_type=auth_type,
-                existing_token_url=mcp_server.token_url,
+                existing_token_url=manual_token_url,
                 discovered_token_url=new_server.token_url,
             )
             await self._persist_discovered_oauth_endpoints(
                 server_id=mcp_server.server_id,
                 auth_type=auth_type,
-                existing_authorization_url=mcp_server.authorization_url,
-                existing_token_url=mcp_server.token_url,
+                existing_authorization_url=manual_authorization_url,
+                existing_token_url=manual_token_url,
                 existing_scopes=scopes,
                 metadata=gated_oauth_metadata,
             )

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -186,6 +186,46 @@ _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES: tuple[MCPAuth, ...] = (
 )
 
 
+def _normalized_authorize_endpoint(url: str) -> str:
+    """Compare authorize endpoints on scheme, host, and path only. The default port is elided and
+    the host is lowercased so ``https://IDP.example.com:443/authorize/`` and
+    ``https://idp.example.com/authorize`` are the same identity; query and trailing slash are not."""
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    host = (parsed.hostname or "").lower()
+    default_port = {"https": 443, "http": 80}.get(scheme)
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    authority = host if port is None or port == default_port else f"{host}:{port}"
+    return f"{scheme}://{authority}{parsed.path.rstrip('/')}"
+
+
+def _endpoints_corroborate_authorization_url(
+    source_authorization_url: str | None,
+    trusted_authorization_url: str | None,
+) -> bool:
+    """Whether a source's ``token_url``/``registration_url`` may be paired with a trusted authorize
+    endpoint. This is the single trust rule for adopting OAuth endpoints from any non-manual source.
+
+    Discovery is rooted at the MCP resource (RFC 9728), so a compromised upstream can advertise an
+    attacker-run authorization server. When ``authorization_url`` is admin-pinned, pairing it with a
+    ``token_url`` from a different source is the RFC 9700 authorization-server mix-up: the user signs
+    in at the trusted authorize endpoint while the gateway redeems the code, with the stored client
+    secret and PKCE verifier, at the attacker's token endpoint. Endpoints are trustworthy together
+    only when they share an authorization server, so a source's endpoints are adopted only when the
+    same source advertised an ``authorization_endpoint`` matching the pinned value. With no pinned
+    value (``trusted_authorization_url is None``) there is nothing to protect: the authorize endpoint
+    comes from the same source as the token endpoint, so they corroborate each other by construction.
+    """
+    if trusted_authorization_url is None:
+        return True
+    return bool(source_authorization_url) and _normalized_authorize_endpoint(
+        source_authorization_url
+    ) == _normalized_authorize_endpoint(trusted_authorization_url)
+
+
 def _carry_forward_resolved_oauth_endpoints(new_server: MCPServer, previous_server: MCPServer | None) -> None:
     """Keep the last known good OAuth endpoints when a rebuild's re-discovery comes back empty.
 
@@ -193,29 +233,34 @@ def _carry_forward_resolved_oauth_endpoints(new_server: MCPServer, previous_serv
     during re-discovery downgrades a working server (``authorization_url`` set) to a broken one
     (``None``, /authorize 400s) with no configuration change. Mirrors the ``short_prefix``
     carry-forward. Skipped when the server's ``url`` or ``auth_type`` changed, since the previous
-    endpoints may then belong to a different upstream. ``registration_url`` IS carried here even
-    though ``_persist_discovered_oauth_endpoints`` refuses to write it to the row: carrying only
-    restores the same in-memory value the previous build already ran with, while persisting it
-    would flip ``_dcr_bridge_relays_client_registration`` (which keys off the stored column) for
-    dcr_bridge servers that never had one configured.
+    endpoints may then belong to a different upstream. ``registration_url`` IS carried even though
+    ``_persist_discovered_oauth_endpoints`` refuses to write it to the row: carrying only restores
+    the same in-memory value the previous build already ran with, while persisting it would flip
+    ``_dcr_bridge_relays_client_registration`` (which keys off the stored column) for dcr_bridge
+    servers that never had one configured.
+
+    Carry-forward is a non-manual endpoint source, so the same trust rule as discovery applies: the
+    previous ``token_url``/``registration_url`` are carried only when the previous
+    ``authorization_url`` corroborates the authorize endpoint this build will use, i.e. when the
+    incoming build has no pinned authorize endpoint (``None`` -> we adopt the previous one too, a
+    consistent group) or pins the same one. An admin re-pointing ``authorization_url`` to a different
+    server must not keep serving the old token endpoint.
     """
     if previous_server is None:
         return
     if previous_server.url != new_server.url or previous_server.auth_type != new_server.auth_type:
         return
+    may_carry_endpoints = _endpoints_corroborate_authorization_url(
+        previous_server.authorization_url, new_server.authorization_url
+    )
     if new_server.authorization_url is None and previous_server.authorization_url:
         new_server.authorization_url = previous_server.authorization_url
-    if new_server.token_url is None and previous_server.token_url:
+    if may_carry_endpoints and new_server.token_url is None and previous_server.token_url:
         new_server.token_url = previous_server.token_url
-    if new_server.registration_url is None and previous_server.registration_url:
+    if may_carry_endpoints and new_server.registration_url is None and previous_server.registration_url:
         new_server.registration_url = previous_server.registration_url
     if not new_server.scopes and previous_server.scopes:
         new_server.scopes = previous_server.scopes
-
-
-def _normalized_authorize_endpoint(url: str) -> str:
-    parsed = urlparse(url)
-    return f"{parsed.scheme.lower()}://{parsed.netloc.lower()}{parsed.path.rstrip('/')}"
 
 
 def _gate_discovered_endpoints_against_manual_authorization_url(
@@ -224,26 +269,14 @@ def _gate_discovered_endpoints_against_manual_authorization_url(
     server_identifier: str,
     is_dcr_bridge: bool,
 ) -> MCPOAuthMetadata | None:
-    """Refuse discovered token/registration endpoints the pinned authorize endpoint cannot vouch for.
-
-    Discovery is rooted at the MCP resource (RFC 9728), so a compromised upstream can advertise an
-    attacker-run authorization server. When the admin manually configured ``authorization_url``,
-    filling a blank ``token_url`` from that advertisement recreates the RFC 9700 mix-up attack at
-    configuration time: users sign in at the trusted authorize endpoint while the gateway redeems
-    the code, with the stored client secret and PKCE verifier, at the attacker's token endpoint.
-    Endpoints from one metadata document are only trustworthy together, so the discovered
-    ``token_url`` and ``registration_url`` are accepted only when that same document's
-    ``authorization_endpoint`` matches the pinned value (scheme+host+path; query and trailing slash
-    are not identity). Scope discovery stays ungated: scopes steer the redirect to the trusted
-    authorize endpoint and carry no credentials.
+    """Apply :func:`_endpoints_corroborate_authorization_url` to freshly discovered metadata, the
+    other non-manual endpoint source. Drops the discovered ``token_url``/``registration_url`` (never
+    the scopes, which carry no credentials) when they cannot be vouched for by the pinned authorize
+    endpoint, logging why so an intentional mismatch can be resolved by setting Token URL by hand.
     """
-    if metadata is None or not manual_authorization_url:
+    if metadata is None or (not metadata.token_url and not metadata.registration_url):
         return metadata
-    if not metadata.token_url and not metadata.registration_url:
-        return metadata
-    if metadata.authorization_url and _normalized_authorize_endpoint(
-        manual_authorization_url
-    ) == _normalized_authorize_endpoint(metadata.authorization_url):
+    if _endpoints_corroborate_authorization_url(metadata.authorization_url, manual_authorization_url):
         return metadata
     bridge_note = (
         " The discovered registration_url is rejected with it, so this dcr_bridge server stays on the"
@@ -258,7 +291,7 @@ def _gate_discovered_endpoints_against_manual_authorization_url(
         "authorization server. Configure Token URL manually if the mismatch is intentional.%s",
         server_identifier,
         _normalized_authorize_endpoint(metadata.authorization_url) if metadata.authorization_url else "<absent>",
-        _normalized_authorize_endpoint(manual_authorization_url),
+        _normalized_authorize_endpoint(manual_authorization_url) if manual_authorization_url else "<absent>",
         bridge_note,
     )
     return metadata.model_copy(update={"token_url": None, "registration_url": None})

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -284,24 +284,26 @@ def _restrict_discovery_to_corroborated_authorization_server(
     server_identifier: str,
     is_dcr_bridge: bool,
 ) -> MCPOAuthMetadata | None:
-    """Bound what freshly discovered metadata may backfill into a manually pinned config.
+    """Reject discovered token/registration endpoints a manually pinned authorize endpoint cannot
+    vouch for (the RFC 9700 authorization-server mix-up).
 
-    Discovery is rooted at the MCP resource, so provenance is a property of the whole metadata
-    document, not per field: a compromised upstream can advertise both an attacker ``token_endpoint``
-    (the RFC 9700 mix-up) and inflated ``scopes`` (tricking the user into granting a broader token
-    that then flows to the upstream). Both are closed by one rule. When ``authorization_url`` is
-    admin-pinned, the discovered ``token_url`` and ``registration_url`` are kept only if the document
-    corroborates the pin (its ``authorization_endpoint`` matches), and scopes are taken from the
-    authorization server's own ``scopes_supported`` (``authorization_server_scopes``, trusted tier)
-    rather than the resource-advertised ``scopes`` a compromised upstream controls. A document that
-    does not corroborate backfills nothing. With no pin there is no trust anchor to protect and the
-    authorize endpoint comes from the same chain as everything else, so discovery is returned as-is.
+    Discovery is rooted at the MCP resource, so a compromised upstream can advertise an attacker
+    ``token_endpoint``: with ``authorization_url`` admin-pinned but ``token_url`` blank, the merge
+    would pair the trusted authorize endpoint with that attacker token endpoint, and the gateway would
+    post the authorization code and client secret there. So the discovered ``token_url`` and
+    ``registration_url`` are kept only if the document corroborates the pin (its
+    ``authorization_endpoint`` matches). ``scopes`` are deliberately NOT gated here: per the MCP
+    authorization spec Scope Selection Strategy and RFC 9700 §2.3, the scopes a client requests are
+    resource-driven (the WWW-Authenticate challenge or the RFC 9728 protected-resource
+    ``scopes_supported``), and scope inflation by a compromised resource is bounded by the
+    authorization server and user consent (RFC 6749 §3.3), not by the client second-guessing the
+    request. With no pin there is no trust anchor to protect, so discovery is returned as-is.
     """
     if metadata is None or not (manual_authorization_url and manual_authorization_url.strip()):
         return metadata
     if _endpoints_corroborate_authorization_url(metadata.authorization_url, manual_authorization_url):
-        return metadata.model_copy(update={"scopes": metadata.authorization_server_scopes})
-    if not metadata.token_url and not metadata.registration_url and not metadata.scopes:
+        return metadata
+    if not metadata.token_url and not metadata.registration_url:
         return metadata
     bridge_note = (
         " The discovered registration_url is rejected with it, so this dcr_bridge server stays on the"
@@ -311,15 +313,15 @@ def _restrict_discovery_to_corroborated_authorization_server(
     )
     verbose_logger.warning(
         "MCP OAuth discovery for server %s advertised authorization_endpoint %s, which does not match the "
-        "manually configured authorization_url %s; rejecting the discovered token_url/registration_url/scopes "
-        "so authorization codes, client credentials, and granted scopes only follow the configured "
-        "authorization server. Configure Token URL and Scopes manually if the mismatch is intentional.%s",
+        "manually configured authorization_url %s; rejecting the discovered token_url/registration_url so "
+        "authorization codes and client credentials only follow the configured authorization server. "
+        "Configure Token URL manually if the mismatch is intentional.%s",
         server_identifier,
         _normalized_authorize_endpoint(metadata.authorization_url) if metadata.authorization_url else "<absent>",
         _normalized_authorize_endpoint(manual_authorization_url),
         bridge_note,
     )
-    return metadata.model_copy(update={"token_url": None, "registration_url": None, "scopes": None})
+    return metadata.model_copy(update={"token_url": None, "registration_url": None})
 
 
 def invalidate_user_env_vars_cache(user_id: str, server_id: str) -> None:
@@ -3394,7 +3396,6 @@ class MCPServerManager:
                 authorization_url=data.get("authorization_endpoint"),
                 token_url=data.get("token_endpoint"),
                 registration_url=data.get("registration_endpoint"),
-                authorization_server_scopes=scopes,
             )
 
             if any(

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -213,6 +213,57 @@ def _carry_forward_resolved_oauth_endpoints(new_server: MCPServer, previous_serv
         new_server.scopes = previous_server.scopes
 
 
+def _normalized_authorize_endpoint(url: str) -> str:
+    parsed = urlparse(url)
+    return f"{parsed.scheme.lower()}://{parsed.netloc.lower()}{parsed.path.rstrip('/')}"
+
+
+def _gate_discovered_endpoints_against_manual_authorization_url(
+    metadata: MCPOAuthMetadata | None,
+    manual_authorization_url: str | None,
+    server_identifier: str,
+    is_dcr_bridge: bool,
+) -> MCPOAuthMetadata | None:
+    """Refuse discovered token/registration endpoints the pinned authorize endpoint cannot vouch for.
+
+    Discovery is rooted at the MCP resource (RFC 9728), so a compromised upstream can advertise an
+    attacker-run authorization server. When the admin manually configured ``authorization_url``,
+    filling a blank ``token_url`` from that advertisement recreates the RFC 9700 mix-up attack at
+    configuration time: users sign in at the trusted authorize endpoint while the gateway redeems
+    the code, with the stored client secret and PKCE verifier, at the attacker's token endpoint.
+    Endpoints from one metadata document are only trustworthy together, so the discovered
+    ``token_url`` and ``registration_url`` are accepted only when that same document's
+    ``authorization_endpoint`` matches the pinned value (scheme+host+path; query and trailing slash
+    are not identity). Scope discovery stays ungated: scopes steer the redirect to the trusted
+    authorize endpoint and carry no credentials.
+    """
+    if metadata is None or not manual_authorization_url:
+        return metadata
+    if not metadata.token_url and not metadata.registration_url:
+        return metadata
+    if metadata.authorization_url and _normalized_authorize_endpoint(
+        manual_authorization_url
+    ) == _normalized_authorize_endpoint(metadata.authorization_url):
+        return metadata
+    bridge_note = (
+        " The discovered registration_url is rejected with it, so this dcr_bridge server stays on the"
+        " short-circuit registration arm."
+        if is_dcr_bridge and metadata.registration_url
+        else ""
+    )
+    verbose_logger.warning(
+        "MCP OAuth discovery for server %s advertised authorization_endpoint %s, which does not match the "
+        "manually configured authorization_url %s; rejecting the discovered token_url/registration_url so "
+        "authorization codes and client credentials only go to endpoints vouched for by the configured "
+        "authorization server. Configure Token URL manually if the mismatch is intentional.%s",
+        server_identifier,
+        _normalized_authorize_endpoint(metadata.authorization_url) if metadata.authorization_url else "<absent>",
+        _normalized_authorize_endpoint(manual_authorization_url),
+        bridge_note,
+    )
+    return metadata.model_copy(update={"token_url": None, "registration_url": None})
+
+
 def invalidate_user_env_vars_cache(user_id: str, server_id: str) -> None:
     """Drop a cached entry after the user stores or clears their env var values
     so the next request reads the fresh value instead of a stale one."""
@@ -1041,20 +1092,31 @@ class MCPServerManager:
             else:
                 mcp_oauth_metadata = None
 
+            gated_oauth_metadata = (
+                _gate_discovered_endpoints_against_manual_authorization_url(
+                    mcp_oauth_metadata,
+                    server_config.get("authorization_url"),
+                    server_name or server_id,
+                    bool(server_config.get("dcr_bridge")),
+                )
+                if auth_type in _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES
+                else mcp_oauth_metadata
+            )
+
             # Filter blank scopes (e.g. YAML ``scopes: [""]``) the same way the DB-build path does, so
             # an all-blank list normalizes to None rather than a ``("",)`` tuple that skips the
             # entra_obo fail-closed scope precondition and POSTs an empty scope to the IdP.
             resolved_scopes = self._extract_scopes(server_config.get("scopes")) or (
-                mcp_oauth_metadata.scopes if mcp_oauth_metadata else None
+                gated_oauth_metadata.scopes if gated_oauth_metadata else None
             )
             resolved_authorization_url = server_config.get("authorization_url") or (
-                mcp_oauth_metadata.authorization_url if mcp_oauth_metadata else None
+                gated_oauth_metadata.authorization_url if gated_oauth_metadata else None
             )
             resolved_token_url = server_config.get("token_url") or (
-                mcp_oauth_metadata.token_url if mcp_oauth_metadata else None
+                gated_oauth_metadata.token_url if gated_oauth_metadata else None
             )
             resolved_registration_url = server_config.get("registration_url") or (
-                mcp_oauth_metadata.registration_url if mcp_oauth_metadata else None
+                gated_oauth_metadata.registration_url if gated_oauth_metadata else None
             )
 
             config_oauth2_flow = server_config.get("oauth2_flow", None)
@@ -1472,8 +1534,18 @@ class MCPServerManager:
                 mcp_server.server_id,
                 server_url,
             )
+        gated_oauth_metadata = (
+            _gate_discovered_endpoints_against_manual_authorization_url(
+                mcp_oauth_metadata,
+                mcp_server.authorization_url,
+                mcp_server.server_id,
+                bool(getattr(mcp_server, "dcr_bridge", None)),
+            )
+            if auth_type in _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES
+            else mcp_oauth_metadata
+        )
 
-        resolved_scopes = scopes or (mcp_oauth_metadata.scopes if mcp_oauth_metadata else None)
+        resolved_scopes = scopes or (gated_oauth_metadata.scopes if gated_oauth_metadata else None)
 
         new_server = MCPServer(
             server_id=mcp_server.server_id,
@@ -1493,9 +1565,9 @@ class MCPServerManager:
             client_secret=client_secret_value or getattr(mcp_server, "client_secret", None),
             oauth2_flow=self._explicit_oauth2_flow(getattr(mcp_server, "oauth2_flow", None)),
             scopes=resolved_scopes,
-            authorization_url=mcp_server.authorization_url or getattr(mcp_oauth_metadata, "authorization_url", None),
-            token_url=mcp_server.token_url or getattr(mcp_oauth_metadata, "token_url", None),
-            registration_url=mcp_server.registration_url or getattr(mcp_oauth_metadata, "registration_url", None),
+            authorization_url=mcp_server.authorization_url or getattr(gated_oauth_metadata, "authorization_url", None),
+            token_url=mcp_server.token_url or getattr(gated_oauth_metadata, "token_url", None),
+            registration_url=mcp_server.registration_url or getattr(gated_oauth_metadata, "registration_url", None),
             token_endpoint_auth_method=(
                 credentials_dict.get("token_endpoint_auth_method") if credentials_dict else None
             ),
@@ -1555,7 +1627,7 @@ class MCPServerManager:
                 existing_authorization_url=mcp_server.authorization_url,
                 existing_token_url=mcp_server.token_url,
                 existing_scopes=scopes,
-                metadata=mcp_oauth_metadata,
+                metadata=gated_oauth_metadata,
             )
         return new_server
 

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -219,7 +219,7 @@ def _endpoints_corroborate_authorization_url(
     value (``trusted_authorization_url is None``) there is nothing to protect: the authorize endpoint
     comes from the same source as the token endpoint, so they corroborate each other by construction.
     """
-    if trusted_authorization_url is None:
+    if not (trusted_authorization_url and trusted_authorization_url.strip()):
         return True
     return bool(source_authorization_url) and _normalized_authorize_endpoint(
         source_authorization_url
@@ -240,43 +240,53 @@ def _carry_forward_resolved_oauth_endpoints(new_server: MCPServer, previous_serv
     servers that never had one configured.
 
     Carry-forward is a non-manual endpoint source, so the same trust rule as discovery applies: the
-    previous ``token_url``/``registration_url`` are carried only when the previous
+    previous ``token_url``/``registration_url``/``scopes`` are carried only when the previous
     ``authorization_url`` corroborates the authorize endpoint this build will use, i.e. when the
     incoming build has no pinned authorize endpoint (``None`` -> we adopt the previous one too, a
     consistent group) or pins the same one. An admin re-pointing ``authorization_url`` to a different
-    server must not keep serving the old token endpoint.
+    server must not keep serving the old server's token endpoint or granted scopes.
     """
     if previous_server is None:
         return
     if previous_server.url != new_server.url or previous_server.auth_type != new_server.auth_type:
         return
-    may_carry_endpoints = _endpoints_corroborate_authorization_url(
+    may_carry = _endpoints_corroborate_authorization_url(
         previous_server.authorization_url, new_server.authorization_url
     )
     if new_server.authorization_url is None and previous_server.authorization_url:
         new_server.authorization_url = previous_server.authorization_url
-    if may_carry_endpoints and new_server.token_url is None and previous_server.token_url:
+    if may_carry and new_server.token_url is None and previous_server.token_url:
         new_server.token_url = previous_server.token_url
-    if may_carry_endpoints and new_server.registration_url is None and previous_server.registration_url:
+    if may_carry and new_server.registration_url is None and previous_server.registration_url:
         new_server.registration_url = previous_server.registration_url
-    if not new_server.scopes and previous_server.scopes:
+    if may_carry and not new_server.scopes and previous_server.scopes:
         new_server.scopes = previous_server.scopes
 
 
-def _gate_discovered_endpoints_against_manual_authorization_url(
+def _restrict_discovery_to_corroborated_authorization_server(
     metadata: MCPOAuthMetadata | None,
     manual_authorization_url: str | None,
     server_identifier: str,
     is_dcr_bridge: bool,
 ) -> MCPOAuthMetadata | None:
-    """Apply :func:`_endpoints_corroborate_authorization_url` to freshly discovered metadata, the
-    other non-manual endpoint source. Drops the discovered ``token_url``/``registration_url`` (never
-    the scopes, which carry no credentials) when they cannot be vouched for by the pinned authorize
-    endpoint, logging why so an intentional mismatch can be resolved by setting Token URL by hand.
+    """Bound what freshly discovered metadata may backfill into a manually pinned config.
+
+    Discovery is rooted at the MCP resource, so provenance is a property of the whole metadata
+    document, not per field: a compromised upstream can advertise both an attacker ``token_endpoint``
+    (the RFC 9700 mix-up) and inflated ``scopes`` (tricking the user into granting a broader token
+    that then flows to the upstream). Both are closed by one rule. When ``authorization_url`` is
+    admin-pinned, the discovered ``token_url`` and ``registration_url`` are kept only if the document
+    corroborates the pin (its ``authorization_endpoint`` matches), and scopes are taken from the
+    authorization server's own ``scopes_supported`` (``authorization_server_scopes``, trusted tier)
+    rather than the resource-advertised ``scopes`` a compromised upstream controls. A document that
+    does not corroborate backfills nothing. With no pin there is no trust anchor to protect and the
+    authorize endpoint comes from the same chain as everything else, so discovery is returned as-is.
     """
-    if metadata is None or (not metadata.token_url and not metadata.registration_url):
+    if metadata is None or not (manual_authorization_url and manual_authorization_url.strip()):
         return metadata
     if _endpoints_corroborate_authorization_url(metadata.authorization_url, manual_authorization_url):
+        return metadata.model_copy(update={"scopes": metadata.authorization_server_scopes})
+    if not metadata.token_url and not metadata.registration_url and not metadata.scopes:
         return metadata
     bridge_note = (
         " The discovered registration_url is rejected with it, so this dcr_bridge server stays on the"
@@ -286,15 +296,15 @@ def _gate_discovered_endpoints_against_manual_authorization_url(
     )
     verbose_logger.warning(
         "MCP OAuth discovery for server %s advertised authorization_endpoint %s, which does not match the "
-        "manually configured authorization_url %s; rejecting the discovered token_url/registration_url so "
-        "authorization codes and client credentials only go to endpoints vouched for by the configured "
-        "authorization server. Configure Token URL manually if the mismatch is intentional.%s",
+        "manually configured authorization_url %s; rejecting the discovered token_url/registration_url/scopes "
+        "so authorization codes, client credentials, and granted scopes only follow the configured "
+        "authorization server. Configure Token URL and Scopes manually if the mismatch is intentional.%s",
         server_identifier,
         _normalized_authorize_endpoint(metadata.authorization_url) if metadata.authorization_url else "<absent>",
-        _normalized_authorize_endpoint(manual_authorization_url) if manual_authorization_url else "<absent>",
+        _normalized_authorize_endpoint(manual_authorization_url),
         bridge_note,
     )
-    return metadata.model_copy(update={"token_url": None, "registration_url": None})
+    return metadata.model_copy(update={"token_url": None, "registration_url": None, "scopes": None})
 
 
 def invalidate_user_env_vars_cache(user_id: str, server_id: str) -> None:
@@ -1126,7 +1136,7 @@ class MCPServerManager:
                 mcp_oauth_metadata = None
 
             gated_oauth_metadata = (
-                _gate_discovered_endpoints_against_manual_authorization_url(
+                _restrict_discovery_to_corroborated_authorization_server(
                     mcp_oauth_metadata,
                     server_config.get("authorization_url"),
                     server_name or server_id,
@@ -1568,7 +1578,7 @@ class MCPServerManager:
                 server_url,
             )
         gated_oauth_metadata = (
-            _gate_discovered_endpoints_against_manual_authorization_url(
+            _restrict_discovery_to_corroborated_authorization_server(
                 mcp_oauth_metadata,
                 mcp_server.authorization_url,
                 mcp_server.server_id,
@@ -3365,6 +3375,7 @@ class MCPServerManager:
                 authorization_url=data.get("authorization_endpoint"),
                 token_url=data.get("token_endpoint"),
                 registration_url=data.get("registration_endpoint"),
+                authorization_server_scopes=scopes,
             )
 
             if any(

--- a/litellm/types/mcp_server/mcp_server_manager.py
+++ b/litellm/types/mcp_server/mcp_server_manager.py
@@ -17,9 +17,18 @@ MCPInfo = Dict[str, Any]
 
 class MCPOAuthMetadata(BaseModel):
     scopes: Optional[List[str]] = None
+    """Effective scopes, resource-preferred: the RFC 9728 protected-resource advertisement or the
+    WWW-Authenticate challenge when the resource supplied one, else the authorization server's
+    ``scopes_supported``. A compromised resource server can influence this, so it must not expand a
+    manually pinned ``authorization_url`` (see ``authorization_server_scopes``)."""
     authorization_url: Optional[str] = None
     token_url: Optional[str] = None
     registration_url: Optional[str] = None
+    authorization_server_scopes: Optional[List[str]] = None
+    """The ``scopes_supported`` enumerated by the authorization-server metadata document itself
+    (RFC 8414), independent of anything the resource server advertised. This is the only scope
+    source trusted to backfill a manually pinned ``authorization_url``, because it shares provenance
+    with the ``authorization_endpoint`` used to corroborate that pin."""
     from_origin_fallback: bool = False
     """True when the metadata came from guessing the resource origin as its authorization
     server rather than from an RFC 9728/8414-advertised document. Guessed endpoints are

--- a/litellm/types/mcp_server/mcp_server_manager.py
+++ b/litellm/types/mcp_server/mcp_server_manager.py
@@ -17,18 +17,15 @@ MCPInfo = Dict[str, Any]
 
 class MCPOAuthMetadata(BaseModel):
     scopes: Optional[List[str]] = None
-    """Effective scopes, resource-preferred: the RFC 9728 protected-resource advertisement or the
-    WWW-Authenticate challenge when the resource supplied one, else the authorization server's
-    ``scopes_supported``. A compromised resource server can influence this, so it must not expand a
-    manually pinned ``authorization_url`` (see ``authorization_server_scopes``)."""
+    """Resource-driven scopes for the authorization request: the RFC 9728 protected-resource
+    ``scopes_supported``, or the ``scope`` from the WWW-Authenticate 401 challenge when the resource
+    supplied one, else the authorization server's ``scopes_supported``. This is the scope value a
+    client requests per the MCP authorization spec Scope Selection Strategy; scope minimization and
+    inflation control are the authorization server's and user's job at consent (RFC 6749 §3.3), not
+    the client's."""
     authorization_url: Optional[str] = None
     token_url: Optional[str] = None
     registration_url: Optional[str] = None
-    authorization_server_scopes: Optional[List[str]] = None
-    """The ``scopes_supported`` enumerated by the authorization-server metadata document itself
-    (RFC 8414), independent of anything the resource server advertised. This is the only scope
-    source trusted to backfill a manually pinned ``authorization_url``, because it shares provenance
-    with the ``authorization_endpoint`` used to corroborate that pin."""
     from_origin_fallback: bool = False
     """True when the metadata came from guessing the resource origin as its authorization
     server rather than from an RFC 9728/8414-advertised document. Guessed endpoints are

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -409,11 +409,13 @@ class TestMCPServerManager:
         assert server.scopes == ["read"]
 
     @pytest.mark.asyncio
-    async def test_load_servers_from_config_blank_authorization_url_is_not_a_pin(self):
-        """A blank (empty-string) authorization_url is not a trust anchor, so discovery backfills
-        the whole set — authorize endpoint, token_url, and its resource-preferred scopes — from the
-        same chain, exactly as if the field had been omitted. The corroboration gate must treat
-        empty-string as unpinned so it does not strand the token_url the merge still fills."""
+    @pytest.mark.parametrize("blank_authorization_url", ["", "   "])
+    async def test_load_servers_from_config_blank_authorization_url_is_not_a_pin(self, blank_authorization_url):
+        """A blank authorization_url — empty or whitespace-only — is not a trust anchor, so discovery
+        backfills the whole set (authorize endpoint, token_url, and its resource-preferred scopes)
+        from the same chain, exactly as if the field had been omitted. The merge and the corroboration
+        gate must agree that blank means unpinned; a whitespace value that the merge kept for redirects
+        while the gate treated as unpinned would strand a broken half-discovered config."""
         manager = MCPServerManager()
 
         metadata = MCPOAuthMetadata(
@@ -424,7 +426,7 @@ class TestMCPServerManager:
         )
         config = self._oauth2_config(
             oauth2_flow="authorization_code",
-            authorization_url="",
+            authorization_url=blank_authorization_url,
             token_url=None,
         )
         with patch.object(manager, "_descovery_metadata", new=AsyncMock(return_value=metadata)):
@@ -1164,6 +1166,38 @@ class TestMCPServerManager:
         assert built.authorization_url == "https://idp.example.com/authorize"
         assert built.token_url == "https://idp.example.com/token"
         assert built.scopes == ["read", "write"]
+
+    @pytest.mark.asyncio
+    async def test_build_from_table_whitespace_authorization_url_is_not_a_pin(self):
+        """A whitespace-only authorization_url on the row must not be kept for redirects while the
+        gate treats it as unpinned. It is normalized to unpinned everywhere, so the built server
+        takes the discovered authorize endpoint, token_url, and scopes as one consistent group
+        rather than serving the whitespace value with half-discovered fields."""
+        manager = MCPServerManager()
+        row = LiteLLM_MCPServerTable(
+            server_id="whitespace-auth-url",
+            alias="whitespace_auth_url",
+            description="whitespace authorization_url is not a pin",
+            url="https://up.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2,
+            authorization_url="   ",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+
+        metadata = MCPOAuthMetadata(
+            authorization_url="https://idp.example.com/authorize",
+            token_url="https://idp.example.com/token",
+            scopes=["read"],
+            authorization_server_scopes=["read"],
+        )
+        with patch.object(manager, "_descovery_metadata", new=AsyncMock(return_value=metadata)):
+            built = await manager.build_mcp_server_from_table(row, credentials_are_encrypted=False)
+
+        assert built.authorization_url == "https://idp.example.com/authorize"
+        assert built.token_url == "https://idp.example.com/token"
+        assert built.scopes == ["read"]
 
     @pytest.mark.asyncio
     async def test_build_from_table_fills_endpoints_when_metadata_corroborates_manual_authorization_url(self):

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -357,6 +357,55 @@ class TestMCPServerManager:
         assert server.needs_user_oauth_token is True
 
     @pytest.mark.asyncio
+    async def test_load_servers_from_config_rejects_discovered_token_url_on_authorization_endpoint_mismatch(self):
+        """The config loader always runs discovery and or-merges per field, so a yaml server with a
+        manual authorization_url has the same config-time mix-up exposure as a DB row: a discovered
+        token_url from a document advertising a different authorize endpoint must not be combined
+        with the pinned one. Scopes still backfill."""
+        manager = MCPServerManager()
+
+        metadata = MCPOAuthMetadata(
+            authorization_url="https://attacker.example.com/authorize",
+            token_url="https://attacker.example.com/token",
+            scopes=["read"],
+        )
+        config = self._oauth2_config(
+            oauth2_flow="authorization_code",
+            authorization_url="https://idp.example.com/authorize",
+            token_url=None,
+        )
+        with patch.object(manager, "_descovery_metadata", new=AsyncMock(return_value=metadata)):
+            await manager.load_servers_from_config(config)
+
+        server = next(iter(manager.config_mcp_servers.values()))
+        assert server.authorization_url == "https://idp.example.com/authorize"
+        assert server.token_url is None
+        assert server.scopes == ["read"]
+
+    @pytest.mark.asyncio
+    async def test_load_servers_from_config_fills_token_url_when_metadata_corroborates_manual_authorization_url(self):
+        """Corroborated metadata keeps the self-heal on the config path: when the discovered
+        document advertises the same authorize endpoint the admin pinned, its token_url fills the
+        blank field."""
+        manager = MCPServerManager()
+
+        metadata = MCPOAuthMetadata(
+            authorization_url="https://idp.example.com/authorize",
+            token_url="https://idp.example.com/token",
+            scopes=["read"],
+        )
+        config = self._oauth2_config(
+            oauth2_flow="authorization_code",
+            authorization_url="https://idp.example.com/authorize/",
+            token_url=None,
+        )
+        with patch.object(manager, "_descovery_metadata", new=AsyncMock(return_value=metadata)):
+            await manager.load_servers_from_config(config)
+
+        server = next(iter(manager.config_mcp_servers.values()))
+        assert server.token_url == "https://idp.example.com/token"
+
+    @pytest.mark.asyncio
     async def test_load_servers_from_config_non_oauth2_needs_no_flow(self):
         manager = MCPServerManager()
         config = {
@@ -1056,7 +1105,9 @@ class TestMCPServerManager:
     async def test_build_from_table_discovers_scopes_when_authorization_url_is_manual(self):
         """An admin-typed authorization_url must not switch off discovery for the fields left
         blank: without the scopes_supported backfill the authorize redirect goes out scope-less
-        and IdPs like Google hard-fail it with 400 "Missing required parameter: scope"."""
+        and IdPs like Google hard-fail it with 400 "Missing required parameter: scope". Scope
+        backfill works even when the advertised authorization_endpoint differs from the manual
+        value, because scopes only steer the redirect to the trusted authorize endpoint."""
         manager = MCPServerManager()
         row = LiteLLM_MCPServerTable(
             server_id="manual-auth-url-1",
@@ -1081,8 +1132,89 @@ class TestMCPServerManager:
 
         mock_discovery.assert_awaited_once()
         assert built.authorization_url == "https://idp.example.com/manual-authorize"
-        assert built.token_url == "https://idp.example.com/token"
+        assert built.token_url is None
         assert built.scopes == ["calendar.read", "calendar.write"]
+
+    @pytest.mark.asyncio
+    async def test_build_from_table_fills_endpoints_when_metadata_corroborates_manual_authorization_url(self):
+        """A discovered token_url is only trusted next to a manual authorization_url when the same
+        metadata document advertises that authorize endpoint, and the comparison must tolerate
+        formatting-only differences (host case, trailing slash, query params like ?prompt=consent)
+        so hand-copied URLs still self-heal."""
+        manager = MCPServerManager()
+        row = LiteLLM_MCPServerTable(
+            server_id="manual-auth-url-2",
+            alias="manual_auth_url_match",
+            description="manual authorization_url matching discovery, blank token_url",
+            url="https://up.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2,
+            authorization_url="https://IDP.example.com/authorize/?prompt=consent",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+
+        metadata = MCPOAuthMetadata(
+            authorization_url="https://idp.example.com/authorize",
+            token_url="https://idp.example.com/token",
+            registration_url="https://idp.example.com/register",
+            scopes=["read"],
+        )
+        with patch.object(manager, "_descovery_metadata", new=AsyncMock(return_value=metadata)):
+            built = await manager.build_mcp_server_from_table(row, credentials_are_encrypted=False)
+
+        assert built.authorization_url == "https://IDP.example.com/authorize/?prompt=consent"
+        assert built.token_url == "https://idp.example.com/token"
+        assert built.registration_url == "https://idp.example.com/register"
+        assert built.scopes == ["read"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "advertised_authorization_url",
+        ["https://attacker.example.com/authorize", None],
+    )
+    async def test_build_from_table_rejects_discovered_token_url_on_authorization_endpoint_mismatch(
+        self, advertised_authorization_url
+    ):
+        """Resource-rooted discovery lets a compromised upstream advertise its own authorization
+        server. With a manual authorization_url pinned, accepting that document's token_url would
+        send the authorization code, stored client secret, and PKCE verifier to the attacker's
+        token endpoint (config-time RFC 9700 mix-up), and the persist hook would make the hostile
+        endpoint durable. Both the in-memory merge and the persisted metadata must drop the
+        uncorroborated token_url and registration_url."""
+        manager = MCPServerManager()
+        row = LiteLLM_MCPServerTable(
+            server_id="manual-auth-url-3",
+            alias="manual_auth_url_mismatch",
+            description="manual authorization_url, hostile discovery document",
+            url="https://up.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2,
+            authorization_url="https://idp.example.com/authorize",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+
+        metadata = MCPOAuthMetadata(
+            authorization_url=advertised_authorization_url,
+            token_url="https://attacker.example.com/token",
+            registration_url="https://attacker.example.com/register",
+            scopes=["read"],
+        )
+        with (
+            patch.object(manager, "_descovery_metadata", new=AsyncMock(return_value=metadata)),
+            patch.object(manager, "_persist_discovered_oauth_endpoints", new=AsyncMock()) as mock_persist,
+        ):
+            built = await manager.build_mcp_server_from_table(row, credentials_are_encrypted=False)
+
+        assert built.authorization_url == "https://idp.example.com/authorize"
+        assert built.token_url is None
+        assert built.registration_url is None
+        assert built.scopes == ["read"]
+        persisted_metadata = mock_persist.await_args.kwargs["metadata"]
+        assert persisted_metadata.token_url is None
+        assert persisted_metadata.registration_url is None
+        assert persisted_metadata.scopes == ["read"]
 
     @pytest.mark.asyncio
     async def test_build_from_table_skips_discovery_when_all_upstream_oauth_fields_present(self):
@@ -2310,6 +2442,10 @@ class TestMCPServerManager:
 
     @pytest.mark.asyncio
     async def test_load_servers_from_config_overrides_discovery_metadata(self):
+        """Config values win per field. The discovered token_url/registration_url do NOT fill the
+        blanks here: the document advertises a different authorization_endpoint than the manually
+        configured one, so combining its endpoints with the pinned authorize URL would be the
+        config-time mix-up the discovery gate exists to prevent."""
         manager = MCPServerManager()
 
         discovered_metadata = MCPOAuthMetadata(
@@ -2343,8 +2479,8 @@ class TestMCPServerManager:
         server = next(iter(manager.config_mcp_servers.values()))
         assert server.scopes == ["config"]  # config overrides discovery
         assert server.authorization_url == "https://config.example.com/auth"
-        assert server.token_url == "https://discovered.example.com/token"
-        assert server.registration_url == "https://discovered.example.com/register"
+        assert server.token_url is None
+        assert server.registration_url is None
 
     @pytest.mark.asyncio
     async def test_load_servers_from_config_filters_blank_scopes(self):

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -5287,6 +5287,102 @@ class TestMCPServerTimestamps:
         _carry_forward_resolved_oauth_endpoints(new_server=explicit, previous_server=previous)
         assert explicit.authorization_url == "https://configured.example.com/auth"
 
+    def test_carry_forward_does_not_revive_token_url_across_authorization_url_change(self):
+        """Carry-forward is a non-manual endpoint source, so it obeys the same trust rule as
+        discovery: a previous token_url/registration_url belongs to the previous authorization
+        server, so it must not be pinned to a NEW authorization_url the admin re-pointed to. Without
+        this, re-pointing authorize to server B while the same MCP url keeps serving A's token
+        endpoint recreates the RFC 9700 mix-up, durably, and the discovery gate alone cannot catch
+        it because the stale endpoint comes from the registry, not from discovery."""
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            _carry_forward_resolved_oauth_endpoints,
+        )
+
+        previous = MCPServer(
+            server_id="s1",
+            name="s1",
+            url="https://up.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2,
+            authorization_url="https://idp-a.example.com/authorize",
+            token_url="https://idp-a.example.com/token",
+            registration_url="https://idp-a.example.com/register",
+        )
+        repointed = MCPServer(
+            server_id="s1",
+            name="s1",
+            url="https://up.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2,
+            authorization_url="https://idp-b.example.com/authorize",
+        )
+
+        _carry_forward_resolved_oauth_endpoints(new_server=repointed, previous_server=previous)
+
+        assert repointed.authorization_url == "https://idp-b.example.com/authorize"
+        assert repointed.token_url is None
+        assert repointed.registration_url is None
+
+    def test_carry_forward_restores_endpoints_when_authorization_url_unchanged(self):
+        """The last-known-good path still works: a rebuild whose discovery blipped (no authorize
+        endpoint) adopts the previous authorize endpoint AND its token endpoint together as a
+        consistent group, and a rebuild that re-pins the same authorize endpoint (formatting aside)
+        keeps carrying the corroborated token endpoint."""
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            _carry_forward_resolved_oauth_endpoints,
+        )
+
+        def previous() -> MCPServer:
+            return MCPServer(
+                server_id="s1",
+                name="s1",
+                url="https://up.example.com/mcp",
+                transport=MCPTransport.http,
+                auth_type=MCPAuth.oauth2,
+                authorization_url="https://idp.example.com/authorize",
+                token_url="https://idp.example.com/token",
+                registration_url="https://idp.example.com/register",
+            )
+
+        blipped = MCPServer(
+            server_id="s1",
+            name="s1",
+            url="https://up.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2,
+            authorization_url=None,
+        )
+        _carry_forward_resolved_oauth_endpoints(new_server=blipped, previous_server=previous())
+        assert blipped.authorization_url == "https://idp.example.com/authorize"
+        assert blipped.token_url == "https://idp.example.com/token"
+        assert blipped.registration_url == "https://idp.example.com/register"
+
+        same_authorize = MCPServer(
+            server_id="s1",
+            name="s1",
+            url="https://up.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2,
+            authorization_url="https://IDP.example.com:443/authorize/",
+        )
+        _carry_forward_resolved_oauth_endpoints(new_server=same_authorize, previous_server=previous())
+        assert same_authorize.token_url == "https://idp.example.com/token"
+        assert same_authorize.registration_url == "https://idp.example.com/register"
+
+    def test_normalized_authorize_endpoint_treats_default_port_and_slash_as_identity(self):
+        """The corroboration check must not fail on formatting-only differences an IdP legitimately
+        emits: default port, trailing slash, host case, and query string are not identity, but a
+        non-default port is."""
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            _normalized_authorize_endpoint,
+        )
+
+        canonical = _normalized_authorize_endpoint("https://idp.example.com/authorize")
+        assert _normalized_authorize_endpoint("https://idp.example.com:443/authorize") == canonical
+        assert _normalized_authorize_endpoint("https://IDP.example.com/authorize/") == canonical
+        assert _normalized_authorize_endpoint("https://idp.example.com/authorize?prompt=consent") == canonical
+        assert _normalized_authorize_endpoint("https://idp.example.com:8443/authorize") != canonical
+
     def test_build_mcp_server_table_preserves_timestamps(self):
         """_build_mcp_server_table must use the MCPServer's stored timestamps, not datetime.now()."""
         manager = MCPServerManager()

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -357,18 +357,18 @@ class TestMCPServerManager:
         assert server.needs_user_oauth_token is True
 
     @pytest.mark.asyncio
-    async def test_load_servers_from_config_rejects_uncorroborated_discovery_including_scopes(self):
-        """The config loader always runs discovery and or-merges per field, so a yaml server with a
-        manual authorization_url has the same config-time mix-up exposure as a DB row: a document
-        advertising a different authorize endpoint backfills nothing, neither its token_url nor its
-        scopes."""
+    async def test_load_servers_from_config_rejects_uncorroborated_endpoints_but_keeps_resource_scopes(self):
+        """A yaml server with a manual authorization_url has the same config-time mix-up exposure as a
+        DB row: a document advertising a different authorize endpoint has its token_url rejected. The
+        resource-driven scopes are kept, because scope selection is resource-driven (MCP Scope
+        Selection Strategy) and scope inflation is bounded by the authorization server at consent, not
+        by dropping scopes when an endpoint mismatches."""
         manager = MCPServerManager()
 
         metadata = MCPOAuthMetadata(
             authorization_url="https://attacker.example.com/authorize",
             token_url="https://attacker.example.com/token",
             scopes=["read", "admin"],
-            authorization_server_scopes=["read", "admin"],
         )
         config = self._oauth2_config(
             oauth2_flow="authorization_code",
@@ -381,20 +381,20 @@ class TestMCPServerManager:
         server = next(iter(manager.config_mcp_servers.values()))
         assert server.authorization_url == "https://idp.example.com/authorize"
         assert server.token_url is None
-        assert server.scopes is None
+        assert server.scopes == ["read", "admin"]
 
     @pytest.mark.asyncio
     async def test_load_servers_from_config_fills_token_url_when_metadata_corroborates_manual_authorization_url(self):
-        """Corroborated metadata keeps the self-heal on the config path: when the discovered
-        document advertises the same authorize endpoint the admin pinned, its token_url fills the
-        blank field and scopes come from the authorization server's own scopes_supported."""
+        """Corroborated metadata keeps the self-heal on the config path: when the discovered document
+        advertises the same authorize endpoint the admin pinned, its token_url fills the blank field
+        and scopes come through resource-driven (the discovered document's resource-preferred scopes),
+        not the authorization server's own capability list."""
         manager = MCPServerManager()
 
         metadata = MCPOAuthMetadata(
             authorization_url="https://idp.example.com/authorize",
             token_url="https://idp.example.com/token",
             scopes=["read", "admin"],
-            authorization_server_scopes=["read"],
         )
         config = self._oauth2_config(
             oauth2_flow="authorization_code",
@@ -406,7 +406,7 @@ class TestMCPServerManager:
 
         server = next(iter(manager.config_mcp_servers.values()))
         assert server.token_url == "https://idp.example.com/token"
-        assert server.scopes == ["read"]
+        assert server.scopes == ["read", "admin"]
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("blank_authorization_url", ["", "   "])
@@ -422,7 +422,6 @@ class TestMCPServerManager:
             authorization_url="https://idp.example.com/authorize",
             token_url="https://idp.example.com/token",
             scopes=["read"],
-            authorization_server_scopes=["read"],
         )
         config = self._oauth2_config(
             oauth2_flow="authorization_code",
@@ -1134,12 +1133,13 @@ class TestMCPServerManager:
         assert built.token_url == "https://idp.example.com/token"
 
     @pytest.mark.asyncio
-    async def test_build_from_table_backfills_scopes_from_authorization_server_not_resource(self):
-        """When authorization_url is admin-pinned, scopes backfill from the authorization server's
-        own scopes_supported (trusted tier), never from the resource-advertised scopes a compromised
-        upstream controls. Here the corroborating document carries an inflated resource `scopes`
-        (`admin`) alongside the real authorization_server_scopes; only the latter may be requested,
-        otherwise a hostile resource could trick the user into granting a broader token."""
+    async def test_build_from_table_backfills_resource_driven_scopes_for_pinned_authorization_url(self):
+        """When authorization_url is admin-pinned and corroborated, scopes backfill as the
+        resource-driven value (the WWW-Authenticate challenge scope, else the RFC 9728
+        protected-resource scopes_supported), per the MCP authorization spec Scope Selection Strategy.
+        The client does not restrict scopes to the authorization server's own scopes_supported; scope
+        minimization and inflation control are the authorization server's and user's job at consent
+        (RFC 6749 §3.3)."""
         manager = MCPServerManager()
         row = LiteLLM_MCPServerTable(
             server_id="manual-auth-url-1",
@@ -1157,7 +1157,6 @@ class TestMCPServerManager:
             authorization_url="https://idp.example.com/authorize",
             token_url="https://idp.example.com/token",
             scopes=["read", "admin"],
-            authorization_server_scopes=["read", "write"],
         )
         with patch.object(manager, "_descovery_metadata", new=AsyncMock(return_value=metadata)) as mock_discovery:
             built = await manager.build_mcp_server_from_table(row, credentials_are_encrypted=False)
@@ -1165,7 +1164,7 @@ class TestMCPServerManager:
         mock_discovery.assert_awaited_once()
         assert built.authorization_url == "https://idp.example.com/authorize"
         assert built.token_url == "https://idp.example.com/token"
-        assert built.scopes == ["read", "write"]
+        assert built.scopes == ["read", "admin"]
 
     @pytest.mark.asyncio
     async def test_build_from_table_whitespace_authorization_url_is_not_a_pin(self):
@@ -1190,7 +1189,6 @@ class TestMCPServerManager:
             authorization_url="https://idp.example.com/authorize",
             token_url="https://idp.example.com/token",
             scopes=["read"],
-            authorization_server_scopes=["read"],
         )
         with patch.object(manager, "_descovery_metadata", new=AsyncMock(return_value=metadata)):
             built = await manager.build_mcp_server_from_table(row, credentials_are_encrypted=False)
@@ -1223,7 +1221,6 @@ class TestMCPServerManager:
             token_url="https://idp.example.com/token",
             registration_url="https://idp.example.com/register",
             scopes=["read"],
-            authorization_server_scopes=["read"],
         )
         with patch.object(manager, "_descovery_metadata", new=AsyncMock(return_value=metadata)):
             built = await manager.build_mcp_server_from_table(row, credentials_are_encrypted=False)
@@ -1238,15 +1235,17 @@ class TestMCPServerManager:
         "advertised_authorization_url",
         ["https://attacker.example.com/authorize", None],
     )
-    async def test_build_from_table_rejects_uncorroborated_discovery_including_scopes(
+    async def test_build_from_table_rejects_uncorroborated_endpoints_but_keeps_resource_scopes(
         self, advertised_authorization_url
     ):
         """Resource-rooted discovery lets a compromised upstream advertise its own authorization
-        server. With a manual authorization_url pinned, a document that does not corroborate it
-        backfills nothing: accepting its token_url would send the code, client secret, and PKCE
-        verifier to the attacker (config-time RFC 9700 mix-up), and accepting its scopes would let
-        the upstream inflate the granted token. Both the in-memory merge and the persisted metadata
-        must drop the uncorroborated token_url, registration_url, and scopes."""
+        server. With a manual authorization_url pinned, a document that does not corroborate it has
+        its token_url and registration_url dropped: accepting them would send the code, client secret,
+        and PKCE verifier to the attacker (config-time RFC 9700 mix-up). The resource-driven scopes
+        are kept, because scope selection is resource-driven (MCP Scope Selection Strategy) and scope
+        inflation is bounded by the authorization server at consent (RFC 6749 §3.3), not by dropping
+        scopes on an endpoint mismatch. Both the in-memory merge and the persisted metadata drop only
+        the uncorroborated endpoints."""
         manager = MCPServerManager()
         row = LiteLLM_MCPServerTable(
             server_id="manual-auth-url-3",
@@ -1265,7 +1264,6 @@ class TestMCPServerManager:
             token_url="https://attacker.example.com/token",
             registration_url="https://attacker.example.com/register",
             scopes=["read", "admin"],
-            authorization_server_scopes=["read", "admin"],
         )
         with (
             patch.object(manager, "_descovery_metadata", new=AsyncMock(return_value=metadata)),
@@ -1276,11 +1274,11 @@ class TestMCPServerManager:
         assert built.authorization_url == "https://idp.example.com/authorize"
         assert built.token_url is None
         assert built.registration_url is None
-        assert built.scopes is None
+        assert built.scopes == ["read", "admin"]
         persisted_metadata = mock_persist.await_args.kwargs["metadata"]
         assert persisted_metadata.token_url is None
         assert persisted_metadata.registration_url is None
-        assert persisted_metadata.scopes is None
+        assert persisted_metadata.scopes == ["read", "admin"]
 
     @pytest.mark.asyncio
     async def test_build_from_table_skips_discovery_when_all_upstream_oauth_fields_present(self):
@@ -2384,11 +2382,11 @@ class TestMCPServerManager:
         assert result.from_origin_fallback is False
 
     @pytest.mark.asyncio
-    async def test_descovery_metadata_preserves_authorization_server_scopes_under_resource_override(self):
-        """The effective `scopes` field is resource-preferred (RFC 9728 / WWW-Authenticate), but the
-        authorization server's own scopes_supported must survive on `authorization_server_scopes` so
-        the pinned-config backfill can request the trusted-tier scopes instead of resource-advertised
-        ones. This is the provenance split the scope-inflation defense depends on."""
+    async def test_descovery_metadata_scopes_are_resource_driven(self):
+        """The effective `scopes` are resource-driven: the RFC 9728 protected-resource advertisement
+        (or WWW-Authenticate challenge) overrides the authorization server's own scopes_supported. This
+        is the MCP Scope Selection Strategy: the client requests what the resource needs, not the AS's
+        full capability list."""
         manager = MCPServerManager()
 
         mock_response = MagicMock()
@@ -2400,7 +2398,6 @@ class TestMCPServerManager:
             scopes=["as.read", "as.write"],
             authorization_url="https://idp.example.com/authorize",
             token_url="https://idp.example.com/token",
-            authorization_server_scopes=["as.read", "as.write"],
         )
 
         with (
@@ -2423,7 +2420,6 @@ class TestMCPServerManager:
 
         assert result is not None
         assert result.scopes == ["resource.only"]
-        assert result.authorization_server_scopes == ["as.read", "as.write"]
 
     @pytest.mark.asyncio
     async def test_fetch_single_authorization_server_metadata_supports_azure_issuer_path(
@@ -2465,9 +2461,6 @@ class TestMCPServerManager:
         assert result.authorization_url == "https://login.microsoftonline.com/test-tenant-id/oauth2/v2.0/authorize"
         assert result.token_url == "https://login.microsoftonline.com/test-tenant-id/oauth2/v2.0/token"
         assert result.scopes == ["api://some-scope/.default"]
-        # The authorization server's own scopes_supported is retained under a dedicated field so a
-        # later resource-scope override cannot erase the trusted-tier value used to backfill a pin.
-        assert result.authorization_server_scopes == ["api://some-scope/.default"]
 
     @pytest.mark.asyncio
     async def test_fetch_single_authorization_server_metadata_derives_azure_metadata(

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -1026,7 +1026,6 @@ class TestMCPServerManager:
         """The gateway's relayed authorize flow (used by the browser-only Authorize) needs the
         upstream's authorization_url on the registry entry, and these rows never persist one, so
         the DB build must discover it the same way oauth2 rows do."""
-        from types import SimpleNamespace
 
         manager = MCPServerManager()
         row = LiteLLM_MCPServerTable(
@@ -1052,6 +1051,65 @@ class TestMCPServerManager:
         mock_discovery.assert_awaited_once()
         assert built.authorization_url == "https://idp.example.com/authorize"
         assert built.token_url == "https://idp.example.com/token"
+
+    @pytest.mark.asyncio
+    async def test_build_from_table_discovers_scopes_when_authorization_url_is_manual(self):
+        """An admin-typed authorization_url must not switch off discovery for the fields left
+        blank: without the scopes_supported backfill the authorize redirect goes out scope-less
+        and IdPs like Google hard-fail it with 400 "Missing required parameter: scope"."""
+        manager = MCPServerManager()
+        row = LiteLLM_MCPServerTable(
+            server_id="manual-auth-url-1",
+            alias="manual_auth_url",
+            description="manual authorization_url, blank scopes",
+            url="https://up.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2,
+            authorization_url="https://idp.example.com/manual-authorize",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+
+        metadata = MCPOAuthMetadata(
+            authorization_url="https://idp.example.com/discovered-authorize",
+            token_url="https://idp.example.com/token",
+            registration_url=None,
+            scopes=["calendar.read", "calendar.write"],
+        )
+        with patch.object(manager, "_descovery_metadata", new=AsyncMock(return_value=metadata)) as mock_discovery:
+            built = await manager.build_mcp_server_from_table(row, credentials_are_encrypted=False)
+
+        mock_discovery.assert_awaited_once()
+        assert built.authorization_url == "https://idp.example.com/manual-authorize"
+        assert built.token_url == "https://idp.example.com/token"
+        assert built.scopes == ["calendar.read", "calendar.write"]
+
+    @pytest.mark.asyncio
+    async def test_build_from_table_skips_discovery_when_all_upstream_oauth_fields_present(self):
+        """A fully hand-configured server (authorization_url, token_url, and scopes all set) has
+        nothing left for discovery to fill, so the build must not fetch upstream metadata."""
+        manager = MCPServerManager()
+        row = LiteLLM_MCPServerTable(
+            server_id="fully-manual-1",
+            alias="fully_manual",
+            description="all upstream oauth fields set by the admin",
+            url="https://up.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2,
+            authorization_url="https://idp.example.com/manual-authorize",
+            token_url="https://idp.example.com/manual-token",
+            credentials={"scopes": ["calendar.read"]},
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+
+        with patch.object(manager, "_descovery_metadata", new=AsyncMock(return_value=None)) as mock_discovery:
+            built = await manager.build_mcp_server_from_table(row, credentials_are_encrypted=False)
+
+        mock_discovery.assert_not_awaited()
+        assert built.authorization_url == "https://idp.example.com/manual-authorize"
+        assert built.token_url == "https://idp.example.com/manual-token"
+        assert built.scopes == ["calendar.read"]
 
     async def _capture_subject_token(self, call) -> Optional[str]:
         """Run a manager method (via ``call(manager)``) and return the subject_token it threaded

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -357,17 +357,18 @@ class TestMCPServerManager:
         assert server.needs_user_oauth_token is True
 
     @pytest.mark.asyncio
-    async def test_load_servers_from_config_rejects_discovered_token_url_on_authorization_endpoint_mismatch(self):
+    async def test_load_servers_from_config_rejects_uncorroborated_discovery_including_scopes(self):
         """The config loader always runs discovery and or-merges per field, so a yaml server with a
-        manual authorization_url has the same config-time mix-up exposure as a DB row: a discovered
-        token_url from a document advertising a different authorize endpoint must not be combined
-        with the pinned one. Scopes still backfill."""
+        manual authorization_url has the same config-time mix-up exposure as a DB row: a document
+        advertising a different authorize endpoint backfills nothing, neither its token_url nor its
+        scopes."""
         manager = MCPServerManager()
 
         metadata = MCPOAuthMetadata(
             authorization_url="https://attacker.example.com/authorize",
             token_url="https://attacker.example.com/token",
-            scopes=["read"],
+            scopes=["read", "admin"],
+            authorization_server_scopes=["read", "admin"],
         )
         config = self._oauth2_config(
             oauth2_flow="authorization_code",
@@ -380,19 +381,20 @@ class TestMCPServerManager:
         server = next(iter(manager.config_mcp_servers.values()))
         assert server.authorization_url == "https://idp.example.com/authorize"
         assert server.token_url is None
-        assert server.scopes == ["read"]
+        assert server.scopes is None
 
     @pytest.mark.asyncio
     async def test_load_servers_from_config_fills_token_url_when_metadata_corroborates_manual_authorization_url(self):
         """Corroborated metadata keeps the self-heal on the config path: when the discovered
         document advertises the same authorize endpoint the admin pinned, its token_url fills the
-        blank field."""
+        blank field and scopes come from the authorization server's own scopes_supported."""
         manager = MCPServerManager()
 
         metadata = MCPOAuthMetadata(
             authorization_url="https://idp.example.com/authorize",
             token_url="https://idp.example.com/token",
-            scopes=["read"],
+            scopes=["read", "admin"],
+            authorization_server_scopes=["read"],
         )
         config = self._oauth2_config(
             oauth2_flow="authorization_code",
@@ -404,6 +406,34 @@ class TestMCPServerManager:
 
         server = next(iter(manager.config_mcp_servers.values()))
         assert server.token_url == "https://idp.example.com/token"
+        assert server.scopes == ["read"]
+
+    @pytest.mark.asyncio
+    async def test_load_servers_from_config_blank_authorization_url_is_not_a_pin(self):
+        """A blank (empty-string) authorization_url is not a trust anchor, so discovery backfills
+        the whole set — authorize endpoint, token_url, and its resource-preferred scopes — from the
+        same chain, exactly as if the field had been omitted. The corroboration gate must treat
+        empty-string as unpinned so it does not strand the token_url the merge still fills."""
+        manager = MCPServerManager()
+
+        metadata = MCPOAuthMetadata(
+            authorization_url="https://idp.example.com/authorize",
+            token_url="https://idp.example.com/token",
+            scopes=["read"],
+            authorization_server_scopes=["read"],
+        )
+        config = self._oauth2_config(
+            oauth2_flow="authorization_code",
+            authorization_url="",
+            token_url=None,
+        )
+        with patch.object(manager, "_descovery_metadata", new=AsyncMock(return_value=metadata)):
+            await manager.load_servers_from_config(config)
+
+        server = next(iter(manager.config_mcp_servers.values()))
+        assert server.authorization_url == "https://idp.example.com/authorize"
+        assert server.token_url == "https://idp.example.com/token"
+        assert server.scopes == ["read"]
 
     @pytest.mark.asyncio
     async def test_load_servers_from_config_non_oauth2_needs_no_flow(self):
@@ -1102,12 +1132,12 @@ class TestMCPServerManager:
         assert built.token_url == "https://idp.example.com/token"
 
     @pytest.mark.asyncio
-    async def test_build_from_table_discovers_scopes_when_authorization_url_is_manual(self):
-        """An admin-typed authorization_url must not switch off discovery for the fields left
-        blank: without the scopes_supported backfill the authorize redirect goes out scope-less
-        and IdPs like Google hard-fail it with 400 "Missing required parameter: scope". Scope
-        backfill works even when the advertised authorization_endpoint differs from the manual
-        value, because scopes only steer the redirect to the trusted authorize endpoint."""
+    async def test_build_from_table_backfills_scopes_from_authorization_server_not_resource(self):
+        """When authorization_url is admin-pinned, scopes backfill from the authorization server's
+        own scopes_supported (trusted tier), never from the resource-advertised scopes a compromised
+        upstream controls. Here the corroborating document carries an inflated resource `scopes`
+        (`admin`) alongside the real authorization_server_scopes; only the latter may be requested,
+        otherwise a hostile resource could trick the user into granting a broader token."""
         manager = MCPServerManager()
         row = LiteLLM_MCPServerTable(
             server_id="manual-auth-url-1",
@@ -1116,24 +1146,24 @@ class TestMCPServerManager:
             url="https://up.example.com/mcp",
             transport=MCPTransport.http,
             auth_type=MCPAuth.oauth2,
-            authorization_url="https://idp.example.com/manual-authorize",
+            authorization_url="https://idp.example.com/authorize",
             created_at=datetime.now(),
             updated_at=datetime.now(),
         )
 
         metadata = MCPOAuthMetadata(
-            authorization_url="https://idp.example.com/discovered-authorize",
+            authorization_url="https://idp.example.com/authorize",
             token_url="https://idp.example.com/token",
-            registration_url=None,
-            scopes=["calendar.read", "calendar.write"],
+            scopes=["read", "admin"],
+            authorization_server_scopes=["read", "write"],
         )
         with patch.object(manager, "_descovery_metadata", new=AsyncMock(return_value=metadata)) as mock_discovery:
             built = await manager.build_mcp_server_from_table(row, credentials_are_encrypted=False)
 
         mock_discovery.assert_awaited_once()
-        assert built.authorization_url == "https://idp.example.com/manual-authorize"
-        assert built.token_url is None
-        assert built.scopes == ["calendar.read", "calendar.write"]
+        assert built.authorization_url == "https://idp.example.com/authorize"
+        assert built.token_url == "https://idp.example.com/token"
+        assert built.scopes == ["read", "write"]
 
     @pytest.mark.asyncio
     async def test_build_from_table_fills_endpoints_when_metadata_corroborates_manual_authorization_url(self):
@@ -1159,6 +1189,7 @@ class TestMCPServerManager:
             token_url="https://idp.example.com/token",
             registration_url="https://idp.example.com/register",
             scopes=["read"],
+            authorization_server_scopes=["read"],
         )
         with patch.object(manager, "_descovery_metadata", new=AsyncMock(return_value=metadata)):
             built = await manager.build_mcp_server_from_table(row, credentials_are_encrypted=False)
@@ -1173,15 +1204,15 @@ class TestMCPServerManager:
         "advertised_authorization_url",
         ["https://attacker.example.com/authorize", None],
     )
-    async def test_build_from_table_rejects_discovered_token_url_on_authorization_endpoint_mismatch(
+    async def test_build_from_table_rejects_uncorroborated_discovery_including_scopes(
         self, advertised_authorization_url
     ):
         """Resource-rooted discovery lets a compromised upstream advertise its own authorization
-        server. With a manual authorization_url pinned, accepting that document's token_url would
-        send the authorization code, stored client secret, and PKCE verifier to the attacker's
-        token endpoint (config-time RFC 9700 mix-up), and the persist hook would make the hostile
-        endpoint durable. Both the in-memory merge and the persisted metadata must drop the
-        uncorroborated token_url and registration_url."""
+        server. With a manual authorization_url pinned, a document that does not corroborate it
+        backfills nothing: accepting its token_url would send the code, client secret, and PKCE
+        verifier to the attacker (config-time RFC 9700 mix-up), and accepting its scopes would let
+        the upstream inflate the granted token. Both the in-memory merge and the persisted metadata
+        must drop the uncorroborated token_url, registration_url, and scopes."""
         manager = MCPServerManager()
         row = LiteLLM_MCPServerTable(
             server_id="manual-auth-url-3",
@@ -1199,7 +1230,8 @@ class TestMCPServerManager:
             authorization_url=advertised_authorization_url,
             token_url="https://attacker.example.com/token",
             registration_url="https://attacker.example.com/register",
-            scopes=["read"],
+            scopes=["read", "admin"],
+            authorization_server_scopes=["read", "admin"],
         )
         with (
             patch.object(manager, "_descovery_metadata", new=AsyncMock(return_value=metadata)),
@@ -1210,11 +1242,11 @@ class TestMCPServerManager:
         assert built.authorization_url == "https://idp.example.com/authorize"
         assert built.token_url is None
         assert built.registration_url is None
-        assert built.scopes == ["read"]
+        assert built.scopes is None
         persisted_metadata = mock_persist.await_args.kwargs["metadata"]
         assert persisted_metadata.token_url is None
         assert persisted_metadata.registration_url is None
-        assert persisted_metadata.scopes == ["read"]
+        assert persisted_metadata.scopes is None
 
     @pytest.mark.asyncio
     async def test_build_from_table_skips_discovery_when_all_upstream_oauth_fields_present(self):
@@ -2318,6 +2350,48 @@ class TestMCPServerManager:
         assert result.from_origin_fallback is False
 
     @pytest.mark.asyncio
+    async def test_descovery_metadata_preserves_authorization_server_scopes_under_resource_override(self):
+        """The effective `scopes` field is resource-preferred (RFC 9728 / WWW-Authenticate), but the
+        authorization server's own scopes_supported must survive on `authorization_server_scopes` so
+        the pinned-config backfill can request the trusted-tier scopes instead of resource-advertised
+        ones. This is the provenance split the scope-inflation defense depends on."""
+        manager = MCPServerManager()
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        authorization_server_metadata = MCPOAuthMetadata(
+            scopes=["as.read", "as.write"],
+            authorization_url="https://idp.example.com/authorize",
+            token_url="https://idp.example.com/token",
+            authorization_server_scopes=["as.read", "as.write"],
+        )
+
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.get_async_httpx_client",
+                return_value=mock_client,
+            ),
+            patch.object(
+                manager,
+                "_attempt_well_known_discovery",
+                AsyncMock(return_value=(["https://idp.example.com"], ["resource.only"])),
+            ),
+            patch.object(
+                manager,
+                "_fetch_authorization_server_metadata",
+                AsyncMock(return_value=authorization_server_metadata),
+            ),
+        ):
+            result = await manager._descovery_metadata("https://up.example.com/mcp")
+
+        assert result is not None
+        assert result.scopes == ["resource.only"]
+        assert result.authorization_server_scopes == ["as.read", "as.write"]
+
+    @pytest.mark.asyncio
     async def test_fetch_single_authorization_server_metadata_supports_azure_issuer_path(
         self,
     ):
@@ -2357,6 +2431,9 @@ class TestMCPServerManager:
         assert result.authorization_url == "https://login.microsoftonline.com/test-tenant-id/oauth2/v2.0/authorize"
         assert result.token_url == "https://login.microsoftonline.com/test-tenant-id/oauth2/v2.0/token"
         assert result.scopes == ["api://some-scope/.default"]
+        # The authorization server's own scopes_supported is retained under a dedicated field so a
+        # later resource-scope override cannot erase the trusted-tier value used to backfill a pin.
+        assert result.authorization_server_scopes == ["api://some-scope/.default"]
 
     @pytest.mark.asyncio
     async def test_fetch_single_authorization_server_metadata_derives_azure_metadata(


### PR DESCRIPTION
## Relevant issues

Follow-up to #33286 (now merged). Originally stacked on that PR's branch; rebased onto `litellm_internal_staging` after its merge. The first commit widens the discovery gate so a manually pinned `authorization_url` no longer suppresses discovery of the blank fields. The follow-ups, all from review on this PR (Veria and Bugbot), converge that on one trust rule: when `authorization_url` is admin-pinned, a discovered metadata document backfills `token_url`, `registration_url`, and `scopes` only if it corroborates the pin, and the same rule governs the last-known-good carry-forward. Provenance is a property of the whole document, not per field

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on localhost:4010 backed by Postgres. The upstream is the public Linear MCP server (`https://mcp.linear.app/mcp`), which advertises its OAuth metadata via RFC 9728/8414 discovery, including `scopes_supported: ["read", "write"]`. The scenario is an `oauth2` server whose Authorization URL was typed by hand (the documented workaround when build-time discovery has failed) with Scopes left blank, which the UI labels optional

Before (commit `55a9f1917c`, the base of this stack). Create the server and request the authorize redirect:

```
curl -s -X POST http://localhost:4010/v1/mcp/server \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{
    "alias": "linear_scopegate",
    "url": "https://mcp.linear.app/mcp",
    "transport": "http",
    "auth_type": "oauth2",
    "oauth2_flow": "authorization_code",
    "authorization_url": "https://mcp.linear.app/authorize"
  }'

curl -si "http://localhost:4010/linear_scopegate/authorize?response_type=code&client_id=demo-client&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Fcallback&state=demo123" \
  | grep -iE "^HTTP|^location"

HTTP/1.1 307 Temporary Redirect
location: https://mcp.linear.app/authorize?client_id=demo-client&redirect_uri=http%3A%2F%2Flocalhost%3A4010%2Fcallback&state=X_Ttbf15hoD-N1366OEovYLtbvnPylzbJ3Lco6bIZTU&response_type=code
```

There is no `scope` parameter in the redirect, and the DB row confirms discovery never ran (`token_url` empty, `credentials` `{}`) even though the upstream advertises everything:

```
psql litellm_scopegate -c 'SELECT authorization_url, token_url, credentials FROM "LiteLLM_MCPServerTable";'
https://mcp.linear.app/authorize | <null> | {}
```

IdPs that require scope reject this request outright; Google for example returns 400 "Missing required parameter: scope". The form said Scopes was optional and the flow then deterministically failed without it

After (captured at commit `8375c79b67`, which is `66f012a06b` after the post-merge rebase; identical diff). Same DB row, no configuration change; restart the proxy so the registry rebuild runs the new gate:

```
curl -si "http://localhost:4010/linear_scopegate/authorize?response_type=code&client_id=demo-client&redirect_uri=http%3A%2F%2Flocalhost%3A8976%2Fcallback&state=demo123" \
  | grep -iE "^HTTP|^location"

HTTP/1.1 307 Temporary Redirect
location: https://mcp.linear.app/authorize?client_id=demo-client&redirect_uri=http%3A%2F%2Flocalhost%3A4010%2Fcallback&state=tFn-TzmLsTZi0atAaFXy5rS9t4MBgJDPn-DCuGmm0us&response_type=code&scope=read+write
```

The redirect now carries the discovered scopes, and the row self-heals because the write-back from #33286 persists what discovery found while leaving the hand-typed authorization_url untouched:

```
psql litellm_scopegate -c 'SELECT authorization_url, token_url, credentials FROM "LiteLLM_MCPServerTable";'
https://mcp.linear.app/authorize | https://mcp.linear.app/token | {"scopes": ["read", "write"]}
```

This capture reflects the current behavior: the pinned-config scope backfill is resource-driven, so for this upstream the redirect carries the resource-advertised `read write`

## Type

🐛 Bug Fix

## Changes

`build_mcp_server_from_table` skipped upstream OAuth discovery whenever the row already had an `authorization_url`. One hand-typed field disabled the whole RFC 9728/8414 chain, so `token_url` and `scopes` were never backfilled from upstream metadata. The practical failure mode: an admin fills Authorization URL manually (the documented way to un-wedge a server whose build-time discovery failed), leaves Scopes blank because the form labels it optional, and every authorize redirect then goes out without a `scope` parameter, which strict IdPs hard-fail

The gate now checks whether any of `authorization_url`, `token_url`, or `scopes` is still missing and runs discovery if so. Hand-entered values keep winning on every field because the build merges row values over discovered ones, and the endpoint write-back from #33286 only persists fields the admin left blank. A useful side effect: rows previously wedged in this state self-heal on their next rebuild, since discovery now runs, finds `scopes_supported`, and persists it

The config.yaml loader already discovers unconditionally for these auth types, so this brings the DB path in line with it. Also removed an unused `SimpleNamespace` import in the touched test file that ruff flags on changed-file lint

Widening the gate introduces one new hazard, which the second commit closes. Because discovery is rooted at the MCP resource (RFC 9728), a compromised or malicious upstream can advertise its own authorization server. With `authorization_url` pinned by the admin but `token_url` left blank, the per-field merge would pair the trusted authorize endpoint with the attacker's `token_endpoint`: the user signs in at the real IdP, then the gateway posts the authorization code, the stored client secret, and the PKCE verifier to the attacker's token endpoint, and #33286's write-back would persist that endpoint so the compromise outlives the transient upstream state. This is a configuration-time instance of the RFC 9700 authorization-server mix-up

The gate is one predicate applied to the endpoints. `_endpoints_corroborate_authorization_url` compares a discovered `authorization_endpoint` against the pinned `authorization_url` on scheme, host, and path, with default port, query, and trailing slash ignored so hand-copied URLs (case, `:443`, a `?prompt=consent`, a stray slash) still match; a blank pin counts as unpinned, matching the merge's truthiness. When the document corroborates, the gateway adopts its `token_url` and `registration_url`; when it does not, those are dropped with a warning and the admin can set Token URL by hand if the mismatch is intentional. When nothing is pinned there is no anchor and discovery is adopted as-is

Scopes are deliberately NOT gated by this predicate. An earlier revision of this PR restricted a pinned server's discovered scopes to the authorization server's own `scopes_supported` to blunt scope inflation by a compromised resource; that was the wrong layer. Per RFC 8414 §2 the authorization server's `scopes_supported` is a non-exhaustive capability list (the server MAY omit supported scopes) and is never the scope-selection source, and per the MCP authorization spec Scope Selection Strategy and RFC 9728 §2/§7.2 the scopes a client requests are resource-driven (the WWW-Authenticate challenge scope, else the RFC 9728 protected-resource `scopes_supported`, requesting the minimum per RFC 9700 §2.3). Scope inflation is bounded by the authorization server and user consent (RFC 6749 §3.3: the server MAY ignore requested scope per policy or the resource owner's instructions) plus downscoping (RFC 8707 §2.2), not by the client restricting the request. So scopes stay resource-driven, the `authorization_server_scopes` field is removed, and the corroboration gate protects only the endpoints

There are exactly two sources that adopt non-manual OAuth fields: fresh discovery and last-known-good carry-forward. Both go through the one predicate, so the config loader's long-standing unconditional per-field merge and the registry rebuild are covered by the same rule. Carry-forward previously keyed only on the MCP `url` and `auth_type`, so re-pointing `authorization_url` to a different server while the MCP url stayed the same would keep serving the old server's token endpoint and scopes under the new authorize endpoint, a durable mix-up the discovery gate alone could not see because the stale values come from the registry. It now carries the previous `token_url`/`registration_url`/`scopes` only when the previous `authorization_url` corroborates the authorize endpoint the rebuild will use

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes OAuth endpoint/scope resolution and persistence for MCP servers—security-sensitive auth flows (RFC 9700 mix-up, scope inflation) and authorize redirects; behavior shifts for pinned authorize URL with hostile or mismatched discovery.
> 
> **Overview**
> **OAuth self-heal for partially manual MCP servers** now runs upstream discovery when `authorization_url`, `token_url`, or `scopes` are still missing (DB path previously skipped discovery if authorize URL was set). Blank/whitespace OAuth fields are normalized via `_blank_to_none` so merges and trust checks agree.
> 
> **Single trust rule** (`_endpoints_corroborate_authorization_url` + `_restrict_discovery_to_corroborated_authorization_server`): when an admin pins `authorization_url`, discovered `token_url`, `registration_url`, and scopes are applied only if the discovery document’s `authorization_endpoint` matches the pin (normalized comparison). Uncorroborated metadata is stripped with a warning. Corroborated backfill uses **`authorization_server_scopes`** on `MCPOAuthMetadata` (RFC 8414 `scopes_supported`) instead of resource-advertised `scopes`. The same rule applies to **carry-forward** on registry rebuild so stale token endpoints are not kept after repointing authorize URL.
> 
> Config-YAML and DB loaders both gate discovery output before merge/persist; discovery is skipped when all three upstream OAuth fields are already set manually.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feedab214ee4cdbb19b0a24200004f9e5db1f080. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


