### PR TITLE
fix(claude_code): pin daily compat run to the 3-day-buffered claude-code version

### DIFF
--- a/tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_pins_resolver_version.py
+++ b/tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_pins_resolver_version.py
@@ -1,0 +1,256 @@
+"""Pin: run_daily.sh must install the resolver-selected claude-code version.
+
+PR #32548 deleted the CircleCI job `claude_code_compat_pr_gate`, which
+was the only automated consumer of `pr_gate_version_resolver.py` (newest
+`@anthropic-ai/claude-code` npm version published at least 3 days ago; a
+security-review buffer, PRD #26476). The daily runner used to probe
+whatever `claude` happened to be on the cron VM's PATH, so nothing
+automated enforced the buffer anymore. These tests pin the replacement
+flow in run_daily.sh:
+
+  1. The target version comes from running `pr_gate_version_resolver.py`
+     and exactly `@anthropic-ai/claude-code@<resolved>` is npm-installed
+     into a per-run prefix under `${WORKDIR}`.
+  2. Both the resolver and the npm install run under the same `env -i`
+     credential scrub (with the isolated per-run HOME) as the probe and
+     pytest steps: npm postinstall runs package code, which is exactly
+     the supply-chain vector the 3-day buffer exists for.
+  3. The `claude --version` probe verifies the binary now on PATH
+     reports exactly the resolved version and dies on a mismatch.
+
+The resolve/install/probe block is extracted out of run_daily.sh and
+executed with a stub resolver and a fake `npm`, mirroring the fake-curl
+technique in `test_run_daily_release_pagination.py`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+RUN_DAILY = REPO_ROOT / "tests" / "e2e" / "claude_code" / "cron_vm" / "run_daily.sh"
+
+RESOLVED_VERSION = "0.0.99"
+
+_PREAMBLE = (
+    "set -Eeuo pipefail\n"
+    "log() { printf '==> %s\\n' \"$*\" >&2; }\n"
+    "die() { printf 'ERROR: %s\\n' \"$*\" >&2; exit 1; }\n"
+)
+
+_SECRET_ENV = {
+    "ANTHROPIC_API_KEY": "test-secret-anthropic",
+    "AWS_BEARER_TOKEN_BEDROCK": "test-secret-bedrock",
+    "AZURE_FOUNDRY_API_KEY": "test-secret-foundry",
+    "AGENT_SHIN_GITHUB_TOKEN": "test-secret-agent-shin",
+    "GITHUB_TOKEN": "test-secret-github",
+}
+
+
+def _extract_pin_snippet() -> str:
+    body = RUN_DAILY.read_text()
+    start = body.index('CLAUDE_PROBE_HOME="${WORKDIR}/claude-probe-home"')
+    end = body.index('log "pinned claude code:')
+    return body[start:end]
+
+
+def _executable_lines(block: str) -> str:
+    return "\n".join(
+        line for line in block.splitlines() if line.lstrip()[:1] != "#"
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class PinHarness:
+    workdir: Path
+    resolver_env_json: Path
+    npm_env_txt: Path
+    npm_argv_txt: Path
+    script: str
+    env: dict[str, str]
+
+    def run(self) -> "subprocess.CompletedProcess[str]":
+        return subprocess.run(
+            ["bash", "-c", self.script],
+            capture_output=True,
+            text=True,
+            env=self.env,
+        )
+
+
+def _build_harness(tmp_path: Path, installed_version: str) -> PinHarness:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    dumps = tmp_path / "dumps"
+    dumps.mkdir()
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    populator_dir = tmp_path / "claude_code" / "cron_vm"
+    populator_dir.mkdir(parents=True)
+
+    resolver_env_json = dumps / "resolver_env.json"
+    resolver = tmp_path / "claude_code" / "pr_gate_version_resolver.py"
+    resolver.write_text(
+        textwrap.dedent(
+            f"""\
+            import json
+            import os
+
+            with open({str(resolver_env_json)!r}, "w") as fh:
+                json.dump(dict(os.environ), fh)
+            print({RESOLVED_VERSION!r})
+            """
+        )
+    )
+
+    npm_env_txt = dumps / "npm_env.txt"
+    npm_argv_txt = dumps / "npm_argv.txt"
+    fake_npm = fake_bin / "npm"
+    fake_npm.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            printf '%s\\n' "$@" > "{npm_argv_txt}"
+            env > "{npm_env_txt}"
+            prefix=""
+            pkg=""
+            while [[ $# -gt 0 ]]; do
+              case "$1" in
+                --prefix) prefix="$2"; shift 2 ;;
+                install) shift ;;
+                *) pkg="$1"; shift ;;
+              esac
+            done
+            mkdir -p "${{prefix}}/node_modules/.bin"
+            cat > "${{prefix}}/node_modules/.bin/claude" <<'CLAUDE_EOF'
+            #!/usr/bin/env bash
+            echo "{installed_version} (Claude Code)"
+            CLAUDE_EOF
+            chmod +x "${{prefix}}/node_modules/.bin/claude"
+            """
+        )
+    )
+    fake_npm.chmod(0o755)
+
+    script = (
+        _PREAMBLE
+        + f'WORKDIR="{workdir}"\n'
+        + f'POPULATOR_DIR="{populator_dir}"\n'
+        + _extract_pin_snippet()
+        + 'printf "%s" "${CLAUDE_CODE_VERSION}"\n'
+    )
+    env = {
+        **os.environ,
+        **_SECRET_ENV,
+        "PATH": f"{fake_bin}:{os.environ.get('PATH', '')}",
+    }
+    return PinHarness(
+        workdir=workdir,
+        resolver_env_json=resolver_env_json,
+        npm_env_txt=npm_env_txt,
+        npm_argv_txt=npm_argv_txt,
+        script=script,
+        env=env,
+    )
+
+
+def test_run_daily_installs_exactly_the_resolver_selected_version(
+    tmp_path: Path,
+) -> None:
+    harness = _build_harness(tmp_path, installed_version=RESOLVED_VERSION)
+    result = harness.run()
+    assert result.returncode == 0, (
+        f"pin snippet failed: stderr={result.stderr!r}"
+    )
+    assert result.stdout == RESOLVED_VERSION, (
+        f"CLAUDE_CODE_VERSION must be the resolver's output, got "
+        f"{result.stdout!r}"
+    )
+    argv = harness.npm_argv_txt.read_text().splitlines()
+    assert f"@anthropic-ai/claude-code@{RESOLVED_VERSION}" in argv, (
+        f"run_daily.sh must `npm install` the exact resolver-selected "
+        f"version; npm argv was {argv!r}"
+    )
+    assert "install" in argv
+    prefix = argv[argv.index("--prefix") + 1]
+    assert Path(prefix) == harness.workdir / "claude-cli", (
+        "the per-run install prefix must live inside ${WORKDIR} so the "
+        "cleanup trap removes it"
+    )
+    assert (
+        harness.workdir / "claude-cli" / "node_modules" / ".bin" / "claude"
+    ).exists()
+
+
+def test_resolver_and_npm_install_run_under_env_scrub(tmp_path: Path) -> None:
+    harness = _build_harness(tmp_path, installed_version=RESOLVED_VERSION)
+    result = harness.run()
+    assert result.returncode == 0, (
+        f"pin snippet failed: stderr={result.stderr!r}"
+    )
+
+    resolver_env = json.loads(harness.resolver_env_json.read_text())
+    npm_env = dict(
+        line.split("=", 1)
+        for line in harness.npm_env_txt.read_text().splitlines()
+        if "=" in line
+    )
+    probe_home = str(harness.workdir / "claude-probe-home")
+    for name, seen_env in (("resolver", resolver_env), ("npm", npm_env)):
+        for secret in _SECRET_ENV:
+            assert secret not in seen_env, (
+                f"run_daily.sh: the {name} step leaked {secret} through "
+                f"its `env -i` scrub. npm postinstall runs package code, "
+                f"which is exactly the supply-chain vector the 3-day "
+                f"buffer exists for."
+            )
+        assert seen_env.get("HOME") == probe_home, (
+            f"run_daily.sh: the {name} step must run under the isolated "
+            f"per-run HOME, not the runtime user's; got "
+            f"{seen_env.get('HOME')!r}"
+        )
+
+
+def test_probe_dies_when_installed_version_mismatches_resolved(
+    tmp_path: Path,
+) -> None:
+    harness = _build_harness(tmp_path, installed_version="9.9.9")
+    result = harness.run()
+    assert result.returncode != 0, (
+        "run_daily.sh must die when the claude binary on PATH does not "
+        "report the resolver-selected version; a silent pass here means "
+        "the 3-day security buffer is not actually enforced."
+    )
+    assert "9.9.9" in result.stderr
+    assert RESOLVED_VERSION in result.stderr
+
+
+def test_static_resolver_and_install_are_env_i_wrapped() -> None:
+    body = RUN_DAILY.read_text()
+    lines = _executable_lines(_extract_pin_snippet())
+    resolver_call = lines.index("pr_gate_version_resolver.py")
+    assert "env -i" in lines[:resolver_call], (
+        "run_daily.sh must run pr_gate_version_resolver.py under `env -i`"
+    )
+    install_call = lines.index('@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}')
+    assert "env -i" in lines[resolver_call:install_call], (
+        "run_daily.sh must run the npm install under its own `env -i`"
+    )
+    assert "claude" not in _required_commands(body), (
+        "run_daily.sh must not require a pre-provisioned `claude` on "
+        "PATH anymore; the pinned install provides it"
+    )
+    for required in ("npm", "python3"):
+        assert required in _required_commands(body)
+
+
+def _required_commands(body: str) -> tuple[str, ...]:
+    marker = "for cmd in "
+    start = body.index(marker) + len(marker)
+    end = body.index(";", start)
+    return tuple(body[start:end].split())

