### PR TITLE
feat(bedrock_mantle): add GPT-5.6 sol/terra/luna to model cost map

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -44261,6 +44261,90 @@
         "supports_response_schema": true,
         "supports_tool_choice": true
     },
+    "bedrock_mantle/openai.gpt-5.6-sol": {
+        "input_cost_per_token": 5.5e-06,
+        "cache_creation_input_token_cost": 6.875e-06,
+        "cache_read_input_token_cost": 5.5e-07,
+        "output_cost_per_token": 3.3e-05,
+        "litellm_provider": "bedrock_mantle",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "use_openai_responses_path": true,
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "bedrock_mantle/openai.gpt-5.6-terra": {
+        "input_cost_per_token": 2.75e-06,
+        "cache_creation_input_token_cost": 3.4375e-06,
+        "cache_read_input_token_cost": 2.75e-07,
+        "output_cost_per_token": 1.65e-05,
+        "litellm_provider": "bedrock_mantle",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "use_openai_responses_path": true,
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "bedrock_mantle/openai.gpt-5.6-luna": {
+        "input_cost_per_token": 1.1e-06,
+        "cache_creation_input_token_cost": 1.375e-06,
+        "cache_read_input_token_cost": 1.1e-07,
+        "output_cost_per_token": 6.6e-06,
+        "litellm_provider": "bedrock_mantle",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "use_openai_responses_path": true,
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "bedrock_mantle/openai.gpt-5.5": {
         "input_cost_per_token": 5.5e-06,
         "cache_read_input_token_cost": 5.5e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -44382,6 +44382,90 @@
         "supports_response_schema": true,
         "supports_tool_choice": true
     },
+    "bedrock_mantle/openai.gpt-5.6-sol": {
+        "input_cost_per_token": 5.5e-06,
+        "cache_creation_input_token_cost": 6.875e-06,
+        "cache_read_input_token_cost": 5.5e-07,
+        "output_cost_per_token": 3.3e-05,
+        "litellm_provider": "bedrock_mantle",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "use_openai_responses_path": true,
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "bedrock_mantle/openai.gpt-5.6-terra": {
+        "input_cost_per_token": 2.75e-06,
+        "cache_creation_input_token_cost": 3.4375e-06,
+        "cache_read_input_token_cost": 2.75e-07,
+        "output_cost_per_token": 1.65e-05,
+        "litellm_provider": "bedrock_mantle",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "use_openai_responses_path": true,
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "bedrock_mantle/openai.gpt-5.6-luna": {
+        "input_cost_per_token": 1.1e-06,
+        "cache_creation_input_token_cost": 1.375e-06,
+        "cache_read_input_token_cost": 1.1e-07,
+        "output_cost_per_token": 6.6e-06,
+        "litellm_provider": "bedrock_mantle",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "use_openai_responses_path": true,
+        "supported_endpoints": [
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "bedrock_mantle/openai.gpt-5.5": {
         "input_cost_per_token": 5.5e-06,
         "cache_read_input_token_cost": 5.5e-07,

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
@@ -397,6 +397,20 @@ class TestBedrockMantleResponsesRegistry:
         assert isinstance(cfg, BedrockMantleResponsesAPIConfig)
         assert cfg.use_openai_path is True
 
+    @pytest.mark.parametrize(
+        "model",
+        ["openai.gpt-5.6-sol", "openai.gpt-5.6-terra", "openai.gpt-5.6-luna"],
+    )
+    def test_registry_returns_config_for_gpt_5_6_family(self, local_cost_map, model):
+        from litellm.utils import ProviderConfigManager
+
+        cfg = ProviderConfigManager.get_provider_responses_api_config(
+            provider="bedrock_mantle",
+            model=model,
+        )
+        assert isinstance(cfg, BedrockMantleResponsesAPIConfig)
+        assert cfg.use_openai_path is True
+
     def test_registry_returns_native_config_for_gpt_oss(self, local_cost_map):
         # Core regression: gpt-oss-120b supports the native Responses API (AWS
         # model card), so it must get a BedrockMantleResponsesAPIConfig on the

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
@@ -1251,6 +1251,25 @@ class TestBedrockMantleResponsesPricing:
         assert info["cache_read_input_token_cost"] == pytest.approx(2.75e-07)
         assert info["max_input_tokens"] == 272000
 
+    @pytest.mark.parametrize(
+        "model, input_cost, cache_creation_cost, cache_read_cost, output_cost",
+        [
+            ("openai.gpt-5.6-sol", 5.5e-06, 6.875e-06, 5.5e-07, 3.3e-05),
+            ("openai.gpt-5.6-terra", 2.75e-06, 3.4375e-06, 2.75e-07, 1.65e-05),
+            ("openai.gpt-5.6-luna", 1.1e-06, 1.375e-06, 1.1e-07, 6.6e-06),
+        ],
+    )
+    def test_gpt_5_6_pricing_and_mode(
+        self, local_cost_map, model, input_cost, cache_creation_cost, cache_read_cost, output_cost
+    ):
+        info = litellm.get_model_info(f"bedrock_mantle/{model}")
+        assert info["mode"] == "responses"
+        assert info["input_cost_per_token"] == pytest.approx(input_cost)
+        assert info["cache_creation_input_token_cost"] == pytest.approx(cache_creation_cost)
+        assert info["cache_read_input_token_cost"] == pytest.approx(cache_read_cost)
+        assert info["output_cost_per_token"] == pytest.approx(output_cost)
+        assert info["max_input_tokens"] == 272000
+
     def test_models_registered(self, local_cost_map):
         assert "bedrock_mantle/openai.gpt-5.5" in litellm.bedrock_mantle_models
         assert "bedrock_mantle/openai.gpt-5.4" in litellm.bedrock_mantle_models


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

All runs below hit a live proxy backed by the real bedrock-mantle endpoint in us-east-1 with SigV4 auth (`LITELLM_LOCAL_MODEL_COST_MAP=True`, config has `bedrock_mantle/openai.gpt-5.6-{sol,terra,luna}` and `bedrock_mantle/openai.gpt-5.5`)

Before (captured at b2202cb1aa): with no cost map entry the gate has no capability signal, so the request falls through to chat-completions emulation and the Mantle endpoint rejects it. This is exactly the failure reported for GPT-5.6 day 0

```
$ curl -s http://localhost:15731/v1/responses -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "gpt-5.6-luna", "input": "Reply with exactly: gpt-5.6 on Bedrock Mantle works"}'
{"error": {"message": "litellm.APIConnectionError: Bedrock_mantleException - {\"error\":{\"code\":\"validation_error\",\"message\":\"The model 'openai.gpt-5.6-luna' does not support the '/v1/chat/completions' API\", ...
```

After (captured at 0a9ac87538): the same request is now routed to the Responses API on the `openai/v1` Mantle base path. The proxy debug log shows every outbound call going to the URL the AWS model card mandates for these models

```
$ grep -oE "https://bedrock-mantle[^\"' ]*" gpt56_proxy_debug.log | sort | uniq -c
   6 https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses
```

AWS then answers with its own model-level entitlement error, because GPT-5.6 is sales-gated and our dev account is not allowlisted for it yet (the AWS console Workbench returns the identical 401 for this account, so this is purely account entitlement, not LiteLLM routing)

```
$ curl -s http://localhost:14653/v1/responses -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "gpt-5.6-luna", "input": "Reply with exactly: gpt-5.6 on Bedrock Mantle works"}'
{"error": {"message": "litellm.APIConnectionError: Bedrock_mantleException - {\"error\":{\"code\":\"access_denied\",\"message\":\"openai.gpt-5.6-luna is not available for this account. ...
```

End-to-end paid proof through the identical data-driven code path with a model the account is entitled to (`bedrock_mantle/openai.gpt-5.5`, same `mode=responses` + `use_openai_responses_path` entry shape): real completion, real spend, and the cost header matches the map exactly (22 x 5.5e-06 + 27 x 3.3e-05 = 0.001012)

```
$ curl -s -D - http://localhost:14653/v1/responses -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "gpt-5.5", "input": "Reply with exactly: gpt-5.5 on Bedrock Mantle works"}'
x-litellm-response-cost: 0.001012
...
"model": "gpt-5.5" | "status": "completed"
"text": ["gpt-5.5 on Bedrock Mantle works"]
"usage": 22 in / 27 out
```

Pricing cross-checked against the AWS Bedrock pricing page and the in-console Mantle model catalog for us-east-1 (Sol $5.50/$33.00, Terra $2.75/$16.50, Luna $1.10/$6.60 per 1M with 90% cached-input discount and 1.25x cache write; 272K context per the model cards). Once this merges to main, deployments on existing releases pick the entries up through the remote cost map fetch at startup, no version upgrade required

## Type

🆕 New Feature

## Changes

Adds `bedrock_mantle/openai.gpt-5.6-sol`, `bedrock_mantle/openai.gpt-5.6-terra`, and `bedrock_mantle/openai.gpt-5.6-luna` to `model_prices_and_context_window.json` and the bundled backup copy, mirroring the existing GPT-5.5/5.4 Mantle entries: `mode: responses`, `/v1/responses` in `supported_endpoints`, and `use_openai_responses_path: true` so `mantle_supports_responses` / `mantle_base_segment` route them through `BedrockMantleResponsesAPIConfig` on the `openai/v1` base path with SigV4 or Bedrock API key auth. Pricing bakes in the published in-region US rates and, new relative to the 5.5/5.4 entries, includes `cache_creation_input_token_cost` since AWS now lists a 30-minute cache write price for these models

Extends the registry regression test with a parametrized case asserting each of the three models resolves to `BedrockMantleResponsesAPIConfig` with `use_openai_path is True`; it fails if the entries are removed or their routing flags are dropped. A second parametrized test asserts the exact per-token prices (input, cache write, cache read, output) and 272K context for all three models, matching the coverage the 5.5/5.4 entries already have, so a typo in any price field fails the suite

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
