### PR TITLE
feat(ptu): runtime UI flag for enable_ptu_cost_attribution + always-registered rollup

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7930,23 +7930,24 @@ class ProxyStartupEvent:
         await cls._initialize_spend_tracking_background_jobs(scheduler=scheduler)
 
         ### PTU RESERVATION DAILY ROLLUP ###
-        if general_settings.get("enable_ptu_cost_attribution", False):
-            from litellm.proxy.spend_tracking.ptu_reservation_rollup import (
-                PTU_ROLLUP_JOB_ID,
-                run_ptu_reservation_rollup,
-            )
+        from litellm.proxy.spend_tracking.ptu_reservation_rollup import (
+            PTU_ROLLUP_JOB_ID,
+            run_ptu_reservation_rollup,
+        )
 
-            scheduler.add_job(
-                run_ptu_reservation_rollup,
-                "cron",
-                hour=0,
-                minute=15,
-                args=[prisma_client],
-                id=PTU_ROLLUP_JOB_ID,
-                replace_existing=True,
-                misfire_grace_time=APSCHEDULER_MISFIRE_GRACE_TIME,
-            )
-            verbose_proxy_logger.info("PTU reservation rollup job scheduled at 00:15 UTC daily")
+        scheduler.add_job(
+            run_ptu_reservation_rollup,
+            "cron",
+            hour=0,
+            minute=15,
+            args=[prisma_client],
+            id=PTU_ROLLUP_JOB_ID,
+            replace_existing=True,
+            misfire_grace_time=APSCHEDULER_MISFIRE_GRACE_TIME,
+        )
+        verbose_proxy_logger.info(
+            "PTU reservation rollup job scheduled at 00:15 UTC daily (no-ops until enable_ptu_cost_attribution is set)"
+        )
 
         ### SPEND LOG CLEANUP ###
         if general_settings.get("maximum_spend_logs_retention_period") is not None:

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -182,6 +182,11 @@ class UISettings(BaseModel):
         description="If true, shows the Chat page in the UI sidebar, letting users chat with an LLM and connect their own MCP server credentials via OAuth.",
     )
 
+    enable_ptu_cost_attribution: bool = Field(
+        default=False,
+        description="If true, enables admin-registered PTU reservations and daily flat-cost attribution on team daily spend. Governs the /ptu_reservation CRUD endpoints, the daily rollup job, the PTU Reservations UI page, and the Flat Cost column on the Usage page.",
+    )
+
 
 class UISettingsResponse(SettingsResponse):
     """Response model for UI settings"""
@@ -206,6 +211,7 @@ ALLOWED_UI_SETTINGS_FIELDS = {
     "disable_custom_api_keys",
     "disable_key_generate_for_org_admin",
     "enable_chat_ui",
+    "enable_ptu_cost_attribution",
 }
 
 # Flags that must be synced from the persisted UISettings into
@@ -219,6 +225,7 @@ _RUNTIME_GENERAL_SETTINGS_FLAGS = [
     "disable_vector_stores_for_internal_users",
     "allow_vector_stores_for_team_admins",
     "disable_key_generate_for_org_admin",
+    "enable_ptu_cost_attribution",
 ]
 
 # Extension point: packages outside OSS (e.g. litellm_enterprise) can

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -9718,3 +9718,41 @@ async def test_startup_survives_database_read_failure_for_coordination_redis():
         )
 
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_ptu_rollup_job_registered_regardless_of_flag(monkeypatch):
+    """The PTU rollup cron must be registered at startup so a UI-time flip of enable_ptu_cost_attribution takes effect without a proxy restart. The job itself no-ops when the flag is off (asserted in test_ptu_reservation_rollup.py)."""
+    monkeypatch.delenv("STORE_MODEL_IN_DB", raising=False)
+    from litellm.proxy.proxy_server import ProxyStartupEvent
+    from litellm.proxy.spend_tracking.ptu_reservation_rollup import (
+        PTU_ROLLUP_JOB_ID,
+    )
+    from litellm.proxy.utils import ProxyLogging
+
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db.litellm_config.find_first = AsyncMock(return_value=None)
+
+    mock_proxy_logging = MagicMock(spec=ProxyLogging)
+    mock_proxy_logging.slack_alerting_instance = MagicMock()
+    mock_proxy_config = AsyncMock()
+
+    with (
+        patch("litellm.proxy.proxy_server.proxy_config", mock_proxy_config),
+        patch("litellm.proxy.proxy_server.store_model_in_db", True),
+        patch("litellm.proxy.proxy_server.get_secret_bool", return_value=True),
+    ):
+        # Flag OFF at startup — job must still be registered
+        await ProxyStartupEvent.initialize_scheduled_background_jobs(
+            general_settings={"enable_ptu_cost_attribution": False},
+            prisma_client=mock_prisma_client,
+            proxy_budget_rescheduler_min_time=1,
+            proxy_budget_rescheduler_max_time=2,
+            proxy_batch_write_at=5,
+            proxy_logging_obj=mock_proxy_logging,
+        )
+
+        import litellm.proxy.proxy_server as ps
+
+        assert ps.scheduler is not None
+        assert ps.scheduler.get_job(PTU_ROLLUP_JOB_ID) is not None

