### PR TITLE
fix(proxy): extract leftmost client IP from multi-hop X-Forwarded-For in allowed_ips check

### DIFF
--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -21,7 +21,7 @@ from litellm.types.utils import CustomPricingLiteLLMParams
 def _get_request_ip_address(request: Request, use_x_forwarded_for: Optional[bool] = False) -> Optional[str]:
     client_ip = None
     if use_x_forwarded_for is True and "x-forwarded-for" in request.headers:
-        client_ip = request.headers["x-forwarded-for"]
+        client_ip = request.headers["x-forwarded-for"].split(",")[0].strip()
     elif request.client is not None:
         client_ip = request.client.host
     else:

--- a/tests/proxy_unit_tests/test_user_api_key_auth.py
+++ b/tests/proxy_unit_tests/test_user_api_key_auth.py
@@ -33,6 +33,8 @@ class Request:
         self.client = MagicMock()
         self.client.host = client_ip
         self.headers: Dict[str, str] = {}
+        if headers:
+            self.headers = {k.lower(): v for k, v in headers.items() if v is not None}
 
 
 @pytest.mark.parametrize(
@@ -86,6 +88,31 @@ def test_check_valid_ip_sent_with_x_forwarded_for(
     request = Request(client_ip, headers={"X-Forwarded-For": client_ip})
 
     assert _check_valid_ip(allowed_ips, request, use_x_forwarded_for=True)[0] == expected_result  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "allowed_ips, xff_header, expected_result, expected_ip",
+    [
+        (["203.0.113.10"], "203.0.113.10, 10.0.0.2", True, "203.0.113.10"),
+        (["203.0.113.10"], "203.0.113.10", True, "203.0.113.10"),
+        (["10.0.0.2"], "203.0.113.10, 10.0.0.2", False, "203.0.113.10"),
+        (["198.51.100.5"], "198.51.100.5, 10.0.0.2, 10.0.0.3", True, "198.51.100.5"),
+        (["203.0.113.10"], " 203.0.113.10 , 10.0.0.2", True, "203.0.113.10"),
+    ],
+)
+def test_check_valid_ip_multi_hop_x_forwarded_for(
+    allowed_ips: List[str],
+    xff_header: str,
+    expected_result: bool,
+    expected_ip: str,
+):
+    from litellm.proxy.auth.auth_utils import _check_valid_ip
+
+    request = Request(client_ip="10.0.0.2", headers={"X-Forwarded-For": xff_header})
+
+    result, ip = _check_valid_ip(allowed_ips, request, use_x_forwarded_for=True)  # type: ignore
+    assert result == expected_result
+    assert ip == expected_ip
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
+++ b/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
@@ -374,7 +374,7 @@ class TestXffTrustedHopsAccessControl:
             },
         )
 
-        assert result == "10.0.0.99, 203.0.113.9"
+        assert result == "10.0.0.99"
 
     @pytest.mark.parametrize("bad_value", [0, -1, "abc", 1.5])
     def test_invalid_hops_config_fails_closed_not_legacy(self, bad_value):


### PR DESCRIPTION
## Relevant issues

Fixes #33324

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`allowed_ips` is an Enterprise feature (gated behind `LITELLM_LICENSE` at proxy startup in `proxy_server.py:4634`), so a live proxy cannot be started with it configured without a license. Additionally, Prisma binary download fails in this environment (certificate error), preventing database setup. The proof below directly exercises the production `_get_request_ip_address` and `_check_valid_ip` functions from `litellm.proxy.auth.auth_utils` using real Starlette `Request` objects (not mocks) constructed with multi-hop `X-Forwarded-For` headers

A small script constructs `starlette.requests.Request` objects with various XFF headers and calls the actual production functions:

```python
from starlette.requests import Request
from litellm.proxy.auth.auth_utils import _get_request_ip_address, _check_valid_ip
# ... constructs Request with XFF header, calls _get_request_ip_address and _check_valid_ip
```

**BEFORE (commit `bcd52754de`, parent of the fix):**

```
=== Testing _get_request_ip_address with multi-hop X-Forwarded-For ===

XFF header: '203.0.113.10, 10.0.0.2'
  Extracted IP: '203.0.113.10, 10.0.0.2'

XFF header: '203.0.113.10'
  Extracted IP: '203.0.113.10'

XFF header: '203.0.113.10, 10.0.0.2, 192.168.1.1'
  Extracted IP: '203.0.113.10, 10.0.0.2, 192.168.1.1'

XFF header: '  203.0.113.10  , 10.0.0.2'
  Extracted IP: '  203.0.113.10  , 10.0.0.2'

=== Testing _check_valid_ip with allowed_ips=['203.0.113.10'] ===

XFF header: '203.0.113.10, 10.0.0.2'
  Extracted IP: '203.0.113.10, 10.0.0.2'
  Allowed: False

XFF header: '203.0.113.10'
  Extracted IP: '203.0.113.10'
  Allowed: True

XFF header: '203.0.113.10, 10.0.0.2, 192.168.1.1'
  Extracted IP: '203.0.113.10, 10.0.0.2, 192.168.1.1'
  Allowed: False

XFF header: '  203.0.113.10  , 10.0.0.2'
  Extracted IP: '  203.0.113.10  , 10.0.0.2'
  Allowed: False
```

With the buggy code, multi-hop XFF headers (the common case behind any reverse proxy, CDN, or load balancer) produce the raw header string as the "client IP", which never matches any single IP in `allowed_ips`. The client at `203.0.113.10` is wrongly blocked even though it is in the allowed list

**AFTER (commit `0f83f9d35f`, the fix):**

```
=== Testing _get_request_ip_address with multi-hop X-Forwarded-For ===

XFF header: '203.0.113.10, 10.0.0.2'
  Extracted IP: '203.0.113.10'

XFF header: '203.0.113.10'
  Extracted IP: '203.0.113.10'

XFF header: '203.0.113.10, 10.0.0.2, 192.168.1.1'
  Extracted IP: '203.0.113.10'

XFF header: '  203.0.113.10  , 10.0.0.2'
  Extracted IP: '203.0.113.10'

=== Testing _check_valid_ip with allowed_ips=['203.0.113.10'] ===

XFF header: '203.0.113.10, 10.0.0.2'
  Extracted IP: '203.0.113.10'
  Allowed: True

XFF header: '203.0.113.10'
  Extracted IP: '203.0.113.10'
  Allowed: True

XFF header: '203.0.113.10, 10.0.0.2, 192.168.1.1'
  Extracted IP: '203.0.113.10'
  Allowed: True

XFF header: '  203.0.113.10  , 10.0.0.2'
  Extracted IP: '203.0.113.10'
  Allowed: True
```

With the fix, the leftmost IP is correctly extracted from multi-hop XFF headers, and `allowed_ips` matching works as expected. This follows the same convention already used in `IPAddressUtils.is_internal_ip` (`ip_address_utils.py:125-126`), which already does `client_ip.split(",")[0].strip()`

## Type

🐛 Bug Fix

## Changes

`_get_request_ip_address` in `litellm/proxy/auth/auth_utils.py` returned the raw `X-Forwarded-For` header value. For multi-hop requests (common behind reverse proxies, CDNs, and load balancers), this is a comma-separated list like `"203.0.113.10, 10.0.0.2"`, which never matches any single IP in `allowed_ips`. The fix splits the header on commas and takes the leftmost (stripped) IP, which is the original client IP per RFC 7239. This is the same pattern already used in `IPAddressUtils.is_internal_ip`

The test mock `Request` class in `tests/proxy_unit_tests/test_user_api_key_auth.py` accepted a `headers` parameter in `__init__` but never stored it, so the existing `test_check_valid_ip_sent_with_x_forwarded_for` test was silently not exercising the XFF code path at all. Fixed the mock to store headers (case-insensitive like real Starlette) and added `test_check_valid_ip_multi_hop_x_forwarded_for`, a parametrized test covering multi-hop, single-hop, non-matching, 3-hop, and whitespace edge cases

Also fixed an assertion in `tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py` that was asserting the buggy raw header value `"10.0.0.99, 203.0.113.9"` despite the test name saying "leftmost behavior"

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR