### PR TITLE
fix: handle escaped dots in nested paths

### DIFF
--- a/litellm/litellm_core_utils/dot_notation_indexing.py
+++ b/litellm/litellm_core_utils/dot_notation_indexing.py
@@ -78,7 +78,7 @@ def get_nested_value(data: Dict[str, Any], key_path: str, default: Optional[T] =
     return current if isinstance(current, type(default)) else default
 
 
-def _parse_path_segments(path: str) -> list:
+def _parse_path_segments(path: str) -> list[str]:
     """
     Parse a JSONPath-like string into segments using regex.
 
@@ -101,9 +101,8 @@ def _parse_path_segments(path: str) -> list:
 
     # Match field names OR bracket expressions
     # Pattern: field_name (anything except . or [) | [anything_in_brackets]
-    pattern = r"[^\.\[]+|\[[^\]]*\]"
-    segments = re.findall(pattern, path)
-    return segments
+    pattern = r"(?:\\\.|[^\.\[])+|\[[^\]]*\]"
+    return [segment.replace("\\.", ".") for segment in re.findall(pattern, path)]
 
 
 def _delete_nested_value_custom(

--- a/litellm/litellm_core_utils/dot_notation_indexing.py
+++ b/litellm/litellm_core_utils/dot_notation_indexing.py
@@ -79,11 +79,12 @@ def get_nested_value(data: Dict[str, Any], key_path: str, default: Optional[T] =
 
 
 def _parse_path_segments(path: str) -> list[str]:
-    """
+    r"""
     Parse a JSONPath-like string into segments using regex.
 
     Handles:
     - Dot notation: "a.b.c" → ["a", "b", "c"]
+    - Escaped dots: r"a.b\.c" → ["a", "b.c"]
     - Array wildcards: "a[*].b" → ["a", "[*]", "b"]
     - Array indices: "a[0].b" → ["a", "[0]", "b"]
 

--- a/tests/test_litellm/litellm_core_utils/test_dot_notation_indexing.py
+++ b/tests/test_litellm/litellm_core_utils/test_dot_notation_indexing.py
@@ -113,11 +113,28 @@ class TestDeleteNestedValue:
         assert result == {"a": {"b": {"d": 2}}}
 
     def test_delete_nested_key_with_escaped_dot(self):
+        """Test deleting a key that contains a literal dot, preserving siblings."""
         data = {"metadata": {"trace.id": "remove", "keep": "value"}}
 
         result = delete_nested_value(data, r"metadata.trace\.id")
 
         assert result == {"metadata": {"keep": "value"}}
+
+    def test_delete_top_level_key_with_escaped_dot(self):
+        """Test deleting a top-level key that contains a literal dot."""
+        data = {"trace.id": "remove", "keep": "value"}
+
+        result = delete_nested_value(data, r"trace\.id")
+
+        assert result == {"keep": "value"}
+
+    def test_delete_key_with_multiple_escaped_dots(self):
+        """Test deleting a key whose name contains multiple literal dots."""
+        data = {"a.b.c": "remove", "keep": "value"}
+
+        result = delete_nested_value(data, r"a\.b\.c")
+
+        assert result == {"keep": "value"}
 
     def test_delete_array_wildcard(self):
         """Test deleting a field from all array elements."""

--- a/tests/test_litellm/litellm_core_utils/test_dot_notation_indexing.py
+++ b/tests/test_litellm/litellm_core_utils/test_dot_notation_indexing.py
@@ -112,6 +112,13 @@ class TestDeleteNestedValue:
         result = delete_nested_value(data, "a.b.c")
         assert result == {"a": {"b": {"d": 2}}}
 
+    def test_delete_nested_key_with_escaped_dot(self):
+        data = {"metadata": {"trace.id": "remove", "keep": "value"}}
+
+        result = delete_nested_value(data, r"metadata.trace\.id")
+
+        assert result == {"metadata": {"keep": "value"}}
+
     def test_delete_array_wildcard(self):
         """Test deleting a field from all array elements."""
         data = {


### PR DESCRIPTION
## Relevant issues

No duplicate issue or pull request found after searching for escaped dotted-key deletion behavior

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Before at `265bf871bcb85ef09466b59d1cd93b02d2a0f79e`

```console
$ LITELLM_LOCAL_MODEL_COST_MAP=True python -c 'from litellm.litellm_core_utils.dot_notation_indexing import delete_nested_value; data = {"metadata": {"trace.id": "remove", "keep": "value"}}; print(delete_nested_value(data, r"metadata.trace\.id"))'
{'metadata': {'trace.id': 'remove', 'keep': 'value'}}
```

After at `638b5e92`

```console
$ LITELLM_LOCAL_MODEL_COST_MAP=True python -c 'from litellm.litellm_core_utils.dot_notation_indexing import delete_nested_value; data = {"metadata": {"trace.id": "remove", "keep": "value"}}; print(delete_nested_value(data, r"metadata.trace\.id"))'
{'metadata': {'keep': 'value'}}
```

## Type

Bug Fix

## Changes

Updates nested-path parsing so an escaped dot remains part of a field segment and is unescaped before dictionary traversal

Adds a regression test for deleting a literal dotted key while preserving sibling data

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR