### PR TITLE
test(e2e): bump claude code compat matrix tiers to sonnet-5 and opus-4-8

### DIFF
--- a/tests/e2e/claude_code/_builder_unit_tests/fixtures/expected_matrix.json
+++ b/tests/e2e/claude_code/_builder_unit_tests/fixtures/expected_matrix.json
@@ -26,7 +26,7 @@
       "providers": {
         "anthropic": {
           "status": "fail",
-          "error": "[claude-sonnet-4-6] tool call dropped"
+          "error": "[claude-sonnet-5] tool call dropped"
         },
         "bedrock_invoke": {
           "status": "not_applicable",

--- a/tests/e2e/claude_code/_builder_unit_tests/fixtures/results.json
+++ b/tests/e2e/claude_code/_builder_unit_tests/fixtures/results.json
@@ -10,13 +10,13 @@
     {
       "feature_id": "basic_messaging_non_streaming",
       "provider": "anthropic",
-      "nodeid": "tests/e2e/claude_code/basic_messaging_non_streaming/test_anthropic.py::test_basic_messaging_non_streaming_anthropic[claude-sonnet-4-6]",
+      "nodeid": "tests/e2e/claude_code/basic_messaging_non_streaming/test_anthropic.py::test_basic_messaging_non_streaming_anthropic[claude-sonnet-5]",
       "result": {"status": "pass"}
     },
     {
       "feature_id": "basic_messaging_non_streaming",
       "provider": "anthropic",
-      "nodeid": "tests/e2e/claude_code/basic_messaging_non_streaming/test_anthropic.py::test_basic_messaging_non_streaming_anthropic[claude-opus-4-7]",
+      "nodeid": "tests/e2e/claude_code/basic_messaging_non_streaming/test_anthropic.py::test_basic_messaging_non_streaming_anthropic[claude-opus-4-8]",
       "result": {"status": "pass"}
     },
     {
@@ -28,8 +28,8 @@
     {
       "feature_id": "tool_use",
       "provider": "anthropic",
-      "nodeid": "tests/e2e/claude_code/tool_use/test_anthropic.py::test_x[claude-sonnet-4-6]",
-      "result": {"status": "fail", "error": "[claude-sonnet-4-6] tool call dropped"}
+      "nodeid": "tests/e2e/claude_code/tool_use/test_anthropic.py::test_x[claude-sonnet-5]",
+      "result": {"status": "fail", "error": "[claude-sonnet-5] tool call dropped"}
     },
     {
       "feature_id": "tool_use",

--- a/tests/e2e/claude_code/_builder_unit_tests/test_matrix_builder.py
+++ b/tests/e2e/claude_code/_builder_unit_tests/test_matrix_builder.py
@@ -74,7 +74,7 @@ def test_build_matrix_any_fail_makes_cell_fail():
         {
             "feature_id": "f",
             "provider": "anthropic",
-            "result": {"status": "fail", "error": "[claude-opus-4-7] timeout"},
+            "result": {"status": "fail", "error": "[claude-opus-4-8] timeout"},
         },
         {"feature_id": "f", "provider": "anthropic", "result": {"status": "pass"}},
     ]
@@ -87,7 +87,7 @@ def test_build_matrix_any_fail_makes_cell_fail():
     )
     cell = matrix["features"][0]["providers"]["anthropic"]
     assert cell["status"] == "fail"
-    assert cell["error"] == "[claude-opus-4-7] timeout"
+    assert cell["error"] == "[claude-opus-4-8] timeout"
 
 
 def test_build_matrix_joins_all_failure_errors_in_one_cell():
@@ -110,7 +110,7 @@ def test_build_matrix_joins_all_failure_errors_in_one_cell():
         {
             "feature_id": "f",
             "provider": "anthropic",
-            "result": {"status": "fail", "error": "[claude-opus-4-7] timeout"},
+            "result": {"status": "fail", "error": "[claude-opus-4-8] timeout"},
         },
     ]
     matrix = build_matrix(
@@ -123,7 +123,7 @@ def test_build_matrix_joins_all_failure_errors_in_one_cell():
     cell = matrix["features"][0]["providers"]["anthropic"]
     assert cell["status"] == "fail"
     assert "[claude-haiku-4-5] 429" in cell["error"]
-    assert "[claude-opus-4-7] timeout" in cell["error"]
+    assert "[claude-opus-4-8] timeout" in cell["error"]
 
 
 def test_build_matrix_mixed_pass_and_not_tested_surfaces_pass():
@@ -393,7 +393,7 @@ def test_build_matrix_6x5_grid_matches_published_sample():
 
     feature_ids = [feature["id"] for feature in manifest["features"]]
     providers = manifest["providers"]
-    models = ["claude-haiku-4-5", "claude-sonnet-4-6", "claude-opus-4-7"]
+    models = ["claude-haiku-4-5", "claude-sonnet-5", "claude-opus-4-8"]
 
     results = []
     for feature_id in feature_ids:
@@ -440,7 +440,7 @@ def test_build_matrix_1x5_grid_one_failing_model_breaks_cell():
             "provider": "bedrock_invoke",
             "result": {
                 "status": "fail",
-                "error": "[claude-opus-4-7-bedrock-invoke] claude CLI exited 1: throttled",
+                "error": "[claude-opus-4-8-bedrock-invoke] claude CLI exited 1: throttled",
             },
         },
         {
@@ -459,7 +459,7 @@ def test_build_matrix_1x5_grid_one_failing_model_breaks_cell():
     )
     cell = matrix["features"][0]["providers"]["bedrock_invoke"]
     assert cell["status"] == "fail"
-    assert "claude-opus-4-7-bedrock-invoke" in cell["error"]
+    assert "claude-opus-4-8-bedrock-invoke" in cell["error"]
 
 
 def test_build_from_paths_writes_output(tmp_path):

--- a/tests/e2e/claude_code/_builder_unit_tests/test_v0_layout.py
+++ b/tests/e2e/claude_code/_builder_unit_tests/test_v0_layout.py
@@ -141,18 +141,37 @@ def test_every_manifest_feature_has_per_provider_test_file(feature_id, provider)
     assert test_file.is_file(), f"missing per-provider test file: {test_file}"
 
 
+DEFAULT_TIERS = ("haiku-4-5", "sonnet-5", "opus-4-8")
+
+PROVIDER_TIER_OVERRIDES = {
+    "vertex_ai": ("haiku-4-5", "sonnet-4-6", "opus-4-7"),
+    "azure": ("haiku-4-5", "sonnet-4-6", "opus-4-8"),
+}
+
+
 @pytest.mark.parametrize("feature_id", EXPECTED_FEATURE_IDS)
 @pytest.mark.parametrize("provider", EXPECTED_PROVIDERS)
 def test_per_provider_test_file_imports_and_parametrizes_three_models(
     feature_id, provider
 ):
     """Every test file must reference the three Claude tiers required
-    by the PRD: Haiku 4.5, Sonnet 4.6, Opus 4.7. Implementations may
-    use plain aliases or per-provider-suffixed aliases (e.g.
-    `claude-opus-4-7-bedrock-invoke`), so we check for the tier
-    substrings rather than exact alias names."""
+    by the PRD: small, mid, and large; Haiku 4.5, Sonnet 5, and Opus
+    4.8 as of the 2026-07 tier bump. Implementations may use plain
+    aliases or per-provider-suffixed aliases (e.g.
+    `claude-opus-4-8-bedrock-invoke`), so we check for the tier
+    substrings rather than exact alias names.
+
+    Two provider columns are pinned to older tiers until quota is
+    granted: Vertex AI has 0 TPM for the sonnet-5 / opus-4-8 base
+    models in the suite's project+region (deterministic 429), and
+    Microsoft Foundry has a hard 0 TPM quota limit for Claude Sonnet 5
+    in the suite's subscription, so its sonnet slot stays on
+    sonnet-4-6 while its opus slot runs the deployed opus-4-8. Once
+    quota requests land, flip the overrides here and the matching
+    aliases in `test_config.yaml` and the per-provider test files."""
+    tiers = PROVIDER_TIER_OVERRIDES.get(provider, DEFAULT_TIERS)
     text = (REPO_ROOT / feature_id / f"test_{provider}.py").read_text()
-    for tier in ("haiku-4-5", "sonnet-4-6", "opus-4-7"):
+    for tier in tiers:
         assert (
             tier in text
         ), f"{feature_id}/test_{provider}.py does not reference {tier}"
@@ -179,5 +198,5 @@ def test_azure_test_file_drives_the_proxy(feature_id):
     )
     assert '"status": "not_applicable"' not in text, (
         f"{feature_id}/test_azure.py still reports not_applicable; Microsoft Foundry "
-        "now hosts Claude (Haiku 4.5, Sonnet 4.6, Opus 4.7), so this row must run."
+        "now hosts Claude (Haiku 4.5, Sonnet 4.6, Opus 4.8), so this row must run."
     )

--- a/tests/e2e/claude_code/_driver_unit_tests/test_basic_messaging.py
+++ b/tests/e2e/claude_code/_driver_unit_tests/test_basic_messaging.py
@@ -184,8 +184,8 @@ def test_verify_streaming_requires_all_models_to_stream(monkeypatch):
     fake_result = _FakeResult()
     outcomes = {
         "claude-haiku-4-5": DriverResult(text="ok", events=_streamed_events(5)),
-        "claude-sonnet-4-6": DriverResult(text="ok", events=_buffered_events()),
-        "claude-opus-4-7": DriverResult(text="ok", events=_streamed_events(5)),
+        "claude-sonnet-5": DriverResult(text="ok", events=_buffered_events()),
+        "claude-opus-4-8": DriverResult(text="ok", events=_streamed_events(5)),
     }
     _install_fake_runner(monkeypatch, outcomes_by_model=outcomes)
 

--- a/tests/e2e/claude_code/_driver_unit_tests/test_cli_driver.py
+++ b/tests/e2e/claude_code/_driver_unit_tests/test_cli_driver.py
@@ -97,7 +97,7 @@ def test_run_claude_overlays_proxy_env():
     runner, captured = _make_runner(stdout="")
     run_claude(
         prompt="hi",
-        model="claude-opus-4-7",
+        model="claude-opus-4-8",
         base_url="http://proxy.example:4000",
         api_key="sk-abc",
         runner=runner,
@@ -112,7 +112,7 @@ def test_run_claude_extra_env_is_added_to_subprocess_env():
     runner, captured = _make_runner(stdout="")
     run_claude(
         prompt="hi",
-        model="claude-opus-4-7",
+        model="claude-opus-4-8",
         base_url="http://localhost",
         api_key="sk-abc",
         extra_env={"MAX_THINKING_TOKENS": "4096"},
@@ -146,7 +146,7 @@ def test_run_claude_inherits_only_allowlisted_os_environ(monkeypatch):
     runner, captured = _make_runner(stdout="")
     run_claude(
         prompt="hi",
-        model="claude-opus-4-7",
+        model="claude-opus-4-8",
         base_url="http://localhost",
         api_key="sk-abc",
         runner=runner,
@@ -178,7 +178,7 @@ def test_run_claude_uses_isolated_per_invocation_home(monkeypatch, tmp_path):
     runner, captured = _make_runner(stdout="")
     run_claude(
         prompt="hi",
-        model="claude-opus-4-7",
+        model="claude-opus-4-8",
         base_url="http://localhost",
         api_key="sk-abc",
         runner=runner,
@@ -209,7 +209,7 @@ def test_run_claude_isolated_home_is_distinct_per_invocation(monkeypatch):
     runner, captured = _make_runner(stdout="")
     run_claude(
         prompt="hi",
-        model="claude-opus-4-7",
+        model="claude-opus-4-8",
         base_url="http://localhost",
         api_key="sk-abc",
         runner=runner,
@@ -219,7 +219,7 @@ def test_run_claude_isolated_home_is_distinct_per_invocation(monkeypatch):
     runner, captured = _make_runner(stdout="")
     run_claude(
         prompt="hi",
-        model="claude-opus-4-7",
+        model="claude-opus-4-8",
         base_url="http://localhost",
         api_key="sk-abc",
         runner=runner,
@@ -243,7 +243,7 @@ def test_run_claude_isolated_home_cleaned_up_after_run(monkeypatch):
     runner, captured = _make_runner(stdout="")
     run_claude(
         prompt="hi",
-        model="claude-opus-4-7",
+        model="claude-opus-4-8",
         base_url="http://localhost",
         api_key="sk-abc",
         runner=runner,
@@ -275,7 +275,7 @@ def test_run_claude_isolated_home_cleaned_up_on_subprocess_failure(monkeypatch):
     with pytest.raises(ClaudeCLIError):
         run_claude(
             prompt="hi",
-            model="claude-opus-4-7",
+            model="claude-opus-4-8",
             base_url="http://localhost",
             api_key="sk-abc",
             runner=runner,
@@ -294,7 +294,7 @@ def test_run_claude_extra_env_can_pass_through_otherwise_blocked_var(monkeypatch
     runner, captured = _make_runner(stdout="")
     run_claude(
         prompt="hi",
-        model="claude-opus-4-7",
+        model="claude-opus-4-8",
         base_url="http://localhost",
         api_key="sk-abc",
         extra_env={"ANTHROPIC_API_KEY": "from-arg"},

--- a/tests/e2e/claude_code/_driver_unit_tests/test_rate_limiter.py
+++ b/tests/e2e/claude_code/_driver_unit_tests/test_rate_limiter.py
@@ -60,11 +60,11 @@ from claude_code.rate_limiter import (
     "model, expected",
     [
         ("claude-haiku-4-5", PROVIDER_ANTHROPIC),
-        ("claude-sonnet-4-6", PROVIDER_ANTHROPIC),
-        ("claude-opus-4-7", PROVIDER_ANTHROPIC),
+        ("claude-sonnet-5", PROVIDER_ANTHROPIC),
+        ("claude-opus-4-8", PROVIDER_ANTHROPIC),
         ("claude-haiku-4-5-azure", PROVIDER_AZURE),
-        ("claude-sonnet-4-6-azure", PROVIDER_AZURE),
-        ("claude-opus-4-7-vertex", PROVIDER_VERTEX_AI),
+        ("claude-sonnet-5-azure", PROVIDER_AZURE),
+        ("claude-opus-4-8-vertex", PROVIDER_VERTEX_AI),
         ("claude-haiku-4-5-bedrock-converse", PROVIDER_BEDROCK_CONVERSE),
         ("claude-haiku-4-5-bedrock-invoke", PROVIDER_BEDROCK_INVOKE),
     ],
@@ -87,7 +87,7 @@ def test_infer_provider_rejects_empty_string():
 def test_infer_provider_is_case_insensitive():
     """Aliases in the proxy config sometimes drift between cases; we
     should still route them to the right column."""
-    assert infer_provider("CLAUDE-OPUS-4-7-AZURE") == PROVIDER_AZURE
+    assert infer_provider("CLAUDE-OPUS-4-8-AZURE") == PROVIDER_AZURE
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/claude_code/basic_messaging_non_streaming/test_anthropic.py
+++ b/tests/e2e/claude_code/basic_messaging_non_streaming/test_anthropic.py
@@ -11,8 +11,8 @@ The (feature, provider) for this cell is inferred from the file path by
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^
                        feature_id                         provider
 
-Per the PRD, every cell exercises Claude Haiku 4.5, Sonnet 4.6, and Opus
-4.7; the cell only goes green if all three pass. The shared
+Per the PRD, every cell exercises Claude Haiku 4.5, Sonnet 5, and Opus
+4.8; the cell only goes green if all three pass. The shared
 `run_basic_messaging_cell` helper fans the three model runs out in
 parallel and reports one `compat_result.add(...)` entry per model so
 the matrix builder still sees three rows for this (feature, provider).
@@ -27,8 +27,8 @@ from claude_code._basic_messaging import run_basic_messaging_cell
 # routing config; the driver only sends the alias.
 ANTHROPIC_MODELS = [
     "claude-haiku-4-5",
-    "claude-sonnet-4-6",
-    "claude-opus-4-7",
+    "claude-sonnet-5",
+    "claude-opus-4-8",
 ]
 
 

--- a/tests/e2e/claude_code/basic_messaging_non_streaming/test_azure.py
+++ b/tests/e2e/claude_code/basic_messaging_non_streaming/test_azure.py
@@ -17,7 +17,7 @@ The (feature, provider) for this cell is inferred from the file path by
                        feature_id                          provider
 
 Per the PRD, every cell exercises Claude Haiku 4.5, Sonnet 4.6, and Opus
-4.7; the cell only goes green if all three pass. The shared
+4.8; the cell only goes green if all three pass. The shared
 `run_basic_messaging_cell` helper fans the three model runs out in
 parallel and reports one `compat_result.add(...)` entry per model so
 the matrix builder still sees three rows for this (feature, provider).
@@ -34,7 +34,7 @@ from claude_code._basic_messaging import run_basic_messaging_cell
 AZURE_MODELS = [
     "claude-haiku-4-5-azure",
     "claude-sonnet-4-6-azure",
-    "claude-opus-4-7-azure",
+    "claude-opus-4-8-azure",
 ]
 
 

--- a/tests/e2e/claude_code/basic_messaging_non_streaming/test_bedrock_converse.py
+++ b/tests/e2e/claude_code/basic_messaging_non_streaming/test_bedrock_converse.py
@@ -11,8 +11,8 @@ The (feature, provider) for this cell is inferred from the file path by
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^^^
                        feature_id                          provider
 
-Per the PRD, every cell exercises Claude Haiku 4.5, Sonnet 4.6, and Opus
-4.7; the cell only goes green if all three pass. The shared
+Per the PRD, every cell exercises Claude Haiku 4.5, Sonnet 5, and Opus
+4.8; the cell only goes green if all three pass. The shared
 `run_basic_messaging_cell` helper fans the three model runs out in
 parallel and reports one `compat_result.add(...)` entry per model so
 the matrix builder still sees three rows for this (feature, provider).
@@ -28,8 +28,8 @@ from claude_code._basic_messaging import run_basic_messaging_cell
 # strategy.
 BEDROCK_CONVERSE_MODELS = [
     "claude-haiku-4-5-bedrock-converse",
-    "claude-sonnet-4-6-bedrock-converse",
-    "claude-opus-4-7-bedrock-converse",
+    "claude-sonnet-5-bedrock-converse",
+    "claude-opus-4-8-bedrock-converse",
 ]
 
 

--- a/tests/e2e/claude_code/basic_messaging_non_streaming/test_bedrock_invoke.py
+++ b/tests/e2e/claude_code/basic_messaging_non_streaming/test_bedrock_invoke.py
@@ -11,8 +11,8 @@ The (feature, provider) for this cell is inferred from the file path by
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      ^^^^^^^^^^^^^^
                        feature_id                          provider
 
-Per the PRD, every cell exercises Claude Haiku 4.5, Sonnet 4.6, and Opus
-4.7; the cell only goes green if all three pass. The shared
+Per the PRD, every cell exercises Claude Haiku 4.5, Sonnet 5, and Opus
+4.8; the cell only goes green if all three pass. The shared
 `run_basic_messaging_cell` helper fans the three model runs out in
 parallel and reports one `compat_result.add(...)` entry per model so
 the matrix builder still sees three rows for this (feature, provider).
@@ -28,8 +28,8 @@ from claude_code._basic_messaging import run_basic_messaging_cell
 # routing strategy.
 BEDROCK_INVOKE_MODELS = [
     "claude-haiku-4-5-bedrock-invoke",
-    "claude-sonnet-4-6-bedrock-invoke",
-    "claude-opus-4-7-bedrock-invoke",
+    "claude-sonnet-5-bedrock-invoke",
+    "claude-opus-4-8-bedrock-invoke",
 ]
 
 

--- a/tests/e2e/claude_code/basic_messaging_streaming/test_anthropic.py
+++ b/tests/e2e/claude_code/basic_messaging_streaming/test_anthropic.py
@@ -29,8 +29,8 @@ from claude_code._basic_messaging import run_basic_messaging_cell
 
 ANTHROPIC_MODELS = [
     "claude-haiku-4-5",
-    "claude-sonnet-4-6",
-    "claude-opus-4-7",
+    "claude-sonnet-5",
+    "claude-opus-4-8",
 ]
 
 

--- a/tests/e2e/claude_code/basic_messaging_streaming/test_azure.py
+++ b/tests/e2e/claude_code/basic_messaging_streaming/test_azure.py
@@ -24,7 +24,7 @@ from claude_code._basic_messaging import run_basic_messaging_cell
 AZURE_MODELS = [
     "claude-haiku-4-5-azure",
     "claude-sonnet-4-6-azure",
-    "claude-opus-4-7-azure",
+    "claude-opus-4-8-azure",
 ]
 
 

--- a/tests/e2e/claude_code/basic_messaging_streaming/test_bedrock_converse.py
+++ b/tests/e2e/claude_code/basic_messaging_streaming/test_bedrock_converse.py
@@ -19,8 +19,8 @@ from claude_code._basic_messaging import run_basic_messaging_cell
 
 BEDROCK_CONVERSE_MODELS = [
     "claude-haiku-4-5-bedrock-converse",
-    "claude-sonnet-4-6-bedrock-converse",
-    "claude-opus-4-7-bedrock-converse",
+    "claude-sonnet-5-bedrock-converse",
+    "claude-opus-4-8-bedrock-converse",
 ]
 
 

--- a/tests/e2e/claude_code/basic_messaging_streaming/test_bedrock_invoke.py
+++ b/tests/e2e/claude_code/basic_messaging_streaming/test_bedrock_invoke.py
@@ -19,8 +19,8 @@ from claude_code._basic_messaging import run_basic_messaging_cell
 
 BEDROCK_INVOKE_MODELS = [
     "claude-haiku-4-5-bedrock-invoke",
-    "claude-sonnet-4-6-bedrock-invoke",
-    "claude-opus-4-7-bedrock-invoke",
+    "claude-sonnet-5-bedrock-invoke",
+    "claude-opus-4-8-bedrock-invoke",
 ]
 
 

--- a/tests/e2e/claude_code/count_tokens/test_anthropic.py
+++ b/tests/e2e/claude_code/count_tokens/test_anthropic.py
@@ -51,8 +51,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 ANTHROPIC_MODELS = [
     "claude-haiku-4-5",
-    "claude-sonnet-4-6",
-    "claude-opus-4-7",
+    "claude-sonnet-5",
+    "claude-opus-4-8",
 ]
 
 

--- a/tests/e2e/claude_code/count_tokens/test_azure.py
+++ b/tests/e2e/claude_code/count_tokens/test_azure.py
@@ -52,7 +52,7 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 AZURE_MODELS = [
     "claude-haiku-4-5-azure",
     "claude-sonnet-4-6-azure",
-    "claude-opus-4-7-azure",
+    "claude-opus-4-8-azure",
 ]
 
 

--- a/tests/e2e/claude_code/count_tokens/test_bedrock_converse.py
+++ b/tests/e2e/claude_code/count_tokens/test_bedrock_converse.py
@@ -51,8 +51,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_CONVERSE_MODELS = [
     "claude-haiku-4-5-bedrock-converse",
-    "claude-sonnet-4-6-bedrock-converse",
-    "claude-opus-4-7-bedrock-converse",
+    "claude-sonnet-5-bedrock-converse",
+    "claude-opus-4-8-bedrock-converse",
 ]
 
 

--- a/tests/e2e/claude_code/count_tokens/test_bedrock_invoke.py
+++ b/tests/e2e/claude_code/count_tokens/test_bedrock_invoke.py
@@ -51,8 +51,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_INVOKE_MODELS = [
     "claude-haiku-4-5-bedrock-invoke",
-    "claude-sonnet-4-6-bedrock-invoke",
-    "claude-opus-4-7-bedrock-invoke",
+    "claude-sonnet-5-bedrock-invoke",
+    "claude-opus-4-8-bedrock-invoke",
 ]
 
 

--- a/tests/e2e/claude_code/long_context_1m/test_anthropic.py
+++ b/tests/e2e/claude_code/long_context_1m/test_anthropic.py
@@ -68,12 +68,12 @@ from claude_code.cli_driver import (
 PROXY_BASE_URL_ENV = "LITELLM_PROXY_BASE_URL"
 PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
-# Haiku 4.5 is excluded -- only Sonnet 4.6 and Opus 4.7 support the
+# Haiku 4.5 is excluded -- only Sonnet 5 and Opus 4.8 support the
 # 1M-context beta. See module docstring for the per-cell-aggregator
 # rationale.
 ANTHROPIC_MODELS: Sequence[str] = (
-    "claude-sonnet-4-6",
-    "claude-opus-4-7",
+    "claude-sonnet-5",
+    "claude-opus-4-8",
 )
 
 # Beta header that opts an Anthropic-shape model into the 1M context

--- a/tests/e2e/claude_code/long_context_1m/test_azure.py
+++ b/tests/e2e/claude_code/long_context_1m/test_azure.py
@@ -68,12 +68,12 @@ from claude_code.cli_driver import (
 PROXY_BASE_URL_ENV = "LITELLM_PROXY_BASE_URL"
 PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
-# Haiku 4.5 is excluded -- only Sonnet 4.6 and Opus 4.7 support the
+# Haiku 4.5 is excluded -- only Sonnet 4.6 and Opus 4.8 support the
 # 1M-context beta. See module docstring for the per-cell-aggregator
 # rationale.
 AZURE_MODELS: Sequence[str] = (
     "claude-sonnet-4-6-azure",
-    "claude-opus-4-7-azure",
+    "claude-opus-4-8-azure",
 )
 
 # Beta header that opts an Anthropic-shape model into the 1M context

--- a/tests/e2e/claude_code/long_context_1m/test_bedrock_converse.py
+++ b/tests/e2e/claude_code/long_context_1m/test_bedrock_converse.py
@@ -68,12 +68,12 @@ from claude_code.cli_driver import (
 PROXY_BASE_URL_ENV = "LITELLM_PROXY_BASE_URL"
 PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
-# Haiku 4.5 is excluded -- only Sonnet 4.6 and Opus 4.7 support the
+# Haiku 4.5 is excluded -- only Sonnet 5 and Opus 4.8 support the
 # 1M-context beta. See module docstring for the per-cell-aggregator
 # rationale.
 BEDROCK_CONVERSE_MODELS: Sequence[str] = (
-    "claude-sonnet-4-6-bedrock-converse",
-    "claude-opus-4-7-bedrock-converse",
+    "claude-sonnet-5-bedrock-converse",
+    "claude-opus-4-8-bedrock-converse",
 )
 
 # Beta header that opts an Anthropic-shape model into the 1M context

--- a/tests/e2e/claude_code/long_context_1m/test_bedrock_invoke.py
+++ b/tests/e2e/claude_code/long_context_1m/test_bedrock_invoke.py
@@ -68,12 +68,12 @@ from claude_code.cli_driver import (
 PROXY_BASE_URL_ENV = "LITELLM_PROXY_BASE_URL"
 PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
-# Haiku 4.5 is excluded -- only Sonnet 4.6 and Opus 4.7 support the
+# Haiku 4.5 is excluded -- only Sonnet 5 and Opus 4.8 support the
 # 1M-context beta. See module docstring for the per-cell-aggregator
 # rationale.
 BEDROCK_INVOKE_MODELS: Sequence[str] = (
-    "claude-sonnet-4-6-bedrock-invoke",
-    "claude-opus-4-7-bedrock-invoke",
+    "claude-sonnet-5-bedrock-invoke",
+    "claude-opus-4-8-bedrock-invoke",
 )
 
 # Beta header that opts an Anthropic-shape model into the 1M context

--- a/tests/e2e/claude_code/manifest.yaml
+++ b/tests/e2e/claude_code/manifest.yaml
@@ -36,7 +36,7 @@ features:
     name: Thinking
     # The single row covers both API shapes Anthropic exposes — manual
     # `thinking: {type: "enabled", budget_tokens: N}` (Haiku 4.5) and
-    # `thinking: {type: "adaptive"}` (Opus 4.7); Sonnet 4.6 supports
+    # `thinking: {type: "adaptive"}` (Opus 4.8); Sonnet 5 supports
     # either and Claude Code picks per model. A break in either
     # transformer surfaces as a red cell because all three tiers must
     # pass for the cell to go green. The row was named
@@ -98,6 +98,6 @@ features:
     # 200k context window so the request can only succeed when the
     # beta header makes it all the way through the proxy to the
     # upstream. Haiku 4.5 is intentionally omitted from this row's
-    # model list (its window is 200k); Sonnet 4.6 and Opus 4.7 are
-    # the only tiers exercised. Costs roughly $4/cell/run --
+    # model list (its window is 200k); the Sonnet and Opus tiers are
+    # the only ones exercised. Costs roughly $4/cell/run --
     # tighten the prompt-token target if pricing changes meaningfully.

--- a/tests/e2e/claude_code/pdf_input/test_anthropic.py
+++ b/tests/e2e/claude_code/pdf_input/test_anthropic.py
@@ -37,8 +37,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 ANTHROPIC_MODELS = [
     "claude-haiku-4-5",
-    "claude-sonnet-4-6",
-    "claude-opus-4-7",
+    "claude-sonnet-5",
+    "claude-opus-4-8",
 ]
 
 # Smallest valid PDF that renders a single visible word ("PONG"). Built

--- a/tests/e2e/claude_code/pdf_input/test_azure.py
+++ b/tests/e2e/claude_code/pdf_input/test_azure.py
@@ -31,7 +31,7 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 AZURE_MODELS = [
     "claude-haiku-4-5-azure",
     "claude-sonnet-4-6-azure",
-    "claude-opus-4-7-azure",
+    "claude-opus-4-8-azure",
 ]
 
 PDF_MARKER = "PONG"

--- a/tests/e2e/claude_code/pdf_input/test_bedrock_converse.py
+++ b/tests/e2e/claude_code/pdf_input/test_bedrock_converse.py
@@ -36,8 +36,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_CONVERSE_MODELS = [
     "claude-haiku-4-5-bedrock-converse",
-    "claude-sonnet-4-6-bedrock-converse",
-    "claude-opus-4-7-bedrock-converse",
+    "claude-sonnet-5-bedrock-converse",
+    "claude-opus-4-8-bedrock-converse",
 ]
 
 PDF_MARKER = "PONG"

--- a/tests/e2e/claude_code/pdf_input/test_bedrock_invoke.py
+++ b/tests/e2e/claude_code/pdf_input/test_bedrock_invoke.py
@@ -35,8 +35,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_INVOKE_MODELS = [
     "claude-haiku-4-5-bedrock-invoke",
-    "claude-sonnet-4-6-bedrock-invoke",
-    "claude-opus-4-7-bedrock-invoke",
+    "claude-sonnet-5-bedrock-invoke",
+    "claude-opus-4-8-bedrock-invoke",
 ]
 
 PDF_MARKER = "PONG"

--- a/tests/e2e/claude_code/prompt_caching_1h/test_anthropic.py
+++ b/tests/e2e/claude_code/prompt_caching_1h/test_anthropic.py
@@ -40,8 +40,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 ANTHROPIC_MODELS = [
     "claude-haiku-4-5",
-    "claude-sonnet-4-6",
-    "claude-opus-4-7",
+    "claude-sonnet-5",
+    "claude-opus-4-8",
 ]
 
 # Per the changelog (2.1.108): `ENABLE_PROMPT_CACHING_1H` flips Claude

--- a/tests/e2e/claude_code/prompt_caching_1h/test_azure.py
+++ b/tests/e2e/claude_code/prompt_caching_1h/test_azure.py
@@ -32,7 +32,7 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 AZURE_MODELS = [
     "claude-haiku-4-5-azure",
     "claude-sonnet-4-6-azure",
-    "claude-opus-4-7-azure",
+    "claude-opus-4-8-azure",
 ]
 
 CACHE_1H_ENV = {"ENABLE_PROMPT_CACHING_1H": "1"}

--- a/tests/e2e/claude_code/prompt_caching_1h/test_bedrock_converse.py
+++ b/tests/e2e/claude_code/prompt_caching_1h/test_bedrock_converse.py
@@ -36,8 +36,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_CONVERSE_MODELS = [
     "claude-haiku-4-5-bedrock-converse",
-    "claude-sonnet-4-6-bedrock-converse",
-    "claude-opus-4-7-bedrock-converse",
+    "claude-sonnet-5-bedrock-converse",
+    "claude-opus-4-8-bedrock-converse",
 ]
 
 CACHE_1H_ENV = {

--- a/tests/e2e/claude_code/prompt_caching_1h/test_bedrock_invoke.py
+++ b/tests/e2e/claude_code/prompt_caching_1h/test_bedrock_invoke.py
@@ -38,8 +38,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_INVOKE_MODELS = [
     "claude-haiku-4-5-bedrock-invoke",
-    "claude-sonnet-4-6-bedrock-invoke",
-    "claude-opus-4-7-bedrock-invoke",
+    "claude-sonnet-5-bedrock-invoke",
+    "claude-opus-4-8-bedrock-invoke",
 ]
 
 # Set both the modern and the deprecated-but-honored Bedrock var so we

--- a/tests/e2e/claude_code/prompt_caching_5m/test_anthropic.py
+++ b/tests/e2e/claude_code/prompt_caching_5m/test_anthropic.py
@@ -38,8 +38,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 ANTHROPIC_MODELS = [
     "claude-haiku-4-5",
-    "claude-sonnet-4-6",
-    "claude-opus-4-7",
+    "claude-sonnet-5",
+    "claude-opus-4-8",
 ]
 
 

--- a/tests/e2e/claude_code/prompt_caching_5m/test_azure.py
+++ b/tests/e2e/claude_code/prompt_caching_5m/test_azure.py
@@ -39,7 +39,7 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 AZURE_MODELS = [
     "claude-haiku-4-5-azure",
     "claude-sonnet-4-6-azure",
-    "claude-opus-4-7-azure",
+    "claude-opus-4-8-azure",
 ]
 
 

--- a/tests/e2e/claude_code/prompt_caching_5m/test_bedrock_converse.py
+++ b/tests/e2e/claude_code/prompt_caching_5m/test_bedrock_converse.py
@@ -31,8 +31,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_CONVERSE_MODELS = [
     "claude-haiku-4-5-bedrock-converse",
-    "claude-sonnet-4-6-bedrock-converse",
-    "claude-opus-4-7-bedrock-converse",
+    "claude-sonnet-5-bedrock-converse",
+    "claude-opus-4-8-bedrock-converse",
 ]
 
 

--- a/tests/e2e/claude_code/prompt_caching_5m/test_bedrock_invoke.py
+++ b/tests/e2e/claude_code/prompt_caching_5m/test_bedrock_invoke.py
@@ -31,8 +31,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_INVOKE_MODELS = [
     "claude-haiku-4-5-bedrock-invoke",
-    "claude-sonnet-4-6-bedrock-invoke",
-    "claude-opus-4-7-bedrock-invoke",
+    "claude-sonnet-5-bedrock-invoke",
+    "claude-opus-4-8-bedrock-invoke",
 ]
 
 

--- a/tests/e2e/claude_code/structured_outputs/test_anthropic.py
+++ b/tests/e2e/claude_code/structured_outputs/test_anthropic.py
@@ -65,8 +65,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 ANTHROPIC_MODELS = [
     "claude-haiku-4-5",
-    "claude-sonnet-4-6",
-    "claude-opus-4-7",
+    "claude-sonnet-5",
+    "claude-opus-4-8",
 ]
 
 # Minimal schema with one required integer field. Kept intentionally

--- a/tests/e2e/claude_code/structured_outputs/test_azure.py
+++ b/tests/e2e/claude_code/structured_outputs/test_azure.py
@@ -66,7 +66,7 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 AZURE_MODELS = [
     "claude-haiku-4-5-azure",
     "claude-sonnet-4-6-azure",
-    "claude-opus-4-7-azure",
+    "claude-opus-4-8-azure",
 ]
 
 # Minimal schema with one required integer field. Kept intentionally

--- a/tests/e2e/claude_code/structured_outputs/test_bedrock_converse.py
+++ b/tests/e2e/claude_code/structured_outputs/test_bedrock_converse.py
@@ -65,8 +65,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_CONVERSE_MODELS = [
     "claude-haiku-4-5-bedrock-converse",
-    "claude-sonnet-4-6-bedrock-converse",
-    "claude-opus-4-7-bedrock-converse",
+    "claude-sonnet-5-bedrock-converse",
+    "claude-opus-4-8-bedrock-converse",
 ]
 
 # Minimal schema with one required integer field. Kept intentionally

--- a/tests/e2e/claude_code/structured_outputs/test_bedrock_invoke.py
+++ b/tests/e2e/claude_code/structured_outputs/test_bedrock_invoke.py
@@ -65,8 +65,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_INVOKE_MODELS = [
     "claude-haiku-4-5-bedrock-invoke",
-    "claude-sonnet-4-6-bedrock-invoke",
-    "claude-opus-4-7-bedrock-invoke",
+    "claude-sonnet-5-bedrock-invoke",
+    "claude-opus-4-8-bedrock-invoke",
 ]
 
 # Minimal schema with one required integer field. Kept intentionally

--- a/tests/e2e/claude_code/test_config.yaml
+++ b/tests/e2e/claude_code/test_config.yaml
@@ -21,13 +21,13 @@ model_list:
     litellm_params:
       model: anthropic/claude-haiku-4-5
       api_key: os.environ/ANTHROPIC_API_KEY
-  - model_name: claude-sonnet-4-6
+  - model_name: claude-sonnet-5
     litellm_params:
-      model: anthropic/claude-sonnet-4-6
+      model: anthropic/claude-sonnet-5
       api_key: os.environ/ANTHROPIC_API_KEY
-  - model_name: claude-opus-4-7
+  - model_name: claude-opus-4-8
     litellm_params:
-      model: anthropic/claude-opus-4-7
+      model: anthropic/claude-opus-4-8
       api_key: os.environ/ANTHROPIC_API_KEY
 
   # ---- Bedrock (InvokeModel) ----
@@ -35,13 +35,13 @@ model_list:
     litellm_params:
       model: bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0
       aws_region_name: us-east-1
-  - model_name: claude-sonnet-4-6-bedrock-invoke
+  - model_name: claude-sonnet-5-bedrock-invoke
     litellm_params:
-      model: bedrock/us.anthropic.claude-sonnet-4-6
+      model: bedrock/us.anthropic.claude-sonnet-5
       aws_region_name: us-east-1
-  - model_name: claude-opus-4-7-bedrock-invoke
+  - model_name: claude-opus-4-8-bedrock-invoke
     litellm_params:
-      model: bedrock/us.anthropic.claude-opus-4-7
+      model: bedrock/us.anthropic.claude-opus-4-8
       aws_region_name: us-east-1
 
   # ---- Bedrock (Converse) ----
@@ -49,13 +49,13 @@ model_list:
     litellm_params:
       model: bedrock/converse/us.anthropic.claude-haiku-4-5-20251001-v1:0
       aws_region_name: us-east-1
-  - model_name: claude-sonnet-4-6-bedrock-converse
+  - model_name: claude-sonnet-5-bedrock-converse
     litellm_params:
-      model: bedrock/converse/us.anthropic.claude-sonnet-4-6
+      model: bedrock/converse/us.anthropic.claude-sonnet-5
       aws_region_name: us-east-1
-  - model_name: claude-opus-4-7-bedrock-converse
+  - model_name: claude-opus-4-8-bedrock-converse
     litellm_params:
-      model: bedrock/converse/us.anthropic.claude-opus-4-7
+      model: bedrock/converse/us.anthropic.claude-opus-4-8
       aws_region_name: us-east-1
 
   # ---- Vertex AI ----
@@ -86,9 +86,9 @@ model_list:
       model: azure_ai/claude-sonnet-4-6
       api_base: os.environ/AZURE_FOUNDRY_API_BASE
       api_key: os.environ/AZURE_FOUNDRY_API_KEY
-  - model_name: claude-opus-4-7-azure
+  - model_name: claude-opus-4-8-azure
     litellm_params:
-      model: azure_ai/claude-opus-4-7
+      model: azure_ai/claude-opus-4-8
       api_base: os.environ/AZURE_FOUNDRY_API_BASE
       api_key: os.environ/AZURE_FOUNDRY_API_KEY
 

--- a/tests/e2e/claude_code/thinking/test_anthropic.py
+++ b/tests/e2e/claude_code/thinking/test_anthropic.py
@@ -36,8 +36,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 ANTHROPIC_MODELS = [
     "claude-haiku-4-5",
-    "claude-sonnet-4-6",
-    "claude-opus-4-7",
+    "claude-sonnet-5",
+    "claude-opus-4-8",
 ]
 
 # --effort max maps to the largest thinking budget on every supported
@@ -45,15 +45,15 @@ ANTHROPIC_MODELS = [
 # use a CLI flag (rather than the legacy MAX_THINKING_TOKENS env var)
 # because Claude Code 2.x reads thinking config from --effort, not from
 # the env, and silently no-ops the env var. We use `max` rather than
-# `high` because Sonnet 4.6 / Opus 4.7 only emit thinking blocks when
+# `high` because Sonnet 5 / Opus 4.8 only emit thinking blocks when
 # the budget is generous and the prompt is non-trivial.
 THINKING_ARGS = ["--effort", "max"]
 # A puzzle non-trivial enough that Sonnet/Opus actually engage thinking
 # rather than answer from memory. Trivial arithmetic ("3-2=?") is
 # optimized away on the modern tiers and arrives without a thinking
 # block, which would make this test silently false-fail under
-# `--effort max`. Haiku 4.5 thinks even for trivial prompts; Sonnet 4.6
-# and Opus 4.7 only emit thinking when the upstream judges it useful.
+# `--effort max`. Haiku 4.5 thinks even for trivial prompts; Sonnet 5
+# and Opus 4.8 only emit thinking when the upstream judges it useful.
 THINKING_PROMPT = (
     "I have a 3-gallon jug and a 5-gallon jug. How can I measure "
     "exactly 4 gallons of water? Think through the steps carefully."

--- a/tests/e2e/claude_code/thinking/test_azure.py
+++ b/tests/e2e/claude_code/thinking/test_azure.py
@@ -8,10 +8,7 @@ that the upstream returned a `thinking` content block.
 Foundry's Claude deployments advertise `supports_reasoning: true` in
 LiteLLM's pricing metadata; the `thinking={"type": "enabled", ...}`
 parameter passes through `azure_ai/claude-*` to Foundry's
-`/anthropic/v1/messages` endpoint unchanged. Note that
-`claude-opus-4-7-preview` documents thinking as not supported on
-Foundry; if that lands, this row may flip to a partial pass and we'll
-re-evaluate.
+`/anthropic/v1/messages` endpoint unchanged.
 
 The (feature, provider) for this cell is inferred from the file path by
 `tests/e2e/claude_code/conftest.py`:
@@ -40,7 +37,7 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 AZURE_MODELS = [
     "claude-haiku-4-5-azure",
     "claude-sonnet-4-6-azure",
-    "claude-opus-4-7-azure",
+    "claude-opus-4-8-azure",
 ]
 
 THINKING_ARGS = ["--effort", "max"]

--- a/tests/e2e/claude_code/thinking/test_bedrock_converse.py
+++ b/tests/e2e/claude_code/thinking/test_bedrock_converse.py
@@ -31,8 +31,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_CONVERSE_MODELS = [
     "claude-haiku-4-5-bedrock-converse",
-    "claude-sonnet-4-6-bedrock-converse",
-    "claude-opus-4-7-bedrock-converse",
+    "claude-sonnet-5-bedrock-converse",
+    "claude-opus-4-8-bedrock-converse",
 ]
 
 THINKING_ARGS = ["--effort", "max"]

--- a/tests/e2e/claude_code/thinking/test_bedrock_invoke.py
+++ b/tests/e2e/claude_code/thinking/test_bedrock_invoke.py
@@ -31,8 +31,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_INVOKE_MODELS = [
     "claude-haiku-4-5-bedrock-invoke",
-    "claude-sonnet-4-6-bedrock-invoke",
-    "claude-opus-4-7-bedrock-invoke",
+    "claude-sonnet-5-bedrock-invoke",
+    "claude-opus-4-8-bedrock-invoke",
 ]
 
 THINKING_ARGS = ["--effort", "max"]

--- a/tests/e2e/claude_code/thinking_with_tool_use/test_anthropic.py
+++ b/tests/e2e/claude_code/thinking_with_tool_use/test_anthropic.py
@@ -40,8 +40,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 ANTHROPIC_MODELS = [
     "claude-haiku-4-5",
-    "claude-sonnet-4-6",
-    "claude-opus-4-7",
+    "claude-sonnet-5",
+    "claude-opus-4-8",
 ]
 
 # Extended thinking on, with a small budget — enough to surface a

--- a/tests/e2e/claude_code/thinking_with_tool_use/test_azure.py
+++ b/tests/e2e/claude_code/thinking_with_tool_use/test_azure.py
@@ -35,7 +35,7 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 AZURE_MODELS = [
     "claude-haiku-4-5-azure",
     "claude-sonnet-4-6-azure",
-    "claude-opus-4-7-azure",
+    "claude-opus-4-8-azure",
 ]
 
 THINKING_ARGS = ["--effort", "max"]

--- a/tests/e2e/claude_code/thinking_with_tool_use/test_bedrock_converse.py
+++ b/tests/e2e/claude_code/thinking_with_tool_use/test_bedrock_converse.py
@@ -39,8 +39,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_CONVERSE_MODELS = [
     "claude-haiku-4-5-bedrock-converse",
-    "claude-sonnet-4-6-bedrock-converse",
-    "claude-opus-4-7-bedrock-converse",
+    "claude-sonnet-5-bedrock-converse",
+    "claude-opus-4-8-bedrock-converse",
 ]
 
 THINKING_ARGS = ["--effort", "max"]

--- a/tests/e2e/claude_code/thinking_with_tool_use/test_bedrock_invoke.py
+++ b/tests/e2e/claude_code/thinking_with_tool_use/test_bedrock_invoke.py
@@ -41,8 +41,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_INVOKE_MODELS = [
     "claude-haiku-4-5-bedrock-invoke",
-    "claude-sonnet-4-6-bedrock-invoke",
-    "claude-opus-4-7-bedrock-invoke",
+    "claude-sonnet-5-bedrock-invoke",
+    "claude-opus-4-8-bedrock-invoke",
 ]
 
 THINKING_ARGS = ["--effort", "max"]

--- a/tests/e2e/claude_code/tool_search/test_anthropic.py
+++ b/tests/e2e/claude_code/tool_search/test_anthropic.py
@@ -57,8 +57,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 ANTHROPIC_MODELS = [
     "claude-haiku-4-5",
-    "claude-sonnet-4-6",
-    "claude-opus-4-7",
+    "claude-sonnet-5",
+    "claude-opus-4-8",
 ]
 
 

--- a/tests/e2e/claude_code/tool_search/test_azure.py
+++ b/tests/e2e/claude_code/tool_search/test_azure.py
@@ -58,7 +58,7 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 AZURE_MODELS = [
     "claude-haiku-4-5-azure",
     "claude-sonnet-4-6-azure",
-    "claude-opus-4-7-azure",
+    "claude-opus-4-8-azure",
 ]
 
 

--- a/tests/e2e/claude_code/tool_search/test_bedrock_converse.py
+++ b/tests/e2e/claude_code/tool_search/test_bedrock_converse.py
@@ -57,8 +57,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_CONVERSE_MODELS = [
     "claude-haiku-4-5-bedrock-converse",
-    "claude-sonnet-4-6-bedrock-converse",
-    "claude-opus-4-7-bedrock-converse",
+    "claude-sonnet-5-bedrock-converse",
+    "claude-opus-4-8-bedrock-converse",
 ]
 
 

--- a/tests/e2e/claude_code/tool_search/test_bedrock_invoke.py
+++ b/tests/e2e/claude_code/tool_search/test_bedrock_invoke.py
@@ -57,8 +57,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_INVOKE_MODELS = [
     "claude-haiku-4-5-bedrock-invoke",
-    "claude-sonnet-4-6-bedrock-invoke",
-    "claude-opus-4-7-bedrock-invoke",
+    "claude-sonnet-5-bedrock-invoke",
+    "claude-opus-4-8-bedrock-invoke",
 ]
 
 

--- a/tests/e2e/claude_code/tool_use/test_anthropic.py
+++ b/tests/e2e/claude_code/tool_use/test_anthropic.py
@@ -31,8 +31,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 ANTHROPIC_MODELS = [
     "claude-haiku-4-5",
-    "claude-sonnet-4-6",
-    "claude-opus-4-7",
+    "claude-sonnet-5",
+    "claude-opus-4-8",
 ]
 
 # Built-in tool-use prompt: ask Claude to use the `Bash` tool. The CLI

--- a/tests/e2e/claude_code/tool_use/test_azure.py
+++ b/tests/e2e/claude_code/tool_use/test_azure.py
@@ -36,7 +36,7 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 AZURE_MODELS = [
     "claude-haiku-4-5-azure",
     "claude-sonnet-4-6-azure",
-    "claude-opus-4-7-azure",
+    "claude-opus-4-8-azure",
 ]
 
 TOOL_USE_PROMPT = (

--- a/tests/e2e/claude_code/tool_use/test_bedrock_converse.py
+++ b/tests/e2e/claude_code/tool_use/test_bedrock_converse.py
@@ -31,8 +31,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_CONVERSE_MODELS = [
     "claude-haiku-4-5-bedrock-converse",
-    "claude-sonnet-4-6-bedrock-converse",
-    "claude-opus-4-7-bedrock-converse",
+    "claude-sonnet-5-bedrock-converse",
+    "claude-opus-4-8-bedrock-converse",
 ]
 
 TOOL_USE_PROMPT = (

--- a/tests/e2e/claude_code/tool_use/test_bedrock_invoke.py
+++ b/tests/e2e/claude_code/tool_use/test_bedrock_invoke.py
@@ -31,8 +31,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_INVOKE_MODELS = [
     "claude-haiku-4-5-bedrock-invoke",
-    "claude-sonnet-4-6-bedrock-invoke",
-    "claude-opus-4-7-bedrock-invoke",
+    "claude-sonnet-5-bedrock-invoke",
+    "claude-opus-4-8-bedrock-invoke",
 ]
 
 TOOL_USE_PROMPT = (

--- a/tests/e2e/claude_code/tool_use_streaming/test_anthropic.py
+++ b/tests/e2e/claude_code/tool_use_streaming/test_anthropic.py
@@ -41,8 +41,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 ANTHROPIC_MODELS = [
     "claude-haiku-4-5",
-    "claude-sonnet-4-6",
-    "claude-opus-4-7",
+    "claude-sonnet-5",
+    "claude-opus-4-8",
 ]
 
 # Same shape as the non-streaming `tool_use` cell: ask Claude to call

--- a/tests/e2e/claude_code/tool_use_streaming/test_azure.py
+++ b/tests/e2e/claude_code/tool_use_streaming/test_azure.py
@@ -34,7 +34,7 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 AZURE_MODELS = [
     "claude-haiku-4-5-azure",
     "claude-sonnet-4-6-azure",
-    "claude-opus-4-7-azure",
+    "claude-opus-4-8-azure",
 ]
 
 TOOL_USE_PROMPT = (

--- a/tests/e2e/claude_code/tool_use_streaming/test_bedrock_converse.py
+++ b/tests/e2e/claude_code/tool_use_streaming/test_bedrock_converse.py
@@ -39,8 +39,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_CONVERSE_MODELS = [
     "claude-haiku-4-5-bedrock-converse",
-    "claude-sonnet-4-6-bedrock-converse",
-    "claude-opus-4-7-bedrock-converse",
+    "claude-sonnet-5-bedrock-converse",
+    "claude-opus-4-8-bedrock-converse",
 ]
 
 TOOL_USE_PROMPT = (

--- a/tests/e2e/claude_code/tool_use_streaming/test_bedrock_invoke.py
+++ b/tests/e2e/claude_code/tool_use_streaming/test_bedrock_invoke.py
@@ -37,8 +37,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_INVOKE_MODELS = [
     "claude-haiku-4-5-bedrock-invoke",
-    "claude-sonnet-4-6-bedrock-invoke",
-    "claude-opus-4-7-bedrock-invoke",
+    "claude-sonnet-5-bedrock-invoke",
+    "claude-opus-4-8-bedrock-invoke",
 ]
 
 TOOL_USE_PROMPT = (

--- a/tests/e2e/claude_code/vision/test_anthropic.py
+++ b/tests/e2e/claude_code/vision/test_anthropic.py
@@ -40,8 +40,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 ANTHROPIC_MODELS = [
     "claude-haiku-4-5",
-    "claude-sonnet-4-6",
-    "claude-opus-4-7",
+    "claude-sonnet-5",
+    "claude-opus-4-8",
 ]
 
 # Minimal 1x1 red PNG, base64-encoded. We embed it directly as the

--- a/tests/e2e/claude_code/vision/test_azure.py
+++ b/tests/e2e/claude_code/vision/test_azure.py
@@ -41,7 +41,7 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 AZURE_MODELS = [
     "claude-haiku-4-5-azure",
     "claude-sonnet-4-6-azure",
-    "claude-opus-4-7-azure",
+    "claude-opus-4-8-azure",
 ]
 
 # Minimal 1x1 red PNG, base64-encoded. We embed it directly as the

--- a/tests/e2e/claude_code/vision/test_bedrock_converse.py
+++ b/tests/e2e/claude_code/vision/test_bedrock_converse.py
@@ -40,8 +40,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_CONVERSE_MODELS = [
     "claude-haiku-4-5-bedrock-converse",
-    "claude-sonnet-4-6-bedrock-converse",
-    "claude-opus-4-7-bedrock-converse",
+    "claude-sonnet-5-bedrock-converse",
+    "claude-opus-4-8-bedrock-converse",
 ]
 
 # Minimal 1x1 red PNG, base64-encoded. We embed it directly as the

--- a/tests/e2e/claude_code/vision/test_bedrock_invoke.py
+++ b/tests/e2e/claude_code/vision/test_bedrock_invoke.py
@@ -40,8 +40,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_INVOKE_MODELS = [
     "claude-haiku-4-5-bedrock-invoke",
-    "claude-sonnet-4-6-bedrock-invoke",
-    "claude-opus-4-7-bedrock-invoke",
+    "claude-sonnet-5-bedrock-invoke",
+    "claude-opus-4-8-bedrock-invoke",
 ]
 
 # Minimal 1x1 red PNG, base64-encoded. We embed it directly as the

--- a/tests/e2e/claude_code/web_search/test_anthropic.py
+++ b/tests/e2e/claude_code/web_search/test_anthropic.py
@@ -43,8 +43,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 ANTHROPIC_MODELS = [
     "claude-haiku-4-5",
-    "claude-sonnet-4-6",
-    "claude-opus-4-7",
+    "claude-sonnet-5",
+    "claude-opus-4-8",
 ]
 
 # A prompt the model cannot answer from training data alone — it forces

--- a/tests/e2e/claude_code/web_search/test_azure.py
+++ b/tests/e2e/claude_code/web_search/test_azure.py
@@ -44,7 +44,7 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 AZURE_MODELS = [
     "claude-haiku-4-5-azure",
     "claude-sonnet-4-6-azure",
-    "claude-opus-4-7-azure",
+    "claude-opus-4-8-azure",
 ]
 
 # A prompt the model cannot answer from training data alone — it forces

--- a/tests/e2e/claude_code/web_search/test_bedrock_converse.py
+++ b/tests/e2e/claude_code/web_search/test_bedrock_converse.py
@@ -43,8 +43,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_CONVERSE_MODELS = [
     "claude-haiku-4-5-bedrock-converse",
-    "claude-sonnet-4-6-bedrock-converse",
-    "claude-opus-4-7-bedrock-converse",
+    "claude-sonnet-5-bedrock-converse",
+    "claude-opus-4-8-bedrock-converse",
 ]
 
 # A prompt the model cannot answer from training data alone — it forces

--- a/tests/e2e/claude_code/web_search/test_bedrock_invoke.py
+++ b/tests/e2e/claude_code/web_search/test_bedrock_invoke.py
@@ -43,8 +43,8 @@ PROXY_API_KEY_ENV = "LITELLM_PROXY_API_KEY"
 
 BEDROCK_INVOKE_MODELS = [
     "claude-haiku-4-5-bedrock-invoke",
-    "claude-sonnet-4-6-bedrock-invoke",
-    "claude-opus-4-7-bedrock-invoke",
+    "claude-sonnet-5-bedrock-invoke",
+    "claude-opus-4-8-bedrock-invoke",
 ]
 
 # A prompt the model cannot answer from training data alone — it forces


### PR DESCRIPTION
## Relevant issues

Resolves caveat 4 of #32548 (the model-tier bump follow-up for the Claude Code compatibility matrix)

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All proofs captured at commit 3befa3afc3 against a live proxy booted from this branch with the suite's own config, hitting the real provider APIs (no mocks):

```
python litellm/proxy/proxy_cli.py --config tests/e2e/claude_code/test_config.yaml --port 28255
```

One trivial `/v1/messages` call per configured alias:

```
for m in claude-haiku-4-5 claude-sonnet-5 claude-opus-4-8 \
         claude-haiku-4-5-bedrock-invoke claude-sonnet-5-bedrock-invoke claude-opus-4-8-bedrock-invoke \
         claude-haiku-4-5-bedrock-converse claude-sonnet-5-bedrock-converse claude-opus-4-8-bedrock-converse \
         claude-haiku-4-5-vertex claude-sonnet-4-6-vertex claude-opus-4-7-vertex \
         claude-haiku-4-5-azure claude-sonnet-4-6-azure claude-opus-4-8-azure; do
  curl -s http://localhost:28255/v1/messages \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d "{\"model\": \"$m\", \"max_tokens\": 32, \"messages\": [{\"role\": \"user\", \"content\": \"Reply with the single word pong\"}]}"
done
```

```
claude-haiku-4-5                       HTTP 200  claude-haiku-4-5 | pong
claude-sonnet-5                        HTTP 200  claude-sonnet-5 | pong
claude-opus-4-8                        HTTP 200  claude-opus-4-8 | pong
claude-haiku-4-5-bedrock-invoke        HTTP 200  claude-haiku-4-5-bedrock-invoke | pong
claude-sonnet-5-bedrock-invoke         HTTP 200  claude-sonnet-5-bedrock-invoke | pong
claude-opus-4-8-bedrock-invoke         HTTP 200  claude-opus-4-8-bedrock-invoke | pong
claude-haiku-4-5-bedrock-converse      HTTP 200  claude-haiku-4-5-bedrock-converse | pong
claude-sonnet-5-bedrock-converse       HTTP 200  claude-sonnet-5-bedrock-converse | pong
claude-opus-4-8-bedrock-converse       HTTP 200  claude-opus-4-8-bedrock-converse | pong
claude-haiku-4-5-vertex                HTTP 200  claude-haiku-4-5-vertex | pong
claude-sonnet-4-6-vertex               HTTP 200  claude-sonnet-4-6-vertex | pong
claude-opus-4-7-vertex                 HTTP 429  (pre-existing, see note below)
claude-haiku-4-5-azure                 HTTP 200  claude-haiku-4-5-azure | pong
claude-sonnet-4-6-azure                HTTP 200  claude-sonnet-4-6-azure | pong
claude-opus-4-8-azure                  HTTP 200  claude-opus-4-8-azure | pong
```

Why Vertex AI keeps the old tiers: the same curls with the new-tier aliases (run before pinning the column back) 429 deterministically

```
claude-sonnet-5-vertex   HTTP 429  "Quota exceeded for aiplatform.googleapis.com/online_prediction_input_tokens_per_minute_per_base_model with base model: anthropic-claude-sonnet-5. Please submit a quota increase request."
claude-opus-4-8-vertex   HTTP 429  "Quota exceeded for ... base model: anthropic-claude-opus-4-8. Please submit a quota increase request."
```

The Service Usage API confirms the suite's Vertex project has no TPM granted for either new base model in its region (quota buckets exist with no effective limit), so these 429s are a hard 0-quota condition rather than burst exhaustion

Why Azure keeps sonnet-4-6 in the sonnet slot (opus does bump to 4-8, which is already deployed on the suite's Foundry resource): the subscription's quota limit for Claude Sonnet 5 is 0, so a deployment cannot even be created

```
$ az cognitiveservices account deployment create ... --deployment-name claude-sonnet-5 \
    --model-name claude-sonnet-5 --model-version 2 --model-format Anthropic \
    --sku-name GlobalStandard --sku-capacity 40
ERROR: (InsufficientQuota) This operation require 40 new capacity in quota Tokens Per Minute (thousands) - Claude Sonnet 5, which is bigger than the current available capacity 0. The current quota usage is 0 and the quota limit is 0 for quota Tokens Per Minute (thousands) - Claude Sonnet 5.
```

Note on `claude-opus-4-7-vertex`: that alias is unchanged by this PR (it is the current large tier in the merged suite, and this PR keeps vertex on it). It 429'd on the same per-base-model TPM metric throughout the validation window even though the project has an 8M TPM grant for the opus-4-7 base model and the haiku/sonnet vertex aliases pass, consistent with concurrent live testing consuming that model's quota at capture time. Pre-existing environment condition, orthogonal to this PR

## Type

✅ Test

## Changes

Bumps the Claude Code compatibility matrix's mid and large model tiers from Sonnet 4.6 / Opus 4.7 to Sonnet 5 / Opus 4.8 wherever the suite's live provider environments can actually serve them, per caveat 4 of #32548. The haiku-4-5 small tier is unchanged everywhere, and `run_daily.sh` is untouched (owned by another in-flight PR)

Per provider column: anthropic, bedrock_invoke, and bedrock_converse move fully to `claude-sonnet-5` / `claude-opus-4-8` (aliases in `test_config.yaml`, the per-feature test files, and the `_builder`/`_driver` unit-test fixtures that encode alias names). azure bumps opus to `claude-opus-4-8` but keeps `claude-sonnet-4-6` in its sonnet slot because the suite's Foundry subscription has a hard 0 TPM quota limit for Claude Sonnet 5 (deployment creation rejected with InsufficientQuota; evidence above). vertex_ai stays fully on `claude-sonnet-4-6` / `claude-opus-4-7` because both new base models have 0 TPM in the suite's Vertex project and region and deterministically 429

`test_v0_layout.py::test_per_provider_test_file_imports_and_parametrizes_three_models` now encodes the per-provider tier expectations (`DEFAULT_TIERS` plus `PROVIDER_TIER_OVERRIDES` for the two quota-pinned columns) with a docstring explaining why each pin exists and what to flip once quota lands, so the pins are enforced by a failing test instead of being folklore. Tier-naming comments in `manifest.yaml` and the test docstrings were updated to match; the long-context manifest comment went tier-generic since the exercised models now differ per column. `sample_compatibility-matrix.json` needed no change (it carries no model names)

Follow-ups for whoever owns the provider accounts: request Claude Sonnet 5 TPM quota in the Foundry subscription (self-serve form), request sonnet-5 and opus-4-8 TPM quota in the Vertex project, then flip the pinned aliases plus the layout-test overrides

## QA runbook

Environment prerequisites: a proxy booted from this branch with `--config tests/e2e/claude_code/test_config.yaml` and the suite's provider credentials in the environment (`ANTHROPIC_API_KEY`, AWS credentials for us-east-1 Bedrock, `VERTEXAI_PROJECT`/`VERTEXAI_LOCATION` plus GCP credentials, `AZURE_FOUNDRY_API_BASE`/`AZURE_FOUNDRY_API_KEY` pointing at the Foundry resource that hosts the Claude deployments). Every changed e2e file is the same mechanical alias swap, so the runbook covers one representative cell per provider column plus the structural pin

- tests/e2e/claude_code/basic_messaging_non_streaming/test_anthropic.py::test_basic_messaging_non_streaming_anthropic - the anthropic column now exercises haiku-4-5, sonnet-5, and opus-4-8
  - [ ] POST /v1/messages with `{"model": "claude-sonnet-5", "max_tokens": 32, "messages": [{"role": "user", "content": "Reply with the single word pong"}]}` and the proxy key
  - [ ] Expect 200 with an assistant text reply; repeat for `claude-opus-4-8` and `claude-haiku-4-5`
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
- tests/e2e/claude_code/basic_messaging_non_streaming/test_bedrock_invoke.py::test_basic_messaging_non_streaming_bedrock_invoke - the invoke column routes to `bedrock/us.anthropic.claude-sonnet-5` and `bedrock/us.anthropic.claude-opus-4-8`
  - [ ] Same POST as above with `claude-sonnet-5-bedrock-invoke` then `claude-opus-4-8-bedrock-invoke`
  - [ ] Expect 200 with a text reply from each
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
- tests/e2e/claude_code/basic_messaging_non_streaming/test_bedrock_converse.py::test_basic_messaging_non_streaming_bedrock_converse - the converse column routes to `bedrock/converse/us.anthropic.claude-sonnet-5` and `bedrock/converse/us.anthropic.claude-opus-4-8`
  - [ ] Same POST with `claude-sonnet-5-bedrock-converse` then `claude-opus-4-8-bedrock-converse`
  - [ ] Expect 200 with a text reply from each
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
- tests/e2e/claude_code/basic_messaging_non_streaming/test_vertex_ai.py::test_basic_messaging_non_streaming_vertex_ai - the vertex column intentionally stays on sonnet-4-6 and opus-4-7
  - [ ] Same POST with `claude-sonnet-4-6-vertex`; expect 200
  - [ ] POST with model `claude-sonnet-5-vertex`; expect a 400 invalid-model error from the proxy (alias deliberately not registered), confirming the pin is real
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
- tests/e2e/claude_code/basic_messaging_non_streaming/test_azure.py::test_basic_messaging_non_streaming_azure - the azure column bumps opus to 4-8 and keeps sonnet on 4-6
  - [ ] Same POST with `claude-opus-4-8-azure` then `claude-sonnet-4-6-azure`; expect 200 from each
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
- tests/e2e/claude_code/_builder_unit_tests/test_v0_layout.py::test_per_provider_test_file_imports_and_parametrizes_three_models - every provider file must reference its column's pinned tier set
  - [ ] Run the test and expect all parametrizations to pass; then edit e.g. tool_use/test_azure.py to say sonnet-5-azure and expect the azure parametrizations to fail naming the missing sonnet-4-6 tier
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
