### PR TITLE
chore(release): backport #32956 onto patch-1.93.0rc1 for the 1.93.0 rc2 cut

### DIFF
--- a/litellm/litellm_core_utils/get_litellm_params.py
+++ b/litellm/litellm_core_utils/get_litellm_params.py
@@ -2,26 +2,8 @@ from typing import Optional
 
 from litellm.llms.openai.data_residency import infer_openai_data_residency
 
-# Pre-define optional kwargs keys as frozenset for O(1) lookups
-# These are extracted from kwargs only if present, avoiding unnecessary .get() calls
-OPTIONAL_KWARGS_KEYS = frozenset(
+AWS_CREDENTIAL_KWARGS_KEYS = frozenset(
     {
-        "azure_ad_token",
-        "tenant_id",
-        "client_id",
-        "client_secret",
-        "azure_username",
-        "azure_password",
-        "azure_scope",
-        "timeout",
-        "gcs_bucket_name",
-        "bucket_name",
-        "vertex_credentials",
-        "vertex_project",
-        "vertex_location",
-        "vertex_ai_project",
-        "vertex_ai_location",
-        "vertex_ai_credentials",
         "aws_region_name",
         "aws_access_key_id",
         "aws_secret_access_key",
@@ -34,12 +16,38 @@ OPTIONAL_KWARGS_KEYS = frozenset(
         "aws_external_id",
         "aws_bedrock_runtime_endpoint",
         "aws_bedrock_project_id",
-        "tpm",
-        "rpm",
-        "itpm",
-        "otpm",
-        "use_xai_oauth",
     }
+)
+
+# Pre-define optional kwargs keys as frozenset for O(1) lookups
+# These are extracted from kwargs only if present, avoiding unnecessary .get() calls
+OPTIONAL_KWARGS_KEYS = (
+    frozenset(
+        {
+            "azure_ad_token",
+            "tenant_id",
+            "client_id",
+            "client_secret",
+            "azure_username",
+            "azure_password",
+            "azure_scope",
+            "timeout",
+            "gcs_bucket_name",
+            "bucket_name",
+            "vertex_credentials",
+            "vertex_project",
+            "vertex_location",
+            "vertex_ai_project",
+            "vertex_ai_location",
+            "vertex_ai_credentials",
+            "tpm",
+            "rpm",
+            "itpm",
+            "otpm",
+            "use_xai_oauth",
+        }
+    )
+    | AWS_CREDENTIAL_KWARGS_KEYS
 )
 
 # Backward-compatible alias for existing imports/tests.

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -877,6 +877,15 @@ class BaseAWSLLM:
                     "Resource": "*",
                     "Condition": {"Bool": {"aws:SecureTransport": "true"}},
                 },
+                {
+                    "Sid": "BedrockMantleLiteLLM",
+                    "Effect": "Allow",
+                    "Action": [
+                        "bedrock-mantle:CreateInference",
+                    ],
+                    "Resource": "*",
+                    "Condition": {"Bool": {"aws:SecureTransport": "true"}},
+                },
             ],
         }
         assume_role_params = {

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -92,7 +92,10 @@ from litellm.litellm_core_utils.completion_timeout import CompletionTimeout
 from litellm.litellm_core_utils.request_timeout_resolver import (
     get_configured_request_timeout,
 )
-from litellm.litellm_core_utils.get_litellm_params import OPTIONAL_KWARGS_KEYS
+from litellm.litellm_core_utils.get_litellm_params import (
+    AWS_CREDENTIAL_KWARGS_KEYS,
+    OPTIONAL_KWARGS_KEYS,
+)
 from litellm.litellm_core_utils.dd_tracing import tracer
 from litellm.litellm_core_utils.get_provider_specific_headers import (
     ProviderSpecificHeaderUtils,
@@ -5322,7 +5325,7 @@ def completion(  # type: ignore
             tpm=kwargs.get("tpm"),
             rpm=kwargs.get("rpm"),
             use_xai_oauth=kwargs.get("use_xai_oauth", False),
-            aws_bedrock_project_id=kwargs.get("aws_bedrock_project_id"),
+            **{key: kwargs[key] for key in AWS_CREDENTIAL_KWARGS_KEYS if key in kwargs},
         )
         cast(LiteLLMLoggingObj, logging).update_environment_variables(
             model=model,

--- a/tests/test_litellm/llms/bedrock/test_web_identity_session_policy.py
+++ b/tests/test_litellm/llms/bedrock/test_web_identity_session_policy.py
@@ -158,6 +158,54 @@ class TestClaudePlatformActionsCovered:
         )
 
 
+class TestBedrockMantleActionsCovered:
+    """LIT-3859: bedrock_mantle inference authorizes against the
+    ``bedrock-mantle`` action namespace, so the session-policy ceiling
+    must include it or every Mantle request via OIDC/WIF auth denies
+    with "no session policy allows the bedrock-mantle:CreateInference
+    action" even when the role's identity policy grants it."""
+
+    def test_bedrock_mantle_create_inference_present(self):
+        policy = _captured_policy()
+        all_actions: set = set()
+        for stmt in policy["Statement"]:
+            stmt_actions = stmt.get("Action")
+            if isinstance(stmt_actions, str):
+                all_actions.add(stmt_actions)
+            elif isinstance(stmt_actions, list):
+                all_actions.update(stmt_actions)
+        assert "bedrock-mantle:CreateInference" in all_actions, (
+            "bedrock-mantle:CreateInference missing from session policy — "
+            "bedrock_mantle/* requests will 403 on OIDC/WIF auth"
+        )
+
+    def test_bedrock_mantle_statement_allows(self):
+        policy = _captured_policy()
+        stmt = _statement_by_sid(policy, "BedrockMantleLiteLLM")
+        assert stmt["Effect"] == "Allow"
+        assert stmt["Resource"] == "*"
+
+    def test_no_bedrock_mantle_wildcard(self):
+        policy = _captured_policy()
+        stmt = _statement_by_sid(policy, "BedrockMantleLiteLLM")
+        actions = stmt["Action"]
+        if isinstance(actions, str):
+            actions = [actions]
+        assert "bedrock-mantle:*" not in actions, (
+            "session policy must not grant bedrock-mantle:* — "
+            "the ceiling should match the documented action set"
+        )
+
+    def test_bedrock_mantle_statement_carries_secure_transport_condition(self):
+        policy = _captured_policy()
+        stmt = _statement_by_sid(policy, "BedrockMantleLiteLLM")
+        cond = stmt.get("Condition") or {}
+        assert cond.get("Bool", {}).get("aws:SecureTransport") == "true", (
+            "BedrockMantleLiteLLM must require aws:SecureTransport=true "
+            "to keep parity with the bedrock statement"
+        )
+
+
 def _make_jwt(payload: dict) -> str:
     def _segment(data: dict) -> str:
         return base64.urlsafe_b64encode(json.dumps(data).encode()).rstrip(b"=").decode()

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -2081,3 +2081,79 @@ def test_stream_chunk_builder_text_completion_combines_text_and_usage():
     assert response.usage.prompt_tokens > 0
     assert response.usage.completion_tokens > 0
     assert response.usage.total_tokens == response.usage.prompt_tokens + response.usage.completion_tokens
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "aws_credential_kwargs",
+    [
+        {
+            "aws_session_name": "litellm-gcp",
+            "aws_role_name": "arn:aws:iam::123456789012:role/litellm-bedrock-role",
+            "aws_web_identity_token": "oidc/google/108963886734710037768",
+        },
+        {
+            "aws_access_key_id": "AKIASTATICKEYFORTEST",
+            "aws_secret_access_key": "static-secret-key",
+            "aws_session_token": "static-session-token",
+        },
+    ],
+    ids=["web_identity", "static_keys"],
+)
+async def test_acompletion_forwards_aws_credentials_through_responses_bridge(
+    respx_mock: respx.MockRouter, monkeypatch, aws_credential_kwargs: dict
+):
+    from botocore.credentials import Credentials
+
+    from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+
+    original_disable_aiohttp = litellm.disable_aiohttp_transport
+    try:
+        litellm.disable_aiohttp_transport = True
+        monkeypatch.setenv("DISABLE_AIOHTTP_TRANSPORT", "True")
+        litellm.in_memory_llm_clients_cache.flush_cache()
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        monkeypatch.delenv("BEDROCK_MANTLE_API_KEY", raising=False)
+
+        get_credentials_mock = MagicMock(return_value=Credentials("fake-key", "fake-secret"))
+        monkeypatch.setattr(BaseAWSLLM, "get_credentials", get_credentials_mock)
+
+        respx_mock.post("https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses").respond(
+            json={
+                "id": "resp_123",
+                "object": "response",
+                "created_at": 1760144904,
+                "status": "completed",
+                "model": "openai.gpt-5.4",
+                "output": [
+                    {
+                        "type": "message",
+                        "id": "msg_1",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [{"type": "output_text", "text": "ok", "annotations": []}],
+                    }
+                ],
+            }
+        )
+
+        response = await litellm.acompletion(
+            model="bedrock_mantle/openai.gpt-5.4",
+            messages=[{"role": "user", "content": "hi"}],
+            api_base="https://bedrock-mantle.us-east-2.api.aws/v1",
+            aws_region_name="us-east-2",
+            num_retries=0,
+            **aws_credential_kwargs,
+        )
+
+        assert response.choices[0].message.content == "ok"
+        credential_kwargs = get_credentials_mock.call_args.kwargs
+        assert credential_kwargs["aws_region_name"] == "us-east-2"
+        for key, value in aws_credential_kwargs.items():
+            assert credential_kwargs[key] == value
+        authorization = respx_mock.calls.last.request.headers["Authorization"]
+        assert authorization.startswith("AWS4-HMAC-SHA256")
+        assert "fake-key" in authorization
+    finally:
+        litellm.disable_aiohttp_transport = original_disable_aiohttp
+        litellm.in_memory_llm_clients_cache.flush_cache()


### PR DESCRIPTION
## Relevant issues

Backports #32956 onto a fresh base branch cut from the `v1.93.0-rc.1` tag, so the 1.93.0 rc2 build carries the fix. #32956 forwards AWS credential kwargs (region, access key, secret, session token, web identity token, role name, session name) from the top-level `completion()` call into `litellm_params`, so a chat request that is routed through the chat -> Responses API bridge keeps Web Identity Federation auth instead of dropping the deployment's credentials. It also adds the `bedrock-mantle:CreateInference` action to the STS session policy so the same path works for the responses-only bedrock mantle models. Carries the LIT-3859 fix.

The other PR originally requested for this line, #33248 (left-anchor the Create Key and Create Team CTAs), is intentionally NOT included: rc1 predates the Teams/Keys UI migration, so it renders `OldTeams.tsx` and the legacy keys page, not the migrated `Teams.tsx` / `VirtualKeysTable.tsx` that #33248 edits. The cherry-pick conflicts in every file and has nothing to attach to on this line, so it is dropped rather than hand-adapted.

## Linear ticket

Resolves LIT-3859

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## What is included

- #32956 `fix(completion)`: forward aws credential kwargs into litellm_params so the responses bridge keeps WIF auth (cherry-picked `-x -m 1` from staging merge `c75fccf`; the pick is patch-identical to the source, no adaptation)

No version bump: rc1's `pyproject.toml` already reads `1.93.0` and final `v1.93.0` is unreleased (no `v1.93.0` tag, no `release/v1.93.0` branch, DockerHub `v1.93.0` returns 404; only `v1.93.0-rc.1` is published). The pick rides the pending `1.93.0`; release tooling cuts `v1.93.0-rc.2` from this branch. No production `.tsx` is touched, so there is no UI rebuild.

## Base branch and provenance

Base is `patch-1.93.0rc1`, a new branch created at the exact `v1.93.0-rc.1` commit (`10d5804b`); `git diff v1.93.0-rc.1 patch-1.93.0rc1` is empty. The one commit on this PR carries a `(cherry picked from commit c75fccf)` footer and that SHA is reachable from `litellm_internal_staging`. No merge commits, no `_experimental/out/` artifacts.

## Known noise on this line

None on the targeted test set once `boto3` is present in the env. A bare env without `boto3` fails 22 bedrock/WIF tests with `ModuleNotFoundError: No module named 'boto3'`; that is an environment gap, not a code failure, and CI installs boto3.

## Screenshots / Proof of Fix

The original ticket reproducer needs a live Web Identity Federation setup (a Google-issued OIDC token plus a real IAM role and a bedrock mantle deployment), which is not reproducible on a local dev box, so the end-to-end WIF replay lives in #32956 itself. On this backport branch the evidence is the pick's own tests passing on the rc1 code, plus a live-proxy sanity pass that the credential-forwarding path is intact.

Targeted test delta, captured at `fba058b865` (the pick) versus `10d5804b` (rc1 baseline):

```
# baseline (rc1, pre-pick), boto3 present
94 passed
# post-pick (same set + the pick's new tests)
100 passed, 0 failed
```

The pick's own new tests, all passing on rc1:

```
tests/test_litellm/test_main.py::test_acompletion_forwards_aws_credentials_through_responses_bridge[static_keys] PASSED
tests/test_litellm/test_main.py::test_acompletion_forwards_aws_credentials_through_responses_bridge[web_identity] PASSED
tests/.../test_web_identity_session_policy.py::TestBedrockMantleActionsCovered::test_bedrock_mantle_create_inference_present PASSED
tests/.../test_web_identity_session_policy.py::TestBedrockMantleActionsCovered::test_bedrock_mantle_statement_allows PASSED
tests/.../test_web_identity_session_policy.py::TestBedrockMantleActionsCovered::test_bedrock_mantle_statement_carries_secure_transport_condition PASSED
tests/.../test_web_identity_session_policy.py::TestBedrockMantleActionsCovered::test_no_bedrock_mantle_wildcard PASSED
```

Live proxy on the built branch (`fba058b865`), real API calls:

```
# non-AWS completion hot path still works after the forwarding change
$ curl -s localhost:4001/v1/chat/completions -H 'Authorization: Bearer sk-1234' \
    -d '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"Reply with exactly: rc2 ok"}],"max_tokens":20}'
-> "rc2 ok"

# real bedrock call: credentials are forwarded and reach AWS (rejected only because the
# dev .env AWS creds are stale); a broken-forwarding regression would surface as
# missing-credentials, not an AWS-side token rejection
$ curl -s localhost:4001/v1/chat/completions -H 'Authorization: Bearer sk-1234' \
    -d '{"model":"bedrock-claude-sonnet-4.5","messages":[{"role":"user","content":"Reply with exactly: bedrock ok"}],"max_tokens":20}'
-> BedrockException Invalid Authentication - {"message":"The security token included in the request is invalid."}
```

Adversarial behavioral review (deep mode, five independent lenses including three refutation passes) sealed a SURVIVED verdict with zero verified findings: every symbol the pick references resolves on rc1; a revert-to-red delta proof (reverting the forwarding line turns the WIF-forwarding test red, restoring it turns it green) confirms the pick actually delivers the fix on this line; and `OPTIONAL_KWARGS_KEYS` membership plus the `_OPTIONAL_KWARGS_KEYS` backward-compat alias are byte-identical pre and post pick, so no existing caller of `completion`, `get_litellm_params`, or `BaseAWSLLM` is broken. The real STS AssumeRoleWithWebIdentity exchange was mocked here (it needs live AWS WIF, which is exercised end-to-end in #32956), so that boundary is covered there rather than on this branch.

## Type

🐛 Bug Fix

## Changes

Cherry-pick of #32956 only. No hand-written code; the single commit is a verbatim `-x -m 1` pick of the staging merge, plus this PR targets the new `patch-1.93.0rc1` base branch cut from the rc1 tag.
