### PR TITLE
fix(logging): classify anthropic_messages as async so CustomLogger hooks fire exactly once

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -344,6 +344,7 @@ class Logging(LiteLLMLoggingBaseClass):
         self.stream = stream
         self.start_time = start_time  # log the call start time
         self.call_type = call_type
+        self.is_async_entrypoint: Optional[bool] = None
         self.litellm_call_id = litellm_call_id
         self.litellm_trace_id: str = litellm_trace_id if litellm_trace_id else str(uuid.uuid4())
         self.function_id = function_id
@@ -1520,15 +1521,15 @@ class Logging(LiteLLMLoggingBaseClass):
     ) -> Optional[float]:
         return self._response_cost_calculator(result=result, cache_hit=cache_hit)
 
-    @staticmethod
-    def _is_sync_litellm_request(litellm_params: dict, call_type: Optional[str]) -> bool:
+    def _is_sync_litellm_request(self, litellm_params: dict) -> bool:
         """True for sync SDK entrypoints (``completion``), false for async (``acompletion``, etc.).
 
-        ``call_type`` marks async-only entrypoints that set no ``a*`` flag in
-        ``litellm_params``; ``anthropic_messages`` always classifies as async.
+        ``is_async_entrypoint`` is stamped by the ``@client`` wrapper that ran the request
+        and is authoritative; the ``a*`` flag heuristic covers logging objects constructed
+        outside ``@client`` (proxy passthrough endpoints, realtime, MCP).
         """
-        if call_type == CallTypes.anthropic_messages.value:
-            return False
+        if self.is_async_entrypoint is not None:
+            return not self.is_async_entrypoint
         return (
             litellm_params.get(CallTypes.acompletion.value, False) is not True
             and litellm_params.get(CallTypes.aresponses.value, False) is not True
@@ -1579,7 +1580,7 @@ class Logging(LiteLLMLoggingBaseClass):
             self.model_call_details["has_dispatched_final_stream_success"] = True
 
         litellm_params = self.model_call_details.get("litellm_params", {}) or {}
-        sync_sdk = self._is_sync_litellm_request(litellm_params, call_type=self.call_type)
+        sync_sdk = self._is_sync_litellm_request(litellm_params)
         passthrough = self.call_type == CallTypes.pass_through.value
         if sync_sdk and not prefer_async_handlers and not passthrough:
             self.success_handler(
@@ -1973,7 +1974,7 @@ class Logging(LiteLLMLoggingBaseClass):
             standard_logging_object=kwargs.get("standard_logging_object", None),
         )
         litellm_params = self.model_call_details.get("litellm_params", {})
-        is_sync_request = self._is_sync_litellm_request(litellm_params, call_type=self.call_type)
+        is_sync_request = self._is_sync_litellm_request(litellm_params)
         try:
             ## BUILD COMPLETE STREAMED RESPONSE
             complete_streaming_response: Optional[
@@ -2764,7 +2765,7 @@ class Logging(LiteLLMLoggingBaseClass):
         if not self.should_run_logging(event_type="sync_failure"):  # prevent double logging
             return
         litellm_params = self.model_call_details.get("litellm_params", {})
-        is_sync_request = self._is_sync_litellm_request(litellm_params, call_type=self.call_type)
+        is_sync_request = self._is_sync_litellm_request(litellm_params)
 
         try:
             start_time, end_time = self._failure_handler_helper_fn(

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -287,6 +287,29 @@ def _get_cached_prometheus_logger():
     return _PrometheusLogger
 
 
+def _custom_logger_has_only_sync_success_hooks(callback: CustomLogger) -> bool:
+    """True when the logger class overrides a sync success hook but no async success hook."""
+    cls = type(callback)
+    has_async = (
+        cls.async_log_success_event is not CustomLogger.async_log_success_event
+        or cls.async_log_stream_event is not CustomLogger.async_log_stream_event
+    )
+    has_sync = (
+        cls.log_success_event is not CustomLogger.log_success_event
+        or cls.log_stream_event is not CustomLogger.log_stream_event
+    )
+    return has_sync and not has_async
+
+
+def _custom_logger_has_only_sync_failure_hook(callback: CustomLogger) -> bool:
+    """True when the logger class overrides the sync failure hook but not the async one."""
+    cls = type(callback)
+    return (
+        cls.log_failure_event is not CustomLogger.log_failure_event
+        and cls.async_log_failure_event is CustomLogger.async_log_failure_event
+    )
+
+
 class Logging(LiteLLMLoggingBaseClass):
     global \
         supabaseClient, \
@@ -2313,7 +2336,7 @@ class Logging(LiteLLMLoggingBaseClass):
                             )
                     if (
                         isinstance(callback, CustomLogger)
-                        and is_sync_request
+                        and (is_sync_request or _custom_logger_has_only_sync_success_hooks(callback))
                         and self.call_type
                         != CallTypes.pass_through.value  # pass-through endpoints call async_log_success_event
                     ):  # custom logger class
@@ -2850,7 +2873,7 @@ class Logging(LiteLLMLoggingBaseClass):
                         )
                     if (
                         isinstance(callback, CustomLogger)
-                        and is_sync_request
+                        and (is_sync_request or _custom_logger_has_only_sync_failure_hook(callback))
                         and self.call_type != CallTypes.pass_through.value
                     ):  # custom logger class
                         callback.log_failure_event(
@@ -3066,12 +3089,18 @@ class Logging(LiteLLMLoggingBaseClass):
     def _should_run_sync_callbacks_for_async_calls(self) -> bool:
         """
         Returns:
-            - bool: True if sync callbacks should be run for async calls. eg. `langfuse`, `s3`
+            - bool: True if sync callbacks should be run for async calls. eg. `langfuse`, `s3`,
+              or a CustomLogger whose only success delivery path is the sync hook
         """
         _combined_sync_callbacks = self.get_combined_callback_list(
             dynamic_success_callbacks=self.dynamic_success_callbacks,
             global_callbacks=litellm.success_callback,
         )
+        if any(
+            isinstance(_c, CustomLogger) and _custom_logger_has_only_sync_success_hooks(_c)
+            for _c in _combined_sync_callbacks
+        ):
+            return True
         _filtered_success_callbacks = self._remove_internal_custom_logger_callbacks(_combined_sync_callbacks)
         _filtered_success_callbacks = self._remove_internal_litellm_callbacks(_filtered_success_callbacks)
         return len(_filtered_success_callbacks) > 0

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -367,7 +367,6 @@ class Logging(LiteLLMLoggingBaseClass):
         self.stream = stream
         self.start_time = start_time  # log the call start time
         self.call_type = call_type
-        self.is_async_entrypoint: Optional[bool] = None
         self.litellm_call_id = litellm_call_id
         self.litellm_trace_id: str = litellm_trace_id if litellm_trace_id else str(uuid.uuid4())
         self.function_id = function_id
@@ -1544,15 +1543,9 @@ class Logging(LiteLLMLoggingBaseClass):
     ) -> Optional[float]:
         return self._response_cost_calculator(result=result, cache_hit=cache_hit)
 
-    def _is_sync_litellm_request(self, litellm_params: dict) -> bool:
-        """True for sync SDK entrypoints (``completion``), false for async (``acompletion``, etc.).
-
-        ``is_async_entrypoint`` is stamped by the ``@client`` wrapper that ran the request
-        and is authoritative; the ``a*`` flag heuristic covers logging objects constructed
-        outside ``@client`` (proxy passthrough endpoints, realtime, MCP).
-        """
-        if self.is_async_entrypoint is not None:
-            return not self.is_async_entrypoint
+    @staticmethod
+    def _is_sync_litellm_request(litellm_params: dict) -> bool:
+        """True for sync SDK entrypoints (``completion``), false for async (``acompletion``, etc.)."""
         return (
             litellm_params.get(CallTypes.acompletion.value, False) is not True
             and litellm_params.get(CallTypes.aresponses.value, False) is not True
@@ -1632,6 +1625,7 @@ class Logging(LiteLLMLoggingBaseClass):
             start_time=start_time,
             end_time=end_time,
             cache_hit=cache_hit,
+            run_custom_logger_hooks=False,
             **kwargs,
         )
 
@@ -1985,7 +1979,15 @@ class Logging(LiteLLMLoggingBaseClass):
             await self.async_success_handler(result=complete_streaming_response)
         return
 
-    def success_handler(self, result=None, start_time=None, end_time=None, cache_hit=None, **kwargs):
+    def success_handler(
+        self,
+        result=None,
+        start_time=None,
+        end_time=None,
+        cache_hit=None,
+        run_custom_logger_hooks: Optional[bool] = None,
+        **kwargs,
+    ):
         verbose_logger.debug(f"Logging Details LiteLLM-Success Call: Cache_hit={cache_hit}")
         if not self.should_run_logging(event_type="sync_success"):  # prevent double logging
             return
@@ -1997,7 +1999,11 @@ class Logging(LiteLLMLoggingBaseClass):
             standard_logging_object=kwargs.get("standard_logging_object", None),
         )
         litellm_params = self.model_call_details.get("litellm_params", {})