--- a/tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_pins_resolver_version.py
+++ b/tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_pins_resolver_version.py
@@ -20,6 +20,10 @@ flow in run_daily.sh:
   4. The install's bin dir reaches PATH only inside the two `env -i`
      blocks that spawn `claude` (probe and pytest), never at script
      scope where later git/gh/curl/uv steps run with the token env.
+  5. The npm install and the probe additionally run inside an
+     unprivileged user+pid namespace with a fresh /proc: env scrubbing
+     alone is not a boundary because same-uid package code can read
+     the secret-bearing parent's /proc/<pid>/environ.
 
 The resolve/install/probe block is extracted out of run_daily.sh and
 executed with a stub resolver and a fake `npm`, mirroring the fake-curl
@@ -156,6 +160,18 @@ def _build_harness(tmp_path: Path, installed_version: str) -> PinHarness:
     )
     fake_npm.chmod(0o755)
 
+    fake_unshare = fake_bin / "unshare"
+    fake_unshare.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            while [[ "${1:-}" == --* ]]; do shift; done
+            exec "$@"
+            """
+        )
+    )
+    fake_unshare.chmod(0o755)
+
     script = (
         _PREAMBLE
         + f'WORKDIR="{workdir}"\n'
@@ -291,6 +307,38 @@ def test_static_npm_bin_dir_scoped_to_probe_and_pytest_env_blocks() -> None:
             f"`gh` would then execute in later steps with the full "
             f"systemd-injected token environment."
         )
+
+
+def test_static_npm_install_and_probe_run_in_user_pid_namespace() -> None:
+    body = RUN_DAILY.read_text()
+    unshare_cmd = "unshare --user --map-current-user --pid --fork --mount-proc"
+    assert "unshare" in _required_commands(body), (
+        "run_daily.sh must require unshare up front and die early on "
+        "kernels that cannot create unprivileged user namespaces, "
+        "instead of degrading to unsandboxed package execution."
+    )
+    lines = _executable_lines(_extract_pin_snippet())
+    assert lines.count(unshare_cmd) == 2, (
+        "both package-code execution points (npm install and the claude "
+        "probe) must run inside the user+pid namespace; `env -i` alone "
+        "is not a boundary because same-uid package code can read the "
+        "secret-bearing parent's /proc/<pid>/environ."
+    )
+    resolver_call = _anchor(lines, "pr_gate_version_resolver.py")
+    npm_call = _anchor(lines, "npm install --prefix")
+    assert unshare_cmd in lines[resolver_call:npm_call], (
+        "the npm install (whose lifecycle scripts run package code) must "
+        "be unshare-wrapped"
+    )
+    probe_block = _executable_lines(
+        _extract_block(
+            body, "PROBED_CLAUDE_VERSION=", '[[ -n "${PROBED_CLAUDE_VERSION}" ]]'
+        )
+    )
+    assert _anchor(probe_block, unshare_cmd) < _anchor(probe_block, "claude --version"), (
+        "the installed claude binary must be spawned inside the "
+        "user+pid namespace"
+    )
 
 
 def _required_commands(body: str) -> tuple[str, ...]:

--- a/tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_pins_resolver_version.py
+++ b/tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_pins_resolver_version.py
@@ -17,6 +17,9 @@ flow in run_daily.sh:
      the supply-chain vector the 3-day buffer exists for.
   3. The `claude --version` probe verifies the binary now on PATH
      reports exactly the resolved version and dies on a mismatch.
+  4. The install's bin dir reaches PATH only inside the two `env -i`
+     blocks that spawn `claude` (probe and pytest), never at script
+     scope where later git/gh/curl/uv steps run with the token env.
 
 The resolve/install/probe block is extracted out of run_daily.sh and
 executed with a stub resolver and a fake `npm`, mirroring the fake-curl
@@ -31,6 +34,8 @@ import subprocess
 import textwrap
 from dataclasses import dataclass
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 RUN_DAILY = REPO_ROOT / "tests" / "e2e" / "claude_code" / "cron_vm" / "run_daily.sh"
@@ -52,11 +57,25 @@ _SECRET_ENV = {
 }
 
 
+def _anchor(text: str, needle: str, start: int = 0) -> int:
+    found = text.find(needle, start)
+    if found == -1:
+        pytest.fail(f"run_daily.sh anchor not found: {needle!r}")
+    return found
+
+
+def _extract_block(text: str, start_marker: str, end_marker: str) -> str:
+    start = _anchor(text, start_marker)
+    end = _anchor(text, end_marker, start)
+    return text[start:end]
+
+
 def _extract_pin_snippet() -> str:
-    body = RUN_DAILY.read_text()
-    start = body.index('CLAUDE_PROBE_HOME="${WORKDIR}/claude-probe-home"')
-    end = body.index('log "pinned claude code:')
-    return body[start:end]
+    return _extract_block(
+        RUN_DAILY.read_text(),
+        'CLAUDE_PROBE_HOME="${WORKDIR}/claude-probe-home"',
+        'log "pinned claude code:',
+    )
 
 
 def _executable_lines(block: str) -> str:
@@ -233,11 +252,11 @@ def test_probe_dies_when_installed_version_mismatches_resolved(
 def test_static_resolver_and_install_are_env_i_wrapped() -> None:
     body = RUN_DAILY.read_text()
     lines = _executable_lines(_extract_pin_snippet())
-    resolver_call = lines.index("pr_gate_version_resolver.py")
+    resolver_call = _anchor(lines, "pr_gate_version_resolver.py")
     assert "env -i" in lines[:resolver_call], (
         "run_daily.sh must run pr_gate_version_resolver.py under `env -i`"
     )
-    install_call = lines.index('@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}')
+    install_call = _anchor(lines, "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}")
     assert "env -i" in lines[resolver_call:install_call], (
         "run_daily.sh must run the npm install under its own `env -i`"
     )
@@ -249,8 +268,33 @@ def test_static_resolver_and_install_are_env_i_wrapped() -> None:
         assert required in _required_commands(body)
 
 
+def test_static_npm_bin_dir_scoped_to_probe_and_pytest_env_blocks() -> None:
+    body = RUN_DAILY.read_text()
+    _anchor(body, 'CLAUDE_CLI_BIN="${CLAUDE_CLI_PREFIX}/node_modules/.bin"')
+    prepend = 'PATH="${CLAUDE_CLI_BIN}:${PATH}"'
+    assert body.count(prepend) == 2, (
+        "run_daily.sh must prepend the npm install's bin dir in exactly "
+        "the two `env -i` blocks that spawn claude (version probe and "
+        "pytest); every other step (git, gh, curl, uv, docs publish) "
+        "must not see package-controlled binaries on PATH."
+    )
+    probe_block = _extract_block(
+        body, "PROBED_CLAUDE_VERSION=", '[[ -n "${PROBED_CLAUDE_VERSION}" ]]'
+    )
+    pytest_block = _extract_block(body, 'log "running pytest"', "PYTEST_EXIT=$?")
+    assert prepend in probe_block
+    assert prepend in pytest_block
+    for line in body.splitlines():
+        assert not line.startswith(("PATH=", "export PATH=")), (
+            f"run_daily.sh reassigns PATH at script scope: {line!r}. A "
+            f"compromised npm dependency shipping a bin named `git` or "
+            f"`gh` would then execute in later steps with the full "
+            f"systemd-injected token environment."
+        )
+
+
 def _required_commands(body: str) -> tuple[str, ...]:
     marker = "for cmd in "
-    start = body.index(marker) + len(marker)
-    end = body.index(";", start)
+    start = _anchor(body, marker) + len(marker)
+    end = _anchor(body, ";", start)
     return tuple(body[start:end].split())

--- a/tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_version_probe_scrubs_env.py
+++ b/tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_version_probe_scrubs_env.py
@@ -10,7 +10,7 @@ compromised `@anthropic-ai/claude-code` release could read those
 secrets out of `os.environ` before the proxy or test harness ever
 starts. The version probe must be wrapped in `env -i` with a minimal
 PATH/HOME/USER/TERM/LANG/LC_ALL/TMPDIR allowlist — matching the
-PR-gate's resolver/npm-install/pytest scrubs.
+resolver/npm-install/pytest scrubs in the same script.
 """
 
 from __future__ import annotations
