### PR TITLE
fix(anthropic): honor messages request timeout

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -1932,21 +1932,24 @@ class BaseLLMHTTPHandler:
         litellm_params: GenericLiteLLMParams,
         stream: bool,
         custom_llm_provider: str,
-    ) -> Union[float, httpx.Timeout]:
+    ) -> Optional[Union[float, httpx.Timeout]]:
         from litellm.litellm_core_utils.completion_timeout import CompletionTimeout
         from litellm.litellm_core_utils.request_timeout_resolver import (
             get_configured_request_timeout,
         )
         from litellm.utils import supports_httpx_timeout
 
-        model_timeout = litellm_params.get("stream_timeout") if stream else None
-        if model_timeout is None:
-            model_timeout = litellm_params.get("timeout")
+        stream_timeout = litellm_params.get("stream_timeout") if stream else None
+        model_timeout = stream_timeout if stream_timeout is not None else litellm_params.get("timeout")
+        request_timeout = litellm_params.get("request_timeout")
+        global_timeout = get_configured_request_timeout()
+        if model_timeout is None and request_timeout is None and global_timeout is None:
+            return None
         return CompletionTimeout.resolve(
             model_timeout,
-            {"request_timeout": litellm_params.get("request_timeout")},
+            {"request_timeout": request_timeout},
             custom_llm_provider,
-            global_timeout=get_configured_request_timeout(),
+            global_timeout=global_timeout,
             supports_httpx_timeout=supports_httpx_timeout,
         )
 

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -1879,6 +1879,7 @@ class BaseLLMHTTPHandler:
         litellm_params: GenericLiteLLMParams,
         api_key: Optional[str],
         model: str,
+        timeout: Optional[Union[float, httpx.Timeout]] = None,
     ) -> httpx.Response:
         max_attempts = max(provider_config.max_retry_on_anthropic_messages_http_error, 1)
         litellm_params_dict = dict(litellm_params)
@@ -1891,6 +1892,7 @@ class BaseLLMHTTPHandler:
                     data=signed_json_body or json.dumps(request_body),
                     stream=stream or False,
                     logging_obj=logging_obj,
+                    timeout=timeout,
                 )
                 response.raise_for_status()
                 return response
@@ -1924,6 +1926,29 @@ class BaseLLMHTTPHandler:
                 raise self._handle_error(e=e, provider_config=provider_config)
 
         raise RuntimeError("unreachable: anthropic messages HTTP retry loop exited without return")
