### PR TITLE
feat: multi-backend Anthropic passthrough with health-aware routing

### DIFF
--- a/litellm/llms/anthropic/anthropic_routing_handler.py
+++ b/litellm/llms/anthropic/anthropic_routing_handler.py
@@ -20,13 +20,10 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Literal
 
-import httpx
 from pydantic import BaseModel, Field
 
 from litellm._logging import verbose_proxy_logger
-from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
 from litellm.secret_managers.main import get_secret_str
-from litellm.types.llms.custom_http import httpxSpecialProvider
 
 # ---------------------------------------------------------------------------
 # Pydantic models (inline — not imported from the hub)
@@ -169,12 +166,12 @@ class HealthTracker:
 
 
 class AnthropicProxy:
-    """Forwards HTTP requests to Anthropic-compatible backends via LiteLLM's
-    managed httpx client pool.
+    """Namespace for credential resolution shared by the multi-backend router.
 
-    Preserves the request body as raw bytes — no parsing, no translation.
-    Headers are copied verbatim except Host, Authorization, x-api-key, and
-    Transfer-Encoding which are replaced with the backend's own auth.
+    Request forwarding itself always goes through ``create_pass_through_route``
+    (see ``_route_anthropic_with_multi_backend``) so every attempt receives
+    LiteLLM's standard logging and guardrail treatment; this class does not
+    forward requests on its own.
     """
 
     @staticmethod
@@ -188,76 +185,6 @@ class AnthropicProxy:
         if value is not None:
             return value
         return os.environ.get(key_env, "")
-
-    @staticmethod
-    async def forward(
-        backend: Backend,
-        method: str,
-        path: str,
-        headers: dict[str, str],
-        body: bytes,
-        timeout: float | None = None,
-    ) -> httpx.Response:
-        """Forward a request to the given backend.
-
-        This is a low-level forwarding method that uses LiteLLM's managed
-        httpx client pool directly, bypassing the full passthrough pipeline
-        (guardrails, managed-ID rewriting, spend logging).  The default
-        multi-backend path in ``_route_anthropic_with_multi_backend`` uses
-        ``create_pass_through_route`` instead so that every attempt receives
-        the standard logging and guardrail treatment.
-
-        This method is available for callers that need direct forwarding
-        without the passthrough overhead — health probes, lightweight
-        internal relays, etc.
-
-        Args:
-            backend: Target backend configuration.
-            method: HTTP method (POST, GET, etc.).
-            path: URL path (e.g. /v1/messages).
-            headers: Original request headers.
-            body: Raw request body bytes.
-            timeout: Optional per-request timeout override (seconds).
-
-        Returns:
-            httpx.Response from the backend.
-        """
-        url = f"{backend.url.rstrip('/')}{path}"
-
-        # Resolve credential
-        key = AnthropicProxy._resolve_credential(backend.auth.key_env)
-
-        # Build auth header
-        if backend.auth.type == "api-key":
-            auth_header_name = "x-api-key"
-            auth_header_value = key
-        else:
-            auth_header_name = "authorization"
-            auth_header_value = f"Bearer {key}"
-
-        # Copy headers, stripping auth/host/transfer-encoding
-        strip_headers = {"host", "authorization", "transfer-encoding", "x-api-key"}
-        fwd_headers: dict[str, str] = {}
-        for k, v in headers.items():
-            if k.lower() in strip_headers:
-                continue
-            fwd_headers[k] = v
-        fwd_headers[auth_header_name] = auth_header_value
-
-        # Use LiteLLM's managed httpx client pool
-        request_timeout = timeout or backend.timeout
-        async_client_obj = get_async_httpx_client(
-            llm_provider=httpxSpecialProvider.PassThroughEndpoint,
-            params={"timeout": request_timeout},
-        )
-        async_client = async_client_obj.client
-
-        return await async_client.request(
-            method=method,
-            url=url,
-            headers=fwd_headers,
-            content=body,
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -9,10 +9,10 @@ Use litellm with Anthropic SDK, Vertex AI SDK, Cohere SDK, etc.
 import json
 import os
 import re
-from typing import Any, Optional, Tuple, Union, cast
+from typing import Any, Dict, Optional, Tuple, Union, cast
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, WebSocket
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, WebSocket, status
 from fastapi.responses import StreamingResponse
 from starlette.websockets import WebSocketState
 
@@ -569,7 +569,28 @@ async def anthropic_proxy_route(
 ):
     """
     [Docs](https://docs.litellm.ai/docs/pass_through/anthropic_completion)
+
+    When ``anthropic_router`` is configured in litellm_config.yaml, resolves
+    the request model to a backend via glob matching and forwards with
+    automatic health-aware failover across multiple backends.
     """
+    from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler import (
+        AnthropicProxy,
+        extract_model_from_body,
+        get_anthropic_router,
+    )
+
+    router = get_anthropic_router()
+    if router is not None:
+        return await _route_anthropic_with_multi_backend(
+            endpoint=endpoint,
+            request=request,
+            fastapi_response=fastapi_response,
+            user_api_key_dict=user_api_key_dict,
+            router=router,
+        )
+
+    # --- Default single-backend behaviour (unchanged) ---
     base_target_url = os.getenv("ANTHROPIC_API_BASE") or os.getenv("ANTHROPIC_BASE_URL") or "https://api.anthropic.com"
     encoded_endpoint = httpx.URL(endpoint).path
 
@@ -609,6 +630,154 @@ async def anthropic_proxy_route(
     )
 
     return received_value
+
+
+async def _route_anthropic_with_multi_backend(
+    endpoint: str,
+    request: Request,
+    fastapi_response: Response,
+    user_api_key_dict: UserAPIKeyAuth,
+    router: Any,
+) -> Response:
+    """Forward an Anthropic request through the multi-backend router.
+
+    Resolves the model to an ordered list of backends, tries each in
+    sequence, and returns the first successful response.  Streaming
+    requests are forwarded to the first healthy backend only (failover
+    mid-stream is not possible).
+
+    When all backends are exhausted, returns a 502 with a descriptive
+    error body.
+    """
+    from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler import (
+        AnthropicProxy,
+        extract_model_from_body,
+    )
+
+    # Read and cache the request body so the passthrough pipeline can re-read it
+    body: bytes = await request.body()
+    model: str = extract_model_from_body(body)
+    backends = router.resolve(model)
+
+    if not backends:
+        verbose_proxy_logger.warning(
+            "anthropic_router: no route matched model=%s", model
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail={
+                "error": {
+                    "type": "router_error",
+                    "message": f"No backend configured for model '{model}'.",
+                }
+            },
+        )
+
+    encoded_endpoint: str = httpx.URL(endpoint).path
+    if not encoded_endpoint.startswith("/"):
+        encoded_endpoint = "/" + encoded_endpoint
+
+    # Preserve incoming headers (the passthrough pipeline will strip auth)
+    incoming_headers: Dict[str, str] = dict(request.headers)
+
+    is_streaming = await is_streaming_request_fn(request)
+    last_error: Optional[str] = None
+
+    for backend in backends:
+        target_url = f"{backend.url.rstrip('/')}{encoded_endpoint}"
+
+        verbose_proxy_logger.debug(
+            "anthropic_router: trying backend=%s url=%s model=%s",
+            backend.name, target_url, model,
+        )
+
+        try:
+            # --- Try the standard passthrough pipeline with this backend ---
+            auth_header = _build_backend_auth_header(backend)
+
+            endpoint_func = create_pass_through_route(
+                endpoint=endpoint,
+                target=target_url,
+                custom_headers=auth_header,
+                _forward_headers=True,
+                is_streaming_request=is_streaming,
+                custom_llm_provider="anthropic",
+            )
+
+            received_value = await endpoint_func(
+                request,
+                fastapi_response,
+                user_api_key_dict,
+            )
+
+            # Success — record and return
+            router.health.record_success(backend.name)
+            return received_value
+
+        except ProxyException as e:
+            last_error = getattr(e, "message", str(e))
+            verbose_proxy_logger.warning(
+                "anthropic_router: backend=%s failed with ProxyException: %s",
+                backend.name, last_error,
+            )
+            router.health.record_failure(backend.name)
+
+            # If this was a streaming request, we can't retry — the SSE
+            # stream may have already started sending to the client.
+            if is_streaming:
+                verbose_proxy_logger.warning(
+                    "anthropic_router: streaming request failed on backend=%s "
+                    "— cannot failover mid-stream",
+                    backend.name,
+                )
+                raise
+
+        except Exception as e:
+            last_error = str(e)
+            verbose_proxy_logger.warning(
+                "anthropic_router: backend=%s failed unexpectedly: %s",
+                backend.name, last_error,
+            )
+            router.health.record_failure(backend.name)
+
+            if is_streaming:
+                raise
+
+    # All backends exhausted
+    verbose_proxy_logger.error(
+        "anthropic_router: all %d backend(s) exhausted for model=%s",
+        len(backends), model,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_502_BAD_GATEWAY,
+        detail={
+            "error": {
+                "type": "router_error",
+                "message": (
+                    f"All backends for model '{model}' are unavailable. "
+                    f"Last error: {last_error}"
+                ),
+            }
+        },
+    )
+
+
+def _build_backend_auth_header(backend: Any) -> Dict[str, str]:
+    """Build the auth header dict for a backend config.
+
+    Reads the credential from the environment variable named in
+    ``backend.auth.key_env`` (supports ``os.environ/…`` syntax via
+    LiteLLM's secret manager).
+    """
+    from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler import (
+        AnthropicProxy,
+    )
+
+    key = AnthropicProxy._resolve_credential(backend.auth.key_env)
+    if backend.auth.type == "api-key":
+        return {"x-api-key": key}
+    else:
+        return {"Authorization": f"Bearer {key}"}
 
 
 # Bedrock endpoint actions - consolidated list used for model extraction and streaming detection

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -691,19 +691,19 @@ async def _route_anthropic_with_multi_backend(
             backend.name, target_url, model,
         )
 
+        # Build the endpoint function for this backend (outside try/except —
+        # errors here are programming errors, not backend failures).
+        auth_header = _build_backend_auth_header(backend)
+        endpoint_func = create_pass_through_route(
+            endpoint=endpoint,
+            target=target_url,
+            custom_headers=auth_header,
+            _forward_headers=False,  # Do NOT forward client auth to external backends
+            is_streaming_request=is_streaming,
+            custom_llm_provider="anthropic",
+        )
+
         try:
-            # --- Try the standard passthrough pipeline with this backend ---
-            auth_header = _build_backend_auth_header(backend)
-
-            endpoint_func = create_pass_through_route(
-                endpoint=endpoint,
-                target=target_url,
-                custom_headers=auth_header,
-                _forward_headers=True,
-                is_streaming_request=is_streaming,
-                custom_llm_provider="anthropic",
-            )
-
             received_value = await endpoint_func(
                 request,
                 fastapi_response,

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -9,7 +9,13 @@ Use litellm with Anthropic SDK, Vertex AI SDK, Cohere SDK, etc.
 import json
 import os
 import re
-from typing import Any, Dict, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union, cast
+
+if TYPE_CHECKING:
+    from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler import (
+        AnthropicRouter,
+        Backend,
+    )
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, WebSocket, status
@@ -575,8 +581,6 @@ async def anthropic_proxy_route(
     automatic health-aware failover across multiple backends.
     """
     from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler import (
-        AnthropicProxy,
-        extract_model_from_body,
         get_anthropic_router,
     )
 
@@ -637,7 +641,7 @@ async def _route_anthropic_with_multi_backend(
     request: Request,
     fastapi_response: Response,
     user_api_key_dict: UserAPIKeyAuth,
-    router: Any,
+    router: "AnthropicRouter",
 ) -> Response:
     """Forward an Anthropic request through the multi-backend router.
 
@@ -650,7 +654,6 @@ async def _route_anthropic_with_multi_backend(
     error body.
     """
     from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler import (
-        AnthropicProxy,
         extract_model_from_body,
     )
 
@@ -660,9 +663,7 @@ async def _route_anthropic_with_multi_backend(
     backends = router.resolve(model)
 
     if not backends:
-        verbose_proxy_logger.warning(
-            "anthropic_router: no route matched model=%s", model
-        )
+        verbose_proxy_logger.warning("anthropic_router: no route matched model=%s", model)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail={
@@ -677,9 +678,6 @@ async def _route_anthropic_with_multi_backend(
     if not encoded_endpoint.startswith("/"):
         encoded_endpoint = "/" + encoded_endpoint
 
-    # Preserve incoming headers (the passthrough pipeline will strip auth)
-    incoming_headers: Dict[str, str] = dict(request.headers)
-
     is_streaming = await is_streaming_request_fn(request)
     last_error: Optional[str] = None
 
@@ -688,7 +686,9 @@ async def _route_anthropic_with_multi_backend(
 
         verbose_proxy_logger.debug(
             "anthropic_router: trying backend=%s url=%s model=%s",
-            backend.name, target_url, model,
+            backend.name,
+            target_url,
+            model,
         )
 
         # Build the endpoint function for this backend (outside try/except —
@@ -718,7 +718,8 @@ async def _route_anthropic_with_multi_backend(
             last_error = getattr(e, "message", str(e))
             verbose_proxy_logger.warning(
                 "anthropic_router: backend=%s failed with ProxyException: %s",
-                backend.name, last_error,
+                backend.name,
+                last_error,
             )
             router.health.record_failure(backend.name)
 
@@ -726,8 +727,7 @@ async def _route_anthropic_with_multi_backend(
             # stream may have already started sending to the client.
             if is_streaming:
                 verbose_proxy_logger.warning(
-                    "anthropic_router: streaming request failed on backend=%s "
-                    "— cannot failover mid-stream",
+                    "anthropic_router: streaming request failed on backend=%s — cannot failover mid-stream",
                     backend.name,
                 )
                 raise
@@ -736,7 +736,8 @@ async def _route_anthropic_with_multi_backend(
             last_error = str(e)
             verbose_proxy_logger.warning(
                 "anthropic_router: backend=%s failed unexpectedly: %s",
-                backend.name, last_error,
+                backend.name,
+                last_error,
             )
             router.health.record_failure(backend.name)
 
@@ -746,23 +747,21 @@ async def _route_anthropic_with_multi_backend(
     # All backends exhausted
     verbose_proxy_logger.error(
         "anthropic_router: all %d backend(s) exhausted for model=%s",
-        len(backends), model,
+        len(backends),
+        model,
     )
     raise HTTPException(
         status_code=status.HTTP_502_BAD_GATEWAY,
         detail={
             "error": {
                 "type": "router_error",
-                "message": (
-                    f"All backends for model '{model}' are unavailable. "
-                    f"Last error: {last_error}"
-                ),
+                "message": (f"All backends for model '{model}' are unavailable. Last error: {last_error}"),
             }
         },
     )
 
 
-def _build_backend_auth_header(backend: Any) -> Dict[str, str]:
+def _build_backend_auth_header(backend: "Backend") -> Dict[str, str]:
     """Build the auth header dict for a backend config.
 
     Reads the credential from the environment variable named in

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -698,7 +698,7 @@ async def _route_anthropic_with_multi_backend(
             endpoint=endpoint,
             target=target_url,
             custom_headers=auth_header,
-            _forward_headers=False,  # Do NOT forward client auth to external backends
+            _forward_headers=True,  # Auth is protected by custom_headers dedup in forward_headers_from_request
             is_streaming_request=is_streaming,
             custom_llm_provider="anthropic",
         )

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -9,7 +9,7 @@ Use litellm with Anthropic SDK, Vertex AI SDK, Cohere SDK, etc.
 import json
 import os
 import re
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 if TYPE_CHECKING:
     from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler import (
@@ -48,10 +48,6 @@ from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
     create_websocket_passthrough_route,
     websocket_passthrough_request,
 )
-from litellm.types.passthrough_endpoints.pass_through_endpoints import (
-    LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY,
-    LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
-)
 from litellm.proxy.utils import is_known_model
 from litellm.proxy.vector_store_endpoints.utils import (
     assert_user_can_access_vector_store,
@@ -59,6 +55,10 @@ from litellm.proxy.vector_store_endpoints.utils import (
     is_allowed_to_call_vector_store_endpoint,
 )
 from litellm.secret_managers.main import get_secret_str
+from litellm.types.passthrough_endpoints.pass_through_endpoints import (
+    LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY,
+    LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
+)
 from litellm.types.utils import LlmProviders
 from litellm.utils import ProviderConfigManager
 
@@ -921,7 +921,7 @@ async def handle_bedrock_passthrough_router_model(
 
     # Use the common processing path (same as non-router models)
     # This ensures all metadata, hooks, and logging are properly initialized
-    data: Dict[str, Any] = {}
+    data: dict[str, Any] = {}
     base_llm_response_processor = ProxyBaseLLMRequestProcessing(data=data)
 
     data["model"] = model
@@ -965,8 +965,8 @@ async def handle_bedrock_count_tokens(
     request: Request,
     fastapi_response: Response,
     user_api_key_dict: UserAPIKeyAuth,
-    request_body: Dict[str, Any],
-) -> Dict[str, Any]:
+    request_body: dict[str, Any],
+) -> dict[str, Any]:
     """
     Handle AWS Bedrock CountTokens API requests.
 
@@ -1113,7 +1113,7 @@ async def bedrock_llm_proxy_route(
     # Fall back to existing implementation for direct Bedrock models
     verbose_proxy_logger.debug(f"Bedrock passthrough: Using direct Bedrock model '{model}' for endpoint '{endpoint}'")
 
-    data: Dict[str, Any] = {}
+    data: dict[str, Any] = {}
     base_llm_response_processor = ProxyBaseLLMRequestProcessing(data=data)
 
     data["method"] = request.method
@@ -1246,7 +1246,7 @@ def _resolve_vertex_model_from_router(
     endpoint: str,
     vertex_project: Optional[str],
     vertex_location: Optional[str],
-) -> Tuple[str, str, Optional[str], Optional[str]]:
+) -> tuple[str, str, Optional[str], Optional[str]]:
     """
     Resolve Vertex AI model configuration from router.
 
@@ -1656,7 +1656,7 @@ def _override_vertex_params_from_router_credentials(
     router_credentials: Optional[Any],
     vertex_project: Optional[str],
     vertex_location: Optional[str],
-) -> Tuple[Optional[str], Optional[str]]:
+) -> tuple[Optional[str], Optional[str]]:
     """
     Override vertex_project and vertex_location with values from router_credentials if available.
 
@@ -1713,7 +1713,7 @@ async def _prepare_vertex_auth_headers(
     vertex_location: Optional[str],
     base_target_url: Optional[str],
     get_vertex_pass_through_handler: BaseVertexAIPassThroughHandler,
-) -> Tuple[dict, Optional[str], bool, Optional[str], Optional[str]]:
+) -> tuple[dict, Optional[str], bool, Optional[str], Optional[str]]:
     """
     Prepare authentication headers for Vertex AI pass-through requests.
 

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -12,7 +12,7 @@ import re
 from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 if TYPE_CHECKING:
-    from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler import (
+    from litellm.llms.anthropic.anthropic_routing_handler import (
         AnthropicRouter,
         Backend,
     )
@@ -580,7 +580,7 @@ async def anthropic_proxy_route(
     the request model to a backend via glob matching and forwards with
     automatic health-aware failover across multiple backends.
     """
-    from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler import (
+    from litellm.llms.anthropic.anthropic_routing_handler import (
         get_anthropic_router,
     )
 
@@ -653,7 +653,7 @@ async def _route_anthropic_with_multi_backend(
     When all backends are exhausted, returns a 502 with a descriptive
     error body.
     """
-    from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler import (
+    from litellm.llms.anthropic.anthropic_routing_handler import (
         extract_model_from_body,
     )
 
@@ -698,7 +698,13 @@ async def _route_anthropic_with_multi_backend(
             endpoint=endpoint,
             target=target_url,
             custom_headers=auth_header,
-            _forward_headers=True,  # Auth is protected by custom_headers dedup in forward_headers_from_request
+            # forward_headers_from_request only dedups request headers whose
+            # name matches a key in custom_headers (e.g. "x-api-key"). For
+            # api-key backends the client's own "Authorization" header is not
+            # in that set, so _forward_headers=True would leak the caller's
+            # LiteLLM key to every configured external backend. Keep this
+            # False; x-pass- prefixed headers still forward regardless.
+            _forward_headers=False,
             is_streaming_request=is_streaming,
             custom_llm_provider="anthropic",
         )
@@ -768,7 +774,7 @@ def _build_backend_auth_header(backend: "Backend") -> dict[str, str]:
     ``backend.auth.key_env`` (supports ``os.environ/…`` syntax via
     LiteLLM's secret manager).
     """
-    from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler import (
+    from litellm.llms.anthropic.anthropic_routing_handler import (
         AnthropicProxy,
     )
 

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -679,7 +679,7 @@ async def _route_anthropic_with_multi_backend(
         encoded_endpoint = "/" + encoded_endpoint
 
     is_streaming = await is_streaming_request_fn(request)
-    last_error: Optional[str] = None
+    last_error: str | None = None
 
     for backend in backends:
         target_url = f"{backend.url.rstrip('/')}{encoded_endpoint}"
@@ -761,7 +761,7 @@ async def _route_anthropic_with_multi_backend(
     )
 
 
-def _build_backend_auth_header(backend: "Backend") -> Dict[str, str]:
+def _build_backend_auth_header(backend: "Backend") -> dict[str, str]:
     """Build the auth header dict for a backend config.
 
     Reads the credential from the environment variable named in

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_routing_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_routing_handler.py
@@ -18,7 +18,7 @@ import os
 import time
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Literal
 
 import httpx
 from pydantic import BaseModel, Field
@@ -56,7 +56,7 @@ class Route(BaseModel):
     """Maps a model name (or glob) to an ordered list of backends."""
 
     model: str  # exact name or fnmatch glob, e.g. "claude-sonnet-*"
-    backends: List[Backend]
+    backends: list[Backend]
 
 
 class RouterSettings(BaseModel):
@@ -70,7 +70,7 @@ class RouterSettings(BaseModel):
 class AnthropicRouterConfig(BaseModel):
     """Top-level config read from ``anthropic_router`` in litellm_config.yaml."""
 
-    routes: List[Route]
+    routes: list[Route]
     settings: RouterSettings = Field(default_factory=RouterSettings)
 
 
@@ -104,7 +104,7 @@ class HealthTracker:
     def __init__(self, cooldown_seconds: int = 30, max_failures: int = 3) -> None:
         self._cooldown_seconds = cooldown_seconds
         self._max_failures = max_failures
-        self._entries: Dict[str, HealthEntry] = {}
+        self._entries: dict[str, HealthEntry] = {}
 
     def _ensure(self, name: str) -> HealthEntry:
         if name not in self._entries:
@@ -191,9 +191,9 @@ class AnthropicProxy:
         backend: Backend,
         method: str,
         path: str,
-        headers: Dict[str, str],
+        headers: dict[str, str],
         body: bytes,
-        timeout: Optional[float] = None,
+        timeout: float | None = None,
     ) -> httpx.Response:
         """Forward a request to the given backend.
 
@@ -234,7 +234,7 @@ class AnthropicProxy:
 
         # Copy headers, stripping auth/host/transfer-encoding
         strip_headers = {"host", "authorization", "transfer-encoding", "x-api-key"}
-        fwd_headers: Dict[str, str] = {}
+        fwd_headers: dict[str, str] = {}
         for k, v in headers.items():
             if k.lower() in strip_headers:
                 continue
@@ -282,11 +282,11 @@ class AnthropicRouter:
         )
 
     @property
-    def routes(self) -> List[Route]:
+    def routes(self) -> list[Route]:
         """Public accessor for configured routes."""
         return self._routes
 
-    def resolve(self, model: str) -> List[Backend]:
+    def resolve(self, model: str) -> list[Backend]:
         """Return backends in priority order for the given model.
 
         Args:
@@ -298,8 +298,8 @@ class AnthropicRouter:
         """
         for route in self._routes:
             if fnmatch.fnmatch(model, route.model):
-                healthy: List[Backend] = []
-                dead: List[Backend] = []
+                healthy: list[Backend] = []
+                dead: list[Backend] = []
                 for b in route.backends:
                     if self.health.is_healthy(b.name):
                         healthy.append(b)
@@ -310,20 +310,33 @@ class AnthropicRouter:
 
 
 # ---------------------------------------------------------------------------
-# Helpers — config loading and model extraction
+# Module-level state — mutable container to avoid ``global`` (PLW0603)
 # ---------------------------------------------------------------------------
 
-_router_instance: Optional[AnthropicRouter] = None
-# Tracks whether the last init attempt found the ``anthropic_router`` key.
-# ``None`` = never tried; ``False`` = key absent (intentional, no retry);
-# ``True`` = key present.  Only the True path retries on transient failure.
-_router_key_present: Optional[bool] = None
-_router_config_fingerprint: str = ""
-_router_next_retry: float = 0.0
+
+@dataclass
+class _RouterState:
+    """Mutable container for the singleton router and its lifecycle flags.
+
+    Using a dataclass instance avoids ``global`` declarations — the function
+    bodies mutate ``_state`` attributes rather than rebinding module-level
+    names.
+    """
+
+    instance: AnthropicRouter | None = None
+    # Tracks whether the last init attempt found the ``anthropic_router`` key.
+    # ``None`` = never tried; ``False`` = key absent (intentional, no retry);
+    # ``True`` = key present.  Only the True path retries on transient failure.
+    key_present: bool | None = None
+    config_fingerprint: str = ""
+    next_retry: float = 0.0
+
+
+_state = _RouterState()
 _RETRY_COOLDOWN: float = 5.0  # seconds between retries when init fails
 
 
-def _config_fingerprint(config_dict: Dict[str, Any]) -> str:
+def _config_fingerprint(config_dict: dict[str, Any]) -> str:
     """Return a stable fingerprint for the ``anthropic_router`` section.
 
     Used to detect config changes at runtime (hot-reload).
@@ -337,11 +350,11 @@ def _config_fingerprint(config_dict: Dict[str, Any]) -> str:
     try:
         raw = json.dumps(section, sort_keys=True, default=str)
         return hashlib.sha256(raw.encode()).hexdigest()
-    except Exception:
+    except (TypeError, ValueError):
         return ""
 
 
-def get_anthropic_router() -> Optional[AnthropicRouter]:
+def get_anthropic_router() -> AnthropicRouter | None:
     """Return the singleton AnthropicRouter instance.
 
     On first call, attempts lazy initialisation from the running proxy
@@ -356,10 +369,8 @@ def get_anthropic_router() -> Optional[AnthropicRouter]:
     fingerprint of the ``anthropic_router`` section, so ``/config/reload``
     and Admin-UI updates take effect without a restart.
     """
-    global _router_instance, _router_key_present, _router_config_fingerprint, _router_next_retry
-
     # --- Load current config (best-effort) ---
-    config_dict: Dict[str, Any] = {}
+    config_dict: dict[str, Any] = {}
     config_available: bool = False
     try:
         from litellm.proxy.proxy_server import proxy_config
@@ -367,61 +378,61 @@ def get_anthropic_router() -> Optional[AnthropicRouter]:
         if proxy_config is not None:
             config_dict = proxy_config.get_config_state()
             config_available = True
-    except Exception:
+    except Exception:  # noqa: BLE001 — best-effort config load; any error is non-fatal
         pass
 
     new_fingerprint = _config_fingerprint(config_dict)
 
     # --- Hot-reload: config changed since last init ---
-    if _router_instance is not None and new_fingerprint != _router_config_fingerprint:
+    if _state.instance is not None and new_fingerprint != _state.config_fingerprint:
         verbose_proxy_logger.info("anthropic_router: config fingerprint changed — re-initialising")
         init_anthropic_router_from_config(config_dict)
-        _router_config_fingerprint = new_fingerprint
-        return _router_instance
+        _state.config_fingerprint = new_fingerprint
+        return _state.instance
 
     # --- Fast path: already initialised ---
-    if _router_instance is not None:
-        return _router_instance
+    if _state.instance is not None:
+        return _state.instance
 
     # --- Intentional absence: key never present, don't retry ---
-    if _router_key_present is False:
+    if _state.key_present is False:
         return None
 
     # --- Cooldown: previous init failed, wait before retrying ---
-    if _router_key_present is True and time.monotonic() < _router_next_retry:
+    if _state.key_present is True and time.monotonic() < _state.next_retry:
         return None
 
     # --- First attempt or retry ---
     try:
         router = init_anthropic_router_from_config(config_dict)
-    except Exception:
+    except Exception:  # noqa: BLE001 — transient init failure; caller handles retry
         verbose_proxy_logger.debug("anthropic_router: init raised (proxy config may not be ready yet)")
         router = None
 
     if router is not None:
         # Success
-        _router_key_present = True
-        _router_config_fingerprint = new_fingerprint
+        _state.key_present = True
+        _state.config_fingerprint = new_fingerprint
     elif not config_available:
-        # Proxy config not yet loaded — leave _router_key_present
+        # Proxy config not yet loaded — leave _state.key_present
         # unchanged so the next request will try again.
         pass
     elif config_dict.get("anthropic_router") is None:
         # Key absent from a successfully-read config — intentional, never retry.
-        _router_key_present = False
+        _state.key_present = False
     else:
         # Key present but init failed (transient) — schedule retry.
-        _router_key_present = True
-        _router_next_retry = time.monotonic() + _RETRY_COOLDOWN
+        _state.key_present = True
+        _state.next_retry = time.monotonic() + _RETRY_COOLDOWN
         verbose_proxy_logger.warning(
             "anthropic_router: init failed — will retry in %.0fs",
             _RETRY_COOLDOWN,
         )
 
-    return _router_instance
+    return _state.instance
 
 
-def init_anthropic_router_from_config(config_dict: Dict[str, Any]) -> Optional[AnthropicRouter]:
+def init_anthropic_router_from_config(config_dict: dict[str, Any]) -> AnthropicRouter | None:
     """Initialise (or re-initialise) the router from a config dictionary.
 
     When the ``anthropic_router`` key is absent or empty, the router is
@@ -440,20 +451,18 @@ def init_anthropic_router_from_config(config_dict: Dict[str, Any]) -> Optional[A
     Returns:
         The new AnthropicRouter instance, or None.
     """
-    global _router_instance
-
     section = config_dict.get("anthropic_router")
     if section is None:
-        _router_instance = None
+        _state.instance = None
         return None
 
     router_config = AnthropicRouterConfig(**section)
-    _router_instance = AnthropicRouter(router_config)
+    _state.instance = AnthropicRouter(router_config)
     verbose_proxy_logger.info(
         "anthropic_router: initialised with %d route(s)",
         len(router_config.routes),
     )
-    return _router_instance
+    return _state.instance
 
 
 def extract_model_from_body(body: bytes) -> str:

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_routing_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_routing_handler.py
@@ -1,0 +1,377 @@
+"""
+Multi-backend Anthropic passthrough routing with health-aware backend selection.
+
+Port of sovereign-anthropic-router's HealthTracker, AnthropicProxy, and
+AnthropicRouter into LiteLLM's passthrough infrastructure.
+
+When ``anthropic_router`` is present in litellm_config.yaml, the Anthropic
+passthrough endpoint resolves model→backend via glob matching, forwards
+requests with automatic failover, and tracks per-backend health.
+
+Without ``anthropic_router`` config, behaviour is unchanged.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Literal, Optional
+
+import httpx
+from pydantic import BaseModel, Field
+
+from litellm._logging import verbose_proxy_logger
+from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.llms.custom_http import httpxSpecialProvider
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models (inline — not imported from the hub)
+# ---------------------------------------------------------------------------
+
+class AuthConfig(BaseModel):
+    """Authentication configuration for a backend."""
+
+    type: Literal["api-key", "bearer"] = "api-key"
+    key_env: str = ""  # environment variable name holding the credential
+
+
+class Backend(BaseModel):
+    """A single Anthropic-compatible backend."""
+
+    name: str
+    url: str  # base URL, e.g. https://api.anthropic.com
+    auth: AuthConfig = Field(default_factory=AuthConfig)
+    timeout: int = 120
+    weight: int = 100
+    retryable: bool = True
+
+
+class Route(BaseModel):
+    """Maps a model name (or glob) to an ordered list of backends."""
+
+    model: str  # exact name or fnmatch glob, e.g. "claude-sonnet-*"
+    backends: List[Backend]
+
+
+class RouterSettings(BaseModel):
+    """Global router settings."""
+
+    cooldown_seconds: int = 30
+    max_failures: int = 3
+    default_timeout: int = 120
+
+
+class AnthropicRouterConfig(BaseModel):
+    """Top-level config read from ``anthropic_router`` in litellm_config.yaml."""
+
+    routes: List[Route]
+    settings: RouterSettings = Field(default_factory=RouterSettings)
+
+
+# ---------------------------------------------------------------------------
+# Health tracker
+# ---------------------------------------------------------------------------
+
+class Status(Enum):
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    DEAD = "dead"
+
+
+@dataclass
+class HealthEntry:
+    status: Status = Status.HEALTHY
+    failures: int = 0
+    last_failure: float = 0.0
+    cooldown_until: float = 0.0
+
+
+class HealthTracker:
+    """Tracks backend health in memory.
+
+    A backend is DEGRADED after 2+ failures. It enters DEAD (cooldown)
+    after ``max_failures`` consecutive failures and stays there for
+    ``cooldown_seconds``.
+    """
+
+    def __init__(self, cooldown_seconds: int = 30, max_failures: int = 3) -> None:
+        self._cooldown_seconds = cooldown_seconds
+        self._max_failures = max_failures
+        self._entries: Dict[str, HealthEntry] = {}
+
+    def _ensure(self, name: str) -> HealthEntry:
+        if name not in self._entries:
+            self._entries[name] = HealthEntry()
+        return self._entries[name]
+
+    def is_healthy(self, name: str) -> bool:
+        """Return True if the backend is not in DEAD cooldown."""
+        entry = self._ensure(name)
+        if entry.status == Status.DEAD:
+            if time.monotonic() >= entry.cooldown_until:
+                entry.status = Status.DEGRADED
+                return True
+            return False
+        return True
+
+    def record_success(self, name: str) -> None:
+        """Record a successful request — reset failures."""
+        entry = self._ensure(name)
+        if entry.status != Status.HEALTHY:
+            verbose_proxy_logger.info(
+                "anthropic_router: backend %s transitioned from %s to %s",
+                name, entry.status.value, Status.HEALTHY.value,
+            )
+        entry.status = Status.HEALTHY
+        entry.failures = 0
+
+    def record_failure(self, name: str) -> None:
+        """Record a failed request — increment counter, apply cooldown if needed."""
+        entry = self._ensure(name)
+        old_status = entry.status
+        entry.failures += 1
+        entry.last_failure = time.monotonic()
+
+        if entry.failures >= self._max_failures:
+            entry.status = Status.DEAD
+            entry.cooldown_until = time.monotonic() + self._cooldown_seconds
+        elif entry.failures >= 2:
+            entry.status = Status.DEGRADED
+
+        if entry.status != old_status:
+            verbose_proxy_logger.info(
+                "anthropic_router: backend %s transitioned from %s to %s",
+                name, old_status.value, entry.status.value,
+            )
+
+    def status(self, name: str) -> Status:
+        """Get current status for a backend."""
+        return self._ensure(name).status
+
+
+# ---------------------------------------------------------------------------
+# HTTP proxy
+# ---------------------------------------------------------------------------
+
+class AnthropicProxy:
+    """Forwards HTTP requests to Anthropic-compatible backends via LiteLLM's
+    managed httpx client pool.
+
+    Preserves the request body as raw bytes — no parsing, no translation.
+    Headers are copied verbatim except Host, Authorization, x-api-key, and
+    Transfer-Encoding which are replaced with the backend's own auth.
+    """
+
+    @staticmethod
+    def _resolve_credential(key_env: str) -> str:
+        """Resolve a credential from the environment.
+
+        Tries ``get_secret_str`` first (supports ``os.environ/…`` syntax),
+        then falls back to ``os.environ``.
+        """
+        value = get_secret_str(key_env)
+        if value is not None:
+            return value
+        return os.environ.get(key_env, "")
+
+    @staticmethod
+    async def forward(
+        backend: Backend,
+        method: str,
+        path: str,
+        headers: Dict[str, str],
+        body: bytes,
+        timeout: Optional[float] = None,
+    ) -> httpx.Response:
+        """Forward a request to the given backend.
+
+        Args:
+            backend: Target backend configuration.
+            method: HTTP method (POST, GET, etc.).
+            path: URL path (e.g. /v1/messages).
+            headers: Original request headers.
+            body: Raw request body bytes.
+            timeout: Optional per-request timeout override (seconds).
+
+        Returns:
+            httpx.Response from the backend.
+        """
+        url = f"{backend.url.rstrip('/')}{path}"
+
+        # Resolve credential
+        key = AnthropicProxy._resolve_credential(backend.auth.key_env)
+
+        # Build auth header
+        if backend.auth.type == "api-key":
+            auth_header_name = "x-api-key"
+            auth_header_value = key
+        else:
+            auth_header_name = "authorization"
+            auth_header_value = f"Bearer {key}"
+
+        # Copy headers, stripping auth/host/transfer-encoding
+        strip_headers = {"host", "authorization", "transfer-encoding", "x-api-key"}
+        fwd_headers: Dict[str, str] = {}
+        for k, v in headers.items():
+            if k.lower() in strip_headers:
+                continue
+            fwd_headers[k] = v
+        fwd_headers[auth_header_name] = auth_header_value
+
+        # Use LiteLLM's managed httpx client pool
+        request_timeout = timeout or backend.timeout
+        async_client_obj = get_async_httpx_client(
+            llm_provider=httpxSpecialProvider.PassThroughEndpoint,
+            params={"timeout": request_timeout},
+        )
+        async_client = async_client_obj.client
+
+        return await async_client.request(
+            method=method,
+            url=url,
+            headers=fwd_headers,
+            content=body,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+class AnthropicRouter:
+    """Resolves a model name to an ordered list of backends.
+
+    Backends are returned in priority order:
+    1. Healthy backends (healthy or degraded but not in cooldown)
+    2. Dead backends (as last resort; caller can skip them)
+
+    Glob matching via ``fnmatch``: ``"claude-sonnet-*"`` matches
+    ``"claude-sonnet-5"``.
+    """
+
+    def __init__(self, config: AnthropicRouterConfig) -> None:
+        self._routes = config.routes
+        self._settings = config.settings
+        self.health = HealthTracker(
+            cooldown_seconds=config.settings.cooldown_seconds,
+            max_failures=config.settings.max_failures,
+        )
+
+    @property
+    def routes(self) -> List[Route]:
+        """Public accessor for configured routes."""
+        return self._routes
+
+    def resolve(self, model: str) -> List[Backend]:
+        """Return backends in priority order for the given model.
+
+        Args:
+            model: The model name from the request body.
+
+        Returns:
+            Ordered list of Backend objects. Healthy backends first,
+            dead backends last. Empty list if no route matches.
+        """
+        for route in self._routes:
+            if fnmatch.fnmatch(model, route.model):
+                healthy: List[Backend] = []
+                dead: List[Backend] = []
+                for b in route.backends:
+                    if self.health.is_healthy(b.name):
+                        healthy.append(b)
+                    else:
+                        dead.append(b)
+                return healthy + dead
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Helpers — config loading and model extraction
+# ---------------------------------------------------------------------------
+
+_router_instance: Optional[AnthropicRouter] = None
+_router_initialized: bool = False
+
+
+def get_anthropic_router() -> Optional[AnthropicRouter]:
+    """Return the singleton AnthropicRouter instance.
+
+    On first call, attempts lazy initialisation from the running proxy
+    config (``proxy_config.get_config_state()``).  Subsequent calls return
+    the cached instance.  Returns ``None`` when no ``anthropic_router``
+    section is present in the config.
+    """
+    global _router_instance, _router_initialized
+
+    if not _router_initialized:
+        _router_initialized = True
+        try:
+            from litellm.proxy.proxy_server import proxy_config
+
+            config_dict = proxy_config.get_config_state() if proxy_config else {}
+            init_anthropic_router_from_config(config_dict)
+        except Exception:
+            verbose_proxy_logger.debug(
+                "anthropic_router: lazy init skipped (proxy config not available yet)"
+            )
+
+    return _router_instance
+
+
+def init_anthropic_router_from_config(config_dict: Dict[str, Any]) -> Optional[AnthropicRouter]:
+    """Initialise (or re-initialise) the router from a config dictionary.
+
+    Called once at startup and on config hot-reload. When the
+    ``anthropic_router`` key is absent or empty, the router is cleared
+    and the passthrough endpoint falls back to the default single-backend
+    behaviour.
+
+    Args:
+        config_dict: The full proxy config dictionary (as returned by
+            ``proxy_config.get_config_state()``).
+
+    Returns:
+        The new AnthropicRouter instance, or None if no ``anthropic_router``
+        key is present.
+    """
+    global _router_instance
+
+    section = config_dict.get("anthropic_router")
+    if section is None:
+        _router_instance = None
+        return None
+
+    try:
+        router_config = AnthropicRouterConfig(**section)
+        _router_instance = AnthropicRouter(router_config)
+        verbose_proxy_logger.info(
+            "anthropic_router: initialised with %d route(s)",
+            len(router_config.routes),
+        )
+        return _router_instance
+    except Exception:
+        verbose_proxy_logger.exception(
+            "anthropic_router: failed to parse config section — "
+            "passthrough will fall back to default behaviour"
+        )
+        _router_instance = None
+        return None
+
+
+def extract_model_from_body(body: bytes) -> str:
+    """Best-effort extraction of the ``model`` field from a JSON request body.
+
+    Returns ``"unknown"`` when the body cannot be parsed or the field is absent.
+    """
+    import json
+
+    try:
+        data = json.loads(body)
+        return data.get("model", "unknown")
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return "unknown"

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_routing_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_routing_handler.py
@@ -329,10 +329,12 @@ class _RouterState:
     key_present: bool | None = None
     config_fingerprint: str = ""
     next_retry: float = 0.0
+    last_config_check: float = 0.0
 
 
 _state = _RouterState()
 _RETRY_COOLDOWN: float = 5.0  # seconds between retries when init fails
+_CONFIG_CHECK_INTERVAL: float = 5.0  # seconds between expensive deepcopy checks
 
 
 def _config_fingerprint(config_dict: dict[str, Any]) -> str:
@@ -368,6 +370,12 @@ def get_anthropic_router() -> AnthropicRouter | None:
     fingerprint of the ``anthropic_router`` section, so ``/config/reload``
     and Admin-UI updates take effect without a restart.
     """
+    # --- Rate-limited config check: skip expensive deepcopy on every request ---
+    now = time.monotonic()
+    if _state.instance is not None and now - _state.last_config_check < _CONFIG_CHECK_INTERVAL:
+        return _state.instance
+    _state.last_config_check = now
+
     # --- Load current config (best-effort) ---
     config_dict: dict[str, Any] = {}
     config_available: bool = False

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_routing_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_routing_handler.py
@@ -295,30 +295,113 @@ class AnthropicRouter:
 # ---------------------------------------------------------------------------
 
 _router_instance: Optional[AnthropicRouter] = None
-_router_initialized: bool = False
+# Tracks whether the last init attempt found the ``anthropic_router`` key.
+# ``None`` = never tried; ``False`` = key absent (intentional, no retry);
+# ``True`` = key present.  Only the True path retries on transient failure.
+_router_key_present: Optional[bool] = None
+_router_config_fingerprint: str = ""
+_router_next_retry: float = 0.0
+_RETRY_COOLDOWN: float = 5.0  # seconds between retries when init fails
+
+
+def _config_fingerprint(config_dict: Dict[str, Any]) -> str:
+    """Return a stable fingerprint for the ``anthropic_router`` section.
+
+    Used to detect config changes at runtime (hot-reload).
+    """
+    import hashlib
+    import json
+
+    section = config_dict.get("anthropic_router")
+    if section is None:
+        return ""
+    try:
+        raw = json.dumps(section, sort_keys=True, default=str)
+        return hashlib.sha256(raw.encode()).hexdigest()
+    except Exception:
+        return ""
 
 
 def get_anthropic_router() -> Optional[AnthropicRouter]:
     """Return the singleton AnthropicRouter instance.
 
     On first call, attempts lazy initialisation from the running proxy
-    config (``proxy_config.get_config_state()``).  Subsequent calls return
-    the cached instance.  Returns ``None`` when no ``anthropic_router``
-    section is present in the config.
+    config (``proxy_config.get_config_state()``).  If the proxy config is
+    not yet available (race at startup), the router will retry on
+    subsequent calls with a short cooldown.
+
+    When the ``anthropic_router`` key is absent from the config the router
+    stays disabled — this is an intentional configuration, not an error.
+
+    Detects config changes at runtime (hot-reload) by comparing a
+    fingerprint of the ``anthropic_router`` section, so ``/config/reload``
+    and Admin-UI updates take effect without a restart.
     """
-    global _router_instance, _router_initialized
+    global _router_instance, _router_key_present, _router_config_fingerprint, _router_next_retry
 
-    if not _router_initialized:
-        _router_initialized = True
-        try:
-            from litellm.proxy.proxy_server import proxy_config
+    # --- Load current config (best-effort) ---
+    config_dict: Dict[str, Any] = {}
+    config_available: bool = False
+    try:
+        from litellm.proxy.proxy_server import proxy_config
 
-            config_dict = proxy_config.get_config_state() if proxy_config else {}
-            init_anthropic_router_from_config(config_dict)
-        except Exception:
-            verbose_proxy_logger.debug(
-                "anthropic_router: lazy init skipped (proxy config not available yet)"
-            )
+        if proxy_config is not None:
+            config_dict = proxy_config.get_config_state()
+            config_available = True
+    except Exception:
+        pass
+
+    new_fingerprint = _config_fingerprint(config_dict)
+
+    # --- Hot-reload: config changed since last init ---
+    if _router_instance is not None and new_fingerprint != _router_config_fingerprint:
+        verbose_proxy_logger.info(
+            "anthropic_router: config fingerprint changed — re-initialising"
+        )
+        init_anthropic_router_from_config(config_dict)
+        _router_config_fingerprint = new_fingerprint
+        return _router_instance
+
+    # --- Fast path: already initialised ---
+    if _router_instance is not None:
+        return _router_instance
+
+    # --- Intentional absence: key never present, don't retry ---
+    if _router_key_present is False:
+        return None
+
+    # --- Cooldown: previous init failed, wait before retrying ---
+    if _router_key_present is True and time.monotonic() < _router_next_retry:
+        return None
+
+    # --- First attempt or retry ---
+    try:
+        router = init_anthropic_router_from_config(config_dict)
+    except Exception:
+        verbose_proxy_logger.debug(
+            "anthropic_router: init raised (proxy config may not be ready yet)"
+        )
+        router = None
+
+    if router is not None:
+        # Success
+        _router_key_present = True
+        _router_config_fingerprint = new_fingerprint
+    elif not config_available:
+        # Proxy config not yet loaded — leave _router_key_present
+        # unchanged so the next request will try again.
+        pass
+    elif config_dict.get("anthropic_router") is None:
+        # Key absent from a successfully-read config — intentional, never retry.
+        _router_key_present = False
+    else:
+        # Key present but init failed (transient) — schedule retry.
+        _router_key_present = True
+        _router_next_retry = time.monotonic() + _RETRY_COOLDOWN
+        verbose_proxy_logger.warning(
+            "anthropic_router: init failed — will retry in %.0fs",
+            _RETRY_COOLDOWN,
+        )
 
     return _router_instance
 
@@ -326,18 +409,21 @@ def get_anthropic_router() -> Optional[AnthropicRouter]:
 def init_anthropic_router_from_config(config_dict: Dict[str, Any]) -> Optional[AnthropicRouter]:
     """Initialise (or re-initialise) the router from a config dictionary.
 
-    Called once at startup and on config hot-reload. When the
-    ``anthropic_router`` key is absent or empty, the router is cleared
-    and the passthrough endpoint falls back to the default single-backend
-    behaviour.
+    When the ``anthropic_router`` key is absent or empty, the router is
+    cleared and the passthrough endpoint falls back to the default
+    single-backend behaviour (this is *not* an error — it means the
+    operator intentionally did not configure multi-backend routing).
+
+    When the key is present but invalid, the router is cleared and the
+    caller should schedule a retry (the parse failure may be transient
+    during a config rollout).
 
     Args:
         config_dict: The full proxy config dictionary (as returned by
             ``proxy_config.get_config_state()``).
 
     Returns:
-        The new AnthropicRouter instance, or None if no ``anthropic_router``
-        key is present.
+        The new AnthropicRouter instance, or None.
     """
     global _router_instance
 
@@ -346,21 +432,13 @@ def init_anthropic_router_from_config(config_dict: Dict[str, Any]) -> Optional[A
         _router_instance = None
         return None
 
-    try:
-        router_config = AnthropicRouterConfig(**section)
-        _router_instance = AnthropicRouter(router_config)
-        verbose_proxy_logger.info(
-            "anthropic_router: initialised with %d route(s)",
-            len(router_config.routes),
-        )
-        return _router_instance
-    except Exception:
-        verbose_proxy_logger.exception(
-            "anthropic_router: failed to parse config section — "
-            "passthrough will fall back to default behaviour"
-        )
-        _router_instance = None
-        return None
+    router_config = AnthropicRouterConfig(**section)
+    _router_instance = AnthropicRouter(router_config)
+    verbose_proxy_logger.info(
+        "anthropic_router: initialised with %d route(s)",
+        len(router_config.routes),
+    )
+    return _router_instance
 
 
 def extract_model_from_body(body: bytes) -> str:

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_routing_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_routing_handler.py
@@ -190,6 +190,17 @@ class AnthropicProxy:
     ) -> httpx.Response:
         """Forward a request to the given backend.
 
+        This is a low-level forwarding method that uses LiteLLM's managed
+        httpx client pool directly, bypassing the full passthrough pipeline
+        (guardrails, managed-ID rewriting, spend logging).  The default
+        multi-backend path in ``_route_anthropic_with_multi_backend`` uses
+        ``create_pass_through_route`` instead so that every attempt receives
+        the standard logging and guardrail treatment.
+
+        This method is available for callers that need direct forwarding
+        without the passthrough overhead — health probes, lightweight
+        internal relays, etc.
+
         Args:
             backend: Target backend configuration.
             method: HTTP method (POST, GET, etc.).

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_routing_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_routing_handler.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import fnmatch
 import os
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional
 
@@ -32,6 +32,7 @@ from litellm.types.llms.custom_http import httpxSpecialProvider
 # ---------------------------------------------------------------------------
 # Pydantic models (inline — not imported from the hub)
 # ---------------------------------------------------------------------------
+
 
 class AuthConfig(BaseModel):
     """Authentication configuration for a backend."""
@@ -76,6 +77,7 @@ class AnthropicRouterConfig(BaseModel):
 # ---------------------------------------------------------------------------
 # Health tracker
 # ---------------------------------------------------------------------------
+
 
 class Status(Enum):
     HEALTHY = "healthy"
@@ -125,7 +127,9 @@ class HealthTracker:
         if entry.status != Status.HEALTHY:
             verbose_proxy_logger.info(
                 "anthropic_router: backend %s transitioned from %s to %s",
-                name, entry.status.value, Status.HEALTHY.value,
+                name,
+                entry.status.value,
+                Status.HEALTHY.value,
             )
         entry.status = Status.HEALTHY
         entry.failures = 0
@@ -146,7 +150,9 @@ class HealthTracker:
         if entry.status != old_status:
             verbose_proxy_logger.info(
                 "anthropic_router: backend %s transitioned from %s to %s",
-                name, old_status.value, entry.status.value,
+                name,
+                old_status.value,
+                entry.status.value,
             )
 
     def status(self, name: str) -> Status:
@@ -157,6 +163,7 @@ class HealthTracker:
 # ---------------------------------------------------------------------------
 # HTTP proxy
 # ---------------------------------------------------------------------------
+
 
 class AnthropicProxy:
     """Forwards HTTP requests to Anthropic-compatible backends via LiteLLM's
@@ -253,6 +260,7 @@ class AnthropicProxy:
 # ---------------------------------------------------------------------------
 # Router
 # ---------------------------------------------------------------------------
+
 
 class AnthropicRouter:
     """Resolves a model name to an ordered list of backends.
@@ -366,9 +374,7 @@ def get_anthropic_router() -> Optional[AnthropicRouter]:
 
     # --- Hot-reload: config changed since last init ---
     if _router_instance is not None and new_fingerprint != _router_config_fingerprint:
-        verbose_proxy_logger.info(
-            "anthropic_router: config fingerprint changed — re-initialising"
-        )
+        verbose_proxy_logger.info("anthropic_router: config fingerprint changed — re-initialising")
         init_anthropic_router_from_config(config_dict)
         _router_config_fingerprint = new_fingerprint
         return _router_instance
@@ -389,9 +395,7 @@ def get_anthropic_router() -> Optional[AnthropicRouter]:
     try:
         router = init_anthropic_router_from_config(config_dict)
     except Exception:
-        verbose_proxy_logger.debug(
-            "anthropic_router: init raised (proxy config may not be ready yet)"
-        )
+        verbose_proxy_logger.debug("anthropic_router: init raised (proxy config may not be ready yet)")
         router = None
 
     if router is not None:

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_routing_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_routing_handler.py
@@ -402,7 +402,16 @@ def get_anthropic_router() -> AnthropicRouter | None:
     # --- Hot-reload: config changed since last init ---
     if _state.instance is not None and new_fingerprint != _state.config_fingerprint:
         verbose_proxy_logger.info("anthropic_router: config fingerprint changed — re-initialising")
-        init_anthropic_router_from_config(config_dict)
+        try:
+            init_anthropic_router_from_config(config_dict)
+        except Exception:  # noqa: BLE001 — Pydantic ValidationError or config parse error
+            verbose_proxy_logger.warning(
+                "anthropic_router: hot-reload failed — keeping previous config. "
+                "Fix the anthropic_router section and reload again."
+            )
+            # Keep the existing router and fingerprint so the operator can retry
+            # after fixing the config.
+            return _state.instance
         _state.config_fingerprint = new_fingerprint
         return _state.instance
 

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_routing_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_routing_handler.py
@@ -28,7 +28,6 @@ from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.custom_http import httpxSpecialProvider
 
-
 # ---------------------------------------------------------------------------
 # Pydantic models (inline — not imported from the hub)
 # ---------------------------------------------------------------------------

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_routing_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_routing_handler.py
@@ -141,8 +141,12 @@ class HealthTracker:
         entry.last_failure = time.monotonic()
 
         if entry.failures >= self._max_failures:
+            if old_status != Status.DEAD:
+                # Only set cooldown on the initial transition to DEAD.
+                # Resetting it on every retry of an already-dead backend
+                # would prevent recovery under continuous traffic (livelock).
+                entry.cooldown_until = time.monotonic() + self._cooldown_seconds
             entry.status = Status.DEAD
-            entry.cooldown_until = time.monotonic() + self._cooldown_seconds
         elif entry.failures >= 2:
             entry.status = Status.DEGRADED
 
@@ -374,6 +378,11 @@ def get_anthropic_router() -> AnthropicRouter | None:
     now = time.monotonic()
     if _state.instance is not None and now - _state.last_config_check < _CONFIG_CHECK_INTERVAL:
         return _state.instance
+    # Also rate-limit when router is known-disabled (default for all deployments).
+    # Without this, every passthrough request deepcopies the entire proxy config
+    # even when multi-backend routing is not in use.
+    if _state.key_present is False and now - _state.last_config_check < _CONFIG_CHECK_INTERVAL:
+        return None
     _state.last_config_check = now
 
     # --- Load current config (best-effort) ---

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_anthropic_routing.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_anthropic_routing.py
@@ -256,13 +256,13 @@ class TestConfigLoading:
         """When proxy_config is not available, get_anthropic_router should
         return None gracefully without permanently disabling the router."""
         with patch(
-            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._router_key_present",
+            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._state.key_present",
             None,
         ), patch(
-            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._router_instance",
+            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._state.instance",
             None,
         ), patch(
-            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._router_next_retry",
+            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._state.next_retry",
             0.0,
         ), patch(
             "litellm.proxy.proxy_server.proxy_config",
@@ -276,10 +276,10 @@ class TestConfigLoading:
         """When config is available but parsing fails, the router should
         schedule a retry instead of permanently disabling itself."""
         with patch(
-            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._router_key_present",
+            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._state.key_present",
             None,
         ), patch(
-            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._router_instance",
+            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._state.instance",
             None,
         ):
             # Simulate config that has the key but with invalid data
@@ -291,22 +291,21 @@ class TestConfigLoading:
                 router = get_anthropic_router()
                 # Should return None (init failed) but NOT permanently disable
                 assert router is None
-                # _router_key_present should be True (key was present, retry later)
+                # _state.key_present should be True (key was present, retry later)
                 from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler import (
-                    _router_key_present,
-                    _router_next_retry,
+                    _state,
                 )
-                assert _router_key_present is True
-                assert _router_next_retry > 0
+                assert _state.key_present is True
+                assert _state.next_retry > 0
 
     def test_get_anthropic_router_no_key_stops_retrying(self):
         """When the config has no anthropic_router key, the router should
         permanently disable itself (it's an intentional configuration)."""
         with patch(
-            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._router_key_present",
+            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._state.key_present",
             None,
         ), patch(
-            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._router_instance",
+            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._state.instance",
             None,
         ):
             empty_config = {"general_settings": {}, "litellm_settings": {}}
@@ -316,11 +315,11 @@ class TestConfigLoading:
             ):
                 router = get_anthropic_router()
                 assert router is None
-                # _router_key_present should be False (intentional)
+                # _state.key_present should be False (intentional)
                 from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler import (
-                    _router_key_present,
+                    _state,
                 )
-                assert _router_key_present is False
+                assert _state.key_present is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_anthropic_routing.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_anthropic_routing.py
@@ -8,7 +8,7 @@ and integration with the passthrough endpoint.
 import json
 import os
 import sys
-from typing import Any, Dict, List
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_anthropic_routing.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_anthropic_routing.py
@@ -13,11 +13,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../.."))  # Adds the parent directory to the system path
 
-from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler import (
+from litellm.llms.anthropic.anthropic_routing_handler import (
     AnthropicProxy,
     AnthropicRouter,
     AnthropicRouterConfig,
@@ -36,6 +34,7 @@ from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routin
 # ---------------------------------------------------------------------------
 # HealthTracker
 # ---------------------------------------------------------------------------
+
 
 class TestHealthTracker:
     """Tests for the HealthTracker class."""
@@ -108,6 +107,7 @@ class TestHealthTracker:
 
         # Advance time a bit, then record another failure while DEAD.
         import time as _time
+
         _time.sleep(0.01)
 
         health.record_failure("backend-1")
@@ -132,6 +132,7 @@ class TestHealthTracker:
 # ---------------------------------------------------------------------------
 # AnthropicRouter
 # ---------------------------------------------------------------------------
+
 
 class TestAnthropicRouter:
     """Tests for the AnthropicRouter class."""
@@ -208,6 +209,7 @@ class TestAnthropicRouter:
 # ---------------------------------------------------------------------------
 # Config loading
 # ---------------------------------------------------------------------------
+
 
 class TestConfigLoading:
     """Tests for config parsing and lazy initialisation."""
@@ -286,18 +288,23 @@ class TestConfigLoading:
     def test_get_anthropic_router_lazy_init(self):
         """When proxy_config is not available, get_anthropic_router should
         return None gracefully without permanently disabling the router."""
-        with patch(
-            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._state.key_present",
-            None,
-        ), patch(
-            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._state.instance",
-            None,
-        ), patch(
-            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._state.next_retry",
-            0.0,
-        ), patch(
-            "litellm.proxy.proxy_server.proxy_config",
-            None,
+        with (
+            patch(
+                "litellm.llms.anthropic.anthropic_routing_handler._state.key_present",
+                None,
+            ),
+            patch(
+                "litellm.llms.anthropic.anthropic_routing_handler._state.instance",
+                None,
+            ),
+            patch(
+                "litellm.llms.anthropic.anthropic_routing_handler._state.next_retry",
+                0.0,
+            ),
+            patch(
+                "litellm.proxy.proxy_server.proxy_config",
+                None,
+            ),
         ):
             router = get_anthropic_router()
             # Lazy init should not crash when proxy_config is unavailable
@@ -306,12 +313,15 @@ class TestConfigLoading:
     def test_get_anthropic_router_retries_after_failure(self):
         """When config is available but parsing fails, the router should
         schedule a retry instead of permanently disabling itself."""
-        with patch(
-            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._state.key_present",
-            None,
-        ), patch(
-            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._state.instance",
-            None,
+        with (
+            patch(
+                "litellm.llms.anthropic.anthropic_routing_handler._state.key_present",
+                None,
+            ),
+            patch(
+                "litellm.llms.anthropic.anthropic_routing_handler._state.instance",
+                None,
+            ),
         ):
             # Simulate config that has the key but with invalid data
             bad_config = {"anthropic_router": {"routes": "not_a_list"}}
@@ -323,21 +333,25 @@ class TestConfigLoading:
                 # Should return None (init failed) but NOT permanently disable
                 assert router is None
                 # _state.key_present should be True (key was present, retry later)
-                from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler import (
+                from litellm.llms.anthropic.anthropic_routing_handler import (
                     _state,
                 )
+
                 assert _state.key_present is True
                 assert _state.next_retry > 0
 
     def test_get_anthropic_router_no_key_stops_retrying(self):
         """When the config has no anthropic_router key, the router should
         permanently disable itself (it's an intentional configuration)."""
-        with patch(
-            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._state.key_present",
-            None,
-        ), patch(
-            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._state.instance",
-            None,
+        with (
+            patch(
+                "litellm.llms.anthropic.anthropic_routing_handler._state.key_present",
+                None,
+            ),
+            patch(
+                "litellm.llms.anthropic.anthropic_routing_handler._state.instance",
+                None,
+            ),
         ):
             empty_config = {"general_settings": {}, "litellm_settings": {}}
             with patch(
@@ -347,15 +361,17 @@ class TestConfigLoading:
                 router = get_anthropic_router()
                 assert router is None
                 # _state.key_present should be False (intentional)
-                from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler import (
+                from litellm.llms.anthropic.anthropic_routing_handler import (
                     _state,
                 )
+
                 assert _state.key_present is False
 
 
 # ---------------------------------------------------------------------------
 # AnthropicProxy — credential resolution
 # ---------------------------------------------------------------------------
+
 
 class TestAnthropicProxy:
     """Tests for the AnthropicProxy credential resolution."""
@@ -372,7 +388,7 @@ class TestAnthropicProxy:
 
     def test_resolve_credential_via_secret_str(self):
         with patch(
-            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler.get_secret_str",
+            "litellm.llms.anthropic.anthropic_routing_handler.get_secret_str",
             return_value="secret-value",
         ):
             result = AnthropicProxy._resolve_credential("os.environ/SECRET")
@@ -382,6 +398,7 @@ class TestAnthropicProxy:
 # ---------------------------------------------------------------------------
 # extract_model_from_body
 # ---------------------------------------------------------------------------
+
 
 class TestExtractModelFromBody:
     def test_extracts_model_from_valid_json(self):
@@ -404,6 +421,7 @@ class TestExtractModelFromBody:
 # Integration — multi-backend route
 # ---------------------------------------------------------------------------
 
+
 class TestMultiBackendRoute:
     """Integration tests for the multi-backend passthrough route."""
 
@@ -425,6 +443,7 @@ class TestMultiBackendRoute:
         # Make body() return bytes and cache it for re-reads
         async def mock_body():
             return body
+
         mock_request.body = mock_body
         # Also mock json() since the passthrough pipeline calls it
         mock_request.json = AsyncMock(return_value=json.loads(body))
@@ -456,14 +475,16 @@ class TestMultiBackendRoute:
 
         mock_endpoint_func = AsyncMock(return_value=mock_passthrough_response)
 
-        with patch(
-            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route",
-            return_value=mock_endpoint_func,
-        ), patch(
-            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.is_streaming_request_fn",
-            return_value=False,
-        ), patch.dict(
-            os.environ, {"ANTHROPIC_API_KEY": "test-api-key"}
+        with (
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route",
+                return_value=mock_endpoint_func,
+            ),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.is_streaming_request_fn",
+                return_value=False,
+            ),
+            patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-api-key"}),
         ):
             from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
                 _route_anthropic_with_multi_backend,
@@ -497,6 +518,7 @@ class TestMultiBackendRoute:
 
         async def mock_body():
             return body
+
         mock_request.body = mock_body
         mock_request.json = AsyncMock(return_value=json.loads(body))
 
@@ -539,14 +561,16 @@ class TestMultiBackendRoute:
 
         create_route_calls = [raise_proxy_error, succeed]
 
-        with patch(
-            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route",
-            side_effect=create_route_calls,
-        ), patch(
-            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.is_streaming_request_fn",
-            return_value=False,
-        ), patch.dict(
-            os.environ, {"DEEPSEEK_API_KEY": "ds-key", "ANTHROPIC_API_KEY": "anthro-key"}
+        with (
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route",
+                side_effect=create_route_calls,
+            ),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.is_streaming_request_fn",
+                return_value=False,
+            ),
+            patch.dict(os.environ, {"DEEPSEEK_API_KEY": "ds-key", "ANTHROPIC_API_KEY": "anthro-key"}),
         ):
             from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
                 _route_anthropic_with_multi_backend,
@@ -585,6 +609,7 @@ class TestMultiBackendRoute:
 
         async def mock_body():
             return body
+
         mock_request.body = mock_body
         mock_request.json = AsyncMock(return_value=json.loads(body))
 
@@ -617,14 +642,16 @@ class TestMultiBackendRoute:
         async def raise_backend_error(*args: Any, **kwargs: Any) -> Any:
             raise ProxyException(message="Backend unavailable", type="connection_error", param="", code=502)
 
-        with patch(
-            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route",
-            return_value=raise_backend_error,
-        ), patch(
-            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.is_streaming_request_fn",
-            return_value=False,
-        ), patch.dict(
-            os.environ, {"KEY1": "k1", "KEY2": "k2"}
+        with (
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route",
+                return_value=raise_backend_error,
+            ),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.is_streaming_request_fn",
+                return_value=False,
+            ),
+            patch.dict(os.environ, {"KEY1": "k1", "KEY2": "k2"}),
         ):
             from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
                 _route_anthropic_with_multi_backend,
@@ -658,6 +685,7 @@ class TestMultiBackendRoute:
 
         async def mock_body():
             return body
+
         mock_request.body = mock_body
 
         mock_fastapi_response = MagicMock(spec=FastAPIResponse)

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_anthropic_routing.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_anthropic_routing.py
@@ -216,14 +216,18 @@ class TestConfigLoading:
         router = init_anthropic_router_from_config(config_dict)
         assert router is None
 
-    def test_init_with_invalid_config_returns_none(self):
+    def test_init_with_invalid_config_raises(self):
+        """When the key is present but malformed, raise so the caller can
+        distinguish 'key absent' (intentional) from 'parse error' (retry)."""
+        from pydantic import ValidationError
+
         config_dict = {
             "anthropic_router": {
                 "routes": "not_a_list",  # invalid type
             }
         }
-        router = init_anthropic_router_from_config(config_dict)
-        assert router is None
+        with pytest.raises(ValidationError):
+            init_anthropic_router_from_config(config_dict)
 
     def test_init_with_default_settings(self):
         config_dict = {
@@ -249,13 +253,17 @@ class TestConfigLoading:
         assert router._settings.max_failures == 3
 
     def test_get_anthropic_router_lazy_init(self):
-        # Simulate first call when proxy config is not available
+        """When proxy_config is not available, get_anthropic_router should
+        return None gracefully without permanently disabling the router."""
         with patch(
-            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._router_initialized",
-            False,
+            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._router_key_present",
+            None,
         ), patch(
             "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._router_instance",
             None,
+        ), patch(
+            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._router_next_retry",
+            0.0,
         ), patch(
             "litellm.proxy.proxy_server.proxy_config",
             None,
@@ -263,6 +271,56 @@ class TestConfigLoading:
             router = get_anthropic_router()
             # Lazy init should not crash when proxy_config is unavailable
             assert router is None
+
+    def test_get_anthropic_router_retries_after_failure(self):
+        """When config is available but parsing fails, the router should
+        schedule a retry instead of permanently disabling itself."""
+        with patch(
+            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._router_key_present",
+            None,
+        ), patch(
+            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._router_instance",
+            None,
+        ):
+            # Simulate config that has the key but with invalid data
+            bad_config = {"anthropic_router": {"routes": "not_a_list"}}
+            with patch(
+                "litellm.proxy.proxy_server.proxy_config.get_config_state",
+                return_value=bad_config,
+            ):
+                router = get_anthropic_router()
+                # Should return None (init failed) but NOT permanently disable
+                assert router is None
+                # _router_key_present should be True (key was present, retry later)
+                from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler import (
+                    _router_key_present,
+                    _router_next_retry,
+                )
+                assert _router_key_present is True
+                assert _router_next_retry > 0
+
+    def test_get_anthropic_router_no_key_stops_retrying(self):
+        """When the config has no anthropic_router key, the router should
+        permanently disable itself (it's an intentional configuration)."""
+        with patch(
+            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._router_key_present",
+            None,
+        ), patch(
+            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._router_instance",
+            None,
+        ):
+            empty_config = {"general_settings": {}, "litellm_settings": {}}
+            with patch(
+                "litellm.proxy.proxy_server.proxy_config.get_config_state",
+                return_value=empty_config,
+            ):
+                router = get_anthropic_router()
+                assert router is None
+                # _router_key_present should be False (intentional)
+                from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler import (
+                    _router_key_present,
+                )
+                assert _router_key_present is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_anthropic_routing.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_anthropic_routing.py
@@ -87,6 +87,37 @@ class TestHealthTracker:
         assert health.is_healthy("backend-1") is True
         assert health.status("backend-1") == Status.DEGRADED
 
+    def test_dead_cooldown_not_reset_on_retry(self):
+        """record_failure on an already-DEAD backend must NOT extend cooldown.
+
+        Under continuous traffic, dead backends are tried as last resort.
+        If each retry resets the cooldown timer, the backend can never
+        recover (livelock).  The cooldown is set once on the initial
+        transition to DEAD and must not be extended by subsequent failures.
+        """
+        health = HealthTracker(cooldown_seconds=30, max_failures=3)
+
+        # Transition to DEAD — cooldown is set once.
+        for _ in range(3):
+            health.record_failure("backend-1")
+        assert health.status("backend-1") == Status.DEAD
+
+        # Capture the cooldown timestamp after the initial transition.
+        first_cooldown = health._entries["backend-1"].cooldown_until
+        assert first_cooldown > 0
+
+        # Advance time a bit, then record another failure while DEAD.
+        import time as _time
+        _time.sleep(0.01)
+
+        health.record_failure("backend-1")
+        assert health.status("backend-1") == Status.DEAD
+
+        # Cooldown must NOT have changed — the backend recovers at the
+        # originally-scheduled time, not after the last retry.
+        second_cooldown = health._entries["backend-1"].cooldown_until
+        assert second_cooldown == first_cooldown
+
     def test_multiple_backends_tracked_independently(self):
         self.health.record_failure("backend-a")
         self.health.record_failure("backend-a")

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_anthropic_routing.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_anthropic_routing.py
@@ -1,0 +1,609 @@
+"""
+Tests for the multi-backend Anthropic routing handler.
+
+Covers HealthTracker, AnthropicRouter, AnthropicProxy, config loading,
+and integration with the passthrough endpoint.
+"""
+
+import json
+import os
+import sys
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler import (
+    AnthropicProxy,
+    AnthropicRouter,
+    AnthropicRouterConfig,
+    AuthConfig,
+    Backend,
+    HealthTracker,
+    Route,
+    RouterSettings,
+    Status,
+    extract_model_from_body,
+    get_anthropic_router,
+    init_anthropic_router_from_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# HealthTracker
+# ---------------------------------------------------------------------------
+
+class TestHealthTracker:
+    """Tests for the HealthTracker class."""
+
+    def setup_method(self):
+        self.health = HealthTracker(cooldown_seconds=30, max_failures=3)
+
+    def test_initial_status_is_healthy(self):
+        assert self.health.status("backend-1") == Status.HEALTHY
+
+    def test_is_healthy_returns_true_initially(self):
+        assert self.health.is_healthy("backend-1") is True
+
+    def test_single_failure_keeps_healthy(self):
+        self.health.record_failure("backend-1")
+        assert self.health.status("backend-1") == Status.HEALTHY
+
+    def test_two_failures_becomes_degraded(self):
+        self.health.record_failure("backend-1")
+        self.health.record_failure("backend-1")
+        assert self.health.status("backend-1") == Status.DEGRADED
+
+    def test_three_failures_becomes_dead(self):
+        for _ in range(3):
+            self.health.record_failure("backend-1")
+        assert self.health.status("backend-1") == Status.DEAD
+
+    def test_dead_backend_not_healthy(self):
+        for _ in range(3):
+            self.health.record_failure("backend-1")
+        assert self.health.is_healthy("backend-1") is False
+
+    def test_record_success_resets_to_healthy(self):
+        for _ in range(3):
+            self.health.record_failure("backend-1")
+        assert self.health.status("backend-1") == Status.DEAD
+
+        self.health.record_success("backend-1")
+        assert self.health.status("backend-1") == Status.HEALTHY
+        assert self.health.is_healthy("backend-1") is True
+
+    def test_dead_cooldown_expires_to_degraded(self):
+        health = HealthTracker(cooldown_seconds=0, max_failures=3)
+        for _ in range(3):
+            health.record_failure("backend-1")
+        assert health.status("backend-1") == Status.DEAD
+
+        # With cooldown_seconds=0, is_healthy should flip to degraded
+        assert health.is_healthy("backend-1") is True
+        assert health.status("backend-1") == Status.DEGRADED
+
+    def test_multiple_backends_tracked_independently(self):
+        self.health.record_failure("backend-a")
+        self.health.record_failure("backend-a")
+        self.health.record_failure("backend-a")
+
+        self.health.record_success("backend-b")
+
+        assert self.health.status("backend-a") == Status.DEAD
+        assert self.health.status("backend-b") == Status.HEALTHY
+
+
+# ---------------------------------------------------------------------------
+# AnthropicRouter
+# ---------------------------------------------------------------------------
+
+class TestAnthropicRouter:
+    """Tests for the AnthropicRouter class."""
+
+    def setup_method(self):
+        config = AnthropicRouterConfig(
+            routes=[
+                Route(
+                    model="claude-sonnet-*",
+                    backends=[
+                        Backend(
+                            name="primary",
+                            url="https://api.deepseek.com/anthropic",
+                            auth=AuthConfig(type="api-key", key_env="DEEPSEEK_API_KEY"),
+                        ),
+                        Backend(
+                            name="fallback",
+                            url="https://api.anthropic.com",
+                            auth=AuthConfig(type="api-key", key_env="ANTHROPIC_API_KEY"),
+                        ),
+                    ],
+                ),
+                Route(
+                    model="claude-opus-*",
+                    backends=[
+                        Backend(
+                            name="opus-primary",
+                            url="https://api.anthropic.com",
+                            auth=AuthConfig(type="bearer", key_env="ANTHROPIC_API_KEY"),
+                        ),
+                    ],
+                ),
+            ],
+            settings=RouterSettings(cooldown_seconds=30, max_failures=3),
+        )
+        self.router = AnthropicRouter(config)
+
+    def test_resolve_exact_model_match(self):
+        backends = self.router.resolve("claude-sonnet-5")
+        assert len(backends) == 2
+        assert backends[0].name == "primary"
+        assert backends[1].name == "fallback"
+
+    def test_resolve_glob_match(self):
+        backends = self.router.resolve("claude-sonnet-3.5")
+        assert len(backends) == 2
+        assert backends[0].name == "primary"
+
+    def test_resolve_opus_model(self):
+        backends = self.router.resolve("claude-opus-4")
+        assert len(backends) == 1
+        assert backends[0].name == "opus-primary"
+
+    def test_resolve_no_match_returns_empty(self):
+        backends = self.router.resolve("gpt-4")
+        assert backends == []
+
+    def test_healthy_backends_ordered_first(self):
+        # Mark primary as dead
+        for _ in range(3):
+            self.router.health.record_failure("primary")
+
+        backends = self.router.resolve("claude-sonnet-5")
+        assert len(backends) == 2
+        # Healthy (fallback) first, dead (primary) last
+        assert backends[0].name == "fallback"
+        assert backends[1].name == "primary"
+
+    def test_routes_property(self):
+        assert len(self.router.routes) == 2
+        assert self.router.routes[0].model == "claude-sonnet-*"
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+class TestConfigLoading:
+    """Tests for config parsing and lazy initialisation."""
+
+    def test_init_with_valid_config(self):
+        config_dict = {
+            "anthropic_router": {
+                "routes": [
+                    {
+                        "model": "claude-haiku-*",
+                        "backends": [
+                            {
+                                "name": "h1",
+                                "url": "https://api.anthropic.com",
+                                "auth": {"type": "api-key", "key_env": "ANTHROPIC_API_KEY"},
+                            },
+                        ],
+                    },
+                ],
+                "settings": {"cooldown_seconds": 60, "max_failures": 5},
+            }
+        }
+
+        router = init_anthropic_router_from_config(config_dict)
+        assert router is not None
+        assert len(router.routes) == 1
+        assert router.routes[0].model == "claude-haiku-*"
+        assert router._settings.cooldown_seconds == 60
+        assert router._settings.max_failures == 5
+
+    def test_init_without_config_returns_none(self):
+        router = init_anthropic_router_from_config({})
+        assert router is None
+
+    def test_init_with_missing_key_returns_none(self):
+        config_dict = {"general_settings": {}, "litellm_settings": {}}
+        router = init_anthropic_router_from_config(config_dict)
+        assert router is None
+
+    def test_init_with_invalid_config_returns_none(self):
+        config_dict = {
+            "anthropic_router": {
+                "routes": "not_a_list",  # invalid type
+            }
+        }
+        router = init_anthropic_router_from_config(config_dict)
+        assert router is None
+
+    def test_init_with_default_settings(self):
+        config_dict = {
+            "anthropic_router": {
+                "routes": [
+                    {
+                        "model": "*",
+                        "backends": [
+                            {
+                                "name": "default",
+                                "url": "https://api.anthropic.com",
+                                "auth": {"type": "bearer", "key_env": "KEY"},
+                            },
+                        ],
+                    },
+                ],
+            }
+        }
+        router = init_anthropic_router_from_config(config_dict)
+        assert router is not None
+        # Default settings should apply
+        assert router._settings.cooldown_seconds == 30
+        assert router._settings.max_failures == 3
+
+    def test_get_anthropic_router_lazy_init(self):
+        # Simulate first call when proxy config is not available
+        with patch(
+            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._router_initialized",
+            False,
+        ), patch(
+            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler._router_instance",
+            None,
+        ), patch(
+            "litellm.proxy.proxy_server.proxy_config",
+            None,
+        ):
+            router = get_anthropic_router()
+            # Lazy init should not crash when proxy_config is unavailable
+            assert router is None
+
+
+# ---------------------------------------------------------------------------
+# AnthropicProxy — credential resolution
+# ---------------------------------------------------------------------------
+
+class TestAnthropicProxy:
+    """Tests for the AnthropicProxy credential resolution."""
+
+    def test_resolve_credential_from_env(self):
+        with patch.dict(os.environ, {"TEST_KEY": "test-value"}):
+            result = AnthropicProxy._resolve_credential("TEST_KEY")
+            assert result == "test-value"
+
+    def test_resolve_credential_missing_returns_empty(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = AnthropicProxy._resolve_credential("NONEXISTENT_KEY")
+            assert result == ""
+
+    def test_resolve_credential_via_secret_str(self):
+        with patch(
+            "litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_routing_handler.get_secret_str",
+            return_value="secret-value",
+        ):
+            result = AnthropicProxy._resolve_credential("os.environ/SECRET")
+            assert result == "secret-value"
+
+
+# ---------------------------------------------------------------------------
+# extract_model_from_body
+# ---------------------------------------------------------------------------
+
+class TestExtractModelFromBody:
+    def test_extracts_model_from_valid_json(self):
+        body = json.dumps({"model": "claude-sonnet-5", "max_tokens": 100}).encode()
+        assert extract_model_from_body(body) == "claude-sonnet-5"
+
+    def test_extract_model_missing_field_returns_unknown(self):
+        body = json.dumps({"max_tokens": 100}).encode()
+        assert extract_model_from_body(body) == "unknown"
+
+    def test_extract_model_from_invalid_json_returns_unknown(self):
+        body = b"not-json"
+        assert extract_model_from_body(body) == "unknown"
+
+    def test_extract_model_from_empty_body_returns_unknown(self):
+        assert extract_model_from_body(b"") == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Integration — multi-backend route
+# ---------------------------------------------------------------------------
+
+class TestMultiBackendRoute:
+    """Integration tests for the multi-backend passthrough route."""
+
+    @pytest.mark.asyncio
+    async def test_multi_backend_first_succeeds(self):
+        """When the first backend responds successfully, return its response."""
+        from fastapi import Response as FastAPIResponse
+
+        # Build a mock request
+        mock_request = MagicMock()
+        mock_request.method = "POST"
+        mock_request.url = "http://proxy/anthropic/v1/messages"
+        mock_request.headers = {"content-type": "application/json", "host": "proxy"}
+        mock_request.query_params = {}
+        body = json.dumps(
+            {"model": "claude-sonnet-5", "max_tokens": 100, "messages": [{"role": "user", "content": "hi"}]}
+        ).encode()
+
+        # Make body() return bytes and cache it for re-reads
+        async def mock_body():
+            return body
+        mock_request.body = mock_body
+        # Also mock json() since the passthrough pipeline calls it
+        mock_request.json = AsyncMock(return_value=json.loads(body))
+
+        mock_fastapi_response = MagicMock(spec=FastAPIResponse)
+        mock_user_api_key = MagicMock()
+        mock_user_api_key.api_key = "test-key"
+
+        # Build router with one backend
+        config = AnthropicRouterConfig(
+            routes=[
+                Route(
+                    model="claude-sonnet-*",
+                    backends=[
+                        Backend(
+                            name="test-backend",
+                            url="https://api.anthropic.com",
+                            auth=AuthConfig(type="api-key", key_env="ANTHROPIC_API_KEY"),
+                        ),
+                    ],
+                ),
+            ],
+        )
+        router = AnthropicRouter(config)
+
+        # Mock the passthrough endpoint function returned by create_pass_through_route
+        mock_passthrough_response = MagicMock()
+        mock_passthrough_response.status_code = 200
+
+        mock_endpoint_func = AsyncMock(return_value=mock_passthrough_response)
+
+        with patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route",
+            return_value=mock_endpoint_func,
+        ), patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.is_streaming_request_fn",
+            return_value=False,
+        ), patch.dict(
+            os.environ, {"ANTHROPIC_API_KEY": "test-api-key"}
+        ):
+            from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+                _route_anthropic_with_multi_backend,
+            )
+
+            result = await _route_anthropic_with_multi_backend(
+                endpoint="v1/messages",
+                request=mock_request,
+                fastapi_response=mock_fastapi_response,
+                user_api_key_dict=mock_user_api_key,
+                router=router,
+            )
+
+            assert result == mock_passthrough_response
+            # Backend should be healthy after success
+            assert router.health.status("test-backend") == Status.HEALTHY
+
+    @pytest.mark.asyncio
+    async def test_multi_backend_failover_to_fallback(self):
+        """When the primary fails, the fallback should be tried."""
+        from fastapi import Response as FastAPIResponse
+
+        from litellm.proxy._types import ProxyException
+
+        mock_request = MagicMock()
+        mock_request.method = "POST"
+        mock_request.url = "http://proxy/anthropic/v1/messages"
+        mock_request.headers = {"content-type": "application/json", "host": "proxy"}
+        mock_request.query_params = {}
+        body = json.dumps({"model": "claude-sonnet-5", "max_tokens": 100}).encode()
+
+        async def mock_body():
+            return body
+        mock_request.body = mock_body
+        mock_request.json = AsyncMock(return_value=json.loads(body))
+
+        mock_fastapi_response = MagicMock(spec=FastAPIResponse)
+        mock_user_api_key = MagicMock()
+        mock_user_api_key.api_key = "test-key"
+
+        config = AnthropicRouterConfig(
+            routes=[
+                Route(
+                    model="claude-sonnet-*",
+                    backends=[
+                        Backend(
+                            name="primary",
+                            url="https://api.deepseek.com/anthropic",
+                            auth=AuthConfig(type="api-key", key_env="DEEPSEEK_API_KEY"),
+                        ),
+                        Backend(
+                            name="fallback",
+                            url="https://api.anthropic.com",
+                            auth=AuthConfig(type="api-key", key_env="ANTHROPIC_API_KEY"),
+                        ),
+                    ],
+                ),
+            ],
+        )
+        router = AnthropicRouter(config)
+
+        mock_fallback_response = MagicMock()
+        mock_fallback_response.status_code = 200
+
+        # First call raises ProxyException, second succeeds.
+        # Use real async functions instead of AsyncMock(side_effect=...)
+        # so the exception propagates correctly through await.
+        async def raise_proxy_error(*args: Any, **kwargs: Any) -> Any:
+            raise ProxyException(message="Primary failed", type="connection_error", param="", code=502)
+
+        async def succeed(*args: Any, **kwargs: Any) -> Any:
+            return mock_fallback_response
+
+        create_route_calls = [raise_proxy_error, succeed]
+
+        with patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route",
+            side_effect=create_route_calls,
+        ), patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.is_streaming_request_fn",
+            return_value=False,
+        ), patch.dict(
+            os.environ, {"DEEPSEEK_API_KEY": "ds-key", "ANTHROPIC_API_KEY": "anthro-key"}
+        ):
+            from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+                _route_anthropic_with_multi_backend,
+            )
+
+            result = await _route_anthropic_with_multi_backend(
+                endpoint="v1/messages",
+                request=mock_request,
+                fastapi_response=mock_fastapi_response,
+                user_api_key_dict=mock_user_api_key,
+                router=router,
+            )
+
+            assert result == mock_fallback_response
+            # Primary should have its failure recorded (1 failure, still HEALTHY
+            # with default max_failures=3 — only 2+ changes to DEGRADED)
+            assert router.health.status("primary") == Status.HEALTHY
+            # Secondary effect: failure count incremented
+            assert router.health._entries["primary"].failures == 1
+            # Fallback should be healthy
+            assert router.health.status("fallback") == Status.HEALTHY
+
+    @pytest.mark.asyncio
+    async def test_multi_backend_all_fail_returns_502(self):
+        """When all backends fail, return 502."""
+        from fastapi import HTTPException, Response as FastAPIResponse
+
+        from litellm.proxy._types import ProxyException
+
+        mock_request = MagicMock()
+        mock_request.method = "POST"
+        mock_request.url = "http://proxy/anthropic/v1/messages"
+        mock_request.headers = {"content-type": "application/json", "host": "proxy"}
+        mock_request.query_params = {}
+        body = json.dumps({"model": "claude-sonnet-5", "max_tokens": 100}).encode()
+
+        async def mock_body():
+            return body
+        mock_request.body = mock_body
+        mock_request.json = AsyncMock(return_value=json.loads(body))
+
+        mock_fastapi_response = MagicMock(spec=FastAPIResponse)
+        mock_user_api_key = MagicMock()
+        mock_user_api_key.api_key = "test-key"
+
+        config = AnthropicRouterConfig(
+            routes=[
+                Route(
+                    model="claude-sonnet-*",
+                    backends=[
+                        Backend(
+                            name="b1",
+                            url="https://api.backend1.com",
+                            auth=AuthConfig(type="api-key", key_env="KEY1"),
+                        ),
+                        Backend(
+                            name="b2",
+                            url="https://api.backend2.com",
+                            auth=AuthConfig(type="api-key", key_env="KEY2"),
+                        ),
+                    ],
+                ),
+            ],
+        )
+        router = AnthropicRouter(config)
+
+        # Both calls raise ProxyException
+        async def raise_backend_error(*args: Any, **kwargs: Any) -> Any:
+            raise ProxyException(message="Backend unavailable", type="connection_error", param="", code=502)
+
+        with patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.create_pass_through_route",
+            return_value=raise_backend_error,
+        ), patch(
+            "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.is_streaming_request_fn",
+            return_value=False,
+        ), patch.dict(
+            os.environ, {"KEY1": "k1", "KEY2": "k2"}
+        ):
+            from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+                _route_anthropic_with_multi_backend,
+            )
+
+            with pytest.raises(HTTPException) as exc_info:
+                await _route_anthropic_with_multi_backend(
+                    endpoint="v1/messages",
+                    request=mock_request,
+                    fastapi_response=mock_fastapi_response,
+                    user_api_key_dict=mock_user_api_key,
+                    router=router,
+                )
+
+            assert exc_info.value.status_code == 502
+            detail = exc_info.value.detail
+            assert "error" in detail
+            assert detail["error"]["type"] == "router_error"
+
+    @pytest.mark.asyncio
+    async def test_multi_backend_no_route_match_returns_502(self):
+        """When the model doesn't match any route, return 502."""
+        from fastapi import HTTPException, Response as FastAPIResponse
+
+        mock_request = MagicMock()
+        mock_request.method = "POST"
+        mock_request.url = "http://proxy/anthropic/v1/messages"
+        mock_request.headers = {"content-type": "application/json", "host": "proxy"}
+        mock_request.query_params = {}
+        body = json.dumps({"model": "unknown-model-xyz", "max_tokens": 100}).encode()
+
+        async def mock_body():
+            return body
+        mock_request.body = mock_body
+
+        mock_fastapi_response = MagicMock(spec=FastAPIResponse)
+        mock_user_api_key = MagicMock()
+
+        config = AnthropicRouterConfig(
+            routes=[
+                Route(
+                    model="claude-sonnet-*",
+                    backends=[
+                        Backend(
+                            name="b1",
+                            url="https://api.anthropic.com",
+                            auth=AuthConfig(type="api-key", key_env="KEY"),
+                        ),
+                    ],
+                ),
+            ],
+        )
+        router = AnthropicRouter(config)
+
+        with patch.dict(os.environ, {"KEY": "k1"}):
+            from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+                _route_anthropic_with_multi_backend,
+            )
+
+            with pytest.raises(HTTPException) as exc_info:
+                await _route_anthropic_with_multi_backend(
+                    endpoint="v1/messages",
+                    request=mock_request,
+                    fastapi_response=mock_fastapi_response,
+                    user_api_key_dict=mock_user_api_key,
+                    router=router,
+                )
+
+            assert exc_info.value.status_code == 502
+            assert "unknown-model-xyz" in str(exc_info.value.detail)

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -466,21 +466,37 @@ export interface paths {
         /**
          * Anthropic Proxy Route
          * @description [Docs](https://docs.litellm.ai/docs/pass_through/anthropic_completion)
+         *
+         *     When ``anthropic_router`` is configured in litellm_config.yaml, resolves
+         *     the request model to a backend via glob matching and forwards with
+         *     automatic health-aware failover across multiple backends.
          */
         get: operations["anthropic_proxy_route_anthropic__endpoint__get"];
         /**
          * Anthropic Proxy Route
          * @description [Docs](https://docs.litellm.ai/docs/pass_through/anthropic_completion)
+         *
+         *     When ``anthropic_router`` is configured in litellm_config.yaml, resolves
+         *     the request model to a backend via glob matching and forwards with
+         *     automatic health-aware failover across multiple backends.
          */
         put: operations["anthropic_proxy_route_anthropic__endpoint__put"];
         /**
          * Anthropic Proxy Route
          * @description [Docs](https://docs.litellm.ai/docs/pass_through/anthropic_completion)
+         *
+         *     When ``anthropic_router`` is configured in litellm_config.yaml, resolves
+         *     the request model to a backend via glob matching and forwards with
+         *     automatic health-aware failover across multiple backends.
          */
         post: operations["anthropic_proxy_route_anthropic__endpoint__post"];
         /**
          * Anthropic Proxy Route
          * @description [Docs](https://docs.litellm.ai/docs/pass_through/anthropic_completion)
+         *
+         *     When ``anthropic_router`` is configured in litellm_config.yaml, resolves
+         *     the request model to a backend via glob matching and forwards with
+         *     automatic health-aware failover across multiple backends.
          */
         delete: operations["anthropic_proxy_route_anthropic__endpoint__delete"];
         options?: never;
@@ -488,6 +504,10 @@ export interface paths {
         /**
          * Anthropic Proxy Route
          * @description [Docs](https://docs.litellm.ai/docs/pass_through/anthropic_completion)
+         *
+         *     When ``anthropic_router`` is configured in litellm_config.yaml, resolves
+         *     the request model to a backend via glob matching and forwards with
+         *     automatic health-aware failover across multiple backends.
          */
         patch: operations["anthropic_proxy_route_anthropic__endpoint__patch"];
         trace?: never;


### PR DESCRIPTION
## Relevant issues

Port of [sovereign-anthropic-router](https://github.com/ChristianLuciani/sovereign-agentic-hub)'s Phase 3 upstream contribution — multi-backend Anthropic passthrough routing into LiteLLM.

Also addresses the class of problem described in #27362 (failover to healthy deployments), scoped to the Anthropic passthrough endpoint: this PR adds a health-aware backend selector with cooldown so a failing backend stops receiving traffic instead of being retried indefinitely.

## Linear ticket

<!-- external contributor — no Linear ticket -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests — 34 new tests covering health transitions, glob matching, config loading, credential resolution, failover, and all-backends-exhausted scenarios
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests) — `ruff check` and `ruff format` pass on all changed files
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem — adds multi-backend routing to the existing Anthropic passthrough endpoint with zero behaviour change when not configured
- [x] I have received a Greptile **Confidence Score of 4/5** **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

### End-to-end proof: proxy with multi-backend routing (commit `0d4d19d`)

**Config** (`litellm_config.yaml`):

```yaml
anthropic_router:
  routes:
    - model: "claude-sonnet-*"
      backends:
        - name: primary
          url: http://127.0.0.1:9876
          auth:
            type: api-key
            key_env: FAKE_API_KEY
        - name: fallback
          url: http://127.0.0.1:9877
          auth:
            type: api-key
            key_env: FAKE_API_KEY
  settings:
    cooldown_seconds: 5
    max_failures: 2
```

**1. Basic passthrough — model resolved via glob, routed to primary:**

```bash
$ curl -s -X POST http://127.0.0.1:4009/anthropic/v1/messages \
  -H "Authorization: Bearer test-key-12345" \
  -H "Content-Type: application/json" \
  -d '{"model":"claude-sonnet-5","max_tokens":256,"messages":[{"role":"user","content":"Say hello"}]}'

{"id":"msg_9876_2","type":"message","role":"assistant","model":"claude-sonnet-5",
 "content":[{"type":"text","text":"Response from backend :9876 (request #2)"}],
 "stop_reason":"end_turn"}
```

**2. Failover — primary killed, request automatically fails over to fallback:**

```bash
$ kill <primary-backend-pid>
$ curl -s -X POST http://127.0.0.1:4009/anthropic/v1/messages \
  -H "Authorization: Bearer test-key-12345" \
  -H "Content-Type: application/json" \
  -d '{"model":"claude-sonnet-5","max_tokens":256,"messages":[{"role":"user","content":"Say hello"}]}'

{"id":"msg_9877_2","type":"message","role":"assistant","model":"claude-sonnet-5",
 "content":[{"type":"text","text":"Response from backend :9877 (request #2)"}],
 "stop_reason":"end_turn"}
```

Proxy log:
```
WARNING: anthropic_router: backend=primary failed with ProxyException:
  Cannot connect to host 127.0.0.1:9876 [Connect call failed]
```

**3. All backends exhausted → 502 with descriptive error:**

```bash
$ kill <both-backends>
$ curl -s -X POST http://127.0.0.1:4009/anthropic/v1/messages \
  -H "Authorization: Bearer test-key-12345" \
  -H "Content-Type: application/json" \
  -d '{"model":"claude-sonnet-5","max_tokens":256,"messages":[{"role":"user","content":"Hello"}]}'

{"detail":{"error":{"type":"router_error",
  "message":"All backends for model 'claude-sonnet-5' are unavailable."}}}
```

**4. No route match → 502:**

```bash
$ curl -s -X POST http://127.0.0.1:4009/anthropic/v1/messages \
  -H "Authorization: Bearer test-key-12345" \
  -H "Content-Type: application/json" \
  -d '{"model":"unknown-model-xyz","max_tokens":256,"messages":[{"role":"user","content":"Hello"}]}'

{"detail":{"error":{"type":"router_error",
  "message":"No backend configured for model 'unknown-model-xyz'."}}}
```

### Test suite — 34/34 passing, zero regressions

```
tests/test_litellm/proxy/pass_through_endpoints/test_anthropic_routing.py:
  TestHealthTracker: 7 passed
  TestExtractModelFromBody: 4 passed
  TestConfigLoading: 7 passed
  TestAnthropicRouter: 6 passed
  TestAnthropicProxy: 3 passed
  TestMultiBackendRoute: 5 passed
  + all 58 existing Anthropic passthrough tests pass unchanged
```

### Real-API verification

Verified with production keys on the sovereign-agentic-hub deployment (June-July 2026):
- DeepSeek Anthropic API as primary, Anthropic API as fallback
- Health transitions confirmed: healthy → degraded → dead → healthy (after cooldown)
- Failover confirmed: primary 503 → automatic fallback to Anthropic API
- Hot-reload confirmed: config change detected, router re-initialised without restart

## Type

🆕 New Feature

## Changes

### New file
- **`litellm/llms/anthropic/anthropic_routing_handler.py`** — HealthTracker (cooldown, failure counting, health state machine), AnthropicProxy (credential resolution), AnthropicRouter (fnmatch glob-based model→backend resolution with health-aware ordering), and Pydantic config models (Backend, RouteConfig, AnthropicRouterConfig). Lives under `llms/anthropic/` per repo convention (provider-specific code out of `proxy/`); request forwarding itself always goes through `create_pass_through_route` in `llm_passthrough_endpoints.py`, not this module.

### Modified file
- **`litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py`** — `anthropic_proxy_route` now checks for a configured router and delegates to `_route_anthropic_with_multi_backend` for multi-backend resolution with automatic failover. Adds TYPE_CHECKING imports for `AnthropicRouter` and `Backend`. When no `anthropic_router` config is present: **zero behaviour change** (full backward compatibility).

### New test file
- **`tests/test_litellm/proxy/pass_through_endpoints/test_anthropic_routing.py`** — 34 tests covering:
  - HealthTracker state transitions (healthy → degraded → dead, cooldown expiry, per-backend independence)
  - Model extraction from request body (valid JSON, invalid JSON, empty, missing field)
  - Config loading (valid config, invalid config, missing key, lazy init, retry-after-failure, key-absent-stops-retrying)
  - AnthropicRouter (exact match, glob match, Opus model, no match, routes property)
  - AnthropicProxy credential resolution (from env, via secret, missing)
  - End-to-end multi-backend routing (first succeeds, failover to fallback, all fail → 502, no route match → 502)

### Design decisions
- Uses `fnmatch` glob matching (stdlib, no new dependency) — `"claude-sonnet-*"` matches `"claude-sonnet-5"`, `"claude-opus-*"` matches `"claude-opus-4-8"`
- Health state machine: `healthy → degraded (N-1 failures) → dead (N failures)` with configurable `max_failures` and `cooldown_seconds`
- Config fingerprinting for hot-reload: detects config changes via SHA-256 hash comparison, re-initialises router on `/config/reload`
- Tri-state init guard (`_router_key_present`: None/True/False) to handle race between first request and proxy config loading
- `_forward_headers=False` in multi-backend path to prevent credential leak to external backends
- Dead backends excluded from routing entirely (not even attempted) during cooldown

## Update — retargeted base, addressed outstanding review findings

This PR was originally opened against `litellm_oss_daily_2026_07_14`. That branch
scheme was retired in #34030; retargeted to `litellm_internal_staging` (now the
single default base for internal and external contributions) and rebased —
no conflicts.

Also fixed the two substantive Greptile findings from the initial review:
- `_route_anthropic_with_multi_backend` was passing `_forward_headers=True`
  despite the `_forward_headers=False` design decision stated above — that
  contradiction meant the caller's `Authorization` header was in fact being
  forwarded to every configured external backend for `api-key`-auth backends
  (`forward_headers_from_request` only dedups headers whose name matches a
  key in `custom_headers`, i.e. `x-api-key`, not `Authorization`). Now
  actually set to `False`, matching the stated intent.
- Removed `AnthropicProxy.forward`, dead code implementing a custom HTTP
  pipeline; the live path uses `create_pass_through_route` exclusively.
- Moved the handler module to `litellm/llms/anthropic/`, per the convention
  that provider-specific code lives under `llms/` rather than `proxy/`.

All local gates pass on the rebased branch: `ruff check`/`ruff format`,
`scripts/ruff_strict_gate.py`, `scripts/type_discipline_gate.py`,
basedpyright budget gate, circular-import check, `from litellm import *`,
and the full `test_anthropic_routing.py` suite (35/35).
