### PR TITLE
fix(bedrock): correct max tokens for meta.llama3-70b-instruct-v1:0 in GovCloud regions

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -10518,9 +10518,9 @@
     "bedrock/us-gov-east-1/meta.llama3-70b-instruct-v1:0": {
         "input_cost_per_token": 2.65e-06,
         "litellm_provider": "bedrock",
-        "max_input_tokens": 8000,
-        "max_output_tokens": 2048,
-        "max_tokens": 2048,
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
         "mode": "chat",
         "output_cost_per_token": 3.5e-06,
         "supports_pdf_input": true
@@ -10695,9 +10695,9 @@
     "bedrock/us-gov-west-1/meta.llama3-70b-instruct-v1:0": {
         "input_cost_per_token": 2.65e-06,
         "litellm_provider": "bedrock",
-        "max_input_tokens": 8000,
-        "max_output_tokens": 2048,
-        "max_tokens": 2048,
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
         "mode": "chat",
         "output_cost_per_token": 3.5e-06,
         "supports_pdf_input": true

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -10518,9 +10518,9 @@
     "bedrock/us-gov-east-1/meta.llama3-70b-instruct-v1:0": {
         "input_cost_per_token": 2.65e-06,
         "litellm_provider": "bedrock",
-        "max_input_tokens": 8000,
-        "max_output_tokens": 2048,
-        "max_tokens": 2048,
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
         "mode": "chat",
         "output_cost_per_token": 3.5e-06,
         "supports_pdf_input": true
@@ -10695,9 +10695,9 @@
     "bedrock/us-gov-west-1/meta.llama3-70b-instruct-v1:0": {
         "input_cost_per_token": 2.65e-06,
         "litellm_provider": "bedrock",
-        "max_input_tokens": 8000,
-        "max_output_tokens": 2048,
-        "max_tokens": 2048,
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
         "mode": "chat",
         "output_cost_per_token": 3.5e-06,
         "supports_pdf_input": true


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This is a static data fix to `model_prices_and_context_window.json` — no LLM calls or e2e reproduction apply. Evidence instead:

`bedrock/us-gov-east-1/meta.llama3-70b-instruct-v1:0` and `bedrock/us-gov-west-1/meta.llama3-70b-instruct-v1:0` listed `max_input_tokens: 8000`, `max_output_tokens: 2048`, `max_tokens: 2048` — inconsistent with every other region for this same model (`ap-south-1`, `ca-central-1`, `eu-west-1`, `eu-west-2`, `sa-east-1`, `us-east-1`, `us-west-1`, and the global `meta.llama3-70b-instruct-v1:0` entry), all of which are `8192`/`8192`/`8192`.

[AWS's model card for Llama 3 70B Instruct](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-meta-llama-3-70b-instruct.html) confirms: **Context window: 8K tokens**, **Max output tokens: 8K**.

Before (on `main`):
```json
"bedrock/us-gov-east-1/meta.llama3-70b-instruct-v1:0": {
    "max_input_tokens": 8000,
    "max_output_tokens": 2048,
    "max_tokens": 2048,
    ...
}
```

After (this PR):
```json
"bedrock/us-gov-east-1/meta.llama3-70b-instruct-v1:0": {
    "max_input_tokens": 8192,
    "max_output_tokens": 8192,
    "max_tokens": 8192,
    ...
}
```

Verified both `model_prices_and_context_window.json` and the synced `litellm/model_prices_and_context_window_backup.json` remain valid JSON after the change:
```
python3 -c "import json; json.load(open('model_prices_and_context_window.json'))"
python3 -c "import json; json.load(open('litellm/model_prices_and_context_window_backup.json'))"
```

## Type

🐛 Bug Fix

## Changes

- Fixed `max_input_tokens`, `max_output_tokens`, `max_tokens` for `meta.llama3-70b-instruct-v1:0` in `bedrock/us-gov-east-1` and `bedrock/us-gov-west-1` to `8192`/`8192`/`8192`, matching AWS's model card and every other region for this model.
- Applied the same fix to `litellm/model_prices_and_context_window_backup.json` to keep it in sync with `model_prices_and_context_window.json`.

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR