### PR TITLE
fix(router): honor per-request routing_strategy from key/team router_settings

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -1621,6 +1621,7 @@ async def update_team(
     - allowed_passthrough_routes: Optional[List[str]] - List of allowed pass through routes for the team.
     - model_rpm_limit: Optional[Dict[str, int]] - The RPM (Requests Per Minute) limit per model for this team. Example: {"gpt-4": 100, "gpt-3.5-turbo": 200}
     - model_tpm_limit: Optional[Dict[str, int]] - The TPM (Tokens Per Minute) limit per model for this team. Example: {"gpt-4": 10000, "gpt-3.5-turbo": 20000}
+    - mcp_rpm_limit: Optional[Dict[str, int]] - Per-MCP-server RPM limit for this team, keyed by MCP server name (alias if set, else the configured name). Example: {"github": 100, "slack": 200}. Applied across all keys for this team.
     Example - update team TPM Limit
     - allowed_vector_store_indexes: Optional[List[dict]] - List of allowed vector store indexes for the key. Example - [{"index_name": "my-index", "index_permissions": ["write", "read"]}]. If specified, the key will only be able to use these specific vector store indexes. Create index, using `/v1/indexes` endpoint.
     - secret_manager_settings: Optional[dict] - Secret manager settings for the team. [Docs](https://docs.litellm.ai/docs/secret_managers/overview)

--- a/litellm/proxy/route_llm_request.py
+++ b/litellm/proxy/route_llm_request.py
@@ -407,6 +407,7 @@ async def route_request(
             "num_retries",
             "timeout",
             "model_group_retry_policy",
+            "routing_strategy",
         ]
 
         # Merge override settings into data (only if not already set in request)

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -619,6 +619,8 @@ class Router:
                 routing_strategy_args=routing_strategy_args,
             )
         self._init_routing_groups(self._routing_groups_input)
+        self._override_selectors: dict[str, Any] = {}
+        self._override_selectors_lock = threading.Lock()
         self.access_groups = None
         ## USAGE TRACKING ##
         if isinstance(litellm._async_success_callback, list):
@@ -980,12 +982,67 @@ class Router:
                 {strategy_value: group_selector} if group_selector is not None else {}
             )
 
-    def _get_routing_context(self, model: str) -> Tuple[Optional[str], Optional[Any]]:
+    _OVERRIDABLE_ROUTING_STRATEGIES: frozenset[str] = frozenset({"simple-shuffle", *_DEFAULT_SELECTOR_ATTR_BY_STRATEGY})
+
+    def _get_request_routing_strategy_override(self, request_kwargs: Optional[dict]) -> Optional[str]:
+        """
+        Reads a per-request `routing_strategy` override (forwarded by the proxy
+        from key/team `router_settings`) out of the request kwargs.
+
+        Only strategies with a per-request-capable selector are honored;
+        anything else (unknown strings, `lar1`, `provider-budget-routing`) is
+        ignored with a warning so a bad value stored on a key or team can
+        never take down that caller's traffic.
+        """
+        if not request_kwargs:
+            return None
+        raw_strategy = request_kwargs.get("routing_strategy")
+        if raw_strategy is None:
+            return None
+        strategy = self._normalize_strategy(raw_strategy) if isinstance(raw_strategy, (str, RoutingStrategy)) else None
+        if not isinstance(strategy, str) or strategy not in self._OVERRIDABLE_ROUTING_STRATEGIES:
+            verbose_router_logger.warning(
+                "Ignoring per-request routing_strategy override '%s'; supported overrides: %s.",
+                raw_strategy,
+                sorted(self._OVERRIDABLE_ROUTING_STRATEGIES),
+            )
+            return None
+        return strategy
+
+    def _get_override_strategy_selector(self, strategy: str) -> Optional[Any]:
+        """
+        Returns the selector for a per-request strategy override.
+
+        Reuses the default group's selector when the override matches the
+        router's configured strategy (so shared state keeps accumulating in
+        one place); otherwise lazily builds one selector per strategy and
+        caches it for the router's lifetime so its usage/latency state
+        persists across requests.
+        """
+        if strategy == self._normalize_strategy(self.routing_strategy):
+            attr = self._DEFAULT_SELECTOR_ATTR_BY_STRATEGY.get(strategy)
+            return getattr(self, attr, None) if attr is not None else None
+        with self._override_selectors_lock:
+            if strategy not in self._override_selectors:
+                self._override_selectors[strategy] = self._build_strategy_selector(
+                    strategy=strategy,
+                    routing_strategy_args={},
+                )
+            return self._override_selectors[strategy]
+
+    def _get_routing_context(
+        self, model: str, request_kwargs: Optional[dict] = None
+    ) -> tuple[Optional[str], Optional[Any]]:
         """
         Resolves the routing strategy and selector to use for the given model.
 
-        Every model belongs to exactly one group: an explicit entry from
-        `routing_groups`, or the implicit `"default"` group driven by the
+        A per-request `routing_strategy` in `request_kwargs` (forwarded by the
+        proxy from key/team `router_settings`) takes precedence over both the
+        model's routing group and the router's top-level strategy, since it is
+        the most specific expression of caller intent.
+
+        Otherwise every model belongs to exactly one group: an explicit entry
+        from `routing_groups`, or the implicit `"default"` group driven by the
         router's top-level `routing_strategy` / `routing_strategy_args`.
 
         `self.routing_strategy` may be either a string or a `RoutingStrategy`
@@ -993,6 +1050,11 @@ class Router:
         string here. Downstream call sites and `_select_deployment_*` arms
         compare against string literals.
         """
