### PR TITLE
fix(logging): stop pinning large request payloads past request end

### DIFF
--- a/litellm/caching/caching_handler.py
+++ b/litellm/caching/caching_handler.py
@@ -85,6 +85,22 @@ class CachingHandlerResponse(BaseModel):
 in_memory_cache_obj = InMemoryCache()
 
 
+def _drop_logging_obj_from_kwargs(request_kwargs: dict[str, object]) -> dict[str, object]:
+    """
+    The caching handler is stored on the Logging object
+    (``logging_obj._llm_caching_handler``), so keeping ``litellm_logging_obj``
+    inside ``request_kwargs`` closes a reference cycle
+    (Logging -> LLMCachingHandler -> kwargs -> Logging) that keeps the full
+    request payload (messages included) alive until a generational GC pass
+    instead of being freed by refcount when the request ends. Nothing in the
+    caching layer reads the logging object from these kwargs; cache-key
+    generation ignores litellm-internal params.
+    """
+    if "litellm_logging_obj" not in request_kwargs:
+        return request_kwargs
+    return {k: v for k, v in request_kwargs.items() if k != "litellm_logging_obj"}
+
+
 def _is_chat_completion_cached_dict(cached_result: dict) -> bool:
     cached_id = cached_result.get("id")
     if isinstance(cached_id, str) and cached_id.startswith("chatcmpl"):
@@ -118,7 +134,7 @@ class LLMCachingHandler:
 
         self.async_streaming_chunks: List[ModelResponse] = []
         self.sync_streaming_chunks: List[ModelResponse] = []
-        self.request_kwargs = request_kwargs
+        self.request_kwargs = _drop_logging_obj_from_kwargs(request_kwargs)
         self.preset_cache_key: Optional[str] = None
         self.original_function = original_function
         self.start_time = start_time
@@ -297,7 +313,7 @@ class LLMCachingHandler:
                 new_kwargs.pop("metadata", None)
             if new_kwargs.get("stream") is True and "cache_key" not in new_kwargs:
                 new_kwargs["cache_key"] = litellm.cache.get_cache_key(**new_kwargs)
-            self.request_kwargs = new_kwargs
+            self.request_kwargs = _drop_logging_obj_from_kwargs(new_kwargs)
             print_verbose("Checking Sync Cache")
             cached_result = litellm.cache.get_cache(**new_kwargs)
             if cached_result is not None:
@@ -693,7 +709,7 @@ class LLMCachingHandler:
             new_kwargs.pop("metadata", None)
         if new_kwargs.get("stream") is True and "cache_key" not in new_kwargs:
             new_kwargs["cache_key"] = litellm.cache.get_cache_key(**new_kwargs)
-        self.request_kwargs = new_kwargs
+        self.request_kwargs = _drop_logging_obj_from_kwargs(new_kwargs)
         cached_result: Optional[Any] = None
         if call_type == CallTypes.aembedding.value:
             if isinstance(new_kwargs["input"], str):

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -925,7 +925,6 @@ class Logging(LiteLLMLoggingBaseClass):
 
     def pre_call(self, input, api_key, model=None, additional_args={}):
         # Log the exact input to the LLM API
