### PR TITLE
fix(streaming_chunk_builder): handle empty choices and missing delta role in build_base_response

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -164,7 +164,15 @@ class ChunkProcessor:
         system_fingerprint = chunk.get("system_fingerprint", None)
 
         first_chunk_with_choices = next((c for c in chunks if c.get("choices")), chunk)
-        role = first_chunk_with_choices["choices"][0]["delta"]["role"]
+        if (
+            first_chunk_with_choices.get("choices")
+            and len(first_chunk_with_choices["choices"]) > 0
+            and first_chunk_with_choices["choices"][0].get("delta")
+            and "role" in first_chunk_with_choices["choices"][0]["delta"]
+        ):
+            role = first_chunk_with_choices["choices"][0]["delta"]["role"]
+        else:
+            role = "assistant"
         finish_reason = "stop"
         for chunk in chunks:
             if "choices" in chunk and len(chunk["choices"]) > 0:

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -252,7 +252,15 @@ class ChunkProcessor:
         system_fingerprint: Final = chunk.get("system_fingerprint", None)
 
         first_chunk_with_choices: Final = next((c for c in chunks if c.get("choices")), chunk)
-        role: Final = first_chunk_with_choices["choices"][0]["delta"]["role"]
+        if (
+            first_chunk_with_choices.get("choices")
+            and len(first_chunk_with_choices["choices"]) > 0
+            and first_chunk_with_choices["choices"][0].get("delta")
+            and "role" in first_chunk_with_choices["choices"][0]["delta"]
+        ):
+            role: Final = first_chunk_with_choices["choices"][0]["delta"]["role"]
+        else:
+            role = "assistant"
         finish_reason = "stop"
         for chunk in chunks:
             if "choices" in chunk and len(chunk["choices"]) > 0:

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils_empty_choices.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils_empty_choices.py
@@ -1,0 +1,58 @@
+
+from litellm.litellm_core_utils.streaming_chunk_builder_utils import ChunkProcessor
+
+
+def test_build_base_response_handles_empty_choices():
+    """
+    Regression test for the IndexError in ChunkProcessor.build_base_response
+    when a usage-only chunk has an empty choices list before content chunks
+    arrive. build_base_response should default to role='assistant'.
+    """
+    chunks = [
+        {
+            "id": "chatcmpl-empty-choices",
+            "object": "chat.completion.chunk",
+            "created": 1234567890,
+            "model": "gpt-4.1-mini",
+            "choices": [],
+        },
+        {
+            "id": "chatcmpl-empty-choices",
+            "object": "chat.completion.chunk",
+            "created": 1234567890,
+            "model": "gpt-4.1-mini",
+            "choices": [
+                {"index": 0, "delta": {"role": "assistant", "content": "hello"}}
+            ],
+        },
+    ]
+
+    processor = ChunkProcessor(chunks=chunks)
+    response = processor.build_base_response(chunks)
+
+    assert response.choices[0].message.role == "assistant"
+    assert response.choices[0].message.content == ""
+
+
+def test_build_base_response_falls_back_to_assistant_when_role_missing():
+    """
+    When no chunk carries a delta with a role, build_base_response should still
+    produce a valid response and default to 'assistant'.
+    """
+    chunks = [
+        {
+            "id": "chatcmpl-no-role",
+            "object": "chat.completion.chunk",
+            "created": 1234567890,
+            "model": "gpt-4.1-mini",
+            "choices": [
+                {"index": 0, "delta": {"content": "hello"}}
+            ],
+        }
+    ]
+
+    processor = ChunkProcessor(chunks=chunks)
+    response = processor.build_base_response(chunks)
+
+    assert response.choices[0].message.role == "assistant"
+    assert response.choices[0].message.content == ""

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils_empty_choices.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils_empty_choices.py
@@ -1,0 +1,66 @@
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.litellm_core_utils.streaming_chunk_builder_utils import ChunkProcessor
+
+
+def test_build_base_response_all_chunks_empty_choices():
+    """
+    Regression test for the IndexError in ChunkProcessor.build_base_response
+    when every chunk has choices=[] (e.g. Anthropic usage-only events).
+    ``next((c for c in chunks if c.get("choices")), chunk)`` skips every chunk
+    (empty list is falsy) and falls back to ``chunk``, whose ``choices`` is also
+    ``[]`` — the old code then did ``choices[0]`` and raised IndexError.
+    build_base_response should default to role='assistant'.
+    """
+    chunks = [
+        {
+            "id": "chatcmpl-all-empty-choices",
+            "object": "chat.completion.chunk",
+            "created": 1234567890,
+            "model": "gpt-4.1-mini",
+            "choices": [],
+        },
+        {
+            "id": "chatcmpl-all-empty-choices",
+            "object": "chat.completion.chunk",
+            "created": 1234567890,
+            "model": "gpt-4.1-mini",
+            "choices": [],
+        },
+    ]
+
+    processor = ChunkProcessor(chunks=chunks)
+    response = processor.build_base_response(chunks)
+
+    assert response.choices[0].message.role == "assistant"
+    assert response.choices[0].message.content == ""
+
+
+def test_build_base_response_falls_back_to_assistant_when_role_missing():
+    """
+    When a chunk has non-empty choices but its delta omits the role key,
+    build_base_response should still produce a valid response and default
+    to 'assistant'.
+    """
+    chunks = [
+        {
+            "id": "chatcmpl-no-role",
+            "object": "chat.completion.chunk",
+            "created": 1234567890,
+            "model": "gpt-4.1-mini",
+            "choices": [
+                {"index": 0, "delta": {"content": "hello"}}
+            ],
+        }
+    ]
+
+    processor = ChunkProcessor(chunks=chunks)
+    response = processor.build_base_response(chunks)
+
+    assert response.choices[0].message.role == "assistant"
+    assert response.choices[0].message.content == ""


### PR DESCRIPTION
## Relevant issues

Fixes the `IndexError: list index out of range` in `stream_chunk_builder` reported on `v1.93.0-rc.1` when streaming providers emit usage-only chunks with `choices: []`.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Type

🐛 Bug Fix

## Changes

`ChunkProcessor.build_base_response` previously assumed that the first chunk containing a `choices` key also had a non-empty `choices` array with `choices[0].delta.role`. Some streaming providers (for example Anthropic with usage-only events) can send a chunk where `choices` is empty before content chunks arrive. This caused:

```
role = first_chunk_with_choices["choices"][0]["delta"]["role"]
IndexError: list index out of range
```

This change makes the role extraction defensive: if the first chunk with choices has an non-empty choices array and the first choice's delta contains a role, use it; otherwise default to `role = "assistant"`.

- `litellm/litellm_core_utils/streaming_chunk_builder_utils.py`: defensive role lookup with fallback.
- `tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils_empty_choices.py`: regression tests for empty choices and missing delta role.

## Screenshots / Proof of Fix

```
$ .venv/bin/pytest tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils_empty_choices.py -v
...
2 passed

$ .venv/bin/pytest tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py -v
...
16 passed
```

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
