### PR TITLE
fix(logging): stamp request async-ness at the client wrapper so async entrypoints never double-log

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -344,6 +344,7 @@ class Logging(LiteLLMLoggingBaseClass):
         self.stream = stream
         self.start_time = start_time  # log the call start time
         self.call_type = call_type
+        self.is_async_entrypoint: Optional[bool] = None
         self.litellm_call_id = litellm_call_id
         self.litellm_trace_id: str = litellm_trace_id if litellm_trace_id else str(uuid.uuid4())
         self.function_id = function_id
@@ -1520,15 +1521,15 @@ class Logging(LiteLLMLoggingBaseClass):
     ) -> Optional[float]:
         return self._response_cost_calculator(result=result, cache_hit=cache_hit)
 
-    @staticmethod
-    def _is_sync_litellm_request(litellm_params: dict, call_type: Optional[str]) -> bool:
+    def _is_sync_litellm_request(self, litellm_params: dict) -> bool:
         """True for sync SDK entrypoints (``completion``), false for async (``acompletion``, etc.).
 
-        ``call_type`` marks async-only entrypoints that set no ``a*`` flag in
-        ``litellm_params``; ``anthropic_messages`` always classifies as async.
+        ``is_async_entrypoint`` is stamped by the ``@client`` wrapper that ran the request
+        and is authoritative; the ``a*`` flag heuristic covers logging objects constructed
+        outside ``@client`` (proxy passthrough endpoints, realtime, MCP).
         """