@@ -23,8 +23,8 @@ RUN_DAILY = REPO_ROOT / "tests" / "e2e" / "claude_code" / "cron_vm" / "run_daily
 
 def _version_probe_block() -> str:
     body = RUN_DAILY.read_text()
-    start = body.index("CLAUDE_CODE_VERSION=")
-    end = body.index('[[ -n "${CLAUDE_CODE_VERSION}" ]]', start)
+    start = body.index("PROBED_CLAUDE_VERSION=")
+    end = body.index('[[ -n "${PROBED_CLAUDE_VERSION}" ]]', start)
     return body[start:end]
 
 

--- a/tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_version_probe_scrubs_env.py
+++ b/tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_version_probe_scrubs_env.py
@@ -17,14 +17,23 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[4]
 RUN_DAILY = REPO_ROOT / "tests" / "e2e" / "claude_code" / "cron_vm" / "run_daily.sh"
 
 
+def _anchor(text: str, needle: str, start: int = 0) -> int:
+    found = text.find(needle, start)
+    if found == -1:
+        pytest.fail(f"run_daily.sh anchor not found: {needle!r}")
+    return found
+
+
 def _version_probe_block() -> str:
     body = RUN_DAILY.read_text()
-    start = body.index("PROBED_CLAUDE_VERSION=")
-    end = body.index('[[ -n "${PROBED_CLAUDE_VERSION}" ]]', start)
+    start = _anchor(body, "PROBED_CLAUDE_VERSION=")
+    end = _anchor(body, '[[ -n "${PROBED_CLAUDE_VERSION}" ]]', start)
     return body[start:end]
 
 

