### PR TITLE
fix(ui): guard missing metrics in Usage page aggregations

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.test.tsx
@@ -39,7 +39,12 @@ vi.mock("@/components/view_user_spend", () => ({
 }));
 
 vi.mock("@/components/UsagePage/components/EntityUsage/TopKeyView", () => ({
-  default: () => <div>Top Keys</div>,
+  default: ({ topKeys }: { topKeys: Array<{ api_key: string; spend: number }> }) => (
+    <div>
+      Top Keys
+      <div data-testid="top-keys-data">{topKeys.map(({ api_key, spend }) => `${api_key}:${spend}`).join(",")}</div>
+    </div>
+  ),
 }));
 
 vi.mock("./EntityUsage/EntityUsage", () => ({
@@ -48,7 +53,14 @@ vi.mock("./EntityUsage/EntityUsage", () => ({
 }));
 
 vi.mock("./EntityUsage/SpendByProvider", () => ({
-  default: () => <div>Spend By Provider</div>,
+  default: ({ providerSpend }: { providerSpend: Array<{ provider: string; spend: number }> }) => (
+    <div>
+      Spend By Provider
+      <div data-testid="provider-spend-data">
+        {providerSpend.map(({ provider, spend }) => `${provider}:${spend}`).join(",")}
+      </div>
+    </div>
+  ),
 }));
 
 vi.mock("./EndpointUsage/EndpointUsage", () => ({
@@ -594,6 +606,46 @@ describe("UsagePage", () => {
     // Check for chart titles (these are in the Cost tab)
     expect(screen.getByText("Daily Spend")).toBeInTheDocument();
     expect(screen.getByText("Top Virtual Keys")).toBeInTheDocument();
+  });
+
+  it("should handle breakdown entries without metrics without poisoning totals", async () => {
+    const sparseSpendData = {
+      ...mockSpendData,
+      results: [
+        {
+          ...mockSpendData.results[0],
+          breakdown: {
+            ...mockSpendData.results[0].breakdown,
+            models: {
+              ...mockSpendData.results[0].breakdown.models,
+              "sparse-model": { metadata: {}, api_key_breakdown: {} },
+            },
+            model_groups: {
+              ...mockSpendData.results[0].breakdown.model_groups,
+              "sparse-model-group": { metadata: {}, api_key_breakdown: {} },
+            },
+            api_keys: {
+              ...mockSpendData.results[0].breakdown.api_keys,
+              "sparse-key": { metadata: { key_alias: "Sparse Key", tags: ["partial"] } },
+            },
+            providers: {
+              ...mockSpendData.results[0].breakdown.providers,
+              "sparse-provider": { metadata: {} },
+            },
+          },
+        },
+      ],
+    };
+    mockUserDailyActivityAggregatedCall.mockResolvedValue(sparseSpendData);
+
+    renderWithProviders(<UsagePage {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("top-keys-data")).toHaveTextContent("sk-test123:125.75");
+      expect(screen.getByTestId("top-keys-data")).toHaveTextContent("sparse-key:0");
+      expect(screen.getByTestId("provider-spend-data")).toHaveTextContent("openai:125.75");
+      expect(screen.getByTestId("provider-spend-data")).toHaveTextContent("sparse-provider:0");
+    });
   });
 
   it("should render the daily spend and top models charts with cyan bars", async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.tsx
@@ -51,7 +51,7 @@ import { Tag } from "@/components/tag_management/types";
 import UserAgentActivity from "@/components/user_agent_activity";
 import ViewUserSpend from "@/components/view_user_spend";
 import { usePaginatedDailyActivity } from "../hooks/usePaginatedDailyActivity";
-import { DailyData, KeyMetricWithMetadata, MetricWithMetadata } from "@/components/UsagePage/types";
+import { DailyData, KeyMetricWithMetadata, MetricWithMetadata, SpendMetrics } from "@/components/UsagePage/types";
 import { valueFormatterSpend } from "@/components/UsagePage/utils/value_formatters";
 import EndpointUsage from "./EndpointUsage/EndpointUsage";
 import EntityUsage, { EntityList } from "./EntityUsage/EntityUsage";
@@ -64,6 +64,30 @@ interface UsagePageProps {
   teams: Team[];
   organizations: Organization[];
 }
+
+const createEmptySpendMetrics = (): SpendMetrics => ({
+  spend: 0,
+  prompt_tokens: 0,
+  completion_tokens: 0,
+  total_tokens: 0,
+  api_requests: 0,
+  successful_requests: 0,
+  failed_requests: 0,
+  cache_read_input_tokens: 0,
+  cache_creation_input_tokens: 0,
+});
+
+const addSpendMetrics = (total: SpendMetrics, metrics?: Partial<SpendMetrics>): SpendMetrics => ({
+  spend: total.spend + (metrics?.spend ?? 0),
+  prompt_tokens: total.prompt_tokens + (metrics?.prompt_tokens ?? 0),
+  completion_tokens: total.completion_tokens + (metrics?.completion_tokens ?? 0),
+  total_tokens: total.total_tokens + (metrics?.total_tokens ?? 0),
+  api_requests: total.api_requests + (metrics?.api_requests ?? 0),
+  successful_requests: total.successful_requests + (metrics?.successful_requests ?? 0),
+  failed_requests: total.failed_requests + (metrics?.failed_requests ?? 0),
+  cache_read_input_tokens: total.cache_read_input_tokens + (metrics?.cache_read_input_tokens ?? 0),
+  cache_creation_input_tokens: total.cache_creation_input_tokens + (metrics?.cache_creation_input_tokens ?? 0),
+});
 
 const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
   const { accessToken, userRole, userId: userID, premiumUser } = useAuthorized();
@@ -254,30 +278,12 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
       Object.entries(day.breakdown.models || {}).forEach(([model, metrics]) => {
         if (!modelSpend[model]) {
           modelSpend[model] = {
-            metrics: {
-              spend: 0,
-              prompt_tokens: 0,
-              completion_tokens: 0,
-              total_tokens: 0,
-              api_requests: 0,
-              successful_requests: 0,
-              failed_requests: 0,
-              cache_read_input_tokens: 0,
-              cache_creation_input_tokens: 0,
-            },
+            metrics: createEmptySpendMetrics(),
             metadata: {},
             api_key_breakdown: {},
           };
         }
-        modelSpend[model].metrics.spend += metrics.metrics.spend;
-        modelSpend[model].metrics.prompt_tokens += metrics.metrics.prompt_tokens;
-        modelSpend[model].metrics.completion_tokens += metrics.metrics.completion_tokens;
-        modelSpend[model].metrics.total_tokens += metrics.metrics.total_tokens;
-        modelSpend[model].metrics.api_requests += metrics.metrics.api_requests;
-        modelSpend[model].metrics.successful_requests += metrics.metrics.successful_requests || 0;
-        modelSpend[model].metrics.failed_requests += metrics.metrics.failed_requests || 0;
-        modelSpend[model].metrics.cache_read_input_tokens += metrics.metrics.cache_read_input_tokens || 0;
-        modelSpend[model].metrics.cache_creation_input_tokens += metrics.metrics.cache_creation_input_tokens || 0;
+        modelSpend[model].metrics = addSpendMetrics(modelSpend[model].metrics, metrics?.metrics);
       });
     });
 
@@ -300,31 +306,12 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
       Object.entries(day.breakdown.model_groups || {}).forEach(([modelGroup, metrics]) => {
         if (!modelGroupSpend[modelGroup]) {
           modelGroupSpend[modelGroup] = {
-            metrics: {
-              spend: 0,
-              prompt_tokens: 0,
-              completion_tokens: 0,
-              total_tokens: 0,
-              api_requests: 0,
-              successful_requests: 0,
-              failed_requests: 0,
-              cache_read_input_tokens: 0,
-              cache_creation_input_tokens: 0,
-            },
+            metrics: createEmptySpendMetrics(),
             metadata: {},
             api_key_breakdown: {},
           };
         }
-        modelGroupSpend[modelGroup].metrics.spend += metrics.metrics.spend;
-        modelGroupSpend[modelGroup].metrics.prompt_tokens += metrics.metrics.prompt_tokens;
-        modelGroupSpend[modelGroup].metrics.completion_tokens += metrics.metrics.completion_tokens;
-        modelGroupSpend[modelGroup].metrics.total_tokens += metrics.metrics.total_tokens;
-        modelGroupSpend[modelGroup].metrics.api_requests += metrics.metrics.api_requests;
-        modelGroupSpend[modelGroup].metrics.successful_requests += metrics.metrics.successful_requests || 0;
-        modelGroupSpend[modelGroup].metrics.failed_requests += metrics.metrics.failed_requests || 0;
-        modelGroupSpend[modelGroup].metrics.cache_read_input_tokens += metrics.metrics.cache_read_input_tokens || 0;
-        modelGroupSpend[modelGroup].metrics.cache_creation_input_tokens +=
-          metrics.metrics.cache_creation_input_tokens || 0;
+        modelGroupSpend[modelGroup].metrics = addSpendMetrics(modelGroupSpend[modelGroup].metrics, metrics?.metrics);
       });
     });
 
@@ -348,31 +335,12 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
       Object.entries(day.breakdown.providers || {}).forEach(([provider, metrics]) => {
         if (!providerSpendMap[provider]) {
           providerSpendMap[provider] = {
-            metrics: {
-              spend: 0,
-              prompt_tokens: 0,
-              completion_tokens: 0,
-              total_tokens: 0,
-              api_requests: 0,
-              successful_requests: 0,
-              failed_requests: 0,
-              cache_read_input_tokens: 0,
-              cache_creation_input_tokens: 0,
-            },
+            metrics: createEmptySpendMetrics(),
             metadata: {},
             api_key_breakdown: {},
           };
         }
-        providerSpendMap[provider].metrics.spend += metrics.metrics.spend;
-        providerSpendMap[provider].metrics.prompt_tokens += metrics.metrics.prompt_tokens;
-        providerSpendMap[provider].metrics.completion_tokens += metrics.metrics.completion_tokens;
-        providerSpendMap[provider].metrics.total_tokens += metrics.metrics.total_tokens;
-        providerSpendMap[provider].metrics.api_requests += metrics.metrics.api_requests;
-        providerSpendMap[provider].metrics.successful_requests += metrics.metrics.successful_requests || 0;
-        providerSpendMap[provider].metrics.failed_requests += metrics.metrics.failed_requests || 0;
-        providerSpendMap[provider].metrics.cache_read_input_tokens += metrics.metrics.cache_read_input_tokens || 0;
-        providerSpendMap[provider].metrics.cache_creation_input_tokens +=
-          metrics.metrics.cache_creation_input_tokens || 0;
+        providerSpendMap[provider].metrics = addSpendMetrics(providerSpendMap[provider].metrics, metrics?.metrics);
       });
     });
 
