### PR TITLE
fix: preserve Langfuse prompt selection in callbacks

### DIFF
--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -1042,7 +1042,11 @@ def _add_prompt_to_generation_params(
             verbose_logger.error("[Non-blocking] Langfuse Logger: Invalid prompt format. No prompt logged to Langfuse")
     elif prompt_management_metadata is not None and prompt_management_metadata["prompt_integration"] == "langfuse":
         try:
-            generation_params["prompt"] = langfuse_client.get_prompt(prompt_management_metadata["prompt_id"])
+            generation_params["prompt"] = langfuse_client.get_prompt(
+                prompt_management_metadata["prompt_id"],
+                label=prompt_management_metadata.get("prompt_label"),
+                version=prompt_management_metadata.get("prompt_version"),
+            )
         except Exception as e:
             verbose_logger.debug(f"[Non-blocking] Langfuse Logger: Error getting prompt client for logging: {e}")
             pass

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4582,12 +4582,16 @@ class StandardLoggingPayloadSetup:
         if litellm_params is not None:
             prompt_id = cast(Optional[str], litellm_params.get("prompt_id", None))
             prompt_variables = cast(Optional[dict], litellm_params.get("prompt_variables", None))
+            prompt_label = cast(Optional[str], litellm_params.get("prompt_label", None))
+            prompt_version = cast(Optional[int], litellm_params.get("prompt_version", None))
 
             if prompt_id is not None and prompt_integration is not None:
                 prompt_management_metadata = StandardLoggingPromptManagementMetadata(
                     prompt_id=prompt_id,
                     prompt_variables=prompt_variables,
                     prompt_integration=prompt_integration,
+                    prompt_label=prompt_label,
+                    prompt_version=prompt_version,
                 )
 
         # Initialize with default values

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -41,7 +41,7 @@ from pydantic import (
     field_serializer,
     field_validator,
 )
-from typing_extensions import Required, TypedDict
+from typing_extensions import NotRequired, Required, TypedDict
 
 from litellm._uuid import uuid
 from litellm.types.llms.base import (
@@ -2597,6 +2597,8 @@ class StandardLoggingPromptManagementMetadata(TypedDict):
     prompt_id: str
     prompt_variables: Optional[dict]
     prompt_integration: str
+    prompt_label: NotRequired[Optional[str]]
+    prompt_version: NotRequired[Optional[int]]
 
 
 class StandardLoggingMetadata(StandardLoggingUserAPIKeyMetadata):

--- a/tests/local_testing/test_langfuse_prompt_association.py
+++ b/tests/local_testing/test_langfuse_prompt_association.py
@@ -1,0 +1,58 @@
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+from litellm.integrations.langfuse.langfuse import _add_prompt_to_generation_params
+from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+
+
+def test_standard_logging_metadata_preserves_prompt_selection():
+    metadata = StandardLoggingPayloadSetup.get_standard_logging_metadata(
+        metadata={},
+        litellm_params={
+            "prompt_id": "support-agent",
+            "prompt_label": "production",
+            "prompt_version": 3,
+        },
+        prompt_integration="langfuse",
+    )
+
+    assert metadata["prompt_management_metadata"] == {
+        "prompt_id": "support-agent",
+        "prompt_variables": None,
+        "prompt_integration": "langfuse",
+        "prompt_label": "production",
+        "prompt_version": 3,
+    }
+
+
+def test_add_prompt_uses_preserved_prompt_selection(monkeypatch):
+    langfuse_module = ModuleType("langfuse")
+    langfuse_module.Langfuse = MagicMock
+    langfuse_model_module = ModuleType("langfuse.model")
+    langfuse_model_module.ChatPromptClient = MagicMock
+    langfuse_model_module.Prompt_Chat = MagicMock
+    langfuse_model_module.Prompt_Text = MagicMock
+    langfuse_model_module.TextPromptClient = MagicMock
+    monkeypatch.setitem(sys.modules, "langfuse", langfuse_module)
+    monkeypatch.setitem(sys.modules, "langfuse.model", langfuse_model_module)
+
+    client = MagicMock()
+    prompt = MagicMock()
+    client.get_prompt.return_value = prompt
+
+    generation_params = _add_prompt_to_generation_params(
+        generation_params={},
+        clean_metadata={},
+        prompt_management_metadata={
+            "prompt_id": "support-agent",
+            "prompt_variables": None,
+            "prompt_integration": "langfuse",
+            "prompt_label": "production",
+            "prompt_version": 3,
+        },
+        langfuse_client=client,
+    )
+
+    client.get_prompt.assert_called_once_with("support-agent", label="production", version=3)
+    assert generation_params["prompt"] is prompt


### PR DESCRIPTION
## What

Preserve `prompt_label` and `prompt_version` in standard prompt-management logging metadata and pass them back to `Langfuse.get_prompt()` when linking a generation to its managed prompt.

## Why

Langfuse Prompt Management already uses the requested label/version when compiling the prompt sent to the model. However, the Langfuse logging callback only retained `prompt_id` and fetched the prompt again without the original label/version. This could associate a generation with the default prompt version even though inference used a different selected version.

This change only corrects observability association; it does not change prompt compilation or model input.

The new metadata fields are `NotRequired`, and the callback uses `.get(...)`, preserving compatibility with existing metadata payloads.

## Tests

- `uv run pytest -q --noconftest tests/local_testing/test_langfuse_prompt_association.py` — 2 passed
- `uv run ruff check tests/local_testing/test_langfuse_prompt_association.py` — passed
- `uv run ruff format --check litellm/types/utils.py litellm/litellm_core_utils/litellm_logging.py litellm/integrations/langfuse/langfuse.py tests/local_testing/test_langfuse_prompt_association.py` — passed
- `python -m py_compile` for all changed Python files — passed

The regular `tests/local_testing/conftest.py` autouse fixture was bypassed because its unrelated fake OpenAI endpoint did not become healthy in this environment.