### PR TITLE
fix: /mcp/ endpoint latency

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -195,18 +195,22 @@ _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES: tuple[MCPAuth, ...] = (
     MCPAuth.oauth_delegate,
 )
 
-_BACKGROUND_MCP_TOOL_LISTING_TASKS: set[asyncio.Task[list[MCPTool]]] = set()
+_MCP_TOOL_LISTING_TASKS_MAX_SIZE = 100
+_MCP_TOOL_LISTING_TASKS: set[asyncio.Task[list[MCPTool]]] = set()
 
 
-def _consume_background_task_result(task: asyncio.Task[list[MCPTool]]) -> None:
-    _BACKGROUND_MCP_TOOL_LISTING_TASKS.discard(task)
-    if not task.cancelled():
-        task.exception()
+def _consume_tool_listing_task_result(task: asyncio.Task[list[MCPTool]]) -> None:
+    _MCP_TOOL_LISTING_TASKS.discard(task)
+    if task.cancelled():
+        return
+    exception = task.exception()
+    if exception is not None:
+        verbose_logger.debug("MCP tool-listing task finished with error: %s", exception)
 
 
-def _detach_background_task(task: asyncio.Task[list[MCPTool]]) -> None:
-    _BACKGROUND_MCP_TOOL_LISTING_TASKS.add(task)
-    task.add_done_callback(_consume_background_task_result)
+def _track_tool_listing_task(task: asyncio.Task[list[MCPTool]]) -> None:
+    _MCP_TOOL_LISTING_TASKS.add(task)
+    task.add_done_callback(_consume_tool_listing_task_result)
 
 
 def _blank_to_none(value: str | None) -> str | None:
@@ -3841,12 +3845,20 @@ class MCPServerManager:
         Returns:
             List of tools from the server
         """
+        if len(_MCP_TOOL_LISTING_TASKS) >= _MCP_TOOL_LISTING_TASKS_MAX_SIZE:
+            verbose_logger.warning(
+                "Skipping tool listing for %s because the worker already has %d active MCP tool-listing tasks",
+                server_name,
+                _MCP_TOOL_LISTING_TASKS_MAX_SIZE,
+            )
+            raise MCPServerListError(ServerListFault(tag="internal"), server_name)
+
         list_tools_task = asyncio.create_task(client.list_tools(raise_on_error=True))
+        _track_tool_listing_task(list_tools_task)
         try:
             done, _ = await asyncio.wait((list_tools_task,), timeout=MCP_TOOL_LISTING_TIMEOUT)
             if list_tools_task not in done:
                 list_tools_task.cancel()
-                _detach_background_task(list_tools_task)
                 raise TimeoutError
             tools = await list_tools_task
             verbose_logger.debug(f"Tools from {server_name}: {tools}")
@@ -3855,11 +3867,15 @@ class MCPServerManager:
             verbose_logger.warning(f"Timeout while listing tools from {server_name}")
             raise MCPServerListError(ServerListFault(tag="timeout"), server_name) from e
         except asyncio.CancelledError as e:
+            current_task = asyncio.current_task()
+            if current_task is not None and current_task.cancelling():
+                list_tools_task.cancel()
+                verbose_logger.warning(f"Task cancelled while listing tools from {server_name}")
+                raise
             if list_tools_task.cancelled():
                 verbose_logger.warning(f"Task cancelled while listing tools from {server_name}")
                 raise MCPServerListError(ServerListFault(tag="internal"), server_name) from e
             list_tools_task.cancel()
-            _detach_background_task(list_tools_task)
             verbose_logger.warning(f"Task cancelled while listing tools from {server_name}")
             raise
         except ConnectionError as e:

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -17,7 +17,6 @@ from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Callable, Literal, Optional, Union, cast
 from urllib.parse import urlparse
 
-import anyio
 import httpx
 from fastapi import HTTPException
 from httpx import HTTPStatusError
@@ -195,6 +194,19 @@ _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES: tuple[MCPAuth, ...] = (
     MCPAuth.true_passthrough,
     MCPAuth.oauth_delegate,
 )
+
+_BACKGROUND_MCP_TOOL_LISTING_TASKS: set[asyncio.Task[list[MCPTool]]] = set()
+
+
+def _consume_background_task_result(task: asyncio.Task[list[MCPTool]]) -> None:
+    _BACKGROUND_MCP_TOOL_LISTING_TASKS.discard(task)
+    if not task.cancelled():
+        task.exception()
+
+
+def _detach_background_task(task: asyncio.Task[list[MCPTool]]) -> None:
+    _BACKGROUND_MCP_TOOL_LISTING_TASKS.add(task)
+    task.add_done_callback(_consume_background_task_result)
 
 
 def _blank_to_none(value: str | None) -> str | None:
@@ -3807,8 +3819,8 @@ class MCPServerManager:
         """
         Fetch tools from MCP client with timeout and error handling.
 
