### PR TITLE
fix(ui): navigate to /ui/login/ with trailing slash via hard navigation

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 import React from "react";
 import { renderHook, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import useAuthorized from "./useAuthorized";
 
@@ -24,12 +24,6 @@ const {
   decodeTokenMock: vi.fn(),
   checkTokenValidityMock: vi.fn(),
   buildLoginUrlWithReturnMock: vi.fn((baseUrl: string) => baseUrl),
-}));
-
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({
-    replace: replaceMock,
-  }),
 }));
 
 vi.mock("@/components/networking", async (importOriginal) => {
@@ -91,7 +85,28 @@ const clearCookie = () => {
 };
 
 describe("useAuthorized", () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    Object.defineProperty(window, "location", {
+      value: {
+        href: "http://proxy.example/ui/?page=api-keys",
+        origin: "http://proxy.example",
+        hostname: "proxy.example",
+        pathname: "/ui/",
+        search: "?page=api-keys",
+        protocol: "http:",
+        replace: replaceMock,
+      },
+      writable: true,
+    });
+  });
+
   afterEach(() => {
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+    });
     replaceMock.mockReset();
     clearTokenCookiesMock.mockReset();
     getProxyBaseUrlMock.mockClear();
@@ -164,7 +179,7 @@ describe("useAuthorized", () => {
       expect(clearTokenCookiesMock).toHaveBeenCalled();
     });
 
-    expect(replaceMock).toHaveBeenCalledWith("http://proxy.example/ui/login");
+    expect(replaceMock).toHaveBeenCalledWith("http://proxy.example/ui/login/");
     expect(result.current.accessToken).toBeNull();
     expect(result.current.userRole).toBe("Undefined Role");
   });
@@ -197,7 +212,7 @@ describe("useAuthorized", () => {
     const { result } = renderHook(() => useAuthorized(), { wrapper });
 
     await waitFor(() => {
-      expect(replaceMock).toHaveBeenCalledWith("http://proxy.example/ui/login");
+      expect(replaceMock).toHaveBeenCalledWith("http://proxy.example/ui/login/");
     });
 
     expect(result.current.accessToken).toBe("api-key-123");
@@ -221,7 +236,7 @@ describe("useAuthorized", () => {
     const { result } = renderHook(() => useAuthorized(), { wrapper });
 
     await waitFor(() => {
-      expect(replaceMock).toHaveBeenCalledWith("http://proxy.example/ui/login");
+      expect(replaceMock).toHaveBeenCalledWith("http://proxy.example/ui/login/");
     });
 
     expect(clearTokenCookiesMock).not.toHaveBeenCalled();
@@ -256,7 +271,7 @@ describe("useAuthorized", () => {
       expect(clearTokenCookiesMock).toHaveBeenCalled();
     });
 
-    expect(replaceMock).toHaveBeenCalledWith("http://proxy.example/ui/login");
+    expect(replaceMock).toHaveBeenCalledWith("http://proxy.example/ui/login/");
     expect(checkTokenValidityMock).toHaveBeenCalledWith(token);
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.ts
@@ -3,14 +3,12 @@
 import { getProxyBaseUrl } from "@/components/networking";
 import { clearTokenCookies, getCookie } from "@/utils/cookieUtils";
 import { checkTokenValidity, decodeToken } from "@/utils/jwtUtils";
-import { buildLoginUrlWithReturn, storeReturnUrl } from "@/utils/returnUrlUtils";
-import { useRouter } from "next/navigation";
+import { buildLoginUrlWithReturn, getLoginUrl, storeReturnUrl } from "@/utils/returnUrlUtils";
 import { useCallback, useEffect, useMemo } from "react";
 import { formatUserRole } from "@/utils/roles";
 import { useUIConfig } from "./uiConfig/useUIConfig";
 
 const useAuthorized = () => {
-  const router = useRouter();
   const { data: uiConfig, isLoading: isUIConfigLoading } = useUIConfig();
 
   const token = typeof document !== "undefined" ? getCookie("token") : null;
@@ -23,10 +21,10 @@ const useAuthorized = () => {
   // Helper function to redirect to login while preserving the current URL
   const redirectToLogin = useCallback(() => {
     storeReturnUrl();
-    const baseLoginUrl = `${getProxyBaseUrl()}/ui/login`;
+    const baseLoginUrl = getLoginUrl(getProxyBaseUrl());
     const loginUrlWithReturn = buildLoginUrlWithReturn(baseLoginUrl);
-    router.replace(loginUrlWithReturn);
-  }, [router]);
+    window.location.replace(loginUrlWithReturn);
+  }, []);
 
   // Single useEffect for all redirect logic
   useEffect(() => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/page.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import {
   buildLoginUrlWithReturn,
   consumeReturnUrl,
+  getLoginUrl,
   isValidReturnUrl,
   normalizeUrlForCompare,
   storeReturnUrl,
@@ -33,7 +34,7 @@ function CreateKeyPageContent() {
       // Store the current URL so we can redirect back after login
       storeReturnUrl();
       // Build login URL with return URL parameter
-      const baseLoginUrl = (proxyBaseUrl || "") + "/ui/login";
+      const baseLoginUrl = getLoginUrl(proxyBaseUrl || "");
       const dest = buildLoginUrlWithReturn(baseLoginUrl);
       // Replace instead of assigning to avoid back-button loops
       window.location.replace(dest);

--- a/ui/litellm-dashboard/src/app/login/LoginPage.tsx
+++ b/ui/litellm-dashboard/src/app/login/LoginPage.tsx
@@ -6,7 +6,7 @@ import LoadingScreen from "@/components/common_components/LoadingScreen";
 import { exchangeLoginCode, getProxyBaseUrl, switchToWorkerUrl } from "@/components/networking";
 import { clearTokenCookies, getCookieFromDocument } from "@/utils/cookieUtils";
 import { isJwtExpired } from "@/utils/jwtUtils";
-import { consumeReturnUrl, getReturnUrl, isValidReturnUrl } from "@/utils/returnUrlUtils";
+import { consumeReturnUrl, getLoginUrl, getReturnUrl, isValidReturnUrl } from "@/utils/returnUrlUtils";
 import { InfoCircleOutlined, CloudServerOutlined } from "@ant-design/icons";
 import { Alert, Button, Card, Form, Input, Popover, Select, Space, Typography } from "antd";
 import { useRouter } from "next/navigation";
@@ -295,7 +295,7 @@ function LoginPageContent() {
                     // SSO on the worker (or this instance if no worker), always
                     // include return_to so the callback redirects back here
                     const ssoBase = selectedWorker?.url ?? getProxyBaseUrl();
-                    const returnTo = encodeURIComponent(window.location.origin + "/ui/login");
+                    const returnTo = encodeURIComponent(getLoginUrl(window.location.origin));
                     router.push(`${ssoBase}/sso/key/generate?return_to=${returnTo}`);
                   }}
                   block

--- a/ui/litellm-dashboard/src/app/onboarding/OnboardingErrorView.test.tsx
+++ b/ui/litellm-dashboard/src/app/onboarding/OnboardingErrorView.test.tsx
@@ -14,10 +14,10 @@ describe("OnboardingErrorView", () => {
     expect(screen.getByText("The invitation link may be invalid or expired.")).toBeInTheDocument();
   });
 
-  it("should render a Back to Login link pointing to /ui/login", () => {
+  it("should render a Back to Login link pointing to /ui/login/", () => {
     render(<OnboardingErrorView />);
     // antd Button with href renders as an <a> element
     const link = screen.getByRole("link", { name: "Back to Login" });
-    expect(link).toHaveAttribute("href", "/ui/login");
+    expect(link).toHaveAttribute("href", "/ui/login/");
   });
 });

--- a/ui/litellm-dashboard/src/app/onboarding/OnboardingErrorView.tsx
+++ b/ui/litellm-dashboard/src/app/onboarding/OnboardingErrorView.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Alert, Button } from "antd";
+import { getLoginUrl } from "@/utils/returnUrlUtils";
 
 export function OnboardingErrorView() {
   return (
@@ -11,7 +12,7 @@ export function OnboardingErrorView() {
         showIcon
       />
       <div className="mt-4">
-        <Button href="/ui/login">Back to Login</Button>
+        <Button href={getLoginUrl()}>Back to Login</Button>
       </div>
     </div>
   );

--- a/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.test.tsx
@@ -1,5 +1,5 @@
 import * as networking from "@/components/networking";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders, screen, waitFor } from "../../../tests/test-utils";
 import ModelHubTable from "./ModelHubTable";
 
@@ -7,6 +7,7 @@ const mockUseUISettings = vi.hoisted(() => vi.fn());
 const mockGetCookie = vi.hoisted(() => vi.fn());
 const mockCheckTokenValidity = vi.hoisted(() => vi.fn());
 const mockRouterReplace = vi.hoisted(() => vi.fn());
+const mockLocationReplace = vi.hoisted(() => vi.fn());
 
 vi.mock("@/components/networking", () => ({
   getUiConfig: vi.fn(),
@@ -43,7 +44,28 @@ vi.mock("@/utils/jwtUtils", () => ({
 }));
 
 describe("ModelHubTable", () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    Object.defineProperty(window, "location", {
+      value: {
+        href: "http://localhost:4000/ui/model_hub_table",
+        origin: "http://localhost:4000",
+        hostname: "localhost",
+        pathname: "/ui/model_hub_table",
+        search: "",
+        protocol: "http:",
+        replace: mockLocationReplace,
+      },
+      writable: true,
+    });
+  });
+
   afterEach(() => {
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+    });
     vi.clearAllMocks();
   });
 
@@ -60,6 +82,7 @@ describe("ModelHubTable", () => {
     mockGetCookie.mockReturnValue(tokenValue);
     mockCheckTokenValidity.mockReturnValue(isTokenValid);
     mockRouterReplace.mockClear();
+    mockLocationReplace.mockClear();
 
     // Setup other required mocks
     vi.mocked(networking.getUiConfig).mockResolvedValue({
@@ -92,9 +115,10 @@ describe("ModelHubTable", () => {
 
       await waitFor(() => {
         if (shouldRedirect) {
-          expect(mockRouterReplace).toHaveBeenCalledWith("http://localhost:4000/ui/login");
-        } else {
+          expect(mockLocationReplace).toHaveBeenCalledWith("http://localhost:4000/ui/login/");
           expect(mockRouterReplace).not.toHaveBeenCalled();
+        } else {
+          expect(mockLocationReplace).not.toHaveBeenCalled();
         }
       });
     });

--- a/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
@@ -33,6 +33,7 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { useUISettings } from "@/app/(dashboard)/hooks/uiSettings/useUISettings";
 import { checkTokenValidity } from "@/utils/jwtUtils";
 import { getCookie } from "@/utils/cookieUtils";
+import { getLoginUrl } from "@/utils/returnUrlUtils";
 
 interface ModelHubTableProps {
   accessToken: string | null;
@@ -108,12 +109,12 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
 
       // If token is invalid, redirect to login
       if (!isTokenValid) {
-        router.replace(`${getProxyBaseUrl()}/ui/login`);
+        window.location.replace(getLoginUrl(getProxyBaseUrl()));
         return;
       }
     }
     // If require_auth_for_public_ai_hub is false, allow public access (no change)
-  }, [isUISettingsLoading, publicPage, uiSettings, router]);
+  }, [isUISettingsLoading, publicPage, uiSettings]);
 
   useEffect(() => {
     const fetchData = async (accessToken: string) => {

--- a/ui/litellm-dashboard/src/components/DashboardHeader.tsx
+++ b/ui/litellm-dashboard/src/components/DashboardHeader.tsx
@@ -18,7 +18,7 @@ import WorkerDropdown from "@/components/Navbar/WorkerDropdown/WorkerDropdown";
 import { useWorker } from "@/hooks/useWorker";
 import { useDisableShowPrompts } from "@/app/(dashboard)/hooks/useDisableShowPrompts";
 import { clearTokenCookies } from "@/utils/cookieUtils";
-import { clearStoredReturnUrl } from "@/utils/returnUrlUtils";
+import { clearStoredReturnUrl, getLoginUrl } from "@/utils/returnUrlUtils";
 
 interface DashboardHeaderProps {
   page: string;
@@ -37,7 +37,7 @@ export function DashboardHeader({ page }: DashboardHeaderProps) {
     clearStoredReturnUrl();
     localStorage.removeItem("litellm_selected_worker_id");
     localStorage.removeItem("litellm_worker_url");
-    window.location.href = `/ui/login?worker=${encodeURIComponent(workerId)}`;
+    window.location.href = `${getLoginUrl()}?worker=${encodeURIComponent(workerId)}`;
   };
 
   return (

--- a/ui/litellm-dashboard/src/components/navbar.tsx
+++ b/ui/litellm-dashboard/src/components/navbar.tsx
@@ -5,7 +5,7 @@ import { useWorker } from "@/hooks/useWorker";
 import { getProxyBaseUrl } from "@/components/networking";
 import { useTheme } from "@/contexts/ThemeContext";
 import { clearTokenCookies } from "@/utils/cookieUtils";
-import { clearStoredReturnUrl } from "@/utils/returnUrlUtils";
+import { clearStoredReturnUrl, getLoginUrl } from "@/utils/returnUrlUtils";
 import useProxySettings from "@/app/(dashboard)/hooks/proxySettings/useProxySettings";
 import { DownOutlined, MenuFoldOutlined, MenuUnfoldOutlined } from "@ant-design/icons";
 import { Tag } from "antd";
@@ -56,7 +56,7 @@ const Navbar: React.FC<NavbarProps> = ({
     clearStoredReturnUrl();
     localStorage.removeItem("litellm_selected_worker_id");
     localStorage.removeItem("litellm_worker_url");
-    window.location.href = `/ui/login?worker=${encodeURIComponent(workerId)}`;
+    window.location.href = `${getLoginUrl()}?worker=${encodeURIComponent(workerId)}`;
   };
 
   return (

--- a/ui/litellm-dashboard/src/utils/returnUrlUtils.test.ts
+++ b/ui/litellm-dashboard/src/utils/returnUrlUtils.test.ts
@@ -3,6 +3,7 @@ import {
   clearStoredReturnUrl,
   consumeReturnUrl,
   getCurrentUrl,
+  getLoginUrl,
   getReturnUrl,
   getReturnUrlFromParams,
   getStoredReturnUrl,
@@ -95,6 +96,29 @@ describe("returnUrlUtils", () => {
 
       const returnUrl = getReturnUrlFromParams();
       expect(returnUrl).toBeNull();
+    });
+  });
+
+  describe("getLoginUrl", () => {
+    it("should build a relative login URL with a trailing slash", () => {
+      expect(getLoginUrl()).toBe("/ui/login/");
+    });
+
+    it("should prepend the given base URL and keep the trailing slash", () => {
+      expect(getLoginUrl("http://proxy.example")).toBe("http://proxy.example/ui/login/");
+    });
+
+    it("should keep the trailing slash before the query when composed with buildLoginUrlWithReturn", () => {
+      Object.defineProperty(window, "location", {
+        value: {
+          ...window.location,
+          href: "http://localhost:3000/ui?page=api-keys",
+        },
+        writable: true,
+      });
+
+      const loginUrl = buildLoginUrlWithReturn(getLoginUrl());
+      expect(loginUrl).toBe("/ui/login/?redirect_to=http%3A%2F%2Flocalhost%3A3000%2Fui%3Fpage%3Dapi-keys");
     });
   });
 

--- a/ui/litellm-dashboard/src/utils/returnUrlUtils.ts
+++ b/ui/litellm-dashboard/src/utils/returnUrlUtils.ts
@@ -13,6 +13,10 @@
 const RETURN_URL_COOKIE_NAME = "litellm_return_url";
 const RETURN_URL_PARAM = "redirect_to";
 
+export function getLoginUrl(baseUrl: string = ""): string {
+  return `${baseUrl}/ui/login/`;
+}
+
 /**
  * Gets the current URL with all query parameters.
  * Returns null if running on server-side.

--- a/ui/litellm-dashboard/tests/CreateKeyPage.expiredToken.test.tsx
+++ b/ui/litellm-dashboard/tests/CreateKeyPage.expiredToken.test.tsx
@@ -232,7 +232,7 @@ describe("CreateKeyPage auth behavior", () => {
     // Assert: we eventually redirect to SSO login with return URL (single replace, not assign/href)
     await waitFor(() => {
       expect(window.location.replace).toHaveBeenCalledWith(
-        expect.stringContaining("https://example.com/ui/login?redirect_to="),
+        expect.stringContaining("https://example.com/ui/login/?redirect_to="),
       );
     });
 


### PR DESCRIPTION
## Relevant issues

Fixes #33454

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before (server behavior the old client-side redirect triggered; unchanged by this PR, the point is the new client never hits it). Captured at 14cea73b17 against a live proxy on localhost:4000; the server path is identical before and after since this PR only changes the UI

```
$ curl -sI 'http://localhost:4000/ui/login?redirect_to=x'
HTTP/1.1 307 Temporary Redirect
location: http://localhost:4000/ui/login/?redirect_to=x
```

That Location header's scheme is whatever uvicorn believes the request scheme is. Behind a TLS-terminating reverse proxy (Traefik, nginx, an ALB) uvicorn only trusts `X-Forwarded-Proto` from 127.0.0.1 by default, so the 307 downgrades https to http, exactly the broken URL in the issue. On top of that, the old `router.replace` soft navigation first requested an RSC payload (`/ui/login.txt?...&_rsc=...`) that the static export cannot serve, producing repeated 404s before falling back to a full page load

After, captured at 14cea73b17 with the UI built from this branch and served by the live proxy. The trailing slash means no redirect fires at all

```
$ curl -s -o /dev/null -w '%{http_code}\n' 'http://localhost:4000/ui/login/?redirect_to=x'
200
```

Full logged-out browser flow against the live proxy: visiting http://localhost:4000/ui/ with no session lands directly on `http://localhost:4000/ui/login/?redirect_to=http%3A%2F%2Flocalhost%3A4000%2Fui%2F` with a single 200, no 307 and no `login.txt` 404s in the network tab, the login form renders, and logging in with the master key returns to `/ui/`

Manual QA steps for screenshots

1. Run the proxy with a UI built from this branch and open http://localhost:4000/ui/ in a fresh incognito window
2. In DevTools Network, confirm the document request is `GET /ui/login/?redirect_to=...` returning 200 directly, with no 307 and no `login.txt` 404s
3. Log in and confirm you land back on http://localhost:4000/ui/

## Type

🐛 Bug Fix

## Changes

Logged-out users behind a TLS-terminating reverse proxy could not reach the login page: the auth guard redirected to `/ui/login` (no trailing slash), the StaticFiles mount answered with a 307 whose absolute Location carries the plain-http scheme the container sees, and the browser followed the downgraded URL into a dead end. The guard also used the Next client router for this navigation, which attempts an RSC soft navigation the static export cannot satisfy

This PR adds `getLoginUrl()` in `returnUrlUtils.ts` as the single place the login URL is built, always with the trailing slash so the server never issues a redirect, and converts every login redirect to it: `useAuthorized`, the dashboard index guard, `ModelHubTable`'s public-hub auth check, the worker-switch handlers in `navbar`/`DashboardHeader`, the onboarding error link, and the SSO `return_to` in `LoginPage`. The two client-router login redirects (`useAuthorized`, `ModelHubTable`) now use `window.location.replace`, matching the dashboard index guard, so no RSC payload fetch is attempted

Tests: `getLoginUrl` unit tests pin the trailing slash (including composed with `redirect_to`), the pre-existing `tests/CreateKeyPage.expiredToken.test.tsx` redirect assertion was updated to the slashed URL, and the `useAuthorized`/`ModelHubTable` tests now assert `window.location.replace` is called with the slashed URL and that the Next router is not used, so both regressions fail tests if reintroduced

Note for operators: any other absolute URL the proxy constructs still depends on forwarded-header trust; setting the `FORWARDED_ALLOW_IPS` env var (read natively by uvicorn) makes uvicorn honor `X-Forwarded-Proto` from the reverse proxy. Exposing/documenting that is left as a follow-up since this PR fixes the login flow independently of proxy config

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

