### PR TITLE
fix: remove dead user-cache lookup with None key in spend-update path

### DIFF
--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -27,7 +27,7 @@ from typing import (
 
 import litellm
 from litellm._logging import verbose_proxy_logger
-from litellm.caching import DualCache, RedisCache
+from litellm.caching import RedisCache
 from litellm.constants import (
     DB_SPEND_UPDATE_JOB_NAME,
     DB_DAILY_TAG_SPEND_UPDATE_JOB_NAME,
@@ -44,7 +44,6 @@ from litellm.proxy._types import (
     DailyUserSpendTransaction,
     DBSpendUpdateTransactions,
     Litellm_EntityType,
-    LiteLLM_UserTable,
     SpendLogsMetadata,
     SpendLogsPayload,
     SpendUpdateQueueItem,
@@ -137,7 +136,6 @@ class DBSpendUpdateWriter:
             disable_spend_logs,
             litellm_proxy_budget_name,
             prisma_client,
-            user_api_key_cache,
         )
         from litellm.proxy.utils import ProxyUpdateSpend, hash_token
 
@@ -195,7 +193,6 @@ class DBSpendUpdateWriter:
                     org_id=org_id,
                     end_user_id=end_user_id,
                     prisma_client=prisma_client,
-                    user_api_key_cache=user_api_key_cache,
                     litellm_proxy_budget_name=litellm_proxy_budget_name,
                     payload=payload,
                 )
@@ -326,7 +323,6 @@ class DBSpendUpdateWriter:
         org_id: Optional[str],
         end_user_id: Optional[str],
         prisma_client: Optional[PrismaClient],
-        user_api_key_cache: DualCache,
         litellm_proxy_budget_name: Optional[str],
         payload: SpendLogsPayload,
     ):
@@ -345,7 +341,6 @@ class DBSpendUpdateWriter:
                 response_cost=response_cost,
                 user_id=user_id,
                 prisma_client=prisma_client,
-                user_api_key_cache=user_api_key_cache,
                 litellm_proxy_budget_name=litellm_proxy_budget_name,
                 end_user_id=end_user_id,
             )
@@ -510,7 +505,6 @@ class DBSpendUpdateWriter:
         response_cost: Optional[float],
         user_id: Optional[str],
         prisma_client: Optional[PrismaClient],
-        user_api_key_cache: DualCache,
         litellm_proxy_budget_name: Optional[str],
         end_user_id: Optional[str] = None,
     ):