-        Uses anyio.fail_after() instead of asyncio.wait_for() to avoid conflicts
-        with the MCP SDK's anyio TaskGroup. See GitHub issue #20715 for details.
+        Uses a detached asyncio task so cancellation-resistant MCP SDK cleanup
+        cannot extend the caller-visible timeout.
 
         Failures never return an empty tool list. An upstream 401 or 403 raises
         :class:`MCPUpstreamAuthError` carrying the upstream's own
@@ -3829,17 +3841,27 @@ class MCPServerManager:
         Returns:
             List of tools from the server
         """
+        list_tools_task = asyncio.create_task(client.list_tools(raise_on_error=True))
         try:
-            with anyio.fail_after(MCP_TOOL_LISTING_TIMEOUT):
-                tools = await client.list_tools(raise_on_error=True)
-                verbose_logger.debug(f"Tools from {server_name}: {tools}")
-                return tools
+            done, _ = await asyncio.wait((list_tools_task,), timeout=MCP_TOOL_LISTING_TIMEOUT)
+            if list_tools_task not in done:
+                list_tools_task.cancel()
+                _detach_background_task(list_tools_task)
+                raise TimeoutError
+            tools = await list_tools_task
+            verbose_logger.debug(f"Tools from {server_name}: {tools}")
+            return tools
         except TimeoutError as e:
             verbose_logger.warning(f"Timeout while listing tools from {server_name}")
             raise MCPServerListError(ServerListFault(tag="timeout"), server_name) from e
         except asyncio.CancelledError as e:
+            if list_tools_task.cancelled():
+                verbose_logger.warning(f"Task cancelled while listing tools from {server_name}")
+                raise MCPServerListError(ServerListFault(tag="internal"), server_name) from e
+            list_tools_task.cancel()
+            _detach_background_task(list_tools_task)
             verbose_logger.warning(f"Task cancelled while listing tools from {server_name}")
-            raise MCPServerListError(ServerListFault(tag="internal"), server_name) from e
+            raise
         except ConnectionError as e:
             verbose_logger.warning(f"Connection error while listing tools from {server_name}: {str(e)}")
             raise MCPServerListError(ServerListFault(tag="unreachable"), server_name) from e

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -4216,15 +4216,21 @@ if MCP_AVAILABLE:
                         _track_initialized_stateful_session,
                     )
 
-                async with _gateway_initialize_instructions_request_scope(
-                    user_api_key_auth,
-                    mcp_servers,
-                    _client_ip,
-                    scoped_server_endpoint=scoped_server_endpoint,
-                ):
+                async def _handle_request() -> None:
                     await target_manager.handle_request(scope, receive, local_send)
                     if use_stateful and session_id and scope.get("method") == "DELETE":
                         _remove_stateful_session_tracking(session_id)
+
+                if is_initialize:
+                    async with _gateway_initialize_instructions_request_scope(
+                        user_api_key_auth,
+                        mcp_servers,
+                        _client_ip,
+                        scoped_server_endpoint=scoped_server_endpoint,
+                    ):
+                        await _handle_request()
+                else:
+                    await _handle_request()
 
             try:
                 if session_lock is not None:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_oauth_passthrough_tools.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_oauth_passthrough_tools.py
@@ -1,13 +1,17 @@
 """Unit tests for MCP OAuth passthrough tool-fetch behavior."""
 
+import asyncio
 import sys
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
 sys.path.insert(0, "../../../../../")
 
+from litellm.proxy._experimental.mcp_server import (
+    mcp_server_manager as mcp_server_manager_module,
+)
 from litellm.proxy._experimental.mcp_server.exceptions import MCPUpstreamAuthError
 from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
     MCPServerManager,
@@ -207,6 +211,77 @@ async def test_fetch_tools_from_passthrough_returns_tools_on_success():
 
     tools = await manager._fetch_tools_with_timeout(mock_client, passthrough_server.name)
     assert tools == [tool]
+
+
+@pytest.mark.asyncio
+async def test_fetch_tools_timeout_does_not_wait_for_cancellation_cleanup():
+    manager = MCPServerManager()
+    cancellation_started = asyncio.Event()
+    cleanup_finished = asyncio.Event()
+    background_tasks_before = set(
+        mcp_server_manager_module._BACKGROUND_MCP_TOOL_LISTING_TASKS
+    )
+
+    async def list_tools(*args, **kwargs):
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            cancellation_started.set()
+            await asyncio.sleep(0.2)
+            cleanup_finished.set()
+            raise
+
+    mock_client = MagicMock()
+    mock_client.list_tools = AsyncMock(side_effect=list_tools)
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.MCP_TOOL_LISTING_TIMEOUT",
+        0.01,
+    ):
+        started_at = asyncio.get_running_loop().time()
+        tools = await manager._fetch_tools_with_timeout(mock_client, "slow_server")
+        elapsed = asyncio.get_running_loop().time() - started_at
+
+    assert tools == []
+    assert elapsed < 0.1
+    await asyncio.wait_for(cancellation_started.wait(), timeout=0.1)
+    detached_tasks = (
+        mcp_server_manager_module._BACKGROUND_MCP_TOOL_LISTING_TASKS
+        - background_tasks_before
+    )
+    assert len(detached_tasks) == 1
+    await asyncio.wait_for(cleanup_finished.wait(), timeout=0.5)
+    await asyncio.sleep(0)
+    assert detached_tasks.isdisjoint(
+        mcp_server_manager_module._BACKGROUND_MCP_TOOL_LISTING_TASKS
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_tools_propagates_external_cancellation():
+    manager = MCPServerManager()
+    listing_started = asyncio.Event()
+    listing_finished = asyncio.Event()
+
+    async def list_tools(*args, **kwargs):
+        listing_started.set()
+        try:
+            await asyncio.Future()
+        finally:
+            listing_finished.set()
+
+    mock_client = MagicMock()
+    mock_client.list_tools = AsyncMock(side_effect=list_tools)
+    fetch_task = asyncio.create_task(
+        manager._fetch_tools_with_timeout(mock_client, "cancelled_server")
+    )
+    await asyncio.wait_for(listing_started.wait(), timeout=0.1)
+
+    fetch_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await fetch_task
+
+    await asyncio.wait_for(listing_finished.wait(), timeout=0.1)
 
 
 def test_to_http_exception_preserves_upstream_www_authenticate():

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_oauth_passthrough_tools.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_oauth_passthrough_tools.py
@@ -12,7 +12,10 @@ sys.path.insert(0, "../../../../../")
 from litellm.proxy._experimental.mcp_server import (
     mcp_server_manager as mcp_server_manager_module,
 )
-from litellm.proxy._experimental.mcp_server.exceptions import MCPUpstreamAuthError
+from litellm.proxy._experimental.mcp_server.exceptions import (
+    MCPServerListError,
+    MCPUpstreamAuthError,
+)
 from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
     MCPServerManager,
     _extract_upstream_auth_failure,
@@ -218,9 +221,7 @@ async def test_fetch_tools_timeout_does_not_wait_for_cancellation_cleanup():
     manager = MCPServerManager()
     cancellation_started = asyncio.Event()
     cleanup_finished = asyncio.Event()
-    background_tasks_before = set(
-        mcp_server_manager_module._BACKGROUND_MCP_TOOL_LISTING_TASKS
-    )
+    listing_tasks_before = set(mcp_server_manager_module._MCP_TOOL_LISTING_TASKS)
 
     async def list_tools(*args, **kwargs):
         try:
@@ -239,22 +240,68 @@ async def test_fetch_tools_timeout_does_not_wait_for_cancellation_cleanup():
         0.01,
     ):
         started_at = asyncio.get_running_loop().time()
-        tools = await manager._fetch_tools_with_timeout(mock_client, "slow_server")
+        with pytest.raises(MCPServerListError) as exc_info:
+            await manager._fetch_tools_with_timeout(mock_client, "slow_server")
         elapsed = asyncio.get_running_loop().time() - started_at
 
-    assert tools == []
+    assert exc_info.value.fault.tag == "timeout"
     assert elapsed < 0.1
     await asyncio.wait_for(cancellation_started.wait(), timeout=0.1)
     detached_tasks = (
-        mcp_server_manager_module._BACKGROUND_MCP_TOOL_LISTING_TASKS
-        - background_tasks_before
+        mcp_server_manager_module._MCP_TOOL_LISTING_TASKS - listing_tasks_before
     )
     assert len(detached_tasks) == 1
     await asyncio.wait_for(cleanup_finished.wait(), timeout=0.5)
     await asyncio.sleep(0)
     assert detached_tasks.isdisjoint(
-        mcp_server_manager_module._BACKGROUND_MCP_TOOL_LISTING_TASKS
+        mcp_server_manager_module._MCP_TOOL_LISTING_TASKS
     )
+
+
+@pytest.mark.asyncio
+async def test_fetch_tools_rejects_new_listing_at_task_capacity():
+    manager = MCPServerManager()
+    cancellation_started = asyncio.Event()
+    cleanup_finished = asyncio.Event()
+    active_task_count = len(mcp_server_manager_module._MCP_TOOL_LISTING_TASKS)
+
+    async def slow_list_tools(*args, **kwargs):
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            cancellation_started.set()
+            await asyncio.sleep(0.2)
+            cleanup_finished.set()
+            raise
+
+    slow_client = MagicMock()
+    slow_client.list_tools = AsyncMock(side_effect=slow_list_tools)
+    rejected_client = MagicMock()
+    rejected_client.list_tools = AsyncMock()
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.MCP_TOOL_LISTING_TIMEOUT",
+            0.01,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager._MCP_TOOL_LISTING_TASKS_MAX_SIZE",
+            active_task_count + 1,
+        ),
+    ):
+        with pytest.raises(MCPServerListError) as timeout_exc:
+            await manager._fetch_tools_with_timeout(slow_client, "slow_server")
+        assert timeout_exc.value.fault.tag == "timeout"
+        await asyncio.wait_for(cancellation_started.wait(), timeout=0.1)
+        with pytest.raises(MCPServerListError) as capacity_exc:
+            await manager._fetch_tools_with_timeout(rejected_client, "other_server")
+        assert capacity_exc.value.fault.tag == "internal"
+
+    rejected_client.list_tools.assert_not_called()
+    assert len(mcp_server_manager_module._MCP_TOOL_LISTING_TASKS) == active_task_count + 1
+    await asyncio.wait_for(cleanup_finished.wait(), timeout=0.5)
+    await asyncio.sleep(0)
+    assert len(mcp_server_manager_module._MCP_TOOL_LISTING_TASKS) == active_task_count
 
 
 @pytest.mark.asyncio
@@ -278,6 +325,40 @@ async def test_fetch_tools_propagates_external_cancellation():
     await asyncio.wait_for(listing_started.wait(), timeout=0.1)
 
     fetch_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await fetch_task
+
+    await asyncio.wait_for(listing_finished.wait(), timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_fetch_tools_prioritizes_external_cancellation_over_child_cancellation():
+    manager = MCPServerManager()
+    listing_started = asyncio.Event()
+    listing_finished = asyncio.Event()
+    listing_tasks_before = set(mcp_server_manager_module._MCP_TOOL_LISTING_TASKS)
+
+    async def list_tools(*args, **kwargs):
+        listing_started.set()
+        try:
+            await asyncio.Future()
+        finally:
+            listing_finished.set()
+
+    mock_client = MagicMock()
+    mock_client.list_tools = AsyncMock(side_effect=list_tools)
+    fetch_task = asyncio.create_task(
+        manager._fetch_tools_with_timeout(mock_client, "cancelled_server")
+    )
+    await asyncio.wait_for(listing_started.wait(), timeout=0.1)
+    child_tasks = (
+        mcp_server_manager_module._MCP_TOOL_LISTING_TASKS - listing_tasks_before
+    )
+    assert len(child_tasks) == 1
+    child_task = child_tasks.pop()
+    child_task.add_done_callback(lambda _: fetch_task.cancel())
+    child_task.cancel()
+
     with pytest.raises(asyncio.CancelledError):
         await fetch_task
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextvars
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1450,12 +1451,18 @@ async def test_mcp_routing_initialize_to_stateful_no_session_to_stateless():
 
         stateless_called = []
         stateful_called = []
+        instruction_scope_calls = []
 
         async def stateless_handle(s, r, se):
             stateless_called.append(1)
 
         async def stateful_handle(s, r, se):
             stateful_called.append(1)
+
+        @asynccontextmanager
+        async def instruction_scope(*args, **kwargs):
+            instruction_scope_calls.append(1)
+            yield
 
         with (
             patch(
@@ -1490,20 +1497,26 @@ async def test_mcp_routing_initialize_to_stateful_no_session_to_stateless():
                 "_server_instances",
                 {},
             ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.server._gateway_initialize_instructions_request_scope",
+                side_effect=instruction_scope,
+            ),
         ):
             await handle_streamable_http_mcp(scope, receive, send)
 
-        return bool(stateless_called), bool(stateful_called)
+        return bool(stateless_called), bool(stateful_called), len(instruction_scope_calls)
 
     # initialize → stateful
     init_body = b'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}'
-    stateless_called, stateful_called = await make_request(init_body)
+    stateless_called, stateful_called, instruction_scope_calls = await make_request(init_body)
     assert stateful_called and not stateless_called, "initialize (no session) should route to stateful, not stateless"
+    assert instruction_scope_calls == 1
 
     # tools/list → stateless
     tools_body = b'{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
-    stateless_called, stateful_called = await make_request(tools_body)
+    stateless_called, stateful_called, instruction_scope_calls = await make_request(tools_body)
     assert stateless_called and not stateful_called, "tools/list (no session) should route to stateless, not stateful"
+    assert instruction_scope_calls == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

<!-- e.g., "Fixes #000" -->
Fixes #33374

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