-        if call_type == CallTypes.anthropic_messages.value:
-            return False
+        if self.is_async_entrypoint is not None:
+            return not self.is_async_entrypoint
         return (
             litellm_params.get(CallTypes.acompletion.value, False) is not True
             and litellm_params.get(CallTypes.aresponses.value, False) is not True
@@ -1579,7 +1580,7 @@ class Logging(LiteLLMLoggingBaseClass):
             self.model_call_details["has_dispatched_final_stream_success"] = True
 
         litellm_params = self.model_call_details.get("litellm_params", {}) or {}
-        sync_sdk = self._is_sync_litellm_request(litellm_params, call_type=self.call_type)
+        sync_sdk = self._is_sync_litellm_request(litellm_params)
         passthrough = self.call_type == CallTypes.pass_through.value
         if sync_sdk and not prefer_async_handlers and not passthrough:
             self.success_handler(
@@ -1973,7 +1974,7 @@ class Logging(LiteLLMLoggingBaseClass):
             standard_logging_object=kwargs.get("standard_logging_object", None),
         )
         litellm_params = self.model_call_details.get("litellm_params", {})
-        is_sync_request = self._is_sync_litellm_request(litellm_params, call_type=self.call_type)
+        is_sync_request = self._is_sync_litellm_request(litellm_params)
         try:
             ## BUILD COMPLETE STREAMED RESPONSE
             complete_streaming_response: Optional[
@@ -2764,7 +2765,7 @@ class Logging(LiteLLMLoggingBaseClass):
         if not self.should_run_logging(event_type="sync_failure"):  # prevent double logging
             return
         litellm_params = self.model_call_details.get("litellm_params", {})
-        is_sync_request = self._is_sync_litellm_request(litellm_params, call_type=self.call_type)
+        is_sync_request = self._is_sync_litellm_request(litellm_params)
 
         try:
             start_time, end_time = self._failure_handler_helper_fn(

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1668,7 +1668,7 @@ class CustomStreamWrapper:
             asyncio.run(self.logging_obj.async_success_handler(processed_chunk, None, None, cache_hit))
         ## SYNC LOGGING — only for sync SDK entrypoints; async proxy paths export via async_success_handler
         litellm_params = self.logging_obj.model_call_details.get("litellm_params", {})
-        if self.logging_obj._is_sync_litellm_request(litellm_params, call_type=self.logging_obj.call_type):
+        if self.logging_obj._is_sync_litellm_request(litellm_params):
             self.logging_obj.success_handler(processed_chunk, None, None, cache_hit)
 
     def finish_reason_handler(self):

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1324,6 +1324,8 @@ def client(original_function):
 
             # Type assertion: logging_obj is guaranteed to be non-None after function_setup
             assert logging_obj is not None, "logging_obj should not be None after function_setup"
+            if logging_obj.is_async_entrypoint is None:
+                logging_obj.is_async_entrypoint = False
 
             ## LOAD CREDENTIALS
             load_credentials_from_list(kwargs)
@@ -1605,6 +1607,8 @@ def client(original_function):
 
             # Type assertion: logging_obj is guaranteed to be non-None after function_setup
             assert logging_obj is not None, "logging_obj should not be None after function_setup"
+            if logging_obj.is_async_entrypoint is None:
+                logging_obj.is_async_entrypoint = True
 
             modified_kwargs = await async_pre_call_deployment_hook(kwargs, call_type)
             if modified_kwargs is not None:

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -798,29 +798,23 @@ def test_success_handler_runs_sync_callbacks_for_sync_requests(logging_obj, call
     dummy_logger.log_stream_event.assert_not_called()
 
 
-def test_is_sync_litellm_request():
-    assert LitellmLogging._is_sync_litellm_request({}, call_type=None) is True
-    assert (
-        LitellmLogging._is_sync_litellm_request({"acompletion": True}, call_type=None)
-        is False
-    )
-    assert (
-        LitellmLogging._is_sync_litellm_request(
-            {"allm_passthrough_route": True}, call_type=None
-        )
-        is False
-    )
-    assert LitellmLogging._is_sync_litellm_request({}, call_type="completion") is True
-    assert (
-        LitellmLogging._is_sync_litellm_request({}, call_type="anthropic_messages")
-        is False
-    )
+def test_is_sync_litellm_request(logging_obj):
+    assert logging_obj.is_async_entrypoint is None
+    assert logging_obj._is_sync_litellm_request({}) is True
+    assert logging_obj._is_sync_litellm_request({"acompletion": True}) is False
+    assert logging_obj._is_sync_litellm_request({"allm_passthrough_route": True}) is False
+
+    logging_obj.is_async_entrypoint = True
+    assert logging_obj._is_sync_litellm_request({}) is False
+
+    logging_obj.is_async_entrypoint = False
+    assert logging_obj._is_sync_litellm_request({"acompletion": True}) is True
 
 
 @pytest.mark.asyncio
 async def test_anthropic_messages_success_logs_custom_logger_exactly_once(logging_obj):
-    """anthropic_messages success must reach a CustomLogger exactly once, via the async
-    hook only; the sync success_handler skips CustomLogger hooks for this call type.
+    """A request stamped async by the @client wrapper must reach a CustomLogger exactly
+    once, via the async hook only; the sync success_handler skips CustomLogger hooks.
     Regression guard for LIT-4447."""
     from litellm.integrations.custom_logger import CustomLogger
 
@@ -829,6 +823,7 @@ async def test_anthropic_messages_success_logs_custom_logger_exactly_once(loggin
 
     logging_obj.stream = False
     logging_obj.call_type = "anthropic_messages"
+    logging_obj.is_async_entrypoint = True
     logging_obj.model_call_details["litellm_params"] = {}
     logging_obj.litellm_params = {}
 
@@ -865,9 +860,9 @@ async def test_anthropic_messages_success_logs_custom_logger_exactly_once(loggin
 
 @pytest.mark.asyncio
 async def test_anthropic_messages_failure_logs_custom_logger_exactly_once(logging_obj):
-    """anthropic_messages failure must reach a CustomLogger exactly once, via the async
-    hook only; the sync failure_handler skips CustomLogger hooks for this call type.
-    Regression guard for LIT-4447."""
+    """A request stamped async by the @client wrapper must reach a CustomLogger exactly
+    once on failure, via the async hook only; the sync failure_handler skips CustomLogger
+    hooks. Regression guard for LIT-4447."""
     from litellm.integrations.custom_logger import CustomLogger
 
     class DummyLogger(CustomLogger):
@@ -875,6 +870,7 @@ async def test_anthropic_messages_failure_logs_custom_logger_exactly_once(loggin
 
     logging_obj.stream = False
     logging_obj.call_type = "anthropic_messages"
+    logging_obj.is_async_entrypoint = True
     logging_obj.model_call_details["litellm_params"] = {}
     logging_obj.litellm_params = {}
 
@@ -897,7 +893,90 @@ async def test_anthropic_messages_failure_logs_custom_logger_exactly_once(loggin
     mock_sync_log.assert_not_called()
 
 
-def test_get_litellm_params_propagates_allm_passthrough_route():
+@pytest.mark.asyncio
+async def test_async_client_entrypoint_stamps_and_dedupes_flagless_call_type():
+    """End-to-end through the real @client wrapper: litellm.anthropic_messages sets no
+    `a*` flag in litellm_params, so only the wrapper-stamped is_async_entrypoint marks
+    the request async. With the executor sync dispatch open (a surviving plain-callable
+    callback, same mechanism as a legacy string callback), the CustomLogger must fire
+    via the async hook exactly once. Regression guard for LIT-4447 and LIT-4475."""
+
+    events = []
+
+    class Rec(CustomLogger):
+        def log_success_event(self, kwargs, response_obj, start_time, end_time):
+            events.append(("sync", kwargs.get("call_type")))
+
+        async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+            events.append(("async", kwargs.get("call_type")))
+
+    def _gate_opener(kwargs, completion_response, start_time, end_time):
+        pass
+
+    rec = Rec()
+    original_success = litellm.success_callback
+    original_async = litellm._async_success_callback
+    litellm.success_callback = [rec, _gate_opener]
+    litellm._async_success_callback = [rec]
+    try:
+        await litellm.anthropic_messages(
+            max_tokens=16,
+            messages=[{"role": "user", "content": "hi"}],
+            model="claude-sonnet-5",
+            custom_llm_provider="anthropic",
+            api_key="sk-ant-dummy",
+            mock_response="hello",
+        )
+        for _ in range(50):
+            if events:
+                break
+            await asyncio.sleep(0.1)
+        from litellm.litellm_core_utils.thread_pool_executor import executor
+
+        executor.submit(lambda: None).result()
+    finally:
+        litellm.success_callback = original_success
+        litellm._async_success_callback = original_async
+
+    assert events == [("async", "anthropic_messages")]
+
+
+@pytest.mark.asyncio
+async def test_client_wrapper_stamp_is_first_wins_across_nested_calls():
+    """An async entrypoint that internally invokes a sync @client function with the
+    shared logging object (e.g. agenerate_content delegating to generate_content) must
+    keep is_async_entrypoint=True; the inner sync wrapper must not overwrite the
+    entrypoint's stamp. Regression guard for LIT-4475 (gemini /generate_content kept
+    double-logging because the inner sync wrapper flipped the bit back to sync)."""
+    from litellm.utils import client
+
+    observed = {}
+
+    @client
+    def fake_inner_sync(model: str, messages=None, **kwargs):
+        observed["inner_bit"] = kwargs["litellm_logging_obj"].is_async_entrypoint
+        return ModelResponse(
+            model=model,
+            choices=[{"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop", "index": 0}],
+            usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        )
+
+    @client
+    async def fake_outer_async(model: str, messages=None, **kwargs):
+        result = fake_inner_sync(model=model, messages=messages, **kwargs)
+        observed["outer_bit_after_inner"] = kwargs["litellm_logging_obj"].is_async_entrypoint
+        return result
+
+    await fake_outer_async(model="gpt-4.1-mini", messages=[{"role": "user", "content": "hi"}])
+
+    assert observed == {"inner_bit": True, "outer_bit_after_inner": True}
+
+    fake_inner_sync(model="gpt-4.1-mini", messages=[{"role": "user", "content": "hi"}])
+
+    assert observed["inner_bit"] is False
+
+
+def test_get_litellm_params_propagates_allm_passthrough_route(logging_obj):
     """`allm_passthrough_route=True` set on kwargs by the async passthrough entrypoint
     must land in `litellm_params` so `_is_sync_litellm_request` sees it and the
     request is classified as async. Regression guard for LIT-4192."""
@@ -905,7 +984,7 @@ def test_get_litellm_params_propagates_allm_passthrough_route():
 
     params = get_litellm_params(allm_passthrough_route=True)
     assert params.get("allm_passthrough_route") is True
-    assert LitellmLogging._is_sync_litellm_request(params, call_type=None) is False
+    assert logging_obj._is_sync_litellm_request(params) is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -946,11 +946,24 @@ async def test_client_wrapper_stamp_is_first_wins_across_nested_calls():
     """An async entrypoint that internally invokes a sync @client function with the
     shared logging object (e.g. agenerate_content delegating to generate_content) must
     keep is_async_entrypoint=True; the inner sync wrapper must not overwrite the
-    entrypoint's stamp. Regression guard for LIT-4475 (gemini /generate_content kept
+    entrypoint's stamp, and the nested request must reach a CustomLogger exactly once,
+    via the async hook. Regression guard for LIT-4475 (gemini /generate_content kept
     double-logging because the inner sync wrapper flipped the bit back to sync)."""
+    from litellm.litellm_core_utils.thread_pool_executor import executor
     from litellm.utils import client
 
     observed = {}
+    events = []
+
+    class Rec(CustomLogger):
+        def log_success_event(self, kwargs, response_obj, start_time, end_time):
+            events.append("sync")
+
+        async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+            events.append("async")
+
+    def _gate_opener(kwargs, completion_response, start_time, end_time):
+        pass
 
     @client
     def fake_inner_sync(model: str, messages=None, **kwargs):
@@ -967,9 +980,24 @@ async def test_client_wrapper_stamp_is_first_wins_across_nested_calls():
         observed["outer_bit_after_inner"] = kwargs["litellm_logging_obj"].is_async_entrypoint
         return result
 
-    await fake_outer_async(model="gpt-4.1-mini", messages=[{"role": "user", "content": "hi"}])
+    rec = Rec()
+    original_success = litellm.success_callback
+    original_async = litellm._async_success_callback
+    litellm.success_callback = [rec, _gate_opener]
+    litellm._async_success_callback = [rec]
+    try:
+        await fake_outer_async(model="gpt-4.1-mini", messages=[{"role": "user", "content": "hi"}])
+        for _ in range(50):
+            if events:
+                break
+            await asyncio.sleep(0.1)
+        executor.submit(lambda: None).result()
+    finally:
+        litellm.success_callback = original_success
+        litellm._async_success_callback = original_async
 
     assert observed == {"inner_bit": True, "outer_bit_after_inner": True}
+    assert events == ["async"]
 
     fake_inner_sync(model="gpt-4.1-mini", messages=[{"role": "user", "content": "hi"}])
 

--- a/tests/test_litellm/passthrough/test_passthrough_main.py
+++ b/tests/test_litellm/passthrough/test_passthrough_main.py
@@ -1,4 +1,5 @@
 import json
+import time
 import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -800,4 +801,13 @@ def test_llm_passthrough_route_propagates_allm_passthrough_route_to_logging_obj(
         result.close()
 
     assert captured_litellm_params.get("allm_passthrough_route") is True
-    assert LitellmLogging._is_sync_litellm_request(captured_litellm_params, call_type=None) is False
+    flag_only_logging_obj = LitellmLogging(
+        model="test-model",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        call_type="allm_passthrough_route",
+        start_time=time.time(),
+        litellm_call_id="flag-fallback-check",
+        function_id="fn",
+    )
+    assert flag_only_logging_obj._is_sync_litellm_request(captured_litellm_params) is False

--- a/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
+++ b/tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py
@@ -1088,7 +1088,7 @@ class TestDeferredStreamingClosure:
         )
         # litellm_params with no recognized async marker -> classified sync.
         logging_obj.model_call_details["litellm_params"] = {}
-        assert LiteLLMLoggingObj._is_sync_litellm_request({}, call_type=None) is True
+        assert logging_obj._is_sync_litellm_request({}) is True
 
         with (
             patch.object(


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4475

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Stacked on #33481. Live proxy on localhost:4475 (real Postgres, real Anthropic and Gemini APIs), DataDog logs intake redirected to a local recording sink via `DD_BASE_URL`; config has `success_callback: ["datadog"]` plus `cache: true` (the cache setting registers the legacy `"cache"` string callback that opens the sync dispatch for async calls)

Before (base of this PR, i.e. with only the #33481 call-type guard), one native gemini call double-logs; this upgrades LIT-4475 from suspected to reproduced:

```
curl -sS "http://localhost:4475/v1beta/models/gemini-3.5-flash:generateContent" \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"contents":[{"parts":[{"text":"Say only: L4475-BEFORE-GEMINI"}]}]}'

POST#1 call_type=agenerate_content call_id=f0331010-...   <- immediate single-event POST (sync hook)
POST#2 call_type=anthropic_messages call_id=afaea9dd-...  <- /v1/messages control, exactly one
POST#2 call_type=agenerate_content call_id=f0331010-...   <- batched POST (async hook), same call id
counts: {agenerate_content/f0331010: 2, anthropic_messages/afaea9dd: 1}
```

After (this PR), the same calls plus a `/chat/completions` control and a streaming `/v1/messages` call:

```
POST#1 call_type=anthropic_messages call_id=da34efa6-...
POST#1 call_type=agenerate_content call_id=75ac3afa-...
POST#1 call_type=acompletion       call_id=986c5a27-...
POST#2 call_type=anthropic_messages call_id=cbf7d8a8-...  <- streaming
duplicates: NONE - every call logged exactly once
```

`LiteLLM_SpendLogs` has exactly one row per request throughout (the duplicate-request_id group-by returns zero rows). SDK-level probes confirm the sync entrypoint keeps its sync hook: `litellm.google_genai.generate_content` (sync) fires `log_success_event` exactly once, `litellm.agenerate_content` fires `async_log_success_event` exactly once

## Type

🐛 Bug Fix

## Changes

Follow-up to #33481, which fixed the async-request misclassification for `anthropic_messages` with a call-type guard. This PR replaces that guard with the general mechanism so every async-only entrypoint is classified correctly, including the `agenerate_content` sibling that this PR reproduces live

The `@client` decorator already knows whether a request is sync or async; it selects `wrapper` or `wrapper_async` from `is_async_callable(original_function)`. Each wrapper now records that fact on the logging object it runs (`logging_obj.is_async_entrypoint`), and `_is_sync_litellm_request` reads the recorded bit instead of guessing from an allowlist of `a*` flags in `litellm_params`. The flag heuristic remains only as a fallback for logging objects constructed outside `@client` (passthrough, realtime). The `anthropic_messages` call-type guard from #33481 is deleted; the bit covers it

The stamp is first-wins: an async entrypoint that internally invokes a sync `@client` function with the shared logging object (exactly what `agenerate_content` does when delegating to `generate_content`) keeps its async classification; without first-wins the inner sync wrapper flips the bit back and the gemini double-log survives, which is how the live repro caught it

This is the same pattern the logging object already uses for `call_type` and `stream`: a fact the wrapper knows at entry, recorded at creation, read downstream. It replaces the per-entrypoint flag planting (`acompletion`, `aresponses`, `async_call`) whose forget-one-flag failure mode produced LIT-4192, LIT-4447, and LIT-4475

## Behavior changes

Async-only entrypoints that set no `a*` flag stop double-firing CustomLogger hooks; they now deliver via the async hooks exactly once, matching `/chat/completions`. Verified live for `agenerate_content` (gemini native route) and `/v1/messages`; the same correction applies to any other async `@client` entrypoint without a flag. As in #33481, a custom integration implementing only the sync hooks stops receiving events for those async entrypoints; that profile was already unsupported on every flagged async route

Sync entrypoints are unchanged: the sync wrapper stamps false, which matches what the flag heuristic already said for them, and sync `generate_content` was probe-verified to keep firing its sync hook exactly once. Logging objects created outside `@client` keep the flag-based classification byte-for-byte (the bit stays unset). Spend rows, response bodies, and cost headers are unchanged

## QA runbook

1. Start a proxy with an anthropic model, a gemini model, `success_callback: ["datadog"]`, `cache: true`, and env `DD_API_KEY=<any>`, `DD_SITE=datadoghq.com`, `DD_BASE_URL=<local sink URL>`
2. POST one non-streaming `/v1/messages`, one `/v1beta/models/<gemini-model>:generateContent`, one `/chat/completions`, and one streaming `/v1/messages` request
3. Confirm the sink receives exactly one log event per call (match on `litellm_call_id` in the event `message` payload)
4. Call `litellm.google_genai.generate_content` (sync SDK) with a CustomLogger registered and confirm `log_success_event` still fires once

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
