### PR TITLE
fix(auth): stop re-caching stale auth objects so key updates propagate across replicas

### DIFF
--- a/litellm/caching/dual_cache.py
+++ b/litellm/caching/dual_cache.py
@@ -160,6 +160,8 @@ class DualCache(BaseCache):
 
                 if redis_result is not None:
                     # Update in-memory cache with the value from Redis
+                    if "ttl" not in kwargs and self.default_in_memory_ttl is not None:
+                        kwargs["ttl"] = self.default_in_memory_ttl
                     self.in_memory_cache.set_cache(key, redis_result, **kwargs)
 
                 result = redis_result
@@ -226,6 +228,8 @@ class DualCache(BaseCache):
 
                 if redis_result is not None:
                     # Update in-memory cache with the value from Redis
+                    if "ttl" not in kwargs and self.default_in_memory_ttl is not None:
+                        kwargs["ttl"] = self.default_in_memory_ttl
                     await self.in_memory_cache.async_set_cache(key, redis_result, **kwargs)
 
                 result = redis_result
@@ -312,6 +316,9 @@ class DualCache(BaseCache):
 
                     # Pre-compute key-to-index mapping for O(1) lookup
                     key_to_index = {key: i for i, key in enumerate(keys)}
+
+                    if "ttl" not in kwargs and self.default_in_memory_ttl is not None:
+                        kwargs["ttl"] = self.default_in_memory_ttl
 
                     # Update both result and in-memory cache in a single loop
                     for key, value in redis_result.items():

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1996,16 +1996,6 @@ async def _user_api_key_auth_builder(
                 raise HTTPException(401, detail="Invalid API key, no token associated")
             api_key = valid_token.token
 
-            # Add hashed token to cache
-            asyncio.create_task(
-                _cache_key_object(
-                    hashed_token=api_key,
-                    user_api_key_obj=valid_token,
-                    user_api_key_cache=user_api_key_cache,
-                    proxy_logging_obj=proxy_logging_obj,
-                )
-            )
-
             valid_token_dict = valid_token.model_dump(exclude_none=True)
             valid_token_dict.pop("token", None)
             # budget_throttle_pct is excluded from model_dump (it must not leak

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2814,21 +2814,6 @@ async def update_cache(
             )
             # set cooldown on alert
 
-        if existing_spend_obj is not None and getattr(existing_spend_obj, "team_spend", None) is not None:
-            existing_team_spend = existing_spend_obj.team_spend or 0
-            # Calculate the new cost by adding the existing cost and response_cost
-            existing_spend_obj.team_spend = existing_team_spend + response_cost
-
-        if existing_spend_obj is not None and getattr(existing_spend_obj, "team_member_spend", None) is not None:
-            existing_team_member_spend = existing_spend_obj.team_member_spend or 0
-            # Calculate the new cost by adding the existing cost and response_cost
-            existing_spend_obj.team_member_spend = existing_team_member_spend + response_cost
-
-        # Existing spend_obj is mutated; UserApiKeyCache.async_set_cache_pipeline turns
-        # BaseModel values into dicts for Redis (same Codec path as async_set_cache).
-        existing_spend_obj.spend = new_spend
-        values_to_update_in_cache.append((hashed_token, existing_spend_obj))
-
     ### UPDATE USER SPEND ###
     async def _update_user_cache():
         ## UPDATE CACHE FOR USER ID + GLOBAL PROXY
@@ -3032,13 +3017,14 @@ async def update_cache(
     if tags is not None:
         await _update_tag_cache()
 
-    asyncio.create_task(
-        user_api_key_cache.async_set_cache_pipeline(
-            cache_list=values_to_update_in_cache,
-            ttl=get_management_object_ttl(user_api_key_cache),
-            litellm_parent_otel_span=parent_otel_span,
+    if values_to_update_in_cache:
+        asyncio.create_task(
+            user_api_key_cache.async_set_cache_pipeline(
+                cache_list=values_to_update_in_cache,
+                ttl=get_management_object_ttl(user_api_key_cache),
+                litellm_parent_otel_span=parent_otel_span,
+            )
         )
-    )
 
 
 def run_ollama_serve():

--- a/tests/test_litellm/caching/test_dual_cache.py
+++ b/tests/test_litellm/caching/test_dual_cache.py
@@ -89,6 +89,62 @@ async def test_dual_cache_async_set_cache_injects_default_in_memory_ttl():
 
 
 @pytest.mark.asyncio
+async def test_dual_cache_redis_backfill_injects_default_in_memory_ttl():
+    """The Redis-to-memory backfill must honor default_in_memory_ttl.
+
+    On an in-memory miss with a Redis hit, async_get_cache writes the Redis
+    value into the in-memory cache. Without a ttl this write fell back to
+    InMemoryCache's own default_ttl (600s), so a replica whose copy of a
+    management object came from Redis held it ten times longer than the
+    configured TTL; a deleted or updated virtual key kept working on that
+    replica for up to 10 minutes instead of converging within
+    user_api_key_cache_ttl.
+    """
+    in_memory_cache = InMemoryCache(default_ttl=600)
+    mock_redis = MagicMock(spec=RedisCache)
+    mock_redis.async_get_cache = AsyncMock(return_value="redis_value")
+    dual_cache = DualCache(
+        in_memory_cache=in_memory_cache,
+        redis_cache=mock_redis,
+        default_in_memory_ttl=60,
+    )
+
+    before = time.time()
+    result = await dual_cache.async_get_cache(key="backfill_key")
+    after = time.time()
+
+    assert result == "redis_value"
+    expiry = in_memory_cache.ttl_dict["backfill_key"]
+    assert expiry >= before + 60
+    assert expiry <= after + 60
+
+
+@pytest.mark.asyncio
+async def test_dual_cache_batch_redis_backfill_injects_default_in_memory_ttl():
+    """async_batch_get_cache's Redis-to-memory backfill must honor
+    default_in_memory_ttl, same as the single-key path."""
+    in_memory_cache = InMemoryCache(default_ttl=600)
+    mock_redis = MagicMock(spec=RedisCache)
+    mock_redis.async_batch_get_cache = AsyncMock(
+        return_value={"batch_backfill_key": "redis_value"}
+    )
+    dual_cache = DualCache(
+        in_memory_cache=in_memory_cache,
+        redis_cache=mock_redis,
+        default_in_memory_ttl=60,
+    )
+
+    before = time.time()
+    result = await dual_cache.async_batch_get_cache(keys=["batch_backfill_key"])
+    after = time.time()
+
+    assert result == ["redis_value"]
+    expiry = in_memory_cache.ttl_dict["batch_backfill_key"]
+    assert expiry >= before + 60
+    assert expiry <= after + 60
+
+
+@pytest.mark.asyncio
 async def test_dual_cache_async_set_cache_respects_explicit_ttl():
     """
     Test that async_set_cache does NOT override an explicitly provided ttl.

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import sys
@@ -218,6 +219,103 @@ async def test_should_not_reuse_cached_key_object_for_request_state():
     assert second_request_key is not first_request_key
     assert second_request_key.budget_reservation is None
     assert second_request_key.request_route is None
+
+
+@pytest.mark.asyncio
+async def test_auth_does_not_rewrite_cached_key_object_back_into_cache():
+    """A cache-hit auth must not write the token back into the cache.
+
+    Re-writing on every auth let a replica holding a stale in-memory token
+    republish it to shared Redis with a fresh TTL on each request, so
+    /key/update and /key/delete never propagated across replicas or regional
+    Redis while the key kept calling (stale auth re-cache feedback loop).
+    Only the DB-load paths (IdentityStore._resolve_key / get_key_object) may
+    populate the cache.
+    """
+    from fastapi import Request
+    from starlette.datastructures import URL
+
+    from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
+    from litellm.proxy.proxy_server import hash_token
+
+    api_key = "sk-lit-cached-key-no-rewrite"
+    hashed_key = hash_token(api_key)
+
+    key_cache = UserApiKeyCache()
+    stale_token = UserAPIKeyAuth(
+        api_key=api_key,
+        token=hashed_key,
+        metadata={"model_rpm_limit": {"gpt-5.2": 3}},
+        last_refreshed_at=1000.0,
+    )
+    await key_cache.async_set_cache(
+        key=hashed_key, value=stale_token, model_type=UserAPIKeyAuth
+    )
+
+    fetch_from_db = AsyncMock(
+        side_effect=AssertionError("cache-hit auth must not touch the DB")
+    )
+
+    mock_proxy_logging_obj = MagicMock()
+    mock_proxy_logging_obj.internal_usage_cache = MagicMock()
+    mock_proxy_logging_obj.internal_usage_cache.dual_cache = AsyncMock()
+    mock_proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
+
+    import litellm.proxy.proxy_server as _proxy_server_mod
+
+    _attrs_to_set = {
+        "prisma_client": MagicMock(),
+        "user_api_key_cache": key_cache,
+        "proxy_logging_obj": mock_proxy_logging_obj,
+        "master_key": "sk-master-key",
+        "general_settings": {},
+        "llm_model_list": [],
+        "llm_router": None,
+        "open_telemetry_logger": None,
+        "model_max_budget_limiter": MagicMock(),
+        "user_custom_auth": None,
+        "jwt_handler": None,
+        "litellm_proxy_admin_name": "admin",
+    }
+    _original_values = {
+        attr: getattr(_proxy_server_mod, attr, None) for attr in _attrs_to_set
+    }
+    try:
+        for attr, val in _attrs_to_set.items():
+            setattr(_proxy_server_mod, attr, val)
+
+        request = Request(scope={"type": "http"})
+        request._url = URL(url="/chat/completions")
+
+        with patch(
+            "litellm.proxy.auth.resolvers.store._fetch_key_object_from_db_with_reconnect",
+            fetch_from_db,
+        ):
+            result = await _user_api_key_auth_builder(
+                request=request,
+                api_key=f"Bearer {api_key}",
+                azure_api_key_header="",
+                anthropic_api_key_header=None,
+                google_ai_studio_api_key_header=None,
+                azure_apim_header=None,
+                request_data={},
+            )
+        pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+        if pending:
+            await asyncio.wait(pending, timeout=5)
+
+        assert result.token == hashed_key
+        fetch_from_db.assert_not_called()
+
+        cached_after = await key_cache.async_get_cache(
+            key=hashed_key, model_type=UserAPIKeyAuth
+        )
+        assert cached_after is not None
+        assert cached_after.last_refreshed_at == 1000.0
+        assert cached_after.metadata == {"model_rpm_limit": {"gpt-5.2": 3}}
+    finally:
+        for attr, val in _original_values.items():
+            setattr(_proxy_server_mod, attr, val)
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -4529,6 +4529,61 @@ async def test_tag_cache_update_multiple_tags():
 
 
 @pytest.mark.asyncio
+async def test_spend_tracking_never_writes_the_auth_object_back():
+    """Spend tracking must never write the auth object back into the cache.
+
+    Writing the mutated auth object back after every priced request let a
+    stale copy be re-published with a fresh TTL: to shared Redis it defeated
+    /key/update and /key/delete across replicas, and even a local-only write
+    could race an invalidation and resurrect a revoked key on this worker.
+    Spend is tracked through the spend:key:* counters, so the auth object is
+    only ever written by the DB-load paths.
+    """
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
+
+    original_cache = litellm.proxy.proxy_server.user_api_key_cache
+    cache = UserApiKeyCache()
+    setattr(litellm.proxy.proxy_server, "user_api_key_cache", cache)
+    try:
+        hashed_token = "spend-tracking-no-writeback-token"
+        await cache.async_set_cache(
+            key=hashed_token,
+            value=UserAPIKeyAuth(token=hashed_token, spend=1.0),
+            model_type=UserAPIKeyAuth,
+        )
+        with (
+            patch.object(
+                cache, "async_set_cache_pipeline", new=AsyncMock()
+            ) as mock_pipeline,
+            patch.object(cache, "async_set_cache", new=AsyncMock()) as mock_set,
+        ):
+            await litellm.proxy.proxy_server.update_cache(
+                token=hashed_token,
+                user_id=None,
+                end_user_id=None,
+                team_id=None,
+                response_cost=5.0,
+                parent_otel_span=None,
+            )
+            pending = [
+                t for t in asyncio.all_tasks() if t is not asyncio.current_task()
+            ]
+            if pending:
+                await asyncio.wait(pending, timeout=5)
+
+        key_pipeline_writes = [
+            call
+            for call in mock_pipeline.call_args_list
+            if any(k == hashed_token for k, _ in call.kwargs["cache_list"])
+        ]
+        assert key_pipeline_writes == []
+        mock_set.assert_not_called()
+    finally:
+        setattr(litellm.proxy.proxy_server, "user_api_key_cache", original_cache)
+
+
+@pytest.mark.asyncio
 async def test_update_cache_pipeline_honors_user_api_key_cache_ttl():
     """
     Regression for LIT-3338: the spend-update writeback must honor


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4350

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The branch was rebased on current staging and squashed to a single commit after all proofs were captured; the commit hashes below refer to the pre-squash history and the diff is unchanged (verified hunk-for-hunk against the squashed head).

All runs against two live proxy replicas sharing Postgres and Redis, with `enable_redis_auth_cache: true` and real `gpt-5.2` calls through the OpenAI API. Config:

```yaml
model_list:
  - model_name: gpt-5.2
    litellm_params:
      model: gpt-5.2
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-lit4350-master
  store_model_in_db: true

litellm_settings:
  cache: true
  enable_redis_auth_cache: true
  cache_params:
    type: redis
    url: redis://127.0.0.1:63350/0
```

Replica A on port 44350, replica B on port 44351, launched with `python litellm/proxy/proxy_cli.py --config config.yaml --port <port>`

### Before the fix (commit 69a491e168, current staging)

Generate a key with `model_rpm_limit: {"gpt-5.2": 3}`, prime BOTH replicas with one real completion each, then raise the limit on replica A:

```
$ curl -s -X POST http://127.0.0.1:44350/key/update \
    -H "Authorization: Bearer sk-lit4350-master" -H "Content-Type: application/json" \
    -d '{"key": "'$KEY'", "model_rpm_limit": {"gpt-5.2": 20}}'
{'model_rpm_limit': {'gpt-5.2': 20}}          # DB updated
$ docker exec lit4350-redis redis-cli TTL "$HASH"
-2                                             # Redis auth blob deleted by /key/update
```

Keep traffic on replica B (stale in-memory auth). The stale blob reappears in Redis with the OLD limit and a fresh TTL:

```
$ for i in $(seq 1 6); do curl -s -o /dev/null -w "%{http_code} " ... port 44351 ...; sleep 1; done
200 429 429 429 429 429                        # old RPM=3 still enforced
$ docker exec lit4350-redis redis-cli GET "$HASH" | jq .metadata
{"model_rpm_limit": {"gpt-5.2": 3}}            # STALE blob re-published by replica B
TTL: 59                                        # fresh full TTL
```

Deleting the key is worse: it keeps working indefinitely under continuous traffic:

```
$ curl -s -X POST http://127.0.0.1:44350/key/delete ... -d '{"keys": ["'$KEY'"]}'
{"deleted_keys":["sk-14hpA..."]}
$ # traffic every 20s on replica B, 60s+ after deletion:
t+1x20s replica-B: 200
t+2x20s replica-B: 200
t+3x20s replica-B: 200                         # deleted key still authenticates
  redis TTL now: 60                            # stale blob kept alive forever
```

### After the fix (commit 365c8fb147)

Same rig, same steps. The stale replica no longer republishes its in-memory token; Redis stays clean after `/key/update`:

```
$ # update RPM 3 -> 20 on replica A, then 6 requests on replica B:
200 429 429 429 429 429                        # B's in-memory copy lasts <= its 60s TTL
$ docker exec lit4350-redis redis-cli EXISTS "$HASH"
0                                              # no stale re-publish to Redis
```

Delete now converges within one auth-cache TTL even under continuous traffic (the exact feedback-loop condition, request interval far below the 60s TTL):

```
$ # /key/delete on replica A at 17:19:47, then traffic on replica B every 5s:
17:19:48 replica-B: 200
17:19:53 replica-B: 200
...
17:20:44 replica-B: 200
17:20:49 replica-B: 401                        # dead within 62s, no restarts, no manual Redis ops
$ docker exec lit4350-redis redis-cli EXISTS "$HASH"
0
```

DB-load caching is unchanged: after priming, the auth blob is present in Redis with the correct metadata and TTL, so the cache hit rate for steady-state traffic is the same as before

### Independent e2e verification (Devin)

[Screen recording](https://cdn.filepost.dev/file/filepost/uploads/9d/9d5888ff238344cc9e132fa21bd59d13.mp4)

Recorded at commit `f021f429ba` with two live proxy replicas sharing PostgreSQL and Redis and real `gpt-5.2` calls. Replica A populated Redis before replica B's first request, exercising the Redis-to-memory backfill; updating the key cleared Redis and ten stale-replica requests over 15 seconds did not recreate it. After deletion, replica B changed from HTTP 200 to 401 at 45.1 seconds, 61.9 seconds after hydration, with no restarts or manual Redis changes.

## Type

🐛 Bug Fix

## Changes

`user_api_key_auth.py` ran `_cache_key_object` after every successful key auth, writing the request's auth object back into DualCache regardless of whether it had been loaded from cache or from the DB. Both load paths already cache the pristine object at load time (`IdentityStore._resolve_key` and `get_key_object`), so this write only ever persisted request-mutated state, and under `enable_redis_auth_cache` with multiple replicas it created a feedback loop: a replica holding a stale in-memory token re-published it to shared Redis with a full TTL on every request, so `/key/update`, `/key/delete`, `/key/block`, and rate-limit changes never took effect while the key kept calling. In a multi-region topology (separate Redis per region, shared Postgres) there is no reliable way to kill a runaway key at all without coordinating a DB update, worker restarts, and Redis deletes across every region at once. This PR removes that post-auth write

The per-request key-spend writeback in `proxy_server.update_cache` republished the full cached auth object the same way after every priced request. It is removed entirely: an earlier revision made it a local-only in-memory write, but review flagged that even that can race an invalidation (an in-flight priced request reads the old object, `/key/delete` clears the cache, and the deferred task re-inserts the revoked object with a fresh TTL on that worker), so spend tracking now performs no auth-object cache write at all. Cross-pod spend is tracked by the `spend:key:*` Redis counters, which are unaffected, and budget enforcement reads through `get_current_spend` which prefers those counters. The soft-budget projected-limit alerting that lived in the same function is retained

Independent e2e verification caught a third leg of the same invariant: a replica whose in-memory copy of the auth object was populated by the DualCache Redis-to-memory backfill (rather than a DB load) held it for `InMemoryCache`'s own 600s default because the backfill passed no ttl, so a deleted key converged at 586s instead of within the 60s auth TTL. The backfill in `get_cache`, `async_get_cache`, and `async_batch_get_cache` now injects `default_in_memory_ttl` exactly like `async_set_cache` already did

Regression tests: `test_auth_does_not_rewrite_cached_key_object_back_into_cache` runs the full auth builder against a primed `UserApiKeyCache` and asserts the cached payload is byte-for-byte untouched afterwards (fails on the old code), and `test_spend_tracking_never_writes_the_auth_object_back` asserts spend tracking performs zero auth-object cache writes (fails on the old code)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR




