### PR TITLE
fix: validate_environment returns false all-clear for zai when ZAI_API_KEY is unset (fixes #32962)

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -6141,6 +6141,11 @@ def validate_environment(
                 keys_in_environment = True
             else:
                 missing_keys.append("MOONSHOT_API_KEY")
+        elif custom_llm_provider == "zai":
+            if "ZAI_API_KEY" in os.environ:
+                keys_in_environment = True
+            else:
+                missing_keys.append("ZAI_API_KEY")
     else:
         ## openai - chatcompletion + text completion
         if (

--- a/tests/local_testing/test_validate_environment_zai.py
+++ b/tests/local_testing/test_validate_environment_zai.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: MIT
+# Tests for validate_environment fix: zai provider was missing from the
+# elif chain in litellm/utils.py, causing a false all-clear when ZAI_API_KEY
+# is unset (fixes #32962).
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import litellm
+
+
+def test_zai_missing_key_reports_missing(monkeypatch):
+    monkeypatch.delenv("ZAI_API_KEY", raising=False)
+    result = litellm.validate_environment(model="zai/glm-5.1")
+    assert result["keys_in_environment"] is False
+    assert "ZAI_API_KEY" in result["missing_keys"]
+
+
+def test_zai_key_present_reports_ok(monkeypatch):
+    monkeypatch.setenv("ZAI_API_KEY", "test-key-123")
+    result = litellm.validate_environment(model="zai/glm-5.1")
+    assert result["keys_in_environment"] is True
+    assert "ZAI_API_KEY" not in result["missing_keys"]
+
+
+def test_moonshot_missing_key_still_reports_missing(monkeypatch):
+    """Regression: moonshot neighbour branch still works after the zai addition."""
+    monkeypatch.delenv("MOONSHOT_API_KEY", raising=False)
+    result = litellm.validate_environment(model="moonshot/kimi-k2")
+    assert result["keys_in_environment"] is False
+    assert "MOONSHOT_API_KEY" in result["missing_keys"]


### PR DESCRIPTION
## Summary

Fixes #32962 — `validate_environment()` reported `keys_in_environment: True` and `missing_keys: []` for `zai` models even when `ZAI_API_KEY` was not set.

## Root cause

`validate_environment` in `litellm/utils.py` resolves the provider and walks an explicit `elif` chain. `zai` was not in the chain — `missing_keys` was never populated, so the function failed open with a false all-clear. Sibling providers `moonshot` and `dashscope` are handled correctly; `zai` was simply missed when the provider was added.

`ZAI_API_KEY` is the canonical env var, confirmed in `litellm/llms/zai/chat/transformation.py`.

## Fix

One branch added after `moonshot`, mirroring the existing pattern exactly:

```python
elif custom_llm_provider == "zai":
    if "ZAI_API_KEY" in os.environ:
        keys_in_environment = True
    else:
        missing_keys.append("ZAI_API_KEY")
```

## Tests

`tests/local_testing/test_validate_environment_zai.py` — 3 tests, all passing:

| Test | Asserts |
|------|---------|
| `test_zai_missing_key_reports_missing` | no key → `keys_in_environment: False`, `missing_keys: ['ZAI_API_KEY']` |
| `test_zai_key_present_reports_ok` | key set → `keys_in_environment: True`, no missing keys |
| `test_moonshot_missing_key_still_reports_missing` | regression guard for neighbouring branch |

First test fails on unfixed `main`; all 3 pass with the fix.