### PR TITLE
fix(model_armor): sanitize API error detail by default

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/model_armor/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/model_armor/__init__.py
@@ -26,6 +26,7 @@ def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"
         mask_request_content=litellm_params.mask_request_content,
         mask_response_content=litellm_params.mask_response_content,
         fail_on_error=litellm_params.fail_on_error,
+        sanitize_error_detail=litellm_params.sanitize_error_detail,
     )
     litellm.logging_callback_manager.add_litellm_callback(_model_armor_callback)
 

--- a/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
@@ -77,6 +77,7 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
         location: Optional[str] = None,
         credentials: Optional[Any] = None,
         api_endpoint: Optional[str] = None,
+        sanitize_error_detail: bool = True,
         **kwargs,
     ):
         # Set supported event hooks if not already provided
@@ -99,6 +100,7 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
         self.location = location or "us-central1"
         self.credentials = credentials
         self.api_endpoint = api_endpoint
+        self.sanitize_error_detail = sanitize_error_detail is not False
 
         # Store optional params
         self.optional_params = kwargs
@@ -141,6 +143,22 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
         # These response types are not text-based and shouldn't be processed by text guardrails
         verbose_proxy_logger.debug("Model Armor: Skipping non-ModelResponse type: %s", type(response).__name__)
         return ""
+
+    def _build_api_error_detail(self, status_code: int, response_text: str) -> str:
+        if self.sanitize_error_detail:
+            return "Model Armor API error: upstream request failed"
+        return f"Model Armor API error (upstream {status_code}): {response_text}"
+
+    def _build_block_error_detail(self, message: str, armor_response: Any) -> dict:
+        detail = {"error": message}
+        if not self.sanitize_error_detail:
+            detail["model_armor_response"] = armor_response
+        return detail
+
+    def _build_logging_response(self, armor_response: Any) -> Any:
+        if self.sanitize_error_detail:
+            return {}
+        return armor_response
 
     async def make_model_armor_request(
         self,
@@ -195,6 +213,8 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
                 file_type,
                 len(file_bytes),
             )
+        elif self.sanitize_error_detail:
+            verbose_proxy_logger.debug("Model Armor request - URL: %s", url)
         else:
             verbose_proxy_logger.debug(
                 "Model Armor request - URL: %s, Body: %s",
@@ -212,22 +232,26 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
             headers=headers,
         )
 
