### PR TITLE
feat(proxy): add LDAP login

### DIFF
--- a/litellm/proxy/auth/ldap_auth.py
+++ b/litellm/proxy/auth/ldap_auth.py
@@ -1,0 +1,374 @@
+import json
+import os
+from dataclasses import dataclass, field
+from hashlib import sha256
+from typing import Any
+
+from pydantic import Field
+from starlette.concurrency import run_in_threadpool
+
+from litellm.proxy._types import LiteLLM_UserTable, LitellmUserRoles, ProxyErrorTypes, ProxyException
+from litellm.proxy.management_helpers.utils import get_new_internal_user_defaults
+from litellm.proxy.utils import PrismaClient
+from litellm.repositories.config_repository import ConfigRepository
+from litellm.repositories.user_repository import UserRepository
+from litellm.types.utils import LiteLLMPydanticObjectBase
+
+LDAP_SETTINGS_PARAM_NAME = "ldap_settings"
+LDAP_SENSITIVE_FIELDS = {"ldap_bind_password"}
+
+
+class LDAPConfig(LiteLLMPydanticObjectBase):
+    ldap_enabled: bool = Field(default=False, description="Enable LDAP login for the Admin UI")
+    ldap_url: str | None = Field(default=None, description="LDAP server URL, for example ldap://host:389")
+    ldap_base_dn: str | None = Field(default=None, description="Base DN used to search for users")
+    ldap_search_base: str | None = Field(default=None, description="Optional search base. Defaults to base DN")
+    ldap_bind_dn: str | None = Field(default=None, description="Service account DN used to search users")
+    ldap_bind_password: str | None = Field(default=None, description="Service account password")
+    ldap_user_search_filter: str = Field(
+        default="(|(uid={username})(sAMAccountName={username})(userPrincipalName={username}))",
+        description="LDAP user search filter. The {username} placeholder is escaped before use",
+    )
+    ldap_email_attribute: str = Field(default="mail", description="LDAP attribute used as the LiteLLM user email")
+    ldap_user_id_attribute: str | None = Field(
+        default=None,
+        description="Immutable LDAP attribute used as the LiteLLM identity, for example objectGUID or entryUUID",
+    )
+    ldap_display_name_attribute: str = Field(
+        default="displayName",
+        description="LDAP attribute used as the LiteLLM user display name",
+    )
+    ldap_group_attribute: str = Field(default="memberOf", description="LDAP attribute containing user group DNs")
+    ldap_admin_group_dn: str | None = Field(
+        default=None,
+        description="LDAP group DN whose members should become LiteLLM proxy admins",
+    )
+    ldap_use_ssl: bool = Field(default=False, description="Connect to LDAP with SSL")
+    ldap_start_tls: bool = Field(default=False, description="Upgrade LDAP connection with StartTLS before bind")
+    ldap_allow_insecure: bool = Field(
+        default=False,
+        description="Allow LDAP bind without SSL or StartTLS. Not recommended outside isolated development environments",
+    )
+
+
+@dataclass
+class LDAPDirectoryUser:
+    username: str
+    dn: str
+    email: str | None
+    display_name: str | None
+    principal_id: str | None = None
+    groups: list[str] = field(default_factory=list)
+    user_role: LitellmUserRoles = LitellmUserRoles.INTERNAL_USER
+
+    @property
+    def principal_hash(self) -> str:
+        normalized_principal = (self.principal_id or self.dn).strip().casefold()
+        return sha256(normalized_principal.encode("utf-8")).hexdigest()
+
+    @property
+    def user_id(self) -> str:
+        return f"ldap:{self.principal_hash}"
+
+    @property
+    def legacy_user_id(self) -> str:
+        identifier = self.email or self.username
+        return f"ldap:{identifier.casefold()}"
+
+
+def _parse_bool(value: str | None, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def _load_ldap_config_from_env() -> LDAPConfig:
+    ldap_url = os.getenv("LDAP_URL")
+    return LDAPConfig(
+        ldap_enabled=_parse_bool(os.getenv("LDAP_ENABLED"), default=bool(ldap_url)),
+        ldap_url=ldap_url,
+        ldap_base_dn=os.getenv("LDAP_BASE_DN"),
+        ldap_search_base=os.getenv("LDAP_SEARCH_BASE"),
+        ldap_bind_dn=os.getenv("LDAP_BIND_DN") or os.getenv("LDAP_BIND_USER"),
+        ldap_bind_password=os.getenv("LDAP_BIND_PASSWORD"),
+        ldap_user_search_filter=os.getenv(
+            "LDAP_USER_SEARCH_FILTER",
+            "(|(uid={username})(sAMAccountName={username})(userPrincipalName={username}))",
+        ),
+        ldap_email_attribute=os.getenv("LDAP_EMAIL_ATTRIBUTE", "mail"),
+        ldap_user_id_attribute=os.getenv("LDAP_USER_ID_ATTRIBUTE"),
+        ldap_display_name_attribute=os.getenv("LDAP_DISPLAY_NAME_ATTRIBUTE", "displayName"),
+        ldap_group_attribute=os.getenv("LDAP_GROUP_ATTRIBUTE", "memberOf"),
+        ldap_admin_group_dn=os.getenv("LDAP_ADMIN_GROUP_DN"),
+        ldap_use_ssl=_parse_bool(os.getenv("LDAP_USE_SSL"), default=False),
+        ldap_start_tls=_parse_bool(os.getenv("LDAP_START_TLS"), default=False),
+        ldap_allow_insecure=_parse_bool(os.getenv("LDAP_ALLOW_INSECURE"), default=False),
+    )
+
+
+def _parse_db_param_value(param_value: Any) -> dict[str, Any]:
+    if param_value is None:
+        return {}
+    if isinstance(param_value, str):
+        return json.loads(param_value)
+    return dict(param_value)
+
+
+async def load_ldap_config(prisma_client: PrismaClient | None) -> LDAPConfig:
+    if prisma_client is None:
+        return _load_ldap_config_from_env()
+
+    record = await ConfigRepository(prisma_client).table.find_unique(where={"param_name": LDAP_SETTINGS_PARAM_NAME})
+    if record is None or not getattr(record, "param_value", None):
+        return _load_ldap_config_from_env()
+
+    settings = _parse_db_param_value(record.param_value)
+    from litellm.proxy.proxy_server import proxy_config
+
+    decrypted_settings = proxy_config._decrypt_db_variables(settings)
+    return LDAPConfig(**decrypted_settings)
+
+
+async def is_ldap_configured(prisma_client: PrismaClient | None = None) -> bool:
+    config = await load_ldap_config(prisma_client)
+    return is_ldap_config_enabled(config)
+
+
+def is_ldap_config_enabled(config: LDAPConfig) -> bool:
+    return bool(config.ldap_enabled and config.ldap_url and config.ldap_base_dn)
+
+
+def _entry_values(entry: Any, attribute_name: str) -> list[str]:
+    attr = getattr(entry, attribute_name, None)
+    if attr is None:
+        return []
+    values = getattr(attr, "values", None)
+    if values is None:
+        value = getattr(attr, "value", None)
+        return [str(value)] if value is not None else []
+    if isinstance(values, (list, tuple, set)):
+        return [str(value) for value in values if value is not None]
+    return [str(values)]
+
+
+def _entry_first_value(entry: Any, attribute_name: str) -> str | None:
+    values = _entry_values(entry, attribute_name)
+    return values[0] if values else None
+
+
+def _authenticate_ldap_credentials(
+    config: LDAPConfig,
+    username: str,
+    password: str,
+) -> LDAPDirectoryUser | None:
+    if not config.ldap_allow_insecure and not config.ldap_use_ssl and not config.ldap_start_tls:
+        raise ProxyException(
+            message="LDAP authentication requires SSL or StartTLS unless insecure LDAP is explicitly enabled.",
+            type=ProxyErrorTypes.auth_error,
+            param="ldap_allow_insecure",
+            code=400,
+        )
+    try:
+        from ldap3 import NONE, SUBTREE, Connection, Server
+        from ldap3.utils.conv import escape_filter_chars
+    except ImportError as e:
+        raise ProxyException(
+            message="LDAP login requires the `ldap3` package. Install LiteLLM proxy with ldap3 support.",
+            type=ProxyErrorTypes.auth_error,
+            param="ldap3",
+            code=500,
+        ) from e
+
+    if not config.ldap_url or not config.ldap_base_dn:
+        return None
+
+    server = Server(config.ldap_url, get_info=NONE, use_ssl=config.ldap_use_ssl)
+    bind_conn = Connection(
+        server,
+        user=config.ldap_bind_dn,
+        password=config.ldap_bind_password,
+        auto_bind=False,
+    )
+    if config.ldap_start_tls and not bind_conn.start_tls():
+        return None
+    if not bind_conn.bind():
+        return None
+
+    escaped_username = escape_filter_chars(username)
+    search_filter = config.ldap_user_search_filter.replace("{username}", escaped_username)
+    search_base = config.ldap_search_base or config.ldap_base_dn
+    attributes = list(
+        {
+            config.ldap_email_attribute,
+            config.ldap_display_name_attribute,
+            config.ldap_group_attribute,
+            *([config.ldap_user_id_attribute] if config.ldap_user_id_attribute else []),
+        }
+    )
+
+    search_ok = bind_conn.search(
+        search_base=search_base,
+        search_filter=search_filter,
+        search_scope=SUBTREE,
+        attributes=attributes,
+        size_limit=1,
+    )
+    if not search_ok or not bind_conn.entries:
+        bind_conn.unbind()
+        return None
+
+    entry = bind_conn.entries[0]
+    user_dn = str(entry.entry_dn)
+    email = _entry_first_value(entry, config.ldap_email_attribute)
+    display_name = _entry_first_value(entry, config.ldap_display_name_attribute)
+    groups = _entry_values(entry, config.ldap_group_attribute)
+    principal_id = (
+        _entry_first_value(entry, config.ldap_user_id_attribute) if config.ldap_user_id_attribute else user_dn
+    )
+    bind_conn.unbind()
+
+    user_conn = Connection(server, user=user_dn, password=password, auto_bind=False)
+    if config.ldap_start_tls and not user_conn.start_tls():
+        return None
+    if not user_conn.bind():
+        return None
+    user_conn.unbind()
+
+    user_role = LitellmUserRoles.INTERNAL_USER
+    normalized_groups = frozenset(group.strip().casefold() for group in groups)
+    if config.ldap_admin_group_dn and config.ldap_admin_group_dn.strip().casefold() in normalized_groups:
+        user_role = LitellmUserRoles.PROXY_ADMIN
+
+    return LDAPDirectoryUser(
+        username=username,
+        dn=user_dn,
+        email=email,
+        display_name=display_name,
+        principal_id=principal_id,
+        groups=groups,
+        user_role=user_role,
+    )
+
+
+async def _resolve_ldap_user_id(
+    user_repository: UserRepository,
+    directory_user: LDAPDirectoryUser,
+) -> str:
+    from prisma import Json
+
+    stable_user = await user_repository.table.find_unique(where={"user_id": directory_user.user_id})
+    if stable_user is not None:
+        return str(getattr(stable_user, "user_id", None) or stable_user["user_id"])
+
+    legacy_user = await user_repository.table.find_unique(where={"user_id": directory_user.legacy_user_id})
+    if legacy_user is not None:
+        return str(getattr(legacy_user, "user_id", None) or legacy_user["user_id"])
+
+    metadata_user = await user_repository.table.find_first(
+        where={
+            "OR": [
+                {
+                    "metadata": {
+                        "path": ["ldap_principal_hash"],
+                        "equals": Json(directory_user.principal_hash),
+                    }
+                },
+                {"metadata": {"path": ["ldap_dn"], "equals": Json(directory_user.dn)}},
+            ]
+        }
+    )
+    if metadata_user is not None:
+        return str(getattr(metadata_user, "user_id", None) or metadata_user["user_id"])
+    return directory_user.user_id
+
+
+async def _sync_ldap_user(
+    prisma_client: PrismaClient,
+    directory_user: LDAPDirectoryUser,
+    sync_user_role: bool = False,
+) -> LiteLLM_UserTable:
+    user_repository = UserRepository(prisma_client)
+    resolved_user_id = await _resolve_ldap_user_id(user_repository, directory_user)
+    ldap_metadata = json.dumps(
+        {
+            "auth_provider": "ldap",
+            "ldap_dn": directory_user.dn,
+            "ldap_principal_hash": directory_user.principal_hash,
+        }
+    )
+    create_data = get_new_internal_user_defaults(
+        user_id=resolved_user_id,
+        user_email=directory_user.email,
+    )
+    if sync_user_role:
+        create_data["user_role"] = directory_user.user_role
+    create_data["user_alias"] = directory_user.display_name or directory_user.username
+    create_data["metadata"] = ldap_metadata
+
+    update_data: dict[str, Any] = {
+        "user_alias": directory_user.display_name or directory_user.username,
+        "metadata": ldap_metadata,
+    }
+    if sync_user_role:
+        update_data["user_role"] = directory_user.user_role
+    if directory_user.email is not None:
+        update_data["user_email"] = directory_user.email
+
+    row = await user_repository.table.upsert(
+        where={"user_id": resolved_user_id},
+        data={
+            "create": create_data,
+            "update": update_data,
+        },
+    )
+    if isinstance(row, LiteLLM_UserTable):
+        return row
+    user_model = user_repository._to_model(row)
+    if user_model is not None:
+        return user_model
+    return LiteLLM_UserTable(**create_data)
+
+
+async def authenticate_ldap_user(
+    username: str,
+    password: str,
+    prisma_client: PrismaClient | None,
+) -> LiteLLM_UserTable:
+    if prisma_client is None:
+        raise ProxyException(
+            message="Database connection is required for LDAP login.",
+            type=ProxyErrorTypes.auth_error,
+            param="DATABASE_URL",
+            code=500,
+        )
+    if not password:
+        raise ProxyException(
+            message="Invalid LDAP credentials.",
+            type=ProxyErrorTypes.auth_error,
+            param="invalid_credentials",
+            code=401,
+        )
+
+    config = await load_ldap_config(prisma_client)
+    if not is_ldap_config_enabled(config):
+        raise ProxyException(
+            message="LDAP login is not configured.",
+            type=ProxyErrorTypes.auth_error,
+            param="ldap_settings",
+            code=401,
+        )
+
+    directory_user = await run_in_threadpool(_authenticate_ldap_credentials, config, username, password)
+    if directory_user is None:
+        raise ProxyException(
+            message="Invalid LDAP credentials.",
+            type=ProxyErrorTypes.auth_error,
+            param="invalid_credentials",
+            code=401,
+        )
+
+    return await _sync_ldap_user(
+        prisma_client=prisma_client,
+        directory_user=directory_user,
+        sync_user_role=bool(config.ldap_admin_group_dn),
+    )

--- a/litellm/proxy/auth/login_utils.py
+++ b/litellm/proxy/auth/login_utils.py
@@ -7,7 +7,7 @@ login endpoints (e.g., /login and /v2/login).
 
 import os
 import secrets
-from typing import Literal, Optional, cast
+from typing import Literal, cast
 
 from fastapi import HTTPException
 
@@ -21,6 +21,7 @@ from litellm.proxy._types import (
     UpdateUserRequest,
     UserAPIKeyAuth,
 )
+from litellm.proxy.auth.ldap_auth import authenticate_ldap_user
 from litellm.proxy.management_endpoints.internal_user_endpoints import user_update
 from litellm.proxy.management_endpoints.key_management_endpoints import (
     generate_key_helper_fn,
@@ -52,7 +53,7 @@ async def _rehash_password_if_needed(user_id: str, password: str, stored: str) -
         )
 
 
-def get_ui_credentials(master_key: Optional[str]) -> tuple[str, str]:
+def get_ui_credentials(master_key: str | None) -> tuple[str, str]:
     """
     Get UI username and password from environment variables or master key.
 
@@ -84,7 +85,7 @@ class LoginResult:
 
     user_id: str
     key: str
-    user_email: Optional[str]
+    user_email: str | None
     user_role: str
     login_method: Literal["sso", "username_password"]
 
@@ -92,7 +93,7 @@ class LoginResult:
         self,
         user_id: str,
         key: str,
-        user_email: Optional[str],
+        user_email: str | None,
         user_role: str,
         login_method: Literal["sso", "username_password"] = "username_password",
     ):
@@ -103,11 +104,11 @@ class LoginResult:
         self.login_method = login_method
 
 
-async def authenticate_user(
+async def _authenticate_local_user(
     username: str,
     password: str,
-    master_key: Optional[str],
-    prisma_client: Optional[PrismaClient],
+    master_key: str | None,
+    prisma_client: PrismaClient | None,
 ) -> LoginResult:
     """
     Authenticate a user and generate an API key for UI access.
@@ -139,19 +140,20 @@ async def authenticate_user(
     ui_username, ui_password = get_ui_credentials(master_key)
 
     # Check if we can find the `username` in the db. On the UI, users can enter username=their email
-    _user_row: Optional[LiteLLM_UserTable] = None
-    user_role: Optional[
+    _user_row: LiteLLM_UserTable | None = None
+    user_role: (
         Literal[
             LitellmUserRoles.PROXY_ADMIN,
             LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY,
             LitellmUserRoles.INTERNAL_USER,
             LitellmUserRoles.INTERNAL_USER_VIEW_ONLY,
         ]
-    ] = None
+        | None
+    ) = None
 
     if prisma_client is not None:
         _user_row = cast(
-            Optional[LiteLLM_UserTable],
+            LiteLLM_UserTable | None,
             await UserRepository(prisma_client).table.find_first(
                 where={"user_email": {"equals": username, "mode": "insensitive"}}
             ),
@@ -218,7 +220,7 @@ async def authenticate_user(
         if get_secret_bool("EXPERIMENTAL_UI_LOGIN"):
             from litellm.proxy.auth.auth_checks import ExperimentalUIJWTToken
 
-            user_info: Optional[LiteLLM_UserTable] = None
+            user_info: LiteLLM_UserTable | None = None
             if _user_row is not None:
                 user_info = _user_row
             elif user_id is not None:  # if user_id is not None, we are using the UI_USERNAME and UI_PASSWORD
@@ -311,6 +313,76 @@ async def authenticate_user(
             param="invalid_credentials",
             code=401,
         )
+
+
+async def _authenticate_ldap_ui_user(
+    username: str,
+    password: str,
+    master_key: str | None,
+    prisma_client: PrismaClient | None,
+) -> LoginResult:
+    if master_key is None:
+        raise ProxyException(
+            message="Master Key not set for Proxy. Please set Master Key to use Admin UI. Set `LITELLM_MASTER_KEY` in .env or set general_settings:master_key in config.yaml.",
+            type=ProxyErrorTypes.auth_error,
+            param="master_key",
+            code=500,
+        )
+
+    ldap_user = await authenticate_ldap_user(
+        username=username,
+        password=password,
+        prisma_client=prisma_client,
+    )
+    user_role = ldap_user.user_role or LitellmUserRoles.INTERNAL_USER.value
+    response = await generate_key_helper_fn(
+        request_type="key",
+        user_role=user_role,
+        duration=LITELLM_UI_SESSION_DURATION,
+        key_max_budget=litellm.max_ui_session_budget,
+        models=[],
+        aliases={},
+        config={},
+        spend=0,
+        user_id=ldap_user.user_id,
+        team_id="litellm-dashboard",
+    )
+    return LoginResult(
+        user_id=ldap_user.user_id,
+        key=response["token"],
+        user_email=ldap_user.user_email,
+        user_role=user_role,
+        login_method="username_password",
+    )
+
+
+async def authenticate_user(
+    username: str,
+    password: str,
+    master_key: str | None,
+    prisma_client: PrismaClient | None,
+    auth_method: str | None = None,
+) -> LoginResult:
+    if auth_method in (None, "local"):
+        return await _authenticate_local_user(
+            username=username,
+            password=password,
+            master_key=master_key,
+            prisma_client=prisma_client,
+        )
+    if auth_method == "ldap":
+        return await _authenticate_ldap_ui_user(
+            username=username,
+            password=password,
+            master_key=master_key,
+            prisma_client=prisma_client,
+        )
+    raise ProxyException(
+        message=f"Unsupported auth_method: {auth_method}",
+        type=ProxyErrorTypes.auth_error,
+        param="auth_method",
+        code=400,
+    )
 
 
 def create_ui_token_object(

--- a/litellm/proxy/discovery_endpoints/ui_discovery_endpoints.py
+++ b/litellm/proxy/discovery_endpoints/ui_discovery_endpoints.py
@@ -14,9 +14,8 @@ router = APIRouter()
 @router.get("/litellm/.well-known/litellm-ui-config", response_model=UiDiscoveryEndpoints)  # if mounted at root path
 async def get_ui_config():
     from litellm.proxy.auth.auth_utils import _has_user_setup_sso
-    from litellm.proxy.utils import get_proxy_base_url, get_server_root_path
-
     from litellm.proxy.proxy_server import general_settings
+    from litellm.proxy.utils import get_proxy_base_url, get_server_root_path
 
     auto_redirect_ui_login_to_sso = (
         os.getenv("AUTO_REDIRECT_UI_LOGIN_TO_SSO", "false").lower() == "true"
@@ -30,9 +29,11 @@ async def get_ui_config():
 
     sso_configured = _has_user_setup_sso()
 
-    from litellm.proxy.proxy_server import proxy_config
+    from litellm.proxy.auth.ldap_auth import is_ldap_configured
+    from litellm.proxy.proxy_server import prisma_client, proxy_config
 
     is_control_plane = len(proxy_config.worker_registry) > 0
+    ldap_configured = await is_ldap_configured(prisma_client=prisma_client)
 
     return UiDiscoveryEndpoints(
         server_root_path=get_server_root_path(),
@@ -40,6 +41,7 @@ async def get_ui_config():
         auto_redirect_to_sso=sso_configured and auto_redirect_ui_login_to_sso,
         admin_ui_disabled=admin_ui_disabled,
         sso_configured=sso_configured,
+        ldap_configured=ldap_configured,
         hide_default_credentials_hint=hide_default_credentials_hint,
         is_control_plane=is_control_plane,
         workers=proxy_config.worker_registry if is_control_plane else [],

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -13237,6 +13237,8 @@ async def login(request: Request):
     form = await request.form()
     username = str(form.get("username"))
     password = str(form.get("password"))
+    auth_method_value = form.get("auth_method")
+    auth_method = str(auth_method_value) if auth_method_value is not None else None
 
     # Authenticate user and get login result
     login_result = await authenticate_user(
@@ -13244,6 +13246,7 @@ async def login(request: Request):
         password=password,
         master_key=master_key,
         prisma_client=prisma_client,
+        auth_method=auth_method,
     )
 
     # Create UI token object
@@ -13286,12 +13289,15 @@ async def login_v2(request: Request):
         body = await request.json()
         username = str(body.get("username"))
         password = str(body.get("password"))
+        auth_method_value = body.get("auth_method")
+        auth_method = str(auth_method_value) if auth_method_value is not None else None
 
         login_result = await authenticate_user(
             username=username,
             password=password,
             master_key=master_key,
             prisma_client=prisma_client,
+            auth_method=auth_method,
         )
 
         returned_ui_token_object = create_ui_token_object(
@@ -13365,12 +13371,15 @@ async def login_v3(request: Request):
         body = await request.json()
         username = str(body.get("username"))
         password = str(body.get("password"))
+        auth_method_value = body.get("auth_method")
+        auth_method = str(auth_method_value) if auth_method_value is not None else None
 
         login_result = await authenticate_user(
             username=username,
             password=password,
             master_key=master_key,
             prisma_client=prisma_client,
+            auth_method=auth_method,
         )
 
         returned_ui_token_object = create_ui_token_object(

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -1,7 +1,7 @@
 #### CRUD ENDPOINTS for UI Settings #####
 import asyncio
 import json
-from typing import Any, Dict, List, Optional, Set, Tuple, Type, Union
+from typing import Annotated, Any, Union
 from urllib.parse import urlparse
 
 from fastapi import APIRouter, Body, Depends, File, HTTPException, UploadFile
@@ -12,6 +12,12 @@ import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.litellm_core_utils.sensitive_data_masker import mask_sensitive_keys
 from litellm.proxy._types import *
+from litellm.proxy.auth.ldap_auth import (
+    LDAP_SENSITIVE_FIELDS,
+    LDAP_SETTINGS_PARAM_NAME,
+    LDAPConfig,
+    _parse_db_param_value,
+)
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.repositories.config_repository import ConfigRepository
 from litellm.repositories.table_repositories import (
@@ -29,7 +35,7 @@ router = APIRouter()
 # the UI can show "(set)" without ever transporting the plaintext OAuth secret
 # off the server, matching the write-once + masked-on-read contract used for
 # the HashiCorp Vault config override.
-_SSO_SENSITIVE_FIELDS: Set[str] = {
+_SSO_SENSITIVE_FIELDS: set[str] = {
     "google_client_secret",
     "microsoft_client_secret",
     "generic_client_secret",
@@ -44,13 +50,13 @@ class UIThemeConfig(BaseModel):
     """Configuration for UI theme customization"""
 
     # Logo configuration
-    logo_url: Optional[str] = Field(
+    logo_url: str | None = Field(
         default=None,
         description="URL or path to custom logo image. Can be a local file path or HTTP/HTTPS URL",
     )
 
     # Favicon configuration
-    favicon_url: Optional[str] = Field(
+    favicon_url: str | None = Field(
         default=None,
         description="URL to custom favicon image. Must be an HTTP/HTTPS URL to a .ico, .png, or .svg file",
     )
@@ -59,15 +65,21 @@ class UIThemeConfig(BaseModel):
 class SettingsResponse(BaseModel):
     """Base response model for settings with values and schema information"""
 
-    values: Dict[str, Any]
+    values: dict[str, Any]
     """The current configuration values"""
 
-    field_schema: Dict[str, Any]
+    field_schema: dict[str, Any]
     """Schema information including descriptions and property types for UI display"""
 
 
 class SSOSettingsResponse(SettingsResponse):
     """Response model for SSO settings"""
+
+    pass
+
+
+class LDAPSettingsResponse(SettingsResponse):
+    """Response model for LDAP settings"""
 
     pass
 
@@ -105,7 +117,7 @@ class UISettings(BaseModel):
         description="Prevents Team Admins from deleting users from the teams they manage. Useful for SCIM provisioning where team membership is defined externally.",
     )
 
-    enabled_ui_pages_internal_users: Optional[List[str]] = Field(
+    enabled_ui_pages_internal_users: list[str] | None = Field(
         default=None,
         description="List of page keys that internal users (non-admins) can see in the UI sidebar. If not set, all pages are visible based on role permissions.",
     )
@@ -231,16 +243,16 @@ _RUNTIME_GENERAL_SETTINGS_FLAGS = [
 # include generics like ``Optional[int]`` / ``List[str]`` that are not
 # instances of ``type`` — so tightening this to ``type`` would reject
 # valid inputs.
-_EXTRA_UI_SETTINGS_FIELDS: Dict[str, Tuple[Any, FieldInfo]] = {}
+_EXTRA_UI_SETTINGS_FIELDS: dict[str, tuple[Any, FieldInfo]] = {}
 
 # Settings OSS knows about as enterprise-gated. If a caller sends one of
 # these keys and no extension package has registered it, the PATCH
 # endpoint returns 403 instead of silently dropping the value, so the
 # client gets a clear signal that the feature requires LiteLLM Enterprise.
-_ENTERPRISE_ONLY_UI_SETTINGS: Set[str] = {"enable_projects_ui"}
+_ENTERPRISE_ONLY_UI_SETTINGS: set[str] = {"enable_projects_ui"}
 
 # Memoized effective class; invalidated on registration.
-_EFFECTIVE_UI_SETTINGS_CLASS: Optional[Type[UISettings]] = None
+_EFFECTIVE_UI_SETTINGS_CLASS: type[UISettings] | None = None
 
 
 def register_extra_ui_setting(name: str, annotation: Any, field: FieldInfo) -> None:
@@ -257,7 +269,7 @@ def register_extra_ui_setting(name: str, annotation: Any, field: FieldInfo) -> N
     _EFFECTIVE_UI_SETTINGS_CLASS = None
 
 
-def _get_effective_ui_settings_class() -> Type[UISettings]:
+def _get_effective_ui_settings_class() -> type[UISettings]:
     """Return UISettings with any extension-registered fields merged in.
 
     Memoized — pydantic ``create_model`` runs metaclass + schema work
@@ -344,7 +356,7 @@ async def add_allowed_ip(
     if prisma_client is None:
         raise Exception("No DB Connected")
 
-    _allowed_ips: List = general_settings.get("allowed_ips", [])
+    _allowed_ips: list = general_settings.get("allowed_ips", [])
     if ip_address.ip not in _allowed_ips:
         _allowed_ips.append(ip_address.ip)
         general_settings["allowed_ips"] = _allowed_ips
@@ -403,7 +415,7 @@ async def delete_allowed_ip(
         proxy_config,
     )
 
-    _allowed_ips: List = general_settings.get("allowed_ips", [])
+    _allowed_ips: list = general_settings.get("allowed_ips", [])
     if ip_address.ip in _allowed_ips:
         _allowed_ips.remove(ip_address.ip)
         general_settings["allowed_ips"] = _allowed_ips
@@ -562,7 +574,7 @@ async def get_default_team_settings():
     )
 
 
-async def update_default_team_member_budget(teams: List[NewUserRequestTeam], user_api_key_dict: UserAPIKeyAuth):
+async def update_default_team_member_budget(teams: list[NewUserRequestTeam], user_api_key_dict: UserAPIKeyAuth):
     """
     1. Update the max member budget for the team
     """
@@ -703,6 +715,120 @@ async def update_default_team_settings(
         success_message="Default team settings updated successfully",
         user_api_key_dict=user_api_key_dict,
     )
+
+
+@router.get(
+    "/get/ldap_settings",
+    tags=["LDAP Settings"],
+    dependencies=[Depends(user_api_key_auth)],
+    response_model=LDAPSettingsResponse,
+)
+async def get_ldap_settings():
+    from litellm.proxy.proxy_server import prisma_client, proxy_config
+
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": "Database not connected. Please connect a database."},
+        )
+
+    db_record = await ConfigRepository(prisma_client).table.find_unique(where={"param_name": LDAP_SETTINGS_PARAM_NAME})
+    ldap_settings_dict: dict[str, Any] = {}
+    if db_record and db_record.param_value:
+        ldap_settings_dict = _parse_db_param_value(db_record.param_value)
+
+    decrypted_settings = proxy_config._decrypt_db_variables(ldap_settings_dict)
+    ldap_config = LDAPConfig(**decrypted_settings)
+
+    from pydantic import TypeAdapter
+
+    schema = TypeAdapter(LDAPConfig).json_schema(by_alias=True)
+    ldap_dict = mask_sensitive_keys(ldap_config.model_dump(), LDAP_SENSITIVE_FIELDS)
+
+    result = {
+        "values": ldap_dict,
+        "field_schema": {
+            "description": schema.get("description", ""),
+            "properties": {},
+        },
+    }
+    for field_name, field_info in schema["properties"].items():
+        result["field_schema"]["properties"][field_name] = {
+            "description": field_info.get("description", ""),
+            "type": field_info.get("type", "string"),
+        }
+
+    return result
+
+
+@router.patch(
+    "/update/ldap_settings",
+    tags=["LDAP Settings"],
+    dependencies=[Depends(user_api_key_auth)],
+)
+async def update_ldap_settings(
+    ldap_config: LDAPConfig,
+    user_api_key_dict: Annotated[UserAPIKeyAuth, Depends(user_api_key_auth)],
+):
+    from litellm.proxy.proxy_server import (
+        create_config_audit_log,
+        prisma_client,
+        proxy_config,
+        store_model_in_db,
+    )
+
+    if prisma_client is None:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": "Database not connected. Please connect a database."},
+        )
+
+    if store_model_in_db is not True:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": "Set `'STORE_MODEL_IN_DB='True'` in your env to enable this feature."},
+        )
+
+    existing_record = await ConfigRepository(prisma_client).table.find_unique(
+        where={"param_name": LDAP_SETTINGS_PARAM_NAME}
+    )
+    before_ldap_data: dict[str, Any] | None = None
+    if existing_record and existing_record.param_value:
+        before_ldap_data = proxy_config._decrypt_db_variables(_parse_db_param_value(existing_record.param_value))
+
+    ldap_data = ldap_config.model_dump()
+    if not ldap_data.get("ldap_bind_password") and before_ldap_data:
+        ldap_data["ldap_bind_password"] = before_ldap_data.get("ldap_bind_password")
+    encrypted_ldap_data = proxy_config._encrypt_env_variables(environment_variables=ldap_data)
+
+    await ConfigRepository(prisma_client).table.upsert(
+        where={"param_name": LDAP_SETTINGS_PARAM_NAME},
+        data={
+            "create": {
+                "param_name": LDAP_SETTINGS_PARAM_NAME,
+                "param_value": json.dumps(encrypted_ldap_data),
+            },
+            "update": {
+                "param_value": json.dumps(encrypted_ldap_data),
+            },
+        },
+    )
+
+    asyncio.create_task(
+        create_config_audit_log(
+            param_name=LDAP_SETTINGS_PARAM_NAME,
+            action="updated",
+            before_value=before_ldap_data,
+            after_value=ldap_data,
+            user_api_key_dict=user_api_key_dict,
+        )
+    )
+
+    return {
+        "message": "LDAP settings updated successfully",
+        "status": "success",
+        "settings": mask_sensitive_keys(ldap_data, LDAP_SENSITIVE_FIELDS),
+    }
 
 
 @router.get(
@@ -862,7 +988,7 @@ async def update_sso_settings(
     # create_config_audit_log's secret-name redaction to mask the
     # *_client_secret fields before the audit row is written.
     existing_sso_record = await SSOConfigRepository(prisma_client).table.find_unique(where={"id": "sso_config"})
-    before_sso_data: Optional[Dict[str, Any]] = None
+    before_sso_data: dict[str, Any] | None = None
     if existing_sso_record and existing_sso_record.sso_settings:
         stored = existing_sso_record.sso_settings
         if isinstance(stored, str):
@@ -984,7 +1110,7 @@ async def get_ui_theme_settings():
     )
 
 
-def _validate_public_image_url(value: Optional[str], field_name: str) -> None:
+def _validate_public_image_url(value: str | None, field_name: str) -> None:
     """
     Reject anything that isn't a plain http(s) URL with a host. This value is
     later served via the unauthenticated /get_image endpoint, so local paths
@@ -1193,7 +1319,7 @@ UI_SETTINGS_CACHE_KEY = "ui_settings:settings_dict"
 UI_SETTINGS_CACHE_TTL = 600  # 10 minutes
 
 
-async def get_ui_settings_cached() -> Dict[str, Any]:
+async def get_ui_settings_cached() -> dict[str, Any]:
     """
     Return the persisted UI settings dict, using DualCache for reads.
 
@@ -1212,7 +1338,7 @@ async def get_ui_settings_cached() -> Dict[str, Any]:
         return {}
 
     db_record = await UISettingsRepository(prisma_client).table.find_unique(where={"id": "ui_settings"})
-    ui_settings: Dict[str, Any] = {}
+    ui_settings: dict[str, Any] = {}
     if db_record and db_record.ui_settings:
         raw = db_record.ui_settings
         ui_settings = json.loads(raw) if isinstance(raw, str) else dict(raw)
@@ -1244,7 +1370,7 @@ async def get_ui_settings():
             detail={"error": "Database not connected. Please connect a database."},
         )
 
-    ui_settings: Dict[str, Any] = {}
+    ui_settings: dict[str, Any] = {}
 
     db_record = await UISettingsRepository(prisma_client).table.find_unique(where={"id": "ui_settings"})
 
@@ -1272,7 +1398,7 @@ async def get_ui_settings():
     await user_api_key_cache.async_set_cache(key=UI_SETTINGS_CACHE_KEY, value=ui_settings, ttl=UI_SETTINGS_CACHE_TTL)
 
     # Build config-like object for schema helper
-    config: Dict[str, Any] = {"litellm_settings": {"ui_settings": ui_settings}}
+    config: dict[str, Any] = {"litellm_settings": {"ui_settings": ui_settings}}
 
     return await _get_settings_with_schema(
         settings_key="ui_settings",
@@ -1287,7 +1413,7 @@ async def get_ui_settings():
     dependencies=[Depends(user_api_key_auth)],
 )
 async def update_ui_settings(
-    settings_body: Dict[str, Any] = Body(...),
+    settings_body: dict[str, Any] = Body(...),
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
     """

--- a/litellm/types/proxy/discovery_endpoints/ui_discovery_endpoints.py
+++ b/litellm/types/proxy/discovery_endpoints/ui_discovery_endpoints.py
@@ -11,6 +11,7 @@ class UiDiscoveryEndpoints(BaseModel):
     auto_redirect_to_sso: bool
     admin_ui_disabled: bool
     sso_configured: bool
+    ldap_configured: bool = False
     hide_default_credentials_hint: bool = False
     is_control_plane: bool = False
     workers: List[WorkerRegistryEntry] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ proxy = [
     "pyroscope-io>=0.8.16,<1.0; sys_platform != 'win32'",
     "pydantic-settings>=2.14.1,<3.0",
     "expression>=5.6.0,<6.0",
+    "ldap3>=2.9.0,<3.0",
 ]
 # Thin client install for the `lite` CLI on developer laptops. The CLI's heavy
 # imports (fastapi, cryptography, ...) are all guarded, so it runs on the base

--- a/tests/test_litellm/proxy/auth/test_ldap_auth.py
+++ b/tests/test_litellm/proxy/auth/test_ldap_auth.py
@@ -1,0 +1,351 @@
+import sys
+import types
+from hashlib import sha256
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import litellm.proxy.auth.ldap_auth as ldap_auth
+from litellm.proxy._types import LitellmUserRoles
+from litellm.proxy._types import ProxyException
+from litellm.proxy.auth.ldap_auth import (
+    LDAPConfig,
+    LDAPDirectoryUser,
+    _authenticate_ldap_credentials,
+    _sync_ldap_user,
+    load_ldap_config,
+)
+
+
+@pytest.mark.asyncio
+async def test_load_ldap_config_decrypts_db_values_without_setting_env(monkeypatch):
+    from litellm.proxy.proxy_server import proxy_config
+
+    monkeypatch.delenv("ldap_use_ssl", raising=False)
+    mock_prisma = MagicMock()
+    mock_record = MagicMock()
+    mock_record.param_value = {
+        "ldap_enabled": True,
+        "ldap_url": "ldaps://ldap.example.com:636",
+        "ldap_base_dn": "dc=example,dc=com",
+        "ldap_use_ssl": True,
+    }
+    mock_prisma.db.litellm_config.find_unique = AsyncMock(return_value=mock_record)
+
+    def fail_if_setting_env(environment_variables):
+        raise AssertionError("LDAP settings must not be written to os.environ")
+
+    monkeypatch.setattr(proxy_config, "_decrypt_and_set_db_env_variables", fail_if_setting_env)
+    monkeypatch.setattr(proxy_config, "_decrypt_db_variables", lambda variables_dict: variables_dict)
+
+    config = await load_ldap_config(mock_prisma)
+
+    assert config.ldap_enabled is True
+    assert config.ldap_url == "ldaps://ldap.example.com:636"
+    assert config.ldap_base_dn == "dc=example,dc=com"
+    assert config.ldap_use_ssl is True
+
+
+@pytest.mark.asyncio
+async def test_sync_ldap_user_serializes_metadata_for_prisma():
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+    mock_prisma.db.litellm_usertable.find_first = AsyncMock(return_value=None)
+    mock_prisma.db.litellm_usertable.upsert = AsyncMock(
+        return_value={
+            "user_id": "ldap:alice@example.com",
+            "user_email": "alice@example.com",
+            "user_role": LitellmUserRoles.INTERNAL_USER,
+            "user_alias": "Alice",
+            "metadata": {"auth_provider": "ldap", "ldap_dn": "uid=alice,dc=example,dc=com"},
+        }
+    )
+
+    await _sync_ldap_user(
+        mock_prisma,
+        LDAPDirectoryUser(
+            username="alice",
+            dn="uid=alice,dc=example,dc=com",
+            email="alice@example.com",
+            display_name="Alice",
+        ),
+    )
+
+    data = mock_prisma.db.litellm_usertable.upsert.call_args.kwargs["data"]
+    metadata_filter = mock_prisma.db.litellm_usertable.find_first.call_args.kwargs["where"]
+    principal_hash = sha256(b"uid=alice,dc=example,dc=com").hexdigest()
+    expected_metadata = (
+        '{"auth_provider": "ldap", "ldap_dn": "uid=alice,dc=example,dc=com", '
+        f'"ldap_principal_hash": "{principal_hash}"}}'
+    )
+    assert data["create"]["metadata"] == expected_metadata
+    assert data["update"]["metadata"] == expected_metadata
+    assert type(metadata_filter["OR"][0]["metadata"]["equals"]).__name__ == "Json"
+    assert type(metadata_filter["OR"][1]["metadata"]["equals"]).__name__ == "Json"
+    assert data["create"]["user_role"] == "internal_user"
+    assert "user_role" not in data["update"]
+
+
+@pytest.mark.asyncio
+async def test_sync_ldap_user_updates_role_when_admin_group_configured():
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+    mock_prisma.db.litellm_usertable.find_first = AsyncMock(return_value=None)
+    mock_prisma.db.litellm_usertable.upsert = AsyncMock(
+        return_value={
+            "user_id": "ldap:alice@example.com",
+            "user_email": "alice@example.com",
+            "user_role": LitellmUserRoles.PROXY_ADMIN,
+            "user_alias": "Alice",
+            "metadata": {"auth_provider": "ldap", "ldap_dn": "uid=alice,dc=example,dc=com"},
+        }
+    )
+
+    await _sync_ldap_user(
+        mock_prisma,
+        LDAPDirectoryUser(
+            username="alice",
+            dn="uid=alice,dc=example,dc=com",
+            email="alice@example.com",
+            display_name="Alice",
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        ),
+        sync_user_role=True,
+    )
+
+    data = mock_prisma.db.litellm_usertable.upsert.call_args.kwargs["data"]
+    assert data["create"]["user_role"] == LitellmUserRoles.PROXY_ADMIN
+    assert data["update"]["user_role"] == LitellmUserRoles.PROXY_ADMIN
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "ldap_admin_group_dn,expected_sync_user_role",
+    [
+        (None, False),
+        ("cn=litellm-admins,ou=Groups,dc=example,dc=com", True),
+    ],
+)
+async def test_authenticate_ldap_user_syncs_role_only_when_admin_group_configured(
+    monkeypatch,
+    ldap_admin_group_dn,
+    expected_sync_user_role,
+):
+    mock_prisma = MagicMock()
+    directory_user = LDAPDirectoryUser(
+        username="alice",
+        dn="uid=alice,dc=example,dc=com",
+        email="alice@example.com",
+        display_name="Alice",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+    synced_user = MagicMock()
+
+    monkeypatch.setattr(
+        ldap_auth,
+        "load_ldap_config",
+        AsyncMock(
+            return_value=LDAPConfig(
+                ldap_enabled=True,
+                ldap_url="ldaps://ldap.example.com:636",
+                ldap_base_dn="dc=example,dc=com",
+                ldap_admin_group_dn=ldap_admin_group_dn,
+            )
+        ),
+    )
+    monkeypatch.setattr(ldap_auth, "_authenticate_ldap_credentials", MagicMock(return_value=directory_user))
+    sync_mock = AsyncMock(return_value=synced_user)
+    monkeypatch.setattr(ldap_auth, "_sync_ldap_user", sync_mock)
+
+    result = await ldap_auth.authenticate_ldap_user(
+        username="alice",
+        password="ldap-password",
+        prisma_client=mock_prisma,
+    )
+
+    assert result == synced_user
+    sync_mock.assert_awaited_once_with(
+        prisma_client=mock_prisma,
+        directory_user=directory_user,
+        sync_user_role=expected_sync_user_role,
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_ldap_user_parses_prisma_json_string_metadata():
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+    mock_prisma.db.litellm_usertable.find_first = AsyncMock(return_value=None)
+    mock_prisma.db.litellm_usertable.upsert = AsyncMock(
+        return_value={
+            "user_id": "ldap:alice@example.com",
+            "user_email": "alice@example.com",
+            "user_role": LitellmUserRoles.INTERNAL_USER,
+            "user_alias": "Alice",
+            "metadata": '{"auth_provider": "ldap", "ldap_dn": "uid=alice,dc=example,dc=com"}',
+        }
+    )
+
+    user = await _sync_ldap_user(
+        mock_prisma,
+        LDAPDirectoryUser(
+            username="alice",
+            dn="uid=alice,dc=example,dc=com",
+            email="alice@example.com",
+            display_name="Alice",
+        ),
+    )
+
+    assert user.metadata == {"auth_provider": "ldap", "ldap_dn": "uid=alice,dc=example,dc=com"}
+
+
+@pytest.mark.asyncio
+async def test_sync_ldap_user_preserves_legacy_user_id_after_email_change():
+    mock_prisma = MagicMock()
+    legacy_user = {
+        "user_id": "ldap:old@example.com",
+        "user_email": "old@example.com",
+        "user_role": LitellmUserRoles.INTERNAL_USER,
+        "user_alias": "Alice",
+        "metadata": {
+            "auth_provider": "ldap",
+            "ldap_dn": "uid=alice,dc=example,dc=com",
+        },
+    }
+    mock_prisma.db.litellm_usertable.find_unique = AsyncMock(side_effect=[None, None])
+    mock_prisma.db.litellm_usertable.find_first = AsyncMock(return_value=legacy_user)
+    mock_prisma.db.litellm_usertable.upsert = AsyncMock(
+        return_value={
+            **legacy_user,
+            "user_email": "new@example.com",
+        }
+    )
+
+    await _sync_ldap_user(
+        mock_prisma,
+        LDAPDirectoryUser(
+            username="alice",
+            dn="uid=alice,dc=example,dc=com",
+            principal_id="directory-object-123",
+            email="new@example.com",
+            display_name="Alice",
+        ),
+    )
+
+    where = mock_prisma.db.litellm_usertable.upsert.call_args.kwargs["where"]
+    data = mock_prisma.db.litellm_usertable.upsert.call_args.kwargs["data"]
+    assert where == {"user_id": "ldap:old@example.com"}
+    assert data["update"]["user_email"] == "new@example.com"
+    assert sha256(b"directory-object-123").hexdigest() in data["update"]["metadata"]
+
+
+def test_ldap_directory_user_id_is_based_on_stable_principal_not_email():
+    directory_user = LDAPDirectoryUser(
+        username="alice",
+        dn="uid=alice,dc=example,dc=com",
+        principal_id="Directory-Object-123",
+        email="alice@example.com",
+        display_name="Alice",
+    )
+
+    expected = sha256(b"directory-object-123").hexdigest()
+    assert directory_user.user_id == f"ldap:{expected}"
+
+
+def test_authenticate_ldap_credentials_escapes_username_and_maps_admin_group(monkeypatch):
+    captured = {}
+
+    class FakeServer:
+        def __init__(self, url, get_info=None, use_ssl=False):
+            captured["server"] = {"url": url, "get_info": get_info, "use_ssl": use_ssl}
+
+    class FakeAttribute:
+        def __init__(self, values):
+            self.values = values
+            self.value = values[0] if values else None
+
+    class FakeEntry:
+        entry_dn = "uid=alice,ou=People,dc=example,dc=com"
+        mail = FakeAttribute(["alice@example.com"])
+        displayName = FakeAttribute(["Alice"])
+        memberOf = FakeAttribute(["cn=litellm-admins,ou=Groups,dc=example,dc=com"])
+
+    class FakeConnection:
+        def __init__(self, server, user=None, password=None, auto_bind=False):
+            self.server = server
+            self.user = user
+            self.password = password
+            self.entries = []
+
+        def start_tls(self):
+            return True
+
+        def bind(self):
+            if self.user == "uid=alice,ou=People,dc=example,dc=com":
+                return self.password == "ldap-password"
+            return True
+
+        def search(self, search_base, search_filter, search_scope, attributes, size_limit):
+            captured["search"] = {
+                "search_base": search_base,
+                "search_filter": search_filter,
+                "search_scope": search_scope,
+                "attributes": attributes,
+                "size_limit": size_limit,
+            }
+            self.entries = [FakeEntry()]
+            return True
+
+        def unbind(self):
+            return True
+
+    ldap3_module = types.ModuleType("ldap3")
+    ldap3_module.NONE = "NONE"
+    ldap3_module.SUBTREE = "SUBTREE"
+    ldap3_module.Server = FakeServer
+    ldap3_module.Connection = FakeConnection
+
+    ldap3_utils_module = types.ModuleType("ldap3.utils")
+    ldap3_conv_module = types.ModuleType("ldap3.utils.conv")
+    ldap3_conv_module.escape_filter_chars = lambda value: value.replace("*", "\\2a").replace("(", "\\28")
+
+    monkeypatch.setitem(sys.modules, "ldap3", ldap3_module)
+    monkeypatch.setitem(sys.modules, "ldap3.utils", ldap3_utils_module)
+    monkeypatch.setitem(sys.modules, "ldap3.utils.conv", ldap3_conv_module)
+
+    config = LDAPConfig(
+        ldap_enabled=True,
+        ldap_url="ldaps://ldap.example.com:636",
+        ldap_base_dn="dc=example,dc=com",
+        ldap_search_base="ou=People,dc=example,dc=com",
+        ldap_bind_dn="cn=admin,dc=example,dc=com",
+        ldap_bind_password="bind-password",
+        ldap_user_search_filter="(uid={username})",
+        ldap_admin_group_dn="cn=litellm-admins,ou=Groups,dc=example,dc=com",
+        ldap_start_tls=True,
+    )
+
+    result = _authenticate_ldap_credentials(config, "ali*(ce", "ldap-password")
+
+    assert result is not None
+    expected_user_id = sha256(b"uid=alice,ou=people,dc=example,dc=com").hexdigest()
+    assert result.user_id == f"ldap:{expected_user_id}"
+    assert result.user_role == LitellmUserRoles.PROXY_ADMIN
+    assert captured["server"]["url"] == "ldaps://ldap.example.com:636"
+    assert captured["search"]["search_base"] == "ou=People,dc=example,dc=com"
+    assert captured["search"]["search_filter"] == r"(uid=ali\2a\28ce)"
+    assert set(captured["search"]["attributes"]) == {"mail", "displayName", "memberOf"}
+
+
+def test_authenticate_ldap_credentials_rejects_plaintext_bind_by_default():
+    config = LDAPConfig(
+        ldap_enabled=True,
+        ldap_url="ldap://ldap.example.com:389",
+        ldap_base_dn="dc=example,dc=com",
+    )
+
+    with pytest.raises(ProxyException) as exc_info:
+        _authenticate_ldap_credentials(config, "alice", "ldap-password")
+
+    assert exc_info.value.code == "400"
+    assert exc_info.value.param == "ldap_allow_insecure"

--- a/tests/test_litellm/proxy/auth/test_login_utils.py
+++ b/tests/test_litellm/proxy/auth/test_login_utils.py
@@ -559,3 +559,57 @@ async def test_authenticate_user_database_login_with_non_ascii_password():
             assert isinstance(result, LoginResult)
             assert result.user_id == "test-user-123"
             assert result.user_email == user_email
+
+
+@pytest.mark.asyncio
+async def test_authenticate_user_ldap_method_generates_ui_session(monkeypatch):
+    master_key = "sk-1234"
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(return_value=None)
+
+    ldap_user = MagicMock()
+    ldap_user.user_id = "ldap:alice"
+    ldap_user.user_email = "alice@example.com"
+    ldap_user.user_role = LitellmUserRoles.INTERNAL_USER
+
+    mock_authenticate_ldap_user = AsyncMock(return_value=ldap_user)
+    monkeypatch.setattr(
+        "litellm.proxy.auth.login_utils.authenticate_ldap_user",
+        mock_authenticate_ldap_user,
+        raising=False,
+    )
+
+    with patch.dict(
+        os.environ,
+        {
+            "DATABASE_URL": "postgresql://test:test@localhost/test",
+            "UI_USERNAME": "admin",
+            "UI_PASSWORD": "admin-password",
+        },
+    ):
+        with patch(
+            "litellm.proxy.auth.login_utils.generate_key_helper_fn",
+            new_callable=AsyncMock,
+        ) as mock_generate_key:
+            mock_generate_key.return_value = {"token": "ldap-session-token"}
+
+            result = await authenticate_user(
+                username="alice",
+                password="ldap-password",
+                master_key=master_key,
+                prisma_client=mock_prisma_client,
+                auth_method="ldap",
+            )
+
+    assert result.user_id == "ldap:alice"
+    assert result.user_email == "alice@example.com"
+    assert result.user_role == LitellmUserRoles.INTERNAL_USER
+    assert result.key == "ldap-session-token"
+    mock_authenticate_ldap_user.assert_awaited_once_with(
+        username="alice",
+        password="ldap-password",
+        prisma_client=mock_prisma_client,
+    )
+    mock_generate_key.assert_awaited_once()
+    assert mock_generate_key.await_args.kwargs["user_id"] == "ldap:alice"
+    assert mock_generate_key.await_args.kwargs["user_role"] == LitellmUserRoles.INTERNAL_USER

--- a/tests/test_litellm/proxy/discovery_endpoints/test_ui_discovery_endpoints.py
+++ b/tests/test_litellm/proxy/discovery_endpoints/test_ui_discovery_endpoints.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -33,6 +33,28 @@ def test_ui_discovery_endpoints_with_defaults():
         assert data["auto_redirect_to_sso"] is False
         assert data["admin_ui_disabled"] is False
         assert data["sso_configured"] is False
+        assert data["ldap_configured"] is False
+
+
+def test_ui_discovery_endpoints_with_ldap_configured():
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    with (
+        patch("litellm.proxy.utils.get_server_root_path", return_value="/"),
+        patch("litellm.proxy.utils.get_proxy_base_url", return_value=None),
+        patch("litellm.proxy.auth.auth_utils._has_user_setup_sso", return_value=False),
+        patch("litellm.proxy.auth.ldap_auth.is_ldap_configured", new=AsyncMock(return_value=True)),
+        patch.dict(os.environ, {"DISABLE_ADMIN_UI": "false"}, clear=False),
+    ):
+
+        response = client.get("/.well-known/litellm-ui-config")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["sso_configured"] is False
+        assert data["ldap_configured"] is True
 
 
 def test_ui_discovery_endpoints_with_custom_server_root_path():

--- a/tests/test_litellm/proxy/proxy_server/test_routes_login_sso.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_login_sso.py
@@ -29,7 +29,7 @@ def _install_login_mocks(monkeypatch, raise_on_auth: bool = False) -> None:
     """
     from litellm.proxy import proxy_server as ps
 
-    async def _fake_auth(username, password, master_key, prisma_client):
+    async def _fake_auth(username, password, master_key, prisma_client, auth_method=None):
         if raise_on_auth:
             raise Exception("boom-auth-failure")
         fake = MagicMock()

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -121,6 +121,7 @@ def test_login_v2_returns_redirect_url_and_sets_cookie(monkeypatch):
         password="secret",
         master_key="test-master-key",
         prisma_client=mock_prisma_client,
+        auth_method=None,
     )
     mock_create_ui_token_object.assert_called_once_with(
         login_result=mock_login_result,
@@ -131,6 +132,43 @@ def test_login_v2_returns_redirect_url_and_sets_cookie(monkeypatch):
         {"user_id": "test-user"},
         "test-master-key",
         algorithm="HS256",
+    )
+
+
+def test_login_v2_passes_auth_method_to_authenticate_user(monkeypatch):
+    mock_login_result = {"user_id": "ldap-user"}
+    mock_prisma_client = MagicMock()
+    mock_authenticate_user = AsyncMock(return_value=mock_login_result)
+    mock_create_ui_token_object = MagicMock(return_value={"user_id": "ldap-user"})
+    mock_jwt_encode = MagicMock(return_value="signed-token")
+
+    monkeypatch.setattr(
+        "litellm.proxy.auth.login_utils.authenticate_user",
+        mock_authenticate_user,
+    )
+    monkeypatch.setattr(
+        "litellm.proxy.auth.login_utils.create_ui_token_object",
+        mock_create_ui_token_object,
+    )
+    monkeypatch.setattr("jwt.encode", mock_jwt_encode)
+    monkeypatch.setattr("litellm.proxy.proxy_server.master_key", "test-master-key")
+    monkeypatch.setattr("litellm.proxy.proxy_server.general_settings", {})
+    monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", False)
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    client = TestClient(app)
+    response = client.post(
+        "/v2/login",
+        json={"username": "alice", "password": "secret", "auth_method": "ldap"},
+    )
+
+    assert response.status_code == 200
+    mock_authenticate_user.assert_awaited_once_with(
+        username="alice",
+        password="secret",
+        master_key="test-master-key",
+        prisma_client=mock_prisma_client,
+        auth_method="ldap",
     )
 
 

--- a/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
+++ b/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
@@ -386,6 +386,98 @@ class TestProxySettingEndpoints:
         call_args = mock_prisma.db.litellm_ssoconfig.find_unique.call_args
         assert call_args.kwargs["where"]["id"] == "sso_config"
 
+    def test_get_ldap_settings_masks_bind_password(self, mock_proxy_config, mock_auth, monkeypatch):
+        """LDAP settings are stored separately from SSO and mask the bind password on read."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        mock_prisma = MagicMock()
+        mock_db_record = MagicMock()
+        mock_db_record.param_value = {
+            "ldap_enabled": True,
+            "ldap_url": "ldaps://ldap.example.com:636",
+            "ldap_base_dn": "dc=example,dc=com",
+            "ldap_bind_dn": "cn=admin,dc=example,dc=com",
+            "ldap_bind_password": "super-secret",
+            "ldap_user_search_filter": "(uid={username})",
+        }
+        mock_prisma.db.litellm_config.find_unique = AsyncMock(return_value=mock_db_record)
+        monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
+
+        from litellm.proxy.proxy_server import proxy_config
+
+        def fail_if_setting_env(environment_variables):
+            raise AssertionError("LDAP settings must not be written to os.environ")
+
+        monkeypatch.setattr(
+            proxy_config,
+            "_decrypt_and_set_db_env_variables",
+            fail_if_setting_env,
+        )
+        monkeypatch.setattr(
+            proxy_config,
+            "_decrypt_db_variables",
+            lambda environment_variables: environment_variables,
+        )
+
+        response = client.get("/get/ldap_settings")
+
+        assert response.status_code == 200
+        data = response.json()
+        values = data["values"]
+        assert values["ldap_enabled"] is True
+        assert values["ldap_url"] == "ldaps://ldap.example.com:636"
+        assert values["ldap_bind_password"] != "super-secret"
+        assert "*" in values["ldap_bind_password"]
+        assert data["field_schema"]["properties"]["ldap_url"]["description"]
+        mock_prisma.db.litellm_config.find_unique.assert_called_once_with(
+            where={"param_name": "ldap_settings"}
+        )
+
+    def test_update_ldap_settings_to_database(self, mock_proxy_config, mock_auth, monkeypatch):
+        """LDAP settings can be updated through their own Admin settings endpoint."""
+        import json
+        from unittest.mock import AsyncMock, MagicMock
+
+        monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_config.find_unique = AsyncMock(return_value=None)
+        mock_prisma.db.litellm_config.upsert = AsyncMock()
+        monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
+
+        from litellm.proxy.proxy_server import proxy_config
+
+        monkeypatch.setattr(
+            proxy_config,
+            "_encrypt_env_variables",
+            lambda environment_variables: environment_variables,
+        )
+
+        new_ldap_settings = {
+            "ldap_enabled": True,
+            "ldap_url": "ldaps://ldap.example.com:636",
+            "ldap_base_dn": "dc=example,dc=com",
+            "ldap_search_base": "ou=People,dc=example,dc=com",
+            "ldap_bind_dn": "cn=admin,dc=example,dc=com",
+            "ldap_bind_password": "super-secret",
+            "ldap_user_search_filter": "(uid={username})",
+            "ldap_email_attribute": "mail",
+            "ldap_display_name_attribute": "displayName",
+        }
+
+        response = client.patch("/update/ldap_settings", json=new_ldap_settings)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["settings"]["ldap_enabled"] is True
+        assert data["settings"]["ldap_bind_password"] != "super-secret"
+        assert "*" in data["settings"]["ldap_bind_password"]
+        upsert_data = mock_prisma.db.litellm_config.upsert.call_args.kwargs["data"]
+        assert upsert_data["create"]["param_name"] == "ldap_settings"
+        stored_settings = json.loads(upsert_data["create"]["param_value"])
+        assert stored_settings["ldap_url"] == "ldaps://ldap.example.com:636"
+        assert stored_settings["ldap_bind_password"] == "super-secret"
+
     def test_update_sso_settings(self, mock_proxy_config, mock_auth, monkeypatch):
         """Test updating the SSO settings to the dedicated database table"""
         import json

--- a/ui/litellm-dashboard/src/app/(dashboard)/admin-panel/_components/AdminPanel.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/admin-panel/_components/AdminPanel.test.tsx
@@ -23,6 +23,10 @@ vi.mock("@/components/Settings/AdminSettings/SSOSettings/SSOSettings", () => ({
   default: () => <div>SSO Settings</div>,
 }));
 
+vi.mock("@/components/Settings/AdminSettings/LDAPSettings/LDAPSettings", () => ({
+  default: () => <div>LDAP Settings</div>,
+}));
+
 vi.mock("@/components/Settings/AdminSettings/UISettings/UISettings", () => ({
   default: () => <div>UI Settings</div>,
 }));
@@ -69,10 +73,16 @@ describe("AdminPanel", () => {
   describe("Tabs", () => {
     it("should render all tabs", () => {
       render(<AdminPanel />);
-      expect(screen.getByRole("tab", { name: /sso settings/i })).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: /authentication/i })).toBeInTheDocument();
       expect(screen.getByRole("tab", { name: /security settings/i })).toBeInTheDocument();
       expect(screen.getByRole("tab", { name: /scim/i })).toBeInTheDocument();
       expect(screen.getByRole("tab", { name: /ui settings/i })).toBeInTheDocument();
+    });
+
+    it("should display SSO and LDAP settings in the Authentication tab", () => {
+      render(<AdminPanel />);
+      expect(screen.getByText("SSO Settings")).toBeInTheDocument();
+      expect(screen.getByText("LDAP Settings")).toBeInTheDocument();
     });
 
     it("should display Security Settings content when Security Settings tab is clicked", async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/admin-panel/_components/AdminPanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/admin-panel/_components/AdminPanel.tsx
@@ -22,6 +22,7 @@ import NotificationsManager from "@/components/molecules/notifications_manager";
 import { addAllowedIP, deleteAllowedIP, getAllowedIPs, getSSOSettings } from "@/components/networking";
 import SCIMConfig from "@/components/SCIM";
 import LoggingSettings from "@/components/Settings/AdminSettings/LoggingSettings/LoggingSettings";
+import LDAPSettings from "@/components/Settings/AdminSettings/LDAPSettings/LDAPSettings";
 import SSOSettings from "@/components/Settings/AdminSettings/SSOSettings/SSOSettings";
 import UISettings from "@/components/Settings/AdminSettings/UISettings/UISettings";
 import HashicorpVault from "@/components/Settings/AdminSettings/HashicorpVault/HashicorpVault";
@@ -186,9 +187,14 @@ const AdminPanel: React.FC<AdminPanelProps> = ({ proxySettings }) => {
 
   const tabItems = [
     {
-      key: "sso-settings",
-      label: "SSO Settings",
-      children: <SSOSettings />,
+      key: "authentication-settings",
+      label: "Authentication",
+      children: (
+        <Space direction="vertical" size="large" className="w-full">
+          <SSOSettings />
+          <LDAPSettings />
+        </Space>
+      ),
     },
     {
       key: "security-settings",

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/ldap/useLDAPSettings.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/ldap/useLDAPSettings.ts
@@ -1,0 +1,48 @@
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import { getLDAPSettings } from "@/components/networking";
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { createQueryKeys } from "../common/queryKeysFactory";
+
+export interface LDAPFieldSchema {
+  description: string;
+  properties: {
+    [key: string]: {
+      description: string;
+      type: string;
+    };
+  };
+}
+
+export interface LDAPSettingsValues {
+  ldap_enabled: boolean;
+  ldap_url: string | null;
+  ldap_base_dn: string | null;
+  ldap_search_base: string | null;
+  ldap_bind_dn: string | null;
+  ldap_bind_password: string | null;
+  ldap_user_search_filter: string;
+  ldap_user_id_attribute: string | null;
+  ldap_email_attribute: string;
+  ldap_display_name_attribute: string;
+  ldap_group_attribute: string;
+  ldap_admin_group_dn: string | null;
+  ldap_use_ssl: boolean;
+  ldap_start_tls: boolean;
+  ldap_allow_insecure: boolean;
+}
+
+export interface LDAPSettingsResponse {
+  values: LDAPSettingsValues;
+  field_schema: LDAPFieldSchema;
+}
+
+export const ldapKeys = createQueryKeys("ldap");
+
+export const useLDAPSettings = (): UseQueryResult<LDAPSettingsResponse> => {
+  const { accessToken, userId, userRole } = useAuthorized();
+  return useQuery<LDAPSettingsResponse>({
+    queryKey: ldapKeys.detail("settings"),
+    queryFn: async () => await getLDAPSettings(accessToken!),
+    enabled: Boolean(accessToken && userId && userRole),
+  });
+};

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/ldap/useUpdateLDAPSettings.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/ldap/useUpdateLDAPSettings.ts
@@ -1,0 +1,21 @@
+import { updateLDAPSettings } from "@/components/networking";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ldapKeys } from "./useLDAPSettings";
+
+export const useUpdateLDAPSettings = (accessToken: string) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (settings: Record<string, unknown>) => {
+      if (!accessToken) {
+        throw new Error("Access token is required");
+      }
+      return updateLDAPSettings(accessToken, settings);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ldapKeys.all,
+      });
+    },
+  });
+};

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/login/useLogin.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/login/useLogin.ts
@@ -3,8 +3,8 @@ import { loginCall, LoginRequest } from "@/components/networking";
 
 export const useLogin = () => {
   return useMutation({
-    mutationFn: async ({ username, password, useV3 }: LoginRequest) => {
-      const result = await loginCall(username, password, useV3);
+    mutationFn: async ({ username, password, useV3, authMethod }: LoginRequest) => {
+      const result = await loginCall(username, password, useV3, authMethod);
       return result;
     },
   });

--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users/columns.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users/columns.tsx
@@ -5,6 +5,14 @@ import { UserInfo } from "@/components/networking";
 import { PencilAltIcon, TrashIcon, InformationCircleIcon, RefreshIcon } from "@heroicons/react/outline";
 import { DateCell, IdCell, MoneyCell } from "@/components/shared/table_cells";
 
+const getLdapDn = (metadata: Record<string, unknown> | null | undefined): string | null => {
+  if (metadata?.auth_provider !== "ldap") {
+    return null;
+  }
+
+  return typeof metadata.ldap_dn === "string" && metadata.ldap_dn.length > 0 ? metadata.ldap_dn : null;
+};
+
 interface SelectionOptions {
   selectedUsers: UserInfo[];
   onSelectUser: (user: UserInfo, isSelected: boolean) => void;
@@ -97,6 +105,23 @@ export const columns = (
       cell: ({ row }) => (
         <span className="text-xs">{row.original.sso_user_id !== null ? row.original.sso_user_id : "-"}</span>
       ),
+    },
+    {
+      header: () => (
+        <div className="flex items-center gap-2">
+          <span>LDAP DN</span>
+          <Tooltip title="LDAP DN is the distinguished name from the LDAP directory for users authenticated via LDAP. If the user is not using LDAP, this will be null.">
+            <InformationCircleIcon className="w-4 h-4" />
+          </Tooltip>
+        </div>
+      ),
+      id: "ldap_dn",
+      enableSorting: false,
+      cell: ({ row }) => {
+        const ldapDn = getLdapDn(row.original.metadata as Record<string, unknown> | null | undefined);
+
+        return <span className="text-xs">{ldapDn ?? "-"}</span>;
+      },
     },
     {
       header: "Virtual Keys",

--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users/table.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/view_users/table.test.tsx
@@ -108,6 +108,7 @@ describe("UserDataTable", () => {
       "Spend (USD)",
       "Budget (USD)",
       "SSO ID",
+      "LDAP DN",
       "Virtual Keys",
       "Created At",
       "Updated At",
@@ -197,5 +198,53 @@ describe("UserDataTable", () => {
     render(<>{cell}</>);
     expect(screen.getByText("Active")).toBeInTheDocument();
     expect(screen.queryByText("Inactive")).not.toBeInTheDocument();
+  });
+
+  it("should render LDAP DN from metadata for LDAP users", () => {
+    const possibleUIRoles = { admin: { ui_label: "Admin" } };
+    const ldapUser: UserInfo = {
+      user_id: "ldap:user@example.com",
+      user_email: "ldap@example.com",
+      user_alias: null,
+      user_role: "internal_user",
+      spend: 0,
+      max_budget: null,
+      models: [],
+      key_count: 0,
+      created_at: "",
+      updated_at: "",
+      sso_user_id: null,
+      budget_duration: null,
+      metadata: { auth_provider: "ldap", ldap_dn: "cn=user,ou=users,dc=example,dc=com" },
+    };
+
+    render(<UserDataTable {...getDefaultProps()} data={[ldapUser]} possibleUIRoles={possibleUIRoles} />);
+
+    expect(screen.getByRole("columnheader", { name: "LDAP DN" })).toBeInTheDocument();
+    expect(screen.getByText("cn=user,ou=users,dc=example,dc=com")).toBeInTheDocument();
+  });
+
+  it("should render dash for non-LDAP users in LDAP DN column", () => {
+    const possibleUIRoles = { admin: { ui_label: "Admin" } };
+    const ssoUser: UserInfo = {
+      user_id: "u-sso",
+      user_email: "sso@example.com",
+      user_alias: null,
+      user_role: "internal_user",
+      spend: 0,
+      max_budget: null,
+      models: [],
+      key_count: 0,
+      created_at: "",
+      updated_at: "",
+      sso_user_id: "sso-123",
+      budget_duration: null,
+      metadata: { auth_provider: "sso" },
+    };
+
+    render(<UserDataTable {...getDefaultProps()} data={[ssoUser]} possibleUIRoles={possibleUIRoles} />);
+
+    expect(screen.getByRole("columnheader", { name: "LDAP DN" })).toBeInTheDocument();
+    expect(screen.getAllByText("-").length).toBeGreaterThan(0);
   });
 });

--- a/ui/litellm-dashboard/src/app/login/LoginPage.test.tsx
+++ b/ui/litellm-dashboard/src/app/login/LoginPage.test.tsx
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import LoginPage from "./LoginPage";
 
 const mockPush = vi.fn();
 const mockReplace = vi.fn();
+const mockLoginMutate = vi.hoisted(() => vi.fn());
 
 vi.mock("next/navigation", () => ({
   useRouter: vi.fn(() => ({
@@ -36,7 +37,7 @@ vi.mock("@/components/networking", async (importOriginal) => {
 
 vi.mock("@/app/(dashboard)/hooks/login/useLogin", () => ({
   useLogin: vi.fn(() => ({
-    mutate: vi.fn(),
+    mutate: mockLoginMutate,
     isPending: false,
     error: null,
   })),
@@ -259,10 +260,10 @@ describe("LoginPage", () => {
       expect(screen.getByRole("heading", { name: "Login" })).toBeInTheDocument();
     });
 
-    expect(screen.getByRole("button", { name: "Login with SSO" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Continue with SSO" })).toBeInTheDocument();
   });
 
-  it("should show disabled Login with SSO button with popover when sso_configured is false", async () => {
+  it("should hide the SSO action when sso_configured is false", async () => {
     (useUIConfig as ReturnType<typeof vi.fn>).mockReturnValue({
       data: {
         auto_redirect_to_sso: false,
@@ -286,9 +287,131 @@ describe("LoginPage", () => {
       expect(screen.getByRole("heading", { name: "Login" })).toBeInTheDocument();
     });
 
-    const ssoButton = screen.getByRole("button", { name: "Login with SSO" });
-    expect(ssoButton).toBeInTheDocument();
-    expect(ssoButton).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Continue with SSO" })).not.toBeInTheDocument();
+  });
+
+  it("should allow selecting LDAP and submit it through the single sign-in button", async () => {
+    (useUIConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        auto_redirect_to_sso: false,
+        server_root_path: "/",
+        proxy_base_url: null,
+        sso_configured: false,
+        ldap_configured: true,
+      },
+      isLoading: false,
+    });
+    (getCookieFromDocument as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    (isJwtExpired as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <LoginPage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("radio", { name: "LDAP" })).toBeInTheDocument();
+    });
+    expect(screen.getAllByRole("button", { name: "Sign in" })).toHaveLength(1);
+
+    fireEvent.change(screen.getByLabelText("Username"), { target: { value: "alice" } });
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "ldap-password" } });
+    fireEvent.click(screen.getByRole("radio", { name: "LDAP" }));
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    await waitFor(() => {
+      expect(mockLoginMutate).toHaveBeenCalledWith(
+        {
+          username: "alice",
+          password: "ldap-password",
+          authMethod: "ldap",
+          useV3: false,
+        },
+        expect.any(Object),
+      );
+    });
+  });
+
+  it("should use LDAP authentication by default when LDAP is configured", async () => {
+    (useUIConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        auto_redirect_to_sso: false,
+        server_root_path: "/",
+        proxy_base_url: null,
+        sso_configured: false,
+        ldap_configured: true,
+      },
+      isLoading: false,
+    });
+    (getCookieFromDocument as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    (isJwtExpired as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <LoginPage />
+      </QueryClientProvider>,
+    );
+
+    const ldapAuthOption = await screen.findByRole("radio", { name: "LDAP" });
+    expect(ldapAuthOption).toBeChecked();
+    expect(screen.getAllByRole("radio").map((option) => option.closest("label")?.textContent)).toEqual([
+      "LDAP",
+      "LiteLLM account",
+    ]);
+
+    fireEvent.change(screen.getByLabelText("Username"), { target: { value: "admin" } });
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "local-password" } });
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    await waitFor(() => {
+      expect(mockLoginMutate).toHaveBeenCalledWith(
+        {
+          username: "admin",
+          password: "local-password",
+          authMethod: "ldap",
+          useV3: false,
+        },
+        expect.any(Object),
+      );
+    });
+  });
+
+  it("should validate required fields before directory login", async () => {
+    (useUIConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {
+        auto_redirect_to_sso: false,
+        server_root_path: "/",
+        proxy_base_url: null,
+        sso_configured: false,
+        ldap_configured: true,
+      },
+      isLoading: false,
+    });
+    (getCookieFromDocument as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    (isJwtExpired as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    const queryClient = createQueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <LoginPage />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("radio", { name: "LDAP" })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("radio", { name: "LDAP" }));
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Please enter your username")).toBeInTheDocument();
+      expect(screen.getByText("Please enter your password")).toBeInTheDocument();
+    });
+    expect(mockLoginMutate).not.toHaveBeenCalled();
   });
 
   describe("URL ?token= legacy path is rejected (security regression test)", () => {

--- a/ui/litellm-dashboard/src/app/login/LoginPage.tsx
+++ b/ui/litellm-dashboard/src/app/login/LoginPage.tsx
@@ -8,7 +8,7 @@ import { clearTokenCookies, getCookieFromDocument } from "@/utils/cookieUtils";
 import { isJwtExpired } from "@/utils/jwtUtils";
 import { consumeReturnUrl, getReturnUrl, isValidReturnUrl } from "@/utils/returnUrlUtils";
 import { InfoCircleOutlined, CloudServerOutlined } from "@ant-design/icons";
-import { Alert, Button, Card, Form, Input, Popover, Select, Space, Typography } from "antd";
+import { Alert, Button, Card, Divider, Form, Input, Radio, Select, Space, Typography } from "antd";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useWorker } from "@/hooks/useWorker";
@@ -16,7 +16,9 @@ import { useWorker } from "@/hooks/useWorker";
 function LoginPageContent() {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+  const [selectedAuthMethod, setSelectedAuthMethod] = useState<"local" | "ldap" | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [form] = Form.useForm();
   const { data: uiConfig, isLoading: isConfigLoading } = useUIConfig();
   const loginMutation = useLogin();
   const router = useRouter();
@@ -98,7 +100,7 @@ function LoginPageContent() {
     setIsLoading(false);
   }, [isConfigLoading, router, uiConfig]);
 
-  const handleSubmit = () => {
+  const handleSubmit = (authMethod: "local" | "ldap" = "local") => {
     // If a worker is selected, point proxyBaseUrl at it before login
     const selectedWorker = workers.find((w) => w.worker_id === selectedWorkerId);
     if (selectedWorker) {
@@ -106,7 +108,7 @@ function LoginPageContent() {
     }
 
     loginMutation.mutate(
-      { username, password, useV3: !!selectedWorker },
+      { username, password, useV3: !!selectedWorker, authMethod },
       {
         onSuccess: (data) => {
           // Update the worker context with the selected worker
@@ -136,6 +138,7 @@ function LoginPageContent() {
 
   const error = loginMutation.error instanceof Error ? loginMutation.error.message : null;
   const isLoginLoading = loginMutation.isPending;
+  const authMethod = selectedAuthMethod ?? (uiConfig?.ldap_configured ? "ldap" : "local");
 
   const { Title, Text, Paragraph } = Typography;
 
@@ -215,7 +218,7 @@ function LoginPageContent() {
 
           {error && <Alert message={error} type="error" showIcon />}
 
-          <Form onFinish={handleSubmit} layout="vertical" requiredMark={false}>
+          <Form form={form} onFinish={() => handleSubmit(authMethod)} layout="vertical" requiredMark={false}>
             {uiConfig?.is_control_plane && workers.length > 0 && (
               <Form.Item label="Worker" style={{ marginBottom: 16 }}>
                 <Select
@@ -228,6 +231,27 @@ function LoginPageContent() {
                     label: w.name,
                     value: w.worker_id,
                   }))}
+                />
+              </Form.Item>
+            )}
+
+            {uiConfig?.ldap_configured && (
+              <Form.Item label="Sign in with">
+                <Radio.Group
+                  value={authMethod}
+                  onChange={(event) => {
+                    const nextAuthMethod: unknown = event.target.value;
+                    if (nextAuthMethod === "local" || nextAuthMethod === "ldap") {
+                      setSelectedAuthMethod(nextAuthMethod);
+                    }
+                  }}
+                  disabled={isLoginLoading}
+                  optionType="button"
+                  buttonStyle="solid"
+                  options={[
+                    { label: "LDAP", value: "ldap" },
+                    { label: "LiteLLM account", value: "local" },
+                  ]}
                 />
               </Form.Item>
             )}
@@ -272,55 +296,34 @@ function LoginPageContent() {
                 block
                 size="large"
               >
-                {isLoginLoading ? "Logging in..." : "Login"}
+                {isLoginLoading ? "Signing in..." : "Sign in"}
               </Button>
             </Form.Item>
-            <Form.Item>
-              {!uiConfig?.sso_configured ? (
-                <Popover content="Please configure SSO to log in with SSO." trigger="hover">
-                  <Button disabled block size="large">
-                    Login with SSO
-                  </Button>
-                </Popover>
-              ) : (
-                <Button
-                  disabled={isLoginLoading || (!!selectedWorkerId && workers.length === 0)}
-                  onClick={() => {
-                    const selectedWorker = workers.find((w) => w.worker_id === selectedWorkerId);
-                    if (selectedWorker) {
-                      // Store worker selection so useWorker hook restores it after redirect
-                      localStorage.setItem("litellm_selected_worker_id", selectedWorkerId!);
-                      switchToWorkerUrl(selectedWorker.url);
-                    }
-                    // SSO on the worker (or this instance if no worker), always
-                    // include return_to so the callback redirects back here
-                    const ssoBase = selectedWorker?.url ?? getProxyBaseUrl();
-                    const returnTo = encodeURIComponent(window.location.origin + "/ui/login");
-                    router.push(`${ssoBase}/sso/key/generate?return_to=${returnTo}`);
-                  }}
-                  block
-                  size="large"
-                >
-                  Login with SSO
-                </Button>
-              )}
-            </Form.Item>
           </Form>
+
+          {uiConfig?.sso_configured && (
+            <div className="w-full">
+              <Divider plain>or</Divider>
+              <Button
+                disabled={isLoginLoading || (!!selectedWorkerId && workers.length === 0)}
+                onClick={() => {
+                  const selectedWorker = workers.find((w) => w.worker_id === selectedWorkerId);
+                  if (selectedWorker) {
+                    localStorage.setItem("litellm_selected_worker_id", selectedWorkerId!);
+                    switchToWorkerUrl(selectedWorker.url);
+                  }
+                  const ssoBase = selectedWorker?.url ?? getProxyBaseUrl();
+                  const returnTo = encodeURIComponent(window.location.origin + "/ui/login");
+                  router.push(`${ssoBase}/sso/key/generate?return_to=${returnTo}`);
+                }}
+                block
+                size="large"
+              >
+                Continue with SSO
+              </Button>
+            </div>
+          )}
         </Space>
-        {uiConfig?.sso_configured && (
-          <Alert
-            type="info"
-            showIcon
-            closable
-            message={
-              <Text>
-                Single Sign-On (SSO) is enabled. LiteLLM no longer automatically redirects to the SSO login flow upon
-                loading this page. To re-enable auto-redirect-to-SSO, set{" "}
-                <Text code>AUTO_REDIRECT_UI_LOGIN_TO_SSO=true</Text> in your environment configuration.
-              </Text>
-            }
-          />
-        )}
       </Card>
     </div>
   );

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/LDAPSettings/LDAPSettings.test.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/LDAPSettings/LDAPSettings.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import LDAPSettings from "./LDAPSettings";
+
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
+  default: () => ({ accessToken: "test-token" }),
+}));
+
+vi.mock("@/app/(dashboard)/hooks/ldap/useLDAPSettings", () => ({
+  useLDAPSettings: () => ({
+    data: { values: { ldap_enabled: false } },
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock("@/app/(dashboard)/hooks/ldap/useUpdateLDAPSettings", () => ({
+  useUpdateLDAPSettings: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+describe("LDAPSettings", () => {
+  it("exposes stable identity and explicit insecure transport settings", () => {
+    render(<LDAPSettings />);
+
+    expect(screen.getByText("Stable User ID Attribute")).toBeInTheDocument();
+    expect(screen.getByText("Allow Insecure LDAP")).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/LDAPSettings/LDAPSettings.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/LDAPSettings/LDAPSettings.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useLDAPSettings } from "@/app/(dashboard)/hooks/ldap/useLDAPSettings";
+import { useUpdateLDAPSettings } from "@/app/(dashboard)/hooks/ldap/useUpdateLDAPSettings";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import NotificationsManager from "@/components/molecules/notifications_manager";
+import { Alert, Button, Card, Form, Input, Space, Switch, Typography } from "antd";
+import { KeyRound } from "lucide-react";
+import { useEffect } from "react";
+
+const { Title, Text } = Typography;
+
+export default function LDAPSettings() {
+  const [form] = Form.useForm();
+  const { accessToken } = useAuthorized();
+  const { data, isLoading, isError, error, refetch } = useLDAPSettings();
+  const { mutate: updateSettings, isPending } = useUpdateLDAPSettings(accessToken || "");
+
+  useEffect(() => {
+    if (!data?.values) {
+      return;
+    }
+    form.setFieldsValue({
+      ...data.values,
+      ldap_bind_password: undefined,
+    });
+  }, [data, form]);
+
+  const handleSubmit = (values: Record<string, unknown>) => {
+    const payload: Record<string, unknown> = {
+      ...values,
+      ldap_enabled: Boolean(values.ldap_enabled),
+      ldap_use_ssl: Boolean(values.ldap_use_ssl),
+      ldap_start_tls: Boolean(values.ldap_start_tls),
+      ldap_allow_insecure: Boolean(values.ldap_allow_insecure),
+    };
+    if (!payload.ldap_bind_password) {
+      delete payload.ldap_bind_password;
+    }
+
+    updateSettings(payload, {
+      onSuccess: () => {
+        NotificationsManager.success("LDAP settings updated successfully");
+        refetch();
+      },
+      onError: (updateError) => {
+        NotificationsManager.fromBackend(`Failed to update LDAP settings: ${updateError.message}`);
+      },
+    });
+  };
+
+  const isConfigured = Boolean(data?.values.ldap_enabled && data?.values.ldap_url && data?.values.ldap_base_dn);
+
+  return (
+    <Card>
+      <Space direction="vertical" size="large" className="w-full">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <KeyRound className="w-6 h-6 text-gray-400" />
+            <div>
+              <Title level={3}>LDAP Configuration</Title>
+              <Text type="secondary">Directory login for the Admin UI</Text>
+            </div>
+          </div>
+          <Text type={isConfigured ? "success" : "secondary"}>{isConfigured ? "Configured" : "Not configured"}</Text>
+        </div>
+
+        {isError && <Alert type="error" showIcon message={error?.message || "Failed to load LDAP settings"} />}
+
+        <Form
+          form={form}
+          layout="vertical"
+          onFinish={handleSubmit}
+          disabled={isLoading || isPending}
+          initialValues={{
+            ldap_enabled: false,
+            ldap_user_search_filter: "(|(uid={username})(sAMAccountName={username})(userPrincipalName={username}))",
+            ldap_email_attribute: "mail",
+            ldap_display_name_attribute: "displayName",
+            ldap_group_attribute: "memberOf",
+            ldap_use_ssl: false,
+            ldap_start_tls: false,
+            ldap_allow_insecure: false,
+          }}
+        >
+          <Form.Item name="ldap_enabled" label="Enabled" valuePropName="checked">
+            <Switch />
+          </Form.Item>
+          <Form.Item name="ldap_url" label="LDAP URL" rules={[{ required: true, message: "LDAP URL is required" }]}>
+            <Input placeholder="ldap://ldap.example.com:389" />
+          </Form.Item>
+          <Form.Item name="ldap_base_dn" label="Base DN" rules={[{ required: true, message: "Base DN is required" }]}>
+            <Input placeholder="dc=example,dc=com" />
+          </Form.Item>
+          <Form.Item name="ldap_search_base" label="Search Base">
+            <Input placeholder="ou=People,dc=example,dc=com" />
+          </Form.Item>
+          <Form.Item name="ldap_bind_dn" label="Bind DN">
+            <Input placeholder="cn=admin,dc=example,dc=com" />
+          </Form.Item>
+          <Form.Item name="ldap_bind_password" label="Bind Password">
+            <Input.Password
+              placeholder={data?.values.ldap_bind_password ? "Configured" : ""}
+              autoComplete="new-password"
+            />
+          </Form.Item>
+          <Form.Item
+            name="ldap_user_search_filter"
+            label="User Search Filter"
+            rules={[{ required: true, message: "User search filter is required" }]}
+          >
+            <Input />
+          </Form.Item>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <Form.Item
+              name="ldap_user_id_attribute"
+              label="Stable User ID Attribute"
+              extra="Use an immutable value such as objectGUID or entryUUID. Defaults to the LDAP DN."
+            >
+              <Input placeholder="objectGUID" />
+            </Form.Item>
+            <Form.Item name="ldap_email_attribute" label="Email Attribute">
+              <Input />
+            </Form.Item>
+            <Form.Item name="ldap_display_name_attribute" label="Display Name Attribute">
+              <Input />
+            </Form.Item>
+            <Form.Item name="ldap_group_attribute" label="Group Attribute">
+              <Input />
+            </Form.Item>
+          </div>
+          <Form.Item name="ldap_admin_group_dn" label="Admin Group DN">
+            <Input placeholder="cn=litellm-admins,ou=Groups,dc=example,dc=com" />
+          </Form.Item>
+          <Space size="large">
+            <Form.Item name="ldap_use_ssl" label="Use SSL" valuePropName="checked">
+              <Switch />
+            </Form.Item>
+            <Form.Item name="ldap_start_tls" label="StartTLS" valuePropName="checked">
+              <Switch />
+            </Form.Item>
+            <Form.Item name="ldap_allow_insecure" label="Allow Insecure LDAP" valuePropName="checked">
+              <Switch />
+            </Form.Item>
+          </Space>
+          <Form.Item>
+            <Button type="primary" htmlType="submit" loading={isPending}>
+              Save LDAP Settings
+            </Button>
+          </Form.Item>
+        </Form>
+      </Space>
+    </Card>
+  );
+}

--- a/ui/litellm-dashboard/src/components/networking.test.ts
+++ b/ui/litellm-dashboard/src/components/networking.test.ts
@@ -111,6 +111,23 @@ describe("loginCall - storeLoginToken integration", () => {
     await Networking.loginCall("admin", "pass");
     expect(storeLoginToken).not.toHaveBeenCalled();
   });
+
+  it("sends auth_method when loginCall receives an auth method", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ redirect_url: "/ui/?login=success", token: "ldap-jwt" }),
+    }) as any;
+
+    await Networking.loginCall("alice", "ldap-password", false, "ldap");
+
+    expect(global.fetch).toHaveBeenCalledOnce();
+    const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+    expect(body).toEqual({
+      username: "alice",
+      password: "ldap-password",
+      auth_method: "ldap",
+    });
+  });
 });
 
 describe("daily activity helpers", () => {

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -288,6 +288,7 @@ export interface LiteLLMWellKnownUiConfig {
   auto_redirect_to_sso: boolean;
   admin_ui_disabled: boolean;
   sso_configured: boolean;
+  ldap_configured?: boolean;
   hide_default_credentials_hint?: boolean;
   is_control_plane?: boolean;
   workers?: WorkerInfo[];
@@ -6443,6 +6444,26 @@ export const updateSSOSettings = async (accessToken: string, settings: Record<st
   }
 };
 
+export const getLDAPSettings = async (accessToken: string) => {
+  try {
+    const data = await apiClient.get(`/get/ldap_settings`, { accessToken });
+    return data;
+  } catch (error) {
+    console.error("Failed to fetch LDAP configuration:", error);
+    throw error;
+  }
+};
+
+export const updateLDAPSettings = async (accessToken: string, settings: Record<string, unknown>) => {
+  try {
+    const data = await apiClient.patch(`/update/ldap_settings`, { accessToken, body: settings });
+    return data;
+  } catch (error) {
+    console.error("Failed to update LDAP configuration:", error);
+    throw error;
+  }
+};
+
 interface UiAuditLogsParams {
   action?: string;
   table_name?: string;
@@ -7077,6 +7098,7 @@ export interface LoginRequest {
   username: string;
   password: string;
   useV3?: boolean;
+  authMethod?: "local" | "ldap";
 }
 
 interface LoginResponse {
@@ -7086,7 +7108,12 @@ interface LoginResponse {
   expires_in?: number;
 }
 
-export const loginCall = async (username: string, password: string, useV3?: boolean): Promise<LoginResponse> => {
+export const loginCall = async (
+  username: string,
+  password: string,
+  useV3?: boolean,
+  authMethod?: "local" | "ldap",
+): Promise<LoginResponse> => {
   const proxyBaseUrl = getProxyBaseUrl();
   const loginPath = useV3 ? "/v3/login" : "/v2/login";
   const loginUrl = proxyBaseUrl ? `${proxyBaseUrl}${loginPath}` : loginPath;
@@ -7094,6 +7121,7 @@ export const loginCall = async (username: string, password: string, useV3?: bool
   const body = JSON.stringify({
     username,
     password,
+    ...(authMethod ? { auth_method: authMethod } : {}),
   });
 
   const response = await fetch(loginUrl, {

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -4154,6 +4154,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/get/ldap_settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Ldap Settings */
+        get: operations["get_ldap_settings_get_ldap_settings_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/get/mcp_semantic_filter_settings": {
         parameters: {
             query?: never;
@@ -14249,6 +14266,23 @@ export interface paths {
          *     These settings will be applied to new users who sign in via SSO.
          */
         patch: operations["update_internal_user_settings_update_internal_user_settings_patch"];
+        trace?: never;
+    };
+    "/update/ldap_settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update Ldap Settings */
+        patch: operations["update_ldap_settings_update_ldap_settings_patch"];
         trace?: never;
     };
     "/update/mcp_semantic_filter_settings": {
@@ -24645,6 +24679,106 @@ export interface components {
             /** Tpm Limit Type */
             tpm_limit_type?: ("guaranteed_throughput" | "best_effort_throughput" | "dynamic") | null;
         };
+        /** LDAPConfig */
+        LDAPConfig: {
+            /**
+             * Ldap Admin Group Dn
+             * @description LDAP group DN whose members should become LiteLLM proxy admins
+             */
+            ldap_admin_group_dn?: string | null;
+            /**
+             * Ldap Allow Insecure
+             * @description Allow LDAP bind without SSL or StartTLS. Not recommended outside isolated development environments
+             * @default false
+             */
+            ldap_allow_insecure: boolean;
+            /**
+             * Ldap Base Dn
+             * @description Base DN used to search for users
+             */
+            ldap_base_dn?: string | null;
+            /**
+             * Ldap Bind Dn
+             * @description Service account DN used to search users
+             */
+            ldap_bind_dn?: string | null;
+            /**
+             * Ldap Bind Password
+             * @description Service account password
+             */
+            ldap_bind_password?: string | null;
+            /**
+             * Ldap Display Name Attribute
+             * @description LDAP attribute used as the LiteLLM user display name
+             * @default displayName
+             */
+            ldap_display_name_attribute: string;
+            /**
+             * Ldap Email Attribute
+             * @description LDAP attribute used as the LiteLLM user email
+             * @default mail
+             */
+            ldap_email_attribute: string;
+            /**
+             * Ldap Enabled
+             * @description Enable LDAP login for the Admin UI
+             * @default false
+             */
+            ldap_enabled: boolean;
+            /**
+             * Ldap Group Attribute
+             * @description LDAP attribute containing user group DNs
+             * @default memberOf
+             */
+            ldap_group_attribute: string;
+            /**
+             * Ldap Search Base
+             * @description Optional search base. Defaults to base DN
+             */
+            ldap_search_base?: string | null;
+            /**
+             * Ldap Start Tls
+             * @description Upgrade LDAP connection with StartTLS before bind
+             * @default false
+             */
+            ldap_start_tls: boolean;
+            /**
+             * Ldap Url
+             * @description LDAP server URL, for example ldap://host:389
+             */
+            ldap_url?: string | null;
+            /**
+             * Ldap Use Ssl
+             * @description Connect to LDAP with SSL
+             * @default false
+             */
+            ldap_use_ssl: boolean;
+            /**
+             * Ldap User Id Attribute
+             * @description Immutable LDAP attribute used as the LiteLLM identity, for example objectGUID or entryUUID
+             */
+            ldap_user_id_attribute?: string | null;
+            /**
+             * Ldap User Search Filter
+             * @description LDAP user search filter. The {username} placeholder is escaped before use
+             * @default (|(uid={username})(sAMAccountName={username})(userPrincipalName={username}))
+             */
+            ldap_user_search_filter: string;
+        };
+        /**
+         * LDAPSettingsResponse
+         * @description Response model for LDAP settings
+         */
+        LDAPSettingsResponse: {
+            /** Field Schema */
+            field_schema: {
+                [key: string]: unknown;
+            };
+            /** Values */
+            values: {
+                [key: string]: unknown;
+            };
+        };
         /** LakeraCategoryThresholds */
         LakeraCategoryThresholds: {
             /** Jailbreak */
@@ -31854,6 +31988,11 @@ export interface components {
              * @default false
              */
             is_control_plane: boolean;
+            /**
+             * Ldap Configured
+             * @default false
+             */
+            ldap_configured: boolean;
             /** Proxy Base Url */
             proxy_base_url: string | null;
             /** Server Root Path */
@@ -39960,6 +40099,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["InternalUserSettingsResponse"];
+                };
+            };
+        };
+    };
+    get_ldap_settings_get_ldap_settings_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LDAPSettingsResponse"];
                 };
             };
         };
@@ -51114,6 +51273,39 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["DefaultInternalUserParams"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_ldap_settings_update_ldap_settings_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LDAPConfig"];
             };
         };
         responses: {

--- a/uv.lock
+++ b/uv.lock
@@ -3273,6 +3273,18 @@ wheels = [
 ]
 
 [[package]]
+name = "ldap3"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/ac/96bd5464e3edbc61595d0d69989f5d9969ae411866427b2500a8e5b812c0/ldap3-2.9.1.tar.gz", hash = "sha256:f3e7fc4718e3f09dda568b57100095e0ce58633bcabbed8667ce3f8fbaa4229f", size = 398830, upload-time = "2021-07-18T06:34:21.786Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/f6/71d6ec9f18da0b2201287ce9db6afb1a1f637dedb3f0703409558981c723/ldap3-2.9.1-py2.py3-none-any.whl", hash = "sha256:5869596fc4948797020d3f03b7939da938778a0f9e2009f7a072ccf92b8e8d70", size = 432192, upload-time = "2021-07-18T06:34:12.905Z" },
+]
+
+[[package]]
 name = "legacy-cgi"
 version = "2.6.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3340,6 +3352,7 @@ proxy = [
     { name = "fastapi-sso" },
     { name = "granian" },
     { name = "gunicorn" },
+    { name = "ldap3" },
     { name = "litellm-enterprise" },
     { name = "litellm-proxy-extras" },
     { name = "mcp" },
@@ -3520,6 +3533,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.6,<4.0" },
     { name = "jsonschema", specifier = ">=4.0.0,<5.0" },
     { name = "langfuse", marker = "extra == 'proxy-runtime'", specifier = ">=2.59.7,<3.0" },
+    { name = "ldap3", marker = "extra == 'proxy'", specifier = ">=2.9.0,<3.0" },
     { name = "litellm-enterprise", marker = "extra == 'proxy'", editable = "enterprise" },
     { name = "litellm-proxy-extras", marker = "extra == 'proxy'", editable = "litellm-proxy-extras" },
     { name = "llm-sandbox", marker = "extra == 'proxy-runtime'", specifier = ">=0.3.39,<1.0" },


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Proof captured at commit `30be8a9336`

A local proxy was run against isolated PostgreSQL 16 and OpenLDAP 1.5.0 services. LDAP settings were saved through the authenticated `/update/ldap_settings` endpoint, and the UI discovery endpoint reported LDAP as configured

```text
{'ldap_configured': True, 'sso_configured': False}
```

A directory user in the configured administrator group and a regular directory user both signed in through `/v2/login` with `auth_method=ldap`

```text
alice: {'status': 200, 'has_token': True, 'has_redirect': True}
bob:   {'status': 200, 'has_token': True, 'has_redirect': True}
```

The synchronized database rows contained stable hashed LDAP user IDs, directory metadata, aliases, and the expected roles

```text
alice@example.org|proxy_admin|Alice Admin|uid=alice,ou=people,dc=example,dc=org|ldap:|69
bob@example.org|internal_user|Bob User|uid=bob,ou=people,dc=example,dc=org|ldap:|69
```

Repeated login preserved the same user ID and did not create a duplicate user

```text
status=200 stable_id=true user_count=1
```

The secure transport default rejected plaintext LDAP unless the local development override was explicitly enabled

```text
{'settings_update': 200, 'login_status': 400, 'transport_rejected': True, 'token_returned': False}
```

The dashboard production build showed LDAP first and selected by default, submitted `auth_method=ldap`, allowed switching to the local LiteLLM account, and did not write test credentials to the browser console. The proxy logs also contained no test credentials

## Type

🆕 New Feature

## Changes

Adds LDAP authentication for the Admin UI, including environment and database-backed configuration, encrypted bind credentials, secure transport defaults, stable LDAP identities, configurable directory attributes, case-insensitive administrator group mapping, and role synchronization

Adds LDAP configuration to the Admin UI, LDAP-first login selection with local account fallback, LDAP directory metadata in the users table, discovery support, generated API types, and the `ldap3` proxy dependency

Adds focused backend and dashboard regression coverage. The backend suite passed 352 tests, the dashboard suite passed 74 tests, the dashboard production build passed, and `make pre-commit` passed

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
