### PR TITLE
feat(anthropic): add enable_anthropic_prompt_caching for automatic cache_control injection

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -315,6 +315,8 @@ disable_token_counter: bool = False
 disable_add_transform_inline_image_block: bool = False
 disable_add_user_agent_to_request_tags: bool = False
 disable_anthropic_gemini_context_caching_transform: bool = False
+enable_anthropic_prompt_caching: bool = False
+anthropic_prompt_caching_ttl: Optional[Literal["5m", "1h"]] = None
 disable_vertex_batch_output_transformation: bool = False
 extra_spend_tag_headers: Optional[List[str]] = None
 in_memory_llm_clients_cache: "LLMClientCache"

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -315,8 +315,11 @@ disable_token_counter: bool = False
 disable_add_transform_inline_image_block: bool = False
 disable_add_user_agent_to_request_tags: bool = False
 disable_anthropic_gemini_context_caching_transform: bool = False
-enable_anthropic_prompt_caching: bool = False
-anthropic_prompt_caching_ttl: Optional[Literal["5m", "1h"]] = None
+enable_anthropic_prompt_caching: bool = os.getenv("LITELLM_ENABLE_ANTHROPIC_PROMPT_CACHING", "false").lower() == "true"
+_anthropic_prompt_caching_ttl_env: Optional[str] = os.getenv("LITELLM_ANTHROPIC_PROMPT_CACHING_TTL")
+anthropic_prompt_caching_ttl: Optional[Literal["5m", "1h"]] = (
+    "1h" if _anthropic_prompt_caching_ttl_env == "1h" else "5m" if _anthropic_prompt_caching_ttl_env == "5m" else None
+)
 disable_vertex_batch_output_transformation: bool = False
 extra_spend_tag_headers: Optional[List[str]] = None
 in_memory_llm_clients_cache: "LLMClientCache"

--- a/litellm/integrations/anthropic_cache_control_hook.py
+++ b/litellm/integrations/anthropic_cache_control_hook.py
@@ -311,16 +311,26 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         return ChatCompletionCachedContent(type="ephemeral")
 
     @staticmethod
-    def _request_has_cache_control(messages: list[AllMessageValues], system: Optional[Union[str, list]]) -> bool:
+    def _request_has_cache_control(
+        messages: list[AllMessageValues],
+        system: Optional[Union[str, list]],
+        tools: Optional[list] = None,
+    ) -> bool:
         """Return True if the request already carries any client-supplied cache_control.
 
         When the client (e.g. Claude Code) already marks its own breakpoints we
         stand down entirely rather than add more, per the auto-caching contract.
+        Tools count: they are a breakpoint the client can mark, they count toward
+        the provider's four-block limit, and caching only the tool definitions is
+        a common pattern, so injecting alongside them can exceed the cap.
         """
         if any(AnthropicCacheControlHook._count_cache_control_blocks(msg) for msg in messages):
             return True
         if isinstance(system, list):
-            return any(isinstance(block, dict) and block.get("cache_control") is not None for block in system)
+            if any(isinstance(block, dict) and block.get("cache_control") is not None for block in system):
+                return True
+        if tools is not None:
+            return any(isinstance(tool, dict) and tool.get("cache_control") is not None for tool in tools)
         return False
 
     @staticmethod
@@ -329,6 +339,7 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         system: Optional[Union[str, list]],
         model: str,
         custom_llm_provider: Optional[str],
+        tools: Optional[list] = None,
     ) -> list[CacheControlInjectionPoint]:
         """Default breakpoints when ``litellm.enable_anthropic_prompt_caching`` is on.
 
@@ -363,7 +374,7 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         if not supports_prompt_caching(model=model, custom_llm_provider=provider):
             return []
 
-        if AnthropicCacheControlHook._request_has_cache_control(messages, system):
+        if AnthropicCacheControlHook._request_has_cache_control(messages, system, tools):
             return []
 
         control = AnthropicCacheControlHook._default_control()
@@ -379,6 +390,7 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         messages: list[AllMessageValues],
         model: str,
         custom_llm_provider: Optional[str],
+        tools: Optional[list] = None,
     ) -> None:
         """For /chat/completions: add default injection points to the request params.
 
@@ -393,6 +405,7 @@ class AnthropicCacheControlHook(CustomPromptManagement):
             system=None,
             model=model,
             custom_llm_provider=custom_llm_provider,
+            tools=tools,
         )
         if points:
             non_default_params["cache_control_injection_points"] = points
@@ -404,6 +417,7 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         kwargs: Dict[str, Any],
         model: Optional[str] = None,
         custom_llm_provider: Optional[str] = None,
+        tools: Optional[list[dict]] = None,
     ) -> Tuple[List[Dict], str | list | None]:
         """Extract cache_control_injection_points from kwargs and apply if present.
 
@@ -420,6 +434,7 @@ class AnthropicCacheControlHook(CustomPromptManagement):
             injection_points = AnthropicCacheControlHook.get_default_injection_points(
                 messages=cast(list[AllMessageValues], messages),  # cast-ok: Anthropic-shaped dicts from v1/messages
                 system=system,
+                tools=tools,
                 model=model,
                 custom_llm_provider=custom_llm_provider,
             )

--- a/litellm/integrations/anthropic_cache_control_hook.py
+++ b/litellm/integrations/anthropic_cache_control_hook.py
@@ -313,8 +313,8 @@ class AnthropicCacheControlHook(CustomPromptManagement):
     @staticmethod
     def _request_has_cache_control(
         messages: list[AllMessageValues],
-        system: Optional[Union[str, list]],
-        tools: Optional[list] = None,
+        system: str | list | None,
+        tools: list | None = None,
     ) -> bool:
         """Return True if the request already carries any client-supplied cache_control.
 