--- a/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
+++ b/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
@@ -1336,6 +1336,61 @@ class TestProxySettingEndpoints:
         # Synced into general_settings so the enforcement helper sees it
         assert general_settings.get(flag_name) is True
 
+    def test_update_ui_settings_persists_and_syncs_enable_ptu_cost_attribution(
+        self, mock_auth, monkeypatch
+    ):
+        """enable_ptu_cost_attribution must be allowlisted, persisted, and synced to general_settings so PTU endpoints and rollup pick it up without a proxy restart."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from litellm.proxy._types import UserAPIKeyAuth
+        from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+        mock_user_auth = UserAPIKeyAuth(
+            user_id="test-user-123",
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
+        app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+
+        monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
+
+        general_settings: dict = {}
+        monkeypatch.setattr(
+            "litellm.proxy.proxy_server.general_settings", general_settings
+        )
+
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_uisettings.upsert = AsyncMock()
+        mock_prisma.db.litellm_uisettings.find_unique = AsyncMock(return_value=None)
+        monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
+
+        flag_name = "enable_ptu_cost_attribution"
+        payload = {flag_name: True}
+
+        try:
+            response = client.patch("/update/ui_settings", json=payload)
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["settings"][flag_name] is True
+
+        call_args = mock_prisma.db.litellm_uisettings.upsert.call_args
+        stored_settings = json.loads(call_args.kwargs["data"]["create"]["ui_settings"])
+        assert stored_settings[flag_name] is True
+
+        assert general_settings.get(flag_name) is True
+
+    def test_enable_ptu_cost_attribution_registered_as_runtime_flag(self):
+        """The runtime-sync list must include the PTU flag so a UI flip lands in general_settings without a restart."""
+        from litellm.proxy.ui_crud_endpoints.proxy_setting_endpoints import (
+            _RUNTIME_GENERAL_SETTINGS_FLAGS,
+            ALLOWED_UI_SETTINGS_FIELDS,
+        )
+
+        assert "enable_ptu_cost_attribution" in _RUNTIME_GENERAL_SETTINGS_FLAGS
+        assert "enable_ptu_cost_attribution" in ALLOWED_UI_SETTINGS_FIELDS
+
     def test_get_sso_settings_from_database(
         self, mock_proxy_config, mock_auth, monkeypatch
     ):

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/UISettings/UISettings.test.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/UISettings/UISettings.test.tsx
@@ -41,12 +41,16 @@ const buildSettingsResponse = (overrides?: Partial<Record<string, unknown>>) => 
         require_auth_for_public_ai_hub: {
           description: "Require authentication for public AI Hub",
         },
+        enable_ptu_cost_attribution: {
+          description: "Enable PTU cost attribution",
+        },
       },
     },
     values: {
       disable_model_add_for_internal_users: false,
       disable_team_admin_delete_team_user: false,
       require_auth_for_public_ai_hub: false,
+      enable_ptu_cost_attribution: false,
     },
   },
   isLoading: false,
@@ -161,5 +165,34 @@ describe("UISettings", () => {
       }),
     );
     expect(NotificationManager.success).toHaveBeenCalledWith("UI settings updated successfully");
+  });
+
+  it("should toggle enable PTU cost attribution setting and call update with page-refresh notice", () => {
+    const mutateMock = vi.fn((_settings, options) => {
+      options?.onSuccess?.();
+    });
+
+    mockUseUpdateUISettings.mockReturnValue({
+      mutate: mutateMock,
+      isPending: false,
+      error: null,
+    });
+
+    render(<UISettings />);
+
+    const toggle = screen.getByRole("switch", { name: "Enable PTU cost attribution" });
+
+    act(() => {
+      fireEvent.click(toggle);
+    });
+
+    expect(mutateMock).toHaveBeenCalledWith(
+      { enable_ptu_cost_attribution: true },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
+    );
+    expect(NotificationManager.success).toHaveBeenCalledWith("UI settings updated successfully. Refreshing page...");
   });
 });

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/UISettings/UISettings.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/UISettings/UISettings.tsx
@@ -20,6 +20,7 @@ export default function UISettings() {
   const forwardLLMProviderAuthHeadersProperty = schema?.properties?.forward_llm_provider_auth_headers;
   const enableProjectsUIProperty = schema?.properties?.enable_projects_ui;
   const enableChatUIProperty = schema?.properties?.enable_chat_ui;
+  const enablePtuCostAttributionProperty = schema?.properties?.enable_ptu_cost_attribution;
   const enabledPagesProperty = schema?.properties?.enabled_ui_pages_internal_users;
   const disableAgentsProperty = schema?.properties?.disable_agents_for_internal_users;
   const allowAgentsTeamAdminsProperty = schema?.properties?.allow_agents_for_team_admins;
@@ -118,6 +119,21 @@ export default function UISettings() {
   const handleToggleEnableChatUI = (checked: boolean) => {
     updateSettings(
       { enable_chat_ui: checked },
+      {
+        onSuccess: () => {
+          NotificationManager.success("UI settings updated successfully. Refreshing page...");
+          setTimeout(() => window.location.reload(), 1000);
+        },
+        onError: (error) => {
+          NotificationManager.fromBackend(error);
+        },
+      },
+    );
+  };
+
+  const handleToggleEnablePtuCostAttribution = (checked: boolean) => {
+    updateSettings(
+      { enable_ptu_cost_attribution: checked },
       {
         onSuccess: () => {
           NotificationManager.success("UI settings updated successfully. Refreshing page...");
@@ -364,6 +380,23 @@ export default function UISettings() {
               <Typography.Text type="secondary">
                 {enableChatUIProperty?.description ??
                   "If enabled, shows the Chat page in the UI sidebar, letting users chat with an LLM and connect their own MCP server credentials via OAuth."}
+              </Typography.Text>
+            </Space>
+          </Space>
+
+          <Space align="start" size="middle">
+            <Switch
+              checked={Boolean(values.enable_ptu_cost_attribution)}
+              disabled={isUpdating}
+              loading={isUpdating}
+              onChange={handleToggleEnablePtuCostAttribution}
+              aria-label={enablePtuCostAttributionProperty?.description ?? "Enable PTU cost attribution"}
+            />
+            <Space direction="vertical" size={4}>
+              <Typography.Text strong>Enable PTU cost attribution (page will refresh)</Typography.Text>
+              <Typography.Text type="secondary">
+                {enablePtuCostAttributionProperty?.description ??
+                  "If enabled, unlocks admin-registered PTU reservations and daily flat-cost attribution on team daily spend."}
               </Typography.Text>
             </Space>
           </Space>


### PR DESCRIPTION
## Relevant issues

Stage 5 of the LIT-1697 stack, sitting on top of #33302

## Linear ticket

Resolves LIT-1697

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

QA runbook below has the concrete steps against a live proxy hitting real Azure PTU + gpt-4. Paste output from steps 1 through 5 back once run

## Type

New Feature

## Changes

Wires `enable_ptu_cost_attribution` into the runtime-flippable UI settings pipeline so an admin can turn the whole PTU cost attribution feature on and off from the Admin Settings page without a proxy restart. The flag is now declared on `UISettings`, added to `ALLOWED_UI_SETTINGS_FIELDS`, and added to `_RUNTIME_GENERAL_SETTINGS_FLAGS`, which is the list `/update/ui_settings` and `/get/ui_settings` sync into `general_settings`; the same sync also runs on startup via `_sync_ui_settings_to_general_settings`, so a value persisted through the UI survives a restart.

Moves the daily rollup job's `scheduler.add_job` call outside the flag gate. `run_ptu_reservation_rollup` already returns early when the flag is off (added in #33137 as `skipped_flag_off=True`), so scheduling the job unconditionally is a no-op until the flag flips. This is what makes the flag actually live-flippable; before this PR, flipping the flag would only affect the endpoints and UI, and the rollup would still need a restart to attach.

Adds a Switch on the Admin Settings > UI Settings page ("Enable PTU cost attribution") next to the existing `enable_chat_ui` toggle, with the same page-refresh notice pattern used for enable_projects_ui and enable_chat_ui. The page-refresh handles reflowing the leftnav to show the PTU Reservations item and the Usage page column.

## Behavior changes

- `PATCH /update/ui_settings` now accepts `enable_ptu_cost_attribution: bool`; unknown-field validation keeps the same shape it did for the other UI flags
- `GET /get/ui_settings` returns `enable_ptu_cost_attribution` in `values` and its description in `field_schema`
- The `ptu_reservation_rollup_job` cron is registered on every startup regardless of flag state; it fires daily at 00:15 UTC and no-ops (returning `RollupResult(skipped_flag_off=True)`) while the flag is off. Zero-write, zero-read while disabled
- The nav item and the Usage page's Flat Cost column continue to gate on the runtime flag through `useIsPtuCostAttributionEnabled`; no config-file change required to unlock them once the UI toggle is on

Nothing else changes for tenants that never touch the flag. The per-request spend hot path is not modified in this PR (or any earlier stage in the stack).

## QA runbook

Prereq: real Azure PTU deployment. Run against a live proxy started with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log` and a fresh DB.

1. Confirm the flag is off by default. `curl -H "Authorization: Bearer sk-1234" http://localhost:4000/get/ui_settings | jq '.values.enable_ptu_cost_attribution'` returns `false` (or absent). `curl -H "Authorization: Bearer sk-1234" -X POST http://localhost:4000/ptu_reservation/new -H "Content-Type: application/json" -d '{"team_id":"any","model":"gpt-4","ptu_count":1,"cost_per_ptu":100.0,"effective_from":"2026-08-01T00:00:00Z"}'` returns 403 with `PTU cost attribution is not enabled.`

2. Flip it on via the UI. Open http://localhost:4000/ui/ > Admin Settings > UI Settings. Toggle "Enable PTU cost attribution" on. The page reloads. The leftnav now shows "PTU Reservations".

3. Confirm the sync happened without a restart. `curl -H "Authorization: Bearer sk-1234" http://localhost:4000/get/ui_settings | jq '.values.enable_ptu_cost_attribution'` returns `true`.

4. Create a reservation and see the flat cost land. Follow steps 2 through 5 of `05-stage-rollout.md`'s original runbook (create reservation for a real Azure gpt-4 team, run `python scripts/ptu_reservation_backfill.py --date 2026-07-15`, then `GET /team/daily/activity` for that team). Confirm `metrics.flat_cost` is nonzero for that day.

5. Flip it off. Toggle back off in the UI, refresh. Nav item disappears. `POST /ptu_reservation/new` returns 403 again. `GET /team/daily/activity` still returns the historical row from step 4 unchanged (flag-off does not delete data).

6. Restart the proxy after step 2 (with the flag still on in the DB). Confirm on restart that the log shows `Synced UI settings to general_settings on startup: ['enable_ptu_cost_attribution']` and step 3's curl still returns `true`. Persistence survives restart.

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/33439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->