### PR TITLE
fix(vertex): surface Gemini grounding toolUsePromptTokenCount in usage

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1739,7 +1739,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         """
         if usage_metadata.get("promptTokenCount", 0) + usage_metadata.get(
             "candidatesTokenCount", 0
-        ) == usage_metadata.get("totalTokenCount", 0):
+        ) + usage_metadata.get("toolUsePromptTokenCount", 0) == usage_metadata.get("totalTokenCount", 0):
             return True
         else:
             return False
@@ -1894,6 +1894,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             text_tokens=prompt_text_tokens,
             image_tokens=prompt_image_tokens,
             video_tokens=prompt_video_tokens,
+            tool_use_tokens=usage_metadata.get("toolUsePromptTokenCount"),
         )
 
         completion_tokens = response_tokens or completion_response["usageMetadata"].get("candidatesTokenCount", 0)

--- a/litellm/types/llms/vertex_ai.py
+++ b/litellm/types/llms/vertex_ai.py
@@ -304,6 +304,8 @@ class UsageMetadata(TypedDict, total=False):
     thoughtsTokenCount: int
     responseTokensDetails: List[PromptTokensDetails]
     candidatesTokensDetails: List[PromptTokensDetails]  # Alternative key name used in some responses
+    toolUsePromptTokenCount: int
+    toolUsePromptTokensDetails: List[PromptTokensDetails]
 
 
 class TokenCountDetailsResponse(TypedDict):

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1474,6 +1474,9 @@ class PromptTokensDetailsWrapper(
     web_search_requests: Optional[int] = None
     """Number of web search requests made by the tool call. Used for Anthropic to calculate web search cost."""
 
+    tool_use_tokens: Optional[int] = None
+    """Number of tokens consumed by tool-use prompts (e.g. Gemini grounding). Kept out of prompt_tokens so the flat grounding fee is not also charged per input token."""
+
     character_count: Optional[int] = None
     """Character count sent to the model. Used for Vertex AI multimodal embeddings."""
 

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -5254,3 +5254,70 @@ def test_process_candidates_merges_thought_signatures_and_server_side_tools():
     fields = model_response.choices[-1].message.provider_specific_fields
     assert fields["thought_signatures"] == ["sig-text"]
     assert fields["server_side_tool_invocations"][0]["id"] == "tool-1"
+
+
+def test_vertex_ai_usage_metadata_grounding_surfaces_tool_use_tokens():
+    """Grounded (googleSearch) request: toolUsePromptTokenCount is surfaced and reconciles the total.
+
+    Regression for https://github.com/BerriAI/litellm/issues/33530
+    """
+    v = VertexGeminiConfig()
+    usage_metadata = UsageMetadata(
+        promptTokenCount=100,
+        candidatesTokenCount=40,
+        toolUsePromptTokenCount=25,
+        totalTokenCount=165,
+    )
+    result = v._calculate_usage(completion_response={"usageMetadata": usage_metadata})
+
+    assert result.prompt_tokens == 100
+    assert result.completion_tokens == 40
+    assert result.total_tokens == 165
+    assert result.prompt_tokens_details.tool_use_tokens == 25
+    assert (
+        result.prompt_tokens + result.completion_tokens + result.prompt_tokens_details.tool_use_tokens
+        == result.total_tokens
+    )
+
+
+def test_vertex_ai_usage_metadata_grounding_does_not_double_count_reasoning():
+    """Grounded request whose candidatesTokenCount already includes thoughts.
+
+    Without accounting for toolUsePromptTokenCount, is_candidate_token_count_inclusive treats
+    candidates as exclusive and double-counts reasoning into completion_tokens.
+    Regression for https://github.com/BerriAI/litellm/issues/33530
+    """
+    v = VertexGeminiConfig()
+    usage_metadata = UsageMetadata(
+        promptTokenCount=100,
+        candidatesTokenCount=60,
+        toolUsePromptTokenCount=30,
+        thoughtsTokenCount=10,
+        totalTokenCount=190,
+    )
+    result = v._calculate_usage(completion_response={"usageMetadata": usage_metadata})
+
+    assert result.completion_tokens == 60
+    assert result.prompt_tokens_details.tool_use_tokens == 30
+
+
+def test_is_candidate_token_count_inclusive_accounts_for_grounding():
+    """toolUsePromptTokenCount must be part of the inclusive/exclusive determination.
+
+    Regression for https://github.com/BerriAI/litellm/issues/33530
+    """
+    inclusive = UsageMetadata(
+        promptTokenCount=100,
+        candidatesTokenCount=60,
+        toolUsePromptTokenCount=30,
+        totalTokenCount=190,
+    )
+    exclusive = UsageMetadata(
+        promptTokenCount=100,
+        candidatesTokenCount=50,
+        toolUsePromptTokenCount=30,
+        thoughtsTokenCount=10,
+        totalTokenCount=190,
+    )
+    assert VertexGeminiConfig.is_candidate_token_count_inclusive(inclusive) is True
+    assert VertexGeminiConfig.is_candidate_token_count_inclusive(exclusive) is False


### PR DESCRIPTION
## Relevant issues

Fixes #33530

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

I did not have a Gemini key with grounding in this environment to make a billed live call, so the reproduction below drives litellm's real `VertexGeminiConfig._calculate_usage` with the `usageMetadata` a grounded (googleSearch) request returns, using the shape from the report and discussion #33198. The end-to-end curl a reviewer with a key can run is at the bottom

before, base at `265bf871b`

```
prompt_tokens        = 100
completion_tokens    = 40
total_tokens         = 165
tool_use_tokens      = None
prompt + completion            = 140
prompt + completion + tool_use = 140
matches total_tokens?          = False
```

after, this PR at `42e96d398`

```
prompt_tokens        = 100
completion_tokens    = 40
total_tokens         = 165
tool_use_tokens      = 25
prompt + completion            = 140
prompt + completion + tool_use = 165
matches total_tokens?          = True
```

end-to-end check against live Gemini (needs a key with grounding enabled)

```bash
curl http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $LITELLM_KEY" -H "Content-Type: application/json" -d '{
  "model": "gemini/gemini-2.5-flash",
  "messages": [{"role": "user", "content": "Who won the most recent F1 race?"}],
  "tools": [{"googleSearch": {}}]
}' | jq '.usage'
```

`usage.prompt_tokens_details.tool_use_tokens` should be populated and `prompt_tokens + completion_tokens + tool_use_tokens` should equal `total_tokens`

## Type

🐛 Bug Fix

## Changes

Grounded Gemini requests return a `toolUsePromptTokenCount` in `usageMetadata`, but it was never declared on the `UsageMetadata` typed dict and never read in `_calculate_usage`, so the grounding tokens were silently dropped and `prompt_tokens + completion_tokens` fell short of `total_tokens` by exactly that amount

This surfaces the count as `prompt_tokens_details.tool_use_tokens` rather than folding it into `prompt_tokens`, because grounding is billed with a flat fee; adding it to `prompt_tokens` would also charge it per input token in the vertex cost calculator (`prompt_cost = prompt_tokens * input_cost_per_token`) and double-count the cost. Keeping it in a details field leaves cost untouched while making the total reconcile as `prompt + completion + tool_use`

`is_candidate_token_count_inclusive` compared `promptTokenCount + candidatesTokenCount` against `totalTokenCount` to decide whether the thought tokens were already inside the candidate count. With grounding active the total also carries the tool-use tokens, so the check wrongly read as exclusive and added the reasoning tokens into `completion_tokens` a second time. It now accounts for `toolUsePromptTokenCount`, so the inclusive and exclusive paths both stay correct when grounding is on

Tests extend the mapped `test_vertex_and_google_ai_studio_gemini.py` with three regressions: the surfaced count and reconciliation, the reasoning double-count guard, and the inclusive/exclusive determination with grounding. Each one fails on the pre-fix code

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