@@ -336,10 +336,10 @@ class AnthropicCacheControlHook(CustomPromptManagement):
     @staticmethod
     def get_default_injection_points(
         messages: list[AllMessageValues],
-        system: Optional[Union[str, list]],
+        system: str | list | None,
         model: str,
-        custom_llm_provider: Optional[str],
-        tools: Optional[list] = None,
+        custom_llm_provider: str | None,
+        tools: list | None = None,
     ) -> list[CacheControlInjectionPoint]:
         """Default breakpoints when ``litellm.enable_anthropic_prompt_caching`` is on.
 
@@ -389,8 +389,8 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         non_default_params: dict[str, Any],
         messages: list[AllMessageValues],
         model: str,
-        custom_llm_provider: Optional[str],
-        tools: Optional[list] = None,
+        custom_llm_provider: str | None,
+        tools: list | None = None,
     ) -> None:
         """For /chat/completions: add default injection points to the request params.
 
@@ -415,9 +415,9 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         messages: List[Dict],
         system: str | list | None,
         kwargs: Dict[str, Any],
-        model: Optional[str] = None,
-        custom_llm_provider: Optional[str] = None,
-        tools: Optional[list[dict]] = None,
+        model: str | None = None,
+        custom_llm_provider: str | None = None,
+        tools: list[dict] | None = None,
     ) -> Tuple[List[Dict], str | list | None]:
         """Extract cache_control_injection_points from kwargs and apply if present.
 
@@ -427,7 +427,7 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         are written back so downstream transforms can handle them.
         """
         configured = cast(  # cast-ok: kwargs is untyped; this key only holds the documented injection-point list
-            Optional[list[CacheControlInjectionPoint]], kwargs.pop("cache_control_injection_points", None)
+            list[CacheControlInjectionPoint] | None, kwargs.pop("cache_control_injection_points", None)
         )
         injection_points: list[CacheControlInjectionPoint] = configured or []
         if not injection_points and model is not None:

--- a/litellm/integrations/anthropic_cache_control_hook.py
+++ b/litellm/integrations/anthropic_cache_control_hook.py
@@ -297,17 +297,132 @@ class AnthropicCacheControlHook(CustomPromptManagement):
         return processed_messages, processed_system, remaining_points
 
     @staticmethod
+    def _default_control() -> ChatCompletionCachedContent:
+        """Build the cache_control block for auto-injected breakpoints.
+
+        Defaults to Anthropic's 5-minute ephemeral cache; honors the optional
+        ``litellm.anthropic_prompt_caching_ttl`` override ("5m" or "1h").
+        """
+        import litellm
+
+        ttl = litellm.anthropic_prompt_caching_ttl
+        if ttl == "5m" or ttl == "1h":
+            return ChatCompletionCachedContent(type="ephemeral", ttl=ttl)
+        return ChatCompletionCachedContent(type="ephemeral")
+
+    @staticmethod
+    def _request_has_cache_control(messages: list[AllMessageValues], system: Optional[Union[str, list]]) -> bool:
+        """Return True if the request already carries any client-supplied cache_control.
+
+        When the client (e.g. Claude Code) already marks its own breakpoints we
+        stand down entirely rather than add more, per the auto-caching contract.
+        """
+        if any(AnthropicCacheControlHook._count_cache_control_blocks(msg) for msg in messages):
+            return True
+        if isinstance(system, list):
+            return any(isinstance(block, dict) and block.get("cache_control") is not None for block in system)
+        return False
+
+    @staticmethod
+    def get_default_injection_points(
+        messages: list[AllMessageValues],
+        system: Optional[Union[str, list]],
+        model: str,
+        custom_llm_provider: Optional[str],
+    ) -> list[CacheControlInjectionPoint]:
+        """Default breakpoints when ``litellm.enable_anthropic_prompt_caching`` is on.
+
+        Caches the system prompt and the trailing turn, so the stable prefix
+        (system + tools + history) is reused while the breakpoint advances with
+        the conversation. Returns [] (stand down) when the flag is off, the
+        provider does not consume cache_control breakpoints (only anthropic /
+        bedrock do), the model lacks prompt-caching support, or the request
+        already carries client-supplied cache_control.
+        """
+        import litellm
+
+        if litellm.enable_anthropic_prompt_caching is not True:
+            return []
+
+        provider = custom_llm_provider
+        if provider is None:
+            from litellm.litellm_core_utils.get_llm_provider_logic import (
+                get_llm_provider,
+            )
+
+            try:
+                _, provider, _, _ = get_llm_provider(model=model)
+            except Exception:  # noqa: BLE001  # unroutable model must never block the call, just skip auto-caching
+                return []
+
+        if provider not in ("anthropic", "bedrock"):
+            return []
+
+        from litellm.utils import supports_prompt_caching
+
+        if not supports_prompt_caching(model=model, custom_llm_provider=provider):
+            return []
+
+        if AnthropicCacheControlHook._request_has_cache_control(messages, system):
+            return []
+
+        control = AnthropicCacheControlHook._default_control()
+        points: list[CacheControlInjectionPoint] = [
+            CacheControlMessageInjectionPoint(location="message", role="system", index=None, control=control),
+            CacheControlMessageInjectionPoint(location="message", role=None, index=-1, control=control),
+        ]
+        return points
+
+    @staticmethod
+    def maybe_seed_default_injection_points(
+        non_default_params: dict[str, Any],
+        messages: list[AllMessageValues],
+        model: str,
+        custom_llm_provider: Optional[str],
+    ) -> None:
+        """For /chat/completions: add default injection points to the request params.
+
+        No-op when injection points are already configured (explicit config wins).
+        Seeding the param lets the existing prompt-management gate and the
+        AnthropicCacheControlHook run unchanged.
+        """
+        if non_default_params.get("cache_control_injection_points"):
+            return
+        points = AnthropicCacheControlHook.get_default_injection_points(
+            messages=messages,
+            system=None,
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+        )
+        if points:
+            non_default_params["cache_control_injection_points"] = points
+
+    @staticmethod
     def maybe_inject_cache_control(
         messages: List[Dict],
         system: str | list | None,
         kwargs: Dict[str, Any],
+        model: Optional[str] = None,
+        custom_llm_provider: Optional[str] = None,
     ) -> Tuple[List[Dict], str | list | None]:
         """Extract cache_control_injection_points from kwargs and apply if present.
 
+        When none are configured but ``litellm.enable_anthropic_prompt_caching``
+        is on, synthesize default breakpoints for the native /v1/messages path.
         Pops the key from kwargs; if remaining (non-message) points exist they
         are written back so downstream transforms can handle them.
         """
