### PR TITLE
fix(router): apply team/key enable_tag_filtering to tag routing

### DIFF
--- a/litellm/proxy/route_llm_request.py
+++ b/litellm/proxy/route_llm_request.py
@@ -362,6 +362,8 @@ async def route_request(
     for _key in _MOCK_TESTING_KWARG_NAMES:
         data.pop(_key, None)
 
+    data.pop("enable_tag_filtering", None)
+
     team_id = get_team_id_from_data(data)
     router_model_names = llm_router.model_names if llm_router is not None else []
     is_proxy_admin_without_team = team_id is None and _is_proxy_admin_request(data)
@@ -410,6 +412,7 @@ async def route_request(
             "timeout",
             "model_group_retry_policy",
             "routing_strategy",
+            "enable_tag_filtering",
         ]
 
         # Merge override settings into data (only if not already set in request)

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9778,6 +9778,7 @@ class Router:
             "retry_policy",
             "model_group_alias",
             "enable_weighted_failover",
+            "enable_tag_filtering",
         ]
 
         for var in vars_to_include:
@@ -9814,6 +9815,7 @@ class Router:
             "model_group_retry_policy",
             "model_group_alias",
             "enable_weighted_failover",
+            "enable_tag_filtering",
         ]
 
         _int_settings = [

--- a/litellm/router_strategy/tag_based_routing.py
+++ b/litellm/router_strategy/tag_based_routing.py
@@ -160,8 +160,14 @@ async def get_deployments_for_tag(
     Returns a list of deployments that match the requested model and tags in the request.
 
     Executes tag based filtering based on the tags in request metadata and the tags on the deployments
+
+    Runs when the router-level `enable_tag_filtering` is True or the request carries
+    `enable_tag_filtering=True` (set from key/team router_settings by the proxy).
+    A request-level False never disables a router-level True, so per-request settings
+    cannot escape an operator's global tag-routing policy.
     """
-    if llm_router_instance.enable_tag_filtering is not True:
+    request_enable_tag_filtering = request_kwargs.get("enable_tag_filtering") if request_kwargs else None
+    if request_enable_tag_filtering is not True and llm_router_instance.enable_tag_filtering is not True:
         return healthy_deployments
 
     if request_kwargs is None:

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -117,6 +117,7 @@ class UpdateRouterConfig(BaseModel):
     fallbacks: Optional[List[dict]] = None
     context_window_fallbacks: Optional[List[dict]] = None
     model_group_alias: Optional[Dict[str, Union[str, Dict]]] = {}
+    enable_tag_filtering: Optional[bool] = None
 
     model_config = ConfigDict(protected_namespaces=())
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3222,6 +3222,7 @@ all_litellm_params = (
         "shared_session",
         "search_tool_name",
         "order",
+        "enable_tag_filtering",
         "enable_json_schema_validation",
         "use_xai_oauth",
         "_litellm_rate_limit_descriptors",

--- a/tests/test_litellm/proxy/test_proxy_types.py
+++ b/tests/test_litellm/proxy/test_proxy_types.py
@@ -124,3 +124,18 @@ def test_proxy_exception_str_returns_message():
         "param": "key",
         "code": "401",
     }
+
+
+def test_key_request_router_settings_keeps_enable_tag_filtering():
+    """``router_settings`` on key requests validates through
+    ``UpdateRouterConfig``; a field missing from that model is silently
+    dropped at parse time, so a key's "Enable Tag Filtering" toggle would
+    never reach the DB even though the team path (plain dict) kept it."""
+    from litellm.proxy._types import GenerateKeyRequest
+
+    req = GenerateKeyRequest(router_settings={"enable_tag_filtering": True, "num_retries": 2})
+
+    assert req.router_settings is not None
+    dumped = req.router_settings.model_dump(exclude_none=True)
+    assert dumped["enable_tag_filtering"] is True
+    assert dumped["num_retries"] == 2

--- a/tests/test_litellm/proxy/test_route_llm_request.py
+++ b/tests/test_litellm/proxy/test_route_llm_request.py
@@ -819,3 +819,71 @@ async def test_route_request_realtime_transcription_session_resolves_credentials
         )
 
     assert mock_handler.call_args.kwargs["api_key"] == "transcription-key"
+
+
+@pytest.mark.asyncio
+async def test_route_request_merges_enable_tag_filtering_from_override():
+    """Key/team router_settings carry enable_tag_filtering; the override
+    whitelist must forward it to the router call or the team's tag-routing
+    toggle saved in the UI is silently ignored at request time."""
+    data = {
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "router_settings_override": {
+            "enable_tag_filtering": True,
+        },
+    }
+
+    llm_router = MagicMock()
+    llm_router.acompletion.return_value = "success"
+
+    response = await route_request(data, llm_router, None, "acompletion")
+
+    assert response == "success"
+    call_kwargs = llm_router.acompletion.call_args[1]
+    assert call_kwargs["enable_tag_filtering"] is True
+
+
+@pytest.mark.asyncio
+async def test_route_request_strips_client_supplied_enable_tag_filtering():
+    """enable_tag_filtering influences deployment selection and is only
+    trusted when it comes from key/team router_settings via
+    router_settings_override. A caller putting it in the request body must
+    not reach the router with it."""
+    data = {
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "enable_tag_filtering": True,
+    }
+
+    llm_router = MagicMock()
+    llm_router.acompletion.return_value = "ok"
+
+    await route_request(data, llm_router, None, "acompletion")
+
+    call_kwargs = llm_router.acompletion.call_args[1]
+    assert "enable_tag_filtering" not in call_kwargs
+    assert "enable_tag_filtering" not in data
+
+
+@pytest.mark.asyncio
+async def test_route_request_override_enable_tag_filtering_beats_body_value():
+    """A client-sent enable_tag_filtering must not shadow the key/team
+    setting: the body copy is stripped first, so the override value is the
+    one the router sees."""
+    data = {
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "enable_tag_filtering": False,
+        "router_settings_override": {
+            "enable_tag_filtering": True,
+        },
+    }
+
+    llm_router = MagicMock()
+    llm_router.acompletion.return_value = "ok"
+
+    await route_request(data, llm_router, None, "acompletion")
+
+    call_kwargs = llm_router.acompletion.call_args[1]
+    assert call_kwargs["enable_tag_filtering"] is True

--- a/tests/test_litellm/router_strategy/test_router_tag_routing.py
+++ b/tests/test_litellm/router_strategy/test_router_tag_routing.py
@@ -1019,3 +1019,99 @@ async def test_negation_removes_tag_regex_deployment_falls_to_ban_only():
             mock_response="hi",
         )
         assert response._hidden_params["model_id"] == "openai-deployment"
+
+
+@pytest.mark.asyncio()
+async def test_request_level_enable_tag_filtering_applies_when_global_off():
+    """
+    A request carrying enable_tag_filtering=True (set by the proxy from key/team
+    router_settings) must activate tag filtering even when the router-level flag
+    is off. Without this, a team's "Enable Tag Filtering" toggle saved in the UI
+    is silently ignored at request time.
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_base": "https://exampleopenaiendpoint-production.up.railway.app/",
+                    "tags": ["teamA"],
+                },
+                "model_info": {"id": "team-a-deployment"},
+            },
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {
+                    "model": "gpt-4o-mini",
+                    "api_base": "https://exampleopenaiendpoint-production.up.railway.app/",
+                    "tags": ["teamB"],
+                },
+                "model_info": {"id": "team-b-deployment"},
+            },
+        ],
+        enable_tag_filtering=False,
+    )
+
+    for _ in range(5):
+        response = await router.acompletion(
+            model="gpt-4",
+            messages=[{"role": "user", "content": "hi"}],
+            metadata={"tags": ["teamA"]},
+            enable_tag_filtering=True,
+            mock_response="hi",
+        )
+        assert response._hidden_params["model_id"] == "team-a-deployment"
+
+    for _ in range(5):
+        response = await router.acompletion(
+            model="gpt-4",
+            messages=[{"role": "user", "content": "hi"}],
+            metadata={"tags": ["teamB"]},
+            enable_tag_filtering=True,
+            mock_response="hi",
+        )
+        assert response._hidden_params["model_id"] == "team-b-deployment"
+
+
+@pytest.mark.asyncio()
+async def test_request_level_enable_tag_filtering_false_cannot_disable_global():
+    """
+    A request-level enable_tag_filtering=False must not bypass a router-level
+    True: tag filtering can be an operator-level restriction on which
+    deployments a caller may reach, so per-request settings may only scope
+    down, never escape the global policy.
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {
+                    "model": "gpt-4o",
+                    "api_base": "https://exampleopenaiendpoint-production.up.railway.app/",
+                    "tags": ["teamA"],
+                },
+                "model_info": {"id": "team-a-deployment"},
+            },
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {
+                    "model": "gpt-4o-mini",
+                    "api_base": "https://exampleopenaiendpoint-production.up.railway.app/",
+                    "tags": ["teamB"],
+                },
+                "model_info": {"id": "team-b-deployment"},
+            },
+        ],
+        enable_tag_filtering=True,
+    )
+
+    for _ in range(5):
+        response = await router.acompletion(
+            model="gpt-4",
+            messages=[{"role": "user", "content": "hi"}],
+            metadata={"tags": ["teamA"]},
+            enable_tag_filtering=False,
+            mock_response="hi",
+        )
+        assert response._hidden_params["model_id"] == "team-a-deployment"

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -32245,6 +32245,8 @@ export interface components {
             }[] | null;
             /** Cooldown Time */
             cooldown_time?: number | null;
+            /** Enable Tag Filtering */
+            enable_tag_filtering?: boolean | null;
             /** Fallbacks */
             fallbacks?: {
                 [key: string]: unknown;


### PR DESCRIPTION
## Description

## Relevant issues

## Linear ticket

Resolves LIT-4390

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on localhost:4390 with a real Postgres and real OpenAI calls (gpt-4o-mini), two deployments of `gpt-4` tagged `teamA` / `teamB`, global `router_settings.enable_tag_filtering: false`

Setup (same on both runs):

```bash
curl -sS -X POST http://127.0.0.1:4390/team/new -H "Authorization: Bearer $MASTER_KEY" \
  -H "Content-Type: application/json" \
  -d '{"team_alias":"team-a","tags":["teamA"],"router_settings":{"enable_tag_filtering":true}}'
# same for team-b with tags ["teamB"], then /key/generate for each team

curl -sS "http://127.0.0.1:4390/team/info?team_id=$TEAM_A_ID" -H "Authorization: Bearer $MASTER_KEY"
# stored tags: ['teamA']
# stored router_settings: {'enable_tag_filtering': True}
```

Before the fix, the saved toggle is ignored and requests from each team's key spread across both deployments:

```bash
for i in 1 2 3 4 5 6; do
  curl -sS -D - -o /dev/null -X POST http://127.0.0.1:4390/v1/chat/completions \
    -H "Authorization: Bearer $KEY_A" -H "Content-Type: application/json" \
    -d '{"model":"gpt-4","messages":[{"role":"user","content":"ping"}],"max_tokens":4}' | grep -i x-litellm-model-id
done
# x-litellm-model-id: team-b-deployment
# x-litellm-model-id: team-b-deployment
# x-litellm-model-id: team-a-deployment
# x-litellm-model-id: team-b-deployment
# x-litellm-model-id: team-a-deployment
# x-litellm-model-id: team-a-deployment
```

After the fix, the same curls pin every request to the team's tagged deployment (8/8 for each team):

```
team A key: x-litellm-model-id: team-a-deployment  (8 of 8 requests)
team B key: x-litellm-model-id: team-b-deployment  (8 of 8 requests)
```

Edge cases on the fixed proxy: a team with tags but no `enable_tag_filtering` keeps the old load-balanced behavior; a key-level `router_settings.enable_tag_filtering` (no team) pins routing the same way; a caller injecting `"enable_tag_filtering": true` in the request body is stripped at the proxy boundary and still gets load balanced

### Admin UI plus live proxy walkthrough

Full end-to-end run on a fixed proxy driven from the proxy-served Admin UI at http://localhost:4000/ui, config with two `gpt-4` deployments tagged `teamA` / `teamB` and global `router_settings.enable_tag_filtering: false`. team-a and team-b are created in the UI with Enable Tag Filtering turned on, a virtual key is generated for each, then six real chat completions are sent per key

Animated walkthrough (open Teams, set tag, toggle Enable Tag Filtering, save, create key, then the curl loops)

![Admin UI walkthrough creating a team, setting its tag, toggling Enable Tag Filtering, saving, creating a key, then the terminal curl loops pinning each team to its deployment](https://raw.githubusercontent.com/BerriAI/litellm/devin-tag-filtering-media/media/tag_filtering_demo.gif)

Saved team settings showing the persisted toggle

![team-a Team Settings page showing Router Settings Tag Filtering: Enabled](https://raw.githubusercontent.com/BerriAI/litellm/devin-tag-filtering-media/media/team_a_settings_tag_filtering_enabled.png)

All six team-a requests pin to team-a-deployment

![six team-a key requests all returning x-litellm-model-id: team-a-deployment](https://raw.githubusercontent.com/BerriAI/litellm/devin-tag-filtering-media/media/team_a_curl_pins_team_a_deployment.png)

All six team-b requests pin to team-b-deployment

![six team-b key requests all returning x-litellm-model-id: team-b-deployment](https://raw.githubusercontent.com/BerriAI/litellm/devin-tag-filtering-media/media/team_b_curl_pins_team_b_deployment.png)

## Type

🐛 Bug Fix

## Changes

Team/key `router_settings.enable_tag_filtering` was saved and echoed by `/team/info` but never applied at request time. Three separate drops along the path:

`route_llm_request.py` merges `router_settings_override` (built from key/team settings) into router kwargs through a whitelist that did not include `enable_tag_filtering`, so the flag never left the proxy layer. It is now whitelisted, and any client-supplied top-level `enable_tag_filtering` is popped from the request body first so only the key/team value can reach the router

`tag_based_routing.get_deployments_for_tag` only consulted the router-level global flag. It now also honors a request-level `enable_tag_filtering=True`; a request-level `False` cannot disable a router-level `True`, so per-request settings can only opt in to filtering, never escape a global tag-routing policy

`UpdateRouterConfig` lacked the field entirely, so pydantic silently dropped it on `/key/generate` (key `router_settings` validate through that model) and on `/config/update` (the Admin UI global save path). The field is added there, to `all_litellm_params` (so the kwarg is never forwarded into provider request bodies), and to `Router.update_settings` / `get_settings` so the global UI toggle persists across DB config reloads

The team path (`/team/new`, `/team/update`) already persisted the value as a plain dict; no UI changes are needed since the dashboard already renders the toggle on teams, keys, and global router settings. `schema.d.ts` is regenerated for the new `UpdateRouterConfig` field

## QA runbook

1. Start the proxy with two deployments of one model group tagged `teamA` / `teamB` and `router_settings.enable_tag_filtering: false`
2. In the Admin UI go to Teams, create a team with Tags `teamA`, and under Router Settings turn Enable Tag Filtering on, then save
3. Create a virtual key for that team and send chat completions with it; every response's `x-litellm-model-id` header must be the `teamA`-tagged deployment
4. Repeat with a second team tagged `teamB`; its key must pin to the `teamB` deployment
5. A team without the toggle keeps load balancing across both deployments, and sending `"enable_tag_filtering": true` in the request body with a plain key must not activate filtering

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


Link to Devin session: https://app.devin.ai/sessions/428243b834d94be6a1a580ab4b7e66f0