### PR TITLE
fix(router): honor weights when first deployment has none in simple-shuffle

### DIFF
--- a/litellm/router_strategy/simple_shuffle.py
+++ b/litellm/router_strategy/simple_shuffle.py
@@ -41,8 +41,7 @@ def simple_shuffle(
 
     ############## Check if 'weight' or 'rpm' or 'tpm' param set for a weighted pick #################
     for weight_by in ["weight", "rpm", "tpm"]:
-        weight = healthy_deployments[0].get("litellm_params").get(weight_by, None)
-        if weight is not None:
+        if any(m["litellm_params"].get(weight_by) is not None for m in healthy_deployments):
             weights = [m["litellm_params"].get(weight_by, 0) for m in healthy_deployments]
             verbose_router_logger.debug(f"\nweight {weights}")
             total_weight = sum(weights)

--- a/tests/test_litellm/router_strategy/test_simple_shuffle.py
+++ b/tests/test_litellm/router_strategy/test_simple_shuffle.py
@@ -1,0 +1,44 @@
+"""Tests for litellm/router_strategy/simple_shuffle.py"""
+
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))  # Adds the parent directory to the system path
+
+from litellm.router_strategy.simple_shuffle import simple_shuffle
+
+
+@pytest.mark.parametrize("weight_by", ["weight", "rpm", "tpm"])
+def test_weighted_pick_used_when_only_a_later_deployment_sets_metric(weight_by: str):
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/33329
+
+    Weighted routing must be enabled when any healthy deployment sets the
+    metric, regardless of list order. Previously only the first deployment
+    was inspected, so a metric set only on a later deployment silently
+    degraded routing to a uniform random pick.
+    """
+    router = SimpleNamespace(print_deployment=lambda deployment: str(deployment))
+    unweighted = {"model_name": "chat", "litellm_params": {"model": "openai/first"}}
+    weighted = {"model_name": "chat", "litellm_params": {"model": "openai/second", weight_by: 1}}
+
+    for deployments in ([unweighted, weighted], [weighted, unweighted]):
+        weighted_index = deployments.index(weighted)
+        with (
+            patch("litellm.router_strategy.simple_shuffle.random.choice") as uniform_pick,
+            patch(
+                "litellm.router_strategy.simple_shuffle.random.choices",
+                return_value=[weighted_index],
+            ) as weighted_pick,
+        ):
+            selected = simple_shuffle(router, deployments, "chat")
+
+        uniform_pick.assert_not_called()
+        weighted_pick.assert_called_once()
+        expected_weights = [0.0, 1.0] if weighted_index == 1 else [1.0, 0.0]
+        assert weighted_pick.call_args.kwargs["weights"] == expected_weights
+        assert selected["litellm_params"]["model"] == "openai/second"


### PR DESCRIPTION
## Relevant issues

Fixes #33329

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The bug is a pure routing decision inside simple_shuffle, so the proof runs the exact offline reproduction script from the issue body, which patches only the two random pick functions so the chosen routing path is observable and deterministic. Both runs use the identical script saved as repro_33329.py; the only variable is the checked out commit

Before, at base commit 10d5804b3ef4ead5abb77c3f5fafdd0c0159de0f (litellm_oss_daily_2026_07_14):

```shell
$ PYTHONPATH=. uv run --no-sync python repro_33329.py
openai/first
uniform calls: 1
weighted calls: 0
```

After, at fix commit ebb0c0de9dc27528210dc033fc1453f258b56119:

```shell
$ PYTHONPATH=. uv run --no-sync python repro_33329.py
openai/second
uniform calls: 0
weighted calls: 1
```

The deployment that has the configured weight is now selected through the weighted pick path, and reversing the deployment list no longer changes the routing mode; the regression test asserts both orders

## Type

Bug Fix

## Changes

simple_shuffle decided whether to use a weighted pick by reading the metric (weight, rpm, tpm) from healthy_deployments[0] only. When the first healthy deployment did not set the metric but a later one did, the function fell through to uniform random.choice, so whether configured weights were honored depended on list order, which shifts with cooldowns, filtering, and attempted-deployment exclusion

The fix enables a metric when any healthy deployment has a non-null value for it. The weight vector is still built with m["litellm_params"].get(weight_by, 0), so deployments without the metric keep contributing weight 0 and the existing zero-total fallthrough to the next metric is unchanged

Added tests/test_litellm/router_strategy/test_simple_shuffle.py with a regression test parametrized over weight, rpm, and tpm that puts the metric only on the second deployment, asserts the weighted path is used with the normalized weight vector, and repeats the assertion with the deployment list reversed
