### PR TITLE
test(claude_code): rename misleading REPO_ROOT to SUITE_ROOT in test_v0_layout

### DIFF
--- a/tests/e2e/claude_code/_builder_unit_tests/test_v0_layout.py
+++ b/tests/e2e/claude_code/_builder_unit_tests/test_v0_layout.py
@@ -16,8 +16,8 @@ from pathlib import Path
 import pytest
 import yaml
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-MANIFEST_PATH = REPO_ROOT / "manifest.yaml"
+SUITE_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = SUITE_ROOT / "manifest.yaml"
 
 # The PRD's "Features in v0" section, in row order.
 EXPECTED_FEATURE_IDS = [
@@ -90,14 +90,14 @@ def test_manifest_every_feature_has_human_readable_name(manifest):
 
 @pytest.mark.parametrize("feature_id", EXPECTED_FEATURE_IDS)
 def test_feature_directory_exists(feature_id):
-    feature_dir = REPO_ROOT / feature_id
+    feature_dir = SUITE_ROOT / feature_id
     assert feature_dir.is_dir(), f"missing feature directory: {feature_dir}"
 
 
 @pytest.mark.parametrize("feature_id", EXPECTED_FEATURE_IDS)
 @pytest.mark.parametrize("provider", EXPECTED_PROVIDERS)
 def test_per_provider_test_file_exists(feature_id, provider):
-    test_file = REPO_ROOT / feature_id / f"test_{provider}.py"
+    test_file = SUITE_ROOT / feature_id / f"test_{provider}.py"
     assert test_file.is_file(), f"missing per-provider test file: {test_file}"
 
 
@@ -106,7 +106,7 @@ def test_feature_directory_has_init_file(feature_id):
     """Each feature directory needs an __init__.py so pytest collects
     the per-provider test files as a package — matches the layout
     established by `basic_messaging_non_streaming/`."""
-    init_file = REPO_ROOT / feature_id / "__init__.py"
+    init_file = SUITE_ROOT / feature_id / "__init__.py"
     assert init_file.is_file(), f"missing __init__.py: {init_file}"
 
 
@@ -117,7 +117,7 @@ def test_feature_directory_has_init_file(feature_id):
 # a broken post-v0 directory still fails CI.
 @pytest.mark.parametrize("feature_id", ALL_FEATURE_IDS)
 def test_every_manifest_feature_has_directory(feature_id):
-    feature_dir = REPO_ROOT / feature_id
+    feature_dir = SUITE_ROOT / feature_id
     assert feature_dir.is_dir(), (
         f"manifest declares {feature_id!r} but {feature_dir} is missing — "
         "feature_id MUST match its on-disk directory (see manifest.yaml header)."
@@ -126,7 +126,7 @@ def test_every_manifest_feature_has_directory(feature_id):
 
 @pytest.mark.parametrize("feature_id", ALL_FEATURE_IDS)
 def test_every_manifest_feature_has_init_file(feature_id):
-    init_file = REPO_ROOT / feature_id / "__init__.py"
+    init_file = SUITE_ROOT / feature_id / "__init__.py"
     assert init_file.is_file(), f"missing __init__.py: {init_file}"
 
 
@@ -137,7 +137,7 @@ def test_every_manifest_feature_has_per_provider_test_file(feature_id, provider)
     backed by a per-provider test file. Without this check, a missing
     file silently becomes a `not_tested` cell in the published matrix
     rather than a CI failure surfacing the layout drift."""
-    test_file = REPO_ROOT / feature_id / f"test_{provider}.py"
+    test_file = SUITE_ROOT / feature_id / f"test_{provider}.py"
     assert test_file.is_file(), f"missing per-provider test file: {test_file}"
 
 
@@ -151,7 +151,7 @@ def test_per_provider_test_file_imports_and_parametrizes_three_models(
     use plain aliases or per-provider-suffixed aliases (e.g.
     `claude-opus-4-7-bedrock-invoke`), so we check for the tier
     substrings rather than exact alias names."""
-    text = (REPO_ROOT / feature_id / f"test_{provider}.py").read_text()
+    text = (SUITE_ROOT / feature_id / f"test_{provider}.py").read_text()
     for tier in ("haiku-4-5", "sonnet-4-6", "opus-4-7"):
         assert (
             tier in text
@@ -171,7 +171,7 @@ def test_azure_test_file_drives_the_proxy(feature_id):
     that wraps them — both shapes drive the proxy, and we don't want
     this layout pin to block legitimate de-duplication of test bodies.
     """
-    text = (REPO_ROOT / feature_id / "test_azure.py").read_text()
+    text = (SUITE_ROOT / feature_id / "test_azure.py").read_text()
     assert "run_claude" in text or "run_basic_messaging_cell" in text, (
         f"{feature_id}/test_azure.py must drive the claude CLI via run_claude() "
         "or a shared helper that wraps it; the not_applicable stub was removed "


### PR DESCRIPTION
## Relevant issues

Follow-up to a post-merge review of #32548

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests (none added; this is a pure variable rename with no behavior change)
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a variable rename inside a structural test file with no runtime surface; it never touches the proxy, so there is no proxy behavior to demonstrate. The full `_builder_unit_tests` suite (203 tests) passes unchanged and `make lint-e2e-basedpyright` reports 0 errors at ec4639fc0e

## Type

🧹 Refactoring
✅ Test

## Changes

In `tests/e2e/claude_code/_builder_unit_tests/test_v0_layout.py`, the module-level constant `REPO_ROOT = Path(__file__).resolve().parents[1]` actually resolves to `tests/e2e/claude_code/` (the suite directory), not the repository root. Every sibling test file that names a variable `REPO_ROOT` uses `parents[4]`, which is the real repo root, so the name here was misleading even though every usage was functionally correct. This renames it to `SUITE_ROOT` at all 10 occurrences in that one file (the definition, `MANIFEST_PATH`, and the path joins inside the layout tests). No paths, assertions, or test behavior change

## QA runbook

The only change is a rename of a module-level path constant in `_builder_unit_tests/test_v0_layout.py`. These builder unit tests are structural (they verify the on-disk layout of the suite) and never drive a proxy, and no assertion changed, so there are no new manual steps to reproduce

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