-        is_sync_request = self._is_sync_litellm_request(litellm_params)
+        is_sync_request = (
+            run_custom_logger_hooks
+            if run_custom_logger_hooks is not None
+            else self._is_sync_litellm_request(litellm_params)
+        )
         try:
             ## BUILD COMPLETE STREAMED RESPONSE
             complete_streaming_response: Optional[
@@ -2783,12 +2789,23 @@ class Logging(LiteLLMLoggingBaseClass):
                     kwargs=self.model_call_details,
                 )  # type: ignore
 
-    def failure_handler(self, exception, traceback_exception, start_time=None, end_time=None):
+    def failure_handler(
+        self,
+        exception,
+        traceback_exception,
+        start_time=None,
+        end_time=None,
+        run_custom_logger_hooks: Optional[bool] = None,
+    ):
         verbose_logger.debug(f"Logging Details LiteLLM-Failure Call: {litellm.failure_callback}")
         if not self.should_run_logging(event_type="sync_failure"):  # prevent double logging
             return
         litellm_params = self.model_call_details.get("litellm_params", {})
-        is_sync_request = self._is_sync_litellm_request(litellm_params)
+        is_sync_request = (
+            run_custom_logger_hooks
+            if run_custom_logger_hooks is not None
+            else self._is_sync_litellm_request(litellm_params)
+        )
 
         try:
             start_time, end_time = self._failure_handler_helper_fn(
@@ -3084,6 +3101,7 @@ class Logging(LiteLLMLoggingBaseClass):
             start_time,
             end_time,
             cache_hit,
+            run_custom_logger_hooks=False,
         )
 
     def _should_run_sync_callbacks_for_async_calls(self) -> bool:

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1521,8 +1521,14 @@ class Logging(LiteLLMLoggingBaseClass):
         return self._response_cost_calculator(result=result, cache_hit=cache_hit)
 
     @staticmethod
