### PR TITLE
fix(claude-code): correct skill install command and marketplace setup UXLitellm fix skills marketplace commands

### DIFF
--- a/ui/litellm-dashboard/src/components/claude_code_plugins/helpers.test.ts
+++ b/ui/litellm-dashboard/src/components/claude_code_plugins/helpers.test.ts
@@ -21,28 +21,12 @@ import {
 import { MarketplacePluginEntry, PluginSource } from "./types";
 
 describe("formatInstallCommand", () => {
-  it("formats github source with repo", () => {
-    const source: PluginSource = { source: "github", repo: "org/repo" };
-    expect(formatInstallCommand({ name: "my-plugin", source })).toBe("/plugin marketplace add org/repo");
+  it("produces a /plugin install command scoped to the litellm marketplace", () => {
+    expect(formatInstallCommand({ name: "my-plugin" })).toBe("/plugin install my-plugin@litellm");
   });
 
-  it("formats url source", () => {
-    const source: PluginSource = { source: "url", url: "https://example.com/plugin" };
-    expect(formatInstallCommand({ name: "my-plugin", source })).toBe(
-      "/plugin marketplace add https://example.com/plugin",
-    );
-  });
-
-  it("formats git-subdir source using its url", () => {
-    const source: PluginSource = { source: "git-subdir", url: "https://github.com/org/repo", path: "plugins/x" };
-    expect(formatInstallCommand({ name: "my-plugin", source })).toBe(
-      "/plugin marketplace add https://github.com/org/repo",
-    );
-  });
-
-  it("falls back to plugin name when no repo or url", () => {
-    const source: PluginSource = { source: "github" };
-    expect(formatInstallCommand({ name: "my-plugin", source })).toBe("/plugin marketplace add my-plugin");
+  it("uses the plugin name as the identifier", () => {
+    expect(formatInstallCommand({ name: "code-review" })).toBe("/plugin install code-review@litellm");
   });
 });
 

--- a/ui/litellm-dashboard/src/components/claude_code_plugins/helpers.ts
+++ b/ui/litellm-dashboard/src/components/claude_code_plugins/helpers.ts
@@ -177,20 +177,11 @@ export const parseSkillSource = (rawUrl: string, subPath?: string): SkillSourceP
 };
 
 /**
- * Generate install command for Claude Code CLI
- * Format: /plugin marketplace add org/repo OR /plugin marketplace add url
+ * Generate install command for Claude Code CLI.
+ * Installs the named plugin from the "litellm" marketplace registered in settings.json.
  */
-export const formatInstallCommand = (plugin: { name: string; source: PluginSource }): string => {
-  const { source } = plugin;
-  if (source.source === "github" && source.repo) {
-    return `/plugin marketplace add ${source.repo}`;
-  }
-  if ((source.source === "url" || source.source === "git-subdir") && source.url) {
-    return `/plugin marketplace add ${source.url}`;
-  }
-  // Fallback to plugin name
-  return `/plugin marketplace add ${plugin.name}`;
-};
+export const formatInstallCommand = (plugin: { name: string }): string =>
+  `/plugin install ${plugin.name}@litellm`;
 
 /**
  * Extract unique categories from plugins list

--- a/ui/litellm-dashboard/src/components/claude_code_plugins/skill_detail.tsx
+++ b/ui/litellm-dashboard/src/components/claude_code_plugins/skill_detail.tsx
@@ -257,6 +257,32 @@ const SkillDetail: React.FC<SkillDetailProps> = ({ skill, onBack }) => {
             </pre>
           </div>
 
+          {/* Shown when the marketplace catalog is stale and the plugin isn't found yet */}
+          <div
+            style={{
+              border: "1px solid #fce8b2",
+              borderRadius: 8,
+              padding: "12px 16px",
+              backgroundColor: "#fefce8",
+              marginBottom: 16,
+            }}
+          >
+            <p style={{ fontSize: 13, color: "#5f6368", lineHeight: 1.6, margin: "0 0 8px 0" }}>
+              If you see &quot;Plugin {skill.name} not found in marketplace&quot;, update the catalog first:
+            </p>
+            <pre
+              style={{
+                margin: 0,
+                fontSize: 13,
+                fontFamily: "monospace",
+                color: "#202124",
+                backgroundColor: "transparent",
+              }}
+            >
+              /plugin marketplace update litellm
+            </pre>
+          </div>
+
           <p style={{ fontSize: 13, color: "#5f6368", lineHeight: 1.6, margin: 0 }}>
             Don&apos;t have the marketplace configured yet?{" "}
             <span onClick={() => setActiveTab("setup")} style={{ color: "#1a73e8", cursor: "pointer" }}>
@@ -272,12 +298,73 @@ const SkillDetail: React.FC<SkillDetailProps> = ({ skill, onBack }) => {
           <h2 style={{ fontSize: 18, fontWeight: 400, color: "#202124", margin: "0 0 8px 0" }}>
             One-time marketplace setup
           </h2>
-          <p style={{ fontSize: 14, color: "#5f6368", margin: "0 0 24px 0", lineHeight: 1.6 }}>
-            Add this to{" "}
+
+          {/* Option 1: single command — fastest path for most users */}
+          <p style={{ fontSize: 14, color: "#5f6368", margin: "0 0 12px 0", lineHeight: 1.6 }}>
+            Run this command in Claude Code to register the marketplace:
+          </p>
+          <div
+            style={{
+              border: "1px solid #dadce0",
+              borderRadius: 8,
+              overflow: "hidden",
+              marginBottom: 24,
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                padding: "10px 16px",
+                backgroundColor: "#f8f9fa",
+                borderBottom: "1px solid #dadce0",
+              }}
+            >
+              <span style={{ fontSize: 13, color: "#3c4043", fontWeight: 500 }}>Run in Claude Code</span>
+              <button
+                onClick={() => {
+                  const origin = typeof window !== "undefined" ? window.location.origin : "";
+                  copyToClipboard(`/plugin marketplace add ${origin}/claude-code/marketplace.json`, "marketplace-cmd");
+                }}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 4,
+                  fontSize: 12,
+                  color: copiedKey === "marketplace-cmd" ? "#137333" : "#1a73e8",
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  padding: 0,
+                }}
+              >
+                {copiedKey === "marketplace-cmd" ? <CheckOutlined /> : <CopyOutlined />}
+                {copiedKey === "marketplace-cmd" ? "Copied" : "Copy"}
+              </button>
+            </div>
+            <pre
+              style={{
+                margin: 0,
+                padding: "14px 16px",
+                fontSize: 13,
+                fontFamily: "monospace",
+                color: "#202124",
+                backgroundColor: "#fff",
+              }}
+            >
+              {`/plugin marketplace add ${typeof window !== "undefined" ? window.location.origin : "<proxy-url>"}/claude-code/marketplace.json`}
+            </pre>
+          </div>
+
+          {/* Option 2: settings.json — for persistent config or managed deployments.
+              extraKnownMarketplaces requires source to be a nested object, not a flat string. */}
+          <p style={{ fontSize: 14, color: "#5f6368", margin: "0 0 12px 0", lineHeight: 1.6 }}>
+            Or add this to{" "}
             <code style={{ fontSize: 13, backgroundColor: "#f1f3f4", padding: "1px 6px", borderRadius: 4 }}>
               ~/.claude/settings.json
             </code>{" "}
-            to point Claude Code at your proxy:
+            for a persistent configuration:
           </p>
           <div
             style={{
@@ -302,9 +389,11 @@ const SkillDetail: React.FC<SkillDetailProps> = ({ skill, onBack }) => {
                   const snippet = JSON.stringify(
                     {
                       extraKnownMarketplaces: {
-                        "my-org": {
-                          source: "url",
-                          url: `${typeof window !== "undefined" ? window.location.origin : ""}/claude-code/marketplace.json`,
+                        litellm: {
+                          source: {
+                            source: "url",
+                            url: `${typeof window !== "undefined" ? window.location.origin : ""}/claude-code/marketplace.json`,
+                          },
                         },
                       },
                     },
@@ -342,9 +431,11 @@ const SkillDetail: React.FC<SkillDetailProps> = ({ skill, onBack }) => {
               {JSON.stringify(
                 {
                   extraKnownMarketplaces: {
-                    "my-org": {
-                      source: "url",
-                      url: `${typeof window !== "undefined" ? window.location.origin : "<proxy-url>"}/claude-code/marketplace.json`,
+                    litellm: {
+                      source: {
+                        source: "url",
+                        url: `${typeof window !== "undefined" ? window.location.origin : "<proxy-url>"}/claude-code/marketplace.json`,
+                      },
                     },
                   },
                 },


### PR DESCRIPTION
## Relevant issues

Fixes #33512

## Linear ticket

## Pre-Submission checklist


- [X] I have added meaningful tests
- [X] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [X] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [X] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

See linked issue for reproduction steps. UI changes are in the "How to Use" and "One-time setup" tabs of any skill detail page.

## Type

🐛 Bug Fix

## Changes

Three bugs in the Claude Code skills page fixed.

The install command shown to users was `/plugin marketplace add {source}`, which adds a marketplace source rather than installing a plugin. It now correctly shows `/plugin install {name}@litellm`.

The settings.json snippet had `extraKnownMarketplaces.litellm.source` as a flat string, which Claude Code rejects with "Expected object, received string" and skips the file entirely. The source is now a properly nested object.

The marketplace key was hardcoded as "my-org" instead of "litellm", which would register the marketplace under the wrong name and make `/plugin install {name}@litellm` fail to resolve it.

Two UX improvements were also added: the setup tab now shows a one-line `/plugin marketplace add` command as the primary option with settings.json as a secondary persistent option, and the usage tab shows a hint to run `/plugin marketplace update litellm` when a plugin is not found.

## QA runbook

1. Start the proxy: `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml`
2. Start the dashboard: `cd ui/litellm-dashboard && npm run dev`
3. Go to http://localhost:3000, navigate to Skills, click any skill
4. "How to Use" tab: verify install command shows `/plugin install {name}@litellm` and the yellow update hint is visible
5. "One-time setup" tab: verify the command option appears first, then the settings.json snippet with nested source structure and "litellm" key


### Final Attestation

- [X] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