+        override = self._get_request_routing_strategy_override(request_kwargs)
+        if override is not None:
+            verbose_router_logger.debug("routing_group=request-override model=%s strategy=%s", model, override)
+            return override, self._get_override_strategy_selector(override)
+
         group_name = self._model_to_group.get(model)
         if group_name is None:
             strategy = self._normalize_strategy(self.routing_strategy)
@@ -5933,7 +5995,7 @@ class Router:
         input_kwargs: dict,
     ) -> Optional[Any]:
         """Same-model-group retry after a failed deployment; returns None if not applicable."""
-        strategy, _ = self._get_routing_context(original_model_group)
+        strategy, _ = self._get_routing_context(original_model_group, kwargs)
         if strategy != "simple-shuffle":
             return None
 
@@ -10422,7 +10484,7 @@ class Router:
             # Resolve the strategy and logger AFTER the pre-routing hook, since
             # the hook can replace `model` and routing-group lookup must key
             # off the final model name.
-            strategy, strategy_selector = self._get_routing_context(model)
+            strategy, strategy_selector = self._get_routing_context(model, request_kwargs)
 
             healthy_deployments = await self.async_get_healthy_deployments(
                 model=model,
@@ -10566,7 +10628,7 @@ class Router:
 
             # 5. Apply load balancing strategy
             start_time = time.perf_counter()
-            strategy, strategy_selector = self._get_routing_context(model)
+            strategy, strategy_selector = self._get_routing_context(model, request_kwargs)
             if strategy == "simple-shuffle":
                 return simple_shuffle(
                     llm_router_instance=self,
@@ -10853,7 +10915,7 @@ class Router:
                 cooldown_list=_cooldown_list,
             )
 
-        strategy, strategy_selector = self._get_routing_context(model)
+        strategy, strategy_selector = self._get_routing_context(model, request_kwargs)
         if strategy == "simple-shuffle":
             # if users pass rpm or tpm, we do a random weighted pick - based on rpm/tpm
             ############## Check 'weight' param set for weighted pick #################
@@ -10993,7 +11055,7 @@ class Router:
             )
 
         # 6. Apply load balancing strategy