@@ -393,33 +361,15 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
       Object.entries(day.breakdown.api_keys || {}).forEach(([key, metrics]) => {
         if (!keySpend[key]) {
           keySpend[key] = {
-            metrics: {
-              spend: 0,
-              prompt_tokens: 0,
-              completion_tokens: 0,
-              total_tokens: 0,
-              api_requests: 0,
-              successful_requests: 0,
-              failed_requests: 0,
-              cache_read_input_tokens: 0,
-              cache_creation_input_tokens: 0,
-            },
+            metrics: createEmptySpendMetrics(),
             metadata: {
-              key_alias: metrics.metadata.key_alias,
+              key_alias: metrics?.metadata?.key_alias ?? null,
               team_id: null,
-              tags: metrics.metadata.tags || [],
+              tags: metrics?.metadata?.tags ?? [],
             },
           };
         }
-        keySpend[key].metrics.spend += metrics.metrics.spend;
-        keySpend[key].metrics.prompt_tokens += metrics.metrics.prompt_tokens;
-        keySpend[key].metrics.completion_tokens += metrics.metrics.completion_tokens;
-        keySpend[key].metrics.total_tokens += metrics.metrics.total_tokens;
-        keySpend[key].metrics.api_requests += metrics.metrics.api_requests;
-        keySpend[key].metrics.successful_requests += metrics.metrics.successful_requests;
-        keySpend[key].metrics.failed_requests += metrics.metrics.failed_requests;
-        keySpend[key].metrics.cache_read_input_tokens += metrics.metrics.cache_read_input_tokens || 0;
-        keySpend[key].metrics.cache_creation_input_tokens += metrics.metrics.cache_creation_input_tokens || 0;
+        keySpend[key].metrics = addSpendMetrics(keySpend[key].metrics, metrics?.metrics);
       });
     });
 
