### PR TITLE
feat(proxy): add disable_auto_add_proxy_admin_to_teams flag

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2367,6 +2367,10 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         None,
         description="If True, stores request messages and responses in spend logs. Default is False.",
     )
+    disable_auto_add_proxy_admin_to_teams: bool | None = Field(
+        None,
+        description="By default, the user calling /team/new is automatically added to the new team as a team admin. If True, proxy admins are no longer auto-added; members explicitly listed in members_with_roles are unaffected. Default is False.",
+    )
     maximum_spend_logs_retention_period: Optional[str] = Field(
         None,
         description="Maximum retention period for spend logs (e.g., '7d' for 7 days). Logs older than this will be deleted.",

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -14,7 +14,7 @@ import json
 import math
 import traceback
 from datetime import datetime, timezone
-from typing import Annotated, Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Annotated, Any, Dict, List, Mapping, Optional, Tuple, Union, cast
 
 import fastapi
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
@@ -894,6 +894,17 @@ def _check_team_budget_update_authority(
         )
 
 
+def _should_auto_add_team_creator(
+    user_api_key_dict: UserAPIKeyAuth,
+    general_settings: Mapping[str, object],
+) -> bool:
+    if user_api_key_dict.user_id is None:
+        return False
+    if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
+        return True
+    return general_settings.get("disable_auto_add_proxy_admin_to_teams") is not True
+
+
 #### TEAM MANAGEMENT ####
 @router.post(
     "/team/new",
@@ -997,6 +1008,7 @@ async def new_team(
         from litellm.proxy.proxy_server import (
             _license_check,
             create_audit_log_for_update,
+            general_settings,
             litellm_proxy_admin_name,
             prisma_client,
             user_api_key_cache,
@@ -1123,13 +1135,11 @@ async def new_team(
                     user_api_key_cache=user_api_key_cache,
                 )
 
-        if user_api_key_dict.user_id is not None:
-            creating_user_in_list = False
-            for member in data.members_with_roles:
-                if member.user_id == user_api_key_dict.user_id:
-                    creating_user_in_list = True
-
-            if creating_user_in_list is False:
+        if _should_auto_add_team_creator(user_api_key_dict, general_settings):
+            creating_user_in_list = any(
+                member.user_id == user_api_key_dict.user_id for member in data.members_with_roles
+            )
+            if not creating_user_in_list:
                 data.members_with_roles.append(Member(role="admin", user_id=user_api_key_dict.user_id))
 
         _check_passthrough_routes_caller_permission(data, user_api_key_dict, entity="team")

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5785,6 +5785,13 @@ class ProxyConfig:
                 # For other types, convert to bool
                 general_settings["store_prompts_in_spend_logs"] = bool(value)
 
+        if "disable_auto_add_proxy_admin_to_teams" in _general_settings:
+            value = _general_settings["disable_auto_add_proxy_admin_to_teams"]
+            if isinstance(value, str):
+                general_settings["disable_auto_add_proxy_admin_to_teams"] = value.lower() == "true"
+            else:
+                general_settings["disable_auto_add_proxy_admin_to_teams"] = value if value is None else bool(value)
+
         ## STORE MODEL IN DB ##
         if "store_model_in_db" in _general_settings:
             value = _general_settings["store_model_in_db"]
@@ -14898,6 +14905,7 @@ async def get_config_list(
         "mcp_required_fields": {"type": "List"},
         "cancel_on_disconnect": {"type": "Boolean"},
         "skip_user_budget_on_team_key": {"type": "Boolean"},
+        "disable_auto_add_proxy_admin_to_teams": {"type": "Boolean"},
     }
 
     return_val = []

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -555,6 +555,84 @@ async def test_new_team_with_mcp_tool_permissions(mock_db_client, mock_admin_aut
     assert created_permission_data["mcp_servers"] == ["server_a", "server_b"]
 
 
+@pytest.mark.parametrize(
+    "user_role,user_id,flag_value,expected",
+    [
+        (LitellmUserRoles.PROXY_ADMIN, "admin-1", True, False),
+        (LitellmUserRoles.PROXY_ADMIN, "admin-1", False, True),
+        (LitellmUserRoles.PROXY_ADMIN, "admin-1", None, True),
+        (LitellmUserRoles.INTERNAL_USER, "user-1", True, True),
+        (LitellmUserRoles.ORG_ADMIN, "org-admin-1", True, True),
+        (LitellmUserRoles.PROXY_ADMIN, None, False, False),
+    ],
+)
+def test_should_auto_add_team_creator(user_role, user_id, flag_value, expected):
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _should_auto_add_team_creator,
+    )
+
+    general_settings = (
+        {} if flag_value is None else {"disable_auto_add_proxy_admin_to_teams": flag_value}
+    )
+    auth = UserAPIKeyAuth(user_role=user_role, user_id=user_id)
+    assert _should_auto_add_team_creator(auth, general_settings) is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "disable_flag,expect_creator_added", [(True, False), (False, True)]
+)
+async def test_new_team_disable_auto_add_proxy_admin_flag(
+    mock_db_client, disable_flag, expect_creator_added
+):
+    """
+    When general_settings.disable_auto_add_proxy_admin_to_teams is True, a proxy
+    admin calling /team/new must NOT be auto-added to the team's members. When
+    the flag is off, the creator is auto-added as a team admin (default
+    behavior, regression guard for LIT-3739).
+    """
+    mock_db_client.jsonify_team_object = lambda db_data: db_data
+    mock_db_client.get_data = AsyncMock(return_value=None)
+    mock_db_client.update_data = AsyncMock(return_value=MagicMock())
+    mock_db_client.db = MagicMock()
+
+    team_create_result = MagicMock(team_id="team-789")
+    team_create_result.model_dump.return_value = {"team_id": "team-789"}
+    mock_db_client.db.litellm_teamtable = MagicMock()
+    mock_db_client.db.litellm_teamtable.create = AsyncMock(
+        return_value=team_create_result
+    )
+    mock_db_client.db.litellm_teamtable.count = AsyncMock(return_value=0)
+    mock_db_client.db.litellm_usertable = MagicMock()
+    mock_db_client.db.litellm_usertable.update = AsyncMock(return_value=MagicMock())
+
+    from fastapi import Request
+
+    from litellm.proxy._types import NewTeamRequest
+    from litellm.proxy.management_endpoints.team_endpoints import new_team
+
+    admin_auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin-user-1"
+    )
+
+    with patch(
+        "litellm.proxy.proxy_server.general_settings",
+        {"disable_auto_add_proxy_admin_to_teams": disable_flag},
+    ), patch(
+        "litellm.proxy.management_endpoints.team_endpoints._add_team_members_to_team",
+        new_callable=AsyncMock,
+    ) as mock_add_members:
+        await new_team(
+            data=NewTeamRequest(team_alias="flag-test-team"),
+            http_request=MagicMock(spec=Request),
+            user_api_key_dict=admin_auth,
+        )
+
+    member_add_request = mock_add_members.call_args.kwargs["data"]
+    member_user_ids = [m.user_id for m in member_add_request.member]
+    assert ("admin-user-1" in member_user_ids) is expect_creator_added
+
+
 @pytest.mark.asyncio
 async def test_team_update_object_permissions_existing_permission(monkeypatch):
     """

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -628,6 +628,7 @@ async def test_new_team_disable_auto_add_proxy_admin_flag(
             user_api_key_dict=admin_auth,
         )
 
+    mock_add_members.assert_called_once()
     member_add_request = mock_add_members.call_args.kwargs["data"]
     member_user_ids = [m.user_id for m in member_add_request.member]
     assert ("admin-user-1" in member_user_ids) is expect_creator_added

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -6188,6 +6188,32 @@ async def test_update_general_settings_store_model_in_db_false():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "db_value,expected",
+    [(True, True), (False, False), ("true", True), ("false", False), (None, None)],
+)
+async def test_update_general_settings_disable_auto_add_proxy_admin_to_teams(db_value, expected):
+    """
+    Verify _update_general_settings propagates disable_auto_add_proxy_admin_to_teams
+    from the DB config into the live general_settings dict, so a UI toggle via
+    /config/field/update takes effect on the next config poll instead of
+    requiring a proxy restart.
+    """
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    proxy_config = ProxyConfig()
+
+    with patch("litellm.proxy.proxy_server.general_settings", {}):
+        await proxy_config._update_general_settings(
+            db_general_settings={"disable_auto_add_proxy_admin_to_teams": db_value}
+        )
+
+        import litellm.proxy.proxy_server as ps
+
+        assert ps.general_settings["disable_auto_add_proxy_admin_to_teams"] is expected
+
+
+@pytest.mark.asyncio
 async def test_update_general_settings_store_model_in_db_string_normalization():
     """
     Verify _update_general_settings normalizes string values for store_model_in_db.

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -22505,6 +22505,11 @@ export interface components {
              */
             database_url?: string | null;
             /**
+             * Disable Auto Add Proxy Admin To Teams
+             * @description By default, the user calling /team/new is automatically added to the new team as a team admin. If True, proxy admins are no longer auto-added; members explicitly listed in members_with_roles are unaffected. Default is False.
+             */
+            disable_auto_add_proxy_admin_to_teams?: boolean | null;
+            /**
              * Disable Budget Reservation
              * @description If True, disables the optimistic per-request budget reservation introduced in v1.84.0. WARNING: This weakens hard budget enforcement. Without the reservation, a burst of concurrent requests from a single key can each pass the read-time spend check before any of them is charged, allowing a configured budget to be exceeded under high concurrency. Budgets are still evaluated on every request at read time, so an already-exhausted budget is still rejected. Enable only if your deployment is experiencing phantom BudgetExceededError responses caused by leaked reservations (see GitHub issue #27639). A proxy-level WARNING is logged on every request while this flag is active as a reminder that hard enforcement is relaxed.
              */


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3739

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

All runs against a live proxy on localhost:4000 backed by a real Postgres DB

Default behavior (flag not set, commit 573ea90a84): the proxy admin calling /team/new is auto-added as a team admin

```
curl -s http://localhost:4000/team/new \
  -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' \
  -d '{"team_alias": "lit-3739-default-behavior"}'
```

```json
{
  "team_id": "13822fa7-bb72-4493-972f-6d06a140de16",
  "team_alias": "lit-3739-default-behavior",
  "members_with_roles": [
    {
      "user_id": "default_user_id",
      "user_email": null,
      "role": "admin"
    }
  ]
}
```

With the flag enabled in the proxy config and the proxy restarted (commit 573ea90a84):

```yaml
general_settings:
  master_key: sk-1234
  disable_auto_add_proxy_admin_to_teams: true
```

the same request no longer auto-adds the admin:

```
curl -s http://localhost:4000/team/new \
  -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' \
  -d '{"team_alias": "lit-3739-flag-enabled"}'
```

```json
{
  "team_id": "90afa00d-62c5-446b-8b26-c2f79cc74ae0",
  "team_alias": "lit-3739-flag-enabled",
  "members_with_roles": []
}
```

Members explicitly listed in the request are still honored while the flag is on (commit 573ea90a84):

```
curl -s http://localhost:4000/team/new \
  -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' \
  -d '{"team_alias": "lit-3739-flag-enabled-explicit-members", "members_with_roles": [{"role": "admin", "user_id": "default_user_id"}]}'
```

```json
{
  "team_alias": "lit-3739-flag-enabled-explicit-members",
  "members_with_roles": [
    {
      "user_id": "default_user_id",
      "user_email": null,
      "role": "admin"
    }
  ]
}
```

UI toggle path (commit cfd8b0f655, proxy running with `store_model_in_db: true` and the flag NOT in config.yaml): the field is served to the settings page

```
curl -s "http://localhost:4000/config/list?config_type=general_settings" \
  -H 'Authorization: Bearer sk-1234' | jq '.[] | select(.field_name=="disable_auto_add_proxy_admin_to_teams")'
```

```json
{
  "field_name": "disable_auto_add_proxy_admin_to_teams",
  "field_type": "Boolean",
  "field_description": "By default, the user calling /team/new is automatically added to the new team as a team admin. If True, proxy admins are no longer auto-added; members explicitly listed in members_with_roles are unaffected. Default is False.",
  "field_value": null,
  "stored_in_db": null,
  "field_default_value": null,
  "premium_field": false,
  "nested_fields": null
}
```

then toggling it through the same endpoint the UI Switch calls, waiting out one 30s config poll, and creating a team shows it takes effect with no restart:

```
curl -s http://localhost:4000/config/field/update \
  -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' \
  -d '{"field_name": "disable_auto_add_proxy_admin_to_teams", "field_value": true, "config_type": "general_settings"}'
sleep 45
curl -s http://localhost:4000/team/new \
  -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' \
  -d '{"team_alias": "lit-3739-ui-toggle-on"}'
```

```json
{
  "team_id": "81c5d552-3093-4589-8348-565a181fa250",
  "members_with_roles": []
}
```

To exercise the actual UI: run the proxy with `store_model_in_db: true`, open the Admin UI, go to Router Settings, stay on the General tab, flip the `disable_auto_add_proxy_admin_to_teams` switch, click Update, wait ~30s, then create a team from the Teams page and open it; the members list should be empty

## Type

🆕 New Feature

## Changes

`/team/new` unconditionally appends the caller to `members_with_roles` as a team admin. For proxy admins this is pure clutter: they already have full access to every team, yet they show up as a member of each team they create through the API or the Admin UI

This PR adds a `general_settings.disable_auto_add_proxy_admin_to_teams` flag (default false, so existing behavior is unchanged). When true, callers with the `PROXY_ADMIN` role are no longer auto-added on team creation. The gate is deliberately scoped to proxy admins: non-admin creators (org admins, internal users with team creation rights) keep getting auto-added because their subsequent access to the team depends on membership. Members explicitly passed in `members_with_roles` are always honored regardless of the flag

The flag is also toggleable from the Admin UI (Router Settings, General tab). That took two additions in proxy_server.py: the `allowed_args` allowlist in `get_config_list` so the settings page renders the Boolean switch, and the `_update_general_settings` whitelist so a value saved via `/config/field/update` propagates from the DB into the live in-memory `general_settings` on the next 30s config poll (requires `store_model_in_db: true`, same as every other UI-managed setting) instead of only applying after a restart. Note this whitelist gap also silently affects `cancel_on_disconnect` and `skip_user_budget_on_team_key` today; fixing those is out of scope here

The decision lives in a small pure helper, `_should_auto_add_team_creator`, unit-tested across the role/flag matrix, plus an endpoint-level test through `new_team` asserting the member list actually persisted with the flag on and off, and a parametrized test pinning the `_update_general_settings` propagation (including string "true"/"false" normalization)

An audit of membership-dependent code paths (access control, zero-member teams, dashboard) found no breakage: every team write path checks `PROXY_ADMIN` before falling back to membership, zero-member teams were already reachable before this flag (any admin token without a user_id), and the dashboard fetches all teams for admins without filtering by membership. Two intentional consequences worth knowing: a team created this way has no team-level admin until one is added (only proxy/org admins can manage it), and member-scoped views like `/team/list?user_id=<self>` or `GET /team/{id}/members/me` will not include teams the admin is not a member of

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