+
+    @staticmethod
+    def _resolve_anthropic_messages_timeout(
+        litellm_params: GenericLiteLLMParams,
+        stream: bool,
+        custom_llm_provider: str,
+    ) -> Union[float, httpx.Timeout]:
+        from litellm.litellm_core_utils.completion_timeout import CompletionTimeout
+        from litellm.litellm_core_utils.request_timeout_resolver import (
+            get_configured_request_timeout,
+        )
+        from litellm.utils import supports_httpx_timeout
+
+        model_timeout = litellm_params.get("stream_timeout") if stream else None
+        if model_timeout is None:
+            model_timeout = litellm_params.get("timeout")
+        return CompletionTimeout.resolve(
+            model_timeout,
+            {"request_timeout": litellm_params.get("request_timeout")},
+            custom_llm_provider,
+            global_timeout=get_configured_request_timeout(),
+            supports_httpx_timeout=supports_httpx_timeout,
+        )
 
     async def async_anthropic_messages_handler(
         self,
@@ -2075,6 +2100,11 @@ class BaseLLMHTTPHandler:
             litellm_params=litellm_params,
             api_key=api_key,
             model=model,
+            timeout=self._resolve_anthropic_messages_timeout(
+                litellm_params=litellm_params,
+                stream=stream or False,
+                custom_llm_provider=custom_llm_provider,
+            ),
         )
 
         # used for logging + cost tracking

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -1084,6 +1084,90 @@ def test_sync_delete_responses_sets_json_content_type():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize(
+    "litellm_params_kwargs, stream, global_timeout, expected",
+    [
+        ({"timeout": 12.0}, False, None, 12.0),
+        ({"request_timeout": 30.0}, False, None, 30.0),
+        ({}, False, 1500.0, 1500.0),
+        ({"timeout": 5.0, "stream_timeout": 50.0}, True, None, 50.0),
+    ],
+)
+def test_resolve_anthropic_messages_timeout(
+    monkeypatch, litellm_params_kwargs, stream, global_timeout, expected
+):
+    from litellm.constants import DEFAULT_REQUEST_TIMEOUT_SECONDS
+
+    if global_timeout is None:
+        monkeypatch.setattr(
+            "litellm.request_timeout",
+            float(DEFAULT_REQUEST_TIMEOUT_SECONDS),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            "litellm.request_timeout_explicitly_set",
+            False,
+            raising=False,
+        )
+    else:
+        monkeypatch.setattr("litellm.request_timeout", global_timeout, raising=False)
+        monkeypatch.setattr(
+            "litellm.request_timeout_explicitly_set", True, raising=False
+        )
+
+    resolved = BaseLLMHTTPHandler._resolve_anthropic_messages_timeout(
+        litellm_params=GenericLiteLLMParams(**litellm_params_kwargs),
+        stream=stream,
+        custom_llm_provider="anthropic",
+    )
+
+    assert resolved == expected
+
+
+@pytest.mark.asyncio
+async def test_async_anthropic_messages_handler_forwards_request_timeout(monkeypatch):
+    monkeypatch.setattr(litellm, "callbacks", [])
+    handler = BaseLLMHTTPHandler()
+
+    mock_config = Mock()
+    mock_config.validate_anthropic_messages_environment = Mock(
+        return_value=({"x-api-key": "k"}, "https://api.anthropic.com")
+    )
+    mock_config.should_filter_anthropic_beta_headers = Mock(return_value=False)
+    mock_config.transform_anthropic_messages_request = Mock(
+        return_value={"model": "claude", "messages": []}
+    )
+    mock_config.get_complete_url = Mock(return_value="https://api.anthropic.com/v1/messages")
+    mock_config.sign_request = Mock(return_value=({"x-api-key": "k"}, None))
+    mock_config.max_retry_on_anthropic_messages_http_error = 1
+    expected_response = {"id": "msg_1", "content": []}
+    mock_config.transform_anthropic_messages_response = Mock(return_value=expected_response)
+
+    ok_response = Mock()
+    ok_response.raise_for_status = Mock(return_value=None)
+    mock_client = AsyncMock(spec=AsyncHTTPHandler)
+    mock_client.post = AsyncMock(return_value=ok_response)
+
+    logging_obj = Mock()
+    logging_obj.model_call_details = {}
+    logging_obj.dynamic_success_callbacks = []
+
+    result = await handler.async_anthropic_messages_handler(
+        model="claude",
+        messages=[{"role": "user", "content": "hi"}],
+        anthropic_messages_provider_config=mock_config,
+        anthropic_messages_optional_request_params={},
+        custom_llm_provider="anthropic",
+        litellm_params=GenericLiteLLMParams(request_timeout=0.3),
+        logging_obj=logging_obj,
+        client=mock_client,
+        kwargs={},
+    )
+
+    assert result is expected_response
+    assert mock_client.post.await_args.kwargs["timeout"] == 0.3
+
+
 @pytest.mark.asyncio
 async def test_anthropic_post_uses_prebuilt_body_without_redumping():
     """When the caller passes a pre-serialized (unsigned) body, attempt 0 must
@@ -1894,7 +1978,9 @@ async def test_anthropic_invalid_thinking_signature_retry_resigns_bedrock_reques
     ok_response = httpx.Response(200, json={"id": "msg_1"}, request=httpx.Request("POST", request_url))
 
     class FakeAsyncClient:
-        async def post(self, url, headers, data, stream=False, logging_obj=None):
+        async def post(
+            self, url, headers, data, stream=False, logging_obj=None, timeout=None
+        ):
             posts.append({"headers": dict(headers), "data": data})
             return invalid_signature_response if len(posts) == 1 else ok_response
 

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -1130,7 +1130,11 @@ def test_resolve_anthropic_messages_timeout(
 
 @pytest.mark.asyncio
 async def test_async_anthropic_messages_handler_forwards_request_timeout(monkeypatch):
+    from litellm.constants import DEFAULT_REQUEST_TIMEOUT_SECONDS
+
     monkeypatch.setattr(litellm, "callbacks", [])
+    monkeypatch.setattr(litellm, "request_timeout", float(DEFAULT_REQUEST_TIMEOUT_SECONDS))
+    monkeypatch.setattr(litellm, "request_timeout_explicitly_set", False)
     handler = BaseLLMHTTPHandler()
 
     mock_config = Mock()
@@ -1174,7 +1178,11 @@ async def test_async_anthropic_messages_handler_forwards_request_timeout(monkeyp
 
 @pytest.mark.asyncio
 async def test_async_anthropic_messages_handler_forwards_stream_timeout(monkeypatch):
+    from litellm.constants import DEFAULT_REQUEST_TIMEOUT_SECONDS
+
     monkeypatch.setattr(litellm, "callbacks", [])
+    monkeypatch.setattr(litellm, "request_timeout", float(DEFAULT_REQUEST_TIMEOUT_SECONDS))
+    monkeypatch.setattr(litellm, "request_timeout_explicitly_set", False)
     handler = BaseLLMHTTPHandler()
 
     mock_config = Mock()

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -1091,6 +1091,10 @@ def test_sync_delete_responses_sets_json_content_type():
         ({"request_timeout": 30.0}, False, None, 30.0),
         ({}, False, 1500.0, 1500.0),
         ({"timeout": 5.0, "stream_timeout": 50.0}, True, None, 50.0),
+        ({"timeout": 5.0, "stream_timeout": 50.0}, False, None, 5.0),
+        ({"timeout": 5.0, "request_timeout": 30.0}, False, None, 5.0),
+        ({}, False, None, None),
+        ({}, True, None, None),
     ],
 )
 def test_resolve_anthropic_messages_timeout(
@@ -1166,6 +1170,51 @@ async def test_async_anthropic_messages_handler_forwards_request_timeout(monkeyp
 
     assert result is expected_response
     assert mock_client.post.await_args.kwargs["timeout"] == 0.3
+
+
+@pytest.mark.asyncio
+async def test_async_anthropic_messages_handler_forwards_stream_timeout(monkeypatch):
+    monkeypatch.setattr(litellm, "callbacks", [])
+    handler = BaseLLMHTTPHandler()
+
+    mock_config = Mock()
+    mock_config.validate_anthropic_messages_environment = Mock(
+        return_value=({"x-api-key": "k"}, "https://api.anthropic.com")
+    )
+    mock_config.should_filter_anthropic_beta_headers = Mock(return_value=False)
+    mock_config.transform_anthropic_messages_request = Mock(
+        return_value={"model": "claude", "messages": []}
+    )
+    mock_config.get_complete_url = Mock(return_value="https://api.anthropic.com/v1/messages")
+    mock_config.sign_request = Mock(return_value=({"x-api-key": "k"}, None))
+    mock_config.max_retry_on_anthropic_messages_http_error = 1
+    mock_config.get_async_streaming_response_iterator = Mock(return_value=Mock())
+
+    ok_response = Mock()
+    ok_response.raise_for_status = Mock(return_value=None)
+    ok_response.headers = httpx.Headers({})
+    mock_client = AsyncMock(spec=AsyncHTTPHandler)
+    mock_client.post = AsyncMock(return_value=ok_response)
+
+    logging_obj = Mock()
+    logging_obj.model_call_details = {}
+    logging_obj.dynamic_success_callbacks = []
+
+    await handler.async_anthropic_messages_handler(
+        model="claude",
+        messages=[{"role": "user", "content": "hi"}],
+        anthropic_messages_provider_config=mock_config,
+        anthropic_messages_optional_request_params={},
+        custom_llm_provider="anthropic",
+        litellm_params=GenericLiteLLMParams(timeout=9.0, stream_timeout=0.7),
+        logging_obj=logging_obj,
+        client=mock_client,
+        stream=True,
+        kwargs={},
+    )
+
+    assert mock_client.post.await_args.kwargs["stream"] is True
+    assert mock_client.post.await_args.kwargs["timeout"] == 0.7
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

Fixes #26752

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Proof below was captured by the original author on the original PR's commits. The upstream is a local Anthropic-compatible server that sleeps for 1.25s while the model config sets `request_timeout: 0.3`, which keeps the proof deterministic

Config used for both runs:

```yaml
model_list:
  - model_name: claude-timeout-proof
    litellm_params:
      model: anthropic/claude-timeout-proof
      api_key: sk-ant-local-proof
      api_base: http://127.0.0.1:8999
      request_timeout: 0.3

general_settings:
  master_key: sk-1234

litellm_settings:
  drop_params: true
  modify_params: true
  num_retries: 0
```

Before fix, at base commit `bf02a4a47f`, the request waited for the slow upstream and returned `200`, showing that the model-level timeout was not applied to the Anthropic `/v1/messages` HTTP request:

```bash
uv run --extra proxy python litellm/proxy/proxy_cli.py --config /private/tmp/litellm_timeout_proof_config.yaml --port 4010 --detailed_debug

curl -sS -w '\nhttp_code=%{http_code}\ntime_total=%{time_total}\n' \
  -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' \
  -H 'anthropic-version: 2023-06-01' \
  --data '{"model":"claude-timeout-proof","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}' \
  http://127.0.0.1:4010/v1/messages
```

```text
{"id":"msg_timeout_proof","type":"message","role":"assistant","model":"claude-timeout-proof","content":[{"type":"text","text":"slow upstream response"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":5,"output_tokens":3}}
http_code=200
time_total=1.946157
```

After fix, at original commit `63019add86`, the same request returns a LiteLLM timeout. The response body shows the configured `0.3s` timeout reached the HTTP request path:

```text
{"error":{"message":"litellm.Timeout: Connection timed out. Timeout passed=0.3, time taken=0.302 seconds. Received Model Group=claude-timeout-proof\nAvailable Model Group Fallbacks=None","type":"None","param":"None","code":"408"}}
http_code=408
time_total=1.512531
```

## Type

Bug Fix

## Changes

Anthropic `/v1/messages` now resolves per-request and configured timeouts through the shared completion timeout resolver, then forwards the resolved value into the async HTTP POST helper, on the first attempt and on every retry

On top of the original change, the follow-up commit makes the resolver return `None` when no timeout was configured anywhere (no model-level `timeout` or `stream_timeout`, no deployment `request_timeout`, no explicitly set `litellm.request_timeout`). The POST then falls back to the cached client's default `httpx.Timeout(600, connect=5)` instead of an explicit bare `600.0`, which would have set the connect timeout to 600s as well

Regression coverage checks timeout precedence (model `timeout` beats deployment `request_timeout`, `stream_timeout` only applies to streaming requests), the unconfigured fallback returning `None`, and the full async `/v1/messages` handler wiring into the HTTP client for both streaming and non-streaming requests. Each new assertion was mutation-checked: always reading `stream_timeout`, hard-coding `stream=False` at the call site, and dropping the `None` fallback each fail exactly one of the new tests

## Behavior changes

Requests to `/v1/messages` that set a timeout (request body, deployment config, or an explicit `litellm.request_timeout`) now honor it; previously it was ignored and the client default of 600s applied. When the resolved timeout is a bare number, httpx applies it to connect/read/write/pool alike, matching the existing chat completions behavior. When no timeout is configured anywhere, behavior is unchanged: the client default of 600s read with a 5s connect timeout still applies

## Credit

Adopted from #32827 by @MelvinOrichiSocana-hs. Mirrored onto a `litellm_` branch so CircleCI and the internal lint workflow run

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Anthropic messages HTTP wiring; unconfigured requests keep existing client defaults, while configured timeouts may surface 408s where slow calls previously succeeded.
> 
> **Overview**
> Anthropic **`/v1/messages`** async HTTP calls now apply the same timeout resolution as chat completions instead of always using the client’s long default.
> 
> A new **`_resolve_anthropic_messages_timeout`** helper picks **`stream_timeout`** on streaming requests, otherwise **`timeout`**, then deployment **`request_timeout`**, then an explicit global **`litellm.request_timeout`**, via **`CompletionTimeout.resolve`**. That value is passed into **`_async_post_anthropic_messages_with_http_error_retry`** on the initial POST and retries. If nothing is configured at any layer, the resolver returns **`None`** so httpx keeps the cached client default (600s read / 5s connect) rather than forcing a bare numeric timeout that would widen connect.
> 
> Tests cover precedence, the unconfigured **`None`** path, and end-to-end forwarding for non-streaming and streaming handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3eb9dcc7223390cac04539163ca3eccb790d431. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->