### PR TITLE
fix(cohere): map finish_reason for non-streaming Cohere v2 chat responses

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -67,6 +67,8 @@ _FINISH_REASON_MAP: dict[str, OpenAIChatCompletionFinishReason] = {
     "compaction": "length",
     # Cohere
     "COMPLETE": "stop",
+    "STOP_SEQUENCE": "stop",
+    "TOOL_CALL": "tool_calls",
     "ERROR_TOXIC": "content_filter",
     "ERROR": "stop",
     # HuggingFace / Together AI

--- a/litellm/llms/cohere/chat/v2_transformation.py
+++ b/litellm/llms/cohere/chat/v2_transformation.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, Iterator, List, Optional, 
 import httpx
 
 import litellm
-from litellm.litellm_core_utils.core_helpers import map_finish_reason
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.types.llms.cohere import CohereV2ChatResponse
 from litellm.types.llms.openai import (
@@ -248,11 +247,13 @@ class CohereV2ChatConfig(OpenAIGPTConfig):
         completion_tokens = token_usage.get("output_tokens", 0)
 
         ## SET FINISH REASON
+        # Imported locally to avoid a module-level cyclic import between
+        # core_helpers and this transformation module (flagged by CodeQL).
+        from litellm.litellm_core_utils.core_helpers import map_finish_reason
+
         cohere_finish_reason = cohere_v2_chat_response.get("finish_reason")
         if cohere_finish_reason:
-            model_response.choices[0].finish_reason = map_finish_reason(
-                cohere_finish_reason
-            )
+            model_response.choices[0].finish_reason = map_finish_reason(cohere_finish_reason)
 
         model_response.created = int(time.time())
         model_response.model = model

--- a/litellm/llms/cohere/chat/v2_transformation.py
+++ b/litellm/llms/cohere/chat/v2_transformation.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, Iterator, List, Optional, 
 import httpx
 
 import litellm
+from litellm.litellm_core_utils.core_helpers import map_finish_reason
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.types.llms.cohere import CohereV2ChatResponse
 from litellm.types.llms.openai import (
@@ -245,6 +246,13 @@ class CohereV2ChatConfig(OpenAIGPTConfig):
         token_usage = cohere_v2_chat_response["usage"].get("tokens", {})
         prompt_tokens = token_usage.get("input_tokens", 0)
         completion_tokens = token_usage.get("output_tokens", 0)
+
+        ## SET FINISH REASON
+        cohere_finish_reason = cohere_v2_chat_response.get("finish_reason")
+        if cohere_finish_reason:
+            model_response.choices[0].finish_reason = map_finish_reason(
+                cohere_finish_reason
+            )
 
         model_response.created = int(time.time())
         model_response.model = model

--- a/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
+++ b/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
@@ -57,6 +57,7 @@ class TestCohereV2Transform:
     def setup_method(self):
         self.config = CohereV2ChatConfig()
         self.model = "command-r"
+        self.logging_obj = MagicMock()
 
     def test_v2_supports_max_completion_tokens(self):
         """max_completion_tokens must be advertised so get_optional_params does not reject it"""
@@ -117,3 +118,44 @@ class TestCohereV2Transform:
         )
 
         assert optional_params["max_tokens"] == 256
+
+    def _transform_v2_response(self, finish_reason: str):
+        """Run transform_response over a minimal v2 body with the given finish_reason."""
+        from litellm.types.utils import ModelResponse
+
+        raw_response = MagicMock()
+        raw_response.json.return_value = {
+            "id": "abc",
+            "finish_reason": finish_reason,
+            "message": {"content": [{"type": "text", "text": "hi"}]},
+            "usage": {"tokens": {"input_tokens": 3, "output_tokens": 1}},
+        }
+        return self.config.transform_response(
+            model=self.model,
+            raw_response=raw_response,
+            model_response=ModelResponse(),
+            logging_obj=self.logging_obj,
+            request_data={},
+            messages=[],
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+
+    def test_v2_finish_reason_max_tokens_maps_to_length(self):
+        """Regression: a truncated (MAX_TOKENS) v2 response must report finish_reason='length',
+        not the default 'stop'. The non-streaming transform previously never read the response's
+        finish_reason, so every completion silently reported 'stop'."""
+        result = self._transform_v2_response("MAX_TOKENS")
+        assert result.choices[0].finish_reason == "length"
+
+    def test_v2_finish_reason_tool_call_maps_to_tool_calls(self):
+        """A TOOL_CALL finish_reason must surface as OpenAI 'tool_calls' so tool-calling
+        callers can branch on it (the v2 streaming path already propagates finish_reason)."""
+        result = self._transform_v2_response("TOOL_CALL")
+        assert result.choices[0].finish_reason == "tool_calls"
+
+    def test_v2_finish_reason_complete_maps_to_stop(self):
+        """A normal COMPLETE finish still maps to 'stop'."""
+        result = self._transform_v2_response("COMPLETE")
+        assert result.choices[0].finish_reason == "stop"

--- a/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
+++ b/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
@@ -2,9 +2,7 @@ import os
 import sys
 from unittest.mock import MagicMock
 
-sys.path.insert(
-    0, os.path.abspath("../../../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../../.."))  # Adds the parent directory to the system path
 
 import litellm
 from litellm.llms.cohere.chat.transformation import CohereChatConfig
@@ -61,9 +59,7 @@ class TestCohereV2Transform:
 
     def test_v2_supports_max_completion_tokens(self):
         """max_completion_tokens must be advertised so get_optional_params does not reject it"""
-        assert "max_completion_tokens" in self.config.get_supported_openai_params(
-            self.model
-        )
+        assert "max_completion_tokens" in self.config.get_supported_openai_params(self.model)
 
     def test_v2_max_tokens_only_still_maps(self):
         """max_tokens alone maps to cohere max_tokens when max_completion_tokens is absent"""
@@ -158,4 +154,9 @@ class TestCohereV2Transform:
     def test_v2_finish_reason_complete_maps_to_stop(self):
         """A normal COMPLETE finish still maps to 'stop'."""
         result = self._transform_v2_response("COMPLETE")
+        assert result.choices[0].finish_reason == "stop"
+
+    def test_v2_finish_reason_stop_sequence_maps_to_stop(self):
+        """A STOP_SEQUENCE finish must surface as 'stop' (new mapping added by this PR)."""
+        result = self._transform_v2_response("STOP_SEQUENCE")
         assert result.choices[0].finish_reason == "stop"


### PR DESCRIPTION
## Relevant issues

None filed; discovered while auditing provider adapters.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (relying on CI — see note below)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] Greptile confidence score (will address once Greptile reviews)

## Type

🐛 Bug Fix / ✅ Test

## Changes

`CohereV2ChatConfig.transform_response` never read the top-level `finish_reason` that Cohere's `/v2/chat` response returns (`CohereV2ChatResponse["finish_reason"]`, one of `COMPLETE / STOP_SEQUENCE / MAX_TOKENS / TOOL_CALL / ERROR`). Because it was never set, `model_response.choices[0].finish_reason` fell back to the `Choices` default of `"stop"`, so **every non-streaming Cohere v2 completion reported `"stop"` regardless of what actually happened.**

Concrete impact:
- Truncated responses (`MAX_TOKENS`) were reported as `"stop"` instead of `"length"`, so callers/agents could not detect a cut-off output.
- Tool-calling flows that branch on `finish_reason == "tool_calls"` never saw it.

This is inconsistent with the v2 **streaming** path, which already extracts and propagates `finish_reason` in `CohereV2ModelResponseIterator._parse_message_end` (`common_utils.py`). This PR brings the non-streaming path in line.

**Diff:**
- `litellm/llms/cohere/chat/v2_transformation.py` — read `finish_reason` and set it via `map_finish_reason`.
- `litellm/litellm_core_utils/core_helpers.py` — add the two Cohere enum values missing from `_FINISH_REASON_MAP` (`STOP_SEQUENCE -> stop`, `TOOL_CALL -> tool_calls`). `COMPLETE`, `MAX_TOKENS` and `ERROR` were already mapped.
- Tests in `tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py`.

## Tests

Added regression tests that drive `transform_response` over a minimal v2 body and assert the mapping:
- `test_v2_finish_reason_max_tokens_maps_to_length` — `MAX_TOKENS -> "length"` (the core regression)
- `test_v2_finish_reason_tool_call_maps_to_tool_calls` — `TOOL_CALL -> "tool_calls"`
- `test_v2_finish_reason_complete_maps_to_stop` — `COMPLETE -> "stop"`

## Proof of Fix

Note for maintainers: I don't have a live Cohere API key, so I could not capture the real-$ e2e proof the template requests. The bug is deterministic in the transform layer and is covered by the unit tests above; the mapping table (`MAX_TOKENS->length`, `TOOL_CALL->tool_calls`, `COMPLETE/STOP_SEQUENCE->stop`, `ERROR->stop`) is verified directly. Happy to add a live-call recording if a reviewer can point me at a test key, or if a maintainer runs it against Cohere.

### Final Attestation

- [x] The tests check the right things, including the edge cases; the fix only changes the finish_reason field for non-streaming Cohere v2 responses and mirrors the already-correct streaming behavior.