### PR TITLE
fix(secret_redaction): redact GitHub PATs and Slack tokens

### DIFF
--- a/litellm/litellm_core_utils/secret_redaction.py
+++ b/litellm/litellm_core_utils/secret_redaction.py
@@ -54,10 +54,11 @@ def _build_secret_patterns() -> "re.Pattern[str]":
         # LiteLLM supports the `github/` model provider, so these tokens can
         # surface in config dumps / error traces and must be scrubbed.
         r"ghp_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{20,}",
-        # Slack tokens (xoxb- bot, xoxp- user, xoxa- app, xoxr- refresh, xoxs- session)
-        # LiteLLM ships a Slack alerting integration; bare tokens are not covered
-        # by the slack_webhook_url key-name pattern above.
-        r"xox[abprs]-[A-Za-z0-9-]{10,}",
+        # Slack tokens (xoxb- bot, xoxp- user, xoxa- app, xoxr- refresh, xoxs- session,
+        # xapp- app-level, xoxe- config refresh). LiteLLM ships a Slack alerting
+        # integration; bare tokens are not covered by the slack_webhook_url
+        # key-name pattern above.
+        r"(?:xox[abprs]-|xapp-|xoxe(?:\.xox[bp])?-)[A-Za-z0-9-]{10,}",
         # Module-level provider keys logged as litellm.<provider>_key=<value>
         r"litellm\.[A-Za-z0-9_]*_key['\"]?\s*[:=]\s*['\"]?[^\s,'\"})\]{}>]+",
         # ── Key-name-based redaction ──

--- a/litellm/litellm_core_utils/secret_redaction.py
+++ b/litellm/litellm_core_utils/secret_redaction.py
@@ -50,6 +50,14 @@ def _build_secret_patterns() -> "re.Pattern[str]":
         r"(?<=://)[^\s'\"]*:[^\s'\"@]+(?=@)",
         # Databricks personal access tokens
         r"dapi[0-9a-f]{32}",
+        # GitHub personal access tokens (classic ghp_ and fine-grained github_pat_)
+        # LiteLLM supports the `github/` model provider, so these tokens can
+        # surface in config dumps / error traces and must be scrubbed.
+        r"ghp_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{20,}",
+        # Slack tokens (xoxb- bot, xoxp- user, xoxa- app, xoxr- refresh, xoxs- session)
+        # LiteLLM ships a Slack alerting integration; bare tokens are not covered
+        # by the slack_webhook_url key-name pattern above.
+        r"xox[abprs]-[A-Za-z0-9-]{10,}",
         # Module-level provider keys logged as litellm.<provider>_key=<value>
         r"litellm\.[A-Za-z0-9_]*_key['\"]?\s*[:=]\s*['\"]?[^\s,'\"})\]{}>]+",
         # ── Key-name-based redaction ──

--- a/tests/test_litellm/test_secret_redaction.py
+++ b/tests/test_litellm/test_secret_redaction.py
@@ -371,3 +371,46 @@ def test_non_pem_private_key_value_redacted():
 def test_normal_vertex_log_not_redacted():
     msg = "Vertex: Loading vertex credentials, is_file_path=True, current dir /app"
     assert redact_string(msg) == msg
+
+
+def test_github_pat_redacted():
+    """GitHub PATs leak because LiteLLM supports the github/ model provider.
+    Both classic (ghp_) and fine-grained (github_pat_) forms must be scrubbed."""
+    # Tokens are built dynamically to avoid tripping secret scanners.
+    classic_pat = "ghp_" + "A" * 36
+    fine_grained_pat = "github_pat_" + "B" * 22
+    cases = [
+        f"Authorization: Bearer {classic_pat}",
+        f"auth token {fine_grained_pat} for github/gpt-4o",
+    ]
+    for line in cases:
+        result = redact_string(line)
+        assert "ghp_" not in result, f"GitHub classic PAT not redacted: {line!r}"
+        assert "github_pat_" not in result, f"GitHub fine-grained PAT not redacted: {line!r}"
+        assert "REDACTED" in result
+
+
+def test_slack_token_redacted():
+    """Bare Slack tokens (xoxb-/xoxp-/...) must be redacted; the existing
+    slack_webhook_url key-name pattern does not cover token values."""
+    bot_token = "xoxb-" + "1" * 30
+    user_token = "xoxp-" + "2" * 30
+    cases = [
+        f"Slack alert using {bot_token}",
+        f"configured with {user_token}",
+    ]
+    for line in cases:
+        result = redact_string(line)
+        assert "xox" not in result, f"Slack token not redacted: {line!r}"
+        assert "REDACTED" in result
+
+
+def test_github_slack_patterns_no_false_positives():
+    """The new token patterns must not redact ordinary strings that happen to
+    contain similar prefixes."""
+    safe_cases = [
+        "see https://example.com/ghp_ docs",  # ghp_ not followed by 36 alnum
+        "channel named xoxb-test",  # xoxb- followed by only 4 chars (< 10)
+    ]
+    for line in safe_cases:
+        assert redact_string(line) == line, f"False positive on: {line!r}"