@@ -518,10 +512,6 @@ class DBSpendUpdateWriter:
         - Update that user's row
         - Update litellm-proxy-budget row (global proxy spend)
         """
-        ## if an end-user is passed in, do an upsert - we can't guarantee they already exist in db
-        existing_user_obj = await user_api_key_cache.async_get_cache(key=user_id)
-        if existing_user_obj is not None and isinstance(existing_user_obj, dict):
-            existing_user_obj = LiteLLM_UserTable(**existing_user_obj)
         try:
             if prisma_client is not None:  # update
                 user_ids = [user_id]

--- a/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
+++ b/tests/test_litellm/proxy/db/test_db_spend_update_writer.py
@@ -13,7 +13,10 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
+from redis.exceptions import DataError
 
+import litellm
+from litellm.proxy._types import Litellm_EntityType
 from litellm.proxy.db.db_spend_update_writer import DBSpendUpdateWriter
 
 
@@ -1418,7 +1421,6 @@ async def test_batch_database_updates_isolation_on_failure():
         org_id="org1",
         end_user_id="eu1",
         prisma_client=MagicMock(),
-        user_api_key_cache=MagicMock(),
         litellm_proxy_budget_name="budget",
         payload={"key": "value"},
     )
@@ -1818,3 +1820,85 @@ async def test_update_database_does_not_deepcopy_on_request_path():
     fake_payload["nested"]["a"] = 999
     assert batch_payload["model"] == "gpt-4"
     assert batch_payload["nested"]["a"] == 1
+
+
+@pytest.mark.asyncio
+async def test_spend_update_path_never_queries_user_cache_with_none_user_id():
+    """
+    When user_id is None, the spend-update path must not perform a user-cache
+    lookup at all. With a Redis-backed auth cache (enable_redis_auth_cache),
+    a lookup with key=None raises redis.exceptions.DataError, which aborted
+    _update_user_db before any spend updates were enqueued.
+
+    This test fails on the old code twice over: the cache mock records the
+    forbidden lookup, and the DataError it raises kills the end-user spend
+    update that must survive.
+    """
+    db_writer = DBSpendUpdateWriter()
+
+    strict_redis_backed_cache = MagicMock()
+    strict_redis_backed_cache.async_get_cache = AsyncMock(
+        side_effect=DataError("Invalid input of type: 'NoneType'")
+    )
+
+    with (
+        patch.object(litellm, "max_budget", 0),
+        patch("litellm.proxy.proxy_server.disable_spend_logs", True),
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", strict_redis_backed_cache),
+        patch("litellm.proxy.proxy_server.litellm_proxy_budget_name", "litellm-proxy-budget"),
+        patch(
+            "litellm.proxy.spend_tracking.spend_tracking_utils.get_logging_payload",
+            return_value={
+                "startTime": "2024-01-01T00:00:00",
+                "endTime": "2024-01-01T00:01:00",
+                "model": "gpt-4",
+                "custom_llm_provider": "openai",
+                "spend": 0.0,
+            },
+        ),
+    ):
+        await db_writer.update_database(
+            token=None,
+            user_id=None,
+            end_user_id="end-user-1",
+            team_id=None,
+            org_id=None,
+            kwargs={"model": "gpt-4", "custom_llm_provider": "openai"},
+            completion_response=MagicMock(),
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            response_cost=0.1,
+        )
+        await asyncio.sleep(0)
+
+    strict_redis_backed_cache.async_get_cache.assert_not_called()
+
+    queued = await db_writer.spend_update_queue.flush_all_updates_from_in_memory_queue()
+    end_user_updates = [u for u in queued if u["entity_type"] == Litellm_EntityType.END_USER]
+    assert len(end_user_updates) == 1
+    assert end_user_updates[0]["entity_id"] == "end-user-1"
+    assert all(u["entity_type"] != Litellm_EntityType.USER for u in queued)
+
+
+@pytest.mark.asyncio
+async def test_update_user_db_enqueues_user_spend_without_cache_dependency():
+    """
+    _update_user_db needs no cache handle: it enqueues the user spend update
+    (and the end-user one) purely from the ids it is given.
+    """
+    db_writer = DBSpendUpdateWriter()
+
+    with patch.object(litellm, "max_budget", 0):
+        await db_writer._update_user_db(
+            response_cost=0.25,
+            user_id="user-123",
+            prisma_client=MagicMock(),
+            litellm_proxy_budget_name="litellm-proxy-budget",
+            end_user_id="end-user-9",
+        )
+
+    queued = await db_writer.spend_update_queue.flush_all_updates_from_in_memory_queue()
+    by_type = {u["entity_type"]: u["entity_id"] for u in queued}
+    assert by_type[Litellm_EntityType.USER] == "user-123"
+    assert by_type[Litellm_EntityType.END_USER] == "end-user-9"


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4411

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy against real OpenAI (gpt-4o-mini), Postgres and Redis in Docker, config with the auth cache shared over Redis:

```yaml
litellm_settings:
  enable_redis_auth_cache: true
  success_callback: ["prometheus"]
  service_callback: ["prometheus_system"]

general_settings:
  master_key: sk-lit4411-master
  coordination_redis:
    host: localhost
    port: 63411
```

Before the fix (commit 69a491e16887353a4170f571e7698566bd0db607): generate a key with no user_id, send completions through it, and every spend update trips a Redis DataError because the spend-update path looks up the auth cache with key=None

```
$ KEY=$(curl -s http://localhost:44111/key/generate -H "Authorization: Bearer sk-lit4411-master" -H "Content-Type: application/json" -d '{}' | python -c "import sys,json;print(json.load(sys.stdin)['key'])")
$ for i in 1 2 3 4; do curl -s http://localhost:44111/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Say OK"}]}' | python -c "import sys,json;print(json.load(sys.stdin)['choices'][0]['message']['content'])"; done
OK
OK!
OK! How can I assist you today?
OK

$ curl -sL http://localhost:44111/metrics -H "Authorization: Bearer sk-lit4411-master" | grep litellm_redis_failed_requests_total
litellm_redis_failed_requests_total{error_class="DataError",function_name="async_get_cache <- wrapper <- async_get_cache",redis="redis"} 4.0
```

After the fix (captured at commit 07e84fe24362ef164db938277b870b112e35fb87; the current head 77d96b96ef differs only in test isolation, patching litellm.max_budget in the two new tests so unrelated test-suite globals cannot leak into them), same config and same sequence of requests plus an end-user-attributed one and a user-attributed one: zero Redis failures and spend still lands in every table

```
$ for i in 1 2 3 4; do curl -s ... '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Say VERIFY-AFTER"}]}' ...; done
VERIFY-AFTER
VERIFY-AFTER
VERIFY-AFTER
VERIFY-AFTER

$ curl -s ... -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Say VERIFY-ENDUSER"}],"user":"lit4411-enduser"}' ...
VERIFY-ENDUSER

$ curl -sL http://localhost:44111/metrics -H "Authorization: Bearer sk-lit4411-master" | grep litellm_redis_failed_requests_total
# TYPE litellm_redis_failed_requests_total counter        <- no samples, zero failures

$ docker exec lit4411-pg psql -U postgres -d litellm -c 'SELECT user_id, spend FROM "LiteLLM_EndUserTable";'
     user_id     |         spend
-----------------+-----------------------
 lit4411-enduser | 8.400000000000001e-06

$ docker exec lit4411-pg psql -U postgres -d litellm -c "SELECT user_id, spend FROM \"LiteLLM_UserTable\" WHERE user_id = 'lit4411-user';"
   user_id    |  spend
--------------+----------
 lit4411-user | 4.95e-06
```

### Independent e2e verification (Devin)

Devin independently reproduced and verified this fix on a live proxy against real OpenAI gpt-4o-mini, with Postgres and Redis in Docker and the config above. On the merge-base 69a491e16887353a4170f571e7698566bd0db607 a virtual key with no user_id incremented litellm_redis_failed_requests_total{error_class="DataError"} once per spend update (3 requests produced 3 failures), and on the fix head 77d96b96ef799daa1107ce30940b820d97bfa5bf the same sequence of requests plus one attributed to an end user produced zero litellm_redis_failed_requests_total samples while spend still landed in Postgres for both the key row (user_id NULL) and the LiteLLM_EndUserTable row. Recording: https://raw.githubusercontent.com/BerriAI/litellm-docs/devin/pr33555-proof-assets/pr33555-after-demo.mp4

## Type

🐛 Bug Fix

## Changes

With `litellm_settings.enable_redis_auth_cache: true`, `user_api_key_cache` is Redis-backed. `DBSpendUpdateWriter._update_user_db` opened with `await user_api_key_cache.async_get_cache(key=user_id)` where `user_id` is None for any request served by a key without a user attached. The in-memory cache tolerates a None key, but Redis raises `redis.exceptions.DataError: Invalid input of type: 'NoneType'`, so every such spend update logged a Redis failure, incremented `litellm_redis_failed_requests_total`, and fed the Redis circuit breaker's failure count

The looked-up value (`existing_user_obj`) was never read by any subsequent code, so this removes the lookup entirely rather than None-guarding it, along with the `user_api_key_cache` parameter that existed only to perform it (threaded through `_batch_database_updates`) and the imports that are now unused

Regression tests extend the mapped test file: one drives `update_database` end to end with `user_id=None` against a cache mock that raises `DataError` on any get (asserting the cache is never queried and the end-user spend update still enqueues), and one asserts `_update_user_db` enqueues user and end-user updates without any cache handle. Both fail on the pre-fix code

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR



Link to Devin session: https://app.devin.ai/sessions/5991e2dd511d42d0a6f47ab3c865c01e