### PR TITLE
fix(mcp): apply post-call hook edits to the client-facing tool result

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1241,8 +1241,9 @@ class Logging(LiteLLMLoggingBaseClass):
             dynamic_success_callbacks=self.dynamic_success_callbacks,
             global_callbacks=litellm.success_callback,
         )
+        tool_call_content = getattr(response_obj, "content", response_obj)
         post_mcp_tool_call_response_obj: MCPPostCallResponseObject = MCPPostCallResponseObject(
-            mcp_tool_call_response=response_obj, hidden_params=HiddenParams()
+            mcp_tool_call_response=tool_call_content, hidden_params=HiddenParams()
         )
         for callback in callbacks:
             try:
@@ -1258,12 +1259,12 @@ class Logging(LiteLLMLoggingBaseClass):
                     # current implementation returns the first modified response
                     ######################################################################
                     if response is not None:
-                        response_obj = self._parse_post_mcp_call_hook_response(response=response)
+                        tool_call_content = self._parse_post_mcp_call_hook_response(response=response)
             except Exception as e:
                 verbose_logger.exception(
                     "LiteLLM.LoggingError: [Non-Blocking] Exception occurred while logging {}".format(str(e))
                 )
-        return response_obj
+        return tool_call_content
 
     def _parse_post_mcp_call_hook_response(self, response: Optional[MCPPostCallResponseObject]) -> Any:
         """

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2867,12 +2867,14 @@ if MCP_AVAILABLE:
         callbacks.
         """
         logging_obj.post_call(original_response=result)
-        await logging_obj.async_post_mcp_tool_call_hook(
+        post_hook_content = await logging_obj.async_post_mcp_tool_call_hook(
             kwargs=logging_obj.model_call_details,
             response_obj=result,
             start_time=start_time,
             end_time=end_time,
         )
+        if isinstance(post_hook_content, list) and hasattr(result, "content"):
+            result.content = post_hook_content
         logging_obj.call_type = CallTypes.call_mcp_tool.value
         error_message = extract_mcp_tool_result_error_message(result)
         if error_message is None:

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -785,12 +785,14 @@ class LiteLLM_Proxy_MCP_Handler:
                     try:
                         litellm_logging_obj.post_call(original_response=result)
                         end_time = datetime.now()
-                        await litellm_logging_obj.async_post_mcp_tool_call_hook(
+                        post_hook_content = await litellm_logging_obj.async_post_mcp_tool_call_hook(
                             kwargs=litellm_logging_obj.model_call_details,
                             response_obj=result,
                             start_time=start_time,
                             end_time=end_time,
                         )
+                        if isinstance(post_hook_content, list) and hasattr(result, "content"):
+                            result.content = post_hook_content
                         await litellm_logging_obj.async_success_handler(
                             result=result,
                             start_time=start_time,

--- a/tests/mcp_tests/test_mcp_logging.py
+++ b/tests/mcp_tests/test_mcp_logging.py
@@ -446,3 +446,91 @@ async def test_mcp_tool_call_hook():
                 logged_standard_logging_payload is not None
             ), "Standard logging payload should not be None"
             assert logged_standard_logging_payload["response_cost"] == 1.42
+
+
+class MCPRedactingHook(CustomLogger):
+    async def async_post_mcp_tool_call_hook(
+        self, kwargs, response_obj: MCPPostCallResponseObject, start_time, end_time
+    ) -> Optional[MCPPostCallResponseObject]:
+        response_obj.mcp_tool_call_response = [
+            TextContent(type="text", text="[REDACTED]")
+        ]
+        return response_obj
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_call_hook_modifies_client_response():
+    """A post-call hook that rewrites mcp_tool_call_response must change the
+    CallToolResult returned to the MCP client, not only the logged payload."""
+    litellm.logging_callback_manager._reset_all_callbacks()
+    mock_result = CallToolResult(
+        content=[TextContent(type="text", text="SECRET-1234 must be redacted")],
+        isError=False,
+    )
+
+    mock_client = AsyncMock()
+    mock_client.call_tool = AsyncMock(return_value=mock_result)
+    mock_client.list_tools = AsyncMock(
+        return_value=[
+            MCPTool(
+                name="add_tools",
+                description="Test tool",
+                inputSchema={
+                    "type": "object",
+                    "properties": {"test": {"type": "string"}},
+                },
+            )
+        ]
+    )
+
+    def mock_client_constructor(*args, **kwargs):
+        return mock_client
+
+    local_mcp_server_manager = MCPServerManager()
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.mcp_server_manager.MCPClient",
+        mock_client_constructor,
+    ):
+        await local_mcp_server_manager.load_servers_from_config(
+            mcp_servers_config={
+                "zapier_gmail_server": {
+                    "url": os.getenv("ZAPIER_MCP_HTTPS_SERVER_URL"),
+                }
+            }
+        )
+
+        litellm.callbacks = [MCPRedactingHook()]
+
+        await local_mcp_server_manager._initialize_tool_name_to_mcp_server_name_mapping()
+        local_mcp_server_manager.tool_name_to_mcp_server_name_mapping["add_tools"] = (
+            "zapier_gmail_server"
+        )
+        local_mcp_server_manager.tool_name_to_mcp_server_name_mapping[
+            "zapier_gmail_server-add_tools"
+        ] = "zapier_gmail_server"
+
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+                local_mcp_server_manager,
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager",
+                local_mcp_server_manager,
+            ),
+        ):
+            _set_authorized_user(local_mcp_server_manager.get_all_mcp_server_ids())
+
+            response = await mcp_server_tool_call(
+                name="zapier_gmail_server-add_tools",
+                arguments={"test": "test"},
+            )
+
+            assert isinstance(response, CallToolResult)
+            assert len(response.content) == 1
+            assert response.content[0].text == "[REDACTED]"
+            assert all(
+                "SECRET-1234" not in getattr(item, "text", "")
+                for item in response.content
+            )


### PR DESCRIPTION
## Relevant issues

Resolves #33400

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] My PR passes all CI/CD checks (ran the mapped unit tests plus the ruff, format, basedpyright and budget gates locally; have not run the full CI matrix)
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`async_post_mcp_tool_call_hook` is documented as the way to "modify the MCP tool call response before it is returned to the user", but it could not actually change what an MCP client received. Two problems compounded

First, `litellm_logging.py` wrapped the whole `CallToolResult` into `MCPPostCallResponseObject.mcp_tool_call_response`. That field's runtime type is `List[Any]`, because the mcp content types are only imported under `TYPE_CHECKING`, so pydantic coerced the model by iterating it and a hook received a list of `(field_name, value)` tuples such as `[('meta', None), ('content', [...]), ('structuredContent', None), ('isError', False)]` instead of the tool content. The hook now receives `result.content`

Second, both call sites (`_fire_mcp_tool_call_logging` on the streamable gateway path and the responses API handler in `litellm_proxy_mcp_handler.py`) awaited the hook and discarded its return value, then returned the original result. Both now write the returned content back onto the `CallToolResult` before it is returned to the client

The cost tracking use case was unaffected either way, since `response_cost` is carried on `hidden_params` and extracted separately. Only response content modification was broken, which is why the existing tests (they construct the object with an empty list and only assert on cost) did not catch it

## Screenshots / Proof of Fix

Verified against a live proxy over the MCP streamable HTTP transport. The setup is a stub MCP server whose `leak` tool returns `SECRET-1234 should be redacted`, the proxy pointed at that server, and a callback registered via `litellm_settings.callbacks` that rewrites the tool response

```python
class MCPRedactor(CustomLogger):
    async def async_post_mcp_tool_call_hook(self, kwargs, response_obj, start_time, end_time):
        response_obj.mcp_tool_call_response = [TextContent(type="text", text="[REDACTED]")]
        return response_obj
```

The `/mcp` endpoint speaks the streamable transport, confirmed by the initialize response

```
$ curl -s -i -X POST http://127.0.0.1:4000/mcp/ \
    -H 'x-litellm-api-key: Bearer sk-1234' \
    -H 'Accept: application/json, text/event-stream' \
    -H 'Content-Type: application/json' \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"c","version":"1"}}}'
HTTP/1.1 200 OK
content-type: text/event-stream
mcp-session-id: 172e11c9add349a58168c27f966e0052
```

Calling the tool directly on the upstream stub returns the secret

```
stub content: ['SECRET-1234 should be redacted']
```

Calling the same tool through the gateway on the current base, before this PR, with the redacting callback active, still leaks the secret because the hook return is discarded

```
TOOL: stub_server-leak
RESULT_CONTENT: ['SECRET-1234 should be redacted']
```

Calling it through the gateway with this PR applied returns the rewritten content

```
TOOL: stub_server-leak
RESULT_CONTENT: ['[REDACTED]']
```

## QA runbook

1. Save the redacting callback as `mcp_redact.py`

```python
from typing import Optional
from litellm.integrations.custom_logger import CustomLogger
from litellm.types.mcp import MCPPostCallResponseObject
from mcp.types import TextContent


class MCPRedactor(CustomLogger):
    async def async_post_mcp_tool_call_hook(
        self, kwargs, response_obj: MCPPostCallResponseObject, start_time, end_time
    ) -> Optional[MCPPostCallResponseObject]:
        response_obj.mcp_tool_call_response = [TextContent(type="text", text="[REDACTED]")]
        return response_obj


mcp_redactor = MCPRedactor()
```

2. Point `config.yaml` at any MCP server and register the callback

```yaml
general_settings:
  master_key: sk-1234
litellm_settings:
  callbacks: ["mcp_redact.mcp_redactor"]
mcp_servers:
  my_server:
    url: "https://your-mcp-server/mcp/"
    allow_all_keys: true
```

3. Start the proxy with `LITELLM_MASTER_KEY=sk-1234` and the callback on `PYTHONPATH`

4. Call any tool through the gateway with an MCP client pointed at `http://127.0.0.1:4000/mcp/` (send the key as `x-litellm-api-key: Bearer sk-1234`) and confirm the returned `content` is `[REDACTED]` rather than the upstream tool output. On the current base the upstream content comes through unchanged

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
