### PR TITLE
fix(responses): accept empty function argument deltas

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -1196,7 +1196,7 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                 )
         elif event_type == "response.function_call_arguments.delta":
             content_part: Optional[str] = parsed_chunk.get("delta", None)
-            if content_part:
+            if isinstance(content_part, str):
                 tool_call_index = parsed_chunk.get("output_index", 0)
                 return ModelResponseStream(
                     choices=[

--- a/tests/test_litellm/completion_extras/test_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/test_litellm_responses_transformation_transformation.py
@@ -257,3 +257,24 @@ def test_translate_responses_chunk_passthrough_chat_completion_chunk():
 
     assert result.choices[0].delta.content == "Hi! How can I help?"
     assert result.choices[0].finish_reason is None
+
+
+def test_translate_responses_chunk_accepts_empty_function_argument_delta():
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        OpenAiResponsesToChatCompletionStreamIterator,
+    )
+
+    result = OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "fc_test",
+            "output_index": 0,
+            "delta": "",
+            "sequence_number": 3,
+        }
+    )
+
+    tool_calls = result.choices[0].delta.tool_calls
+    assert tool_calls is not None
+    assert tool_calls[0].function is not None
+    assert tool_calls[0].function.arguments == ""


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The failure is provider-stream dependent, so an unpatched request can pass when the provider does not emit an empty argument chunk

The original live reproduction used this request against the Kimi route

```bash
curl --no-buffer "$LITELLM_URL/v1/responses" \
  -H "Authorization: Bearer $LITELLM_API_KEY" \
  -H "Content-Type: application/json" \
  --data-binary @request.json
```

```json
{
  "model": "codex-baseten-kimi-k2-7-code",
  "stream": true,
  "max_output_tokens": 128,
  "input": "Call the get_weather tool for Boston with unit celsius. Do not answer in text.",
  "tools": [{
    "type": "function",
    "name": "get_weather",
    "description": "Get synthetic weather for a city.",
    "parameters": {
      "type": "object",
      "properties": {
        "city": {"type": "string"},
        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]}
      },
      "required": ["city", "unit"],
      "additionalProperties": false
    }
  }]
}
```

Before the fix, the live stream terminated with this error

```text
data: {"error":{"message":"litellm.MidStreamFallbackError: ... Error parsing chunk: Chat provider: Invalid function argument delta {'type': 'response.function_call_arguments.delta', 'delta': '', 'sequence_number': 3} ...","code":"500"}}
```

That capture used the v1.91.0 parser with SHA-256 `e4f981dd6b504142a3533ee268c622b8de4e49a76fbfb7991f71c6eaf1fa87c7`, which is byte-for-byte identical to the parser in base commit `6a797f97b22d74cc5603ddacb16e38bf4a259858` and image `v1.93.0-rc.1` at digest `sha256:2fdd90b14e3d9244ce297f418b983d8cfd90ba6e72a10a8ddb30f7cf64852390`

After applying the fix in this PR to that RC image, the parser SHA-256 was `edafca2d90b397a162c163fff7f293e9f5aafb029bc6fff0f486be9ff6e64b48`, exactly matching the committed file, and both real-provider calls completed

```text
PHASE=after MODEL=codex-baseten-kimi-k2-7-code HTTP=200 CURL=0 DELTAS=5 COMPLETED=1 DONE=1 FAILURES=0
PHASE=after MODEL=codex-baseten-glm-5-2 HTTP=200 CURL=0 DELTAS=5 COMPLETED=1 DONE=1 FAILURES=0
```

## Type

🐛 Bug Fix

## Changes

The Responses-to-chat stream adapter used truthiness to validate function argument deltas, so the valid string `""` followed the same error path as a missing delta

This changes the guard to accept any string while continuing to reject missing, `None`, and non-string values, and adds a focused regression test for the empty-string event