@@ -1014,6 +964,8 @@ const getModelActivityData = (userSpendData: { results: DailyData[]; metadata: a
 
   userSpendData.results.forEach((day: DailyData) => {
     Object.entries(day.breakdown.models || {}).forEach(([model, metrics]) => {
+      if (!metrics?.metrics) return;
+
       if (!modelData[model]) {
         modelData[model] = {
           total_requests: 0,

--- a/ui/litellm-dashboard/src/components/activity_metrics.test.tsx
+++ b/ui/litellm-dashboard/src/components/activity_metrics.test.tsx
@@ -648,6 +648,22 @@ describe("processActivityData", () => {
     expect(result).toEqual({});
   });
 
+  it.each(["models", "api_keys", "mcp_servers"] as const)("should skip %s entries without metrics", (breakdownKey) => {
+    const sparseEntry =
+      breakdownKey === "api_keys"
+        ? { metadata: { key_alias: "Sparse Key", team_id: null } }
+        : { metadata: {}, api_key_breakdown: {} };
+    const sparseBreakdown = {
+      ...EMPTY_BREAKDOWN,
+      [breakdownKey]: { sparse: sparseEntry },
+    } as unknown as typeof EMPTY_BREAKDOWN;
+    const dailyActivity = {
+      results: [createMockDailyData("2025-01-01", EMPTY_SPEND_METRICS, sparseBreakdown)],
+    };
+
+    expect(processActivityData(dailyActivity, breakdownKey, MOCK_TEAMS)).toEqual({});
+  });
+
   it("should process data for api_keys key with teams parameter", () => {
     const result = processActivityData(mockDailyActivity, "api_keys", MOCK_TEAMS);
 

--- a/ui/litellm-dashboard/src/components/activity_metrics.tsx
+++ b/ui/litellm-dashboard/src/components/activity_metrics.tsx
@@ -369,6 +369,8 @@ export const processActivityData = (
 
   dailyActivity.results.forEach((day) => {
     Object.entries(day.breakdown[key] || {}).forEach(([model, modelData]) => {
+      if (!modelData?.metrics) return;
+
       if (!modelMetrics[model]) {
         modelMetrics[model] = {
           label:


### PR DESCRIPTION
## Relevant issues

Fixes #33381

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Type

Bug Fix
Test

## Changes

Usage Cost aggregations read `metrics.metrics.spend` (and sibling fields) without null checks. Sparse or partial breakdown entries can carry `metadata` while `metrics` is undefined, which throws `Cannot read properties of undefined (reading 'spend')` and blank the page.

This PR:

- Adds `createEmptySpendMetrics` / `addSpendMetrics` helpers that treat missing metric fields as 0
- Uses them in top models, model groups, providers, and top keys aggregations
- Guards `metrics?.metadata?.key_alias` / `tags` when seeding key rows
- Skips breakdown entries without `metrics` in `processActivityData` and the model-detail accumulator
- Adds regression coverage for sparse api_keys / providers / models entries so totals are not poisoned

Does not change pagination or the aggregated daily-activity endpoint.

## Screenshots / Proof of Fix

Unit regression: sparse breakdown entries with metadata only no longer throw; existing key/provider totals stay intact. Live multi-page admin Usage repro against a large spend-log deployment was not re-run in this environment.

## Summary

Null-safe Usage page aggregation for missing breakdown `metrics` so the Cost tab does not crash on sparse client data shapes.
