### PR TITLE
test(reasoning_effort_grid): enable azure fable-5 and opus-4-8 grid cells

### DIFF
--- a/tests/llm_translation/reasoning_effort_grid/grid_spec.py
+++ b/tests/llm_translation/reasoning_effort_grid/grid_spec.py
@@ -212,12 +212,6 @@ AZURE_AI_MODELS: Tuple[ModelEntry, ...] = (
         mode="adaptive",
         required_env=_AZURE_FOUNDRY_REQ,
         caps=_CAPS_XHIGH_MAX,
-        fail_reason=(
-            "claude-fable-5 has no deployment on the CI Microsoft Foundry "
-            "resource yet; Foundry returns DeploymentNotFound until someone "
-            "creates the fable-5 deployment, so this cell stays loud in CI. "
-            "Remove this fail_reason once the deployment exists."
-        ),
     ),
     ModelEntry(
         alias="azure-claude-opus-4-8",
@@ -225,12 +219,6 @@ AZURE_AI_MODELS: Tuple[ModelEntry, ...] = (
         mode="adaptive",
         required_env=_AZURE_FOUNDRY_REQ,
         caps=_CAPS_XHIGH_MAX,
-        fail_reason=(
-            "claude-opus-4-8 has no deployment on the CI Microsoft Foundry "
-            "resource yet; Foundry returns DeploymentNotFound until someone "
-            "creates the opus-4-8 deployment, so this cell stays loud in CI. "
-            "Remove this fail_reason once the deployment exists."
-        ),
     ),
     ModelEntry(
         alias="azure-claude-opus-4-7",


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The two fail_reason entries said to remove them once claude-fable-5 and claude-opus-4-8 deployments exist on the CI Microsoft Foundry resource. Both deployments now exist and serve real traffic (real Anthropic calls costing real $):

```
$ curl -sS "https://litellm-e2e-suite-resource.services.ai.azure.com/anthropic/v1/messages" \
    -H "x-api-key: $AZURE_FOUNDRY_API_KEY" -H "anthropic-version: 2023-06-01" -H "content-type: application/json" \
    -d '{"model":"claude-opus-4-8","max_tokens":24,"messages":[{"role":"user","content":"hi"}]}'
{"content":[{"text":"Hi there! How can I help you today?", ...
```

```
$ curl -sS "https://litellm-e2e-suite-resource.services.ai.azure.com/anthropic/v1/messages" \
    -H "x-api-key: $AZURE_FOUNDRY_API_KEY" -H "anthropic-version: 2023-06-01" -H "content-type: application/json" \
    -d '{"model":"claude-fable-5","max_tokens":2048,"messages":[{"role":"user","content":"hi"}]}'
{"content":[{"type":"thinking", ...},{"type":"text","text":"Hi there! How can I help you today?"}], ...
```

Before (commit a61aa82eea on litellm_internal_staging), the 22 cells were unconditionally xfailed by the fail_reason entries:

```
$ python -m pytest tests/llm_translation/reasoning_effort_grid/test_reasoning_effort_grid.py -k "azure-claude-fable-5 or azure-claude-opus-4-8" -q
311 deselected, 22 xfailed in 0.40s
```

After (this PR, commit da47272227), the same 22 cells run live against the Foundry resource and pass:

```
$ python -m pytest tests/llm_translation/reasoning_effort_grid/test_reasoning_effort_grid.py -k "azure-claude-fable-5 or azure-claude-opus-4-8" -q
22 passed, 311 deselected in 71.47s (0:01:11)
```

## Type

✅ Test

## Changes

Removes the two temporary fail_reason (xfail) entries for azure_ai/claude-fable-5 and azure_ai/claude-opus-4-8 in the reasoning effort grid spec. They were added because the CI Foundry resource had no deployments for these models; the deployments now exist, so the 22 cells run for real in CI instead of xfailing

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
