### PR TITLE
fix(batches): attribute Vertex batch cost spend logs to key/team/tags

### DIFF
--- a/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
+++ b/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
@@ -61,6 +61,57 @@ class CheckBatchCost:
             verbose_proxy_logger.error(f"CheckBatchCost: could not look up user {user_id} for batch {batch_id}: {e}")
             return {}
 
+    @staticmethod
+    def _get_batch_attribution(job) -> dict:
+        """
+        Recover the attribution snapshot (user_api_key, team_id, request_tags) stored on the
+        managed object's file_object at batch-create time. Returns {} when none was captured.
+        """
+        import json
+
+        file_object = getattr(job, "file_object", None)
+        if isinstance(file_object, str):
+            try:
+                file_object = json.loads(file_object)
+            except (ValueError, TypeError):
+                return {}
+        if not isinstance(file_object, dict):
+            return {}
+        metadata = file_object.get("metadata") or {}
+        attribution = metadata.get("litellm_batch_attribution") if isinstance(metadata, dict) else None
+        return attribution if isinstance(attribution, dict) else {}
+
+    async def _get_batch_spend_attribution(self, batch_id, job) -> tuple:
+        """
+        Build (spend_log_metadata, request_tags) for a batch-cost row with no per-batch DB
+        lookup. The authenticated key, its owning user/team, their aliases, and the request
+        tags were snapshotted onto the managed object's file_object at create time (read off
+        the already-resolved UserAPIKeyAuth in the passthrough, re-asserted after the client
+        metadata merge so a caller cannot spoof the batch owner), so nothing needs to be
+        re-queried here. Legacy batches created before the snapshot fall back to the stored
+        row (created_by / team_id), preserving the prior user-table enrichment.
+        """
+        attribution = self._get_batch_attribution(job)
+        if attribution:
+            fields = {
+                "user_api_key": attribution.get("user_api_key"),
+                "user_api_key_user_id": attribution.get("user_api_key_user_id"),
+                "user_api_key_team_id": attribution.get("user_api_key_team_id"),
+                "user_api_key_alias": attribution.get("user_api_key_alias"),
+                "user_api_key_team_alias": attribution.get("user_api_key_team_alias"),
+                "user_api_key_user_email": attribution.get("user_api_key_user_email"),
+            }
+            spend_metadata = {k: v for k, v in fields.items() if v is not None}
+            return spend_metadata, (attribution.get("request_tags") or [])
+
+        user_info = await self._get_user_info(batch_id, job.created_by)
+        spend_metadata = {
+            **user_info,
+            "user_api_key_user_id": job.created_by,
+            "user_api_key_team_id": getattr(job, "team_id", None),
+        }
+        return spend_metadata, []
+
     async def _cleanup_stale_managed_objects(self) -> None:
         """
         Mark managed objects older than MANAGED_OBJECT_STALENESS_CUTOFF_DAYS days
@@ -436,21 +487,18 @@ class CheckBatchCost:
             function_id=str(uuid.uuid4()),
         )
 
-        creator_user_id = job.created_by
-        user_info = await self._get_user_info(batch_id, job.created_by)
+        spend_metadata, request_tags = await self._get_batch_spend_attribution(batch_id, job)
 
         logging_obj.update_environment_variables(
             litellm_params={
+                "litellm_metadata": {"tags": request_tags},
                 # set the user-agent header so that S3 callback consumers can easily identify CheckBatchCost callbacks
                 "proxy_server_request": {
                     "headers": {
                         "user-agent": CHECK_BATCH_COST_USER_AGENT,
                     }
                 },
-                "metadata": {
-                    "user_api_key_user_id": creator_user_id,
-                    **user_info,
-                },
+                "metadata": spend_metadata,
             },
             optional_params={},
         )

--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -35,6 +35,7 @@ from litellm.proxy.openai_files_endpoints.common_utils import (
     get_model_id_from_unified_batch_id,
     get_models_from_unified_file_id,
     normalize_mime_type_for_provider,
+    strip_internal_batch_attribution,
 )
 from litellm.types.llms.openai import (  # pyright: ignore[reportAttributeAccessIssue]
     AllMessageValues,
@@ -341,7 +342,7 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
                     if isinstance(batch.file_object, str)
                     else batch.file_object
                 )
-                batch_obj = LiteLLMBatch(**batch_data)
+                batch_obj = LiteLLMBatch(**strip_internal_batch_attribution(batch_data))
                 batch_obj.id = batch.unified_object_id
                 batch_objects.append(batch_obj)
 

--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import mimetypes
 import re
 from dataclasses import dataclass, field
@@ -988,6 +989,29 @@ async def get_batch_from_database(
         return None, None
 
 
+def read_stored_batch_attribution(db_batch_object) -> Optional[dict]:
+    """Return the create-time litellm_batch_attribution snapshot stored on a managed object row.
+
+    The snapshot lives in the row's file_object jsonb (stored either as a JSON string or an
+    already-parsed dict); returns None when the row, its file_object, or the snapshot is absent
+    """
+    if db_batch_object is None:
+        return None
+    stored = getattr(db_batch_object, "file_object", None)
+    if isinstance(stored, str):
+        try:
+            stored = json.loads(stored)
+        except (ValueError, TypeError):
+            return None
+    if not isinstance(stored, dict):
+        return None
+    metadata = stored.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    snapshot = metadata.get("litellm_batch_attribution")
+    return snapshot if isinstance(snapshot, dict) else None
+
+
 async def update_batch_in_database(
     batch_id: str,
     unified_batch_id: Union[str, Literal[False]],
@@ -1047,6 +1071,13 @@ async def update_batch_in_database(
 
         # Normalize status for database storage
         db_status = response.status if response.status != "completed" else "complete"
+
+        stored_attribution = read_stored_batch_attribution(db_batch_object)
+        if stored_attribution is not None:
+            response.metadata = {
+                **(getattr(response, "metadata", None) or {}),
+                "litellm_batch_attribution": stored_attribution,
+            }
 
         update_data: dict = {
             "status": db_status,

--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -974,7 +974,7 @@ async def get_batch_from_database(
             if isinstance(db_batch_object.file_object, str)
             else db_batch_object.file_object
         )
-        response = LiteLLMBatch(**batch_data)
+        response = LiteLLMBatch(**strip_internal_batch_attribution(batch_data))
         response.id = batch_id
 
         # The stored batch object has the raw provider input_file_id. Resolve to unified ID.
@@ -987,6 +987,19 @@ async def get_batch_from_database(
     except Exception as e:
         verbose_proxy_logger.warning(f"Failed to retrieve batch from ManagedObjectTable: {e}, falling back to provider")
         return None, None
+
+
+def strip_internal_batch_attribution(file_object_data: dict) -> dict:
+    """Return a copy of a stored batch file_object with the internal attribution snapshot removed.
+
+    litellm_batch_attribution is persisted under metadata for cost attribution only; it carries the
+    creator's key hash, email, and aliases, so it must never surface in a batch returned to a caller
+    """
+    metadata = file_object_data.get("metadata")
+    if not isinstance(metadata, dict) or "litellm_batch_attribution" not in metadata:
+        return file_object_data
+    cleaned_metadata = {k: v for k, v in metadata.items() if k != "litellm_batch_attribution"}
+    return {**file_object_data, "metadata": cleaned_metadata or None}
 
 
 def read_stored_batch_attribution(db_batch_object) -> Optional[dict]:
@@ -1073,15 +1086,18 @@ async def update_batch_in_database(
         db_status = response.status if response.status != "completed" else "complete"
 
         stored_attribution = read_stored_batch_attribution(db_batch_object)
+        file_object_json = response.model_dump_json()
         if stored_attribution is not None:
-            response.metadata = {
-                **(getattr(response, "metadata", None) or {}),
+            file_object_data = json.loads(file_object_json)
+            file_object_data["metadata"] = {
+                **(file_object_data.get("metadata") or {}),
                 "litellm_batch_attribution": stored_attribution,
             }
+            file_object_json = json.dumps(file_object_data)
 
         update_data: dict = {
             "status": db_status,
-            "file_object": response.model_dump_json(),
+            "file_object": file_object_json,
             "updated_at": litellm.utils.get_utc_datetime(),
         }
 

--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -1002,7 +1002,7 @@ def strip_internal_batch_attribution(file_object_data: dict) -> dict:
     return {**file_object_data, "metadata": cleaned_metadata or None}
 
 
-def read_stored_batch_attribution(db_batch_object) -> Optional[dict]:
+def read_stored_batch_attribution(db_batch_object) -> dict | None:
     """Return the create-time litellm_batch_attribution snapshot stored on a managed object row.
 
     The snapshot lives in the row's file_object jsonb (stored either as a JSON string or an

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
@@ -804,7 +804,7 @@ class VertexPassthroughLoggingHandler:
                 _request_metadata = (kwargs.get("litellm_params", {}) or {}).get("metadata", {}) or {}
 
                 user_api_key_dict = UserAPIKeyAuth(
-                    user_id=_request_metadata.get("user_api_key_user_id", "default-user"),
+                    user_id=_request_metadata.get("user_api_key_user_id") or "default-user",
                     api_key="",
                     team_id=_request_metadata.get("user_api_key_team_id"),
                     team_alias=None,
@@ -825,6 +825,42 @@ class VertexPassthroughLoggingHandler:
                     model_max_budget={},  # Set to empty dict instead of None
                     model_spend={},  # Set to empty dict instead of None
                 )
