### PR TITLE
ci: run zizmor and proxy-db unit tests on PRs targeting litellm_ branches

### DIFF
--- a/.github/workflows/test-unit-proxy-db.yml
+++ b/.github/workflows/test-unit-proxy-db.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - litellm_internal_staging
+      - litellm_oss_staging
+      - "litellm_**"
 
 permissions:
   contents: read

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches: [main, litellm_internal_staging]
   pull_request:
-    branches: [main, litellm_internal_staging]
+    branches:
+      - main
+      - litellm_internal_staging
+      - litellm_oss_staging
+      - "litellm_**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a CI trigger change with no runtime surface, so the proof lives in workflow run history rather than a curl session. On PR #32964, which was based on litellm_e2e_key_rate_limit_coverage at the time, zero runs of these two workflows were created for either push to the branch, while sibling unit-test workflows that already use the `litellm_**` glob ran on both pushes. After this change the same stacked setup triggers both workflows. Both workflows also run on this PR itself since it targets litellm_internal_staging, so their results on head commit 9d88f9a894 are visible directly in this PR's checks

## Type

🚄 Infrastructure

## Changes

Workflows whose `on.pull_request.branches` filter is limited to main and litellm_internal_staging never trigger while a PR's base is a stacked `litellm_` branch. When the parent PR merges, GitHub automatically retargets the stacked PR to litellm_internal_staging, but that base change fires only a pull_request "edited" event, which no workflow listens to. As a result the ruleset-required checks zizmor, assert-shard-coverage, and the seven proxy-db shard contexts stay stuck at "Expected - Waiting for status to be reported" and block an otherwise approved PR. PR #32964 is the concrete incident: it sat approved and fully green while nine required checks waited for statuses that would never arrive, and it needed an empty commit push to recover

This PR widens the `pull_request` branch filters in `.github/workflows/zizmor.yml` and `.github/workflows/test-unit-proxy-db.yml` to the same glob list the other unit-test workflows already use (main, litellm_internal_staging, litellm_oss_staging, `litellm_**`). With that in place these checks run while the PR is still stacked, so the results are already posted on the head SHA by the time GitHub retargets the PR. The `on.push.branches` list in zizmor.yml is unchanged

No tests are added because the change is a workflow trigger list; there is no code path a unit test could exercise

## QA runbook

Open a PR whose base is another open PR's `litellm_` branch and confirm that zizmor, assert-shard-coverage, and the "Unit Tests: Proxy DB Operations" shards (for example "budgets / Run tests" and "jwt-and-keys / Run tests") appear in its checks and start running while the PR is still stacked

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