-        litellm.error_logs["PRE_CALL"] = locals()
         try:
             self._pre_call(
                 input=input,
@@ -1135,7 +1134,6 @@ class Logging(LiteLLMLoggingBaseClass):
 
     def post_call(self, original_response, input=None, api_key=None, additional_args={}):
         # Log the exact result from the LLM API, for streaming - log the type of response received
-        litellm.error_logs["POST_CALL"] = locals()
         if isinstance(original_response, dict):
             original_response = json.dumps(original_response, default=str)
         try:

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2986,7 +2986,7 @@ class Router:
         # here before it's wiped below, instead of relying on that attempt's
         # (possibly still-pending) failure event to do it.
         refund_stale_reservation_before_retry(self.cache, kwargs)
-        set_io_token_rate_limit_request_kwargs(kwargs)
+        set_io_token_rate_limit_request_kwargs(kwargs, store_in_context=deployment_has_io_token_limits(deployment))
 
         ## DEPLOYMENT-LEVEL TAGS
         deployment_tags = deployment.get("litellm_params", {}).get("tags")

--- a/litellm/router_utils/pre_call_checks/io_token_rate_limit_check.py
+++ b/litellm/router_utils/pre_call_checks/io_token_rate_limit_check.py
@@ -43,14 +43,21 @@ ITPM_CACHE_KEY = "_litellm_itpm_cache_key"
 OTPM_CACHE_KEY = "_litellm_otpm_cache_key"
 
 
-def set_io_token_rate_limit_request_kwargs(kwargs: Optional[dict[str, Any]]) -> None:
+def set_io_token_rate_limit_request_kwargs(kwargs: Optional[dict[str, Any]], store_in_context: bool = True) -> None:
     # The reservation sentinels are server-only, but `metadata` is caller
     # controlled on proxy requests. Strip any client-supplied copies here (this
     # runs before the router stashes its own reservation) so a forged
     # reservation can't drive the post-call reconcile/refund against an
     # arbitrary counter and bypass the configured limits.
     _clear_reservation_from_kwargs(kwargs)
-    _io_token_rate_limit_request_kwargs.set(kwargs)
+    # The context slot pins the entire request kwargs (messages included) for
+    # the lifetime of the surrounding context, which outlives the request when
+    # the context is captured by pooled resources (e.g. a redis connection
+    # created mid-request). Only ITPM/OTPM-limited deployments read it, so for
+    # every other deployment overwrite the slot with None instead of the
+    # kwargs; overwriting (rather than skipping) also releases a previous
+    # request's kwargs when a context is reused.
+    _io_token_rate_limit_request_kwargs.set(kwargs if store_in_context else None)
 
 
 def get_io_token_rate_limit_request_kwargs() -> Optional[dict[str, Any]]:

--- a/tests/test_litellm/caching/test_caching_handler.py
+++ b/tests/test_litellm/caching/test_caching_handler.py
@@ -556,3 +556,31 @@ async def test_embedding_cache_falls_back_to_token_counter_for_legacy_entries():
     assert cache_hit
     # token_counter over "hello world" yields a nonzero count — fallback path still runs
     assert response.usage.prompt_tokens > 0
+
+
+def test_request_kwargs_does_not_retain_logging_obj():
+    """
+    The caching handler lives on logging_obj._llm_caching_handler, so keeping
+    litellm_logging_obj inside request_kwargs closes a reference cycle
+    (Logging -> LLMCachingHandler -> kwargs -> Logging). That cycle keeps the
+    full request payload alive until a generational GC pass instead of being
+    freed by refcount when the request finishes; under bursts of large-token
+    requests this presents as stepwise RSS growth that never returns to
+    baseline. Other kwargs (messages included) must be preserved.
+    """
+    logging_obj = MagicMock()
+    kwargs = {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "hello"}],
+        "litellm_logging_obj": logging_obj,
+    }
+
+    handler = LLMCachingHandler(
+        original_function=MagicMock(),
+        request_kwargs=kwargs,
+        start_time=datetime.now(),
+    )
+
+    assert "litellm_logging_obj" not in handler.request_kwargs
+    assert handler.request_kwargs["messages"] == kwargs["messages"]
+    assert handler.request_kwargs["model"] == "gpt-4o"

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -3773,3 +3773,19 @@ def test_zero_token_video_usage_preserves_duration_seconds(logging_obj):
     assert payload["metadata"]["usage_object"]["duration_seconds"] == 4.0
     assert payload["total_tokens"] == 0
     assert payload["completion_tokens"] == 0
+
+
+def test_pre_call_does_not_pin_request_in_module_state(logging_obj):
+    """
+    pre_call/post_call must not stash their locals (full messages, the Logging
+    object, complete_input_dict) into module-level state. That pinned the most
+    recent request's entire payload in memory for the life of the worker,
+    which with multi-hundred-KB requests is a permanent per-worker leak.
+    """
+    litellm.error_logs.clear()
+    big_input = [{"role": "user", "content": "x" * 10_000}]
+
+    logging_obj.pre_call(input=big_input, api_key="sk-test")
+    logging_obj.post_call(original_response='{"ok": true}', input=big_input, api_key="sk-test")
+
+    assert litellm.error_logs == {}

