### PR TITLE
fix(mcp): index authed request-time tools missing from the semantic filter startup index

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -184,6 +184,10 @@ class SemanticMCPToolFilter:
                 return
             raise
 
+    def _has_tools_missing_from_index(self, tools: list[Any]) -> bool:
+        """Allocation-free check for any named tool not yet in the semantic index."""
+        return any(name and name not in self._tool_map for name in (self._extract_tool_info(t)[0] for t in tools))
+
     def _tools_missing_from_index(self, tools: list[Any]) -> dict[str, Any]:
         """Map name -> tool for every named tool not yet in the semantic index."""
         return {
@@ -205,7 +209,7 @@ class SemanticMCPToolFilter:
         """
         from semantic_router.routers.base import Route
 
-        if not self._tools_missing_from_index(available_tools):
+        if not self._has_tools_missing_from_index(available_tools):
             return
 
         async with self._index_sync_lock:
@@ -215,6 +219,10 @@ class SemanticMCPToolFilter:
 
             if self.tool_router is None:
                 self._build_router(list(missing.values()))
+                if self.tool_router is not None:
+                    verbose_logger.info(
+                        f"Semantic tool filter indexed {len(missing)} request-time tools missing from the startup index"
+                    )
                 return
 
             descriptions = {name: self._extract_tool_info(tool)[1] for name, tool in missing.items()}

--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -4,6 +4,7 @@ Semantic MCP Tool Filtering using semantic-router
 Filters MCP tools semantically for /chat/completions and /responses endpoints.
 """
 
+import asyncio
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from litellm._logging import verbose_logger
@@ -76,6 +77,7 @@ class SemanticMCPToolFilter:
         self.tool_router: Optional["SemanticRouter"] = None
         self.context_window_error: Optional[str] = None
         self._tool_map: Dict[str, Any] = {}  # MCPTool objects or OpenAI function dicts
+        self._index_sync_lock = asyncio.Lock()
 
     async def build_router_from_mcp_registry(self) -> None:
         """Build semantic router from all MCP tools in the registry (no auth checks)."""
@@ -182,6 +184,55 @@ class SemanticMCPToolFilter:
                 return
             raise
 
+    def _tools_missing_from_index(self, tools: list[Any]) -> dict[str, Any]:
+        """Map name -> tool for every named tool not yet in the semantic index."""
+        return {
+            name: tool
+            for name, tool in ((self._extract_tool_info(t)[0], t) for t in tools)
+            if name and name not in self._tool_map
+        }
+
+    async def _ensure_tools_indexed(self, available_tools: list[Any]) -> None:
+        """
+        Index request-time tools the startup build never saw.
+
+        The startup index lists every registered MCP server WITHOUT per-user
+        credentials, so servers requiring per-user auth (interactive OAuth
+        tokens, user-scoped env vars) contribute zero routes. Tools reaching
+        the filter came through an authenticated expansion; without indexing
+        them here they can never be selected, so requests either bypass
+        filtering entirely (N->N) or lose every tool to unrelated matches.
+        """
+        from semantic_router.routers.base import Route
+
+        if not self._tools_missing_from_index(available_tools):
+            return
+
+        async with self._index_sync_lock:
+            missing = self._tools_missing_from_index(available_tools)
+            if not missing:
+                return
+
+            if self.tool_router is None:
+                self._build_router(list(missing.values()))
+                return
+
+            descriptions = {name: self._extract_tool_info(tool)[1] for name, tool in missing.items()}
+            routes = [
+                Route(
+                    name=name,
+                    description=description,
+                    utterances=[description],
+                    score_threshold=self.similarity_threshold,
+                )
+                for name, description in descriptions.items()
+            ]
+            await self.tool_router.aadd(routes)
+            self._tool_map.update(missing)
+            verbose_logger.info(
+                f"Semantic tool filter indexed {len(routes)} request-time tools missing from the startup index"
+            )
+
     async def filter_tools(
         self,
         query: str,
@@ -216,13 +267,21 @@ class SemanticMCPToolFilter:
         if not query or not query.strip():
             return available_tools
 
-        # Router should be built on startup - if not, something went wrong
-        if self.tool_router is None:
-            verbose_logger.warning("Router not initialized - was build_router_from_mcp_registry() called on startup?")
-            return available_tools
-
         # Run semantic filtering
         try:
+            await self._ensure_tools_indexed(available_tools)
+
+            if self.context_window_error is not None:
+                raise SemanticToolFilterContextWindowError(
+                    embedding_model=self.embedding_model,
+                    stage="the MCP tool descriptions during semantic router build",
+                    original_error=self.context_window_error,
+                )
+
+            if self.tool_router is None:
+                verbose_logger.warning("Semantic router could not be built from the request's tools")
+                return available_tools
+
             limit = top_k or self.top_k
             matches = self.tool_router(text=query, limit=limit)
             matched_tool_names = self._extract_tool_names_from_matches(matches)
@@ -230,8 +289,13 @@ class SemanticMCPToolFilter:
             if not matched_tool_names:
                 return available_tools
 
-            return self._get_tools_by_names(matched_tool_names, available_tools)
+            filtered_tools = self._get_tools_by_names(matched_tool_names, available_tools)
+            if not filtered_tools:
+                return available_tools
+            return filtered_tools
 
+        except SemanticToolFilterContextWindowError:
+            raise
         except Exception as e:
             if _is_context_window_error(e):
                 verbose_logger.error(
@@ -240,7 +304,7 @@ class SemanticMCPToolFilter:
                 )
                 raise SemanticToolFilterContextWindowError(
                     embedding_model=self.embedding_model,
-                    stage="the user query",
+                    stage="the user query or the MCP tool descriptions being indexed",
                     original_error=str(e),
                 ) from e
             verbose_logger.error(f"Semantic tool filter failed: {e}", exc_info=True)

--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -206,8 +206,18 @@ class SemanticMCPToolFilter:
         the filter came through an authenticated expansion; without indexing
         them here they can never be selected, so requests either bypass
         filtering entirely (N->N) or lose every tool to unrelated matches.
+
+        Runs async-only (no synchronous embedding on the request path) and
+        never writes shared error state: an embedding failure here raises and
+        is scoped to the requesting call, so one request's oversized tool
+        description cannot poison the filter for other users on the worker.
         """
+        from semantic_router.routers import SemanticRouter
         from semantic_router.routers.base import Route
+
+        from litellm.router_strategy.auto_router.litellm_encoder import (
+            LiteLLMRouterEncoder,
+        )
 
         if not self._has_tools_missing_from_index(available_tools):
             return
@@ -215,14 +225,6 @@ class SemanticMCPToolFilter:
         async with self._index_sync_lock:
             missing = self._tools_missing_from_index(available_tools)
             if not missing:
-                return
-
-            if self.tool_router is None:
-                self._build_router(list(missing.values()))
-                if self.tool_router is not None:
-                    verbose_logger.info(
-                        f"Semantic tool filter indexed {len(missing)} request-time tools missing from the startup index"
-                    )
                 return
 
             descriptions = {name: self._extract_tool_info(tool)[1] for name, tool in missing.items()}
@@ -235,7 +237,23 @@ class SemanticMCPToolFilter:
                 )
                 for name, description in descriptions.items()
             ]
-            await self.tool_router.aadd(routes)
+
+            if self.tool_router is None:
+                router = SemanticRouter(
+                    routes=[],
+                    encoder=LiteLLMRouterEncoder(
+                        litellm_router_instance=self.router_instance,
+                        model_name=self.embedding_model,
+                        score_threshold=self.similarity_threshold,
+                    ),
+                    auto_sync="local",
+                    top_k=self.top_k,
+                )
+                await router.aadd(routes)
+                self.tool_router = router
+            else:
+                await self.tool_router.aadd(routes)
+
             self._tool_map.update(missing)
             verbose_logger.info(
                 f"Semantic tool filter indexed {len(routes)} request-time tools missing from the startup index"
@@ -279,19 +297,18 @@ class SemanticMCPToolFilter:
         try:
             await self._ensure_tools_indexed(available_tools)
 
-            if self.context_window_error is not None:
-                raise SemanticToolFilterContextWindowError(
-                    embedding_model=self.embedding_model,
-                    stage="the MCP tool descriptions during semantic router build",
-                    original_error=self.context_window_error,
-                )
-
             if self.tool_router is None:
                 verbose_logger.warning("Semantic router could not be built from the request's tools")
                 return available_tools
 
+            available_names = [name for name in (self._extract_tool_info(t)[0] for t in available_tools) if name]
+            if not available_names:
+                return available_tools
+
             limit = top_k or self.top_k
-            matches = self.tool_router(text=query, limit=limit)
+            if self.tool_router.top_k < limit:
+                self.tool_router.top_k = limit
+            matches = self.tool_router(text=query, limit=limit, route_filter=available_names)
             matched_tool_names = self._extract_tool_names_from_matches(matches)
 
             if not matched_tool_names:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -1678,6 +1678,8 @@ def _make_keyword_embedding_router(recorded_inputs):
 
     def _vector(text):
         lowered = text.lower()
+        if "kanban" in lowered:
+            return [0.6, 0.8]
         if "linear" in lowered or "issue" in lowered or "ticket" in lowered:
             return [1.0, 0.0]
         return [0.0, 1.0]
@@ -1812,3 +1814,102 @@ async def test_filter_fails_open_when_matches_are_not_in_available_tools():
 
     assert [t.name for t in filtered] == ["linear_stub-get_issue", "linear_stub-list_issues"]
     print("✅ Matches outside available_tools fail open instead of dropping every tool")
+
+
+@pytest.mark.asyncio
+async def test_request_time_context_window_error_is_request_scoped():
+    """
+    Regression test: an oversized tool description hitting the embedding
+    context window while lazily indexing request-time tools must fail only
+    the requesting call. Previously the lazy path reused the startup build
+    and recorded the overflow in the shared context_window_error, after
+    which EVERY user's MCP requests on the worker were blocked with a 400
+    until restart (index poisoning via a single request).
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticToolFilterContextWindowError,
+    )
+
+    state = {"raise_context_error": True}
+    filter_instance = _make_context_window_filter(state)
+    tools = [
+        MCPTool(name="tool_a", description="Tool A", inputSchema={"type": "object"}),
+        MCPTool(name="tool_b", description="Tool B", inputSchema={"type": "object"}),
+    ]
+
+    with pytest.raises(SemanticToolFilterContextWindowError):
+        await filter_instance.filter_tools(query="send an email", available_tools=tools)
+
+    assert filter_instance.context_window_error is None
+    assert filter_instance.tool_router is None
+
+    state["raise_context_error"] = False
+    filtered = await filter_instance.filter_tools(query="send an email", available_tools=tools)
+
+    assert len(filtered) > 0
+    assert filter_instance.context_window_error is None
+    assert filter_instance.tool_router is not None
+    print("✅ Request-time context window overflow is scoped to the request, not the worker")
+
+
+@pytest.mark.asyncio
+async def test_foreign_index_routes_cannot_displace_available_tools():
+    """
+    Regression test: routes indexed from OTHER principals' tool listings must
+    not occupy the match candidate set for this request. Previously the
+    router matched over the whole shared index, so foreign routes that
+    embedded closer to the query displaced the caller's own tools from
+    top_k, degrading results to the fail-open list (or, before the
+    empty-result guard, stripping every tool). Matching is now scoped to the
+    request's own tool names via route_filter.
+    """
+    filter_instance = _make_keyword_filter([], top_k=1)
+    foreign_tools = [
+        MCPTool(
+            name=f"other_user-linear_tool_{i}",
+            description=f"Get a Linear issue variant {i}",
+            inputSchema={"type": "object"},
+        )
+        for i in range(6)
+    ]
+    filter_instance._build_router(foreign_tools)
+
+    my_kanban = MCPTool(
+        name="mine-kanban_board",
+        description="Manage kanban board cards",
+        inputSchema={"type": "object"},
+    )
+    filtered = await filter_instance.filter_tools(
+        query="what is Linear ticket LIT-3794 about",
+        available_tools=[my_kanban, _weather_tool()],
+    )
+
+    assert [t.name for t in filtered] == ["mine-kanban_board"]
+    print("✅ Foreign index routes cannot displace the caller's own tools")
+
+
+@pytest.mark.asyncio
+async def test_top_k_above_router_default_is_respected():
+    """
+    Regression test: semantic-router's SemanticRouter defaults to top_k=5 at
+    the index-query layer, silently capping any configured filter top_k
+    above 5 regardless of the limit passed to __call__. The router must be
+    sized (and resized) to honor the configured top_k.
+    """
+    filter_instance = _make_keyword_filter([], top_k=6)
+    tools = [
+        MCPTool(
+            name=f"linear_stub-tool_{i}",
+            description=f"Work with Linear issues part {i}",
+            inputSchema={"type": "object"},
+        )
+        for i in range(6)
+    ]
+
+    filtered = await filter_instance.filter_tools(
+        query="Linear ticket work",
+        available_tools=tools,
+    )
+
+    assert len(filtered) == 6
+    print("✅ Configured top_k above the semantic-router default of 5 is honored")

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -1664,3 +1664,151 @@ def test_is_context_window_error_detection_variants():
     assert _is_context_window_error(ValueError("Invalid 'input[0]': maximum input length is 8192 tokens."))
     assert not _is_context_window_error(ValueError("A generic API error occurred."))
     assert not _is_context_window_error(None)
+
+
+def _make_keyword_embedding_router(recorded_inputs):
+    """
+    Mock litellm Router whose embeddings are deterministic keyword one-hots:
+    texts mentioning linear/issue/ticket embed to [1, 0], everything else to
+    [0, 1]. Lets tests assert real similarity ranking through the actual
+    semantic-router index. Every embedding input batch is appended to
+    recorded_inputs.
+    """
+    from litellm.types.utils import Embedding, EmbeddingResponse
+
+    def _vector(text):
+        lowered = text.lower()
+        if "linear" in lowered or "issue" in lowered or "ticket" in lowered:
+            return [1.0, 0.0]
+        return [0.0, 1.0]
+
+    def mock_embedding_sync(*args, **kwargs):
+        texts = kwargs["input"]
+        recorded_inputs.append(list(texts))
+        return EmbeddingResponse(
+            data=[Embedding(embedding=_vector(t), index=i, object="embedding") for i, t in enumerate(texts)],
+            model="text-embedding-3-small",
+            object="list",
+            usage={"prompt_tokens": 10, "total_tokens": 10},
+        )
+
+    async def mock_embedding_async(*args, **kwargs):
+        return mock_embedding_sync(*args, **kwargs)
+
+    mock_router = Mock()
+    mock_router.embedding = mock_embedding_sync
+    mock_router.aembedding = mock_embedding_async
+    return mock_router
+
+
+def _make_keyword_filter(recorded_inputs, top_k: int = 3):
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+
+    return SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=_make_keyword_embedding_router(recorded_inputs),
+        top_k=top_k,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+
+
+def _linear_issue_tool():
+    return MCPTool(
+        name="linear_stub-get_issue",
+        description="Get a Linear issue (ticket) by its identifier such as LIT-1234",
+        inputSchema={"type": "object"},
+    )
+
+
+def _linear_list_tool():
+    return MCPTool(
+        name="linear_stub-list_issues",
+        description="List Linear issues (tickets) in the workspace",
+        inputSchema={"type": "object"},
+    )
+
+
+def _weather_tool():
+    return MCPTool(
+        name="weather_stub-get_weather",
+        description="Get the current weather conditions for a city",
+        inputSchema={"type": "object"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_filter_indexes_request_tools_when_startup_index_is_empty():
+    """
+    Regression test: the startup index is built by listing every MCP server
+    WITHOUT per-user credentials, so a gateway whose servers all require
+    per-user auth (e.g. interactive OAuth) starts with an empty index
+    (tool_router is None). filter_tools then failed open and returned all N
+    tools unfiltered (customer-visible as an N->N header and, past 128 tools,
+    an OpenAI 400 "tools array too long"). The authed request-time tools must
+    instead be indexed on first sight so filtering actually runs.
+    """
+    filter_instance = _make_keyword_filter([])
+    assert filter_instance.tool_router is None
+
+    tools = [_linear_issue_tool(), _weather_tool()]
+    filtered = await filter_instance.filter_tools(
+        query="what is Linear ticket LIT-3794 about",
+        available_tools=tools,
+    )
+
+    assert [t.name for t in filtered] == ["linear_stub-get_issue"]
+    print("✅ Empty startup index is built from authed request-time tools")
+
+
+@pytest.mark.asyncio
+async def test_filter_indexes_tools_missing_from_partial_index():
+    """
+    Regression test: servers whose tools/list needs per-user auth contribute
+    zero routes to the startup index while anonymously listable servers are
+    indexed. Tools reaching the filter through the authed request-time
+    expansion must be added to the existing router (and only embedded once;
+    repeat requests embed just the query).
+    """
+    recorded_inputs = []
+    filter_instance = _make_keyword_filter(recorded_inputs)
+    filter_instance._build_router([_weather_tool()])
+    assert filter_instance.tool_router is not None
+
+    tools = [_linear_issue_tool(), _weather_tool()]
+    query = "what is Linear ticket LIT-3794 about"
+
+    filtered = await filter_instance.filter_tools(query=query, available_tools=tools)
+    assert [t.name for t in filtered] == ["linear_stub-get_issue"]
+
+    calls_after_first = len(recorded_inputs)
+    filtered_again = await filter_instance.filter_tools(query=query, available_tools=tools)
+    assert [t.name for t in filtered_again] == ["linear_stub-get_issue"]
+    assert len(recorded_inputs) == calls_after_first + 1
+
+    print("✅ Partial startup index is completed from request-time tools, embedding each tool once")
+
+
+@pytest.mark.asyncio
+async def test_filter_fails_open_when_matches_are_not_in_available_tools():
+    """
+    Regression test: when the semantic router's matches are all tools that are
+    NOT in the request's available_tools (an index/request mismatch), the
+    filter returned an empty list, stripping every tool from the request and
+    breaking it outright (observed live as a 3->0 header followed by a
+    provider 400). It must fail open with the full tool list instead, matching
+    the zero-match fallback.
+    """
+    filter_instance = _make_keyword_filter([])
+    filter_instance._build_router([_weather_tool()])
+
+    tools = [_linear_issue_tool(), _linear_list_tool()]
+    filtered = await filter_instance.filter_tools(
+        query="current weather in San Francisco",
+        available_tools=tools,
+    )
+
+    assert [t.name for t in filtered] == ["linear_stub-get_issue", "linear_stub-list_issues"]
+    print("✅ Matches outside available_tools fail open instead of dropping every tool")


### PR DESCRIPTION
## Relevant issues

Enables semantic tool filtering for MCP servers that require per-user auth (interactive OAuth, user-scoped env vars). Their tools never entered the startup index because it lists servers without user credentials, so on a gateway where every server uses OAuth the filter silently passed all tools through (an N->N filter header) and requests with more than 128 tools failed with OpenAI's "tools array too long" 400; with a partially built index the filter could instead strip every tool from the request

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on localhost:4000 (Postgres-backed, semantic filter enabled with `top_k: 1`), two stub streamable-http MCP servers, chat hitting the real Anthropic API. `linear_stub` (:8321) requires `Authorization: Bearer <token>` on every request and is registered with `static_headers: {"Authorization": "Bearer ${USER_TOKEN}"}` plus a user-scoped `USER_TOKEN` env var, so the startup index's anonymous `tools/list` gets a 401 while the request-time expansion authenticates from the caller's stored value. `weather_stub` (:8322) lists anonymously. Embeddings run against a local OpenAI-compatible server (:8323) backed by a real bge-small model because no hosted embedding key was live on this machine; the mechanism under test is identical

Before, empty startup index (only `linear_stub` registered; startup log shows `MCP registry is empty`): every tool passes through unfiltered, which on a real gateway with 151 tools is what produces OpenAI's `400 Invalid 'tools': array too long`

```
$ curl -s -D - -o /dev/null http://localhost:4000/v1/responses \
    -H "Authorization: Bearer $USER_KEY" -H "Content-Type: application/json" \
    -d '{"model": "claude-haiku-4-5",
         "input": [{"role": "user", "content": "tell me what LIT-3794 is about", "type": "message"}],
         "tools": [{"type": "mcp", "server_url": "litellm_proxy", "require_approval": "never"}],
         "tool_choice": "required"}' | grep -i "^HTTP\|semantic-filter"
HTTP/1.1 200 OK
x-litellm-semantic-filter: 3->3
x-litellm-semantic-filter-tools: linear_stub-get_issue,linear_stub-list_issues,linear_stub-create_comment
```

Before, partial startup index (`weather_stub` indexed at startup, `linear_stub` 401'd; startup log shows `Upstream auth failure from MCP server linear_stub: HTTP 401` then `Fetched 2 tools from 2 MCP servers`): the router matches only indexed-but-unavailable tools, every tool is stripped, and the request itself dies

```
$ <same curl>
HTTP/1.1 400 Bad Request
x-litellm-semantic-filter: 3->0
{"error":{"message":"litellm.BadRequestError: AnthropicException - ... tool_choice.any may only be specified while providing tools ..."}}
```

After (same rig, same curls, both index states): the request's authed tools are indexed on first sight and the filter selects the relevant tool

```
$ <same curl>
HTTP/1.1 200 OK
x-litellm-semantic-filter: 3->1
x-litellm-semantic-filter-tools: linear_stub-get_issue

$ <same curl again>
HTTP/1.1 200 OK
x-litellm-semantic-filter: 3->1
x-litellm-semantic-filter-tools: linear_stub-get_issue
```

Proxy log on the first call: `Semantic tool filter indexed 3 request-time tools missing from the startup index`; the line does not repeat on the second call, so repeat requests embed only the query

## Type

🐛 Bug Fix

## Changes

The MCP semantic tool filter builds its index at startup by listing every registered MCP server without per-user credentials (`build_router_from_mcp_registry` -> `get_tools_for_server` -> `_get_tools_from_server(server)` with no `user_api_key_auth`). Servers whose `tools/list` needs per-user auth (interactive OAuth tokens from `LiteLLM_MCPUserCredentials`, user-scoped `${VAR}` env vars from `LiteLLM_MCPUserEnvVars`) reject the anonymous listing; the error is swallowed and they contribute zero routes. At request time the hook expands MCP refs WITH the caller's auth, so `filter_tools` receives tools the index has never seen and can never select

On a gateway whose servers all need per-user auth the index is empty, `tool_router` stays `None`, and every request fails open: the response header reports `N->N`, all tools are forwarded, and past 128 tools OpenAI rejects the request with `400 Invalid 'tools': array too long`. With a partially built index it is worse: the router matches only indexed-but-unavailable tools, `_get_tools_by_names` maps them to nothing, and the filter returns an empty list, stripping every tool from the request (observed live as a `3->0` header followed by a provider 400)

Fix: `filter_tools` now syncs the index with the request's tools before matching. Tools missing from `_tool_map` are added to the router via semantic-router's async `aadd` (creating an empty router first when none exists, so no synchronous embedding ever runs on the request path), guarded by an `asyncio.Lock` so concurrent requests embed each tool once. When the router's matches map to none of the available tools the filter fails open with the full list, consistent with the existing zero-match fallback, instead of returning an empty tool list

Matching is additionally scoped to the requesting call: the router is queried with `route_filter` set to the request's own tool names, so routes learned from other principals' listings can never occupy the candidate set or displace the caller's tools from `top_k`. Indexing errors are request-scoped; an oversized tool description raises the typed context-window error for that call only and never writes the shared `context_window_error`, so a single request cannot block the filter for other users on the worker (the startup-build fail-closed contract is unchanged). The router is also sized to the configured `top_k`, which semantic-router's index layer otherwise silently caps at its default of 5

Six regression tests cover the empty-index case, the partial-index case (including that repeat requests embed only the query, not the tool descriptions again), the matches-outside-available-tools case, request-scoped context-window errors, foreign-route displacement, and top_k above the semantic-router default. All six fail on the previous code

## QA runbook

1. Start a streamable-http MCP server that 401s any request without `Authorization: Bearer linear-secret-token` and register it via `POST /v1/mcp/server` with `static_headers: {"Authorization": "Bearer ${USER_TOKEN}"}` and `env_vars: [{"name": "USER_TOKEN", "scope": "user"}]`, `allow_all_keys: true`
2. Enable the filter in `litellm_settings`: `mcp_semantic_tool_filter: {enabled: true, embedding_model: <any working embedding model>, top_k: 1, similarity_threshold: 0.3}` and run the proxy with a database
3. Create a key (`POST /key/generate` with a `user_id`) and store the user's token: `POST /v1/mcp/server/{server_id}/user-env-vars` with `{"values": {"USER_TOKEN": "linear-secret-token"}}` using that key
4. Restart the proxy and confirm the startup log shows the server contributing nothing to the index (401 or empty registry)
5. Send the `/v1/responses` curl from the proof above with the user key and check the `x-litellm-semantic-filter` response header: on current staging it reads `N->N` (or `N->0` with a second anonymously listable server registered); with this PR it reads `N->1` and names the relevant tool
6. Send the same curl again and confirm the proxy log line about indexing request-time tools does not repeat

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