+
+                # Snapshot the authenticated identity + request tags onto the managed
+                # object's file_object so CheckBatchCost can attribute the batch-cost spend
+                # log at poll time with no per-batch DB lookup. These identity fields are
+                # re-asserted from the authenticated key in the passthrough (after the
+                # client-metadata merge), so they are the key's own values and cannot be
+                # spoofed by the request body. The snapshot rides along in file_object jsonb.
+                # Request tags come from the request itself (metadata/header) when present,
+                # otherwise from the key's own tags, which auth exposes in-memory as
+                # user_api_key_auth_metadata (a tagged key does not put its tags in the
+                # top-level metadata "tags" on the passthrough path).
+                _litellm_metadata = (kwargs.get("litellm_params", {}) or {}).get("litellm_metadata", {}) or {}
+                _key_auth_metadata = _request_metadata.get("user_api_key_auth_metadata") or {}
+                _raw_tags = (
+                    _request_metadata.get("tags")
+                    or _litellm_metadata.get("tags")
+                    or (_key_auth_metadata.get("tags") if isinstance(_key_auth_metadata, dict) else None)
+                    or []
+                )
+                request_tags = [tag for tag in _raw_tags if isinstance(tag, str)] if isinstance(_raw_tags, list) else []
+                batch_attribution = {
+                    "user_api_key": _request_metadata.get("user_api_key"),
+                    "user_api_key_user_id": _request_metadata.get("user_api_key_user_id"),
+                    "user_api_key_team_id": _request_metadata.get("user_api_key_team_id"),
+                    "user_api_key_alias": _request_metadata.get("user_api_key_alias"),
+                    "user_api_key_team_alias": _request_metadata.get("user_api_key_team_alias"),
+                    "user_api_key_user_email": _request_metadata.get("user_api_key_user_email"),
+                    "request_tags": request_tags,
+                }
+                try:
+                    batch_object.metadata = {
+                        **(batch_object.metadata or {}),
+                        "litellm_batch_attribution": batch_attribution,
+                    }
+                except Exception as stash_err:
+                    verbose_proxy_logger.warning(f"CheckBatchCost: could not stash batch attribution: {stash_err}")
 
                 # Store the unified object for batch cost tracking
                 import asyncio

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -554,6 +554,14 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
         # real parent span.
         _metadata["user_api_key"] = user_api_key_dict.api_key
         _metadata["litellm_parent_otel_span"] = user_api_key_dict.parent_otel_span