--- a/tests/test_litellm/test_secret_redaction.py
+++ b/tests/test_litellm/test_secret_redaction.py
@@ -380,7 +380,7 @@ def test_github_pat_redacted():
     classic_pat = "ghp_" + "A" * 36
     fine_grained_pat = "github_pat_" + "B" * 22
     cases = [
-        f"Authorization: Bearer {classic_pat}",
+        f"github_token={classic_pat}",
         f"auth token {fine_grained_pat} for github/gpt-4o",
     ]
     for line in cases:
@@ -395,9 +395,13 @@ def test_slack_token_redacted():
     slack_webhook_url key-name pattern does not cover token values."""
     bot_token = "xoxb-" + "1" * 30
     user_token = "xoxp-" + "2" * 30
+    app_token = "xapp-" + "3" * 30
+    refresh_token = "xoxe-" + "4" * 30
     cases = [
         f"Slack alert using {bot_token}",
         f"configured with {user_token}",
+        f"app token {app_token}",
+        f"refresh {refresh_token}",
     ]
     for line in cases:
         result = redact_string(line)


### PR DESCRIPTION
## Summary

`redact_string()` did not scrub GitHub personal access tokens (`ghp_` / `github_pat_`) or bare Slack tokens (`xox[abprs]-`), allowing them to leak into logs and error traces.

This is in scope because LiteLLM:
- Supports the `github/` model provider (tokens can appear in config dumps / auth headers)
- Ships a Slack alerting integration (the existing `slack_webhook_url` key-name pattern only covers webhook URLs, not bare bot/user tokens)

## Changes

Added two ReDoS-safe regex patterns to `_build_secret_patterns()` in `secret_redaction.py`:

| Pattern | Matches | Example |
|---|---|---|
| `ghp_[A-Za-z0-9]{36}` | GitHub classic PAT | `ghp_` + 36 base62 chars |
| `github_pat_[A-Za-z0-9_]{20,}` | GitHub fine-grained PAT | `github_pat_` + 20+ chars |
| `xox[abprs]-[A-Za-z0-9-]{10,}` | Slack bot/user/app/refresh/session tokens | `xoxb-…`, `xoxp-…` |

Both patterns use single greedy character classes with no partition ambiguity, ensuring linear (non-quadratic) scaling on adversarial inputs.

## Testing

Added 3 regression tests to `tests/test_litellm/test_secret_redaction.py`:

- `test_github_pat_redacted` — verifies classic and fine-grained GitHub PATs are redacted
- `test_slack_token_redacted` — verifies Slack bot (`xoxb-`) and user (`xoxp-`) tokens are redacted
- `test_github_slack_patterns_no_false_positives` — verifies short/non-matching strings are NOT redacted

All 25 tests in the file pass (22 existing + 3 new).

```
$ uv run pytest tests/test_litellm/test_secret_redaction.py -v
========================= 25 passed in 0.20s =========================
```

## Verification

Before the fix, all of these leaked through `redact_string()`:
```
ghp_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX  →  NOT redacted
github_pat_XXXXXXXXXXXXXXXXXXXXXX          →  NOT redacted
xoxb-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX        →  NOT redacted
```

After the fix, all are scrubbed to `******REDACTED******`.

<!-- Contributor CLA: I am submitting this contribution under the project's CLA. -->