### PR TITLE
fix(e2e): resolve claude_code unit-test paths relative to the suite dir

### DIFF
--- a/tests/e2e/claude_code/_pr_gate_unit_tests/test_bash_tool_restrictions.py
+++ b/tests/e2e/claude_code/_pr_gate_unit_tests/test_bash_tool_restrictions.py
@@ -35,8 +35,7 @@ from typing import Iterable
 
 import pytest
 
-REPO_ROOT = Path(__file__).resolve().parents[4]
-CLAUDE_CODE_DIR = REPO_ROOT / "tests" / "e2e" / "claude_code"
+CLAUDE_CODE_DIR = Path(__file__).resolve().parents[1]
 
 # Feature directories whose cells drive the `Bash` built-in tool. Add
 # new entries here when a new Bash-using feature is added; the test
@@ -74,14 +73,14 @@ def _has_bare_bash_token(text: str) -> bool:
 
 
 @pytest.mark.parametrize(
-    "cell", list(_bash_cells()), ids=lambda p: str(p.relative_to(REPO_ROOT))
+    "cell", list(_bash_cells()), ids=lambda p: str(p.relative_to(CLAUDE_CODE_DIR))
 )
 def test_bash_allow_rule_is_pinned_to_exact_echo_pong(cell: Path) -> None:
     """The cell must pass `Bash(echo pong)` as the allow rule, not the
     unrestricted `Bash` value that was originally flagged."""
     text = cell.read_text()
     assert '"Bash(echo pong)"' in text, (
-        f"{cell.relative_to(REPO_ROOT)} must restrict `--allowed-tools` to "
+        f"{cell.relative_to(CLAUDE_CODE_DIR)} must restrict `--allowed-tools` to "
         f'`Bash(echo pong)` (exact-match pattern). Unrestricted `"Bash"` '
         f"grants arbitrary host command execution to model-controlled "
         f"tool_use blocks, which can read `docker inspect compat-proxy` "
@@ -95,7 +94,7 @@ def test_bash_allow_rule_is_pinned_to_exact_echo_pong(cell: Path) -> None:
     # in text` short-circuits to True and lets a stray bare `"Bash"`
     # slip through silently.
     assert not _has_bare_bash_token(text), (
-        f"{cell.relative_to(REPO_ROOT)} still references the unrestricted "
+        f"{cell.relative_to(CLAUDE_CODE_DIR)} still references the unrestricted "
         f'`"Bash"` value outside the `"Bash(echo pong)"` allow rule — '
         f"sweep it out before merging."
     )
@@ -130,7 +129,7 @@ def test_has_bare_bash_token_ignores_unrelated_substrings():
 
 
 @pytest.mark.parametrize(
-    "cell", list(_bash_cells()), ids=lambda p: str(p.relative_to(REPO_ROOT))
+    "cell", list(_bash_cells()), ids=lambda p: str(p.relative_to(CLAUDE_CODE_DIR))
 )
 def test_bash_cell_uses_dontask_permission_mode(cell: Path) -> None:
     """The cell must pair the allow rule with `--permission-mode dontAsk`
@@ -139,7 +138,7 @@ def test_bash_cell_uses_dontask_permission_mode(cell: Path) -> None:
     succeed without ever surfacing the security issue)."""
     text = cell.read_text()
     assert '"--permission-mode"' in text and '"dontAsk"' in text, (
-        f"{cell.relative_to(REPO_ROOT)} must pass `--permission-mode dontAsk` "
+        f"{cell.relative_to(CLAUDE_CODE_DIR)} must pass `--permission-mode dontAsk` "
         f"alongside the `Bash(echo pong)` allow rule. Without dontAsk, "
         f"commands outside the allow rule fall back to the default ask-"
         f"mode behavior, which in `--print` (headless) mode is non-"

--- a/tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_pytest_scrubs_env.py
+++ b/tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_pytest_scrubs_env.py
@@ -18,8 +18,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[4]
-RUN_DAILY = REPO_ROOT / "tests" / "e2e" / "claude_code" / "cron_vm" / "run_daily.sh"
+RUN_DAILY = Path(__file__).resolve().parents[1] / "cron_vm" / "run_daily.sh"
 
 
 def _pytest_invocation_block() -> str:

--- a/tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_release_pagination.py
+++ b/tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_release_pagination.py
@@ -32,8 +32,7 @@ from pathlib import Path
 
 import pytest
 
-REPO_ROOT = Path(__file__).resolve().parents[4]
-RUN_DAILY = REPO_ROOT / "tests" / "e2e" / "claude_code" / "cron_vm" / "run_daily.sh"
+RUN_DAILY = Path(__file__).resolve().parents[1] / "cron_vm" / "run_daily.sh"
 
 # The extracted snippet starts AFTER `log`/`die` are defined in run_daily.sh,
 # so the test harness has to provide its own stubs. Without them, a failure

--- a/tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_version_probe_scrubs_env.py
+++ b/tests/e2e/claude_code/_publisher_unit_tests/test_run_daily_version_probe_scrubs_env.py
@@ -17,8 +17,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[4]
-RUN_DAILY = REPO_ROOT / "tests" / "e2e" / "claude_code" / "cron_vm" / "run_daily.sh"
+RUN_DAILY = Path(__file__).resolve().parents[1] / "cron_vm" / "run_daily.sh"
 
 
 def _version_probe_block() -> str:

--- a/tests/e2e/claude_code/_publisher_unit_tests/test_systemd_unit_credential_isolation.py
+++ b/tests/e2e/claude_code/_publisher_unit_tests/test_systemd_unit_credential_isolation.py
@@ -23,9 +23,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[4]
 SERVICE = (
-    REPO_ROOT / "tests" / "e2e" / "claude_code" / "cron_vm" / "litellm-compat-matrix.service"
+    Path(__file__).resolve().parents[1] / "cron_vm" / "litellm-compat-matrix.service"
 )
 
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The scheduled e2e suite runs from an image where `tests/e2e` is copied to `/app/e2e`, so `Path(__file__).resolve().parents[4]` resolves to `/` instead of the repo root and collection of the entire suite dies before a single test runs. Tonight's run (job `litellm-e2e-1-0-0-main-20260716001737` on the stage cluster):

```
ERROR collecting claude_code/_pr_gate_unit_tests/test_bash_tool_restrictions.py
E   AssertionError: /tests/e2e/claude_code/tool_use is missing — BASH_FEATURE_DIRS is out of sync with the layout under tests/e2e/claude_code/.
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
========================= 1 skipped, 1 error in 5.57s ==========================
```

Reproduced locally by copying `tests/e2e` to a scratch dir exactly like the image build does. Before (commit 614dd8756e):

```
$ cp -R tests/e2e /tmp/imgsim/e2e && cd /tmp/imgsim/e2e
$ python -m pytest claude_code/_pr_gate_unit_tests/ claude_code/_publisher_unit_tests/ -q
ERROR claude_code/_pr_gate_unit_tests/test_bash_tool_restrictions.py - Assert...
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
1 error in 0.07s
```

After (commit f708740afd), same copy-and-run:

```
$ python -m pytest claude_code/_pr_gate_unit_tests/ claude_code/_publisher_unit_tests/ -q
2 failed, 54 passed in 0.11s
```

The 2 remaining failures are `test_run_daily_release_pagination.py` tests whose fake-curl shim is blocked by the local sandbox on this machine; they fail identically at the base commit in the normal repo layout, so they are pre-existing and unrelated to this change. The same in-repo run at f708740afd also gives 54 passed with only those 2 environment failures, so the path change is behavior-neutral for the PR gate

## Type

🐛 Bug Fix

## Changes

Five unit-test files under `tests/e2e/claude_code/` located repo files via `Path(__file__).resolve().parents[4]` followed by `"tests" / "e2e" / "claude_code" / ...`. That arithmetic only works when the files sit at their in-repo depth; in the e2e suite image the tests live at `/app/e2e/claude_code/...`, so the lookup resolved to `/tests/e2e/...` and the module-level assert in `test_bash_tool_restrictions.py` aborted collection of the whole scheduled suite. All five now resolve their targets relative to the `claude_code` directory itself (`parents[1]`), which is correct in both layouts. Test ids and assertion messages that printed paths relative to the repo root now print them relative to `claude_code`