-        strategy, strategy_selector = self._get_routing_context(model)
+        strategy, strategy_selector = self._get_routing_context(model, request_kwargs)
         if strategy == "simple-shuffle":
             return simple_shuffle(
                 llm_router_instance=self,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -892,7 +892,9 @@ class Router:
 
         self._unregister_router_selectors(
             [getattr(self, attr, None) for attr in self._DEFAULT_SELECTOR_ATTR_BY_STRATEGY.values()]
+            + list(getattr(self, "_override_selectors", {}).values())
         )
+        self._override_selectors = {}
 
         self.leastbusy_logger: Optional[LeastBusyLoggingHandler] = None
         self.lowesttpm_logger: Optional[LowestTPMLoggingHandler] = None

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3136,6 +3136,7 @@ all_litellm_params = (
         "use_client",
         "id",
         "fallbacks",
+        "routing_strategy",
         "azure",
         "headers",
         "model_list",

--- a/tests/test_litellm/proxy/test_route_llm_request.py
+++ b/tests/test_litellm/proxy/test_route_llm_request.py
@@ -188,8 +188,8 @@ async def test_route_request_with_router_settings_override():
             "num_retries": 5,
             "timeout": 30,
             "model_group_retry_policy": {"gpt-3.5-turbo": {"RateLimitErrorRetries": 3}},
-            # These settings should be ignored (not in per_request_settings list)
             "routing_strategy": "least-busy",
+            # This setting should be ignored (not in per_request_settings list)
             "model_group_alias": {"alias": "real_model"},
         },
     }
@@ -206,8 +206,8 @@ async def test_route_request_with_router_settings_override():
     assert call_kwargs["num_retries"] == 5
     assert call_kwargs["timeout"] == 30
     assert call_kwargs["model_group_retry_policy"] == {"gpt-3.5-turbo": {"RateLimitErrorRetries": 3}}
+    assert call_kwargs["routing_strategy"] == "least-busy"
     # Verify unsupported settings were NOT merged
-    assert "routing_strategy" not in call_kwargs
     assert "model_group_alias" not in call_kwargs
     # Verify router_settings_override was removed from data
     assert "router_settings_override" not in call_kwargs

--- a/tests/test_litellm/router_strategy/test_router_routing_groups.py
+++ b/tests/test_litellm/router_strategy/test_router_routing_groups.py
@@ -629,3 +629,68 @@ async def test_async_dispatch_falls_back_to_sync_for_usage_based_routing_v1():
         )
 
     assert v1_spy.called, "async dispatch must route v1 strategy through sync method"
+
+
+def test_request_routing_strategy_override_beats_top_level():
+    router = _build_router(routing_strategy="least-busy")
+    strategy, selector = router._get_routing_context(
+        "other-model", {"routing_strategy": "simple-shuffle"}
+    )
+    assert strategy == "simple-shuffle"
+    assert selector is None
+
+
+def test_request_routing_strategy_override_beats_explicit_group():
+    router = _build_router(
+        routing_strategy="simple-shuffle",
+        routing_groups=[
+            {
+                "group_name": "fast",
+                "models": ["filtered-model"],
+                "routing_strategy": "latency-based-routing",
+            }
+        ],
+    )
+    strategy, _ = router._get_routing_context(
+        "filtered-model", {"routing_strategy": "least-busy"}
+    )
+    assert strategy == "least-busy"
+
+
+def test_request_routing_strategy_override_builds_and_caches_selector():
+    router = _build_router(routing_strategy="simple-shuffle")
+    strategy, selector = router._get_routing_context(
+        "other-model", {"routing_strategy": "latency-based-routing"}
+    )
+    assert strategy == "latency-based-routing"
+    assert selector is not None
+    _, selector_again = router._get_routing_context(
+        "other-model", {"routing_strategy": "latency-based-routing"}
+    )
+    assert selector_again is selector
+
+
+def test_request_routing_strategy_override_matching_global_reuses_default_selector():
+    router = _build_router(routing_strategy="least-busy")
+    _, selector = router._get_routing_context(
+        "other-model", {"routing_strategy": "least-busy"}
+    )
+    assert selector is router.leastbusy_logger
+    assert router._override_selectors == {}
+
+
+def test_invalid_request_routing_strategy_override_falls_back():
+    router = _build_router(routing_strategy="least-busy")
+    strategy, selector = router._get_routing_context(
+        "other-model", {"routing_strategy": "not-a-real-strategy"}
+    )
+    assert strategy == "least-busy"
+    assert selector is router.leastbusy_logger
+
+
+def test_no_override_key_keeps_existing_behavior():
+    router = _build_router(routing_strategy="least-busy")
+    strategy, _ = router._get_routing_context("other-model", {"messages": []})
+    assert strategy == "least-busy"
+    strategy_none_kwargs, _ = router._get_routing_context("other-model", None)
+    assert strategy_none_kwargs == "least-busy"

