### PR TITLE
feat(pricing): add Veo 3.1 Lite generate model

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -20038,6 +20038,21 @@
             "video"
         ]
     },
+    "gemini/veo-3.1-lite-generate-001": {
+        "litellm_provider": "gemini",
+        "max_input_tokens": 1024,
+        "max_tokens": 1024,
+        "mode": "video_generation",
+        "output_cost_per_second": 0.05,
+        "output_cost_per_second_1080p": 0.08,
+        "source": "https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ]
+    },
     "gemini/veo-3.1-fast-generate-001": {
         "litellm_provider": "gemini",
         "max_input_tokens": 1024,
@@ -37671,6 +37686,21 @@
         "mode": "video_generation",
         "output_cost_per_second": 0.15,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/veo",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ]
+    },
+    "vertex_ai/veo-3.1-lite-generate-001": {
+        "litellm_provider": "vertex_ai-video-models",
+        "max_input_tokens": 1024,
+        "max_tokens": 1024,
+        "mode": "video_generation",
+        "output_cost_per_second": 0.05,
+        "output_cost_per_second_1080p": 0.08,
+        "source": "https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/veo/3-1-generate",
         "supported_modalities": [
             "text"
         ],

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -20199,6 +20199,21 @@
             "video"
         ]
     },
+    "gemini/veo-3.1-lite-generate-001": {
+        "litellm_provider": "gemini",
+        "max_input_tokens": 1024,
+        "max_tokens": 1024,
+        "mode": "video_generation",
+        "output_cost_per_second": 0.05,
+        "output_cost_per_second_1080p": 0.08,
+        "source": "https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ]
+    },
     "gemini/veo-3.1-fast-generate-001": {
         "litellm_provider": "gemini",
         "max_input_tokens": 1024,
@@ -37873,6 +37888,21 @@
         "mode": "video_generation",
         "output_cost_per_second": 0.15,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/veo",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "video"
+        ]
+    },
+    "vertex_ai/veo-3.1-lite-generate-001": {
+        "litellm_provider": "vertex_ai-video-models",
+        "max_input_tokens": 1024,
+        "max_tokens": 1024,
+        "mode": "video_generation",
+        "output_cost_per_second": 0.05,
+        "output_cost_per_second_1080p": 0.08,
+        "source": "https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/veo/3-1-generate",
         "supported_modalities": [
             "text"
         ],

--- a/tests/test_litellm/litellm_core_utils/test_get_model_cost_map.py
+++ b/tests/test_litellm/litellm_core_utils/test_get_model_cost_map.py
@@ -4,8 +4,10 @@ count actual model entries, not reserved meta keys) and the extraction of the
 ``fallback_generalizations`` block out of the raw map.
 """
 
+import json
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -23,6 +25,35 @@ from litellm.litellm_core_utils.get_model_cost_map import (
     _count_model_entries,
     _finalize_model_cost_map,
 )
+
+
+def test_veo_31_lite_generate_001_model_cost_map_entries():
+    repo_root = Path(__file__).parents[3]
+    root_map = json.loads(
+        (repo_root / "model_prices_and_context_window.json").read_text()
+    )
+    backup_map = GetModelCostMap.load_local_model_cost_map()
+
+    expected = {
+        "max_input_tokens": 1024,
+        "max_tokens": 1024,
+        "mode": "video_generation",
+        "output_cost_per_second": 0.05,
+        "output_cost_per_second_1080p": 0.08,
+        "supported_modalities": ["text"],
+        "supported_output_modalities": ["video"],
+    }
+    provider_by_model = {
+        "gemini/veo-3.1-lite-generate-001": "gemini",
+        "vertex_ai/veo-3.1-lite-generate-001": "vertex_ai-video-models",
+    }
+
+    for model_map in [root_map, backup_map]:
+        for model, provider in provider_by_model.items():
+            entry = model_map[model]
+            for key, value in expected.items():
+                assert entry[key] == value
+            assert entry["litellm_provider"] == provider
 
 
 def _make_models(n: int) -> dict:
@@ -133,7 +164,10 @@ def test_shipped_backup_carries_the_claude_routing_rules():
     try:
         set_fallback_generalizations(rules)
         assert match_routing_generalization("claude-opus-4-9") == "anthropic"
-        assert match_routing_generalization("global.anthropic.claude-opus-4-9") == "bedrock"
+        assert (
+            match_routing_generalization("global.anthropic.claude-opus-4-9")
+            == "bedrock"
+        )
     finally:
         set_fallback_generalizations(previous)
 
@@ -152,7 +186,9 @@ def test_shipped_backup_marks_claude_4_6_plus_adaptive_not_4_0():
 
     rules = backup[FALLBACK_GENERALIZATIONS_KEY]["rules"]
     baseline_rule = next(r for r in rules if r.get("name") == "claude-family-baseline")
-    adaptive_rule = next(r for r in rules if r.get("name") == "claude-adaptive-thinking")
+    adaptive_rule = next(
+        r for r in rules if r.get("name") == "claude-adaptive-thinking"
+    )
     assert "supports_adaptive_thinking" not in baseline_rule["model_info"]
     assert "litellm_provider" not in baseline_rule["model_info"]
     assert adaptive_rule["model_info"] == {"supports_adaptive_thinking": True}


### PR DESCRIPTION
## Relevant issues

Closes #33199

## Linear ticket


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes the relevant local checks for this isolated pricing-map change
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Validated locally with:

- `python -m pytest tests/test_litellm/litellm_core_utils/test_get_model_cost_map.py -q`
- `python -m black --check tests/test_litellm/litellm_core_utils/test_get_model_cost_map.py`
- `python -m json.tool model_prices_and_context_window.json`
- `python -m json.tool litellm/model_prices_and_context_window_backup.json`
- `git diff --check`

Official sources:

- Model details: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/veo/3-1-generate
- Pricing: https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing

## Type

? Test

## Changes

- Added `gemini/veo-3.1-lite-generate-001` to `model_prices_and_context_window.json` and the shipped backup map.
- Added `vertex_ai/veo-3.1-lite-generate-001` alongside the existing Vertex AI Veo 3.1 GA entries.
- Added a regression test to keep the root and backup cost maps in sync for both provider entries.