-        verbose_proxy_logger.debug(
-            "Model Armor response - Status: %s, Body: %s",
-            response.status_code,
-            response.text,
-        )
-
-        if response.status_code != 200:
-            verbose_proxy_logger.error(
-                "Model Armor API error - Status: %s, Response: %s",
+        if self.sanitize_error_detail:
+            verbose_proxy_logger.debug(
+                "Model Armor response - Status: %s",
+                response.status_code,
+            )
+        else:
+            verbose_proxy_logger.debug(
+                "Model Armor response - Status: %s, Body: %s",
                 response.status_code,
                 response.text,
             )
-            raise HTTPException(
-                status_code=400,
-                detail=f"Model Armor API error (upstream {response.status_code}): {response.text}",
+
+        if response.status_code != 200:
+            detail = self._build_api_error_detail(response.status_code, response.text)
+            verbose_proxy_logger.error(
+                "Model Armor API error - Status: %s, Detail: %s",
+                response.status_code,
+                detail,
             )
+            raise HTTPException(status_code=400, detail=detail)
 
         json_response = response.json()
         if hasattr(json_response, "__await__"):
@@ -352,10 +376,16 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
         Override to store only the Model Armor API response, not the entire data dict.
         This prevents circular references in logging.
         """
-        # Retrieve the Model Armor response & status stored on the per-request `metadata` object.
-        metadata = request_data.get("metadata", {}) if isinstance(request_data, dict) else {}
+        from litellm.proxy.common_utils.callback_utils import (
+            get_metadata_variable_name_from_kwargs,
+        )
 
-        guardrail_response = metadata.get("_model_armor_response", {})
+        metadata = (
+            request_data.get(get_metadata_variable_name_from_kwargs(request_data), {})
+            if isinstance(request_data, dict)
+            else {}
+        )
+        guardrail_response = self._build_logging_response(metadata.get("_model_armor_response", {}))
 
         # Determine status – default to "success" but prefer the explicit value if present.
         guardrail_status: GuardrailStatus = metadata.get("_model_armor_status", "success")  # type: ignore
@@ -457,7 +487,8 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
             # otherwise a PII-only (SDP deidentify) document would pass through unscrubbed.
             blocked = self._should_block_content(armor_response, allow_sanitization=False)
             metadata["_model_armor_response"] = self._append_armor_response(
-                metadata.get("_model_armor_response"), armor_response
+                metadata.get("_model_armor_response"),
+                self._build_logging_response(armor_response),
             )
             if blocked or metadata.get("_model_armor_status") == "blocked":
                 metadata["_model_armor_status"] = "blocked"
@@ -467,10 +498,7 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
             if blocked:
                 raise HTTPException(
                     status_code=400,
-                    detail={
-                        "error": "Content blocked by Model Armor",
-                        "model_armor_response": armor_response,
-                    },
+                    detail=self._build_block_error_detail("Content blocked by Model Armor", armor_response),
                 )
 
     @log_guardrail_information
@@ -528,7 +556,8 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
                 metadata = data.setdefault("metadata", {})  # ensures metadata exists and is unique per request
                 # Accumulate so a prior file scan on the same request is not overwritten by this text scan.
                 metadata["_model_armor_response"] = self._append_armor_response(
-                    metadata.get("_model_armor_response"), armor_response
+                    metadata.get("_model_armor_response"),
+                    self._build_logging_response(armor_response),
                 )
                 # Pre-compute guardrail status for downstream logging. A blocked response will eventually raise
                 #   an HTTPException, however in scenarios where the caller decides to ignore the exception (e.g.
@@ -546,10 +575,7 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
             if blocked:
                 raise HTTPException(
                     status_code=400,
-                    detail={
-                        "error": "Content blocked by Model Armor",
-                        "model_armor_response": armor_response,
-                    },
+                    detail=self._build_block_error_detail("Content blocked by Model Armor", armor_response),
                 )
 
             # If mask_request_content is enabled, update messages with sanitized content
@@ -623,7 +649,8 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
                 metadata = data.setdefault("metadata", {})
                 # Accumulate so a prior file scan on the same request is not overwritten by this text scan.
                 metadata["_model_armor_response"] = self._append_armor_response(
-                    metadata.get("_model_armor_response"), armor_response
+                    metadata.get("_model_armor_response"),
+                    self._build_logging_response(armor_response),
                 )
                 if blocked or metadata.get("_model_armor_status") == "blocked":
                     metadata["_model_armor_status"] = "blocked"
@@ -638,10 +665,7 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
             if blocked:
                 raise HTTPException(
                     status_code=400,
-                    detail={
-                        "error": "Content blocked by Model Armor",
-                        "model_armor_response": armor_response,
-                    },
+                    detail=self._build_block_error_detail("Content blocked by Model Armor", armor_response),
                 )
 
             # If mask_request_content is enabled, update messages with sanitized content
@@ -696,7 +720,7 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
             # Attach Model Armor response & status to this request's metadata to prevent race conditions
             if isinstance(armor_response, dict):
                 model_armor_logged_object = {
-                    "model_armor_response": armor_response,
+                    "model_armor_response": self._build_logging_response(armor_response),
                     "model_armor_status": (
                         "blocked"
                         if self._should_block_content(
@@ -711,7 +735,7 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
                     guardrail_provider="model_armor",
                     guardrail_mode=GuardrailEventHooks.post_call,
                     guardrail_response=model_armor_logged_object,
-                    guardrail_status="success",
+                    guardrail_status=model_armor_logged_object["model_armor_status"],
                     start_time=data.get("start_time"),
                 )
                 add_guardrail_response_to_standard_logging_object(
@@ -727,10 +751,7 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
             if self._should_block_content(armor_response, allow_sanitization=self.mask_response_content):
                 raise HTTPException(
                     status_code=400,
-                    detail={
-                        "error": "Response blocked by Model Armor",
-                        "model_armor_response": armor_response,
-                    },
+                    detail=self._build_block_error_detail("Response blocked by Model Armor", armor_response),
                 )
 
             # If mask_response_content is enabled, update response with sanitized content
@@ -788,7 +809,7 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
                     # Attach Model Armor response & status to this request's metadata to avoid race conditions
                     if isinstance(request_data, dict):
                         metadata = request_data.setdefault("metadata", {})
-                        metadata["_model_armor_response"] = armor_response
+                        metadata["_model_armor_response"] = self._build_logging_response(armor_response)
                         metadata["_model_armor_status"] = (
                             "blocked" if self._should_block_content(armor_response) else "success"
                         )
@@ -807,10 +828,10 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
                     if self._should_block_content(armor_response):
                         raise HTTPException(
                             status_code=400,
-                            detail={
-                                "error": "Streaming response blocked by Model Armor",
-                                "model_armor_response": armor_response,
-                            },
+                            detail=self._build_block_error_detail(
+                                "Streaming response blocked by Model Armor",
+                                armor_response,
+                            ),
                         )
 
                     # Apply sanitization if enabled

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -687,6 +687,13 @@ class BaseLitellmParams(ContentFilterConfigModel):  # works for new and patch up
             "so only a valid guardrail response can block or modify it."
         ),
     )
+    sanitize_error_detail: Optional[bool] = Field(
+        default=True,
+        description=(
+            "For guardrail='model_armor': omit the raw Model Armor response from "
+            "caller-facing errors and logs by default. Set False to restore verbose output."
+        ),
+    )
 
     additional_provider_specific_params: Optional[Dict[str, Any]] = Field(
         default=None,

--- a/litellm/types/proxy/guardrails/guardrail_hooks/model_armor.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/model_armor.py
@@ -20,6 +20,13 @@ class ModelArmorGuardrailConfigModel(GuardrailConfigModel):
         default=True,
         description="Whether to fail the request if Model Armor encounters an error",
     )
+    sanitize_error_detail: Optional[bool] = Field(
+        default=True,
+        description=(
+            "Omit the raw Model Armor response from caller-facing errors and logs "
+            "by default. Set False to restore verbose output."
+        ),
+    )
 
     @staticmethod
     def ui_friendly_name() -> str:

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_model_armor.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_model_armor.py
@@ -413,8 +413,8 @@ async def test_model_armor_api_error_handling():
             )
 
         assert exc_info.value.status_code == 400
-        assert "Model Armor API error" in str(exc_info.value.detail)
-        assert "upstream 500" in str(exc_info.value.detail)
+        assert exc_info.value.detail == "Model Armor API error: upstream request failed"
+        assert "Internal Server Error" not in str(exc_info.value.detail)
 
 
 @pytest.mark.asyncio
@@ -651,7 +651,119 @@ async def test_model_armor_api_failure_returns_400():
 
         # Should be 400, NOT the upstream 500
         assert exc_info.value.status_code == 400
-        assert "upstream 500" in str(exc_info.value.detail)
+        assert exc_info.value.detail == "Model Armor API error: upstream request failed"
+        assert "Internal Server Error" not in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sanitize", [True, False])
+async def test_model_armor_error_output_sanitization(sanitize: bool):
+    marker = "SYNTHETIC_MODEL_ARMOR_MARKER"
+    guardrail = ModelArmorGuardrail(
+        template_id="test-template",
+        project_id="test-project",
+        guardrail_name="model-armor-test",
+        sanitize_error_detail=sanitize,
+    )
+    guardrail._ensure_access_token_async = AsyncMock(
+        return_value=("test-token", "test-project")
+    )
+
+    error_response = AsyncMock(status_code=500, text=marker)
+    with patch.object(
+        guardrail.async_handler, "post", AsyncMock(return_value=error_response)
+    ), patch.object(verbose_proxy_logger, "debug") as debug_log, patch.object(
+        verbose_proxy_logger, "error"
+    ) as error_log, pytest.raises(HTTPException) as exc_info:
+        await guardrail.make_model_armor_request(content=marker)
+
+    direct_log = f"{debug_log.call_args_list} {error_log.call_args_list}"
+    if sanitize:
+        assert marker not in str(exc_info.value.detail)
+        assert marker not in direct_log
+    else:
+        assert marker in str(exc_info.value.detail)
+        assert marker in direct_log
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sanitize", [True, False])
+async def test_model_armor_match_found_sanitizes_caller_and_logging(sanitize: bool):
+    marker = "SYNTHETIC_MATCH_FOUND_MARKER"
+    armor_response = {
+        "sanitizationResult": {
+            "filterResults": {
+                "sdp": {
+                    "sdpFilterResult": {
+                        "inspectResult": {
+                            "matchState": "MATCH_FOUND",
+                            "findings": [{"marker": marker}],
+                        }
+                    }
+                }
+            }
+        }
+    }
+    guardrail = ModelArmorGuardrail(
+        template_id="test-template",
+        project_id="test-project",
+        guardrail_name="model-armor-test",
+        event_hook=[GuardrailEventHooks.pre_mcp_call],
+        sanitize_error_detail=sanitize,
+    )
+    guardrail.make_model_armor_request = AsyncMock(return_value=armor_response)
+    guardrail.should_run_guardrail = Mock(return_value=True)
+    request_data = {
+        "messages": [{"role": "user", "content": "synthetic input"}],
+        "metadata": {},
+    }
+
+    with pytest.raises(HTTPException) as exc_info:
+        await guardrail.async_pre_call_hook(
+            user_api_key_dict=UserAPIKeyAuth(),
+            cache=MagicMock(spec=DualCache),
+            data=request_data,
+            call_type=litellm.types.utils.CallTypes.call_mcp_tool.value,
+        )
+
+    detail = exc_info.value.detail
+    logged_response = request_data["metadata"]["_model_armor_response"]
+    if sanitize:
+        assert detail == {"error": "Content blocked by Model Armor"}
+        assert logged_response == {}
+        assert marker not in str(detail)
+        assert marker not in str(logged_response)
+    else:
+        assert detail["model_armor_response"] == armor_response
+        assert logged_response == armor_response
+        assert marker in str(detail)
+        assert marker in str(logged_response)
+
+
+def test_model_armor_sanitize_error_detail_config_wiring():
+    from litellm.proxy.guardrails.guardrail_hooks.model_armor import (
+        initialize_guardrail,
+    )
+    from litellm.types.guardrails import LitellmParams
+
+    config = {"guardrail_name": "model-armor-test"}
+    params = {
+        "guardrail": "model_armor",
+        "mode": "pre_mcp_call",
+        "template_id": "test-template",
+        "project_id": "test-project",
+    }
+    opted_out = initialize_guardrail(
+        LitellmParams(**params, sanitize_error_detail=False), config
+    )
+    explicit_null = initialize_guardrail(
+        LitellmParams(**params, sanitize_error_detail=None), config
+    )
+    default = initialize_guardrail(LitellmParams(**params), config)
+
+    assert opted_out.sanitize_error_detail is False
+    assert explicit_null.sanitize_error_detail is True
+    assert default.sanitize_error_detail is True
 
 
 def test_model_armor_ui_friendly_name():
@@ -1394,7 +1506,10 @@ async def test_model_armor_guardrail_status_intervened_vs_failed():
             )
 
         info = request_data["metadata"]["standard_logging_guardrail_information"]
+        assert info[0]["guardrail_name"] == guardrail.guardrail_name
         assert info[0]["guardrail_status"] == "guardrail_intervened"
+        assert "model_armor_response" not in info[0]["guardrail_response"]
+        assert "sanitizationResult" not in info[0]["guardrail_response"]
 
     # 2: if an API error - guardrail status should be guardrail_failed_to_respond"
     guardrail2 = ModelArmorGuardrail(


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

### Reproducible unit suite

The Model Armor HTTP call is mocked, so this suite runs without credentials or network access

```text
pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/test_model_armor.py
77 passed, 3 skipped
```

The 3 skips are existing `google.auth`-gated credential tests and are unrelated to this change. The new tests cover sanitized API failures, blocked MCP calls, direct request and response logs, standard guardrail logging, configuration wiring, explicit opt-out behavior, and `null` safety

### Live proxy validation

The validation environment applies Model Armor to MCP calls only, so a chat-completions `curl` would not exercise the affected guardrail path. I instead invoked an MCP tool directly through a running LiteLLM proxy using the MCP SDK, with no LLM in the loop and fixed fabricated input

```text
SYNTHETIC TEST RECORD ONLY. Fictional patient TEST PERSON, DOB 01/01/1900, MRN TEST-000000. This is fabricated validation data
```

The live proxy used a functionally equivalent vendored implementation. The public PR head itself was not the deployed artifact

The client required all of these checks before reporting success

```python
serialized = json.dumps(result)
assert result["isError"] is True
assert "Content blocked by Model Armor" in serialized
assert not any(
    marker in serialized
    for marker in (
        "model_armor_response",
        "sanitizationResult",
        "filterResults",
        "sdpFilterResult",
        "inspectResult",
        "deidentifyResult",
    )
)
```

Live output

```text
PASS: MCP call was blocked and the caller-visible result was sanitized
```

The returned MCP result retained the safe block reason and guardrail metadata and did not contain the raw Model Armor response, findings, or filter details. Credentials, endpoint details, and the synthetic tool result body are omitted from this public PR

A generalized direct MCP client and replay command are included below so the same check can be run against any proxy where Model Armor is configured on an MCP guardrail path

<details>
<summary>Generalized direct MCP replay client</summary>

Save as `repro_model_armor_mcp.py`

```python
#!/usr/bin/env python3
from __future__ import annotations

import argparse
import asyncio
import json
import os
import sys
from typing import Any

SYNTHETIC_PAYLOAD = (
    "SYNTHETIC TEST RECORD ONLY. Fictional patient TEST PERSON, "
    "DOB 01/01/1900, MRN TEST-000000. This is fabricated validation data."
)
EXPECTED_BLOCK_REASON = "Content blocked by Model Armor"
FORBIDDEN_MARKERS = (
    "model_armor_response",
    "sanitizationResult",
    "filterResults",
    "sdpFilterResult",
    "inspectResult",
    "deidentifyResult",
)


def parse_args() -> argparse.Namespace:
    parser = argparse.ArgumentParser()
    parser.add_argument("--endpoint", required=True)
    parser.add_argument("--tool", required=True)
    parser.add_argument("--arg-name", default="query")
    return parser.parse_args()


async def call_tool(
    endpoint: str, tool: str, arg_name: str, api_key: str
) -> dict[str, Any]:
    import httpx
    from mcp import ClientSession
    from mcp.client.streamable_http import streamable_http_client

    async with httpx.AsyncClient(
        headers={"x-litellm-api-key": f"Bearer {api_key}"},
        follow_redirects=True,
        timeout=120,
    ) as http_client:
        async with streamable_http_client(
            endpoint, http_client=http_client
        ) as transport:
            read_stream, write_stream = transport[0], transport[1]
            async with ClientSession(read_stream, write_stream) as session:
                await session.initialize()
                result = await session.call_tool(
                    tool, arguments={arg_name: SYNTHETIC_PAYLOAD}
                )
                return result.model_dump(mode="json", exclude_none=True)


def marker_leaks(value: Any) -> list[str]:
    serialized = json.dumps(value, sort_keys=True)
    return sorted(
        marker
        for marker in FORBIDDEN_MARKERS
        if marker.lower() in serialized.lower()
    )


def validate(result: dict[str, Any]) -> None:
    leaks = marker_leaks(result)
    if leaks:
        raise AssertionError(
            "UNSAFE: caller-visible result leaked raw Model Armor markers: "
            + ", ".join(leaks)
        )
    if result.get("isError") is not True:
        raise AssertionError("expected isError=true; result body omitted")
    if EXPECTED_BLOCK_REASON not in json.dumps(result):
        raise AssertionError("expected safe Model Armor block reason")


def main() -> int:
    args = parse_args()
    api_key = os.environ.get("MCP_API_KEY")
    if not api_key:
        raise RuntimeError("set MCP_API_KEY to a LiteLLM virtual key")
    try:
        result = asyncio.run(
            call_tool(args.endpoint, args.tool, args.arg_name, api_key)
        )
    except Exception as error:
        leaks = marker_leaks({"type": type(error).__name__, "message": str(error)})
        if leaks:
            raise AssertionError(
                "UNSAFE: caller-visible exception leaked raw Model Armor markers: "
                + ", ".join(leaks)
            ) from error
        raise RuntimeError("MCP call failed before returning a tool result") from error
    validate(result)
    print("PASS: MCP call was blocked and the caller-visible result was sanitized")
    return 0


if __name__ == "__main__":
    try:
        raise SystemExit(main())
    except (AssertionError, RuntimeError) as error:
        print(f"FAIL: {error}", file=sys.stderr)
        raise SystemExit(1)
```

Run it against a streamable HTTP MCP endpoint whose `pre_mcp_call` guardrails include Model Armor

```text
MCP_API_KEY=<virtual-key> uv run --with mcp==1.28.1 \
  python repro_model_armor_mcp.py \
  --endpoint http://localhost:4000/mcp/<server> \
  --tool <tool-name>
```

If the remote MCP server requires its own OAuth flow, attach the MCP SDK's `OAuthClientProvider` to the `httpx.AsyncClient`; this does not change the call or validation logic above

</details>

## Type

🐛 Bug Fix

## Changes

Model Armor responses can contain fragments and findings from the content being scanned. This change adds `sanitize_error_detail`, enabled by default, and removes raw Model Armor details from caller-facing errors, direct request/response logs, and standard guardrail logging

The sanitized behavior covers non-200 API failures and `MATCH_FOUND` blocks in file scanning, pre-call, MCP pre-call, during-call, MCP during-call, post-call, and streaming paths. Safe guardrail identity, mode, reason, and blocked/success status remain available

Only an explicit `sanitize_error_detail: false` restores the previous verbose behavior. Omitted, `true`, and `null` values remain sanitized

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