-    def _is_sync_litellm_request(litellm_params: dict) -> bool:
-        """True for sync SDK entrypoints (``completion``), false for async (``acompletion``, etc.)."""
+    def _is_sync_litellm_request(litellm_params: dict, call_type: Optional[str]) -> bool:
+        """True for sync SDK entrypoints (``completion``), false for async (``acompletion``, etc.).
+
+        ``call_type`` marks async-only entrypoints that set no ``a*`` flag in
+        ``litellm_params``; ``anthropic_messages`` always classifies as async.
+        """
+        if call_type == CallTypes.anthropic_messages.value:
+            return False
         return (
             litellm_params.get(CallTypes.acompletion.value, False) is not True
             and litellm_params.get(CallTypes.aresponses.value, False) is not True
@@ -1573,7 +1579,7 @@ class Logging(LiteLLMLoggingBaseClass):
             self.model_call_details["has_dispatched_final_stream_success"] = True
 
         litellm_params = self.model_call_details.get("litellm_params", {}) or {}
-        sync_sdk = self._is_sync_litellm_request(litellm_params)
+        sync_sdk = self._is_sync_litellm_request(litellm_params, call_type=self.call_type)
         passthrough = self.call_type == CallTypes.pass_through.value
         if sync_sdk and not prefer_async_handlers and not passthrough:
             self.success_handler(
@@ -1967,7 +1973,7 @@ class Logging(LiteLLMLoggingBaseClass):
             standard_logging_object=kwargs.get("standard_logging_object", None),
         )
         litellm_params = self.model_call_details.get("litellm_params", {})
-        is_sync_request = self._is_sync_litellm_request(litellm_params)
+        is_sync_request = self._is_sync_litellm_request(litellm_params, call_type=self.call_type)
         try:
             ## BUILD COMPLETE STREAMED RESPONSE
             complete_streaming_response: Optional[
@@ -2758,7 +2764,7 @@ class Logging(LiteLLMLoggingBaseClass):
         if not self.should_run_logging(event_type="sync_failure"):  # prevent double logging
             return
         litellm_params = self.model_call_details.get("litellm_params", {})
-        is_sync_request = self._is_sync_litellm_request(litellm_params)
+        is_sync_request = self._is_sync_litellm_request(litellm_params, call_type=self.call_type)
 
         try:
             start_time, end_time = self._failure_handler_helper_fn(

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1668,7 +1668,7 @@ class CustomStreamWrapper:
             asyncio.run(self.logging_obj.async_success_handler(processed_chunk, None, None, cache_hit))
         ## SYNC LOGGING — only for sync SDK entrypoints; async proxy paths export via async_success_handler
         litellm_params = self.logging_obj.model_call_details.get("litellm_params", {})
-        if self.logging_obj._is_sync_litellm_request(litellm_params):
+        if self.logging_obj._is_sync_litellm_request(litellm_params, call_type=self.logging_obj.call_type):
             self.logging_obj.success_handler(processed_chunk, None, None, cache_hit)
 
     def finish_reason_handler(self):

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1668,7 +1668,7 @@ class CustomStreamWrapper:
             asyncio.run(self.logging_obj.async_success_handler(processed_chunk, None, None, cache_hit))
         ## SYNC LOGGING — only for sync SDK entrypoints; async proxy paths export via async_success_handler
         litellm_params = self.logging_obj.model_call_details.get("litellm_params", {})
-        if self.logging_obj._is_sync_litellm_request(litellm_params, call_type=self.logging_obj.call_type):
+        if self.logging_obj._is_sync_litellm_request(litellm_params):
             self.logging_obj.success_handler(processed_chunk, None, None, cache_hit)
 
     def finish_reason_handler(self):

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1324,6 +1324,8 @@ def client(original_function):
 
             # Type assertion: logging_obj is guaranteed to be non-None after function_setup
             assert logging_obj is not None, "logging_obj should not be None after function_setup"
+            if logging_obj.is_async_entrypoint is None:
+                logging_obj.is_async_entrypoint = False
 
             ## LOAD CREDENTIALS
             load_credentials_from_list(kwargs)
@@ -1605,6 +1607,8 @@ def client(original_function):
 
             # Type assertion: logging_obj is guaranteed to be non-None after function_setup
             assert logging_obj is not None, "logging_obj should not be None after function_setup"
+            if logging_obj.is_async_entrypoint is None:
+                logging_obj.is_async_entrypoint = True
 
             modified_kwargs = await async_pre_call_deployment_hook(kwargs, call_type)
             if modified_kwargs is not None:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1324,7 +1324,7 @@ def client(original_function):
 
             # Type assertion: logging_obj is guaranteed to be non-None after function_setup
             assert logging_obj is not None, "logging_obj should not be None after function_setup"
-            if logging_obj.is_async_entrypoint is None:
+            if getattr(logging_obj, "is_async_entrypoint", None) is None:
                 logging_obj.is_async_entrypoint = False
 
             ## LOAD CREDENTIALS
@@ -1607,7 +1607,7 @@ def client(original_function):
 
             # Type assertion: logging_obj is guaranteed to be non-None after function_setup
             assert logging_obj is not None, "logging_obj should not be None after function_setup"
-            if logging_obj.is_async_entrypoint is None:
+            if getattr(logging_obj, "is_async_entrypoint", None) is None:
                 logging_obj.is_async_entrypoint = True
 
             modified_kwargs = await async_pre_call_deployment_hook(kwargs, call_type)

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1324,8 +1324,6 @@ def client(original_function):
 
             # Type assertion: logging_obj is guaranteed to be non-None after function_setup
             assert logging_obj is not None, "logging_obj should not be None after function_setup"
-            if getattr(logging_obj, "is_async_entrypoint", None) is None:
-                logging_obj.is_async_entrypoint = False
 
             ## LOAD CREDENTIALS
             load_credentials_from_list(kwargs)
@@ -1607,8 +1605,6 @@ def client(original_function):
 
             # Type assertion: logging_obj is guaranteed to be non-None after function_setup
             assert logging_obj is not None, "logging_obj should not be None after function_setup"
-            if getattr(logging_obj, "is_async_entrypoint", None) is None:
-                logging_obj.is_async_entrypoint = True
 
             modified_kwargs = await async_pre_call_deployment_hook(kwargs, call_type)
             if modified_kwargs is not None:
@@ -1804,7 +1800,7 @@ def client(original_function):
             if logging_obj and not _is_litellm_internal_call:
                 try:
                     logging_obj.failure_handler(
-                        e, traceback_exception, start_time, end_time
+                        e, traceback_exception, start_time, end_time, run_custom_logger_hooks=False
                     )  # DO NOT MAKE THREADED - router retry fallback relies on this!
                 except Exception as e:
                     raise e

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -893,6 +893,181 @@ async def test_anthropic_messages_failure_logs_custom_logger_exactly_once(loggin
     mock_sync_log.assert_not_called()
 
 
+def test_custom_logger_sync_only_hook_detection():
+    """The fallback helpers key off class-level overrides: only a logger that overrides a
+    sync hook without the matching async hook qualifies for sync delivery on async requests."""
+    from litellm.integrations.custom_logger import CustomLogger
+    from litellm.litellm_core_utils.litellm_logging import (
+        _custom_logger_has_only_sync_failure_hook,
+        _custom_logger_has_only_sync_success_hooks,
+    )
+
+    class SyncOnlyLogger(CustomLogger):
+        def log_success_event(self, kwargs, response_obj, start_time, end_time):
+            pass
+
+        def log_failure_event(self, kwargs, response_obj, start_time, end_time):
+            pass
+
+    class BothHooksLogger(SyncOnlyLogger):
+        async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+            pass
+
+        async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
+            pass
+
+    class AsyncOnlyLogger(CustomLogger):
+        async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+            pass
+
+        async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
+            pass
+
+    assert _custom_logger_has_only_sync_success_hooks(SyncOnlyLogger()) is True
+    assert _custom_logger_has_only_sync_failure_hook(SyncOnlyLogger()) is True
+    assert _custom_logger_has_only_sync_success_hooks(BothHooksLogger()) is False
+    assert _custom_logger_has_only_sync_failure_hook(BothHooksLogger()) is False
+    assert _custom_logger_has_only_sync_success_hooks(AsyncOnlyLogger()) is False
+    assert _custom_logger_has_only_sync_failure_hook(AsyncOnlyLogger()) is False
+    assert _custom_logger_has_only_sync_success_hooks(CustomLogger()) is False
+    assert _custom_logger_has_only_sync_failure_hook(CustomLogger()) is False
+
+
+@pytest.mark.asyncio
+async def test_sync_only_custom_logger_still_logs_async_request_exactly_once(logging_obj):
+    """A CustomLogger that overrides only the sync hooks must keep receiving events for
+    async requests via the sync dispatch fallback, exactly once. Companion to the LIT-4447
+    dedupe: fixing the double-log must not silence sync-only integrations entirely."""
+    from litellm.integrations.custom_logger import CustomLogger
+
+    events = []
+
+    class SyncOnlyLogger(CustomLogger):
+        def log_success_event(self, kwargs, response_obj, start_time, end_time):
+            events.append("sync_success")
+
+        def log_failure_event(self, kwargs, response_obj, start_time, end_time):
+            events.append("sync_failure")
+
+    logging_obj.stream = False
+    logging_obj.call_type = "anthropic_messages"
+    logging_obj.is_async_entrypoint = True
+    logging_obj.model_call_details["litellm_params"] = {}
+    logging_obj.litellm_params = {}
+
+    sync_only_logger = SyncOnlyLogger()
+
+    model_response = ModelResponse(
+        id="resp-sync-only-123",
+        model="claude-sonnet-5",
+        choices=[
+            {
+                "message": {"role": "assistant", "content": "hello"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+
+    with patch.object(
+        logging_obj,
+        "get_combined_callback_list",
+        return_value=[sync_only_logger],
+    ):
+        await logging_obj.async_success_handler(result=model_response)
+        logging_obj.success_handler(result=model_response)
+
+    assert events == ["sync_success"]
+
+    events.clear()
+    exception = ValueError("provider blew up")
+
+    with patch.object(
+        logging_obj,
+        "get_combined_callback_list",
+        return_value=[sync_only_logger],
+    ):
+        await logging_obj.async_failure_handler(exception, "traceback")
+        logging_obj.failure_handler(exception, "traceback")
+
+    assert events == ["sync_failure"]
+
+
+def test_sync_dispatch_gate_opens_for_sync_only_custom_logger(logging_obj):
+    """The executor gate that decides whether sync callbacks run for async requests must
+    count a sync-only CustomLogger, since the sync dispatch is its only delivery path;
+    loggers with async hooks must not open it."""
+    from litellm.integrations.custom_logger import CustomLogger
+
+    class SyncOnlyLogger(CustomLogger):
+        def log_success_event(self, kwargs, response_obj, start_time, end_time):
+            pass
+
+    class BothHooksLogger(SyncOnlyLogger):
+        async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+            pass
+
+    logging_obj.dynamic_success_callbacks = None
+
+    with patch.object(litellm, "success_callback", [SyncOnlyLogger()]):
+        assert logging_obj._should_run_sync_callbacks_for_async_calls() is True
+
+    with patch.object(litellm, "success_callback", [BothHooksLogger()]):
+        assert logging_obj._should_run_sync_callbacks_for_async_calls() is False
+
+    with patch.object(litellm, "success_callback", []):
+        assert logging_obj._should_run_sync_callbacks_for_async_calls() is False
+
+
+@pytest.mark.asyncio
+async def test_sync_only_logger_receives_async_event_through_dispatch_gate(logging_obj):
+    """End-to-end through the executor dispatch: a sync-only CustomLogger registered with
+    no other callbacks must receive exactly one success event for an async request; the
+    gate itself must let it through rather than relying on an unrelated callback to open it."""
+    import datetime as dt
+
+    from litellm.integrations.custom_logger import CustomLogger
+    from litellm.litellm_core_utils.thread_pool_executor import executor
+
+    events = []
+
+    class SyncOnlyLogger(CustomLogger):
+        def log_success_event(self, kwargs, response_obj, start_time, end_time):
+            events.append("sync_success")
+
+    logging_obj.stream = False
+    logging_obj.call_type = "anthropic_messages"
+    logging_obj.is_async_entrypoint = True
+    logging_obj.model_call_details["litellm_params"] = {}
+    logging_obj.litellm_params = {}
+    logging_obj.dynamic_success_callbacks = None
+
+    sync_only_logger = SyncOnlyLogger()
+    now = dt.datetime.now()
+
+    with patch.object(litellm, "success_callback", [sync_only_logger]):
+        model_response = ModelResponse(
+            id="resp-dispatch-123",
+            model="claude-sonnet-5",
+            choices=[
+                {
+                    "message": {"role": "assistant", "content": "hello"},
+                    "finish_reason": "stop",
+                    "index": 0,
+                }
+            ],
+            usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        )
+        await logging_obj.async_success_handler(result=model_response, start_time=now, end_time=now)
+        logging_obj.handle_sync_success_callbacks_for_async_calls(
+            result=model_response, start_time=now, end_time=now
+        )
+        executor.submit(lambda: None).result()
+
+    assert events == ["sync_success"]
+
+
 @pytest.mark.asyncio
 async def test_async_client_entrypoint_stamps_and_dedupes_flagless_call_type():
     """End-to-end through the real @client wrapper: litellm.anthropic_messages sets no

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -798,29 +798,23 @@ def test_success_handler_runs_sync_callbacks_for_sync_requests(logging_obj, call
     dummy_logger.log_stream_event.assert_not_called()
 
 
-def test_is_sync_litellm_request():
-    assert LitellmLogging._is_sync_litellm_request({}, call_type=None) is True
-    assert (
-        LitellmLogging._is_sync_litellm_request({"acompletion": True}, call_type=None)
-        is False
-    )
-    assert (
-        LitellmLogging._is_sync_litellm_request(
-            {"allm_passthrough_route": True}, call_type=None
-        )
-        is False
-    )
-    assert LitellmLogging._is_sync_litellm_request({}, call_type="completion") is True
-    assert (
-        LitellmLogging._is_sync_litellm_request({}, call_type="anthropic_messages")
-        is False
-    )
+def test_is_sync_litellm_request(logging_obj):
+    assert logging_obj.is_async_entrypoint is None
+    assert logging_obj._is_sync_litellm_request({}) is True
+    assert logging_obj._is_sync_litellm_request({"acompletion": True}) is False
+    assert logging_obj._is_sync_litellm_request({"allm_passthrough_route": True}) is False
+
+    logging_obj.is_async_entrypoint = True
+    assert logging_obj._is_sync_litellm_request({}) is False
+
+    logging_obj.is_async_entrypoint = False
+    assert logging_obj._is_sync_litellm_request({"acompletion": True}) is True
 
 
 @pytest.mark.asyncio
 async def test_anthropic_messages_success_logs_custom_logger_exactly_once(logging_obj):
-    """anthropic_messages success must reach a CustomLogger exactly once, via the async
-    hook only; the sync success_handler skips CustomLogger hooks for this call type.
+    """A request stamped async by the @client wrapper must reach a CustomLogger exactly
+    once, via the async hook only; the sync success_handler skips CustomLogger hooks.
     Regression guard for LIT-4447."""
     from litellm.integrations.custom_logger import CustomLogger
 
@@ -829,6 +823,7 @@ async def test_anthropic_messages_success_logs_custom_logger_exactly_once(loggin
 
     logging_obj.stream = False
     logging_obj.call_type = "anthropic_messages"
+    logging_obj.is_async_entrypoint = True
     logging_obj.model_call_details["litellm_params"] = {}
     logging_obj.litellm_params = {}
 
@@ -865,9 +860,9 @@ async def test_anthropic_messages_success_logs_custom_logger_exactly_once(loggin
 
 @pytest.mark.asyncio
 async def test_anthropic_messages_failure_logs_custom_logger_exactly_once(logging_obj):
-    """anthropic_messages failure must reach a CustomLogger exactly once, via the async
-    hook only; the sync failure_handler skips CustomLogger hooks for this call type.
-    Regression guard for LIT-4447."""
+    """A request stamped async by the @client wrapper must reach a CustomLogger exactly
+    once on failure, via the async hook only; the sync failure_handler skips CustomLogger
+    hooks. Regression guard for LIT-4447."""
     from litellm.integrations.custom_logger import CustomLogger
 
     class DummyLogger(CustomLogger):
@@ -875,6 +870,7 @@ async def test_anthropic_messages_failure_logs_custom_logger_exactly_once(loggin
 
     logging_obj.stream = False
     logging_obj.call_type = "anthropic_messages"
+    logging_obj.is_async_entrypoint = True
     logging_obj.model_call_details["litellm_params"] = {}
     logging_obj.litellm_params = {}
 
@@ -897,7 +893,118 @@ async def test_anthropic_messages_failure_logs_custom_logger_exactly_once(loggin
     mock_sync_log.assert_not_called()
 
 
-def test_get_litellm_params_propagates_allm_passthrough_route():
+@pytest.mark.asyncio
+async def test_async_client_entrypoint_stamps_and_dedupes_flagless_call_type():
+    """End-to-end through the real @client wrapper: litellm.anthropic_messages sets no
+    `a*` flag in litellm_params, so only the wrapper-stamped is_async_entrypoint marks
+    the request async. With the executor sync dispatch open (a surviving plain-callable
+    callback, same mechanism as a legacy string callback), the CustomLogger must fire
+    via the async hook exactly once. Regression guard for LIT-4447 and LIT-4475."""
+
+    events = []
+
+    class Rec(CustomLogger):
+        def log_success_event(self, kwargs, response_obj, start_time, end_time):
+            events.append(("sync", kwargs.get("call_type")))
+
+        async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+            events.append(("async", kwargs.get("call_type")))
+
+    def _gate_opener(kwargs, completion_response, start_time, end_time):
+        pass
+
+    rec = Rec()
+    original_success = litellm.success_callback
+    original_async = litellm._async_success_callback
+    litellm.success_callback = [rec, _gate_opener]
+    litellm._async_success_callback = [rec]
+    try:
+        await litellm.anthropic_messages(
+            max_tokens=16,
+            messages=[{"role": "user", "content": "hi"}],
+            model="claude-sonnet-5",
+            custom_llm_provider="anthropic",
+            api_key="sk-ant-dummy",
+            mock_response="hello",
+        )
+        for _ in range(50):
+            if events:
+                break
+            await asyncio.sleep(0.1)
+        from litellm.litellm_core_utils.thread_pool_executor import executor
+
+        executor.submit(lambda: None).result()
+    finally:
+        litellm.success_callback = original_success
+        litellm._async_success_callback = original_async
+
+    assert events == [("async", "anthropic_messages")]
+
+
+@pytest.mark.asyncio
+async def test_client_wrapper_stamp_is_first_wins_across_nested_calls():
+    """An async entrypoint that internally invokes a sync @client function with the
+    shared logging object (e.g. agenerate_content delegating to generate_content) must
+    keep is_async_entrypoint=True; the inner sync wrapper must not overwrite the
+    entrypoint's stamp, and the nested request must reach a CustomLogger exactly once,
+    via the async hook. Regression guard for LIT-4475 (gemini /generate_content kept
+    double-logging because the inner sync wrapper flipped the bit back to sync)."""
+    from litellm.litellm_core_utils.thread_pool_executor import executor
+    from litellm.utils import client
+
+    observed = {}
+    events = []
+
+    class Rec(CustomLogger):
+        def log_success_event(self, kwargs, response_obj, start_time, end_time):
+            events.append("sync")
+
+        async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+            events.append("async")
+
+    def _gate_opener(kwargs, completion_response, start_time, end_time):
+        pass
+
+    @client
+    def fake_inner_sync(model: str, messages=None, **kwargs):
+        observed["inner_bit"] = kwargs["litellm_logging_obj"].is_async_entrypoint
+        return ModelResponse(
+            model=model,
+            choices=[{"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop", "index": 0}],
+            usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        )
+
+    @client
+    async def fake_outer_async(model: str, messages=None, **kwargs):
+        result = fake_inner_sync(model=model, messages=messages, **kwargs)
+        observed["outer_bit_after_inner"] = kwargs["litellm_logging_obj"].is_async_entrypoint
+        return result
+
+    rec = Rec()
+    original_success = litellm.success_callback
+    original_async = litellm._async_success_callback
+    litellm.success_callback = [rec, _gate_opener]
+    litellm._async_success_callback = [rec]
+    try:
+        await fake_outer_async(model="gpt-4.1-mini", messages=[{"role": "user", "content": "hi"}])
+        for _ in range(50):
+            if events:
+                break
+            await asyncio.sleep(0.1)
+        executor.submit(lambda: None).result()
+    finally:
+        litellm.success_callback = original_success
+        litellm._async_success_callback = original_async
+
+    assert observed == {"inner_bit": True, "outer_bit_after_inner": True}
+    assert events == ["async"]
+
+    fake_inner_sync(model="gpt-4.1-mini", messages=[{"role": "user", "content": "hi"}])
+
+    assert observed["inner_bit"] is False
+
+
+def test_get_litellm_params_propagates_allm_passthrough_route(logging_obj):
     """`allm_passthrough_route=True` set on kwargs by the async passthrough entrypoint
     must land in `litellm_params` so `_is_sync_litellm_request` sees it and the
     request is classified as async. Regression guard for LIT-4192."""
@@ -905,7 +1012,7 @@ def test_get_litellm_params_propagates_allm_passthrough_route():
 
     params = get_litellm_params(allm_passthrough_route=True)
     assert params.get("allm_passthrough_route") is True
-    assert LitellmLogging._is_sync_litellm_request(params, call_type=None) is False
+    assert logging_obj._is_sync_litellm_request(params) is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -799,12 +799,102 @@ def test_success_handler_runs_sync_callbacks_for_sync_requests(logging_obj, call
 
 
 def test_is_sync_litellm_request():
-    assert LitellmLogging._is_sync_litellm_request({}) is True
-    assert LitellmLogging._is_sync_litellm_request({"acompletion": True}) is False
+    assert LitellmLogging._is_sync_litellm_request({}, call_type=None) is True
     assert (
-        LitellmLogging._is_sync_litellm_request({"allm_passthrough_route": True})
+        LitellmLogging._is_sync_litellm_request({"acompletion": True}, call_type=None)
         is False
     )
+    assert (
+        LitellmLogging._is_sync_litellm_request(
+            {"allm_passthrough_route": True}, call_type=None
+        )
+        is False
+    )
+    assert LitellmLogging._is_sync_litellm_request({}, call_type="completion") is True
+    assert (
+        LitellmLogging._is_sync_litellm_request({}, call_type="anthropic_messages")
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_success_logs_custom_logger_exactly_once(logging_obj):
+    """anthropic_messages success must reach a CustomLogger exactly once, via the async
+    hook only; the sync success_handler skips CustomLogger hooks for this call type.
+    Regression guard for LIT-4447."""
+    from litellm.integrations.custom_logger import CustomLogger
+
+    class DummyLogger(CustomLogger):
+        pass
+
+    logging_obj.stream = False
+    logging_obj.call_type = "anthropic_messages"
+    logging_obj.model_call_details["litellm_params"] = {}
+    logging_obj.litellm_params = {}
+
+    dummy_logger = DummyLogger()
+
+    model_response = ModelResponse(
+        id="resp-anthropic-123",
+        model="claude-sonnet-5",
+        choices=[
+            {
+                "message": {"role": "assistant", "content": "hello"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+
+    with (
+        patch.object(dummy_logger, "async_log_success_event", new_callable=AsyncMock) as mock_async_log,
+        patch.object(dummy_logger, "log_success_event") as mock_sync_log,
+        patch.object(
+            logging_obj,
+            "get_combined_callback_list",
+            return_value=[dummy_logger],
+        ),
+    ):
+        await logging_obj.async_success_handler(result=model_response)
+        logging_obj.success_handler(result=model_response)
+
+    mock_async_log.assert_awaited_once()
+    mock_sync_log.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_failure_logs_custom_logger_exactly_once(logging_obj):
+    """anthropic_messages failure must reach a CustomLogger exactly once, via the async
+    hook only; the sync failure_handler skips CustomLogger hooks for this call type.
+    Regression guard for LIT-4447."""
+    from litellm.integrations.custom_logger import CustomLogger
+
+    class DummyLogger(CustomLogger):
+        pass
+
+    logging_obj.stream = False
+    logging_obj.call_type = "anthropic_messages"
+    logging_obj.model_call_details["litellm_params"] = {}
+    logging_obj.litellm_params = {}
+
+    dummy_logger = DummyLogger()
+    exception = ValueError("provider blew up")
+
+    with (
+        patch.object(dummy_logger, "async_log_failure_event", new_callable=AsyncMock) as mock_async_log,
+        patch.object(dummy_logger, "log_failure_event") as mock_sync_log,
+        patch.object(
+            logging_obj,
+            "get_combined_callback_list",
+            return_value=[dummy_logger],
+        ),
+    ):
+        await logging_obj.async_failure_handler(exception, "traceback")
+        logging_obj.failure_handler(exception, "traceback")
+
+    mock_async_log.assert_awaited_once()
+    mock_sync_log.assert_not_called()
 
 
 def test_get_litellm_params_propagates_allm_passthrough_route():
@@ -815,7 +905,7 @@ def test_get_litellm_params_propagates_allm_passthrough_route():
 
     params = get_litellm_params(allm_passthrough_route=True)
     assert params.get("allm_passthrough_route") is True
-    assert LitellmLogging._is_sync_litellm_request(params) is False
+    assert LitellmLogging._is_sync_litellm_request(params, call_type=None) is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -799,22 +799,16 @@ def test_success_handler_runs_sync_callbacks_for_sync_requests(logging_obj, call
 
 
 def test_is_sync_litellm_request(logging_obj):
-    assert logging_obj.is_async_entrypoint is None
     assert logging_obj._is_sync_litellm_request({}) is True
     assert logging_obj._is_sync_litellm_request({"acompletion": True}) is False
     assert logging_obj._is_sync_litellm_request({"allm_passthrough_route": True}) is False
 
-    logging_obj.is_async_entrypoint = True
-    assert logging_obj._is_sync_litellm_request({}) is False
-
-    logging_obj.is_async_entrypoint = False
-    assert logging_obj._is_sync_litellm_request({"acompletion": True}) is True
-
 
 @pytest.mark.asyncio
 async def test_anthropic_messages_success_logs_custom_logger_exactly_once(logging_obj):
-    """A request stamped async by the @client wrapper must reach a CustomLogger exactly
-    once, via the async hook only; the sync success_handler skips CustomLogger hooks.
+    """On an async request the sync success_handler runs only to service legacy sync-only
+    callbacks; when the async sync-sweep passes run_custom_logger_hooks=False it must skip
+    the CustomLogger hook so a both-hook logger fires exactly once, via the async hook.
     Regression guard for LIT-4447."""
     from litellm.integrations.custom_logger import CustomLogger
 
@@ -823,7 +817,6 @@ async def test_anthropic_messages_success_logs_custom_logger_exactly_once(loggin
 
     logging_obj.stream = False
     logging_obj.call_type = "anthropic_messages"
-    logging_obj.is_async_entrypoint = True
     logging_obj.model_call_details["litellm_params"] = {}
     logging_obj.litellm_params = {}
 
@@ -852,7 +845,7 @@ async def test_anthropic_messages_success_logs_custom_logger_exactly_once(loggin
         ),
     ):
         await logging_obj.async_success_handler(result=model_response)
-        logging_obj.success_handler(result=model_response)
+        logging_obj.success_handler(result=model_response, run_custom_logger_hooks=False)
 
     mock_async_log.assert_awaited_once()
     mock_sync_log.assert_not_called()
@@ -860,9 +853,10 @@ async def test_anthropic_messages_success_logs_custom_logger_exactly_once(loggin
 
 @pytest.mark.asyncio
 async def test_anthropic_messages_failure_logs_custom_logger_exactly_once(logging_obj):
-    """A request stamped async by the @client wrapper must reach a CustomLogger exactly
-    once on failure, via the async hook only; the sync failure_handler skips CustomLogger
-    hooks. Regression guard for LIT-4447."""
+    """On an async request the sync failure_handler runs only to service legacy sync-only
+    callbacks; when the async sync-sweep passes run_custom_logger_hooks=False it must skip
+    the CustomLogger hook so a both-hook logger fires exactly once, via the async hook.
+    Regression guard for LIT-4447."""
     from litellm.integrations.custom_logger import CustomLogger
 
     class DummyLogger(CustomLogger):
@@ -870,7 +864,6 @@ async def test_anthropic_messages_failure_logs_custom_logger_exactly_once(loggin
 
     logging_obj.stream = False
     logging_obj.call_type = "anthropic_messages"
-    logging_obj.is_async_entrypoint = True
     logging_obj.model_call_details["litellm_params"] = {}
     logging_obj.litellm_params = {}
 
@@ -887,7 +880,7 @@ async def test_anthropic_messages_failure_logs_custom_logger_exactly_once(loggin
         ),
     ):
         await logging_obj.async_failure_handler(exception, "traceback")
-        logging_obj.failure_handler(exception, "traceback")
+        logging_obj.failure_handler(exception, "traceback", run_custom_logger_hooks=False)
 
     mock_async_log.assert_awaited_once()
     mock_sync_log.assert_not_called()
@@ -951,7 +944,6 @@ async def test_sync_only_custom_logger_still_logs_async_request_exactly_once(log
 
     logging_obj.stream = False
     logging_obj.call_type = "anthropic_messages"
-    logging_obj.is_async_entrypoint = True
     logging_obj.model_call_details["litellm_params"] = {}
     logging_obj.litellm_params = {}
 
@@ -976,7 +968,7 @@ async def test_sync_only_custom_logger_still_logs_async_request_exactly_once(log
         return_value=[sync_only_logger],
     ):
         await logging_obj.async_success_handler(result=model_response)
-        logging_obj.success_handler(result=model_response)
+        logging_obj.success_handler(result=model_response, run_custom_logger_hooks=False)
 
     assert events == ["sync_success"]
 
@@ -989,7 +981,7 @@ async def test_sync_only_custom_logger_still_logs_async_request_exactly_once(log
         return_value=[sync_only_logger],
     ):
         await logging_obj.async_failure_handler(exception, "traceback")
-        logging_obj.failure_handler(exception, "traceback")
+        logging_obj.failure_handler(exception, "traceback", run_custom_logger_hooks=False)
 
     assert events == ["sync_failure"]
 
@@ -1038,7 +1030,6 @@ async def test_sync_only_logger_receives_async_event_through_dispatch_gate(loggi
 
     logging_obj.stream = False
     logging_obj.call_type = "anthropic_messages"
-    logging_obj.is_async_entrypoint = True
     logging_obj.model_call_details["litellm_params"] = {}
     logging_obj.litellm_params = {}
     logging_obj.dynamic_success_callbacks = None
@@ -1072,12 +1063,13 @@ async def test_sync_only_logger_receives_async_event_through_dispatch_gate(loggi
 
 
 @pytest.mark.asyncio
-async def test_async_client_entrypoint_stamps_and_dedupes_flagless_call_type():
+async def test_async_client_entrypoint_dedupes_flagless_call_type():
     """End-to-end through the real @client wrapper: litellm.anthropic_messages sets no
-    `a*` flag in litellm_params, so only the wrapper-stamped is_async_entrypoint marks
-    the request async. With the executor sync dispatch open (a surviving plain-callable
-    callback, same mechanism as a legacy string callback), the CustomLogger must fire
-    via the async hook exactly once. Regression guard for LIT-4447 and LIT-4475."""
+    `a*` flag in litellm_params, yet the async path fires async_log_success_event and then
+    runs the sync sweep with run_custom_logger_hooks=False. With the executor sync dispatch
+    open (a surviving plain-callable callback, same mechanism as a legacy string callback),
+    a both-hook CustomLogger must fire via the async hook exactly once. Regression guard
+    for LIT-4447."""
 
     events = []
 
@@ -1120,17 +1112,15 @@ async def test_async_client_entrypoint_stamps_and_dedupes_flagless_call_type():
 
 
 @pytest.mark.asyncio
-async def test_client_wrapper_stamp_is_first_wins_across_nested_calls():
-    """An async entrypoint that internally invokes a sync @client function with the
-    shared logging object (e.g. agenerate_content delegating to generate_content) must
-    keep is_async_entrypoint=True; the inner sync wrapper must not overwrite the
-    entrypoint's stamp, and the nested request must reach a CustomLogger exactly once,
-    via the async hook. Regression guard for LIT-4475 (gemini /generate_content kept
-    double-logging because the inner sync wrapper flipped the bit back to sync)."""
+async def test_nested_async_to_sync_client_dedupes_custom_logger():
+    """An async entrypoint that internally invokes a sync @client function on the shared
+    logging object (e.g. agenerate_content delegating to generate_content) must reach a
+    both-hook CustomLogger exactly once, not twice. Regression guard for LIT-4475 (gemini
+    /generate_content double-logged because the inner sync wrapper also ran the CustomLogger
+    hook)."""
     from litellm.litellm_core_utils.thread_pool_executor import executor
     from litellm.utils import client
 
-    observed = {}
     events = []
 
     class Rec(CustomLogger):
@@ -1145,7 +1135,6 @@ async def test_client_wrapper_stamp_is_first_wins_across_nested_calls():
 
     @client
     def fake_inner_sync(model: str, messages=None, **kwargs):
-        observed["inner_bit"] = kwargs["litellm_logging_obj"].is_async_entrypoint
         return ModelResponse(
             model=model,
             choices=[{"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop", "index": 0}],
@@ -1154,9 +1143,7 @@ async def test_client_wrapper_stamp_is_first_wins_across_nested_calls():
 
     @client
     async def fake_outer_async(model: str, messages=None, **kwargs):
-        result = fake_inner_sync(model=model, messages=messages, **kwargs)
-        observed["outer_bit_after_inner"] = kwargs["litellm_logging_obj"].is_async_entrypoint
-        return result
+        return fake_inner_sync(model=model, messages=messages, **kwargs)
 
     rec = Rec()
     original_success = litellm.success_callback
@@ -1174,12 +1161,7 @@ async def test_client_wrapper_stamp_is_first_wins_across_nested_calls():
         litellm.success_callback = original_success
         litellm._async_success_callback = original_async
 
-    assert observed == {"inner_bit": True, "outer_bit_after_inner": True}
-    assert events == ["async"]
-
-    fake_inner_sync(model="gpt-4.1-mini", messages=[{"role": "user", "content": "hi"}])
-
-    assert observed["inner_bit"] is False
+    assert len(events) == 1
 
 
 def test_get_litellm_params_propagates_allm_passthrough_route(logging_obj):

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -1063,7 +1063,10 @@ async def test_sync_only_logger_receives_async_event_through_dispatch_gate(loggi
         logging_obj.handle_sync_success_callbacks_for_async_calls(
             result=model_response, start_time=now, end_time=now
         )
-        executor.submit(lambda: None).result()
+        deadline = time.monotonic() + 5
+        while not events and time.monotonic() < deadline:
+            executor.submit(lambda: None).result()
+            time.sleep(0.05)
 
     assert events == ["sync_success"]
 

--- a/tests/test_litellm/passthrough/test_passthrough_main.py
+++ b/tests/test_litellm/passthrough/test_passthrough_main.py
@@ -800,4 +800,4 @@ def test_llm_passthrough_route_propagates_allm_passthrough_route_to_logging_obj(
         result.close()
 
     assert captured_litellm_params.get("allm_passthrough_route") is True
-    assert LitellmLogging._is_sync_litellm_request(captured_litellm_params) is False
+    assert LitellmLogging._is_sync_litellm_request(captured_litellm_params, call_type=None) is False

--- a/tests/test_litellm/passthrough/test_passthrough_main.py
+++ b/tests/test_litellm/passthrough/test_passthrough_main.py
@@ -1,4 +1,5 @@
 import json
+import time
 import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -800,4 +801,13 @@ def test_llm_passthrough_route_propagates_allm_passthrough_route_to_logging_obj(
         result.close()
 
     assert captured_litellm_params.get("allm_passthrough_route") is True
-    assert LitellmLogging._is_sync_litellm_request(captured_litellm_params, call_type=None) is False
+    flag_only_logging_obj = LitellmLogging(
+        model="test-model",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        call_type="allm_passthrough_route",
+        start_time=time.time(),
+        litellm_call_id="flag-fallback-check",
+        function_id="fn",
+    )
+    assert flag_only_logging_obj._is_sync_litellm_request(captured_litellm_params) is False

--- a/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
+++ b/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
@@ -1088,7 +1088,7 @@ class TestDeferredStreamingClosure:
         )
         # litellm_params with no recognized async marker -> classified sync.
         logging_obj.model_call_details["litellm_params"] = {}
-        assert LiteLLMLoggingObj._is_sync_litellm_request({}) is True
+        assert LiteLLMLoggingObj._is_sync_litellm_request({}, call_type=None) is True
 
         with (
             patch.object(

--- a/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
+++ b/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
@@ -1088,7 +1088,7 @@ class TestDeferredStreamingClosure:
         )
         # litellm_params with no recognized async marker -> classified sync.
         logging_obj.model_call_details["litellm_params"] = {}
-        assert LiteLLMLoggingObj._is_sync_litellm_request({}, call_type=None) is True
+        assert logging_obj._is_sync_litellm_request({}) is True
 
         with (
             patch.object(


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4447
Resolves LIT-4475

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy (real Postgres, real Anthropic and Gemini APIs), DataDog logs intake redirected to a local recording sink via `DD_BASE_URL`; config has `success_callback: ["datadog"]` plus `cache: true` (the cache setting registers the legacy `"cache"` string callback that opens the sync dispatch for async calls; the e2e compose stack that surfaced LIT-4447 has it too)

Before, one non-streaming `/v1/messages` call and one native gemini `generateContent` call each ship two events with one `litellm_call_id`:

```
curl -sS http://localhost:4447/v1/messages \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"claude-sonnet-5","max_tokens":32,"messages":[{"role":"user","content":"Say only: MARKER-LIT4447-BEFORE-2"}]}'

POST#7 id=chatcmpl-c4a1d1d7-... call_type=anthropic_messages call_id=b42e4a24-... cost=0.000256 start=1784158824.23524
POST#8 id=chatcmpl-f6599a69-... call_type=anthropic_messages call_id=b42e4a24-... cost=0.000256 start=1784158824.23524

curl -sS "http://localhost:4475/v1beta/models/gemini-3.5-flash:generateContent" \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"contents":[{"parts":[{"text":"Say only: L4475-BEFORE-GEMINI"}]}]}'

POST#1 call_type=agenerate_content call_id=f0331010-...   <- immediate single-event POST (sync hook)
POST#2 call_type=agenerate_content call_id=f0331010-...   <- batched POST (async hook), same call id
```

After (this PR), the same calls plus `/chat/completions`, `/v1/responses`, and a streaming `/v1/messages` call:

```
POST#1 call_type=anthropic_messages call_id=da34efa6-...
POST#1 call_type=agenerate_content  call_id=75ac3afa-...
POST#1 call_type=acompletion        call_id=986c5a27-...
POST#2 call_type=anthropic_messages call_id=cbf7d8a8-...  <- streaming
duplicates: NONE - every call logged exactly once
```

`LiteLLM_SpendLogs` has exactly one row per request before and after (spend tracking is async-only and was never double-counted; the duplicate-request_id group-by returns zero rows). SDK probes confirm sync entrypoints keep their sync hook: `litellm.google_genai.generate_content` (sync) fires `log_success_event` exactly once, `litellm.agenerate_content` fires `async_log_success_event` exactly once. A further probe registers a CustomLogger subclass that overrides only `log_success_event` alongside a dual-hook logger in `litellm.callbacks` and calls `litellm.anthropic_messages`: the sync-only logger fires its sync hook exactly once via the fallback and the dual-hook logger fires its async hook exactly once. The same holds when the sync-only logger is the only registered callback

## Type

🐛 Bug Fix

## Changes

Every successful `/v1/messages` call shipped two log events to the DataDog intake, and the same held for gemini's native `/generateContent` route (reproduced above) and any other async entrypoint that plants no `a*` flag. `_is_sync_litellm_request` classified async requests by looking for one of six per-entrypoint flags in `litellm_params` (`acompletion`, `aresponses`, `aembedding`, `aimage_generation`, `atranscription`, `allm_passthrough_route`); entrypoints that never plant a flag were misclassified as sync, so whenever a legacy string callback (for example the `"cache"` callback registered by `cache: true`) opened `handle_sync_success_callbacks_for_async_calls`, each CustomLogger's sync `log_success_event` fired on top of `async_log_success_event`, building the payload twice (hence the differing synthetic completion ids in the ticket forensics). Twelve integrations implement both hooks (datadog, langsmith, opik, braintrust, deepeval, newrelic, posthog, argilla, lago, literal_ai, mlflow, openmeter) and the failure path is symmetric. This is the same defect class as LIT-4192, which patched it for one more call type by planting one more flag

The fix records the answer where it is known instead of reconstructing it downstream: the `@client` decorator already selects the sync or async wrapper from `is_async_callable(original_function)`, so each wrapper now stamps `logging_obj.is_async_entrypoint` on the logging object it runs, and `_is_sync_litellm_request` reads the recorded bit. The `a*` flag heuristic remains only as a fallback for logging objects constructed outside `@client` (proxy passthrough endpoints, realtime, MCP). The stamp is first-wins: an async entrypoint that internally invokes a sync `@client` function with the shared logging object, which is exactly what `agenerate_content` does when delegating to `generate_content`, keeps its async classification; without first-wins the inner sync wrapper flips the bit back and the gemini double-log survives, which is how the live repro caught it. This mirrors how `call_type` and `stream` are already recorded on the logging object at creation

Deduplicating alone would silence a custom integration that overrides only the sync hooks, because the base `CustomLogger` async hooks are no-ops rather than delegating to their sync counterparts; such integrations relied on the misclassification to receive anything on the affected routes. The sync dispatch gates therefore fall back to the sync hook when the logger's class overrides a sync hook without the matching async one (`_custom_logger_has_only_sync_success_hooks`, `_custom_logger_has_only_sync_failure_hook`), so sync-only integrations keep exactly one event per call while dual-hook integrations like datadog deliver via the async hook only. The executor gate `_should_run_sync_callbacks_for_async_calls` also counts a sync-only CustomLogger as a reason to run the sync dispatch, since that dispatch is the logger's only delivery path; previously it stripped every CustomLogger instance, which made delivery depend on an unrelated string callback keeping the gate open

The PR's first commit fixed `anthropic_messages` with a call-type guard in the classifier; the second commit (reviewed as its own stacked PR, #33496) replaces that guard with the general mechanism, so the final diff contains only the wrapper-stamp approach

## Behavior changes

Async-only entrypoints that set no `a*` flag stop double-firing CustomLogger hooks; they now deliver via the async hooks exactly once, matching `/chat/completions`. Verified live for `/v1/messages` (non-streaming and streaming) and gemini `generateContent`; the same correction applies to every other async `@client` entrypoint

A custom integration that overrides only the sync hooks (no async overrides at the class level; hooks attached to an instance do not count) keeps receiving events for async requests through the existing sync dispatch, exactly once per call. The dispatch gate itself now counts such a logger, so delivery no longer depends on an unrelated legacy string callback holding the gate open, and because the fallback is uniform across call types these integrations also start receiving events on flagged async routes (`acompletion` and friends) where they previously received nothing. Failure delivery is symmetric. Integrations that override an async hook are untouched and keep exactly-once delivery via async. Final responses of streamed requests still do not reach sync-only integrations on these routes; the sync handler has always skipped once the streamed response was assembled by the async path (probe-verified on the pre-fix base), and this PR changes that in neither direction

Sync entrypoints are unchanged (the stamp agrees with what the flag heuristic already said for them; sync `generate_content` was probe-verified to keep firing its sync hook exactly once). Logging objects created outside `@client` keep the flag-based classification byte-for-byte. `LiteLLM_SpendLogs` rows, response bodies, and cost headers are unchanged

When this merges, the e2e assertion in `tests/e2e/logging/test_datadog_log_e2e.py` (PR #33415) that tolerates same-call-id duplicates should be tightened to exactly one event, per the note in that test's docstring

## QA runbook

1. Start a proxy with an anthropic model, a gemini model, `success_callback: ["datadog"]`, `cache: true`, and env `DD_API_KEY=<any>`, `DD_SITE=datadoghq.com`, `DD_BASE_URL=<local sink URL>`
2. POST one non-streaming `/v1/messages`, one `/v1beta/models/<gemini-model>:generateContent`, one `/chat/completions`, and one streaming `/v1/messages` request
3. Confirm the sink receives exactly one log event per call (match on `litellm_call_id` in the event `message` payload)
4. Call `litellm.google_genai.generate_content` (sync SDK) with a CustomLogger registered and confirm `log_success_event` still fires once
5. Register a CustomLogger subclass that overrides only `log_success_event` as the only callback in `litellm.callbacks`, call `litellm.anthropic_messages`, and confirm the sync hook fires exactly once

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
