### PR TITLE
refactor: remove unreachable duplicate elif branches

### DIFF
--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -464,8 +464,6 @@ def get_llm_provider(
             custom_llm_provider = "compactifai"
         elif model.startswith("ovhcloud/"):
             custom_llm_provider = "ovhcloud"
-        elif model.startswith("lemonade/"):
-            custom_llm_provider = "lemonade"
         elif model.startswith("clarifai/"):
             custom_llm_provider = "clarifai"
         elif model.startswith("amazon_nova"):

--- a/litellm/llms/databricks/cost_calculator.py
+++ b/litellm/llms/databricks/cost_calculator.py
@@ -31,8 +31,6 @@ def cost_per_token(model: str, usage: Usage) -> Tuple[float, float]:
         base_model = "databricks-meta-llama-3-1-405b-instruct"
     elif model.startswith("databricks/mixtral-8x7b-instruct-v0.1") or model.startswith("mixtral-8x7b-instruct-v0.1"):
         base_model = "databricks-mixtral-8x7b-instruct"
-    elif model.startswith("databricks/mixtral-8x7b-instruct-v0.1") or model.startswith("mixtral-8x7b-instruct-v0.1"):
-        base_model = "databricks-mixtral-8x7b-instruct"
     elif model.startswith("databricks/bge-large-en") or model.startswith("bge-large-en"):
         base_model = "databricks-bge-large-en"
     elif model.startswith("databricks/gte-large-en") or model.startswith("gte-large-en"):

--- a/litellm/llms/huggingface/rerank/transformation.py
+++ b/litellm/llms/huggingface/rerank/transformation.py
@@ -111,8 +111,6 @@ class HuggingFaceRerankConfig(BaseRerankConfig):
                     optional_rerank_params["return_text"] = v
                 elif k == "top_n" and v is not None:
                     optional_rerank_params["top_n"] = v
-                elif k == "documents" and v is not None:
-                    optional_rerank_params["texts"] = v
                 elif k == "query" and v is not None:
                     optional_rerank_params["query"] = v
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -6026,11 +6026,6 @@ def validate_environment(
                 keys_in_environment = True
             else:
                 missing_keys.append("CEREBRAS_API_KEY")
-        elif custom_llm_provider == "baseten":
-            if "BASETEN_API_KEY" in os.environ:
-                keys_in_environment = True
-            else:
-                missing_keys.append("BASETEN_API_KEY")
         elif custom_llm_provider == "xai":
             if "XAI_API_KEY" in os.environ:
                 keys_in_environment = True


### PR DESCRIPTION
## The problem

Four `if`/`elif` chains each test the same condition twice. An earlier branch already matches, so the later duplicate is unreachable. In all four cases the duplicated branch body is **identical** to the branch that shadows it, so removing it is a no-op rather than a behavior change.

| File | Condition | Shadowed by | Dead line |
|---|---|---|---|
| `litellm_core_utils/get_llm_provider_logic.py` | `model.startswith("lemonade/")` | L454 | L467 |
| `llms/databricks/cost_calculator.py` | `mixtral-8x7b-instruct-v0.1` | L32 | L34 |
| `llms/huggingface/rerank/transformation.py` | `k == "documents"` | L108 | L114 |
| `utils.py` | `custom_llm_provider == "baseten"` | L5967 | L6031 |

These look like merge artifacts where provider support was added twice independently.

Scope is limited to deleting the unreachable branches. I did not touch the surrounding logic.

## How I verified

Each removed branch was checked to confirm the surviving branch still handles the same input, running against the patched working tree:

```
get_llm_provider('lemonade/foo')     -> 'lemonade'
get_llm_provider('lemonade/llama-3') -> 'lemonade'
get_llm_provider('ovhcloud/x')       -> 'ovhcloud'   # neighbours unaffected
get_llm_provider('clarifai/y')       -> 'clarifai'

validate_environment('baseten/my-model')              -> {'keys_in_environment': True, 'missing_keys': []}
validate_environment('baseten/my-model')  # no key    -> {'keys_in_environment': False, 'missing_keys': ['BASETEN_API_KEY']}
```

For the two pure functions I diffed old vs new behavior directly by extracting both versions and comparing outputs:

- `databricks/cost_calculator.py`: 9 model strings compared, **0 mismatches** (`databricks/mixtral-8x7b-instruct-v0.1` still maps to `databricks-mixtral-8x7b-instruct`)
- `huggingface/rerank/transformation.py`: 36 param combinations compared, **0 mismatches** (`{'documents': [...]}` still maps to `{'texts': [...]}`)

The `baseten` result is the clearest evidence the removed branches were dead: the key check still works, which means the earlier branch was always the one handling it.

## Note

These were found with an AST scan for repeated conditions within a single if/elif chain (AI-assisted). The scan reports zero remaining instances in `litellm/` after this change. I reviewed and verified each one individually before submitting.