### PR TITLE
chore(codeowners): exempt generated schema.d.ts from UI ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 /ui/ @yuneng-jiang @ryan-crabbe-berri
 /litellm/proxy/_experimental/out/ @yuneng-jiang @ryan-crabbe-berri
+/ui/litellm-dashboard/src/lib/http/schema.d.ts


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`ui/litellm-dashboard/src/lib/http/schema.d.ts` is generated from the backend OpenAPI spec by pre-commit, so backend-only PRs that touch endpoint signatures drag it along and trigger a UI code-owner review request for a change with no UI work in it. #33222 is a live example: a pure streaming fix that requested a UI owner review solely because of the regenerated schema.d.ts

The fix relies on documented CODEOWNERS behavior: entries are last-match-wins, and a matching pattern with no owners after it unsets ownership for that path. GitHub's own CODEOWNERS syntax docs show this exact pattern (an owned `/apps/` directory with an ownerless `/apps/github` line beneath it to exempt the subdirectory). After this lands, backend PRs carrying only the regenerated schema.d.ts will no longer request UI-owner review, while any other file under `/ui/` still does

No tests apply; CODEOWNERS is evaluated by GitHub, not by anything in this repo

## Type

🚄 Infrastructure

## Changes

Adds one line to `.github/CODEOWNERS`: an ownerless entry for `ui/litellm-dashboard/src/lib/http/schema.d.ts`, which exempts that generated file from the `/ui/` ownership rule. Everything else under `/ui/` and `/litellm/proxy/_experimental/out/` keeps its current owners

The tradeoff is that a hand-edited change to schema.d.ts would also skip UI-owner review, but the file is machine-generated and any manual drift gets overwritten by the next pre-commit run, so the exposure is negligible
