### PR TITLE
feat(ui): show exact license expiration date in usage cards

### DIFF
--- a/ui/litellm-dashboard/src/components/SidebarUsageCard.test.tsx
+++ b/ui/litellm-dashboard/src/components/SidebarUsageCard.test.tsx
@@ -128,6 +128,29 @@ describe("SidebarUsageCard", () => {
     expect(container.querySelector('[data-slot="meter"]')).toBeNull();
   });
 
+  it("shows the exact license expiration date as the subtitle instead of time remaining", async () => {
+    mockUseLicenseInfo.mockReturnValue(licenseResult({ ...ACTIVE_LICENSE, expiration_date: "2099-12-31" }));
+
+    renderWithClient(<SidebarUsageCard accessToken="token" collapsed={false} onExpandRail={() => {}} />);
+
+    expect(await screen.findByText("Expires Dec 31, 2099")).toBeInTheDocument();
+    expect(screen.queryByText(/(day|days|month|months) remaining/)).not.toBeInTheDocument();
+  });
+
+  it("shows the exact date as the subtitle when the license is expired", async () => {
+    mockUseLicenseInfo.mockReturnValue(licenseResult({ ...ACTIVE_LICENSE, expiration_date: "2020-01-01" }));
+
+    renderWithClient(<SidebarUsageCard accessToken="token" collapsed={false} onExpandRail={() => {}} />);
+
+    expect(await screen.findByText("Expired Jan 1, 2020")).toBeInTheDocument();
+  });
+
+  it("falls back to Active plan when the license has no expiration date", async () => {
+    renderWithClient(<SidebarUsageCard accessToken="token" collapsed={false} onExpandRail={() => {}} />);
+
+    expect(await screen.findByText("Active plan")).toBeInTheDocument();
+  });
+
   it("shows a collapsed rail button that expands the sidebar", async () => {
     const onExpandRail = vi.fn();
     const user = userEvent.setup();

--- a/ui/litellm-dashboard/src/components/SidebarUsageCard.tsx
+++ b/ui/litellm-dashboard/src/components/SidebarUsageCard.tsx
@@ -1,6 +1,6 @@
 import { useDisableUsageIndicator } from "@/app/(dashboard)/hooks/useDisableUsageIndicator";
 import { useLicenseInfo } from "@/app/(dashboard)/hooks/license/useLicenseInfo";
-import { getDaysUntilExpiration } from "@/utils/licenseUtils";
+import { formatExpirationStatus } from "@/utils/licenseUtils";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Meter, MeterIndicator, MeterLabel, MeterTrack } from "@/components/ui/meter";
@@ -19,16 +19,6 @@ interface MeterData {
   used: number;
   total: number;
 }
-
-const formatExpiration = (daysRemaining: number | null): string => {
-  if (daysRemaining === null) return "No expiration";
-  if (daysRemaining < 0) return "Expired";
-  if (daysRemaining === 0) return "Expires today";
-  if (daysRemaining === 1) return "1 day remaining";
-  if (daysRemaining < 30) return `${daysRemaining} days remaining`;
-  if (daysRemaining < 60) return "1 month remaining";
-  return `${Math.floor(daysRemaining / 30)} months remaining`;
-};
 
 const meterTone = (pct: number): "default" | "warning" | "over" => {
   if (pct > 100) return "over";
@@ -104,8 +94,7 @@ export default function SidebarUsageCard({ accessToken, collapsed, onExpandRail 
     );
   }
 
-  const daysUntilExpiration = licenseInfo?.expiration_date ? getDaysUntilExpiration(licenseInfo.expiration_date) : null;
-  const subtitle = licenseInfo?.expiration_date ? formatExpiration(daysUntilExpiration) : "Active plan";
+  const subtitle = licenseInfo?.expiration_date ? formatExpirationStatus(licenseInfo.expiration_date) : "Active plan";
   const meters = buildMeters(data);
 
   return (

--- a/ui/litellm-dashboard/src/components/UsageIndicator.test.tsx
+++ b/ui/litellm-dashboard/src/components/UsageIndicator.test.tsx
@@ -14,9 +14,19 @@ vi.mock("@/app/(dashboard)/hooks/useDisableUsageIndicator", () => ({
   useDisableUsageIndicator: vi.fn(() => false),
 }));
 
-import { getRemainingUsers } from "./networking";
+import { getLicenseInfo, getRemainingUsers } from "./networking";
+import type { LicenseInfo } from "./networking";
 
 const mockGetRemainingUsers = vi.mocked(getRemainingUsers);
+const mockGetLicenseInfo = vi.mocked(getLicenseInfo);
+
+const licenseWithExpiry = (expiration_date: string): LicenseInfo => ({
+  has_license: true,
+  license_type: "enterprise",
+  expiration_date,
+  allowed_features: [],
+  limits: { max_users: null, max_teams: null },
+});
 
 const renderWithClient = (ui: React.ReactElement) => {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -36,6 +46,7 @@ describe("UsageIndicator", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetRemainingUsers.mockResolvedValue(DEFAULT_USAGE_DATA);
+    mockGetLicenseInfo.mockResolvedValue(null);
   });
 
   it("should render when given access token and usage data loads", async () => {
@@ -124,6 +135,23 @@ describe("UsageIndicator", () => {
 
     expect(screen.getByText("Teams")).toBeInTheDocument();
     expect(screen.getByText("Over limit")).toBeInTheDocument();
+  });
+
+  it("should show the exact license expiration date instead of time remaining", async () => {
+    mockGetLicenseInfo.mockResolvedValue(licenseWithExpiry("2099-12-31"));
+
+    renderWithClient(<UsageIndicator accessToken="token" width={220} />);
+
+    expect(await screen.findByText("Expires Dec 31, 2099")).toBeInTheDocument();
+    expect(screen.queryByText(/(day|days|month|months) remaining/)).not.toBeInTheDocument();
+  });
+
+  it("should show the exact date when the license is expired", async () => {
+    mockGetLicenseInfo.mockResolvedValue(licenseWithExpiry("2020-01-01"));
+
+    renderWithClient(<UsageIndicator accessToken="token" width={220} />);
+
+    expect(await screen.findByText("Expired Jan 1, 2020")).toBeInTheDocument();
   });
 
   it("should render nothing when accessToken is null", () => {

--- a/ui/litellm-dashboard/src/components/UsageIndicator.tsx
+++ b/ui/litellm-dashboard/src/components/UsageIndicator.tsx
@@ -15,7 +15,7 @@ import { useEffect, useState } from "react";
 import { getRemainingUsers } from "./networking";
 
 import { cn } from "@/lib/cva.config";
-import { getDaysUntilExpiration } from "@/utils/licenseUtils";
+import { formatExpirationStatus, getDaysUntilExpiration } from "@/utils/licenseUtils";
 import { useLicenseInfo } from "@/app/(dashboard)/hooks/license/useLicenseInfo";
 
 interface UsageIndicatorProps {
@@ -31,18 +31,6 @@ interface UsageData {
   total_teams_used: number;
   total_teams_remaining: number | null;
 }
-
-// Format expiration for display
-const formatExpirationDisplay = (daysRemaining: number | null): string => {
-  if (daysRemaining === null) return "No expiration";
-  if (daysRemaining < 0) return "Expired";
-  if (daysRemaining === 0) return "Expires today";
-  if (daysRemaining === 1) return "1 day remaining";
-  if (daysRemaining < 30) return `${daysRemaining} days remaining`;
-  if (daysRemaining < 60) return "1 month remaining";
-  const months = Math.floor(daysRemaining / 30);
-  return `${months} months remaining`;
-};
 
 export default function UsageIndicator({ accessToken, width = 220 }: UsageIndicatorProps) {
   const disableUsageIndicator = useDisableUsageIndicator();
@@ -292,7 +280,7 @@ export default function UsageIndicator({ accessToken, width = 220 }: UsageIndica
                   ) : isLicenseExpiringSoon ? (
                     <TrendingUp className="h-3 w-3" />
                   ) : null}
-                  <span className="truncate">{formatExpirationDisplay(daysUntilExpiration)}</span>
+                  <span className="truncate">{formatExpirationStatus(licenseInfo.expiration_date)}</span>
                 </div>
               </div>
             )}
@@ -529,7 +517,7 @@ export default function UsageIndicator({ accessToken, width = 220 }: UsageIndica
                     isLicenseExpiringSoon && "text-yellow-600",
                   )}
                 >
-                  {formatExpirationDisplay(daysUntilExpiration)}
+                  {formatExpirationStatus(licenseInfo.expiration_date)}
                 </span>
               </div>
               {licenseInfo.license_type && (

--- a/ui/litellm-dashboard/src/utils/licenseUtils.test.ts
+++ b/ui/litellm-dashboard/src/utils/licenseUtils.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { type LicenseExpiryTier, formatExpiryDate, getDaysUntilExpiration, getLicenseExpiryTier } from "./licenseUtils";
+import {
+  type LicenseExpiryTier,
+  formatExpirationStatus,
+  formatExpiryDate,
+  getDaysUntilExpiration,
+  getLicenseExpiryTier,
+} from "./licenseUtils";
 
 const NOW = new Date("2026-07-08T00:00:00Z");
 
@@ -57,5 +63,27 @@ describe("formatExpiryDate", () => {
 
   it("returns the input unchanged when unparseable", () => {
     expect(formatExpiryDate("bogus")).toBe("bogus");
+  });
+});
+
+describe("formatExpirationStatus", () => {
+  it("shows the exact date for a future expiration", () => {
+    expect(formatExpirationStatus("2026-08-07", NOW)).toBe("Expires Aug 7, 2026");
+  });
+
+  it("still reads as upcoming on the expiration day itself", () => {
+    expect(formatExpirationStatus("2026-07-08", NOW)).toBe("Expires Jul 8, 2026");
+  });
+
+  it("shows the exact date for a past expiration", () => {
+    expect(formatExpirationStatus("2026-07-07", NOW)).toBe("Expired Jul 7, 2026");
+  });
+
+  it("returns No expiration for a null date", () => {
+    expect(formatExpirationStatus(null, NOW)).toBe("No expiration");
+  });
+
+  it("returns No expiration for an unparseable date", () => {
+    expect(formatExpirationStatus("not-a-date", NOW)).toBe("No expiration");
   });
 });

--- a/ui/litellm-dashboard/src/utils/licenseUtils.ts
+++ b/ui/litellm-dashboard/src/utils/licenseUtils.ts
@@ -49,3 +49,11 @@ export const formatExpiryDate = (expirationDate: string): string => {
   }
   return date.toLocaleDateString("en-US", EXPIRY_DATE_FORMAT);
 };
+
+export const formatExpirationStatus = (expirationDate: string | null, now: Date = new Date()): string => {
+  const days = getDaysUntilExpiration(expirationDate, now);
+  if (expirationDate === null || days === null) {
+    return "No expiration";
+  }
+  return days < 0 ? `Expired ${formatExpiryDate(expirationDate)}` : `Expires ${formatExpiryDate(expirationDate)}`;
+};


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3319

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Steps to verify against a live proxy (screenshots to be added after running them):

1. Start the proxy with `LITELLM_LICENSE` set to a license that carries an expiration date, e.g. `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug`
2. Start the dashboard dev server: `npm run dev` in `ui/litellm-dashboard`, then open http://localhost:3000/ui and log in
3. Look at the "Enterprise usage" card docked at the bottom of the left sidebar: the subtitle now reads "Expires Jan 5, 2027" (the exact date from `/health/license`) instead of "7 months remaining"
4. For an expired license the subtitle reads "Expired Jan 5, 2026" instead of "Expired"

## Type

🆕 New Feature

## Changes

The usage card in the sidebar showed license expiration only as relative time ("1 month remaining"), so answering "when exactly does our license expire" required decoding the license key. It now shows the exact date from `/health/license`: "Expires Jan 5, 2027", or "Expired Jan 5, 2026" once past

`SidebarUsageCard` and the older `UsageIndicator` each had their own copy of the relative formatter; both copies are deleted and replaced with a single `formatExpirationStatus` helper in `licenseUtils.ts`, next to the existing `formatExpiryDate` the expiry banner already uses. Unit tests pin the new helper (future, same-day, past, null, and unparseable dates) and component tests assert both cards render the absolute date and no longer render "N months remaining"

<img width="304" height="222" alt="image" src="https://github.com/user-attachments/assets/1ac0631b-2e51-4522-827e-9be1ffc5e101" />
