### PR TITLE
fix: Replicate cost undercharges by 1000x when total_time is in seconds (fixes #33328)

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -699,12 +699,12 @@ def get_replicate_completion_pricing(completion_response: dict, total_time=0.0):
     a100_80gb_price_per_second_public = (
         DEFAULT_REPLICATE_GPU_PRICE_PER_SECOND  # assume all calls sent to A100 80GB for now
     )
-    if total_time == 0.0:  # total time is in ms
+    if total_time == 0.0:  # total_time is in seconds; fallback derives it from timestamps
         start_time = completion_response.get("created", time.time())
         end_time = getattr(completion_response, "ended", time.time())
-        total_time = end_time - start_time
+        total_time = end_time - start_time  # wall-clock seconds
 
-    return a100_80gb_price_per_second_public * total_time / 1000
+    return a100_80gb_price_per_second_public * total_time
 
 
 def has_hidden_params(obj: Any) -> bool:
@@ -1283,7 +1283,7 @@ def completion_cost(
                         prompt_tokens_details = _usage.get("prompt_tokens_details") or {}
                         cache_read_input_tokens = prompt_tokens_details.get("cached_tokens", 0)
 
-                    total_time = getattr(completion_response, "_response_ms", 0)
+                    total_time = getattr(completion_response, "_response_ms", 0) / 1000  # convert ms -> s
 
                     hidden_params = getattr(completion_response, "_hidden_params", None)
                     if hidden_params is not None:

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -3479,3 +3479,37 @@ def test_batch_cost_calculator_cache_creation_falls_back_to_input_rate():
     )
 
     assert prompt_cost == pytest.approx((1000 * 3e-6 + 8000 * 3e-7 + 2000 * 3e-6) / 2)
+
+
+# ---------------------------------------------------------------------------
+# Tests for fix: get_replicate_completion_pricing mixed seconds / milliseconds
+# causing 1000x undercharge when total_time is passed in seconds (fixes #33328)
+# ---------------------------------------------------------------------------
+
+
+def test_replicate_pricing_seconds_passed_directly():
+    """Caller passes total_time in seconds (documented API) — cost must be correct."""
+    from litellm.constants import DEFAULT_REPLICATE_GPU_PRICE_PER_SECOND
+    from litellm.cost_calculator import get_replicate_completion_pricing
+
+    seconds = 2.0
+    actual = get_replicate_completion_pricing({}, total_time=seconds)
+    expected = DEFAULT_REPLICATE_GPU_PRICE_PER_SECOND * seconds
+    assert actual == pytest.approx(expected), (
+        f"Expected {expected}, got {actual} — likely still dividing seconds by 1000"
+    )
+
+
+def test_replicate_pricing_timestamp_fallback():
+    """When total_time=0 the function falls back to end_time - start_time (seconds)."""
+    import time
+    from litellm.constants import DEFAULT_REPLICATE_GPU_PRICE_PER_SECOND
+    from litellm.cost_calculator import get_replicate_completion_pricing
+
+    now = time.time()
+    response = {"created": now - 3.0, "ended": now}
+    actual = get_replicate_completion_pricing(response, total_time=0.0)
+    expected = DEFAULT_REPLICATE_GPU_PRICE_PER_SECOND * 3.0
+    assert actual == pytest.approx(expected, rel=0.01), (
+        f"Expected ~{expected}, got {actual}"
+    )


### PR DESCRIPTION
## Summary

`get_replicate_completion_pricing` always divides `total_time` by 1000. That was correct when the only caller passed `_response_ms` (milliseconds). Two code paths were broken:

1. **External callers** that follow the documented API (`total_time` in seconds) were undercharged by 1000×.
2. **The internal timestamp fallback** (`end_time - start_time`) produces wall-clock seconds, so dividing again made it 1000× too small.

## Fix

- Convert `_response_ms → seconds` at the call site in `completion_cost` (`/ 1000`) so `get_replicate_completion_pricing` always receives seconds.
- Remove the `/ 1000` from the return statement in `get_replicate_completion_pricing` — the formula is now consistently `price_per_second * seconds`.
- Update the stale `# total time is in ms` comment to reflect the new contract.

## Changes

- `litellm/cost_calculator.py`: two-line change (call site conversion + remove division)
- `tests/test_litellm/test_cost_calculator.py`: 2 new tests

## Test plan

- [x] `test_replicate_pricing_seconds_passed_directly` — external caller passes 2 s, verifies cost = `PRICE_PER_SECOND * 2`
- [x] `test_replicate_pricing_timestamp_fallback` — response with `created`/`ended` 3 s apart, verifies cost = `PRICE_PER_SECOND * 3`
- [x] Full `test_cost_calculator.py` suite — 81 tests, all pass

Closes #33328