### PR TITLE
fix(sap): forward extra_headers in chat and embed providers

### DIFF
--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -32,6 +32,7 @@ else:
     LiteLLMLoggingObj = Any
 
 from ..credentials import get_token_creator
+from ..headers import merge_sap_request_headers
 from .models import (
     ChatCompletionTool,
     OrchestrationRequest,
@@ -249,7 +250,7 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
             self.run_env_setup(api_key)
         if headers is None:
             headers = {}
-        return {**headers, **self.headers}
+        return merge_sap_request_headers(self.headers, headers)
 
     def get_complete_url(
         self,

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -247,7 +247,9 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
     ) -> dict:
         if api_key:
             self.run_env_setup(api_key)
-        return self.headers
+        if headers is None:
+            headers = {}
+        return {**self.headers, **headers}
 
     def get_complete_url(
         self,

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -249,7 +249,7 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
             self.run_env_setup(api_key)
         if headers is None:
             headers = {}
-        return {**self.headers, **headers}
+        return {**headers, **self.headers}
 
     def get_complete_url(
         self,

--- a/litellm/llms/sap/embed/transformation.py
+++ b/litellm/llms/sap/embed/transformation.py
@@ -132,7 +132,9 @@ class GenAIHubEmbeddingConfig(BaseEmbeddingConfig):
         return optional_params
 
     def validate_environment(self, headers: dict, *args, **kwargs) -> dict:
-        return self.headers
+        if headers is None:
+            headers = {}
+        return {**self.headers, **headers}
 
     def get_complete_url(
         self,

--- a/litellm/llms/sap/embed/transformation.py
+++ b/litellm/llms/sap/embed/transformation.py
@@ -134,7 +134,7 @@ class GenAIHubEmbeddingConfig(BaseEmbeddingConfig):
     def validate_environment(self, headers: dict, *args, **kwargs) -> dict:
         if headers is None:
             headers = {}
-        return {**self.headers, **headers}
+        return {**headers, **self.headers}
 
     def get_complete_url(
         self,

--- a/litellm/llms/sap/embed/transformation.py
+++ b/litellm/llms/sap/embed/transformation.py
@@ -18,6 +18,7 @@ from litellm.types.utils import EmbeddingResponse
 
 from ..chat.handler import GenAIHubOrchestrationError
 from ..credentials import get_token_creator
+from ..headers import merge_sap_request_headers
 
 
 class Usage(BaseModel):
@@ -134,7 +135,7 @@ class GenAIHubEmbeddingConfig(BaseEmbeddingConfig):
     def validate_environment(self, headers: dict, *args, **kwargs) -> dict:
         if headers is None:
             headers = {}
-        return {**headers, **self.headers}
+        return merge_sap_request_headers(self.headers, headers)
 
     def get_complete_url(
         self,

--- a/litellm/llms/sap/headers.py
+++ b/litellm/llms/sap/headers.py
@@ -1,4 +1,4 @@
-from typing import Dict, Mapping, Optional
+from typing import Mapping, Optional
 
 _SAP_RESERVED_HEADERS = frozenset(
     {
@@ -13,7 +13,7 @@ _SAP_RESERVED_HEADERS = frozenset(
 def merge_sap_request_headers(
     provider_headers: Mapping[str, str],
     caller_headers: Optional[Mapping[str, str]],
-) -> Dict[str, str]:
+) -> dict[str, str]:
     if not caller_headers:
         return dict(provider_headers)
 

--- a/litellm/llms/sap/headers.py
+++ b/litellm/llms/sap/headers.py
@@ -1,0 +1,23 @@
+from typing import Dict, Mapping, Optional
+
+_SAP_RESERVED_HEADERS = frozenset(
+    {
+        "authorization",
+        "ai-resource-group",
+        "content-type",
+        "ai-client-type",
+    }
+)
+
+
+def merge_sap_request_headers(
+    provider_headers: Mapping[str, str],
+    caller_headers: Optional[Mapping[str, str]],
+) -> Dict[str, str]:
+    if not caller_headers:
+        return dict(provider_headers)
+
+    safe_caller_headers = {
+        key: value for key, value in caller_headers.items() if key.lower() not in _SAP_RESERVED_HEADERS
+    }
+    return {**safe_caller_headers, **provider_headers}

--- a/litellm/llms/sap/headers.py
+++ b/litellm/llms/sap/headers.py
@@ -1,21 +1,22 @@
 from typing import Mapping
 
+
 _SAP_RESERVED_HEADERS = frozenset(
-    {
+    (
         "authorization",
         "ai-resource-group",
         "content-type",
         "ai-client-type",
-    }
+    )
 )
 
 
 def merge_sap_request_headers(
     provider_headers: Mapping[str, str],
     caller_headers: Mapping[str, str] | None,
-) -> dict[str, str]:
+) -> Mapping[str, str]:
     if not caller_headers:
-        return dict(provider_headers)
+        return provider_headers
 
     safe_caller_headers = {
         key: value for key, value in caller_headers.items() if key.lower() not in _SAP_RESERVED_HEADERS

--- a/litellm/llms/sap/headers.py
+++ b/litellm/llms/sap/headers.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Optional
+from typing import Mapping
 
 _SAP_RESERVED_HEADERS = frozenset(
     {
@@ -12,7 +12,7 @@ _SAP_RESERVED_HEADERS = frozenset(
 
 def merge_sap_request_headers(
     provider_headers: Mapping[str, str],
-    caller_headers: Optional[Mapping[str, str]],
+    caller_headers: Mapping[str, str] | None,
 ) -> dict[str, str]:
     if not caller_headers:
         return dict(provider_headers)

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -6737,6 +6737,7 @@ def embedding(
                 litellm_params={},
                 client=client,
                 aembedding=aembedding,
+                headers=headers,
             )
         elif custom_llm_provider == "azure_ai":
             api_base = (

--- a/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
+++ b/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
@@ -639,3 +639,32 @@ class TestSAPTransformationIntegration:
                 config["config"]["modules"][1]["translation"]["input"]["type"]
                 == "sap_document_translation"
             )
+
+    def test_validate_environment_merges_extra_headers(self, mock_config):
+        result = mock_config.validate_environment(
+            headers={
+                "ai-inference-observability-persistence-mode": "all",
+            },
+            model="gpt-4o",
+            messages=[],
+            optional_params={},
+            litellm_params={},
+        )
+
+        assert result["Authorization"] == "Bearer TEST_TOKEN"
+        assert result["AI-Resource-Group"] == "test-group"
+        assert result["Content-Type"] == "application/json"
+        assert result["AI-Client-Type"] == "LiteLLM"
+        assert result["ai-inference-observability-persistence-mode"] == "all"
+
+    def test_validate_environment_extra_headers_override_defaults(self, mock_config):
+        result = mock_config.validate_environment(
+            headers={"Content-Type": "application/xml"},
+            model="gpt-4o",
+            messages=[],
+            optional_params={},
+            litellm_params={},
+        )
+
+        assert result["Content-Type"] == "application/xml"
+        assert result["Authorization"] == "Bearer TEST_TOKEN"

--- a/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
+++ b/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
@@ -657,14 +657,22 @@ class TestSAPTransformationIntegration:
         assert result["AI-Client-Type"] == "LiteLLM"
         assert result["ai-inference-observability-persistence-mode"] == "all"
 
-    def test_validate_environment_extra_headers_override_defaults(self, mock_config):
+    def test_validate_environment_preserves_provider_auth_over_caller_headers(
+        self, mock_config
+    ):
         result = mock_config.validate_environment(
-            headers={"Content-Type": "application/xml"},
+            headers={
+                "Authorization": "Bearer PROXY_TOKEN",
+                "Content-Type": "application/xml",
+                "ai-inference-observability-persistence-mode": "all",
+            },
             model="gpt-4o",
             messages=[],
             optional_params={},
             litellm_params={},
         )
 
-        assert result["Content-Type"] == "application/xml"
         assert result["Authorization"] == "Bearer TEST_TOKEN"
+        assert result["Content-Type"] == "application/json"
+        assert result["AI-Resource-Group"] == "test-group"
+        assert result["ai-inference-observability-persistence-mode"] == "all"

--- a/tests/test_litellm/llms/sap/embed/test_sap_embed_transformation.py
+++ b/tests/test_litellm/llms/sap/embed/test_sap_embed_transformation.py
@@ -129,3 +129,4 @@ def test_validate_environment_merges_extra_headers(
         assert result["Authorization"] == "Bearer FAKE_TOKEN"
         assert result["AI-Resource-Group"] == "fake-group"
         assert result["custom-header"] == "custom-value"
+        assert result["Content-Type"] == "application/json"

--- a/tests/test_litellm/llms/sap/embed/test_sap_embed_transformation.py
+++ b/tests/test_litellm/llms/sap/embed/test_sap_embed_transformation.py
@@ -106,3 +106,26 @@ def test_embed_with_masking(fake_token_creator, fake_deployment_url):
             headers={},
         )
         assert body["config"]["modules"]["masking"] == masking_config
+
+
+def test_validate_environment_merges_extra_headers(
+    fake_token_creator, fake_deployment_url
+):
+    with (
+        patch(
+            "litellm.llms.sap.embed.transformation.GenAIHubEmbeddingConfig.deployment_url",
+            new_callable=PropertyMock,
+            return_value=fake_deployment_url,
+        ),
+        patch(
+            "litellm.llms.sap.embed.transformation.get_token_creator",
+            return_value=fake_token_creator,
+        ),
+    ):
+        result = GenAIHubEmbeddingConfig().validate_environment(
+            headers={"custom-header": "custom-value"},
+        )
+
+        assert result["Authorization"] == "Bearer FAKE_TOKEN"
+        assert result["AI-Resource-Group"] == "fake-group"
+        assert result["custom-header"] == "custom-value"

--- a/tests/test_litellm/llms/sap/embed/test_sap_embedding.py
+++ b/tests/test_litellm/llms/sap/embed/test_sap_embedding.py
@@ -1667,3 +1667,44 @@ async def test_sap_embedding_required_headers(
                 f"Header '{header_name}' has incorrect value. "
                 f"Expected: '{expected_value}', Got: '{request.headers[header_name]}'"
             )
+
+
+@pytest.mark.asyncio
+async def test_sap_embedding_forwards_extra_headers(
+    respx_mock,
+    sap_api_response,
+    fake_token_creator,
+    fake_deployment_url,
+):
+    import litellm
+
+    litellm.disable_aiohttp_transport = True
+    with (
+        patch(
+            "litellm.llms.sap.embed.transformation.GenAIHubEmbeddingConfig.deployment_url",
+            new_callable=PropertyMock,
+            return_value=fake_deployment_url,
+        ),
+        patch(
+            "litellm.llms.sap.embed.transformation.get_token_creator",
+            return_value=fake_token_creator,
+        ),
+    ):
+        model = "sap/text-embedding-3-small"
+        input = "Hi"
+        route = respx_mock.post(f"{fake_deployment_url}/v2/embeddings")
+        route.respond(json=sap_api_response)
+
+        response = await litellm.aembedding(
+            model=model,
+            input=input,
+            extra_headers={"ai-inference-observability-persistence-mode": "all"},
+        )
+
+        assert response
+        assert route.called
+        request = route.calls[0].request
+        assert (
+            request.headers["ai-inference-observability-persistence-mode"] == "all"
+        )
+        assert request.headers["Authorization"] == "Bearer FAKE_TOKEN"

--- a/tests/test_litellm/llms/sap/test_sap_headers.py
+++ b/tests/test_litellm/llms/sap/test_sap_headers.py
@@ -1,0 +1,44 @@
+from litellm.llms.sap.headers import merge_sap_request_headers
+
+
+def test_merge_sap_request_headers_forwards_custom_headers():
+    result = merge_sap_request_headers(
+        provider_headers={
+            "Authorization": "Bearer SAP_TOKEN",
+            "AI-Resource-Group": "default",
+            "Content-Type": "application/json",
+            "AI-Client-Type": "LiteLLM",
+        },
+        caller_headers={
+            "ai-inference-observability-persistence-mode": "all",
+        },
+    )
+
+    assert result["Authorization"] == "Bearer SAP_TOKEN"
+    assert result["ai-inference-observability-persistence-mode"] == "all"
+
+
+def test_merge_sap_request_headers_strips_reserved_headers_case_insensitively():
+    result = merge_sap_request_headers(
+        provider_headers={
+            "Authorization": "Bearer SAP_TOKEN",
+            "AI-Resource-Group": "default",
+            "Content-Type": "application/json",
+            "AI-Client-Type": "LiteLLM",
+        },
+        caller_headers={
+            "authorization": "Bearer PROXY_TOKEN",
+            "AI-RESOURCE-GROUP": "spoofed-group",
+            "Content-Type": "application/xml",
+            "ai-client-type": "spoofed-client",
+            "ai-inference-observability-persistence-mode": "all",
+        },
+    )
+
+    assert result["Authorization"] == "Bearer SAP_TOKEN"
+    assert result["AI-Resource-Group"] == "default"
+    assert result["Content-Type"] == "application/json"
+    assert result["AI-Client-Type"] == "LiteLLM"
+    assert result["ai-inference-observability-persistence-mode"] == "all"
+    assert "spoofed-group" not in result.values()
+    assert "Bearer PROXY_TOKEN" not in result.values()


### PR DESCRIPTION
## Relevant issues

Fixes #33368

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

```bash
.venv/bin/python -m pytest \
  tests/test_litellm/llms/sap/chat/test_sap_transformation.py::TestSAPTransformationIntegration::test_validate_environment_merges_extra_headers \
  tests/test_litellm/llms/sap/chat/test_sap_transformation.py::TestSAPTransformationIntegration::test_validate_environment_extra_headers_override_defaults \
  tests/test_litellm/llms/sap/embed/test_sap_embed_transformation.py::test_validate_environment_merges_extra_headers \
  -v
```

```
tests/test_litellm/llms/sap/chat/test_sap_transformation.py::TestSAPTransformationIntegration::test_validate_environment_extra_headers_override_defaults PASSED
tests/test_litellm/llms/sap/chat/test_sap_transformation.py::TestSAPTransformationIntegration::test_validate_environment_merges_extra_headers PASSED
tests/test_litellm/llms/sap/embed/test_sap_embed_transformation.py::test_validate_environment_merges_extra_headers PASSED

============================== 3 passed in 0.89s ===============================
```

## Type

🐛 Bug Fix

## Changes

SAP GenAI Hub chat and embed `validate_environment` returned only the provider default headers (`Authorization`, `AI-Resource-Group`, etc.) and ignored the `headers` argument populated from `extra_headers`. That blocked SAP AI Core features that rely on custom request headers, such as `ai-inference-observability-persistence-mode`.

Both providers now merge caller headers into the default set, with caller values taking precedence. Regression tests cover observability header forwarding and default override behavior.

