### PR TITLE
fix: re-land video status/content credential injection for wildcard models

### DIFF
--- a/litellm/proxy/video_endpoints/endpoints.py
+++ b/litellm/proxy/video_endpoints/endpoints.py
@@ -264,7 +264,9 @@ async def video_status(
     # Resolve model_name from model_id if available
     # This allows the router to automatically inject litellm_params from the model config
     if model_id_from_decoded and llm_router:
-        resolved_model = llm_router.resolve_model_name_from_model_id(model_id_from_decoded)
+        resolved_model = llm_router.resolve_model_name_from_model_id(
+            model_id_from_decoded, custom_llm_provider=provider_from_id
+        )
         if resolved_model:
             data["model"] = resolved_model
 
@@ -362,7 +364,9 @@ async def video_content(
     # Resolve model_name from model_id if available
     # This allows the router to automatically inject litellm_params from the model config
     if model_id_from_decoded and llm_router:
-        resolved_model = llm_router.resolve_model_name_from_model_id(model_id_from_decoded)
+        resolved_model = llm_router.resolve_model_name_from_model_id(
+            model_id_from_decoded, custom_llm_provider=provider_from_id
+        )
         if resolved_model:
             data["model"] = resolved_model
     # Process request using ProxyBaseLLMRequestProcessing
@@ -472,7 +476,9 @@ async def video_remix(
     # Resolve model_name from model_id if available
     # This allows the router to automatically inject litellm_params from the model config
     if model_id_from_decoded and llm_router:
-        resolved_model = llm_router.resolve_model_name_from_model_id(model_id_from_decoded)
+        resolved_model = llm_router.resolve_model_name_from_model_id(
+            model_id_from_decoded, custom_llm_provider=provider_from_id
+        )
         if resolved_model:
             data["model"] = resolved_model
 
@@ -673,7 +679,9 @@ async def video_get_character(
     data["custom_llm_provider"] = custom_llm_provider
 
     if model_id_from_decoded and llm_router:
-        resolved_model = llm_router.resolve_model_name_from_model_id(model_id_from_decoded)
+        resolved_model = llm_router.resolve_model_name_from_model_id(
+            model_id_from_decoded, custom_llm_provider=provider_from_id
+        )
         if resolved_model:
             data["model"] = resolved_model
 
@@ -782,7 +790,9 @@ async def video_edit(
     data["custom_llm_provider"] = custom_llm_provider
 
     if model_id_from_decoded and llm_router:
-        resolved_model = llm_router.resolve_model_name_from_model_id(model_id_from_decoded)
+        resolved_model = llm_router.resolve_model_name_from_model_id(
+            model_id_from_decoded, custom_llm_provider=provider_from_id
+        )
         if resolved_model:
             data["model"] = resolved_model
 
@@ -882,7 +892,9 @@ async def video_extension(
     data["custom_llm_provider"] = custom_llm_provider
 
     if model_id_from_decoded and llm_router:
-        resolved_model = llm_router.resolve_model_name_from_model_id(model_id_from_decoded)
+        resolved_model = llm_router.resolve_model_name_from_model_id(
+            model_id_from_decoded, custom_llm_provider=provider_from_id
+        )
         if resolved_model:
             data["model"] = resolved_model
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9194,7 +9194,9 @@ class Router:
         """
         return candidate_id in self.model_id_to_deployment_index_map
 
-    def resolve_model_name_from_model_id(self, model_id: Optional[str]) -> Optional[str]:
+    def resolve_model_name_from_model_id(
+        self, model_id: Optional[str], custom_llm_provider: Optional[str] = None
+    ) -> Optional[str]:
         """
         Resolve model_name from model_id.
 
@@ -9203,12 +9205,16 @@ class Router:
 
         Strategy:
         1. First, check if model_id directly matches a model_name or deployment ID
-        2. If not, search through router's model_list to find a match by litellm_params.model
-        3. Return the model_name if found, None otherwise
+        2. If custom_llm_provider is provided, check with provider prefix
+        3. Prefer provider-qualified litellm_params.model exact match
+        4. Search through router's model_list to find by litellm_params.model
+        5. If custom_llm_provider is provided, try to find a wildcard pattern match
+        6. Return the model_name if found, None otherwise
 
         Args:
             model_id: The model_id extracted from decoded video_id
                      (could be model_name or litellm_params.model value)
+            custom_llm_provider: The provider name (e.g., "vertex_ai") for wildcard matching
 
         Returns:
             model_name if found, None otherwise. If None, the request will fall through
@@ -9221,14 +9227,41 @@ class Router:
         if model_id in self.model_names or self.has_model_id(model_id):
             return model_id
 
-        # Strategy 2: Search through router's model_list to find by litellm_params.model
+        # Strategy 2: Check with provider prefix (e.g., "vertex_ai/veo-3.0-generate-preview")
+        if custom_llm_provider:
+            full_model_name = f"{custom_llm_provider}/{model_id}"
+            if full_model_name in self.model_names or self.has_model_id(full_model_name):
+                return full_model_name
+
+        # Strategy 3/4: Search through router's model_list to find by litellm_params.model
         all_models = self.get_model_list(model_name=None)
         if not all_models:
             return None
 
+        # First pass: provider-qualified exact match when provider is known.
+        # Prefer litellm_params.model == "{provider}/{model_id}" so a Vertex id
+        # does not resolve to a Gemini alias (or any other provider) that only
+        # shares the same model suffix.
+        if custom_llm_provider:
+            qualified_model = f"{custom_llm_provider}/{model_id}"
+            for deployment in all_models:
+                litellm_params = deployment.get("litellm_params", {})
+                actual_model = litellm_params.get("model")
+                if actual_model and actual_model.endswith("/*"):
+                    continue
+                if actual_model == qualified_model:
+                    model_name = deployment.get("model_name")
+                    if model_name:
+                        return model_name
+
+        # Second pass: provider-agnostic exact / suffix matches (non-wildcard)
         for deployment in all_models:
             litellm_params = deployment.get("litellm_params", {})
             actual_model = litellm_params.get("model")
+
+            # Skip wildcard patterns in first pass
+            if actual_model and actual_model.endswith("/*"):
+                continue
 
             # Match by exact match or by checking if actual_model ends with /model_id or :model_id
             # e.g., model_id="veo-2.0-generate-001" matches actual_model="vertex_ai/veo-2.0-generate-001"
@@ -9242,6 +9275,19 @@ class Router:
                 model_name = deployment.get("model_name")
                 if model_name:
                     return model_name
+
+        # Strategy 5: Wildcard patterns using PatternMatchRouter
+        # For video status/content, we need to match model_id like "veo-3.0-generate-preview"
+        # to wildcard patterns like "vertex_ai/*"
+        if custom_llm_provider:
+            full_model_name = f"{custom_llm_provider}/{model_id}"
+            pattern_deployments = self.pattern_router.route(full_model_name)
+            if pattern_deployments:
+                # Return the first matching wildcard model_name
+                for pattern_deployment in pattern_deployments:
+                    matched_model_name = pattern_deployment.get("model_name")
+                    if matched_model_name:
+                        return matched_model_name
 
         # No match found
         return None

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9258,8 +9258,10 @@ class Router:
         1. Direct model_name / deployment ID match
         2. Provider-prefixed model_name / deployment ID match
         3. Provider-qualified litellm_params.model exact match
-        4. Provider-agnostic exact / suffix match
-        5. Wildcard pattern match via PatternMatchRouter
+        4. Same-provider wildcard pattern match via PatternMatchRouter
+           (before any provider-agnostic suffix scan, so a gemini exact
+           deployment cannot shadow a vertex_ai/* wildcard)
+        5. Provider-agnostic exact / suffix match as last resort
         """
         if not model_id:
             return None
@@ -9283,14 +9285,12 @@ class Router:
             if matched:
                 return matched
 
-        matched = self._match_model_id_suffix(all_models, model_id)
-        if matched:
-            return matched
+            # Prefer same-provider wildcard over cross-provider suffix matches.
+            matched = self._match_wildcard_model(model_id, custom_llm_provider)
+            if matched:
+                return matched
 
-        if custom_llm_provider:
-            return self._match_wildcard_model(model_id, custom_llm_provider)
-
-        return None
+        return self._match_model_id_suffix(all_models, model_id)
 
     def map_team_model(self, team_model_name: Optional[str], team_id: str) -> Optional[str]:
         """

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9194,102 +9194,102 @@ class Router:
         """
         return candidate_id in self.model_id_to_deployment_index_map
 
+    def _deployment_model_name(self, deployment: dict) -> Optional[str]:
+        model_name = deployment.get("model_name")
+        return model_name if model_name else None
+
+    def _non_wildcard_actual_model(self, deployment: dict) -> Optional[str]:
+        litellm_params = deployment.get("litellm_params", {})
+        actual_model = litellm_params.get("model")
+        if actual_model and actual_model.endswith("/*"):
+            return None
+        return actual_model
+
+    def _match_provider_qualified_model(
+        self, all_models: list, model_id: str, custom_llm_provider: str
+    ) -> Optional[str]:
+        """Prefer litellm_params.model == provider/model_id over suffix matches."""
+        qualified_model = f"{custom_llm_provider}/{model_id}"
+        for deployment in all_models:
+            actual_model = self._non_wildcard_actual_model(deployment)
+            if actual_model == qualified_model:
+                return self._deployment_model_name(deployment)
+        return None
+
+    def _match_model_id_suffix(self, all_models: list, model_id: str) -> Optional[str]:
+        """Provider-agnostic exact or suffix match on litellm_params.model."""
+        for deployment in all_models:
+            actual_model = self._non_wildcard_actual_model(deployment)
+            if not actual_model:
+                continue
+            matches = (
+                actual_model == model_id
+                or actual_model.endswith(f"/{model_id}")
+                or actual_model.endswith(f":{model_id}")
+            )
+            if matches:
+                return self._deployment_model_name(deployment)
+        return None
+
+    def _match_wildcard_model(
+        self, model_id: str, custom_llm_provider: str
+    ) -> Optional[str]:
+        """Match provider/model_id against wildcard deployments via PatternMatchRouter."""
+        full_model_name = f"{custom_llm_provider}/{model_id}"
+        pattern_deployments = self.pattern_router.route(full_model_name)
+        if not pattern_deployments:
+            return None
+        for pattern_deployment in pattern_deployments:
+            matched = self._deployment_model_name(pattern_deployment)
+            if matched:
+                return matched
+        return None
+
     def resolve_model_name_from_model_id(
         self, model_id: Optional[str], custom_llm_provider: Optional[str] = None
     ) -> Optional[str]:
         """
         Resolve model_name from model_id.
 
-        This method attempts to find the correct model_name to use with the router
-        so that litellm_params can be automatically injected from the model config.
+        Used by video status/content so the router can inject litellm_params
+        (credentials/project) from the matching deployment.
 
         Strategy:
-        1. First, check if model_id directly matches a model_name or deployment ID
-        2. If custom_llm_provider is provided, check with provider prefix
-        3. Prefer provider-qualified litellm_params.model exact match
-        4. Search through router's model_list to find by litellm_params.model
-        5. If custom_llm_provider is provided, try to find a wildcard pattern match
-        6. Return the model_name if found, None otherwise
-
-        Args:
-            model_id: The model_id extracted from decoded video_id
-                     (could be model_name or litellm_params.model value)
-            custom_llm_provider: The provider name (e.g., "vertex_ai") for wildcard matching
-
-        Returns:
-            model_name if found, None otherwise. If None, the request will fall through
-            to normal flow using environment variables.
+        1. Direct model_name / deployment ID match
+        2. Provider-prefixed model_name / deployment ID match
+        3. Provider-qualified litellm_params.model exact match
+        4. Provider-agnostic exact / suffix match
+        5. Wildcard pattern match via PatternMatchRouter
         """
         if not model_id:
             return None
 
-        # Strategy 1: Check if model_id directly matches a model_name or deployment ID
         if model_id in self.model_names or self.has_model_id(model_id):
             return model_id
 
-        # Strategy 2: Check with provider prefix (e.g., "vertex_ai/veo-3.0-generate-preview")
         if custom_llm_provider:
             full_model_name = f"{custom_llm_provider}/{model_id}"
             if full_model_name in self.model_names or self.has_model_id(full_model_name):
                 return full_model_name
 
-        # Strategy 3/4: Search through router's model_list to find by litellm_params.model
         all_models = self.get_model_list(model_name=None)
         if not all_models:
             return None
 
-        # First pass: provider-qualified exact match when provider is known.
-        # Prefer litellm_params.model == "{provider}/{model_id}" so a Vertex id
-        # does not resolve to a Gemini alias (or any other provider) that only
-        # shares the same model suffix.
         if custom_llm_provider:
-            qualified_model = f"{custom_llm_provider}/{model_id}"
-            for deployment in all_models:
-                litellm_params = deployment.get("litellm_params", {})
-                actual_model = litellm_params.get("model")
-                if actual_model and actual_model.endswith("/*"):
-                    continue
-                if actual_model == qualified_model:
-                    model_name = deployment.get("model_name")
-                    if model_name:
-                        return model_name
-
-        # Second pass: provider-agnostic exact / suffix matches (non-wildcard)
-        for deployment in all_models:
-            litellm_params = deployment.get("litellm_params", {})
-            actual_model = litellm_params.get("model")
-
-            # Skip wildcard patterns in first pass
-            if actual_model and actual_model.endswith("/*"):
-                continue
-
-            # Match by exact match or by checking if actual_model ends with /model_id or :model_id
-            # e.g., model_id="veo-2.0-generate-001" matches actual_model="vertex_ai/veo-2.0-generate-001"
-            matches = (
-                actual_model == model_id
-                or (actual_model and actual_model.endswith(f"/{model_id}"))
-                or (actual_model and actual_model.endswith(f":{model_id}"))
+            matched = self._match_provider_qualified_model(
+                all_models, model_id, custom_llm_provider
             )
+            if matched:
+                return matched
 
-            if matches:
-                model_name = deployment.get("model_name")
-                if model_name:
-                    return model_name
+        matched = self._match_model_id_suffix(all_models, model_id)
+        if matched:
+            return matched
 
-        # Strategy 5: Wildcard patterns using PatternMatchRouter
-        # For video status/content, we need to match model_id like "veo-3.0-generate-preview"
-        # to wildcard patterns like "vertex_ai/*"
         if custom_llm_provider:
-            full_model_name = f"{custom_llm_provider}/{model_id}"
-            pattern_deployments = self.pattern_router.route(full_model_name)
-            if pattern_deployments:
-                # Return the first matching wildcard model_name
-                for pattern_deployment in pattern_deployments:
-                    matched_model_name = pattern_deployment.get("model_name")
-                    if matched_model_name:
-                        return matched_model_name
+            return self._match_wildcard_model(model_id, custom_llm_provider)
 
-        # No match found
         return None
 
     def map_team_model(self, team_model_name: Optional[str], team_id: str) -> Optional[str]:

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9194,11 +9194,11 @@ class Router:
         """
         return candidate_id in self.model_id_to_deployment_index_map
 
-    def _deployment_model_name(self, deployment: dict) -> Optional[str]:
+    def _deployment_model_name(self, deployment: dict) -> str | None:
         model_name = deployment.get("model_name")
         return model_name if model_name else None
 
-    def _non_wildcard_actual_model(self, deployment: dict) -> Optional[str]:
+    def _non_wildcard_actual_model(self, deployment: dict) -> str | None:
         litellm_params = deployment.get("litellm_params", {})
         actual_model = litellm_params.get("model")
         if actual_model and actual_model.endswith("/*"):
@@ -9207,7 +9207,7 @@ class Router:
 
     def _match_provider_qualified_model(
         self, all_models: list, model_id: str, custom_llm_provider: str
-    ) -> Optional[str]:
+    ) -> str | None:
         """Prefer litellm_params.model == provider/model_id over suffix matches."""
         qualified_model = f"{custom_llm_provider}/{model_id}"
         for deployment in all_models:
@@ -9216,7 +9216,7 @@ class Router:
                 return self._deployment_model_name(deployment)
         return None
 
-    def _match_model_id_suffix(self, all_models: list, model_id: str) -> Optional[str]:
+    def _match_model_id_suffix(self, all_models: list, model_id: str) -> str | None:
         """Provider-agnostic exact or suffix match on litellm_params.model."""
         for deployment in all_models:
             actual_model = self._non_wildcard_actual_model(deployment)
@@ -9233,7 +9233,7 @@ class Router:
 
     def _match_wildcard_model(
         self, model_id: str, custom_llm_provider: str
-    ) -> Optional[str]:
+    ) -> str | None:
         """Match provider/model_id against wildcard deployments via PatternMatchRouter."""
         full_model_name = f"{custom_llm_provider}/{model_id}"
         pattern_deployments = self.pattern_router.route(full_model_name)
@@ -9246,8 +9246,8 @@ class Router:
         return None
 
     def resolve_model_name_from_model_id(
-        self, model_id: Optional[str], custom_llm_provider: Optional[str] = None
-    ) -> Optional[str]:
+        self, model_id: str | None, custom_llm_provider: str | None = None
+    ) -> str | None:
         """
         Resolve model_name from model_id.
 

--- a/tests/test_litellm/proxy/video_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/video_endpoints/test_endpoints.py
@@ -280,7 +280,9 @@ async def test_status__model_encoded_id_full_contract(harness):
     assert resp is SENTINEL
     assert harness.route_type() == "avideo_status"
     # provider comes from the decoded id; model_id resolved to a model name.
-    harness.resolve_model.assert_called_once_with(VIDEO_MODEL_ID)
+    harness.resolve_model.assert_called_once_with(
+        VIDEO_MODEL_ID, custom_llm_provider="azure"
+    )
     assert harness.processor_data() == {
         "video_id": AZURE_VIDEO_ID,
         "custom_llm_provider": "azure",
@@ -361,7 +363,9 @@ async def test_content__model_encoded_id(harness):
 
     await call_content(harness, AZURE_VIDEO_ID)
 
-    harness.resolve_model.assert_called_once_with(VIDEO_MODEL_ID)
+    harness.resolve_model.assert_called_once_with(
+        VIDEO_MODEL_ID, custom_llm_provider="azure"
+    )
     assert harness.processor_data() == {
         "video_id": AZURE_VIDEO_ID,
         "custom_llm_provider": "azure",
@@ -392,7 +396,9 @@ async def test_edit__extracts_nested_video_id_full_contract(harness):
 
     assert resp is SENTINEL
     assert harness.route_type() == "avideo_edit"
-    harness.resolve_model.assert_called_once_with(VIDEO_MODEL_ID)
+    harness.resolve_model.assert_called_once_with(
+        VIDEO_MODEL_ID, custom_llm_provider="azure"
+    )
     # nested video object is popped; its id becomes video_id; provider/model
     # derived from the encoded id.
     assert harness.processor_data() == {
@@ -490,7 +496,9 @@ async def test_remix__model_encoded_id_full_contract(harness):
 
     assert resp is SENTINEL
     assert harness.route_type() == "avideo_remix"
-    harness.resolve_model.assert_called_once_with(VIDEO_MODEL_ID)
+    harness.resolve_model.assert_called_once_with(
+        VIDEO_MODEL_ID, custom_llm_provider="azure"
+    )
     assert harness.processor_data() == {
         "prompt": "new colors",
         "video_id": AZURE_VIDEO_ID,
@@ -600,7 +608,9 @@ async def test_get_character__encoded_id_full_contract(harness):
     resp = await call_get_character(harness, AZURE_CHARACTER_ID)
 
     assert harness.route_type() == "avideo_get_character"
-    harness.resolve_model.assert_called_once_with(VIDEO_MODEL_ID)
+    harness.resolve_model.assert_called_once_with(
+        VIDEO_MODEL_ID, custom_llm_provider="azure"
+    )
     # character_id decoded to its inner value; provider/model from the encoded id.
     assert harness.processor_data() == {
         "character_id": "char_orig",
@@ -649,7 +659,9 @@ async def test_extension__extracts_nested_video_id_full_contract(harness):
 
     assert resp is SENTINEL
     assert harness.route_type() == "avideo_extension"
-    harness.resolve_model.assert_called_once_with(VIDEO_MODEL_ID)
+    harness.resolve_model.assert_called_once_with(
+        VIDEO_MODEL_ID, custom_llm_provider="azure"
+    )
     assert harness.processor_data() == {
         "prompt": "continue",
         "video_id": AZURE_VIDEO_ID,

--- a/tests/test_litellm/proxy/video_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/video_endpoints/test_endpoints.py
@@ -117,7 +117,9 @@ def harness():
 
     router = MagicMock(spec=Router)
     resolve_model = MagicMock(
-        side_effect=lambda model_id: RESOLVED_MODELS.get(model_id)
+        side_effect=lambda model_id, custom_llm_provider=None: RESOLVED_MODELS.get(
+            model_id
+        )
     )
     router.resolve_model_name_from_model_id = resolve_model
 

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -5515,3 +5515,37 @@ def test_resolve_model_name_from_model_id_prefers_provider_qualified_model():
     )
     assert result == "gemini-veo", f"Expected 'gemini-veo', got '{result}'"
 
+
+def test_resolve_model_name_from_model_id_wildcard_beats_cross_provider_suffix():
+    """
+    When provider is known, same-provider wildcard must win over a different
+    provider's exact deployment that only shares the model-name suffix.
+
+    Regression for Greptile P1 on the video credential re-land:
+    gemini/veo-... exact must not shadow vertex_ai/* for a Vertex video id.
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gemini-veo",
+                "litellm_params": {
+                    "model": "gemini/veo-3.0-generate-preview",
+                    "api_key": "gemini-key",
+                },
+            },
+            {
+                "model_name": "vertex_ai/*",
+                "litellm_params": {
+                    "model": "vertex_ai/*",
+                    "vertex_project": "vertex-project",
+                },
+            },
+        ],
+    )
+
+    result = router.resolve_model_name_from_model_id(
+        model_id="veo-3.0-generate-preview",
+        custom_llm_provider="vertex_ai",
+    )
+    assert result == "vertex_ai/*", f"Expected 'vertex_ai/*', got '{result}'"
+

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -5304,3 +5304,214 @@ class TestRouterRequestTimeoutPropagation:
             )
             == 60
         )
+
+
+def test_resolve_model_name_from_model_id_wildcard_pattern():
+    """
+    Test that resolve_model_name_from_model_id correctly resolves model names
+    for wildcard patterns using PatternMatchRouter.
+
+    This is critical for video status/content endpoints where model_id extracted
+    from video_id (e.g., "veo-3.0-generate-preview") needs to match wildcard
+    patterns like "vertex_ai/*" to inject credentials from the model config.
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "vertex_ai/*",
+                "litellm_params": {
+                    "model": "vertex_ai/*",
+                    "vertex_project": "test-project",
+                    "vertex_location": "us-central1",
+                },
+            },
+            {
+                "model_name": "specific-model",
+                "litellm_params": {
+                    "model": "vertex_ai/gemini-pro",
+                    "vertex_project": "specific-project",
+                    "vertex_location": "us-east1",
+                },
+            },
+        ],
+    )
+
+    result = router.resolve_model_name_from_model_id(
+        model_id="veo-3.0-generate-preview",
+        custom_llm_provider="vertex_ai",
+    )
+    assert result == "vertex_ai/*", f"Expected 'vertex_ai/*', got '{result}'"
+
+    result = router.resolve_model_name_from_model_id(
+        model_id="gemini-2.0-flash",
+        custom_llm_provider="vertex_ai",
+    )
+    assert result == "vertex_ai/*", f"Expected 'vertex_ai/*', got '{result}'"
+
+    result = router.resolve_model_name_from_model_id(
+        model_id="veo-3.0-generate-preview",
+        custom_llm_provider=None,
+    )
+    assert result is None, f"Expected None without provider, got '{result}'"
+
+    result = router.resolve_model_name_from_model_id(
+        model_id="specific-model",
+        custom_llm_provider="vertex_ai",
+    )
+    assert result == "specific-model", f"Expected 'specific-model', got '{result}'"
+
+
+def test_resolve_model_name_from_model_id_exact_match():
+    """
+    Test that resolve_model_name_from_model_id correctly resolves exact model names.
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "my-gpt-model",
+                "litellm_params": {
+                    "model": "azure/gpt-4",
+                    "api_key": "test-key",
+                },
+            },
+            {
+                "model_name": "veo-model",
+                "litellm_params": {
+                    "model": "vertex_ai/veo-2.0-generate-001",
+                    "vertex_project": "test-project",
+                },
+            },
+        ],
+    )
+
+    result = router.resolve_model_name_from_model_id(model_id="my-gpt-model")
+    assert result == "my-gpt-model", f"Expected 'my-gpt-model', got '{result}'"
+
+    result = router.resolve_model_name_from_model_id(model_id="veo-2.0-generate-001")
+    assert result == "veo-model", f"Expected 'veo-model', got '{result}'"
+
+    result = router.resolve_model_name_from_model_id(model_id="non-existent-model")
+    assert result is None, f"Expected None, got '{result}'"
+
+
+def test_resolve_model_name_from_model_id_provider_prefix():
+    """
+    Test that resolve_model_name_from_model_id handles provider prefix correctly.
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "vertex_ai/gemini-pro",
+                "litellm_params": {
+                    "model": "vertex_ai/gemini-pro",
+                    "vertex_project": "test-project",
+                },
+            },
+        ],
+    )
+
+    result = router.resolve_model_name_from_model_id(
+        model_id="vertex_ai/gemini-pro",
+        custom_llm_provider=None,
+    )
+    assert result == "vertex_ai/gemini-pro", f"Expected 'vertex_ai/gemini-pro', got '{result}'"
+
+    result = router.resolve_model_name_from_model_id(
+        model_id="gemini-pro",
+        custom_llm_provider="vertex_ai",
+    )
+    assert result == "vertex_ai/gemini-pro", f"Expected 'vertex_ai/gemini-pro', got '{result}'"
+
+
+def test_resolve_model_name_from_model_id_multiple_wildcards():
+    """
+    Test that resolve_model_name_from_model_id works with multiple wildcard patterns.
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "vertex_ai/*",
+                "litellm_params": {
+                    "model": "vertex_ai/*",
+                    "vertex_project": "vertex-project",
+                },
+            },
+            {
+                "model_name": "openai/*",
+                "litellm_params": {
+                    "model": "openai/*",
+                    "api_key": "openai-key",
+                },
+            },
+            {
+                "model_name": "anthropic/*",
+                "litellm_params": {
+                    "model": "anthropic/*",
+                    "api_key": "anthropic-key",
+                },
+            },
+        ],
+    )
+
+    result = router.resolve_model_name_from_model_id(
+        model_id="veo-3.0-generate-preview",
+        custom_llm_provider="vertex_ai",
+    )
+    assert result == "vertex_ai/*", f"Expected 'vertex_ai/*', got '{result}'"
+
+    result = router.resolve_model_name_from_model_id(
+        model_id="gpt-4o",
+        custom_llm_provider="openai",
+    )
+    assert result == "openai/*", f"Expected 'openai/*', got '{result}'"
+
+    result = router.resolve_model_name_from_model_id(
+        model_id="claude-3-opus",
+        custom_llm_provider="anthropic",
+    )
+    assert result == "anthropic/*", f"Expected 'anthropic/*', got '{result}'"
+
+    result = router.resolve_model_name_from_model_id(
+        model_id="some-model",
+        custom_llm_provider="bedrock",
+    )
+    assert result is None, f"Expected None for non-matching provider, got '{result}'"
+
+
+def test_resolve_model_name_from_model_id_prefers_provider_qualified_model():
+    """
+    When multiple providers expose the same concrete model suffix under different
+    public aliases, provider-aware resolve must pick the matching provider's
+    deployment rather than the first suffix match.
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gemini-veo",
+                "litellm_params": {
+                    "model": "gemini/veo-3.0-generate-preview",
+                    "api_key": "gemini-key",
+                },
+            },
+            {
+                "model_name": "vertex-veo",
+                "litellm_params": {
+                    "model": "vertex_ai/veo-3.0-generate-preview",
+                    "vertex_project": "vertex-project",
+                },
+            },
+        ],
+    )
+
+    result = router.resolve_model_name_from_model_id(
+        model_id="veo-3.0-generate-preview",
+        custom_llm_provider="vertex_ai",
+    )
+    assert result == "vertex-veo", f"Expected 'vertex-veo', got '{result}'"
+
+    result = router.resolve_model_name_from_model_id(
+        model_id="veo-3.0-generate-preview",
+        custom_llm_provider="gemini",
+    )
+    assert result == "gemini-veo", f"Expected 'gemini-veo', got '{result}'"
+


### PR DESCRIPTION
## Relevant issues

Fixes #33521

Re-lands the lost fix from #18854 (merged into staging, then bulk-reverted; currently missing from daily OSS / main).

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit` (proxy-endpoints + lint green on this PR)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix
✅ Test

## Changes

When video status/content endpoints resolve a model from the encoded video id, wildcard deployments like `vertex_ai/*` were not matched. That skipped credential injection and caused failures such as:

```text
vertex_project is required for Vertex AI video generation.
```

This PR restores / hardens the #18854 behavior:

1. `resolve_model_name_from_model_id(..., custom_llm_provider=...)`
2. provider-prefix matching (`vertex_ai/{model_id}`)
3. **provider-qualified exact match** before provider-agnostic suffix fallback
4. wildcard matching via `pattern_router` (`vertex_ai/*`)
5. pass `provider_from_id` from video status/content/remix and related video endpoints into the resolver
6. unit tests for wildcard / exact / provider-prefix / cross-provider alias resolve
7. update proxy video endpoint contract fixture/assertions for the new resolver signature

## Review follow-ups

Addressed here:
- broken endpoint test fixture (`custom_llm_provider` kwarg + call assertions)
- provider-blind alias collision (prefer `litellm_params.model == provider/model_id`)
- ruff complexity / UP045 cleanup for the new helpers
- external fork retarget to daily OSS branch (cannot target `main`)

Still out of scope / follow-ups (not claimed fixed here):
- full auth path propagation of `custom_llm_provider` for managed video IDs
- team-BYOK `team_pattern_routers` for video status/content
- deployment-level discriminator for same-provider multi-project wildcards

## CI notes

Green on this PR:
- `proxy-endpoints / Run tests`
- `lint`
- `codecov/patch`

Known base/repo noise still red and unrelated to this change:
- `osv-scan` (`ddtrace` lockfile vulnerability)
- `code-quality` (repo-wide)

## Target branch

`litellm_oss_daily_2026_07_15` (required for external fork PRs)
