### PR TITLE
fix(ui): stop sending the complexity-router pseudo-model to /health/test_connection

### DIFF
--- a/ui/litellm-dashboard/src/components/model_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.test.tsx
@@ -16,6 +16,7 @@ vi.mock("./molecules/notifications_manager", () => ({
     success: vi.fn(),
     error: vi.fn(),
     info: vi.fn(),
+    warning: vi.fn(),
     fromBackend: vi.fn(),
   },
 }));
@@ -788,6 +789,102 @@ describe("ModelInfoView", () => {
       expect(mockTestModelGroupConnection).toHaveBeenCalledWith("test-token", "gpt-4o", "chat");
     });
     expect(mockTestConnectionRequest).not.toHaveBeenCalled();
+  });
+
+  it("also tests the configured default model when an unconfigured tier would fall back to it in production", async () => {
+    const complexityRouterModelData = {
+      ...defaultModelData,
+      litellm_params: {
+        ...defaultModelData.litellm_params,
+        model: "auto_router/complexity_router",
+        complexity_router_config: {
+          tiers: { SIMPLE: ["gpt-4o-mini"], MEDIUM: [], COMPLEX: [], REASONING: [] },
+        },
+        complexity_router_default_model: "gpt-4o",
+      },
+    };
+
+    mockUseModelsInfo.mockReturnValue({
+      data: {
+        data: [complexityRouterModelData],
+      },
+      isLoading: false,
+      error: null,
+    });
+    mockTestModelGroupConnection.mockResolvedValue({ status: "success" });
+
+    render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
+    const testConnectionButton = await screen.findByTestId("test-connection-button");
+    await userEvent.click(testConnectionButton);
+
+    await waitFor(() => {
+      expect(mockTestModelGroupConnection).toHaveBeenCalledWith("test-token", "gpt-4o-mini", "chat");
+      expect(mockTestModelGroupConnection).toHaveBeenCalledWith("test-token", "gpt-4o", "chat");
+    });
+  });
+
+  it("does not duplicate the default model as a test target when it is already covered by a configured tier", async () => {
+    const complexityRouterModelData = {
+      ...defaultModelData,
+      litellm_params: {
+        ...defaultModelData.litellm_params,
+        model: "auto_router/complexity_router",
+        complexity_router_config: {
+          tiers: { SIMPLE: ["gpt-4o-mini"], MEDIUM: ["gpt-4o"], COMPLEX: [], REASONING: [] },
+        },
+        complexity_router_default_model: "gpt-4o",
+      },
+    };
+
+    mockUseModelsInfo.mockReturnValue({
+      data: {
+        data: [complexityRouterModelData],
+      },
+      isLoading: false,
+      error: null,
+    });
+    mockTestModelGroupConnection.mockResolvedValue({ status: "success" });
+
+    render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
+    const testConnectionButton = await screen.findByTestId("test-connection-button");
+    await userEvent.click(testConnectionButton);
+
+    await waitFor(() => {
+      expect(mockTestModelGroupConnection).toHaveBeenCalledWith("test-token", "gpt-4o", "chat");
+    });
+    expect(mockTestModelGroupConnection).toHaveBeenCalledTimes(2);
+  });
+
+  it("warns instead of erroring when no complexity tiers are configured to test", async () => {
+    const complexityRouterModelData = {
+      ...defaultModelData,
+      litellm_params: {
+        ...defaultModelData.litellm_params,
+        model: "auto_router/complexity_router",
+        complexity_router_config: {
+          tiers: { SIMPLE: [], MEDIUM: [], COMPLEX: [], REASONING: [] },
+        },
+      },
+    };
+
+    mockUseModelsInfo.mockReturnValue({
+      data: {
+        data: [complexityRouterModelData],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
+    const testConnectionButton = await screen.findByTestId("test-connection-button");
+    await userEvent.click(testConnectionButton);
+
+    await waitFor(() => {
+      expect(mockNotificationsManager.warning).toHaveBeenCalledWith(
+        "No complexity tiers are configured yet, so there is nothing to test.",
+      );
+    });
+    expect(mockTestModelGroupConnection).not.toHaveBeenCalled();
   });
 
   it("should display model access groups field", async () => {

--- a/ui/litellm-dashboard/src/components/model_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.test.tsx
@@ -27,6 +27,7 @@ vi.mock("./networking", () => ({
   getGuardrailsList: vi.fn(),
   tagListCall: vi.fn(),
   testConnectionRequest: vi.fn(),
+  testModelGroupConnection: vi.fn(),
   modelPatchUpdateCall: vi.fn(),
   modelDeleteCall: vi.fn(),
   credentialCreateCall: vi.fn(),
@@ -52,6 +53,7 @@ const mockCredentialListCall = vi.mocked(networking.credentialListCall);
 const mockGetGuardrailsList = vi.mocked(networking.getGuardrailsList);
 const mockTagListCall = vi.mocked(networking.tagListCall);
 const mockTestConnectionRequest = vi.mocked(networking.testConnectionRequest);
+const mockTestModelGroupConnection = vi.mocked(networking.testModelGroupConnection);
 const mockModelPatchUpdateCall = vi.mocked(networking.modelPatchUpdateCall);
 const mockModelDeleteCall = vi.mocked(networking.modelDeleteCall);
 const mockCredentialCreateCall = vi.mocked(networking.credentialCreateCall);
@@ -730,6 +732,62 @@ describe("ModelInfoView", () => {
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /edit auto router/i })).toBeInTheDocument();
     });
+  });
+
+  it("does not offer Test Connection for semantic auto router models (no tier-based test exists yet)", async () => {
+    const semanticAutoRouterModelData = {
+      ...defaultModelData,
+      litellm_params: {
+        ...defaultModelData.litellm_params,
+        auto_router_config: {},
+      },
+    };
+
+    mockUseModelsInfo.mockReturnValue({
+      data: {
+        data: [semanticAutoRouterModelData],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
+    await waitFor(() => {
+      expect(screen.getByText("Model Settings")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("test-connection-button")).not.toBeInTheDocument();
+  });
+
+  it("tests each complexity tier's model group instead of sending the router pseudo-model to /health/test_connection (regression: raw test previously threw 'Unmapped LLM provider... model=complexity_router')", async () => {
+    const complexityRouterModelData = {
+      ...defaultModelData,
+      litellm_params: {
+        ...defaultModelData.litellm_params,
+        model: "auto_router/complexity_router",
+        complexity_router_config: {
+          tiers: { SIMPLE: ["gpt-4o-mini"], MEDIUM: ["gpt-4o"], COMPLEX: [], REASONING: [] },
+        },
+      },
+    };
+
+    mockUseModelsInfo.mockReturnValue({
+      data: {
+        data: [complexityRouterModelData],
+      },
+      isLoading: false,
+      error: null,
+    });
+    mockTestModelGroupConnection.mockResolvedValue({ status: "success" });
+
+    render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
+    const testConnectionButton = await screen.findByTestId("test-connection-button");
+    await userEvent.click(testConnectionButton);
+
+    await waitFor(() => {
+      expect(mockTestModelGroupConnection).toHaveBeenCalledWith("test-token", "gpt-4o-mini", "chat");
+      expect(mockTestModelGroupConnection).toHaveBeenCalledWith("test-token", "gpt-4o", "chat");
+    });
+    expect(mockTestConnectionRequest).not.toHaveBeenCalled();
   });
 
   it("should display model access groups field", async () => {

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -23,6 +23,8 @@ import { CheckIcon, CopyIcon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { copyToClipboard as utilCopyToClipboard } from "../utils/dataUtils";
 import { formItemValidateJSON, truncateString } from "../utils/textUtils";
+import AutoRouterConnectionTest from "./add_model/auto_router_connection_test";
+import { AutoRouterTestTarget, buildAutoRouterTestTargets } from "./add_model/build_auto_router_test_targets";
 import CacheControlSettings from "./add_model/cache_control_settings";
 import DeleteResourceModal from "./common_components/DeleteResourceModal";
 import EditAutoRouterModal from "./edit_auto_router/edit_auto_router_modal";
@@ -68,6 +70,37 @@ const isMaskedSecret = (value: unknown): boolean => typeof value === "string" &&
 const stripMaskedSecrets = (params: Record<string, unknown>): Record<string, unknown> =>
   Object.fromEntries(Object.entries(params).filter(([, value]) => !isMaskedSecret(value)));
 
+const normalizeTierModels = (value: unknown): string[] => {
+  if (Array.isArray(value)) return value;
+  if (typeof value === "string" && value) return [value];
+  return [];
+};
+
+// A complexity-router deployment (litellm_params.model="auto_router/complexity_router") is a
+// routing-strategy config, not a real provider endpoint -- there is nothing for a raw
+// litellm.ahealth_check() completion call to hit. "Test Connection" instead probes each
+// configured tier's underlying model group, mirroring the Add Auto Router wizard's test.
+const buildComplexityRouterTestTargets = (modelData: any): AutoRouterTestTarget[] => {
+  let config = modelData?.litellm_params?.complexity_router_config ?? {};
+  if (typeof config === "string") {
+    try {
+      config = JSON.parse(config);
+    } catch {
+      config = {};
+    }
+  }
+  return buildAutoRouterTestTargets({
+    tiers: {
+      SIMPLE: normalizeTierModels(config?.tiers?.SIMPLE),
+      MEDIUM: normalizeTierModels(config?.tiers?.MEDIUM),
+      COMPLEX: normalizeTierModels(config?.tiers?.COMPLEX),
+      REASONING: normalizeTierModels(config?.tiers?.REASONING),
+    },
+    semanticMatchingEnabled: Boolean(config?.semantic_keyword_matching),
+    embeddingModel: config?.embedding_model,
+  });
+};
+
 export default function ModelInfoView({
   modelId,
   onClose,
@@ -91,6 +124,9 @@ export default function ModelInfoView({
   const [showCacheControl, setShowCacheControl] = useState(false);
   const [copiedStates, setCopiedStates] = useState<Record<string, boolean>>({});
   const [isAutoRouterModalOpen, setIsAutoRouterModalOpen] = useState(false);
+  const [isAutoRouterTestModalOpen, setIsAutoRouterTestModalOpen] = useState(false);
+  const [autoRouterTestId, setAutoRouterTestId] = useState(0);
+  const [autoRouterTestTargets, setAutoRouterTestTargets] = useState<AutoRouterTestTarget[]>([]);
   const [guardrailsList, setGuardrailsList] = useState<string[]>([]);
   const [tagsList, setTagsList] = useState<Record<string, Tag>>({});
   const [credentialsList, setCredentialsList] = useState<CredentialItem[]>([]);
@@ -126,6 +162,9 @@ export default function ModelInfoView({
   const isAdmin = userRole === "Admin";
   const isAutoRouter =
     modelData?.litellm_params?.auto_router_config != null ||
+    modelData?.litellm_params?.complexity_router_config != null ||
+    modelData?.litellm_params?.model?.startsWith("auto_router/complexity_router");
+  const isComplexityRouter =
     modelData?.litellm_params?.complexity_router_config != null ||
     modelData?.litellm_params?.model?.startsWith("auto_router/complexity_router");
 
@@ -435,6 +474,17 @@ export default function ModelInfoView({
 
   const handleTestConnection = async () => {
     if (!accessToken) return;
+    if (isComplexityRouter) {
+      const targets = buildComplexityRouterTestTargets(localModelData ?? modelData);
+      if (targets.length === 0) {
+        NotificationsManager.fromBackend("No complexity tiers are configured yet, so there is nothing to test.");
+        return;
+      }
+      setAutoRouterTestTargets(targets);
+      setAutoRouterTestId((id) => id + 1);
+      setIsAutoRouterTestModalOpen(true);
+      return;
+    }
     try {
       NotificationsManager.info("Testing connection...");
       const response = await testConnectionRequest(
@@ -536,14 +586,16 @@ export default function ModelInfoView({
           </div>
         </div>
         <div className="flex gap-2">
-          <Button
-            icon={<RefreshIcon className="h-4 w-4" />}
-            onClick={handleTestConnection}
-            className="flex items-center gap-2"
-            data-testid="test-connection-button"
-          >
-            Test Connection
-          </Button>
+          {(!isAutoRouter || isComplexityRouter) && (
+            <Button
+              icon={<RefreshIcon className="h-4 w-4" />}
+              onClick={handleTestConnection}
+              className="flex items-center gap-2"
+              data-testid="test-connection-button"
+            >
+              Test Connection
+            </Button>
+          )}
 
           <Button
             icon={<KeyIcon className="h-4 w-4" />}
@@ -1433,6 +1485,23 @@ export default function ModelInfoView({
         accessToken={accessToken || ""}
         userRole={userRole || ""}
       />
+
+      {/* Complexity Router Connection Test Modal */}
+      <Modal
+        title="Connection Test Results"
+        open={isAutoRouterTestModalOpen}
+        onCancel={() => setIsAutoRouterTestModalOpen(false)}
+        footer={[
+          <Button key="close" onClick={() => setIsAutoRouterTestModalOpen(false)}>
+            Close
+          </Button>,
+        ]}
+        width={700}
+      >
+        {isAutoRouterTestModalOpen && accessToken && (
+          <AutoRouterConnectionTest key={autoRouterTestId} accessToken={accessToken} targets={autoRouterTestTargets} />
+        )}
+      </Modal>
     </div>
   );
 }

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -76,29 +76,58 @@ const normalizeTierModels = (value: unknown): string[] => {
   return [];
 };
 
-// A complexity-router deployment (litellm_params.model="auto_router/complexity_router") is a
-// routing-strategy config, not a real provider endpoint -- there is nothing for a raw
-// litellm.ahealth_check() completion call to hit. "Test Connection" instead probes each
-// configured tier's underlying model group, mirroring the Add Auto Router wizard's test.
-const buildComplexityRouterTestTargets = (modelData: any): AutoRouterTestTarget[] => {
-  let config = modelData?.litellm_params?.complexity_router_config ?? {};
-  if (typeof config === "string") {
+interface ComplexityRouterTierConfig {
+  tiers?: {
+    SIMPLE?: unknown;
+    MEDIUM?: unknown;
+    COMPLEX?: unknown;
+    REASONING?: unknown;
+  };
+  semantic_keyword_matching?: boolean;
+  embedding_model?: string;
+}
+
+interface ComplexityRouterModelData {
+  litellm_params?: {
+    complexity_router_config?: ComplexityRouterTierConfig | string;
+    complexity_router_default_model?: string;
+  };
+}
+
+const buildComplexityRouterTestTargets = (
+  modelData: ComplexityRouterModelData | null | undefined,
+): AutoRouterTestTarget[] => {
+  const rawConfig = modelData?.litellm_params?.complexity_router_config;
+  let config: ComplexityRouterTierConfig = {};
+  if (typeof rawConfig === "string") {
     try {
-      config = JSON.parse(config);
+      config = JSON.parse(rawConfig);
     } catch {
       config = {};
     }
+  } else if (rawConfig) {
+    config = rawConfig;
   }
-  return buildAutoRouterTestTargets({
+
+  const tierTargets = buildAutoRouterTestTargets({
     tiers: {
-      SIMPLE: normalizeTierModels(config?.tiers?.SIMPLE),
-      MEDIUM: normalizeTierModels(config?.tiers?.MEDIUM),
-      COMPLEX: normalizeTierModels(config?.tiers?.COMPLEX),
-      REASONING: normalizeTierModels(config?.tiers?.REASONING),
+      SIMPLE: normalizeTierModels(config.tiers?.SIMPLE),
+      MEDIUM: normalizeTierModels(config.tiers?.MEDIUM),
+      COMPLEX: normalizeTierModels(config.tiers?.COMPLEX),
+      REASONING: normalizeTierModels(config.tiers?.REASONING),
     },
-    semanticMatchingEnabled: Boolean(config?.semantic_keyword_matching),
-    embeddingModel: config?.embedding_model,
+    semanticMatchingEnabled: Boolean(config.semantic_keyword_matching),
+    embeddingModel: config.embedding_model,
   });
+
+  const defaultModel = modelData?.litellm_params?.complexity_router_default_model?.trim();
+  if (!defaultModel || tierTargets.some((target) => target.modelGroup === defaultModel)) {
+    return tierTargets;
+  }
+  return [
+    ...tierTargets,
+    { labels: ["Default (unconfigured tiers)"], modelGroup: defaultModel, mode: "chat" as const },
+  ];
 };
 
 export default function ModelInfoView({
@@ -477,7 +506,7 @@ export default function ModelInfoView({
     if (isComplexityRouter) {
       const targets = buildComplexityRouterTestTargets(localModelData ?? modelData);
       if (targets.length === 0) {
-        NotificationsManager.fromBackend("No complexity tiers are configured yet, so there is nothing to test.");
+        NotificationsManager.warning("No complexity tiers are configured yet, so there is nothing to test.");
         return;
       }
       setAutoRouterTestTargets(targets);
@@ -1486,7 +1515,6 @@ export default function ModelInfoView({
         userRole={userRole || ""}
       />
 
-      {/* Complexity Router Connection Test Modal */}
       <Modal
         title="Connection Test Results"
         open={isAutoRouterTestModalOpen}


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a UI fix, so here's how to reproduce and verify it against a locally running proxy + dashboard dev server:

1. Start the proxy with `STORE_MODEL_IN_DB=True` set, and run the dashboard dev server (`npm run dev` in `ui/litellm-dashboard`)
2. In the Admin UI, add an auto router with `classifier_type` recommended (complexity router), configuring at least one tier with a real model group
3. Open the saved model's detail page (`http://localhost:4000/ui/?page=models` and click into it) and click "Test Connection"
4. Before this fix: the request fails immediately with `litellm.BadRequestError: Unmapped LLM provider for this endpoint. You passed model=complexity_router...`, because the raw `auto_router/complexity_router` pseudo-model was sent straight to `/health/test_connection`
5. After this fix: a "Connection Test Results" modal opens and tests each configured tier's underlying model group instead, matching the behavior already used in the "Add Auto Router" creation wizard
6. For a semantic-type auto router (one created via the older `auto_router_config` path, not complexity tiers), confirm the "Test Connection" button is no longer shown on its detail page, since there's no equivalent tier-based test for that router type yet

## Type

Bug Fix

## Changes

Test Connection on a saved complexity-router model sent the router's pseudo-model name (`auto_router/complexity_router`) directly to the generic `/health/test_connection` endpoint. That endpoint calls `litellm.ahealth_check()`, a raw completion call with no Router involved, so it always failed: `auto_router` is only registered as an `LlmProviders` enum member so the `Router` can recognize auto-router deployments internally, and nothing in `litellm.completion`'s provider dispatch handles it as a real provider.

The "Add Auto Router" creation wizard already solved this correctly by testing each configured tier's underlying model group instead of the router itself, via `buildAutoRouterTestTargets` and `AutoRouterConnectionTest`. That logic just wasn't wired into the post-save model detail page.

`model_info_view.tsx` now reuses that same per-tier test for complexity-router models. Semantic-type auto routers (`auto_router_config`) have no equivalent tier-based test implemented anywhere yet, so the button is hidden for them instead of remaining wired to a call that's guaranteed to fail.
