### PR TITLE
fix(proxy): skip key budget checks for model discovery

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1346,20 +1346,12 @@ async def _user_api_key_auth_builder(
                             valid_token = auto_registered
                             api_key = valid_token.token or ""
 
-                    # Check if model has zero cost - if so, skip all budget checks
-                    model = _get_model_from_request_context(
+                    skip_budget_checks = _should_skip_budget_checks(
                         request_data=request_data,
                         route=route,
                         request=request,
                         llm_router=llm_router,
                     )
-                    skip_budget_checks = False
-                    if model is not None and llm_router is not None:
-                        from litellm.proxy.auth.auth_checks import _is_model_cost_zero
-
-                        skip_budget_checks = _is_model_cost_zero(model=model, llm_router=llm_router)
-                        if skip_budget_checks:
-                            verbose_proxy_logger.info(f"Skipping all budget checks for zero-cost model: {model}")
 
                     # Fetch project object for JWT path if project_id is set
                     _jwt_project_obj = None
@@ -1733,20 +1725,13 @@ async def _user_api_key_auth_builder(
                         f"User={valid_token.user_id} has been deactivated via SCIM. Keys owned by this user cannot be used."
                     )
 
-            # Check 2a. Check if model has zero cost - if so, skip all budget checks
-            model = _get_model_from_request_context(
+            # Check 2a. Skip budget checks for non-spending routes and zero-cost models.
+            skip_budget_checks = _should_skip_budget_checks(
                 request_data=request_data,
                 route=route,
                 request=request,
                 llm_router=llm_router,
             )
-            skip_budget_checks = False
-            if model is not None and llm_router is not None:
-                from litellm.proxy.auth.auth_checks import _is_model_cost_zero
-
-                skip_budget_checks = _is_model_cost_zero(model=model, llm_router=llm_router)
-                if skip_budget_checks:
-                    verbose_proxy_logger.info(f"Skipping all budget checks for zero-cost model: {model}")
 
             # Check 3. Check if user is in their team budget
             if not skip_budget_checks and valid_token.team_member_spend is not None:

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1346,13 +1346,6 @@ async def _user_api_key_auth_builder(
                             valid_token = auto_registered
                             api_key = valid_token.token or ""
 
-                    skip_budget_checks = _should_skip_budget_checks(
-                        request_data=request_data,
-                        route=route,
-                        request=request,
-                        llm_router=llm_router,
-                    )
-
                     # Fetch project object for JWT path if project_id is set
                     _jwt_project_obj = None
                     if valid_token.project_id is not None:
@@ -2438,6 +2431,7 @@ def _should_skip_budget_checks(
     llm_router: Optional[Any],
 ) -> bool:
     if route in MODEL_DISCOVERY_ROUTES:
+        verbose_proxy_logger.info("Skipping budget checks for model discovery route: %s", route)
         return True
     model = _get_model_from_request_context(
         request_data=request_data,
@@ -2445,8 +2439,9 @@ def _should_skip_budget_checks(
         request=request,
         llm_router=llm_router,
     )
-    if model is not None and llm_router is not None:
-        return _is_model_cost_zero(model=model, llm_router=llm_router)
+    if model is not None and llm_router is not None and _is_model_cost_zero(model=model, llm_router=llm_router):
+        verbose_proxy_logger.info("Skipping budget checks for zero-cost model: %s", model)
+        return True
     return False
 
 

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -31,6 +31,7 @@ from litellm.litellm_core_utils.dot_notation_indexing import get_nested_value
 from litellm.proxy._types import *
 from litellm.proxy.auth.auth_checks import (
     ExperimentalUIJWTToken,
+    MODEL_DISCOVERY_ROUTES,
     _cache_key_object,
     _can_object_call_model,
     _check_end_user_budget,
@@ -2451,6 +2452,8 @@ def _should_skip_budget_checks(
     request: Optional[Request],
     llm_router: Optional[Any],
 ) -> bool:
+    if route in MODEL_DISCOVERY_ROUTES:
+        return True
     model = _get_model_from_request_context(
         request_data=request_data,
         route=route,

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -55,14 +55,51 @@ class _RoutingRequest:
 
 @pytest.mark.parametrize("route", ["/models", "/v1/models"])
 def test_model_discovery_routes_skip_virtual_key_budget_checks(route):
-    assert (
-        _should_skip_budget_checks(
-            request_data={},
-            route=route,
-            request=None,
-            llm_router=None,
+    with patch(
+        "litellm.proxy.auth.user_api_key_auth.verbose_proxy_logger.info"
+    ) as mock_info:
+        assert (
+            _should_skip_budget_checks(
+                request_data={},
+                route=route,
+                request=None,
+                llm_router=None,
+            )
+            is True
         )
-        is True
+
+    mock_info.assert_called_once_with(
+        "Skipping budget checks for model discovery route: %s", route
+    )
+
+
+def test_zero_cost_model_skip_logs_budget_bypass():
+    llm_router = MagicMock()
+    with (
+        patch(
+            "litellm.proxy.auth.user_api_key_auth._get_model_from_request_context",
+            return_value="free-model",
+        ),
+        patch(
+            "litellm.proxy.auth.user_api_key_auth._is_model_cost_zero",
+            return_value=True,
+        ),
+        patch(
+            "litellm.proxy.auth.user_api_key_auth.verbose_proxy_logger.info"
+        ) as mock_info,
+    ):
+        assert (
+            _should_skip_budget_checks(
+                request_data={"model": "free-model"},
+                route="/v1/chat/completions",
+                request=None,
+                llm_router=llm_router,
+            )
+            is True
+        )
+
+    mock_info.assert_called_once_with(
+        "Skipping budget checks for zero-cost model: %s", "free-model"
     )
 
 

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -39,6 +39,7 @@ from litellm.proxy.auth.user_api_key_auth import (
     _routing_selector_matches_claim,
     _run_centralized_common_checks,
     _run_post_custom_auth_checks,
+    _should_skip_budget_checks,
     _user_api_key_auth_builder,
     get_api_key,
     user_api_key_auth,
@@ -50,6 +51,31 @@ class _RoutingRequest:
         self.headers = headers or {}
         self.query_params = query_params or {}
         self.state = SimpleNamespace()
+
+
+@pytest.mark.parametrize("route", ["/models", "/v1/models"])
+def test_model_discovery_routes_skip_virtual_key_budget_checks(route):
+    assert (
+        _should_skip_budget_checks(
+            request_data={},
+            route=route,
+            request=None,
+            llm_router=None,
+        )
+        is True
+    )
+
+
+def test_inference_routes_do_not_skip_virtual_key_budget_checks():
+    assert (
+        _should_skip_budget_checks(
+            request_data={},
+            route="/v1/chat/completions",
+            request=None,
+            llm_router=None,
+        )
+        is False
+    )
 
 
 def test_get_api_key():

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -78,6 +78,86 @@ def test_inference_routes_do_not_skip_virtual_key_budget_checks():
     )
 
 
+@pytest.mark.parametrize("route", ["/models", "/v1/models"])
+@pytest.mark.asyncio
+async def test_model_discovery_bypasses_virtual_key_budget_in_auth_builder(route):
+    from fastapi import Request
+
+    import litellm.proxy.proxy_server as proxy_server
+    from litellm.proxy._types import LitellmUserRoles
+    from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
+    from litellm.proxy.utils import hash_token
+
+    api_key = "sk-model-discovery-budget-test"
+    valid_token = UserAPIKeyAuth(
+        api_key=api_key,
+        token=hash_token(api_key),
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        max_budget=0.0,
+        spend=0.0,
+    )
+    mock_cache = AsyncMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=valid_token)
+    mock_logging = MagicMock()
+    mock_logging.internal_usage_cache.dual_cache = AsyncMock()
+    attrs = {
+        "prisma_client": MagicMock(),
+        "user_api_key_cache": mock_cache,
+        "proxy_logging_obj": mock_logging,
+        "master_key": "sk-master-key",
+        "general_settings": {},
+        "llm_model_list": [],
+        "llm_router": None,
+        "open_telemetry_logger": None,
+        "model_max_budget_limiter": MagicMock(),
+        "user_custom_auth": None,
+        "jwt_handler": None,
+        "litellm_proxy_admin_name": "admin",
+    }
+    originals = {name: getattr(proxy_server, name, None) for name in attrs}
+
+    try:
+        for name, value in attrs.items():
+            setattr(proxy_server, name, value)
+
+        request = Request(
+            scope={
+                "type": "http",
+                "path": route,
+                "root_path": "",
+                "headers": [],
+                "query_string": b"",
+                "method": "GET",
+            }
+        )
+        with (
+            patch(
+                "litellm.proxy.auth.resolvers.store.IdentityStore._resolve_key",
+                new_callable=AsyncMock,
+                return_value=valid_token,
+            ),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth._virtual_key_max_budget_check",
+                new_callable=AsyncMock,
+            ) as max_budget_check,
+        ):
+            result = await _user_api_key_auth_builder(
+                request=request,
+                api_key=f"Bearer {api_key}",
+                azure_api_key_header="",
+                anthropic_api_key_header=None,
+                google_ai_studio_api_key_header=None,
+                azure_apim_header=None,
+                request_data={},
+            )
+
+        assert result.token == valid_token.token
+        max_budget_check.assert_not_awaited()
+    finally:
+        for name, value in originals.items():
+            setattr(proxy_server, name, value)
+
+
 def test_get_api_key():
     bearer_token = "Bearer sk-12345678"
     api_key = "sk-12345678"


### PR DESCRIPTION
## Relevant issues

Fixes #27923

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (the relevant proxy-auth, lint, code-quality, and secret-scan checks pass; documentation and OSV currently fail on unrelated base-branch files)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

End-to-end test against a running proxy and a temporary virtual key with `max_budget=0`:

Before the corrected auth-builder change, commit `01c37d4e90` still failed during early virtual-key auth:

```text
models_status=429
models_body={"error":{"message":"Budget has been exceeded! ... Current cost: 0.0, Max budget: 0.0"}}
alias_status=429
chat_status=429
```

After the fix:

```text
models_status=200
alias_status=200
chat_status=429
unauthenticated_status=401
```

This proves exhausted keys can discover only their allowed models while inference remains budget-blocked and unauthenticated discovery remains rejected

## Type

Bug Fix

## Changes

- Reuse `MODEL_DISCOVERY_ROUTES` when deciding whether to run virtual-key budget checks
- Apply the decision before early budget enforcement for regular virtual keys and centralized common checks
- Keep budget checks enabled for inference routes
- Log model-discovery and zero-cost-model budget bypasses from the shared decision helper
- Add auth-builder regression coverage for `/models` and `/v1/models`, plus inference and observability coverage