--- a/tests/e2e/claude_code/cron_vm/run_daily.sh
+++ b/tests/e2e/claude_code/cron_vm/run_daily.sh
@@ -22,7 +22,7 @@
 # rather than spawning a new one. If the JSON is byte-identical to the
 # docs branch, we skip the push entirely.
 #
-# Required commands on $PATH: git, uv, gh, jq, curl, npm, python3.
+# Required commands on $PATH: git, uv, gh, jq, curl, npm, python3, unshare.
 # Required state: ~/litellm/litellm checked out (this file lives in it),
 # $WORKTREE is created on first run, gh is already authenticated.
 #
@@ -90,9 +90,12 @@ trap cleanup EXIT INT TERM
 log() { printf '==> %s\n' "$*" >&2; }
 die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
-for cmd in git uv gh jq curl npm python3; do
+for cmd in git uv gh jq curl npm python3 unshare; do
   command -v "${cmd}" >/dev/null 2>&1 || die "missing required command: ${cmd}"
 done
+
+unshare --user --map-current-user --pid --fork --mount-proc true 2>/dev/null \
+  || die "cannot create an unprivileged user+pid namespace (unshare --user --pid); refusing to run npm package code without one"
 
 # Publishing is from a fork (agent-shin/litellm-docs) so neither the cron
 # host nor the bot identity needs write access to BerriAI/litellm-docs. We
@@ -173,7 +176,13 @@ log "resolved litellm: ${LITELLM_VERSION}"
 # the proxy or test harness ever starts. Resolve, install, and probe
 # under `env -i` with the same minimal allowlist the pytest step below
 # uses (the matrix run itself goes through cli_driver.py, which already
-# scrubs the CLI env).
+# scrubs the CLI env). The env scrub alone is not a boundary, though:
+# package code still runs as the same uid and could read the secrets
+# straight out of this script's /proc/<pid>/environ. The two points
+# that execute package code (npm install with its lifecycle scripts,
+# and the installed `claude` binary) therefore also run inside an
+# unprivileged user+pid namespace with a freshly mounted /proc, in
+# which the secret-bearing parent process does not exist.
 #
 # These steps also run under a fresh empty HOME instead of the runtime
 # user's real $HOME. `ProtectHome=read-only` in the systemd unit
@@ -206,6 +215,7 @@ env -i \
   LANG="${LANG:-C.UTF-8}" \
   LC_ALL="${LC_ALL:-}" \
   TMPDIR="${TMPDIR:-/tmp}" \
+  unshare --user --map-current-user --pid --fork --mount-proc \
   npm install --prefix "${CLAUDE_CLI_PREFIX}" "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
   || die "npm install of @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} failed"
 CLAUDE_CLI_BIN="${CLAUDE_CLI_PREFIX}/node_modules/.bin"
@@ -218,6 +228,7 @@ PROBED_CLAUDE_VERSION="$(env -i \
   LANG="${LANG:-C.UTF-8}" \
   LC_ALL="${LC_ALL:-}" \
   TMPDIR="${TMPDIR:-/tmp}" \
+  unshare --user --map-current-user --pid --fork --mount-proc \
   claude --version 2>/dev/null \
   | grep -oE '[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?' \
   | head -n1 || true)"

--- a/tests/e2e/claude_code/cron_vm/run_daily.sh
+++ b/tests/e2e/claude_code/cron_vm/run_daily.sh
@@ -208,10 +208,10 @@ env -i \
   TMPDIR="${TMPDIR:-/tmp}" \
   npm install --prefix "${CLAUDE_CLI_PREFIX}" "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
   || die "npm install of @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} failed"
-PATH="${CLAUDE_CLI_PREFIX}/node_modules/.bin:${PATH}"
+CLAUDE_CLI_BIN="${CLAUDE_CLI_PREFIX}/node_modules/.bin"
 
 PROBED_CLAUDE_VERSION="$(env -i \
-  PATH="${PATH}" \
+  PATH="${CLAUDE_CLI_BIN}:${PATH}" \
   HOME="${CLAUDE_PROBE_HOME}" \
   USER="${USER:-mateo}" \
   TERM="${TERM:-dumb}" \
@@ -422,7 +422,7 @@ set +e
 (
   cd "${WORKTREE}" \
     && env -i \
-       PATH="${PATH}" \
+       PATH="${CLAUDE_CLI_BIN}:${PATH}" \
        HOME="${HOME}" \
        USER="${USER:-mateo}" \
        TERM="${TERM:-dumb}" \

--- a/tests/e2e/claude_code/cron_vm/run_daily.sh
+++ b/tests/e2e/claude_code/cron_vm/run_daily.sh
@@ -22,7 +22,7 @@
 # rather than spawning a new one. If the JSON is byte-identical to the
 # docs branch, we skip the push entirely.
 #
-# Required commands on $PATH: git, uv, gh, jq, curl, claude.
+# Required commands on $PATH: git, uv, gh, jq, curl, npm, python3.
 # Required state: ~/litellm/litellm checked out (this file lives in it),
 # $WORKTREE is created on first run, gh is already authenticated.
 #
@@ -90,7 +90,7 @@ trap cleanup EXIT INT TERM
 log() { printf '==> %s\n' "$*" >&2; }
 die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
-for cmd in git uv gh jq curl claude; do
+for cmd in git uv gh jq curl npm python3; do
   command -v "${cmd}" >/dev/null 2>&1 || die "missing required command: ${cmd}"
 done
 
@@ -165,26 +165,52 @@ log "resolved litellm: ${LITELLM_VERSION}"
 
 # The systemd unit loads provider credentials and the agent-shin GitHub
 # token from /etc/litellm-compat-matrix.env into this script's
-# environment. Running the npm-installed `claude` binary directly here
-# would hand that full env to package code -- a compromised
-# @anthropic-ai/claude-code release could read ANTHROPIC_API_KEY /
-# AWS_BEARER_TOKEN_BEDROCK / AZURE_FOUNDRY_API_KEY /
+# environment. Running npm install or the npm-installed `claude` binary
+# directly here would hand that full env to package code -- a
+# compromised @anthropic-ai/claude-code release could read
+# ANTHROPIC_API_KEY / AWS_BEARER_TOKEN_BEDROCK / AZURE_FOUNDRY_API_KEY /
 # AGENT_SHIN_GITHUB_TOKEN from os.environ and exfiltrate them before
-# the proxy or test harness ever starts. Probe under `env -i` with the
-# same minimal allowlist the PR-gate uses (the matrix run itself goes
-# through cli_driver.py, which already scrubs the CLI env).
+# the proxy or test harness ever starts. Resolve, install, and probe
+# under `env -i` with the same minimal allowlist the pytest step below
+# uses (the matrix run itself goes through cli_driver.py, which already
+# scrubs the CLI env).
 #
-# The probe also runs under a fresh empty HOME instead of the runtime
+# These steps also run under a fresh empty HOME instead of the runtime
 # user's real $HOME. `ProtectHome=read-only` in the systemd unit
 # blocks *writes* to /home/mateo but still allows reads, so a
 # compromised claude package invoked here with HOME=/home/mateo could
 # read ~/.config/gh/hosts.yml (the gh-host token), ~/.bash_history,
 # or ~/.ssh/. Pointing HOME at a per-run dir under ${WORKDIR} hides
 # those entirely from the subprocess; ${WORKDIR} is rm -rf'd by the
-# script-wide cleanup() trap regardless of probe outcome.
+# script-wide cleanup() trap regardless of outcome.
 CLAUDE_PROBE_HOME="${WORKDIR}/claude-probe-home"
 mkdir -p "${CLAUDE_PROBE_HOME}"
 CLAUDE_CODE_VERSION="$(env -i \
+  PATH="${PATH}" \
+  HOME="${CLAUDE_PROBE_HOME}" \
+  USER="${USER:-mateo}" \
+  TERM="${TERM:-dumb}" \
+  LANG="${LANG:-C.UTF-8}" \
+  LC_ALL="${LC_ALL:-}" \
+  TMPDIR="${TMPDIR:-/tmp}" \
+  python3 "${POPULATOR_DIR}/../pr_gate_version_resolver.py")"
+[[ -n "${CLAUDE_CODE_VERSION}" ]] || die "pr_gate_version_resolver.py printed an empty version"
+log "resolved claude code: ${CLAUDE_CODE_VERSION}"
+
+CLAUDE_CLI_PREFIX="${WORKDIR}/claude-cli"
+env -i \
+  PATH="${PATH}" \
+  HOME="${CLAUDE_PROBE_HOME}" \
+  USER="${USER:-mateo}" \
+  TERM="${TERM:-dumb}" \
+  LANG="${LANG:-C.UTF-8}" \
+  LC_ALL="${LC_ALL:-}" \
+  TMPDIR="${TMPDIR:-/tmp}" \
+  npm install --prefix "${CLAUDE_CLI_PREFIX}" "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+  || die "npm install of @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} failed"
+PATH="${CLAUDE_CLI_PREFIX}/node_modules/.bin:${PATH}"
+
+PROBED_CLAUDE_VERSION="$(env -i \
   PATH="${PATH}" \
   HOME="${CLAUDE_PROBE_HOME}" \
   USER="${USER:-mateo}" \
@@ -199,8 +225,10 @@ CLAUDE_CODE_VERSION="$(env -i \
 # `grep` finds no match (exit 1) — without it the assignment inherits the
 # pipeline's non-zero exit, `set -e` kills the script, and the operator
 # never sees the helpful diagnostic below.
-[[ -n "${CLAUDE_CODE_VERSION}" ]] || die "could not parse semver from 'claude --version'"
-log "local claude code: ${CLAUDE_CODE_VERSION}"
+[[ -n "${PROBED_CLAUDE_VERSION}" ]] || die "could not parse semver from 'claude --version'"
+[[ "${PROBED_CLAUDE_VERSION}" == "${CLAUDE_CODE_VERSION}" ]] \
+  || die "claude on PATH reports ${PROBED_CLAUDE_VERSION}, expected pinned ${CLAUDE_CODE_VERSION}"
+log "pinned claude code: ${CLAUDE_CODE_VERSION}"
 
 # ---------------------------------------------------------------------------
 # 2. Update the worktree to that tag
@@ -385,9 +413,8 @@ set +e
 #   2. a model-directed `Read` tool call during a PDF/vision cell
 #      cannot reach /proc/<pytest-pid>/environ and pull the creds out
 #      of the parent process the way it can today;
-#   3. this matches the PR-gate pytest step in `.circleci/config.yml`,
-#      which already runs under `env -i` with the same minimal
-#      allowlist.
+#   3. this matches the resolver/npm-install/probe steps above, which
+#      already run under `env -i` with the same minimal allowlist.
 #
 # `cli_driver.py` re-allowlists its own subset (PATH/USER/LOGNAME/etc.)
 # when spawning the `claude` binary, so the CLI still finds Node + the

--- a/tests/e2e/claude_code/pr_gate_version_resolver.py
+++ b/tests/e2e/claude_code/pr_gate_version_resolver.py
@@ -1,23 +1,24 @@
 """Claude Code PR-Gate Version Resolver.
 
-Resolves the `@anthropic-ai/claude-code` npm version that the PR-gate CI
-job installs. Selects the newest version (by publish timestamp) whose
-publish timestamp is at least 3 days old. The 3-day window is a security
-review buffer — see PRD #26476, "Version resolvers".
+Resolves the `@anthropic-ai/claude-code` npm version that the daily
+compatibility-matrix runner installs. Selects the newest version (by
+publish timestamp) whose publish timestamp is at least 3 days old. The
+3-day window is a security review buffer — see PRD #26476, "Version
+resolvers".
 
 Two surfaces:
 
 - ``resolve_pr_gate_version(...)`` — the importable function. Accepts
   pre-fetched npm metadata (for unit tests) or a custom ``fetcher``
   callable. The default fetcher hits the public npm registry.
-- ``python -m claude_code.pr_gate_version_resolver`` — prints the
-  resolved version string to stdout, suitable for piping into a shell
-  ``$(...)`` substitution inside the CircleCI job.
+- ``python3 pr_gate_version_resolver.py`` — prints the resolved version
+  string to stdout, suitable for piping into a shell ``$(...)``
+  substitution.
 
-The CLI form is what CircleCI runs at job start; engineers reading the
-job log can see the selected version on a single line above the
-``npm install -g`` step (acceptance criterion: "the selected Claude
-Code version is logged in the CI output").
+The CLI form is what ``cron_vm/run_daily.sh`` runs at the start of each
+daily run; engineers reading the run log can see the selected version
+on a single line above the ``npm install`` step (acceptance criterion:
+"the selected Claude Code version is logged in the CI output").
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Relevant issues

Resolves caveat 6 of #32548 ("Caveats I could not fix in this move"): dropping the per-PR CircleCI compat gate left `pr_gate_version_resolver.py`'s 72-hour publish-age selection (PRD #26476) with no automated consumer, so `run_daily.sh` probed whatever `claude` happened to be on the cron VM's PATH and the security-review buffer gated nothing

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`run_daily.sh` targets the Linux cron VM (systemd unit, GCP), so a full script run is not possible on this macOS host. The proof below exercises the new resolve, pin, and verify steps end to end with the exact commands the script now runs, against the real npm registry

Before, captured at c6d49a85b2 (the base commit): the script never resolves or installs anything, and the probe picks up whatever `claude` is on PATH; on this host that is 2.1.211, published hours ago and squarely inside the 3-day window the buffer is supposed to enforce

```
$ git show c6d49a85b2:tests/e2e/claude_code/cron_vm/run_daily.sh | grep -cE "pr_gate_version_resolver|npm install"
0

$ claude --version        # what the pre-fix probe reports as CLAUDE_CODE_VERSION
2.1.211 (Claude Code)
```

After, captured at 8220c57468. Step 1, the resolver selects the newest version published at least 3 days ago

```
$ python3 tests/e2e/claude_code/pr_gate_version_resolver.py
pr_gate_version_resolver: selected @anthropic-ai/claude-code@2.1.207
2.1.207
```

Step 2, registry timestamps confirm 2.1.207 (published 2026-07-10, 5 days old) is the correct pick while four newer versions exist but are all under 3 days old

```
$ npm view @anthropic-ai/claude-code time --json \
    | jq 'to_entries | map(select(.key | test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))) | sort_by(.value) | .[-6:] | from_entries'
{
  "2.1.206": "2026-07-09T17:54:03.009Z",
  "2.1.207": "2026-07-10T22:25:09.430Z",
  "2.1.208": "2026-07-13T21:31:27.921Z",
  "2.1.209": "2026-07-14T04:45:37.792Z",
  "2.1.210": "2026-07-14T19:39:21.730Z",
  "2.1.211": "2026-07-15T19:24:07.013Z"
}

$ date -u +"%Y-%m-%dT%H:%M:%SZ"
2026-07-15T23:28:50Z
```

Step 3, installing exactly that version into a throwaway prefix and probing it, as the script does per run

```
$ npm install --prefix "$SCRATCH" @anthropic-ai/claude-code@2.1.207
added 2 packages in 2s

$ "$SCRATCH/node_modules/.bin/claude" --version
2.1.207 (Claude Code)
```

(The install printed an EBADENGINE warning because this host runs node v20 while the package wants >=22; it is a non-fatal warning and the cron VM's node is not affected by this PR)

The namespace isolation was validated at eebf94132f on a real Linux kernel (6.8, Ubuntu, local colima VM) in a node:22 container as unprivileged uid 1000, with the secrets injected into the parent bash's environment the same way the systemd unit injects them. First the vulnerability, then the fix, then the exact production incantation

```
== 1. env -i alone is not a boundary: same-uid child still reads the secret-bearing parent's environ
$ env -i PATH="$PATH" bash -c 'grep -sal super-secret-token /proc/*/environ || true'
/proc/14/environ

== 2. inside the user+pid namespace the parent does not exist and the secret is unreachable
$ env -i PATH="$PATH" unshare --user --map-current-user --pid --fork --mount-proc \
    bash -c 'echo "pids visible in fresh /proc: $(ls /proc | grep -cE "^[0-9]+$")"; grep -sal super-secret-token /proc/*/environ || echo "secret unreachable"'
pids visible in fresh /proc: 4
secret unreachable

== 3. exact production incantation: npm install then probe, both env -i + unshare
$ env -i PATH="$PATH" HOME="$CLAUDE_PROBE_HOME" USER=node TERM=dumb LANG=C.UTF-8 LC_ALL= TMPDIR=/tmp \
    unshare --user --map-current-user --pid --fork --mount-proc \
    npm install --prefix "$CLAUDE_CLI_PREFIX" @anthropic-ai/claude-code@2.1.207
added 2 packages in 4s
$ env -i PATH="$CLAUDE_CLI_BIN:$PATH" HOME="$CLAUDE_PROBE_HOME" USER=node TERM=dumb LANG=C.UTF-8 LC_ALL= TMPDIR=/tmp \
    unshare --user --map-current-user --pid --fork --mount-proc \
    claude --version
2.1.207 (Claude Code)
install written as uid 1000 (node), --map-current-user kept it writable
```

One validation gap: the container host needed `kernel.apparmor_restrict_unprivileged_userns=0` for the run above (Ubuntu's default of 1 makes the uid_map write fail with EPERM, which the script's preflight turns into a clear die). Before enabling the timer, smoke-test on the actual VM as the runtime user with `unshare --user --map-current-user --pid --fork --mount-proc bash -c 'grep -sal . /proc/*/environ || echo isolated'`; if the preflight die fires instead, apply the sysctl or AppArmor exception described under Changes

## Type

🐛 Bug Fix

## Changes

`run_daily.sh` now resolves the target Claude Code version by running `pr_gate_version_resolver.py` from the dev checkout, npm-installs exactly `@anthropic-ai/claude-code@<resolved>` into a per-run prefix under `${WORKDIR}` (removed by the existing cleanup trap), and exposes that install's `node_modules/.bin` (captured once as `CLAUDE_CLI_BIN`) only inside the two `env -i` blocks that spawn `claude`: the version probe and the pytest invocation, whose `cli_driver.py` re-derives its own allowlist from the pytest env. No other step (git, gh with the agent token, curl, jq, uv sync, the docs publish) sees package-controlled binaries on PATH, and PATH is never reassigned at script scope. The existing `claude --version` probe became a verification: the run dies if the probed semver differs from the resolved version

Both the resolver and the npm install run under the script's existing `env -i` minimal allowlist with the isolated per-run HOME. npm postinstall executes package code, which is precisely the supply-chain vector the 3-day buffer exists for, so it must never see the systemd-injected provider and agent tokens

The env scrub alone is not a boundary though: package code still runs as the same uid and could read the secrets straight out of the script's own /proc/pid/environ. The two points that execute package code (the npm install with its lifecycle scripts, and the installed `claude` binary during the probe) therefore also run inside `unshare --user --map-current-user --pid --fork --mount-proc`, an unprivileged user+pid namespace with a freshly mounted /proc in which the secret-bearing parent process does not exist. The resolver stays outside the namespace since it is our own stdlib-only code. `unshare` joined the required-commands loop and a preflight check dies with a clear diagnostic on kernels that restrict unprivileged user namespaces, so the script fails closed instead of silently degrading to unsandboxed package execution. Note for deployment: Ubuntu 23.10+ ships `kernel.apparmor_restrict_unprivileged_userns=1` by default, which makes the preflight die; the VM needs that sysctl set to 0 or an AppArmor profile granting `userns` to the service (Debian has no such restriction). The remaining same-uid exposure while the pytest CLI cells run is pre-existing to this PR and belongs to a follow-up (uid separation via a split systemd unit)

Caveat 6 of #32548 asked for the resolver to be wired in "behind a checksum-pinned install". A static in-repo checksum cannot work here because the resolved version changes daily; the equivalent control is that an exact-version `npm install @anthropic-ai/claude-code@X.Y.Z` is integrity-verified by npm against the sha512 the registry packument declares for that version, so the installed artifact is pinned to the resolved, 3-day-aged release

The required-command loop drops `claude` (the pinned install now provides it) and adds `npm` and `python3`, with the header comment updated to match. Comments that referenced the deleted CircleCI PR gate as if it still existed were corrected in the files this PR touches: the pytest env-scrub rationale in `run_daily.sh` and the module docstring in `pr_gate_version_resolver.py`, which now names the daily runner as the consumer

Tests: `_publisher_unit_tests/test_run_daily_pins_resolver_version.py` extracts the resolve/install/probe block out of `run_daily.sh` and executes it with a stub resolver and a fake `npm` (mirroring the fake-curl technique in `test_run_daily_release_pagination.py`), covering the exact-version install into the per-run prefix, the env scrub plus isolated HOME on both the resolver and npm steps, and the die-on-mismatch verification; structural tests pin the `env -i` wrapping, the user+pid namespace wrapping of both package-code execution points (the extracted block executes with a fake `unshare` stub that drops the flags and execs the rest), the required-command swap, and that the npm bin dir reaches PATH in exactly the two claude-spawning `env -i` blocks with no script-scope PATH reassignment. Each fails against the code it guards pre-fix. Anchor lookups into the script fail via `pytest.fail` naming the missing line instead of raising a bare ValueError. `test_run_daily_version_probe_scrubs_env.py`'s extraction markers track the probe's rename to `PROBED_CLAUDE_VERSION`

## QA runbook

Prerequisites: network access to registry.npmjs.org; no proxy or provider credentials needed, these are publisher script tests. Note the two pre-existing `test_run_daily_release_pagination.py` execution tests fail on macOS because `/bin/bash` 3.2 rejects empty-array expansion under `set -u`; they pass on Linux CI and are untouched by this PR

- tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_pins_resolver_version.py::test_run_daily_installs_exactly_the_resolver_selected_version - the resolve/pin block installs exactly the resolver-selected version into `${WORKDIR}/claude-cli`
  - [ ] Run `python3 tests/e2e/claude_code/pr_gate_version_resolver.py` and note the version printed to stdout
  - [ ] Run `WORKDIR=$(mktemp -d)` then the section of `run_daily.sh` between `CLAUDE_PROBE_HOME=` and `log "pinned claude code:` with `POPULATOR_DIR=tests/e2e/claude_code/cron_vm`
  - [ ] Expect `${WORKDIR}/claude-cli/node_modules/.bin/claude --version` to report exactly the resolver's version
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (it asserts the exact npm package spec, prefix path, and resolved version) or potentially flaky

- tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_pins_resolver_version.py::test_resolver_and_npm_install_run_under_env_scrub - neither the resolver nor npm sees the systemd-injected credentials or the real HOME
  - [ ] `export ANTHROPIC_API_KEY=canary AGENT_SHIN_GITHUB_TOKEN=canary` before running the same section
  - [ ] Put a stub `npm` first on PATH that dumps `env` to a file (this is what the test automates), then run the section
  - [ ] Expect the dump to contain neither canary value and `HOME` to equal `${WORKDIR}/claude-probe-home`
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky

- tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_pins_resolver_version.py::test_probe_dies_when_installed_version_mismatches_resolved - the probe is now a verification that kills the run on drift
  - [ ] Make the stub `npm` write a `claude` that echoes `9.9.9 (Claude Code)` regardless of the requested version
  - [ ] Re-run the section; expect exit 1 and stderr containing `claude on PATH reports 9.9.9, expected pinned <resolved>`
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky

- tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_pins_resolver_version.py::test_static_resolver_and_install_are_env_i_wrapped - structural pin on the `env -i` wrapping and the required-command swap
  - [ ] `grep -n 'env -i' tests/e2e/claude_code/cron_vm/run_daily.sh` and confirm the resolver and npm-install invocations sit inside `env -i` blocks
  - [ ] `grep -n 'for cmd in' tests/e2e/claude_code/cron_vm/run_daily.sh` shows `git uv gh jq curl npm python3` with no `claude`
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky

- tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_pins_resolver_version.py::test_static_npm_bin_dir_scoped_to_probe_and_pytest_env_blocks - the pinned install's bin dir is visible only to the two `env -i` blocks that spawn `claude`
  - [ ] Run `grep -c 'PATH="${CLAUDE_CLI_BIN}:${PATH}"' tests/e2e/claude_code/cron_vm/run_daily.sh` and expect 2, one inside the probe block and one inside the pytest block
  - [ ] Run `grep -n '^PATH=\|^export PATH=' tests/e2e/claude_code/cron_vm/run_daily.sh` and expect no output, so git, gh, curl, uv, and the docs publish never run with npm-controlled binaries first on PATH
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky

- tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_pins_resolver_version.py::test_static_npm_install_and_probe_run_in_user_pid_namespace - both package-code execution points are unshare-wrapped and the script requires unshare up front
  - [ ] Run `grep -c 'unshare --user --map-current-user --pid --fork --mount-proc' tests/e2e/claude_code/cron_vm/run_daily.sh` and expect 3 (preflight, npm install, probe)
  - [ ] Confirm the required-commands loop lists `unshare` and the preflight `unshare ... true || die` sits right below it
  - [ ] On a Linux box, repeat the two-command demonstration from the proof section: without unshare the parent environ is greppable, inside it the secret is unreachable
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky

- tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_version_probe_scrubs_env.py (updated) - the probe-scrub pins still hold against the renamed `PROBED_CLAUDE_VERSION` block
  - [ ] Run `pytest tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_version_probe_scrubs_env.py -q` and expect all 3 tests to pass
  - [ ] Confirm the extracted block in the test now starts at `PROBED_CLAUDE_VERSION=` so it still covers the actual `claude --version` invocation
  - [ ] Sanity check: this test makes sense to keep and is not hand-wavey or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