+        # Re-assert the authenticated identity after the client merge so a request body
+        # cannot spoof the owner used for spend attribution (e.g. Vertex batch cost, which
+        # snapshots these from the request metadata at create time).
+        _metadata["user_api_key_user_id"] = user_api_key_dict.user_id
+        _metadata["user_api_key_team_id"] = user_api_key_dict.team_id
+        _metadata["user_api_key_team_alias"] = user_api_key_dict.team_alias
+        _metadata["user_api_key_alias"] = user_api_key_dict.key_alias
+        _metadata["user_api_key_user_email"] = user_api_key_dict.user_email
 
         kwargs = {
             "litellm_params": {

--- a/tests/pass_through_unit_tests/test_pass_through_unit_tests.py
+++ b/tests/pass_through_unit_tests/test_pass_through_unit_tests.py
@@ -239,6 +239,52 @@ def test_init_kwargs_with_litellm_metadata(mock_request, mock_user_api_key_dict)
     assert metadata["user_api_key"] == "test-key"
 
 
+def test_init_kwargs_client_metadata_cannot_spoof_authenticated_identity(
+    mock_request, mock_user_api_key_dict
+):
+    """
+    Regression (#33319): a request body must not be able to override the authenticated
+    identity fields used for spend attribution. Downstream consumers (e.g. Vertex batch
+    cost) snapshot these from metadata, so they are re-asserted from user_api_key_dict
+    after the client-metadata merge.
+    """
+    request = mock_request()
+    parsed_body = {
+        "litellm_metadata": {
+            "user_api_key_user_id": "victim-user",
+            "user_api_key_team_id": "victim-team",
+            "user_api_key_team_alias": "victim-team-alias",
+            "user_api_key_alias": "victim-key-alias",
+            "user_api_key_user_email": "victim@example.com",
+        }
+    }
+    passthrough_payload = PassthroughStandardLoggingPayload(url="https://test.com", request_body={})
+
+    result = HttpPassThroughEndpointHelpers._init_kwargs_for_pass_through_endpoint(
+        request=request,
+        user_api_key_dict=mock_user_api_key_dict,
+        passthrough_logging_payload=passthrough_payload,
+        _parsed_body=parsed_body,
+        litellm_call_id="test-call-id",
+        logging_obj=LiteLLMLoggingObj(
+            model="test-model",
+            messages=[],
+            stream=False,
+            call_type="test-call-type",
+            start_time=datetime.now(),
+            litellm_call_id="test-call-id",
+            function_id="test-function-id",
+        ),
+    )
+
+    metadata = result["litellm_params"]["metadata"]
+    assert metadata["user_api_key_user_id"] == "test-user"
+    assert metadata["user_api_key_team_id"] == "test-team"
+    assert metadata["user_api_key_team_alias"] is None
+    assert metadata["user_api_key_alias"] is None
+    assert metadata["user_api_key_user_email"] is None
+
+
 def test_init_kwargs_with_tags_in_header(mock_request, mock_user_api_key_dict):
     """
     Tags should be added to metadata if they exist in headers

--- a/tests/proxy_unit_tests/test_check_batch_cost.py
+++ b/tests/proxy_unit_tests/test_check_batch_cost.py
@@ -916,3 +916,139 @@ class TestUnmanagedVertexRouting:
         update_data = prisma.db.litellm_managedobjecttable.update.call_args[1]["data"]
         assert update_data["batch_processed"] is True
         assert update_data["status"] == "complete"
+
+
+class TestBatchCostAttribution:
+    """Regression tests for batch-cost spend-log attribution (issue #33316).
+
+    The key, team, and tags must survive from batch-create (snapshotted onto the
+    managed object file_object) to the CheckBatchCost poll. Otherwise the batch-cost
+    spend row is unattributed, and with a blank identity the DB logger drops it."""
+
+    def _instance(self):
+        from litellm_enterprise.proxy.common_utils.check_batch_cost import (
+            CheckBatchCost,
+        )
+
+        prisma = MagicMock()
+        prisma.db = MagicMock()
+        instance = CheckBatchCost(
+            proxy_logging_obj=MagicMock(),
+            prisma_client=prisma,
+            llm_router=MagicMock(),
+        )
+        return instance, prisma
+
+    @staticmethod
+    def _job(metadata):
+        # Shaped like the stored file_object JSON (model_dump_json output), whose
+        # metadata carries the create-time attribution snapshot.
+        import json
+
+        job = MagicMock()
+        job.file_object = json.dumps(
+            {"id": "123", "object": "batch", "status": "completed", "metadata": metadata}
+        )
+        return job
+
+    def test_get_batch_attribution_recovers_snapshot(self):
+        from litellm_enterprise.proxy.common_utils.check_batch_cost import (
+            CheckBatchCost,
+        )
+
+        attribution = {
+            "user_api_key": "sk-hash",
+            "user_api_key_team_id": "team-1",
+            "request_tags": ["a", "b"],
+        }
+        job = self._job({"litellm_batch_attribution": attribution})
+        assert CheckBatchCost._get_batch_attribution(job) == attribution
+
+    def test_get_batch_attribution_absent_or_malformed_returns_empty(self):
+        from litellm_enterprise.proxy.common_utils.check_batch_cost import (
+            CheckBatchCost,
+        )
+
+        assert CheckBatchCost._get_batch_attribution(self._job(None)) == {}
+        malformed = MagicMock()
+        malformed.file_object = "not-json"
+        assert CheckBatchCost._get_batch_attribution(malformed) == {}
+
+    @pytest.mark.asyncio
+    async def test_spend_attribution_reads_snapshot_without_db(self):
+        # The whole point of the create-time snapshot: attribute the batch cost with zero
+        # per-batch DB lookups (the reviewer's concern was key/team/user queries per batch).
+        instance, prisma = self._instance()
+        prisma.db.litellm_usertable.find_unique = AsyncMock()
+        prisma.db.litellm_verificationtoken.find_unique = AsyncMock()
+        prisma.db.litellm_teamtable.find_unique = AsyncMock()
+        snapshot = {
+            "user_api_key": "sk-hash",
+            "user_api_key_user_id": "u1",
+            "user_api_key_team_id": "t1",
+            "user_api_key_alias": "repro-key",
+            "user_api_key_team_alias": "repro-team",
+            "user_api_key_user_email": "u@example.com",
+            "request_tags": ["a", "b"],
+        }
+        job = self._job({"litellm_batch_attribution": snapshot})
+        metadata, tags = await instance._get_batch_spend_attribution("batch-1", job)
+        assert metadata == {
+            "user_api_key": "sk-hash",
+            "user_api_key_user_id": "u1",
+            "user_api_key_team_id": "t1",
+            "user_api_key_alias": "repro-key",
+            "user_api_key_team_alias": "repro-team",
+            "user_api_key_user_email": "u@example.com",
+        }
+        assert tags == ["a", "b"]
+        prisma.db.litellm_usertable.find_unique.assert_not_called()
+        prisma.db.litellm_verificationtoken.find_unique.assert_not_called()
+        prisma.db.litellm_teamtable.find_unique.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_spend_attribution_uses_snapshot_identity_not_stored_columns(self):
+        # Ownership comes from the snapshot (the authenticated identity re-asserted in the
+        # passthrough), never the stored created_by/team_id, so a request cannot redirect
+        # the spend to another user/team.
+        instance, prisma = self._instance()
+        prisma.db.litellm_usertable.find_unique = AsyncMock()
+        snapshot = {
+            "user_api_key": "sk-hash",
+            "user_api_key_user_id": "real-user",
+            "user_api_key_team_id": "real-team",
+        }
+        job = self._job({"litellm_batch_attribution": snapshot})
+        job.created_by = "spoofed-user"
+        job.team_id = "spoofed-team"
+        metadata, _ = await instance._get_batch_spend_attribution("batch-1", job)
+        assert metadata["user_api_key_user_id"] == "real-user"
+        assert metadata["user_api_key_team_id"] == "real-team"
+        prisma.db.litellm_usertable.find_unique.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_spend_attribution_omits_missing_snapshot_fields(self):
+        instance, _ = self._instance()
+        job = self._job({"litellm_batch_attribution": {"user_api_key": "sk-hash", "request_tags": []}})
+        metadata, tags = await instance._get_batch_spend_attribution("batch-1", job)
+        assert metadata == {"user_api_key": "sk-hash"}
+        assert tags == []
+
+    @pytest.mark.asyncio
+    async def test_spend_attribution_legacy_batch_falls_back_to_stored_row(self):
+        # Batches created before the snapshot existed have no attribution; fall back to the
+        # stored row and the pre-existing user-table enrichment.
+        instance, prisma = self._instance()
+        user_row = MagicMock()
+        user_row.user_email = "legacy@example.com"
+        user_row.user_alias = "legacy-alias"
+        prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=user_row)
+        job = self._job(None)
+        job.created_by = "legacy-user"
+        job.team_id = "legacy-team"
+        metadata, tags = await instance._get_batch_spend_attribution("batch-1", job)
+        assert metadata["user_api_key_user_id"] == "legacy-user"
+        assert metadata["user_api_key_team_id"] == "legacy-team"
+        assert metadata["user_api_key_user_email"] == "legacy@example.com"
+        assert tags == []
+        prisma.db.litellm_usertable.find_unique.assert_awaited_once()

--- a/tests/test_litellm/enterprise/proxy/test_batch_update_db_managed_output_file_id.py
+++ b/tests/test_litellm/enterprise/proxy/test_batch_update_db_managed_output_file_id.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.openai_files_endpoints.common_utils import (
     ensure_batch_response_managed_file_ids,
+    read_stored_batch_attribution,
     update_batch_in_database,
 )
 from litellm.types.utils import LiteLLMBatch
@@ -87,6 +88,143 @@ async def test_update_batch_in_database_stores_unified_output_file_id():
     )
     assert stored["output_file_id"] == unified_output_file_id
     assert stored["output_file_id"] != raw_output_file_id
+
+
+_BATCH_ATTRIBUTION = {
+    "user_api_key": "hashed-key-abc",
+    "user_api_key_user_id": "user-real",
+    "user_api_key_team_id": "team-real",
+    "user_api_key_alias": "prod-key",
+    "user_api_key_team_alias": "prod-team",
+    "user_api_key_user_email": "real@corp.com",
+    "request_tags": ["feature-x"],
+}
+
+
+def _db_batch_object_with_snapshot(
+    *, batch_id: str, status: str, file_object=None
+) -> SimpleNamespace:
+    if file_object is None:
+        file_object = json.dumps(
+            {
+                "id": batch_id,
+                "status": status,
+                "metadata": {"litellm_batch_attribution": _BATCH_ATTRIBUTION},
+            }
+        )
+    return SimpleNamespace(
+        created_by="user-real",
+        team_id="team-real",
+        status=status,
+        file_object=file_object,
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_batch_in_database_preserves_attribution_snapshot():
+    """Regression: overwriting file_object on a status change must not erase the create-time
+    litellm_batch_attribution snapshot; the provider response never carries it, so it has to be
+    carried forward from the stored row or the completed batch loses key-level spend attribution
+    """
+    batch_id = "batch_attr_preserve"
+    unified_batch_id = "litellm_proxy;model_id:my-model;llm_batch_id:batch_attr_preserve"
+
+    response = _build_batch_response(
+        batch_id=batch_id,
+        status="completed",
+        output_file_id="file-rawoutput789",
+        hidden_params={"model_id": "my-model", "model_name": "openai/gpt-4o"},
+    )
+    assert response.metadata is None
+
+    db_batch_object = _db_batch_object_with_snapshot(
+        batch_id=batch_id, status="in_progress"
+    )
+    mock_prisma = _build_prisma_mock()
+
+    await update_batch_in_database(
+        batch_id=batch_id,
+        unified_batch_id=unified_batch_id,
+        response=response,
+        managed_files_obj=_build_managed_files_mock(),
+        prisma_client=mock_prisma,
+        verbose_proxy_logger=MagicMock(),
+        db_batch_object=db_batch_object,
+        user_api_key_dict=UserAPIKeyAuth(user_id="user-real"),
+    )
+
+    stored = json.loads(
+        mock_prisma.db.litellm_managedobjecttable.update.call_args.kwargs["data"][
+            "file_object"
+        ]
+    )
+    assert stored["metadata"]["litellm_batch_attribution"] == _BATCH_ATTRIBUTION
+
+
+@pytest.mark.asyncio
+async def test_update_batch_in_database_no_snapshot_leaves_response_metadata_untouched():
+    """When the stored row has no snapshot, nothing is injected into the response metadata."""
+    batch_id = "batch_attr_absent"
+    unified_batch_id = "litellm_proxy;model_id:my-model;llm_batch_id:batch_attr_absent"
+
+    response = _build_batch_response(
+        batch_id=batch_id,
+        status="completed",
+        output_file_id="file-rawoutput789",
+        hidden_params={"model_id": "my-model", "model_name": "openai/gpt-4o"},
+    )
+
+    db_batch_object = _db_batch_object_with_snapshot(
+        batch_id=batch_id,
+        status="in_progress",
+        file_object=json.dumps({"id": batch_id, "status": "in_progress"}),
+    )
+    mock_prisma = _build_prisma_mock()
+
+    await update_batch_in_database(
+        batch_id=batch_id,
+        unified_batch_id=unified_batch_id,
+        response=response,
+        managed_files_obj=_build_managed_files_mock(),
+        prisma_client=mock_prisma,
+        verbose_proxy_logger=MagicMock(),
+        db_batch_object=db_batch_object,
+        user_api_key_dict=UserAPIKeyAuth(user_id="user-real"),
+    )
+
+    stored = json.loads(
+        mock_prisma.db.litellm_managedobjecttable.update.call_args.kwargs["data"][
+            "file_object"
+        ]
+    )
+    assert "litellm_batch_attribution" not in (stored.get("metadata") or {})
+
+
+def test_read_stored_batch_attribution_from_json_string():
+    row = _db_batch_object_with_snapshot(batch_id="b1", status="in_progress")
+    assert read_stored_batch_attribution(row) == _BATCH_ATTRIBUTION
+
+
+def test_read_stored_batch_attribution_from_parsed_dict():
+    row = SimpleNamespace(
+        file_object={"metadata": {"litellm_batch_attribution": _BATCH_ATTRIBUTION}}
+    )
+    assert read_stored_batch_attribution(row) == _BATCH_ATTRIBUTION
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        None,
+        SimpleNamespace(file_object=None),
+        SimpleNamespace(file_object="not-json"),
+        SimpleNamespace(file_object=json.dumps({"id": "b1"})),
+        SimpleNamespace(file_object=json.dumps({"metadata": {}})),
+        SimpleNamespace(file_object=json.dumps({"metadata": {"litellm_batch_attribution": "wrong-type"}})),
+    ],
+)
+def test_read_stored_batch_attribution_returns_none_when_absent(row):
+    assert read_stored_batch_attribution(row) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/enterprise/proxy/test_batch_update_db_managed_output_file_id.py
+++ b/tests/test_litellm/enterprise/proxy/test_batch_update_db_managed_output_file_id.py
@@ -7,9 +7,13 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 from litellm.proxy._types import UserAPIKeyAuth
+from unittest.mock import patch
+
 from litellm.proxy.openai_files_endpoints.common_utils import (
     ensure_batch_response_managed_file_ids,
+    get_batch_from_database,
     read_stored_batch_attribution,
+    strip_internal_batch_attribution,
     update_batch_in_database,
 )
 from litellm.types.utils import LiteLLMBatch
@@ -159,6 +163,8 @@ async def test_update_batch_in_database_preserves_attribution_snapshot():
         ]
     )
     assert stored["metadata"]["litellm_batch_attribution"] == _BATCH_ATTRIBUTION
+    # The snapshot must land only in the persisted row, never on the object returned to the caller
+    assert response.metadata is None
 
 
 @pytest.mark.asyncio
@@ -396,3 +402,69 @@ async def test_ensure_batch_response_returns_early_without_auth():
 
     assert response.output_file_id == "file-raw-output"
     mock_managed_files.get_unified_output_file_id.assert_not_called()
+
+
+def test_strip_internal_batch_attribution_removes_only_internal_key():
+    file_object_data = {
+        "id": "batch_1",
+        "status": "completed",
+        "metadata": {"user_tag": "keep-me", "litellm_batch_attribution": _BATCH_ATTRIBUTION},
+    }
+    cleaned = strip_internal_batch_attribution(file_object_data)
+    assert cleaned["metadata"] == {"user_tag": "keep-me"}
+    # Original is not mutated (the raw row must keep the snapshot for the poller)
+    assert "litellm_batch_attribution" in file_object_data["metadata"]
+
+
+def test_strip_internal_batch_attribution_nulls_metadata_when_only_internal_key():
+    cleaned = strip_internal_batch_attribution(
+        {"id": "batch_1", "metadata": {"litellm_batch_attribution": _BATCH_ATTRIBUTION}}
+    )
+    assert cleaned["metadata"] is None
+
+
+@pytest.mark.parametrize(
+    "file_object_data",
+    [
+        {"id": "batch_1"},
+        {"id": "batch_1", "metadata": None},
+        {"id": "batch_1", "metadata": {"user_tag": "keep-me"}},
+    ],
+)
+def test_strip_internal_batch_attribution_noop_without_internal_key(file_object_data):
+    assert strip_internal_batch_attribution(file_object_data) == file_object_data
+
+
+@pytest.mark.asyncio
+async def test_get_batch_from_database_does_not_leak_attribution_to_caller():
+    """Regression: the batch returned from the stored row must not expose litellm_batch_attribution,
+    while the raw db row handed back for internal use keeps it
+    """
+    batch_id = "litellm_proxy;model_id:m;llm_batch_id:b"
+    stored_file_object = {
+        "id": "b",
+        "object": "batch",
+        "status": "completed",
+        "endpoint": "/v1/chat/completions",
+        "input_file_id": "file-input",
+        "completion_window": "24h",
+        "created_at": 1234567890,
+        "metadata": {"litellm_batch_attribution": _BATCH_ATTRIBUTION},
+    }
+    row = SimpleNamespace(file_object=json.dumps(stored_file_object))
+
+    with patch(
+        "litellm.proxy.openai_files_endpoints.common_utils.ManagedObjectRepository"
+    ) as mock_repo:
+        mock_repo.return_value.table.find_first = AsyncMock(return_value=row)
+        db_batch_object, response = await get_batch_from_database(
+            batch_id=batch_id,
+            unified_batch_id=batch_id,
+            managed_files_obj=MagicMock(),
+            prisma_client=_build_prisma_mock(),
+            verbose_proxy_logger=MagicMock(),
+        )
+
+    assert "litellm_batch_attribution" not in (response.metadata or {})
+    # The raw row still carries the snapshot so update_batch_in_database can preserve it
+    assert read_stored_batch_attribution(db_batch_object) == _BATCH_ATTRIBUTION

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_ai_batch_passthrough.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_ai_batch_passthrough.py
@@ -315,6 +315,132 @@ class TestVertexAIBatchPassthroughHandler:
             assert call_kwargs["user_api_key_dict"].user_id == expected_user_id
             assert call_kwargs["user_api_key_dict"].team_id == expected_team_id
 
+    def test_store_batch_managed_object_stashes_key_and_tags(
+        self, mock_logging_obj, mock_managed_files_hook
+    ):
+        """Regression (#33316): the authenticated identity + request tags are snapshotted
+        onto the batch file_object metadata at create time, so CheckBatchCost can attribute
+        the batch-cost spend log at poll time with no per-batch DB lookup. The identity
+        fields come from metadata that the passthrough re-asserts from the authenticated key
+        after the client merge, so they are not request-spoofable."""
+        from litellm.types.utils import LiteLLMBatch
+
+        batch_object = LiteLLMBatch(
+            id="123456789",
+            completion_window="24h",
+            created_at=1,
+            endpoint="/v1/chat/completions",
+            input_file_id="gs://bucket/in.jsonl",
+            object="batch",
+            status="validating",
+        )
+        with (
+            patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_pl,
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_provider_handlers.vertex_passthrough_logging_handler.verbose_proxy_logger"
+            ),
+        ):
+            mock_pl.get_proxy_hook.return_value = mock_managed_files_hook
+
+            VertexPassthroughLoggingHandler._store_batch_managed_object(
+                unified_object_id="uoi",
+                batch_object=batch_object,
+                model_object_id="123456789",
+                logging_obj=mock_logging_obj,
+                litellm_params={
+                    "metadata": {
+                        "user_api_key": "sk-hash",
+                        "user_api_key_user_id": "u1",
+                        "user_api_key_team_id": "team-456",
+                        "user_api_key_alias": "repro-key",
+                        "user_api_key_team_alias": "repro-team",
+                        "user_api_key_user_email": "u@example.com",
+                        "tags": ["tag-a", "tag-b"],
+                    }
+                },
+            )
+
+            attribution = batch_object.metadata["litellm_batch_attribution"]
+            assert attribution["user_api_key"] == "sk-hash"
+            assert attribution["user_api_key_user_id"] == "u1"
+            assert attribution["user_api_key_team_id"] == "team-456"
+            assert attribution["user_api_key_alias"] == "repro-key"
+            assert attribution["user_api_key_team_alias"] == "repro-team"
+            assert attribution["user_api_key_user_email"] == "u@example.com"
+            assert attribution["request_tags"] == ["tag-a", "tag-b"]
+
+    def test_store_batch_managed_object_stashes_key_tags_when_no_request_tags(
+        self, mock_logging_obj, mock_managed_files_hook
+    ):
+        """A tagged key that sends no request tags: the key's own tags (exposed in-memory
+        as user_api_key_auth_metadata) are snapshotted, so the batch-cost row is still
+        tagged without any DB lookup."""
+        from litellm.types.utils import LiteLLMBatch
+
+        batch_object = LiteLLMBatch(
+            id="123456789",
+            completion_window="24h",
+            created_at=1,
+            endpoint="/v1/chat/completions",
+            input_file_id="gs://bucket/in.jsonl",
+            object="batch",
+            status="validating",
+        )
+        with (
+            patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_pl,
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_provider_handlers.vertex_passthrough_logging_handler.verbose_proxy_logger"
+            ),
+        ):
+            mock_pl.get_proxy_hook.return_value = mock_managed_files_hook
+
+            VertexPassthroughLoggingHandler._store_batch_managed_object(
+                unified_object_id="uoi",
+                batch_object=batch_object,
+                model_object_id="123456789",
+                logging_obj=mock_logging_obj,
+                litellm_params={
+                    "metadata": {
+                        "user_api_key": "sk-hash",
+                        "user_api_key_auth_metadata": {"tags": ["key-tag-a", "key-tag-b"]},
+                    }
+                },
+            )
+
+            attribution = batch_object.metadata["litellm_batch_attribution"]
+            assert attribution["request_tags"] == ["key-tag-a", "key-tag-b"]
+
+    def test_store_batch_managed_object_stash_failure_is_swallowed(
+        self, mock_logging_obj, mock_managed_files_hook
+    ):
+        """The attribution stash is best-effort: if the batch_object metadata cannot be
+        written, it is logged and batch storage still proceeds (no exception escapes)."""
+
+        class _RaisesOnMetadata:
+            status = "validating"
+
+            @property
+            def metadata(self):
+                raise RuntimeError("boom")
+
+        with (
+            patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_pl,
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_provider_handlers.vertex_passthrough_logging_handler.verbose_proxy_logger"
+            ) as mock_logger,
+        ):
+            mock_pl.get_proxy_hook.return_value = mock_managed_files_hook
+
+            VertexPassthroughLoggingHandler._store_batch_managed_object(
+                unified_object_id="uoi",
+                batch_object=_RaisesOnMetadata(),
+                model_object_id="b1",
+                logging_obj=mock_logging_obj,
+                litellm_params={"metadata": {"user_api_key": "sk-hash"}},
+            )
+
+            assert mock_logger.warning.called
+
     def test_batch_cost_calculation_integration(self):
         """Single Vertex AI response → non-zero cost with correct token counts."""
         from litellm.batches.batch_utils import calculate_vertex_ai_batch_cost_and_usage


### PR DESCRIPTION
## Relevant issues

Resolves #33316

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Verified on a local proxy running the equivalent change. A Vertex batch submitted through the passthrough with a team-scoped, tagged virtual key now produces an attributed `aretrieve_batch` cost row with real spend, key alias, team, and tags, where before no row was written at all and the key showed `$0` spend

<img width="1028" height="635" alt="Screenshot 2026-07-15 at 10 50 11 am" src="https://github.com/user-attachments/assets/933789cf-df44-4f3f-b906-edb75c7241cb" />

## Type

🐛 Bug Fix

## Changes

Vertex batches created through the passthrough (`/vertex_ai/.../batchPredictionJobs`) logged no attributed cost row. At create time the managed object was stored with no request identity (`api_key=""`, `user_api_key_user_id` unset), so when the `CheckBatchCost` poller later logged the cost it had a blank key, user, and team. In that state the DB spend-logger drops the row entirely rather than writing an unattributed one, so the batch cost was silently lost and the key showed `$0` spend

The identity needed for attribution is already resolved in memory by auth at create time and copied into the passthrough request metadata, so this snapshots it onto the managed object `file_object` jsonb right then (the key hash, the owning user and team, their aliases, user email, and the request tags, which fall back to the key's own tags when the request sent none) and reads it back when the batch completes. `CheckBatchCost` issues no per-batch key, team, or user database lookup; batches created before the snapshot existed fall back to the stored row. This needs no schema migration

To make that snapshot safe to trust, the passthrough re-asserts the authenticated identity fields (`user_api_key_user_id`, `user_api_key_team_id`, and the aliases and email) in the request metadata after the client-supplied metadata is merged, mirroring how the key hash was already protected. Previously a request body could set `user_api_key_user_id` or `user_api_key_team_id` and have the completed batch charged to another user or team's spend

The snapshot is stored only for internal cost attribution and must never reach a caller. Because `Batch` inherits pydantic `extra="allow"`, anything under the stored `file_object` round-trips into the `LiteLLMBatch` that the retrieve and list endpoints return, which would expose the creator's key hash, email, and aliases to anyone with team-level access to the batch. The two places that build a batch from a stored row now strip the internal key from a copy before returning, and the preserve-on-update path writes the snapshot into the serialized DB `file_object` rather than onto the returned response object, so it stays server-side

The snapshot also has to survive later writes to the same row. When a retrieve detects a status change, `update_batch_in_database` overwrites `file_object` with the raw provider batch, which does not carry `litellm_batch_attribution`, so without care the later cost poll would fall back to attribution with no key hash and the spend would skip the caller's key-level budget. The update path now reads the stored snapshot off the existing row and carries it onto the response before serializing, so it persists across every status update through completion

In `pass_through_endpoints.py` the identity re-assertion closes that spoofing gap. In `vertex_passthrough_logging_handler.py` the create path stashes the authenticated identity plus tags onto `file_object`. In `check_batch_cost.py` the poll path builds the spend-log metadata from that snapshot with no DB call, keeping the pre-existing user-table enrichment only for the legacy no-snapshot fallback

## QA runbook

1. Configure a `vertex_ai` model with `use_in_pass_through: true`, a Postgres-backed proxy, and an enterprise license
2. Create a team-scoped virtual key with tags
3. Submit a Vertex batch through the gateway with that key; wait for completion and one `proxy_batch_polling_interval`
4. `GET /spend/logs`: a `call_type=aretrieve_batch` row appears, attributed to the key alias, team alias, and tags, with non-zero spend

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR



