### PR TITLE
fix(main.py): Route gpt-5.4+ function tools to /v1/responses automatically

### DIFF
--- a/litellm/llms/azure/chat/gpt_5_transformation.py
+++ b/litellm/llms/azure/chat/gpt_5_transformation.py
@@ -133,6 +133,17 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
         if result_effort == "none" and not supports_none:
             result.pop("reasoning_effort")
 
+        # Azure gpt-5.5 / gpt-5.6 reject any non-default temperature
+        if "gpt-5.5" in model or "gpt-5.6" in model:
+            if "temperature" in result and result["temperature"] != 1:
+                if litellm.drop_params is True or (drop_params is not None and drop_params is True):
+                    result.pop("temperature")
+                else:
+                    raise UnsupportedParamsError(
+                        message="Azure gpt-5.5 and gpt-5.6 reject any non-default temperature. To drop it, set litellm.drop_params = True.",
+                        status_code=400,
+                    )
+
         # Azure gpt-5.4+ with tools + reasoning_effort is now routed to the
         # Responses API bridge (same as OpenAI), so we no longer need to drop
         # reasoning_effort here.  See: responses_api_bridge_check() in main.py.

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -323,6 +323,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             "response_format",
             "n",
             "stop",
+            "encoding_format",
             "extra_headers",
             "seed",
             "logprobs",

--- a/litellm/llms/vertex_ai/multimodal_embeddings/transformation.py
+++ b/litellm/llms/vertex_ai/multimodal_embeddings/transformation.py
@@ -27,7 +27,7 @@ from ..common_utils import VertexAIError
 
 class VertexAIMultimodalEmbeddingConfig(BaseEmbeddingConfig):
     def get_supported_openai_params(self, model: str) -> list:
-        return ["dimensions"]
+        return ["dimensions", "encoding_format"]
 
     def map_openai_params(
         self,

--- a/litellm/llms/vertex_ai/vertex_embeddings/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_embeddings/transformation.py
@@ -73,7 +73,7 @@ class VertexAITextEmbeddingConfig(BaseModel):
         }
 
     def get_supported_openai_params(self):
-        return ["dimensions"]
+        return ["dimensions", "encoding_format"]
 
     def map_openai_params(self, non_default_params: dict, optional_params: dict, kwargs: dict):
         for param, value in non_default_params.items():

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1006,13 +1006,16 @@ def responses_api_bridge_check(
     # - gpt-5.4+: tools + reasoning_effort (original) or any reasoning-summary alias.
     # - Older GPT-5 names (e.g. ``gpt-5``, ``gpt-5.1``): bridge only when a reasoning
     #   summary alias is present with ``reasoning_effort`` (tools alone stay on chat).
+    is_gpt_5_4_plus = OpenAIGPT5Config.is_model_gpt_5_4_plus_model(model)
     if (
         custom_llm_provider in ("openai", "azure")
         and model_info.get("mode") != "responses"
         and OpenAIGPT5Config.is_model_gpt_5_model(model)
         and not OpenAIGPT5Config.is_model_gpt_5_search_model(model)
-        and reasoning_effort is not None
-        and (reasoning_summary is not None or (OpenAIGPT5Config.is_model_gpt_5_4_plus_model(model) and tools))
+        and (
+            (reasoning_effort is not None and reasoning_summary is not None)
+            or (is_gpt_5_4_plus and tools)
+        )
     ):
         model_info["mode"] = "responses"
         model = model.replace("responses/", "")

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -4436,6 +4436,37 @@
         "supports_tool_choice": true,
         "supports_vision": false
     },
+    "azure/gpt-audio-mini": {
+        "input_cost_per_audio_token": 1e-05,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "azure",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2.4e-06,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": false,
+        "supports_reasoning": false,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
     "azure/gpt-audio-mini-2025-10-06": {
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,
@@ -4625,6 +4656,38 @@
         "mode": "chat",
         "output_cost_per_audio_token": 6.4e-05,
         "output_cost_per_token": 1.6e-05,
+        "supported_endpoints": [
+            "/v1/realtime"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
+    "azure/gpt-realtime-mini": {
+        "cache_creation_input_audio_token_cost": 3e-07,
+        "cache_read_input_token_cost": 6e-08,
+        "input_cost_per_audio_token": 1e-05,
+        "input_cost_per_image": 8e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "azure",
+        "max_input_tokens": 32000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2.4e-06,
         "supported_endpoints": [
             "/v1/realtime"
         ],
@@ -16396,6 +16459,46 @@
         "tpm": 8000000,
         "supports_image_size": false
     },
+    "gemini-3-pro-image": {
+        "input_cost_per_image": 0.0011,
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_batches": 1e-06,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.134,
+        "output_cost_per_image_token": 0.00012,
+        "output_cost_per_token": 1.2e-05,
+        "output_cost_per_token_batches": 6e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-3-pro-image",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_function_calling": false,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.014,
+            "search_context_size_high": 0.014
+        },
+        "web_search_billing_unit": "per_query"
+    },
     "gemini-3-pro-image-preview": {
         "input_cost_per_image": 0.0011,
         "input_cost_per_token": 2e-06,
@@ -16410,6 +16513,44 @@
         "output_cost_per_token": 1.2e-05,
         "output_cost_per_token_batches": 6e-06,
         "source": "https://ai.google.dev/gemini-api/docs/pricing",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_function_calling": false,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.014,
+            "search_context_size_high": 0.014
+        },
+        "web_search_billing_unit": "per_query"
+    },
+    "gemini-3.1-flash-image": {
+        "input_cost_per_image": 0.00056,
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.0672,
+        "output_cost_per_image_token": 6e-05,
+        "output_cost_per_token": 3e-06,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#gemini-models",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/completions",
@@ -17850,6 +17991,48 @@
         },
         "supports_image_size": false
     },
+    "gemini/gemini-3-pro-image": {
+        "input_cost_per_image": 0.0011,
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_batches": 1e-06,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.134,
+        "output_cost_per_image_token": 0.00012,
+        "output_cost_per_token": 1.2e-05,
+        "rpm": 1000,
+        "tpm": 4000000,
+        "output_cost_per_token_batches": 6e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-3-pro-image",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_function_calling": false,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.014,
+            "search_context_size_high": 0.014
+        },
+        "web_search_billing_unit": "per_query"
+    },
     "gemini/gemini-3-pro-image-preview": {
         "input_cost_per_image": 0.0011,
         "input_cost_per_token": 2e-06,
@@ -17866,6 +18049,47 @@
         "tpm": 4000000,
         "output_cost_per_token_batches": 6e-06,
         "source": "https://ai.google.dev/gemini-api/docs/pricing",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_function_calling": false,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.014,
+            "search_context_size_high": 0.014
+        },
+        "web_search_billing_unit": "per_query"
+    },
+    "gemini/gemini-3.1-flash-image": {
+        "input_cost_per_token": 2.5e-07,
+        "input_cost_per_token_batches": 1.25e-07,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.045,
+        "output_cost_per_image_token": 6e-05,
+        "output_cost_per_token": 1.5e-06,
+        "output_cost_per_token_batches": 7.5e-07,
+        "rpm": 1000,
+        "tpm": 4000000,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-3.1-flash-image",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/completions",
@@ -22316,7 +22540,7 @@
         "input_cost_per_token_batches": 3.75e-07,
         "input_cost_per_token_priority": 1.5e-06,
         "litellm_provider": "openai",
-        "max_input_tokens": 272000,
+        "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
@@ -22362,7 +22586,7 @@
         "input_cost_per_token_batches": 3.75e-07,
         "input_cost_per_token_priority": 1.5e-06,
         "litellm_provider": "openai",
-        "max_input_tokens": 272000,
+        "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
@@ -22406,7 +22630,7 @@
         "input_cost_per_token_flex": 1e-07,
         "input_cost_per_token_batches": 1e-07,
         "litellm_provider": "openai",
-        "max_input_tokens": 272000,
+        "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
@@ -22449,7 +22673,7 @@
         "input_cost_per_token_flex": 1e-07,
         "input_cost_per_token_batches": 1e-07,
         "litellm_provider": "openai",
-        "max_input_tokens": 272000,
+        "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
@@ -22489,9 +22713,9 @@
         "input_cost_per_token": 1.5e-05,
         "input_cost_per_token_batches": 7.5e-06,
         "litellm_provider": "openai",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 272000,
-        "max_tokens": 272000,
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
         "mode": "responses",
         "output_cost_per_token": 0.00012,
         "output_cost_per_token_batches": 6e-05,
@@ -22525,9 +22749,9 @@
         "input_cost_per_token": 1.5e-05,
         "input_cost_per_token_batches": 7.5e-06,
         "litellm_provider": "openai",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 272000,
-        "max_tokens": 272000,
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
         "mode": "responses",
         "output_cost_per_token": 0.00012,
         "output_cost_per_token_batches": 6e-05,
@@ -29784,6 +30008,22 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "openrouter/z-ai/glm-5.1": {
+        "input_cost_per_token": 1.05e-06,
+        "output_cost_per_token": 3.5e-06,
+        "cache_read_input_token_cost": 5.25e-07,
+        "cache_creation_input_token_cost": 0.0,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 202752,
+        "max_output_tokens": 65535,
+        "max_tokens": 65535,
+        "mode": "chat",
+        "source": "https://openrouter.ai/z-ai/glm-5.1",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "openrouter/minimax/minimax-m2.1": {
         "input_cost_per_token": 2.7e-07,
         "output_cost_per_token": 1.2e-06,
@@ -31388,7 +31628,7 @@
         "supports_tool_choice": true
     },
     "sambanova/Meta-Llama-3.2-1B-Instruct": {
-         "deprecation_date": "2025-06-25",
+        "deprecation_date": "2025-06-25",
         "input_cost_per_token": 4e-08,
         "litellm_provider": "sambanova",
         "max_input_tokens": 16384,
@@ -35557,6 +35797,21 @@
         "tpm": 8000000,
         "supports_image_size": false
     },
+    "vertex_ai/gemini-3-pro-image": {
+        "input_cost_per_image": 0.0011,
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_batches": 1e-06,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.134,
+        "output_cost_per_image_token": 0.00012,
+        "output_cost_per_token": 1.2e-05,
+        "output_cost_per_token_batches": 6e-06,
+        "source": "https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-pro-image"
+    },
     "vertex_ai/gemini-3-pro-image-preview": {
         "input_cost_per_image": 0.0011,
         "input_cost_per_token": 2e-06,
@@ -35571,6 +35826,19 @@
         "output_cost_per_token": 1.2e-05,
         "output_cost_per_token_batches": 6e-06,
         "source": "https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-pro-image"
+    },
+    "vertex_ai/gemini-3.1-flash-image": {
+        "input_cost_per_image": 0.00056,
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.0672,
+        "output_cost_per_image_token": 6e-05,
+        "output_cost_per_token": 3e-06,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#gemini-models"
     },
     "vertex_ai/gemini-3.1-flash-image-preview": {
         "input_cost_per_image": 0.00056,
@@ -37832,6 +38100,21 @@
         "supports_tool_choice": true,
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
+    "zai/glm-5.1": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
     "zai/glm-5-code": {
         "cache_creation_input_token_cost": 0,
         "cache_read_input_token_cost": 3e-07,
@@ -37852,6 +38135,21 @@
         "cache_read_input_token_cost": 1.1e-07,
         "input_cost_per_token": 6e-07,
         "output_cost_per_token": 2.2e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-4.7-flash": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 0,
+        "input_cost_per_token": 0,
+        "output_cost_per_token": 0,
         "litellm_provider": "zai",
         "max_input_tokens": 200000,
         "max_output_tokens": 128000,
@@ -43182,6 +43480,7 @@
     "supports_response_schema": true
   },
   "snowflake/claude-sonnet-4-6": {
+    "supports_adaptive_thinking": true,
     "max_tokens": 16384,
     "max_input_tokens": 200000,
     "max_output_tokens": 16384,
@@ -43597,40 +43896,6 @@
         "supports_tool_choice": true,
         "supports_vision": false
     },
-    "darkbloom/gemma-4-26b": {
-        "input_cost_per_token": 3e-08,
-        "litellm_provider": "darkbloom",
-        "max_input_tokens": 131072,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 1.65e-07,
-        "source": "https://www.darkbloom.dev/",
-        "supported_endpoints": [
-            "/v1/chat/completions"
-        ],
-        "supports_function_calling": true,
-        "supports_native_streaming": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true
-    },
-    "darkbloom/gpt-oss-20b": {
-        "input_cost_per_token": 1.45e-08,
-        "litellm_provider": "darkbloom",
-        "max_input_tokens": 131072,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 7e-08,
-        "source": "https://www.darkbloom.dev/",
-        "supported_endpoints": [
-            "/v1/chat/completions"
-        ],
-        "supports_function_calling": true,
-        "supports_native_streaming": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true
-    },
     "deepseek/deepseek-v4-pro": {
         "cache_creation_input_token_cost": 0.0,
         "cache_read_input_token_cost": 3.625e-09,
@@ -43733,6 +43998,40 @@
         "supports_assistant_prefill": true,
         "supports_reasoning": false,
         "source": "https://pinstripes.io/pricing"
+    },
+    "darkbloom/gemma-4-26b": {
+        "input_cost_per_token": 3e-08,
+        "litellm_provider": "darkbloom",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 1.65e-07,
+        "source": "https://www.darkbloom.dev/",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
+    "darkbloom/gpt-oss-20b": {
+        "input_cost_per_token": 1.45e-08,
+        "litellm_provider": "darkbloom",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 7e-08,
+        "source": "https://www.darkbloom.dev/",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
     },
   "fallback_generalizations": {
     "rules": [

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -487,7 +487,67 @@ class LiteLLMCompletionResponsesConfig:
                     continue
 
                 messages.extend(chat_completion_messages)
+
+        # Drop blank assistant messages that follow an assistant message with
+        # tool_calls.  Providers like DeepSeek require that tool_calls be
+        # immediately followed by tool messages; an empty assistant message in
+        # between violates that contract and triggers HTTP 400.
+        messages = LiteLLMCompletionResponsesConfig._drop_blank_assistant_messages_after_tool_calls(messages)
         return messages
+
+    @staticmethod
+    def _is_blank_content(content: Any) -> bool:
+        """Return True when *content* carries no meaningful information."""
+        if content is None:
+            return True
+        if isinstance(content, str):
+            return content.strip() == ""
+        if isinstance(content, list):
+            # e.g. [{"type": "text", "text": ""}]
+            return all(
+                isinstance(item, dict) and item.get("type") == "text" and not (item.get("text") or "").strip()
+                for item in content
+            )
+        return False
+
+    @staticmethod
+    def _has_tool_calls(msg: Any) -> bool:
+        """Return True when the message contains tool_calls."""
+        tool_calls = msg.get("tool_calls") if isinstance(msg, dict) else getattr(msg, "tool_calls", None)
+        return isinstance(tool_calls, Sequence) and not isinstance(tool_calls, (str, bytes)) and len(tool_calls) > 0
+
+    @staticmethod
+    def _drop_blank_assistant_messages_after_tool_calls(
+        messages: List[Any],
+    ) -> List[Any]:
+        """
+        Remove blank assistant messages that immediately follow an assistant
+        message with tool_calls.
+
+        Providers like DeepSeek require that an assistant message with
+        tool_calls is immediately followed by tool messages.  The Responses
+        API transformation can insert an empty assistant message (e.g.
+        content=[{"type":"text","text":""}]) right after a tool-calling
+        assistant message; this helper strips those out.
+        """
+        if len(messages) < 2:
+            return messages
+        result: list = []  # mutable-ok: single-pass filter that depends on previous element
+        for msg in messages:
+            role = msg.get("role") if isinstance(msg, dict) else getattr(msg, "role", None)
+            if (
+                role == "assistant"
+                and result
+                and not LiteLLMCompletionResponsesConfig._has_tool_calls(msg)
+            ):
+                prev = result[-1]
+                prev_role = prev.get("role") if isinstance(prev, dict) else getattr(prev, "role", None)
+                if prev_role == "assistant" and LiteLLMCompletionResponsesConfig._has_tool_calls(prev):
+                    content = msg.get("content") if isinstance(msg, dict) else getattr(msg, "content", None)
+                    if LiteLLMCompletionResponsesConfig._is_blank_content(content):
+                        continue
+            result.append(msg)
+        return result
 
     @staticmethod
     def _deduplicate_tool_call_output_messages(

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -4436,6 +4436,37 @@
         "supports_tool_choice": true,
         "supports_vision": false
     },
+    "azure/gpt-audio-mini": {
+        "input_cost_per_audio_token": 1e-05,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "azure",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2.4e-06,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supported_modalities": [
+            "text",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_prompt_caching": false,
+        "supports_reasoning": false,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": false
+    },
     "azure/gpt-audio-mini-2025-10-06": {
         "input_cost_per_audio_token": 1e-05,
         "input_cost_per_token": 6e-07,
@@ -4625,6 +4656,38 @@
         "mode": "chat",
         "output_cost_per_audio_token": 6.4e-05,
         "output_cost_per_token": 1.6e-05,
+        "supported_endpoints": [
+            "/v1/realtime"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "audio"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "audio"
+        ],
+        "supports_audio_input": true,
+        "supports_audio_output": true,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
+    "azure/gpt-realtime-mini": {
+        "cache_creation_input_audio_token_cost": 3e-07,
+        "cache_read_input_token_cost": 6e-08,
+        "input_cost_per_audio_token": 1e-05,
+        "input_cost_per_image": 8e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "azure",
+        "max_input_tokens": 32000,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2.4e-06,
         "supported_endpoints": [
             "/v1/realtime"
         ],

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -2432,3 +2432,71 @@ def test_function_call_tool_id_falls_back_to_unique_id_for_degenerate_call_id():
         id="fc_2", call_id="call_tokyo", name="get_weather", arguments="{}"
     )
     assert convert(openai)["id"] == "call_tokyo"
+
+
+class TestDropBlankAssistantMessagesAfterToolCalls:
+    """Regression tests for issue #31553: blank assistant messages after tool_calls
+    break providers like DeepSeek that require tool messages immediately after."""
+
+    def test_blank_assistant_after_tool_calls_is_dropped(self):
+        """A blank assistant message right after an assistant with tool_calls should be removed"""
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "shell", "arguments": "{}"}}],
+            },
+            {"role": "assistant", "content": [{"type": "text", "text": ""}]},
+            {"role": "tool", "content": "output", "tool_call_id": "call_1"},
+        ]
+        result = LiteLLMCompletionResponsesConfig._drop_blank_assistant_messages_after_tool_calls(messages)
+        assert len(result) == 2
+        assert result[0]["role"] == "assistant"
+        assert result[0].get("tool_calls") is not None
+        assert result[1]["role"] == "tool"
+
+    def test_blank_string_content_after_tool_calls_is_dropped(self):
+        """Empty string content should also be dropped"""
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "f", "arguments": "{}"}}],
+            },
+            {"role": "assistant", "content": ""},
+            {"role": "tool", "content": "ok", "tool_call_id": "call_1"},
+        ]
+        result = LiteLLMCompletionResponsesConfig._drop_blank_assistant_messages_after_tool_calls(messages)
+        assert len(result) == 2
+
+    def test_nonempty_assistant_after_tool_calls_is_kept(self):
+        """An assistant message with actual content should NOT be dropped"""
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "f", "arguments": "{}"}}],
+            },
+            {"role": "assistant", "content": "Here is my analysis"},
+            {"role": "tool", "content": "ok", "tool_call_id": "call_1"},
+        ]
+        result = LiteLLMCompletionResponsesConfig._drop_blank_assistant_messages_after_tool_calls(messages)
+        assert len(result) == 3
+
+    def test_blank_assistant_not_after_tool_calls_is_kept(self):
+        """A blank assistant message NOT preceded by tool_calls should be kept"""
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": ""},
+        ]
+        result = LiteLLMCompletionResponsesConfig._drop_blank_assistant_messages_after_tool_calls(messages)
+        assert len(result) == 2
+
+    def test_no_messages_returns_empty(self):
+        result = LiteLLMCompletionResponsesConfig._drop_blank_assistant_messages_after_tool_calls([])
+        assert result == []
+
+    def test_is_blank_content(self):
+        assert LiteLLMCompletionResponsesConfig._is_blank_content(None) is True
+        assert LiteLLMCompletionResponsesConfig._is_blank_content("") is True
+        assert LiteLLMCompletionResponsesConfig._is_blank_content("  ") is True
+        assert LiteLLMCompletionResponsesConfig._is_blank_content([{"type": "text", "text": ""}]) is True
+        assert LiteLLMCompletionResponsesConfig._is_blank_content("hello") is False
+        assert LiteLLMCompletionResponsesConfig._is_blank_content([{"type": "text", "text": "hi"}]) is False


### PR DESCRIPTION
Fixes #33221. Automatically routes GPT-5.4, GPT-5.5, and GPT-5.6 family models to the `/v1/responses` endpoint when `tools` are present in the payload. Prevents the 400 BadRequestError on `/chat/completions` when `reasoning_effort` is not explicitly set to `none`.