### PR TITLE
fix(proxy): re-encode video id with routed model_id so status/content resolve per-model key

### DIFF
--- a/litellm/proxy/video_endpoints/endpoints.py
+++ b/litellm/proxy/video_endpoints/endpoints.py
@@ -24,6 +24,7 @@ from litellm.proxy.video_endpoints.utils import (
 from litellm.types.videos.utils import (
     decode_character_id_with_provider,
     decode_video_id_with_provider,
+    encode_video_id_with_provider,
 )
 
 router = APIRouter()
@@ -88,7 +89,7 @@ async def video_generation(
     # Process request using ProxyBaseLLMRequestProcessing
     processor = ProxyBaseLLMRequestProcessing(data=data)
     try:
-        return await processor.base_process_llm_request(
+        response = await processor.base_process_llm_request(
             request=request,
             fastapi_response=fastapi_response,
             user_api_key_dict=user_api_key_dict,
@@ -106,6 +107,20 @@ async def video_generation(
             user_api_base=user_api_base,
             version=version,
         )
+        hidden_params = getattr(response, "_hidden_params", {}) or {}
+        decoded_video_id = decode_video_id_with_provider(response["id"] if isinstance(response, dict) else response.id)
+        encoded_video_id = encode_video_id_with_provider(
+            video_id=decoded_video_id.get("video_id", ""),
+            provider=hidden_params.get("custom_llm_provider")
+            or decoded_video_id.get("custom_llm_provider")
+            or "openai",
+            model_id=hidden_params.get("model_id") or data.get("model"),
+        )
+        if isinstance(response, dict):
+            response["id"] = encoded_video_id
+        else:
+            response.id = encoded_video_id
+        return response
     except Exception as e:
         raise await processor._handle_llm_api_exception(
             e=e,
@@ -479,7 +494,7 @@ async def video_remix(
     # Process request using ProxyBaseLLMRequestProcessing
     processor = ProxyBaseLLMRequestProcessing(data=data)
     try:
-        return await processor.base_process_llm_request(
+        response = await processor.base_process_llm_request(
             request=request,
             fastapi_response=fastapi_response,
             user_api_key_dict=user_api_key_dict,
@@ -497,6 +512,20 @@ async def video_remix(
             user_api_base=user_api_base,
             version=version,
         )
+        hidden_params = getattr(response, "_hidden_params", {}) or {}
+        decoded_video_id = decode_video_id_with_provider(response["id"] if isinstance(response, dict) else response.id)
+        encoded_video_id = encode_video_id_with_provider(
+            video_id=decoded_video_id.get("video_id", ""),
+            provider=hidden_params.get("custom_llm_provider")
+            or decoded_video_id.get("custom_llm_provider")
+            or "openai",
+            model_id=hidden_params.get("model_id") or data.get("model"),
+        )
+        if isinstance(response, dict):
+            response["id"] = encoded_video_id
+        else:
+            response.id = encoded_video_id
+        return response
     except Exception as e:
         raise await processor._handle_llm_api_exception(
             e=e,
@@ -788,7 +817,7 @@ async def video_edit(
 
     processor = ProxyBaseLLMRequestProcessing(data=data)
     try:
-        return await processor.base_process_llm_request(
+        response = await processor.base_process_llm_request(
             request=request,
             fastapi_response=fastapi_response,
             user_api_key_dict=user_api_key_dict,
@@ -806,6 +835,20 @@ async def video_edit(
             user_api_base=user_api_base,
             version=version,
         )
+        hidden_params = getattr(response, "_hidden_params", {}) or {}
+        decoded_video_id = decode_video_id_with_provider(response["id"] if isinstance(response, dict) else response.id)
+        encoded_video_id = encode_video_id_with_provider(
+            video_id=decoded_video_id.get("video_id", ""),
+            provider=hidden_params.get("custom_llm_provider")
+            or decoded_video_id.get("custom_llm_provider")
+            or "openai",
+            model_id=hidden_params.get("model_id") or data.get("model"),
+        )
+        if isinstance(response, dict):
+            response["id"] = encoded_video_id
+        else:
+            response.id = encoded_video_id
+        return response
     except Exception as e:
         raise await processor._handle_llm_api_exception(
             e=e,
@@ -888,7 +931,7 @@ async def video_extension(
 
     processor = ProxyBaseLLMRequestProcessing(data=data)
     try:
-        return await processor.base_process_llm_request(
+        response = await processor.base_process_llm_request(
             request=request,
             fastapi_response=fastapi_response,
             user_api_key_dict=user_api_key_dict,
@@ -906,6 +949,20 @@ async def video_extension(
             user_api_base=user_api_base,
             version=version,
         )
+        hidden_params = getattr(response, "_hidden_params", {}) or {}
+        decoded_video_id = decode_video_id_with_provider(response["id"] if isinstance(response, dict) else response.id)
+        encoded_video_id = encode_video_id_with_provider(
+            video_id=decoded_video_id.get("video_id", ""),
+            provider=hidden_params.get("custom_llm_provider")
+            or decoded_video_id.get("custom_llm_provider")
+            or "openai",
+            model_id=hidden_params.get("model_id") or data.get("model"),
+        )
+        if isinstance(response, dict):
+            response["id"] = encoded_video_id
+        else:
+            response.id = encoded_video_id
+        return response
     except Exception as e:
         raise await processor._handle_llm_api_exception(
             e=e,

--- a/litellm/proxy/video_endpoints/endpoints.py
+++ b/litellm/proxy/video_endpoints/endpoints.py
@@ -17,6 +17,7 @@ from litellm.proxy.common_utils.openai_endpoint_utils import (
 )
 from litellm.proxy.image_endpoints.endpoints import batch_to_bytesio
 from litellm.proxy.video_endpoints.utils import (
+    deployment_id_for_encoding,
     encode_character_id_in_response,
     encode_video_id_in_response,
     extract_model_from_target_model_names,
@@ -108,7 +109,7 @@ async def video_generation(
             user_api_base=user_api_base,
             version=version,
         )
-        encoded_response: Final = encode_video_id_in_response(response, data.get("model"))
+        encoded_response: Final = encode_video_id_in_response(response, deployment_id_for_encoding(response, data))
     except Exception as e:
         raise await processor._handle_llm_api_exception(
             e=e,
@@ -500,7 +501,7 @@ async def video_remix(
             user_api_base=user_api_base,
             version=version,
         )
-        encoded_response: Final = encode_video_id_in_response(response, data.get("model"))
+        encoded_response: Final = encode_video_id_in_response(response, deployment_id_for_encoding(response, data))
     except Exception as e:
         raise await processor._handle_llm_api_exception(
             e=e,
@@ -599,7 +600,7 @@ async def video_create_character(
         if target_model_name:
             hidden_params: Final = getattr(response, "_hidden_params", {}) or {}
             provider_for_encoding: Final = hidden_params.get("custom_llm_provider") or custom_llm_provider or "openai"
-            model_id_for_encoding: Final = hidden_params.get("model_id") or data.get("model")
+            model_id_for_encoding: Final = deployment_id_for_encoding(response, data)
             response = encode_character_id_in_response(
                 response=response,
                 custom_llm_provider=provider_for_encoding,
@@ -814,7 +815,7 @@ async def video_edit(
             user_api_base=user_api_base,
             version=version,
         )
-        encoded_response: Final = encode_video_id_in_response(response, data.get("model"))
+        encoded_response: Final = encode_video_id_in_response(response, deployment_id_for_encoding(response, data))
     except Exception as e:
         raise await processor._handle_llm_api_exception(
             e=e,
@@ -912,7 +913,7 @@ async def video_extension(
             user_api_base=user_api_base,
             version=version,
         )
-        encoded_response: Final = encode_video_id_in_response(response, data.get("model"))
+        encoded_response: Final = encode_video_id_in_response(response, deployment_id_for_encoding(response, data))
     except Exception as e:
         raise await processor._handle_llm_api_exception(
             e=e,

--- a/litellm/proxy/video_endpoints/endpoints.py
+++ b/litellm/proxy/video_endpoints/endpoints.py
@@ -18,6 +18,7 @@ from litellm.proxy.common_utils.openai_endpoint_utils import (
 from litellm.proxy.image_endpoints.endpoints import batch_to_bytesio
 from litellm.proxy.video_endpoints.utils import (
     encode_character_id_in_response,
+    encode_video_id_in_response,
     extract_model_from_target_model_names,
     get_custom_provider_from_data,
     video_reference_to_id,
@@ -89,7 +90,7 @@ async def video_generation(
     # Process request using ProxyBaseLLMRequestProcessing
     processor: Final = ProxyBaseLLMRequestProcessing(data=data)
     try:
-        return await processor.base_process_llm_request(
+        response: Final = await processor.base_process_llm_request(
             request=request,
             fastapi_response=fastapi_response,
             user_api_key_dict=user_api_key_dict,
@@ -107,6 +108,7 @@ async def video_generation(
             user_api_base=user_api_base,
             version=version,
         )
+        encoded_response: Final = encode_video_id_in_response(response, data.get("model"))
     except Exception as e:
         raise await processor._handle_llm_api_exception(
             e=e,
@@ -114,6 +116,8 @@ async def video_generation(
             proxy_logging_obj=proxy_logging_obj,
             version=version,
         )
+    else:
+        return encoded_response
 
 
 @router.get(
@@ -478,7 +482,7 @@ async def video_remix(
     # Process request using ProxyBaseLLMRequestProcessing
     processor: Final = ProxyBaseLLMRequestProcessing(data=data)
     try:
-        return await processor.base_process_llm_request(
+        response: Final = await processor.base_process_llm_request(
             request=request,
             fastapi_response=fastapi_response,
             user_api_key_dict=user_api_key_dict,
@@ -496,6 +500,7 @@ async def video_remix(
             user_api_base=user_api_base,
             version=version,
         )
+        encoded_response: Final = encode_video_id_in_response(response, data.get("model"))
     except Exception as e:
         raise await processor._handle_llm_api_exception(
             e=e,
@@ -503,6 +508,8 @@ async def video_remix(
             proxy_logging_obj=proxy_logging_obj,
             version=version,
         )
+    else:
+        return encoded_response
 
 
 @router.post(
@@ -789,7 +796,7 @@ async def video_edit(
 
     processor: Final = ProxyBaseLLMRequestProcessing(data=data)
     try:
-        return await processor.base_process_llm_request(
+        response: Final = await processor.base_process_llm_request(
             request=request,
             fastapi_response=fastapi_response,
             user_api_key_dict=user_api_key_dict,
@@ -807,6 +814,7 @@ async def video_edit(
             user_api_base=user_api_base,
             version=version,
         )
+        encoded_response: Final = encode_video_id_in_response(response, data.get("model"))
     except Exception as e:
         raise await processor._handle_llm_api_exception(
             e=e,
@@ -814,6 +822,8 @@ async def video_edit(
             proxy_logging_obj=proxy_logging_obj,
             version=version,
         )
+    else:
+        return encoded_response
 
 
 @router.post(
@@ -884,7 +894,7 @@ async def video_extension(
 
     processor: Final = ProxyBaseLLMRequestProcessing(data=data)
     try:
-        return await processor.base_process_llm_request(
+        response: Final = await processor.base_process_llm_request(
             request=request,
             fastapi_response=fastapi_response,
             user_api_key_dict=user_api_key_dict,
@@ -902,6 +912,7 @@ async def video_extension(
             user_api_base=user_api_base,
             version=version,
         )
+        encoded_response: Final = encode_video_id_in_response(response, data.get("model"))
     except Exception as e:
         raise await processor._handle_llm_api_exception(
             e=e,
@@ -909,3 +920,5 @@ async def video_extension(
             proxy_logging_obj=proxy_logging_obj,
             version=version,
         )
+    else:
+        return encoded_response

--- a/litellm/proxy/video_endpoints/utils.py
+++ b/litellm/proxy/video_endpoints/utils.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from typing import Any, Final
 
 import orjson
@@ -57,6 +58,19 @@ def _hidden_param(response: object, key: str) -> str | None:
         return None
     value: Final = params.get(key)
     return value if isinstance(value, str) else None
+
+
+def deployment_id_for_encoding(response: object, data: Mapping[str, Any]) -> str | None:
+    """The deployment the request actually routed to, not the public model group.
+
+    The router leaves ``model_id`` out of ``_hidden_params`` on the generic path and
+    records the selected deployment under ``litellm_metadata.model_info.id`` instead.
+    Encoding ``data["model"]`` there would embed the group, so a later status or
+    content call could load-balance to a different deployment and fail to resolve.
+    """
+    litellm_metadata: Final = data.get("litellm_metadata") or {}
+    model_info: Final = litellm_metadata.get("model_info") or {}
+    return _hidden_param(response, "model_id") or model_info.get("id") or data.get("model")
 
 
 def encode_video_id_in_response(response: object, fallback_model: str | None) -> object:

--- a/litellm/proxy/video_endpoints/utils.py
+++ b/litellm/proxy/video_endpoints/utils.py
@@ -2,7 +2,11 @@ from typing import Any, Final
 
 import orjson
 
-from litellm.types.videos.utils import encode_character_id_with_provider
+from litellm.types.videos.utils import (
+    decode_video_id_with_provider,
+    encode_character_id_with_provider,
+    encode_video_id_with_provider,
+)
 
 
 def extract_model_from_target_model_names(target_model_names: Any) -> str | None:
@@ -45,6 +49,33 @@ def get_custom_provider_from_data(data: dict[str, Any]) -> str | None:
             return extra_body_custom_llm_provider
 
     return None
+
+
+def _hidden_param(response: object, key: str) -> str | None:
+    params: Final = getattr(response, "_hidden_params", None)
+    if not isinstance(params, dict):
+        return None
+    value: Final = params.get(key)
+    return value if isinstance(value, str) else None
+
+
+def encode_video_id_in_response(response: object, fallback_model: str | None) -> object:
+    video_id: Final = response.get("id") if isinstance(response, dict) else getattr(response, "id", None)
+    if not isinstance(video_id, str) or not video_id:
+        return response
+
+    decoded: Final = decode_video_id_with_provider(video_id)
+    encoded: Final = encode_video_id_with_provider(
+        video_id=decoded.get("video_id", ""),
+        provider=_hidden_param(response, "custom_llm_provider") or decoded.get("custom_llm_provider") or "openai",
+        model_id=_hidden_param(response, "model_id") or fallback_model,
+    )
+    if isinstance(response, dict):
+        response["id"] = encoded  # rebind-ok: in-place id rewrite, matching encode_character_id_in_response
+        return response
+
+    response.id = encoded  # rebind-ok: in-place id rewrite, matching encode_character_id_in_response
+    return response
 
 
 def encode_character_id_in_response(response: Any, custom_llm_provider: str, model_id: str | None) -> Any:

--- a/litellm/proxy/video_endpoints/utils.py
+++ b/litellm/proxy/video_endpoints/utils.py
@@ -88,7 +88,7 @@ def encode_video_id_in_response(response: object, fallback_model: str | None) ->
         response["id"] = encoded  # rebind-ok: in-place id rewrite, matching encode_character_id_in_response
         return response
 
-    response.id = encoded  # rebind-ok: in-place id rewrite, matching encode_character_id_in_response
+    response.id = encoded  # pyright: ignore[reportAttributeAccessIssue]  # rebind-ok: in-place id rewrite on a non-dict response, matching encode_character_id_in_response
     return response
 
 

--- a/tests/test_litellm/proxy/video_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/video_endpoints/test_endpoints.py
@@ -44,7 +44,9 @@ from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
 from litellm.proxy.utils import ProxyLogging
 from litellm.router import Router
+from litellm.types.videos.main import VideoObject
 from litellm.types.videos.utils import (
+    decode_video_id_with_provider,
     encode_character_id_with_provider,
     encode_video_id_with_provider,
 )
@@ -69,7 +71,7 @@ AZURE_CHARACTER_ID = encode_character_id_with_provider(
 RESOLVED_MODELS: Dict[str, str] = {VIDEO_MODEL_ID: "azure-sora"}
 
 # Sentinel propagated by base_process for the passthrough endpoints.
-SENTINEL = object()
+SENTINEL = VideoObject(id="video_raw", object="video", status="processing")
 
 
 class FakeRequest:
@@ -113,6 +115,7 @@ class Harness:
 
 @pytest.fixture
 def harness():
+    SENTINEL.id = "video_raw"
     logging = MagicMock(spec=ProxyLogging)
 
     router = MagicMock(spec=Router)
@@ -229,6 +232,26 @@ async def test_generation__route_type_data_and_no_provider_default(harness):
     # future default custom_llm_provider injection would break this row.
     assert harness.processor_data() == {"model": "sora-2", "prompt": "a sunset"}
     harness.batch_to_bytesio.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generation__reencodes_id_with_model_id(harness):
+    response = VideoObject(
+        id=encode_video_id_with_provider("video_raw", "openai", None),
+        object="video",
+        status="processing",
+    )
+    response._hidden_params = {
+        "custom_llm_provider": "openai",
+        "model_id": VIDEO_MODEL_ID,
+    }
+    harness.base_process.return_value = response
+
+    resp = await call_generation(harness, body={"model": "sora-2"})
+
+    decoded_video_id = decode_video_id_with_provider(resp.id)
+    assert decoded_video_id["model_id"] == VIDEO_MODEL_ID
+    assert decoded_video_id["video_id"] == "video_raw"
 
 
 @pytest.mark.asyncio
@@ -402,6 +425,28 @@ async def test_edit__extracts_nested_video_id_full_contract(harness):
 
 
 @pytest.mark.asyncio
+async def test_edit__reencodes_id_with_model_id(harness):
+    response = VideoObject(
+        id=encode_video_id_with_provider("video_raw", "openai", None),
+        object="video",
+        status="processing",
+    )
+    response._hidden_params = {
+        "custom_llm_provider": "openai",
+        "model_id": VIDEO_MODEL_ID,
+    }
+    harness.base_process.return_value = response
+
+    resp = await call_edit(
+        harness, body={"prompt": "brighter", "video": {"id": "video_plain"}}
+    )
+
+    decoded_video_id = decode_video_id_with_provider(resp.id)
+    assert decoded_video_id["model_id"] == VIDEO_MODEL_ID
+    assert decoded_video_id["video_id"] == "video_raw"
+
+
+@pytest.mark.asyncio
 async def test_edit__provider_from_body_data_for_plain_id(harness):
     """For a plain id, get_custom_provider_from_data (run for real) pulls the
     provider out of the request body before the 'openai' default."""
@@ -495,6 +540,26 @@ async def test_remix__model_encoded_id_full_contract(harness):
         "custom_llm_provider": "azure",
         "model": "azure-sora",
     }
+
+
+@pytest.mark.asyncio
+async def test_remix__reencodes_id_with_model_id(harness):
+    response = VideoObject(
+        id=encode_video_id_with_provider("video_raw", "openai", None),
+        object="video",
+        status="processing",
+    )
+    response._hidden_params = {
+        "custom_llm_provider": "openai",
+        "model_id": VIDEO_MODEL_ID,
+    }
+    harness.base_process.return_value = response
+
+    resp = await call_remix(harness, "video_plain", body={"prompt": "new colors"})
+
+    decoded_video_id = decode_video_id_with_provider(resp.id)
+    assert decoded_video_id["model_id"] == VIDEO_MODEL_ID
+    assert decoded_video_id["video_id"] == "video_raw"
 
 
 @pytest.mark.asyncio
@@ -654,3 +719,23 @@ async def test_extension__extracts_nested_video_id_full_contract(harness):
         "custom_llm_provider": "azure",
         "model": "azure-sora",
     }
+
+
+@pytest.mark.asyncio
+async def test_extension__reencodes_id_with_model_id(harness):
+    response = VideoObject(
+        id=encode_video_id_with_provider("video_raw", "openai", None),
+        object="video",
+        status="processing",
+    )
+    response._hidden_params = {
+        "custom_llm_provider": "openai",
+        "model_id": VIDEO_MODEL_ID,
+    }
+    harness.base_process.return_value = response
+
+    resp = await call_extension(harness, body={"prompt": "continue"})
+
+    decoded_video_id = decode_video_id_with_provider(resp.id)
+    assert decoded_video_id["model_id"] == VIDEO_MODEL_ID
+    assert decoded_video_id["video_id"] == "video_raw"

--- a/tests/test_litellm/proxy/video_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/video_endpoints/test_endpoints.py
@@ -253,6 +253,31 @@ async def test_generation__reencodes_id_with_model_id(harness):
 
 
 @pytest.mark.asyncio
+async def test_generation__reencodes_id_with_routed_deployment_id(harness):
+    # data["model"] is the public group here; only litellm_metadata carries the
+    # deployment the router picked.
+    response = VideoObject(
+        id=encode_video_id_with_provider("video_raw", "openai", None),
+        object="video",
+        status="processing",
+    )
+    response._hidden_params = {"custom_llm_provider": "openai"}
+    harness.base_process.return_value = response
+
+    resp = await call_generation(
+        harness,
+        body={
+            "model": "sora-2",
+            "litellm_metadata": {"model_info": {"id": VIDEO_MODEL_ID}},
+        },
+    )
+
+    decoded_video_id = decode_video_id_with_provider(resp.id)
+    assert decoded_video_id["model_id"] == VIDEO_MODEL_ID
+    assert decoded_video_id["video_id"] == "video_raw"
+
+
+@pytest.mark.asyncio
 async def test_generation__input_reference_attached(harness):
     body = {"model": "sora-2", "prompt": "a sunset"}
     upload = MagicMock(name="upload_file")

--- a/tests/test_litellm/proxy/video_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/video_endpoints/test_endpoints.py
@@ -41,7 +41,9 @@ from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
 from litellm.proxy.utils import ProxyLogging
 from litellm.router import Router
+from litellm.types.videos.main import VideoObject
 from litellm.types.videos.utils import (
+    decode_video_id_with_provider,
     encode_character_id_with_provider,
     encode_video_id_with_provider,
 )
@@ -67,7 +69,7 @@ AZURE_CHARACTER_ID = encode_character_id_with_provider(
 RESOLVED_MODELS: Dict[str, str] = {VIDEO_MODEL_ID: "azure-sora"}
 
 # Sentinel propagated by base_process for the passthrough endpoints.
-SENTINEL = object()
+SENTINEL = VideoObject(id="video_raw", object="video", status="processing")
 
 
 class FakeRequest:
@@ -111,6 +113,7 @@ class Harness:
 
 @pytest.fixture
 def harness():
+    SENTINEL.id = "video_raw"
     logging = MagicMock(spec=ProxyLogging)
 
     router = MagicMock(spec=Router)
@@ -227,6 +230,26 @@ async def test_generation__route_type_data_and_no_provider_default(harness):
     # future default custom_llm_provider injection would break this row.
     assert harness.processor_data() == {"model": "sora-2", "prompt": "a sunset"}
     harness.batch_to_bytesio.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generation__reencodes_id_with_model_id(harness):
+    response = VideoObject(
+        id=encode_video_id_with_provider("video_raw", "openai", None),
+        object="video",
+        status="processing",
+    )
+    response._hidden_params = {
+        "custom_llm_provider": "openai",
+        "model_id": VIDEO_MODEL_ID,
+    }
+    harness.base_process.return_value = response
+
+    resp = await call_generation(harness, body={"model": "sora-2"})
+
+    decoded_video_id = decode_video_id_with_provider(resp.id)
+    assert decoded_video_id["model_id"] == VIDEO_MODEL_ID
+    assert decoded_video_id["video_id"] == "video_raw"
 
 
 @pytest.mark.asyncio
@@ -401,6 +424,28 @@ async def test_edit__extracts_nested_video_id_full_contract(harness):
 
 
 @pytest.mark.asyncio
+async def test_edit__reencodes_id_with_model_id(harness):
+    response = VideoObject(
+        id=encode_video_id_with_provider("video_raw", "openai", None),
+        object="video",
+        status="processing",
+    )
+    response._hidden_params = {
+        "custom_llm_provider": "openai",
+        "model_id": VIDEO_MODEL_ID,
+    }
+    harness.base_process.return_value = response
+
+    resp = await call_edit(
+        harness, body={"prompt": "brighter", "video": {"id": "video_plain"}}
+    )
+
+    decoded_video_id = decode_video_id_with_provider(resp.id)
+    assert decoded_video_id["model_id"] == VIDEO_MODEL_ID
+    assert decoded_video_id["video_id"] == "video_raw"
+
+
+@pytest.mark.asyncio
 async def test_edit__provider_from_body_data_for_plain_id(harness):
     """For a plain id, get_custom_provider_from_data (run for real) pulls the
     provider out of the request body before the 'openai' default."""
@@ -541,6 +586,26 @@ async def test_remix__model_encoded_id_full_contract(harness):
         "custom_llm_provider": "azure",
         "model": "azure-sora",
     }
+
+
+@pytest.mark.asyncio
+async def test_remix__reencodes_id_with_model_id(harness):
+    response = VideoObject(
+        id=encode_video_id_with_provider("video_raw", "openai", None),
+        object="video",
+        status="processing",
+    )
+    response._hidden_params = {
+        "custom_llm_provider": "openai",
+        "model_id": VIDEO_MODEL_ID,
+    }
+    harness.base_process.return_value = response
+
+    resp = await call_remix(harness, "video_plain", body={"prompt": "new colors"})
+
+    decoded_video_id = decode_video_id_with_provider(resp.id)
+    assert decoded_video_id["model_id"] == VIDEO_MODEL_ID
+    assert decoded_video_id["video_id"] == "video_raw"
 
 
 @pytest.mark.asyncio
@@ -701,3 +766,23 @@ async def test_extension__extracts_nested_video_id_full_contract(harness):
         "custom_llm_provider": "azure",
         "model": "azure-sora",
     }
+
+
+@pytest.mark.asyncio
+async def test_extension__reencodes_id_with_model_id(harness):
+    response = VideoObject(
+        id=encode_video_id_with_provider("video_raw", "openai", None),
+        object="video",
+        status="processing",
+    )
+    response._hidden_params = {
+        "custom_llm_provider": "openai",
+        "model_id": VIDEO_MODEL_ID,
+    }
+    harness.base_process.return_value = response
+
+    resp = await call_extension(harness, body={"prompt": "continue"})
+
+    decoded_video_id = decode_video_id_with_provider(resp.id)
+    assert decoded_video_id["model_id"] == VIDEO_MODEL_ID
+    assert decoded_video_id["video_id"] == "video_raw"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Video create returned an id carrying no routed deployment
- Status and download then could not resolve which deployment to use
- With per-model keys both calls failed as invalid_api_key

How it solves it:

- Re-encode the returned id with the deployment that served the request
- Read the deployment from `_hidden_params["model_id"]`, then from `litellm_metadata.model_info.id`, then from the request model
- The generic router path sets only the metadata field, so the last two steps are what make a routed create resolvable
- Status and download resolve the same per-model key as create

## User Flow

Before: a developer who starts a video job can never fetch the result

1. The admin runs the proxy with models stored in the database and a key set per model, with no global provider key
2. The developer sends POST https://litellm-domain/v1/videos and gets 200 with a video id
3. The developer polls GET https://litellm-domain/v1/videos/{id} for status
4. The reply is an error naming `invalid_api_key` rather than a status
5. GET https://litellm-domain/v1/videos/{id}/content fails the same way, so the finished video can never be downloaded

After: the same job can be polled and downloaded

1. The admin runs the same configuration, unchanged
2. The developer sends the same POST https://litellm-domain/v1/videos and gets 200 with a video id
3. The developer polls GET https://litellm-domain/v1/videos/{id} and gets a real status back
4. GET https://litellm-domain/v1/videos/{id}/content returns the video
5. No global provider key is needed at any step

## Relevant issues

Fixes #33740

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally: `tests/test_litellm/proxy/video_endpoints/` and `tests/test_litellm/proxy/test_common_request_processing.py`, 380 passed
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

I do not have provider credentials for a video model, so I cannot supply the live create-then-poll run this section asks for. Please treat what follows as short of the bar and ask if you want a live run from someone who can call the provider.

The observable artefact is the id itself. Decoding the id returned by create shows the empty routed model:

```
litellm:custom_llm_provider:openai;model_id:;video_id:video_...
```

`model_id` is empty, which is why status and download cannot pick the deployment.

### Before (`litellm_internal_staging`)

#### Create then status, per-model keys

1. `POST /v1/videos` returns an id whose decoded form carries `model_id:` with nothing after it
2. `GET /v1/videos/{id}` has no deployment to resolve and fails as `invalid_api_key`

### After (`ddf1d49a`)

#### Create then status, per-model keys

1. `POST /v1/videos` returns an id whose decoded form carries the routed `model_id`
2. `GET /v1/videos/{id}` resolves that deployment and returns status
3. `tests/test_litellm/proxy/video_endpoints/test_endpoints.py` covers the re-encoding and the fallback for all four endpoints: 29 passed locally at this head, and 4 of them fail if the re-encode is removed


## Note on this revision

The re-encode helper now lives in `litellm/proxy/video_endpoints/utils.py` as `encode_video_id_in_response`, next to `encode_character_id_in_response`, which fixes the same problem on the character path. `endpoints.py` no longer imports `encode_video_id_with_provider`, which is what the CodeQL cyclic-import alert on this PR pointed at.

The helper reads `_hidden_params` itself rather than taking the provider and `model_id` as arguments, because all four video endpoints derive them the same way. The character helper takes them as arguments because it has two call sites and one of them is gated on `target_model_name`.

A later revision adds `deployment_id_for_encoding` beside it. The five encode sites used to fall back to `data["model"]`. On a routed request that is the public model group, so the encoded id could not name a deployment. The helper reads the hidden `model_id`, then `litellm_metadata.model_info.id`, then the request model, which is the chain `ProxyBaseLLMRequestProcessing._get_model_id_from_response` already uses.

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Scope is video only, since it is the one async create-then-retrieve flow
- Text, image and audio are single-shot and cannot hit this

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

I am leaving this unticked deliberately. The tests pass locally and on CI, and I reviewed what they assert. I have no video deployment to exercise the real customer flow described above. I would rather say that than tick a box I cannot stand behind.




