### PR TITLE
fix(ui): guard against missing metrics in usage breakdown aggregation

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.test.tsx
@@ -381,6 +381,54 @@ describe("EntityUsage", () => {
     expect(screen.getByText("1,000")).toBeInTheDocument(); // Total Requests
   });
 
+  it("does not crash when breakdown entries are missing metrics (partial-page data)", async () => {
+    const partialSpendData = {
+      results: [
+        {
+          date: "2025-01-01",
+          metrics: {
+            spend: 10,
+            api_requests: 100,
+            successful_requests: 95,
+            failed_requests: 5,
+            total_tokens: 5000,
+            prompt_tokens: 3000,
+            completion_tokens: 2000,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+          breakdown: {
+            models: { "gpt-4": { metadata: {} } },
+            api_keys: { "key-1": { metadata: { key_alias: "k1", team_id: null } } },
+            providers: { openai: { metadata: {} } },
+            entities: {
+              "tag-1": {
+                metadata: { team_alias: "Tag 1" },
+                api_key_breakdown: { "key-2": { metadata: {} } },
+              },
+            },
+          },
+        },
+      ],
+      metadata: {
+        total_spend: 10,
+        total_api_requests: 100,
+        total_successful_requests: 95,
+        total_failed_requests: 5,
+        total_tokens: 5000,
+      },
+    };
+    mockTagDailyActivityCall.mockResolvedValue(partialSpendData as any);
+
+    render(<EntityUsage {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(mockTagDailyActivityCall).toHaveBeenCalled();
+    });
+
+    expect(screen.getByText("Tag Spend Overview")).toBeInTheDocument();
+  });
+
   it("should render with team entity type and call team API", async () => {
     render(<EntityUsage {...defaultProps} entityType="team" />);
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.tsx
@@ -161,6 +161,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
     const modelSpend: { [key: string]: any } = {};
     spendData.results.forEach((day) => {
       Object.entries(day.breakdown.models || {}).forEach(([model, metrics]) => {
+        if (!metrics.metrics) return;
         if (!modelSpend[model]) {
           modelSpend[model] = {
             spend: 0,
@@ -195,6 +196,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
     const agentSpend: { [key: string]: any } = {};
     agentSpendData.results.forEach((day) => {
       Object.entries(day.breakdown.entities || {}).forEach(([agentId, data]) => {
+        if (!data.metrics) return;
         if (!agentSpend[agentId]) {
           agentSpend[agentId] = {
             spend: 0,
@@ -230,7 +232,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
       const tagDictionary = Object.keys(entities).reduce((acc: { [key: string]: TagUsage[] }, entity) => {
         const { api_key_breakdown } = entities[entity];
         Object.keys(api_key_breakdown).forEach((key) => {
-          const tagUsage = { tag: entity, usage: api_key_breakdown[key].metrics.spend };
+          const tagUsage = { tag: entity, usage: api_key_breakdown[key].metrics?.spend ?? 0 };
           if (acc[key]) {
             acc[key].push(tagUsage);
           } else {
@@ -240,6 +242,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
         return acc;
       }, {});
       Object.entries(day.breakdown.api_keys || {}).forEach(([key, metrics]) => {
+        if (!metrics.metrics) return;
         if (!keySpend[key]) {
           keySpend[key] = {
             metrics: {
@@ -287,6 +290,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
     const providerSpend: { [key: string]: any } = {};
     spendData.results.forEach((day) => {
       Object.entries(day.breakdown.providers || {}).forEach(([provider, metrics]) => {
+        if (!metrics.metrics) return;
         if (!providerSpend[provider]) {
           providerSpend[provider] = {
             provider,
@@ -351,6 +355,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
     const entitySpend: { [key: string]: EntityMetricWithMetadata } = {};
     spendData.results.forEach((day) => {
       Object.entries(day.breakdown.entities || {}).forEach(([entity, data]) => {
+        if (!data.metrics) return;
         if (!entitySpend[entity]) {
           entitySpend[entity] = {
             metrics: {


### PR DESCRIPTION
## Relevant issues

Fixes #33381

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

The Usage page (Admin UI, Cost / Global Usage) crashes with "This page couldn't load" whenever the `/user/daily/activity` breakdown for the selected range spans more than one page. The page fetches only page 1 (`page_size=1000&page=1`), so the client-side breakdown aggregation runs over partial data and reaches an entry whose `metrics` did not come through on that page, throwing `Cannot read properties of undefined (reading 'spend')` inside the breakdown `useMemo`

To reproduce on a live instance: pick a deployment where the breakdown exceeds one page (confirm with `curl -s "$BASE/user/daily/activity?start_date=...&end_date=...&page_size=1000&page=1" -H "Authorization: Bearer $KEY" | jq '.metadata'` returning `has_more: true`), then open the Admin UI Usage tab -> Cost / Global Usage for that same range. Before this change the page renders briefly then dies; after it renders normally

Added a regression test in `EntityUsage.test.tsx` that renders `EntityUsage` with breakdown entries missing `metrics`; it reproduces the exact `TypeError` before the fix and passes after

## Type

🐛 Bug Fix

## Changes

Guarded the top-models, top-agents, top-API-keys, provider, and entity breakdown aggregations in `EntityUsage` against entries whose `metrics` field is undefined by skipping them with an early return, and null-guarded the tag-dictionary spend read. This is the defensive half of the fix suggested in the issue; fetching all pages for the breakdown (the other half) is a larger change left for a follow-up
