### PR TITLE
fix(router): cast model_info cost values to float in _set_model_group_info

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -251,6 +251,15 @@ else:
     PreRoutingHookResponse = Any
 
 
+def _cost_value_as_float(value: Union[str, int, float, None]) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
 class RoutingArgs(enum.Enum):
     ttl = 60  # 1min (RPM/TPM expire key)
 
@@ -8750,8 +8759,8 @@ class Router:
                 # Get mode from database model_info if available, otherwise default to "chat"
                 db_model_info = model.get("model_info", {})
                 mode = db_model_info.get("mode", "chat")
-                input_cost_per_token = db_model_info.get("input_cost_per_token")
-                output_cost_per_token = db_model_info.get("output_cost_per_token")
+                input_cost_per_token = _cost_value_as_float(db_model_info.get("input_cost_per_token"))
+                output_cost_per_token = _cost_value_as_float(db_model_info.get("output_cost_per_token"))
 
                 model_info = ModelMapInfo(
                     key=model_group,
@@ -8802,16 +8811,18 @@ class Router:
                     )
                 ):
                     model_group_info.max_output_tokens = model_info["max_output_tokens"]
-                if model_info.get("input_cost_per_token", None) is not None and (
+                _input_cost_per_token = _cost_value_as_float(model_info.get("input_cost_per_token"))
+                if _input_cost_per_token is not None and (
                     model_group_info.input_cost_per_token is None
-                    or (model_info["input_cost_per_token"] or 0.0) > (model_group_info.input_cost_per_token or 0.0)
+                    or _input_cost_per_token > (model_group_info.input_cost_per_token or 0.0)
                 ):
-                    model_group_info.input_cost_per_token = model_info["input_cost_per_token"]
-                if model_info.get("output_cost_per_token", None) is not None and (
+                    model_group_info.input_cost_per_token = _input_cost_per_token
+                _output_cost_per_token = _cost_value_as_float(model_info.get("output_cost_per_token"))
+                if _output_cost_per_token is not None and (
                     model_group_info.output_cost_per_token is None
-                    or (model_info["output_cost_per_token"] or 0.0) > (model_group_info.output_cost_per_token or 0.0)
+                    or _output_cost_per_token > (model_group_info.output_cost_per_token or 0.0)
                 ):
-                    model_group_info.output_cost_per_token = model_info["output_cost_per_token"]
+                    model_group_info.output_cost_per_token = _output_cost_per_token
                 if (
                     model_info.get("supports_parallel_function_calling", None) is not None
                     and model_info["supports_parallel_function_calling"] is True  # type: ignore

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -1455,6 +1455,132 @@ def test_model_group_info_cost_none_when_db_model_info_has_no_cost():
         assert result.output_cost_per_token is None
 
 
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("1e-05", 1e-05),
+        ("0.00001", 1e-05),
+        (1e-05, 1e-05),
+        (5, 5.0),
+        (None, None),
+        ("not-a-number", None),
+    ],
+)
+def test_cost_value_as_float(value, expected):
+    from litellm.router import _cost_value_as_float
+
+    assert _cost_value_as_float(value) == expected
+
+
+def test_model_group_info_with_stringified_cost_values():
+    """
+    YAML 1.2 parsers emit '1e-05' (integer mantissa) as a string, so cost
+    values in deployment model_info can arrive as str. Aggregating the model
+    group must not raise TypeError('>' between str and float) and must return
+    float costs.
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "my-custom-model",
+                "litellm_params": {
+                    "model": "openai/my-custom-backend-1",
+                    "api_key": "fake",
+                },
+                "model_info": {
+                    "input_cost_per_token": "1e-05",
+                    "output_cost_per_token": "1e-05",
+                },
+            },
+            {
+                "model_name": "my-custom-model",
+                "litellm_params": {
+                    "model": "openai/my-custom-backend-2",
+                    "api_key": "fake",
+                },
+                "model_info": {
+                    "input_cost_per_token": "2e-05",
+                    "output_cost_per_token": "2e-05",
+                },
+            },
+        ]
+    )
+
+    def _model_info_with_str_costs(model_id: str, model_name: str):
+        for model in router.model_list:
+            if model["model_info"]["id"] == model_id:
+                return {
+                    "key": model_name,
+                    "input_cost_per_token": model["model_info"]["input_cost_per_token"],
+                    "output_cost_per_token": model["model_info"]["output_cost_per_token"],
+                    "litellm_provider": "openai",
+                    "mode": "chat",
+                }
+        return None
+
+    with patch.object(
+        router, "get_deployment_model_info", side_effect=_model_info_with_str_costs
+    ):
+        result = router._set_model_group_info(
+            model_group="my-custom-model",
+            user_facing_model_group_name="my-custom-model",
+        )
+
+    assert result is not None
+    assert result.input_cost_per_token == 2e-05
+    assert result.output_cost_per_token == 2e-05
+    assert isinstance(result.input_cost_per_token, float)
+    assert isinstance(result.output_cost_per_token, float)
+
+
+def test_model_group_info_db_fallback_with_stringified_cost_values():
+    """
+    Fallback path: when get_deployment_model_info returns nothing, costs are
+    read straight from the deployment's model_info dict, which can hold
+    stringified floats parsed from YAML. They must be coerced to float.
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "my-custom-model",
+                "litellm_params": {
+                    "model": "openai/my-custom-backend-1",
+                    "api_key": "fake",
+                },
+                "model_info": {
+                    "input_cost_per_token": "1e-05",
+                    "output_cost_per_token": "3e-05",
+                },
+            },
+            {
+                "model_name": "my-custom-model",
+                "litellm_params": {
+                    "model": "openai/my-custom-backend-2",
+                    "api_key": "fake",
+                },
+                "model_info": {
+                    "input_cost_per_token": "2e-05",
+                    "output_cost_per_token": "2e-05",
+                },
+            },
+        ]
+    )
+
+    with patch.object(
+        router, "get_deployment_model_info", side_effect=Exception("not found")
+    ):
+        result = router._set_model_group_info(
+            model_group="my-custom-model",
+            user_facing_model_group_name="my-custom-model",
+        )
+
+    assert result is not None
+    assert result.input_cost_per_token == 2e-05
+    assert result.output_cost_per_token == 3e-05
+    assert isinstance(result.input_cost_per_token, float)
+    assert isinstance(result.output_cost_per_token, float)
+
+
 def test_get_model_access_groups_caching():
     """
     Test that get_model_access_groups caches the no-args result


### PR DESCRIPTION
## Relevant issues

Fixes #32787

## Linear ticket

Resolves LIT-4345

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

YAML 1.2 parsers (PyYAML 6.x) parse scientific notation with an integer mantissa, e.g. `1e-05`, as a string, not a float. Helm's Go yaml.v3 renderer normalises `0.00001` to exactly that form, so a config like

```yaml
model_list:
  - model_name: cost-repro-model
    litellm_params:
      model: openai/my-custom-backend-1
      api_key: fake-key
      api_base: https://example.com/v1
    model_info:
      input_cost_per_token: 1e-05
      output_cost_per_token: 1e-05
  - model_name: cost-repro-model
    litellm_params:
      model: openai/my-custom-backend-2
      api_key: fake-key
      api_base: https://example.com/v1
    model_info:
      input_cost_per_token: 2e-05
      output_cost_per_token: 2e-05
```

loads `"1e-05"` (str) into the deployment's `model_info`. `litellm.register_model` coerces its own copy to float at startup, which masks the bug until `litellm.model_cost` is replaced wholesale (the scheduled model cost map reload, or the `/reload/model_cost_map` endpoint). After that, `_set_model_group_info` falls back to reading the raw deployment `model_info` and the str-vs-float comparison raises TypeError

**Before (commit 69a491e168, unfixed):**

```
$ curl -s -X POST http://localhost:4045/reload/model_cost_map -H "Authorization: Bearer sk-...master"
{"message":"Price data reloaded successfully! 2967 models updated.","status":"success", ...}

$ curl -s "http://localhost:4045/model_group/info?model_group=cost-repro-model" -H "Authorization: Bearer sk-...master"
{"error":{"message":"Internal server error","type":"internal_server_error"}}
```

Proxy log:

```
  File ".../litellm/router.py", line 8807, in _set_model_group_info
    or (model_info["input_cost_per_token"] or 0.0) > (model_group_info.input_cost_per_token or 0.0)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'str' and 'float'
```

This is the exact traceback from the customer's Prometheus callback (`get_remaining_model_group_usage` delegates to the same function)

**After (commit 6e2061f564, fixed):**

```
$ curl -s -X POST http://localhost:4045/reload/model_cost_map -H "Authorization: Bearer sk-...master"
{"message":"Price data reloaded successfully! 2967 models updated.","status":"success", ...}

$ curl -s "http://localhost:4045/model_group/info?model_group=cost-repro-model" -H "Authorization: Bearer sk-...master"
{
  "model_group": "cost-repro-model",
  "providers": ["openai"],
  "input_cost_per_token": 2e-05,
  "output_cost_per_token": 2e-05
}
```

Costs come back as floats and the group aggregation picks the max across deployments. A real completion against OpenAI with str-parsed custom pricing (`gpt-5.6` with `input_cost_per_token: 1e-05` / `output_cost_per_token: 2e-05` in model_info) also returns the cost header correctly (12 prompt + 8 completion tokens at the custom prices):

```
$ curl -s -D - http://localhost:4045/v1/chat/completions -H "Authorization: Bearer sk-...master" \
    -d '{"model": "gpt-5.6", "messages": [{"role": "user", "content": "Say hi in 3 words"}]}'
...
x-litellm-response-cost: 0.00028000000000000003
...
"content": "Hi there, friend!"
```

Zero occurrences of the TypeError in the fixed proxy's logs across the same flow

Independent e2e verification (Devin session on PR head 6e2061f564: reload/model_cost_map + model_group/info returning float costs, Admin UI model hub loading the group, and the merge-base 500 contrast):

![e2e demo: reload model cost map then model_group/info returns float costs and the Admin UI loads the model group](https://raw.githubusercontent.com/yassin-berriai/litellm-pr33556-e2e-demo/main/pr33556-e2e-demo.gif)

Full-resolution video: https://raw.githubusercontent.com/yassin-berriai/litellm-pr33556-e2e-demo/main/pr33556-e2e-demo.mp4

## Type

🐛 Bug Fix

## Changes

`_set_model_group_info` in `litellm/router.py` compared cost values read from deployment `model_info` directly against the float running aggregate. A new module-level helper `_cost_value_as_float` coerces the value to float (returning None for non-numeric input) before the comparison, and both the merge path and the db-model_info fallback path now store floats into `ModelGroupInfo`. This fixes `/model_group/info`, the Prometheus `get_remaining_model_group_usage` callback, and the `x-litellm-response-cost` response header for configs where cost values survive YAML parsing as strings

Regression tests in `tests/test_litellm/test_router.py` cover the helper's coercion matrix, the merge path with str costs from two deployments (fails with the exact TypeError before this fix), and the db fallback path with str costs

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