-        injection_points = kwargs.pop("cache_control_injection_points", None)
+        configured = cast(  # cast-ok: kwargs is untyped; this key only holds the documented injection-point list
+            Optional[list[CacheControlInjectionPoint]], kwargs.pop("cache_control_injection_points", None)
+        )
+        injection_points: list[CacheControlInjectionPoint] = configured or []
+        if not injection_points and model is not None:
+            injection_points = AnthropicCacheControlHook.get_default_injection_points(
+                messages=cast(list[AllMessageValues], messages),  # cast-ok: Anthropic-shaped dicts from v1/messages
+                system=system,
+                model=model,
+                custom_llm_provider=custom_llm_provider,
+            )
         if not injection_points:
             return messages, system
 

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -236,7 +236,9 @@ async def anthropic_messages(
         AnthropicCacheControlHook,
     )
 
-    messages, system = AnthropicCacheControlHook.maybe_inject_cache_control(messages, system, kwargs)
+    messages, system = AnthropicCacheControlHook.maybe_inject_cache_control(
+        messages, system, kwargs, model=model, custom_llm_provider=custom_llm_provider
+    )
 
     original_stream = stream or kwargs.get("_websearch_interception_converted_stream", False)
 
@@ -425,7 +427,9 @@ def anthropic_messages_handler(
         AnthropicCacheControlHook,
     )
 
-    messages, system = AnthropicCacheControlHook.maybe_inject_cache_control(messages, system, kwargs)
+    messages, system = AnthropicCacheControlHook.maybe_inject_cache_control(
+        messages, system, kwargs, model=model, custom_llm_provider=custom_llm_provider
+    )
 
     metadata = validate_anthropic_api_metadata(metadata)
 

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -237,7 +237,7 @@ async def anthropic_messages(
     )
 
     messages, system = AnthropicCacheControlHook.maybe_inject_cache_control(
-        messages, system, kwargs, model=model, custom_llm_provider=custom_llm_provider
+        messages, system, kwargs, model=model, custom_llm_provider=custom_llm_provider, tools=tools
     )
 
     original_stream = stream or kwargs.get("_websearch_interception_converted_stream", False)
@@ -428,7 +428,7 @@ def anthropic_messages_handler(
     )
 
     messages, system = AnthropicCacheControlHook.maybe_inject_cache_control(
-        messages, system, kwargs, model=model, custom_llm_provider=custom_llm_provider
+        messages, system, kwargs, model=model, custom_llm_provider=custom_llm_provider, tools=tools
     )
 
     metadata = validate_anthropic_api_metadata(metadata)

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -510,6 +510,19 @@ async def acompletion(
     #########################################################
     #########################################################
     litellm_logging_obj = kwargs.get("litellm_logging_obj", None)
+
+    from litellm.integrations.anthropic_cache_control_hook import (
+        AnthropicCacheControlHook,
+    )
+    from litellm.types.llms.openai import AllMessageValues
+
+    AnthropicCacheControlHook.maybe_seed_default_injection_points(
+        non_default_params=kwargs,
+        messages=cast(list[AllMessageValues], messages),  # cast-ok: acompletion types messages as a bare List
+        model=model,
+        custom_llm_provider=cast(Optional[str], custom_llm_provider),  # cast-ok: read from untyped kwargs
+    )
+
     if isinstance(litellm_logging_obj, LiteLLMLoggingObj) and (
         litellm_logging_obj.should_run_prompt_management_hooks(
             prompt_id=kwargs.get("prompt_id", None),
@@ -5054,6 +5067,18 @@ def completion(  # type: ignore
     non_default_params = get_non_default_completion_params(kwargs=kwargs)
     litellm_params = {}  # used to prevent unbound var errors
     ## PROMPT MANAGEMENT HOOKS ##
+
+    from litellm.integrations.anthropic_cache_control_hook import (
+        AnthropicCacheControlHook,
+    )
+    from litellm.types.llms.openai import AllMessageValues
+
+    AnthropicCacheControlHook.maybe_seed_default_injection_points(
+        non_default_params=non_default_params,
+        messages=cast(list[AllMessageValues], messages),  # cast-ok: completion types messages as a bare List
+        model=model,
+        custom_llm_provider=cast(Optional[str], kwargs.get("custom_llm_provider")),  # cast-ok: untyped kwargs
+    )
 
     if isinstance(litellm_logging_obj, LiteLLMLoggingObj) and (
         litellm_logging_obj.should_run_prompt_management_hooks(

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -521,6 +521,7 @@ async def acompletion(
         messages=cast(list[AllMessageValues], messages),  # cast-ok: acompletion types messages as a bare List
         model=model,
         custom_llm_provider=cast(Optional[str], custom_llm_provider),  # cast-ok: read from untyped kwargs
+        tools=tools,
     )
 
     if isinstance(litellm_logging_obj, LiteLLMLoggingObj) and (
@@ -5078,6 +5079,7 @@ def completion(  # type: ignore
         messages=cast(list[AllMessageValues], messages),  # cast-ok: completion types messages as a bare List
         model=model,
         custom_llm_provider=cast(Optional[str], kwargs.get("custom_llm_provider")),  # cast-ok: untyped kwargs
+        tools=tools,
     )
 
     if isinstance(litellm_logging_obj, LiteLLMLoggingObj) and (

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -529,6 +529,7 @@ class ChatCompletionDeltaToolCallChunk(TypedDict, total=False):
 
 class ChatCompletionCachedContent(TypedDict):
     type: Literal["ephemeral"]
+    ttl: NotRequired[Literal["5m", "1h"]]
 
 
 class ChatCompletionThinkingBlock(TypedDict, total=False):

--- a/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
+++ b/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
@@ -1547,12 +1547,13 @@ class TestEnableAnthropicPromptCaching:
         {"role": "user", "content": "latest turn"},
     ]
 
-    def _points(self, model="claude-sonnet-4-5", provider="anthropic", messages=None, system=None):
+    def _points(self, model="claude-sonnet-4-5", provider="anthropic", messages=None, system=None, tools=None):
         return AnthropicCacheControlHook.get_default_injection_points(
             messages=copy.deepcopy(self.MESSAGES) if messages is None else messages,
             system=system,
             model=model,
             custom_llm_provider=provider,
+            tools=tools,
         )
 
     def test_disabled_by_default(self):
@@ -1596,6 +1597,58 @@ class TestEnableAnthropicPromptCaching:
         monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
         system = [{"type": "text", "text": "s", "cache_control": {"type": "ephemeral"}}]
         assert self._points(messages=[{"role": "user", "content": "hi"}], system=system) == []
+
+    @staticmethod
+    def _tools(count: int, cached: bool) -> List[dict]:
+        tool: dict = {"type": "function", "function": {"name": "t", "description": "d", "parameters": {}}}
+        if cached:
+            tool["cache_control"] = {"type": "ephemeral"}
+        return [{**tool, "function": {**tool["function"], "name": f"t{i}"}} for i in range(count)]
+
+    def test_stands_down_when_only_tools_carry_cache_control(self, monkeypatch):
+        """Caching just the tool definitions is a normal client pattern, and those
+        breakpoints count toward the provider's four-block limit. Three of them plus
+        our two would be five, which Anthropic rejects outright."""
+        monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+        assert self._points(tools=self._tools(3, cached=True)) == []
+
+    def test_injects_when_tools_carry_no_cache_control(self, monkeypatch):
+        """Tools alone must not suppress injection; only client-marked ones do."""
+        monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+        assert [p["index"] for p in self._points(tools=self._tools(3, cached=False))] == [None, -1]
+
+    @pytest.mark.parametrize("tools", [None, []])
+    def test_absent_tools_do_not_suppress_injection(self, monkeypatch, tools):
+        monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+        assert [p["index"] for p in self._points(tools=tools)] == [None, -1]
+
+    def test_seed_stands_down_when_only_tools_carry_cache_control(self, monkeypatch):
+        """Same guard on the /chat/completions seeding path."""
+        monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+        params: dict = {}
+        AnthropicCacheControlHook.maybe_seed_default_injection_points(
+            non_default_params=params,
+            messages=copy.deepcopy(self.MESSAGES),
+            model="claude-sonnet-4-5",
+            custom_llm_provider="anthropic",
+            tools=self._tools(3, cached=True),
+        )
+        assert "cache_control_injection_points" not in params
+
+    def test_v1_messages_stands_down_when_only_tools_carry_cache_control(self, monkeypatch):
+        """Same guard on the /v1/messages path, where tools reach the hook directly."""
+        monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+        messages = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+        result_msgs, result_sys = AnthropicCacheControlHook.maybe_inject_cache_control(
+            copy.deepcopy(messages),
+            "sys",
+            {},
+            model="claude-sonnet-4-5",
+            custom_llm_provider="anthropic",
+            tools=self._tools(3, cached=True),
+        )
+        assert result_sys == "sys"
+        assert result_msgs == messages
 
     def test_default_ttl_is_anthropics_five_minute_cache(self, monkeypatch):
         monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)

--- a/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
+++ b/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
@@ -1533,3 +1533,139 @@ class TestApplyToAnthropicMessagesRequest:
         sys_blocks = sum(1 for b in (result_sys or []) if isinstance(b, dict) and b.get("cache_control") is not None)
         total_blocks = sys_blocks + sum(AnthropicCacheControlHook._count_cache_control_blocks(m) for m in result_msgs)
         assert total_blocks <= 4
+
+
+class TestEnableAnthropicPromptCaching:
+    """Auto-injected default breakpoints via litellm.enable_anthropic_prompt_caching."""
+
+    MESSAGES: List[AllMessageValues] = [
+        {"role": "system", "content": "a long system prompt"},
+        {"role": "user", "content": "first turn"},
+        {"role": "assistant", "content": "a reply"},
+        {"role": "user", "content": "latest turn"},
+    ]
+
+    def _points(self, model="claude-sonnet-4-5", provider="anthropic", messages=None, system=None):
+        return AnthropicCacheControlHook.get_default_injection_points(
+            messages=copy.deepcopy(self.MESSAGES) if messages is None else messages,
+            system=system,
+            model=model,
+            custom_llm_provider=provider,
+        )
+
+    def test_disabled_by_default(self):
+        assert litellm.enable_anthropic_prompt_caching is False
+        assert self._points() == []
+
+    def test_injects_system_and_trailing_turn(self, monkeypatch):
+        monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+        assert self._points() == [
+            {"location": "message", "role": "system", "index": None, "control": {"type": "ephemeral"}},
+            {"location": "message", "role": None, "index": -1, "control": {"type": "ephemeral"}},
+        ]
+
+    def test_bedrock_claude_is_injected(self, monkeypatch):
+        monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+        points = self._points(model="us.anthropic.claude-sonnet-4-5-20250929-v1:0", provider="bedrock")
+        assert [p["index"] for p in points] == [None, -1]
+
+    @pytest.mark.parametrize("model, provider", [("gpt-4o", "openai"), ("gemini-2.0-flash", "gemini")])
+    def test_non_anthropic_providers_never_injected(self, monkeypatch, model, provider):
+        """These report supports_prompt_caching=True but never consume cache_control markers."""
+        from litellm.utils import supports_prompt_caching
+
+        monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+        assert supports_prompt_caching(model=model, custom_llm_provider=provider) is True
+        assert self._points(model=model, provider=provider) == []
+
+    def test_model_without_caching_support_not_injected(self, monkeypatch):
+        monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+        assert self._points(model="anthropic.claude-3-5-sonnet-20240620-v1:0", provider="bedrock") == []
+
+    def test_stands_down_when_client_sent_cache_control(self, monkeypatch):
+        monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+        messages = [
+            {"role": "system", "content": [{"type": "text", "text": "s", "cache_control": {"type": "ephemeral"}}]},
+            {"role": "user", "content": "latest turn"},
+        ]
+        assert self._points(messages=messages) == []
+
+    def test_stands_down_when_system_block_has_cache_control(self, monkeypatch):
+        monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+        system = [{"type": "text", "text": "s", "cache_control": {"type": "ephemeral"}}]
+        assert self._points(messages=[{"role": "user", "content": "hi"}], system=system) == []
+
+    def test_default_ttl_is_anthropics_five_minute_cache(self, monkeypatch):
+        monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+        assert all(p["control"] == {"type": "ephemeral"} for p in self._points())
+
+    @pytest.mark.parametrize("ttl", ["5m", "1h"])
+    def test_ttl_override_applied(self, monkeypatch, ttl):
+        monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+        monkeypatch.setattr(litellm, "anthropic_prompt_caching_ttl", ttl)
+        assert all(p["control"] == {"type": "ephemeral", "ttl": ttl} for p in self._points())
+
+    def test_seed_does_not_override_configured_points(self, monkeypatch):
+        monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+        configured = [{"location": "message", "role": "user", "index": 0}]
+        params = {"cache_control_injection_points": configured}
+        AnthropicCacheControlHook.maybe_seed_default_injection_points(
+            non_default_params=params,
+            messages=copy.deepcopy(self.MESSAGES),
+            model="claude-sonnet-4-5",
+            custom_llm_provider="anthropic",
+        )
+        assert params["cache_control_injection_points"] is configured
+
+    def test_seed_adds_defaults_when_enabled(self, monkeypatch):
+        monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+        params: dict = {}
+        AnthropicCacheControlHook.maybe_seed_default_injection_points(
+            non_default_params=params,
+            messages=copy.deepcopy(self.MESSAGES),
+            model="claude-sonnet-4-5",
+            custom_llm_provider="anthropic",
+        )
+        assert [p["index"] for p in params["cache_control_injection_points"]] == [None, -1]
+
+    def test_seed_is_noop_when_disabled(self):
+        params: dict = {}
+        AnthropicCacheControlHook.maybe_seed_default_injection_points(
+            non_default_params=params,
+            messages=copy.deepcopy(self.MESSAGES),
+            model="claude-sonnet-4-5",
+            custom_llm_provider="anthropic",
+        )
+        assert params == {}
+
+    def test_v1_messages_applies_defaults_end_to_end(self, monkeypatch):
+        monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "first"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": "reply"}]},
+            {"role": "user", "content": [{"type": "text", "text": "latest"}]},
+        ]
+        result_msgs, result_sys = AnthropicCacheControlHook.maybe_inject_cache_control(
+            messages,
+            "a system prompt",
+            {},
+            model="claude-sonnet-4-5",
+            custom_llm_provider="anthropic",
+        )
+
+        assert result_sys == [{"type": "text", "text": "a system prompt", "cache_control": {"type": "ephemeral"}}]
+        assert result_msgs[-1]["content"][-1]["cache_control"] == {"type": "ephemeral"}
+        assert "cache_control" not in result_msgs[0]["content"][-1]
+
+    def test_v1_messages_is_noop_when_disabled(self):
+        messages = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+        result_msgs, result_sys = AnthropicCacheControlHook.maybe_inject_cache_control(
+            messages,
+            "sys",
+            {},
+            model="claude-sonnet-4-5",
+            custom_llm_provider="anthropic",
+        )
+
+        assert result_sys == "sys"
+        assert result_msgs == messages

--- a/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
+++ b/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
@@ -2,7 +2,9 @@ import copy
 import datetime
 import json
 import os
+import subprocess
 import sys
+import textwrap
 import unittest
 from typing import List, Optional, Tuple
 from unittest.mock import ANY, MagicMock, Mock, patch
@@ -1669,3 +1671,53 @@ class TestEnableAnthropicPromptCaching:
 
         assert result_sys == "sys"
         assert result_msgs == messages
+
+
+class TestAnthropicPromptCachingEnvVars:
+    """Both settings are read from the environment at import, so an admin can enable
+    auto-caching without a config file. Each case re-imports litellm in a subprocess
+    so the env is read fresh without contaminating this process's module graph.
+    """
+
+    @staticmethod
+    def _import_litellm_with_env(env_override: dict) -> Tuple[bool, Optional[str]]:
+        env = os.environ.copy()
+        env.pop("LITELLM_ENABLE_ANTHROPIC_PROMPT_CACHING", None)
+        env.pop("LITELLM_ANTHROPIC_PROMPT_CACHING_TTL", None)
+        env.update(env_override)
+        script = textwrap.dedent(
+            """
+            import json, litellm
+            print(json.dumps([litellm.enable_anthropic_prompt_caching, litellm.anthropic_prompt_caching_ttl]))
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True, env=env, timeout=300
+        )
+        assert result.returncode == 0, result.stderr
+        enabled, ttl = json.loads(result.stdout.strip().splitlines()[-1])
+        return enabled, ttl
+
+    def test_unset_env_leaves_auto_caching_off(self):
+        assert self._import_litellm_with_env({}) == (False, None)
+
+    @pytest.mark.parametrize("value", ["true", "True", "TRUE"])
+    def test_env_enables_auto_caching_case_insensitively(self, value):
+        enabled, _ = self._import_litellm_with_env({"LITELLM_ENABLE_ANTHROPIC_PROMPT_CACHING": value})
+        assert enabled is True
+
+    @pytest.mark.parametrize("value", ["false", "0", "yes", ""])
+    def test_env_only_enables_on_true(self, value):
+        enabled, _ = self._import_litellm_with_env({"LITELLM_ENABLE_ANTHROPIC_PROMPT_CACHING": value})
+        assert enabled is False
+
+    @pytest.mark.parametrize("value", ["5m", "1h"])
+    def test_ttl_env_is_applied(self, value):
+        _, ttl = self._import_litellm_with_env({"LITELLM_ANTHROPIC_PROMPT_CACHING_TTL": value})
+        assert ttl == value
+
+    @pytest.mark.parametrize("value", ["10m", "1H", "3600", "ephemeral"])
+    def test_unsupported_ttl_env_falls_back_to_provider_default(self, value):
+        """An unparseable TTL must fall back to Anthropic's 5m default, never reach the provider verbatim."""
+        _, ttl = self._import_litellm_with_env({"LITELLM_ANTHROPIC_PROMPT_CACHING_TTL": value})
+        assert ttl is None

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -21871,6 +21871,11 @@ export interface components {
         /** ChatCompletionCachedContent */
         ChatCompletionCachedContent: {
             /**
+             * Ttl
+             * @enum {string}
+             */
+            ttl?: "5m" | "1h";
+            /**
              * Type
              * @constant
              */


### PR DESCRIPTION
## Relevant issues

- The issue: Anthropic only caches a prompt when the request carries explicit `cache_control` breakpoints, unlike OpenAI where prompt caching is automatic. Clients such as Claude Code and Claude Desktop never set them, so Anthropic traffic through the proxy silently pays full price on every repeated prefix. The only way to get caching was for an admin to hand-write `cache_control_injection_points` into each model's `litellm_params`, a recipe that is easy to miss and that end users cannot apply themselves
- The fix: an opt-in `enable_anthropic_prompt_caching` flag, settable from a config file or an environment variable (and from the Admin UI in #33581). When it is on, litellm injects a default pair of breakpoints covering the system prompt and the trailing turn for Anthropic and Bedrock Claude models, and stands down entirely when the request already carries its own `cache_control`. Default is off, so no existing deployment changes behavior

## Linear ticket

Resolves LIT-4478

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on localhost:4000 against the real Anthropic API, one Anthropic model and a system prompt of roughly 7.9k tokens, sent twice so the second call can hit the cache

```yaml
model_list:
  - model_name: claude-sonnet
    litellm_params:
      model: anthropic/claude-sonnet-5
      api_key: os.environ/ANTHROPIC_API_KEY

general_settings:
  master_key: sk-1234

litellm_settings:
  enable_anthropic_prompt_caching: false   # flipped to true for the "after" run
```

### Before (`enable_anthropic_prompt_caching: false`, today's default behavior)

Every call re-reads the same 7940 token prefix at full price and nothing is ever cached, on either surface

```bash
curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" -d @cc.json | jq -c '.usage | {prompt_tokens, cache_creation:.cache_creation_input_tokens, cache_read:.cache_read_input_tokens}'
{"prompt_tokens":7940,"cache_creation":0,"cache_read":0}   # call 1
{"prompt_tokens":7940,"cache_creation":0,"cache_read":0}   # call 2

curl -s http://localhost:4000/v1/messages -H "x-api-key: sk-1234" -H "anthropic-version: 2023-06-01" \
  -H "Content-Type: application/json" -d @msg.json | jq -c '.usage'
{"input_tokens":7940,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,...}   # call 1
{"input_tokens":7940,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,...}   # call 2
```

### After (`enable_anthropic_prompt_caching: true`)

`/v1/chat/completions` writes the cache on the first call and reads it back on the second

```bash
curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" -d @cc.json | jq -c '.usage | {prompt_tokens, cache_creation:.cache_creation_input_tokens, cache_read:.cache_read_input_tokens, cached:.prompt_tokens_details.cached_tokens}'
{"prompt_tokens":7940,"cache_creation":7938,"cache_read":0,"cached":0}      # call 1, cache written
{"prompt_tokens":7940,"cache_creation":0,"cache_read":7938,"cached":7938}   # call 2, cache hit
```

`/v1/messages` (the surface Claude Code and Claude Desktop use) against a cold prefix, same result

```bash
curl -s http://localhost:4000/v1/messages -H "x-api-key: sk-1234" -H "anthropic-version: 2023-06-01" \
  -H "Content-Type: application/json" -d @msg2.json | jq -c '.usage | {input_tokens, cache_creation_input_tokens, cache_read_input_tokens}'
{"input_tokens":2,"cache_creation_input_tokens":7677,"cache_read_input_tokens":0}   # call 1, cache written
{"input_tokens":2,"cache_creation_input_tokens":0,"cache_read_input_tokens":7677}   # call 2, cache hit
```

When the client sends its own `cache_control`, the flag stands down and the client's breakpoint drives the cache, so nothing is double-injected

```bash
curl -s http://localhost:4000/v1/messages -H "x-api-key: sk-1234" -H "anthropic-version: 2023-06-01" \
  -H "Content-Type: application/json" -d @msg_client_cc.json | jq -c '.usage | {input_tokens, cache_creation_input_tokens, cache_read_input_tokens}'
{"input_tokens":12,"cache_creation_input_tokens":0,"cache_read_input_tokens":7667}
```

### Spend, straight from the spend logs

The same rows show why this matters, and confirm the cache tokens reach the spend log for both surfaces, which is what the Logs UI request drawer already renders

```
call_type          | prompt_tokens | cache_creation | cache_read | spend
anthropic_messages | 7679          | 0              | 7667       | 0.001597
anthropic_messages | 7679          | 0              | 7677       | 0.001579
anthropic_messages | 7679          | 7677           | 0          | 0.019237
acompletion        | 7940          | 0              | 7938       | 0.001632
acompletion        | 7940          | 7938           | 0          | 0.019889
anthropic_messages | 7940          | 0              | 0          | 0.015920   <- flag off, no caching
```

An uncached call costs 0.015920, a cache write costs 0.019889 (the documented 1.25x premium for the 5 minute cache) and every subsequent cache read costs 0.001632, roughly 90% less. The flag pays for itself after a single repeat

### Environment variables

The flag can also be turned on without a config file, for deployments that template the environment instead. Same config as above with `litellm_settings` omitted entirely, so the environment is the only thing that can enable caching

Anthropic was intermittently returning `overloaded_error` while this was captured and was not serving cache reads for any request, including ones sent straight to `api.anthropic.com` with client-supplied `cache_control` and litellm entirely out of the loop, so these runs show the write side only. The read side is covered by the runs above

```bash
# env var unset, nothing else changed
curl -s http://localhost:4000/v1/messages -H "x-api-key: sk-1234" -H "anthropic-version: 2023-06-01" \
  -H "Content-Type: application/json" -d @msg.json | jq -c '.usage | {input_tokens, cache_creation_input_tokens, cache_read_input_tokens}'
{"input_tokens":13669,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}   # no caching, full price

# LITELLM_ENABLE_ANTHROPIC_PROMPT_CACHING=true, same config file, nothing else changed
{"input_tokens":2,"cache_creation_input_tokens":13667,"cache_read_input_tokens":0}   # cache written
```

`litellm_settings` still wins when both are set, since the config is applied after import

```bash
# LITELLM_ENABLE_ANTHROPIC_PROMPT_CACHING=false, with enable_anthropic_prompt_caching: true in the config
{"input_tokens":2,"cache_creation_input_tokens":13667}   # config wins, caching stays on
```

## Type

🆕 New Feature

## Changes

Anthropic only caches a prompt when the request carries explicit `cache_control` breakpoints, unlike OpenAI where prompt caching is automatic and needs no configuration. litellm can already inject those breakpoints server-side, but only when an admin hand-writes `cache_control_injection_points` into a model's `litellm_params` or into `router_settings.default_litellm_params`. Clients such as Claude Code and Claude Desktop never set `cache_control` themselves and the admin recipe is easy to miss, so Anthropic traffic through the proxy silently pays full price on every repeated prefix

This adds an opt-in `litellm_settings` flag, `enable_anthropic_prompt_caching`. When it is on, and the request has no injection points configured and no client-supplied `cache_control`, litellm synthesizes a default pair of breakpoints covering the system prompt and the trailing turn, so the stable prefix stays cached while the breakpoint advances with the conversation. Both surfaces are wired to one helper: `/chat/completions` seeds the points just before the existing prompt-management gate, and `/v1/messages` resolves them inside `maybe_inject_cache_control`. The existing `AnthropicCacheControlHook` then applies them unchanged, so the four-block cap and its refusal to overwrite client breakpoints both still hold

The default is off, so no existing deployment changes behavior. Injection is gated to the providers that actually consume `cache_control` markers, meaning `anthropic` and `bedrock`, and to models the cost map flags as supporting prompt caching. `supports_prompt_caching` on its own is not a sufficient gate: OpenAI, Azure and Gemini report it too, but they do not treat `cache_control` the way Anthropic does. A real openai.com host strips the marker, so injecting there is a harmless no-op, while Vertex and Google AI Studio Gemini consume it and convert it into Gemini context caching, which is a different mechanism with its own semantics and cost profile. Gating on that field alone would therefore silently switch on another provider's caching behind a flag named for Anthropic, which is why the provider check sits alongside it. Claude on `vertex_ai` is deliberately left out for now, because Gemini on Vertex reports the same capability while using a different caching mechanism, and separating them needs a model-level check worth doing on its own

The default ttl is Anthropic's 5 minute ephemeral cache, which is both their API default and what Claude Code uses, with an optional `anthropic_prompt_caching_ttl` of `"5m"` or `"1h"` for long agentic sessions. 1h doubles the write premium instead of the 1.25x above, so it is opt-in rather than the default. `ttl` is also added to `ChatCompletionCachedContent`, a field the bedrock and anthropic transforms already read at runtime but the type never declared

Both settings can also be set from the environment, with `LITELLM_ENABLE_ANTHROPIC_PROMPT_CACHING` and `LITELLM_ANTHROPIC_PROMPT_CACHING_TTL`, so a deployment that templates env vars rather than a config file can turn this on without one. `litellm_settings` wins over the environment when both are present, because the config is applied after import. An unsupported ttl value falls back to the provider default instead of reaching the provider verbatim

## A note on cache sharing

Worth stating explicitly, since this flag makes it apply to everyone rather than only to callers who opted in themselves.

Provider prompt caching is not per end user. The provider caches a prefix against the upstream credentials that sent it, and any request repeating that prefix exactly reuses it. That sharing is the point, and it is what makes this worth turning on: a long system prompt cached by one user is reused by everyone else on the same credentials. The consequence is that a caller who reproduces a prefix exactly can tell that someone else on those credentials sent it recently, because the response reports `cache_read_input_tokens` and a cache hit is also faster.

None of that is new behavior. It is how Anthropic prompt caching works, it applies today to anyone who sets `cache_control` themselves or configures `cache_control_injection_points`, and hiding the usage fields would not change it because the latency difference carries the same signal. What this flag changes is the population: with it off, a client that never sends `cache_control` has nothing cached, so nothing about it is observable; with it on, every request through the gateway is cached and therefore observable. The exposure is bounded by the fact that a prefix must be reproduced exactly and providers will not cache a prefix below a minimum size (model-dependent for Anthropic, currently 1k to 4k tokens), so it reveals whether a prompt the caller already holds was recently sent, rather than revealing its contents.

The isolation boundary is the provider account, which is not something the gateway can synthesize; separate credentials per tenant is the only real answer. So this stays an operator decision, and the flag is off by default. The setting description and the env var docs both state it, and the [auto-inject checkpoints doc](https://docs.litellm.ai/docs/tutorials/prompt_caching) now carries a section on it, since the behavior predates this PR and was not documented anywhere.

## QA runbook

1. Point a config at any Anthropic or Bedrock Claude model and leave `enable_anthropic_prompt_caching` unset. Send the same large prompt (it must clear the provider's minimum cacheable prefix, up to 4k tokens on current Anthropic models, or nothing will cache) twice to `/v1/chat/completions` and to `/v1/messages`, and confirm `cache_creation_input_tokens` and `cache_read_input_tokens` stay at 0
2. Set `enable_anthropic_prompt_caching: true` under `litellm_settings`, restart, and repeat. The first call should report `cache_creation_input_tokens` greater than 0 and the second should report `cache_read_input_tokens` greater than 0
3. Send a request that already carries its own `cache_control` and confirm the breakpoint count does not grow and the client's own TTL is preserved
4. Send traffic to an OpenAI or Gemini model with the flag on and confirm no `cache_control` appears in the outgoing request
5. Set `anthropic_prompt_caching_ttl: "1h"` and confirm `cache_creation.ephemeral_1h_input_tokens` is what moves
6. Open http://localhost:4000/ui/?page=logs, click one of the requests from step 2, and confirm the Metrics card shows Cache Read Tokens and Cache Creation Tokens
7. Remove the flag from the config, restart with `LITELLM_ENABLE_ANTHROPIC_PROMPT_CACHING=true` in the environment, and confirm caching engages exactly as in step 2

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR






<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes outbound request shaping and billing-related caching behavior for Anthropic/Bedrock when enabled; mitigated by default-off, provider/model gating, and stand-down when clients supply cache_control.
> 
> **Overview**
> Adds an **opt-in** `enable_anthropic_prompt_caching` setting (config, env `LITELLM_ENABLE_ANTHROPIC_PROMPT_CACHING`, default **off**) plus optional `anthropic_prompt_caching_ttl` (`5m` / `1h`) so LiteLLM can inject Anthropic `cache_control` breakpoints without per-model `cache_control_injection_points`.
> 
> When enabled, `AnthropicCacheControlHook` synthesizes two default breakpoints (system + last message) for **anthropic** and **bedrock** models that support prompt caching, and **stands down** if the client already set `cache_control` on messages, system, or tools. `/chat/completions` seeds `cache_control_injection_points` before prompt-management hooks; `/v1/messages` resolves defaults inside `maybe_inject_cache_control`. `ChatCompletionCachedContent` gains an optional `ttl` field; tests cover gating, tool stand-down, and env parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53c285a94a233ddb99781a197d36faa5690e3bb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->