--- a/tests/test_litellm/router_strategy/test_router_routing_groups.py
+++ b/tests/test_litellm/router_strategy/test_router_routing_groups.py
@@ -694,3 +694,35 @@ def test_no_override_key_keeps_existing_behavior():
     assert strategy == "least-busy"
     strategy_none_kwargs, _ = router._get_routing_context("other-model", None)
     assert strategy_none_kwargs == "least-busy"
+
+
+def test_request_routing_strategy_override_helper_validates_directly():
+    router = _build_router(routing_strategy="least-busy")
+    assert router._get_request_routing_strategy_override({"routing_strategy": "simple-shuffle"}) == "simple-shuffle"
+    assert router._get_request_routing_strategy_override({"routing_strategy": RoutingStrategy.LEAST_BUSY}) == "least-busy"
+    assert router._get_request_routing_strategy_override({"routing_strategy": "lar1"}) is None
+    assert router._get_request_routing_strategy_override({"routing_strategy": {"bad": "type"}}) is None
+    assert router._get_request_routing_strategy_override({}) is None
+    assert router._get_request_routing_strategy_override(None) is None
+
+
+def test_override_strategy_selector_helper_builds_per_strategy():
+    router = _build_router(routing_strategy="least-busy")
+    latency_selector = router._get_override_strategy_selector("latency-based-routing")
+    assert latency_selector is not None
+    assert router._get_override_strategy_selector("latency-based-routing") is latency_selector
+    assert router._get_override_strategy_selector("least-busy") is router.leastbusy_logger
+    assert router._get_override_strategy_selector("simple-shuffle") is None
+
+
+def test_strategy_reinit_unregisters_override_selectors():
+    router = _build_router(routing_strategy="least-busy")
+    override_selector = router._get_override_strategy_selector("latency-based-routing")
+    assert override_selector is not None
+    assert any(id(cb) == id(override_selector) for cb in litellm.callbacks)
+
+    router.update_settings(routing_strategy="latency-based-routing")
+
+    assert router._override_selectors == {}
+    assert not any(id(cb) == id(override_selector) for cb in litellm.callbacks)
+    assert router._get_override_strategy_selector("latency-based-routing") is router.lowestlatency_logger

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -13810,6 +13810,7 @@ export interface paths {
          *     - allowed_passthrough_routes: Optional[List[str]] - List of allowed pass through routes for the team.
          *     - model_rpm_limit: Optional[Dict[str, int]] - The RPM (Requests Per Minute) limit per model for this team. Example: {"gpt-4": 100, "gpt-3.5-turbo": 200}
          *     - model_tpm_limit: Optional[Dict[str, int]] - The TPM (Tokens Per Minute) limit per model for this team. Example: {"gpt-4": 10000, "gpt-3.5-turbo": 20000}
+         *     - mcp_rpm_limit: Optional[Dict[str, int]] - Per-MCP-server RPM limit for this team, keyed by MCP server name (alias if set, else the configured name). Example: {"github": 100, "slack": 200}. Applied across all keys for this team.
          *     Example - update team TPM Limit
          *     - allowed_vector_store_indexes: Optional[List[dict]] - List of allowed vector store indexes for the key. Example - [{"index_name": "my-index", "index_permissions": ["write", "read"]}]. If specified, the key will only be able to use these specific vector store indexes. Create index, using `/v1/indexes` endpoint.
          *     - secret_manager_settings: Optional[dict] - Secret manager settings for the team. [Docs](https://docs.litellm.ai/docs/secret_managers/overview)


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4388

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup: live proxy against a real Postgres and real OpenAI calls. Two `gpt-5-mini` deployments with `weight: 1` (deployment-a) and `weight: 10` (deployment-b); global `router_settings.routing_strategy: least-busy`. A team and a standalone key each store `router_settings: {"routing_strategy": "simple-shuffle"}`

```bash
curl -s http://localhost:4388/team/new -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' \
  -d '{"team_alias": "shuffle-team", "router_settings": {"routing_strategy": "simple-shuffle"}}'
curl -s http://localhost:4388/key/generate -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' \
  -d '{"team_id": "56087170-4852-4a7d-a850-38f7ca0e71c9", "key_alias": "shuffle-team-key"}'

for i in $(seq 1 30); do
  curl -s http://localhost:4388/chat/completions -H "Authorization: Bearer $TEAM_KEY" -H 'Content-Type: application/json' \
    -d '{"model": "gpt-5-mini", "messages": [{"role": "user", "content": "hi"}], "max_completion_tokens": 16}' \
    -D - -o /dev/null | grep -i x-litellm-model-id
done | sort | uniq -c
```

Before the fix (4580ad003a): the team's simple-shuffle is ignored; least-busy pins all 30 calls to one deployment and the router log shows the global strategy driving every request

```
  30 x-litellm-model-id: deployment-a
```
```
  30 routing_group=default model=gpt-5-mini strategy=least-busy
```

The same 30-call loop with a standalone key storing the override (no team) also returned `30 x-litellm-model-id: deployment-a`

After the fix (a0523d3230): the same team key now weight-shuffles across both deployments per its stored strategy, and the router log confirms the override drove the decision

```
   3 x-litellm-model-id: deployment-a
  27 x-litellm-model-id: deployment-b
```
```
  60 routing_group=request-override model=gpt-5-mini strategy=simple-shuffle
```

Key-level override (same commit): `1 deployment-a / 29 deployment-b`

A master-key call with no stored override still uses the global least-busy strategy (`10 routing_group=default ... strategy=least-busy`), and a team storing an invalid value (`routing_strategy: not-a-real-strategy`) still gets a 200 while the router logs

```
LiteLLM Router:WARNING: router.py:1007 - Ignoring per-request routing_strategy override 'not-a-real-strategy'; supported overrides: ['cost-based-routing', 'latency-based-routing', 'least-busy', 'simple-shuffle', 'usage-based-routing', 'usage-based-routing-v2'].
```

Independent e2e run (Devin, on the PR branch): Admin UI team creation with Routing Strategy set to simple-shuffle, key creation on that team, then 30 team-key calls splitting 2/28 across the weighted deployments while the proxy logs `routing_group=request-override strategy=simple-shuffle` only for team-key requests. Screen recording:

https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/pr-33429/routing_strategy_demo.mp4

## Type

🐛 Bug Fix

## Changes

Key and team `router_settings` are stored, returned by `/team/info`, and rendered in the Admin UI, but only `fallbacks`, `num_retries`, `timeout`, and `model_group_retry_policy` were merged into the request at call time; `routing_strategy` was dropped, so the shared Router's global strategy always won

`litellm/proxy/route_llm_request.py` adds `routing_strategy` to the `router_settings_override` per-request merge allowlist. `litellm/router.py` teaches `_get_routing_context` to read a per-request `routing_strategy` from the request kwargs: a validated override takes precedence over routing groups and the top-level strategy, reuses the default selector when it matches the configured strategy, and otherwise lazily builds one selector per strategy (cached for the router's lifetime so usage/latency state persists across requests, guarded by a lock for concurrent first requests). Unsupported or malformed values are ignored with a warning rather than failing that caller's traffic. `litellm/types/utils.py` registers `routing_strategy` in `all_litellm_params` so it is stripped before the outbound provider call and can never leak into a provider request body

A follow-up commit (3a73ce1319) makes `routing_strategy_init` unregister cached override selectors during a strategy re-init, so changing the global strategy via `update_settings` cannot leave a stale override selector registered in `litellm.callbacks`

A docs commit (00ad5b3e47) adds the missing `mcp_rpm_limit` line to the `update_team` docstring; the documentation CI job requires every `UpdateTeamRequest` field to be documented and was failing on this pre-existing gap

Regression tests extend the existing mapped files: `tests/test_litellm/proxy/test_route_llm_request.py` now asserts `routing_strategy` is merged from the override, and `tests/test_litellm/router_strategy/test_router_routing_groups.py` covers override-beats-global, override-beats-routing-group, selector caching and reuse, invalid-value fallback, no-override behavior, and selector cleanup on strategy re-init. All of them fail on the unfixed code

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
