### PR TITLE
fix: normalize Replicate runtime pricing to seconds

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -699,12 +699,12 @@ def get_replicate_completion_pricing(completion_response: dict, total_time=0.0):
     a100_80gb_price_per_second_public = (
         DEFAULT_REPLICATE_GPU_PRICE_PER_SECOND  # assume all calls sent to A100 80GB for now
     )
-    if total_time == 0.0:  # total time is in ms
+    if total_time == 0.0:  # total time is in seconds
         start_time = completion_response.get("created", time.time())
-        end_time = getattr(completion_response, "ended", time.time())
+        end_time = completion_response.get("ended", time.time())
         total_time = end_time - start_time
 
-    return a100_80gb_price_per_second_public * total_time / 1000
+    return a100_80gb_price_per_second_public * total_time
 
 
 def has_hidden_params(obj: Any) -> bool:
@@ -1164,6 +1164,7 @@ def completion_cost(
         - For un-mapped Replicate models, the cost is calculated based on the total time used for the request.
     """
     try:
+        replicate_total_time_seconds = total_time or 0.0
         call_type = _infer_call_type(call_type, completion_response) or "completion"
 
         if (
@@ -1283,7 +1284,10 @@ def completion_cost(
                         prompt_tokens_details = _usage.get("prompt_tokens_details") or {}
                         cache_read_input_tokens = prompt_tokens_details.get("cached_tokens", 0)
 
-                    total_time = getattr(completion_response, "_response_ms", 0)
+                    response_time_ms: float = getattr(completion_response, "_response_ms", 0) or 0
+                    total_time = response_time_ms
+                    if replicate_total_time_seconds == 0.0:
+                        replicate_total_time_seconds = response_time_ms / 1000
 
                     hidden_params = getattr(completion_response, "_hidden_params", None)
                     if hidden_params is not None:
@@ -1521,7 +1525,7 @@ def completion_cost(
                 # see https://replicate.com/pricing
                 elif (model in litellm.replicate_models or "replicate" in model) and model not in litellm.model_cost:
                     # for unmapped replicate model, default to replicate's time tracking logic
-                    return get_replicate_completion_pricing(completion_response, total_time)  # type: ignore
+                    return get_replicate_completion_pricing(completion_response, replicate_total_time_seconds)  # type: ignore
 
                 if model is None:
                     raise ValueError(

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -11,16 +11,38 @@ sys.path.insert(
 from pydantic import BaseModel
 
 import litellm
+from litellm.constants import DEFAULT_REPLICATE_GPU_PRICE_PER_SECOND
 from litellm.cost_calculator import (
     RealtimeAPITokenUsageProcessor,
     completion_cost,
     cost_per_token,
+    get_replicate_completion_pricing,
     handle_realtime_stream_cost_calculation,
     response_cost_calculator,
 )
 from litellm.types.llms.openai import OpenAIRealtimeStreamList
 from litellm.types.utils import ModelResponse, PromptTokensDetailsWrapper, Usage
 from litellm.utils import TranscriptionResponse
+
+
+def test_unmapped_replicate_cost_with_explicit_seconds():
+    cost = completion_cost(model="replicate/unmapped-runtime", total_time=2.0)
+    assert cost == pytest.approx(DEFAULT_REPLICATE_GPU_PRICE_PER_SECOND * 2.0)
+
+
+def test_unmapped_replicate_cost_with_timestamp_fallback():
+    response = {"created": 10.0, "ended": 12.0}
+    cost = get_replicate_completion_pricing(response)
+    assert cost == pytest.approx(DEFAULT_REPLICATE_GPU_PRICE_PER_SECOND * 2.0)
+
+
+def test_unmapped_replicate_cost_converts_response_ms_to_seconds():
+    model = "replicate/unmapped-runtime"
+    response = ModelResponse(model=model)
+    response._response_ms = 2000.0
+
+    cost = completion_cost(model=model, completion_response=response)
+    assert cost == pytest.approx(DEFAULT_REPLICATE_GPU_PRICE_PER_SECOND * 2.0)
 
 
 def test_cost_per_token_duplicate_openai_prefix_matches_model_cost(monkeypatch):


### PR DESCRIPTION
## Relevant issues

Fixes #33328

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests) — local CI-parity checks pass; GitHub CI is pending
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Direct calculation against staging commit `9cca6c3e`:

```text
commit=9cca6c3e actual=2.8e-06 expected=0.0028 ratio=0.001
AssertionError
```

The same calculation after commit `458c8a56`, including timestamp and `_response_ms` paths:

```text
commit=458c8a56 explicit=0.0028 fallback=0.0028 response_ms=0.0028 expected=0.0028
```

## Type

🐛 Bug Fix

## Changes

- Keep Replicate's internal runtime pricing in seconds, matching the public `completion_cost(total_time=...)` contract and timestamp fallback.
- Convert `_response_ms` to seconds only when it feeds unmapped Replicate pricing, while preserving milliseconds for other cost paths.
- Cover explicit seconds, timestamp fallback, and response-millisecond conversion with focused regression tests.

## QA runbook

N/A — this change adds pure unit tests and does not modify proxy E2E behavior.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

## Local validation

- `uv run pytest tests/test_litellm/test_cost_calculator.py -q` — 82 passed
- `uv run ruff check litellm/cost_calculator.py` — passed
- `uv run ruff format --check litellm/cost_calculator.py` — passed
- `uv run python scripts/ruff_strict_gate.py --base upstream/litellm_internal_staging` — passed
- repository basedpyright budget gate against staging — passed
- `git diff --check` — passed