--- a/tests/test_litellm/test_router/test_io_token_rate_limits.py
+++ b/tests/test_litellm/test_router/test_io_token_rate_limits.py
@@ -977,3 +977,65 @@ class TestRouterIOTokenIntegration:
         assert info is not None
         assert info.itpm == 100
         assert info.otpm == 20
+
+
+class TestContextSlotRetention:
+    def test_setter_stores_kwargs_only_for_io_limited_deployments(self):
+        """
+        The context slot pins the entire request kwargs (messages included)
+        for the lifetime of the surrounding asyncio context, and pooled
+        resources created mid-request (e.g. redis connections) capture that
+        context, extending the pin far past the request. Only ITPM/OTPM
+        pre-call checks read the slot, so the setter must store None for
+        deployments without io token limits and still clear reservation
+        sentinels from kwargs either way.
+        """
+        kwargs = {
+            "messages": [{"role": "user", "content": "x" * 1000}],
+            "metadata": {ITPM_RESERVED_KEY: 999, ITPM_CACHE_KEY: "forged"},
+        }
+        set_io_token_rate_limit_request_kwargs(kwargs, store_in_context=False)
+        assert get_io_token_rate_limit_request_kwargs() is None
+        assert ITPM_RESERVED_KEY not in kwargs["metadata"]
+        assert ITPM_CACHE_KEY not in kwargs["metadata"]
+
+        set_io_token_rate_limit_request_kwargs(kwargs, store_in_context=True)
+        assert get_io_token_rate_limit_request_kwargs() is kwargs
+
+        set_io_token_rate_limit_request_kwargs(kwargs, store_in_context=False)
+        assert get_io_token_rate_limit_request_kwargs() is None
+
+    @pytest.mark.asyncio
+    async def test_router_does_not_pin_kwargs_without_io_limits(self):
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "plain",
+                    "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-test"},
+                }
+            ]
+        )
+        set_io_token_rate_limit_request_kwargs(None)
+        kwargs = {"messages": [{"role": "user", "content": "hello"}], "metadata": {}}
+        deployment = router.get_deployment_by_model_group_name("plain")
+        assert deployment is not None
+        router._update_kwargs_with_deployment(deployment=deployment.model_dump(), kwargs=kwargs)
+        assert get_io_token_rate_limit_request_kwargs() is None
+
+    @pytest.mark.asyncio
+    async def test_router_pins_kwargs_for_io_limited_deployment(self):
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "limited",
+                    "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-test", "itpm": 100},
+                }
+            ],
+            optional_pre_call_checks=["enforce_model_rate_limits"],
+        )
+        set_io_token_rate_limit_request_kwargs(None)
+        kwargs = {"messages": [{"role": "user", "content": "hello"}], "metadata": {}}
+        deployment = router.get_deployment_by_model_group_name("limited")
+        assert deployment is not None
+        router._update_kwargs_with_deployment(deployment=deployment.model_dump(), kwargs=kwargs)
+        assert get_io_token_rate_limit_request_kwargs() is kwargs


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4434

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

A production deployment reported stepwise memory growth that never returns to baseline after traffic bursts, ending in periodic restarts to avoid OOM. Their traffic averages ~73K tokens/request (max ~1M) with a PII content-filter guardrail on most requests. The growth reproduces identically on v1.84.0 and v1.90.0, so this is not a version regression; it is a payload-retention problem that large-token traffic surfaces

Rig (mirrors the reporter's config): live proxy + Postgres + Redis cache, `litellm_content_filter` guardrail (`mode: pre_call`, MASK patterns, `default_on: true`), `callbacks: [prometheus]`, `store_prompts_in_spend_logs: error-only`, plus a local openai-compatible upstream for the burst load so the burst itself is free; the end-to-end proof below uses the real OpenAI API. Load: bursts of 30 chat completions x ~300KB message content, 8 concurrent, then a 10s idle read of the worker's RSS

Before (unfixed, v1.90.0 tag `6e8282d406`; the current staging base reproduces the same curve):

```
$ python burst.py 5 30 300 8
baseline rss_total=733.4MB
burst 1:  after 10s idle: rss_total=766.5MB
burst 2:  after 10s idle: rss_total=787.3MB
burst 3:  after 10s idle: rss_total=809.0MB
burst 4:  after 10s idle: rss_total=831.9MB
```

~16-29MB retained per burst, never released; over ~20 bursts one worker ratchets past 1.2GB. A gc census 10 seconds after each burst finds ~55 complete request dicts (~20MB of message content) still referenced, and `gc.DEBUG_SAVEALL` shows them sitting in reference cycles through the request's `Logging` object

After (this branch; captured at `18494e5993`, whose runtime behavior is identical to head `7d53a23d5b` which only widens a type annotation), same rig, same load:

```
$ python burst.py 6 30 300 8
baseline rss_total=876.1MB
burst 1:  after 10s idle: rss_total=967.3MB   (first-burst warmup: arenas, connection pools)
burst 2:  after 10s idle: rss_total=969.2MB
burst 3:  after 10s idle: rss_total=971.0MB
burst 4:  after 10s idle: rss_total=972.6MB
burst 5:  after 10s idle: rss_total=973.3MB
burst 6:  after 10s idle: rss_total=974.6MB
$ python burst.py 8 30 300 8   # continued on the same worker
burst 7..14: 1066.5 -> 1067.0 -> 1067.6 -> 1070.1 -> 1071.0 -> 1071.4 -> 1071.9 -> 1072.1MB
```

Growth per burst drops from ~16-29MB to under 1MB and the curve flattens instead of ratcheting

End-to-end sanity on the fixed proxy against the real OpenAI API (costs real $): the PII guardrail still masks before the provider sees the payload, and the spend log still records the guardrail info

```
$ curl -s http://localhost:4434/v1/chat/completions -H "Authorization: Bearer sk-..." \
    -d '{"model":"gpt-5.4-nano","messages":[{"role":"user","content":"my phone is 13812345678 and my email is jane@example.com. Repeat back exactly the phone and email I just gave you."}]}'
content: Sorry—I can’t repeat back those exact phone number or email details you provided.
usage: 60 total tokens

$ psql ... -c "SELECT model, metadata->'guardrail_information'->0->>'masked_entity_count' FROM \"LiteLLM_SpendLogs\" ORDER BY \"startTime\" DESC LIMIT 2;"
 gpt-5.4-nano | {"email": 1, "china_phone": 1}
 gpt-5.4-nano | {"email": 1, "china_phone": 1}
```

Why this is not a curl-visible bug: the defect is in-process memory retention, so the metric is the worker's RSS across bursts plus a gc census of surviving request dicts; the curls above prove the touched paths (logging, caching handler, router deployment selection, guardrails) still behave end to end

## Type

🐛 Bug Fix

## Changes

Three independent retention points each kept a full request payload (messages included) alive after the request finished

`litellm_core_utils/litellm_logging.py`: `pre_call`/`post_call` stored their entire `locals()` (the messages, the `Logging` object, `complete_input_dict`) into the module-level `litellm.error_logs` dict. Nothing in the codebase reads that dict, so the write pinned the most recent request's whole payload per worker, forever. The two writes are removed; the (now always empty) module attribute stays for import compatibility

`caching/caching_handler.py`: `LLMCachingHandler` stored the raw request kwargs while itself hanging off `logging_obj._llm_caching_handler`, and the kwargs contain `litellm_logging_obj`, closing a reference cycle `Logging -> LLMCachingHandler -> kwargs -> Logging`. Cyclic garbage is only reclaimed by generational GC, so megabytes of dead payload lingered until a rare gen-2 pass, and the churn of large blocks fragments the allocator into a permanent RSS high-water mark. The handler now drops `litellm_logging_obj` from its stored kwargs at every assignment site; the caching layer never reads it (cache-key generation ignores litellm-internal params)

`router.py` + `router_utils/pre_call_checks/io_token_rate_limit_check.py`: `_update_kwargs_with_deployment` stored every request's kwargs in the ITPM/OTPM contextvar even when no deployment configures `itpm`/`otpm`. Pooled resources created mid-request (a redis connection's captured `Context` was one confirmed holder) extend that pin far past the request. The slot is now populated only for deployments that actually have io token limits and is overwritten with `None` otherwise, which also releases a previous request's kwargs when an asyncio context is reused. The reservation-sentinel stripping still runs unconditionally

Tests: one regression test per retention point, in the mapped test files. Each fails on the unfixed tree (verified by reverting the four production files and re-running: 4 failed) and passes with the fix

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

