### PR TITLE
feat(ui): configure Anthropic automatic prompt caching from the Admin UI

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1517,6 +1517,12 @@ LITELLM_SETTINGS_SAFE_DB_OVERRIDES = [
     "cost_discount_config",
     "cost_margin_config",
     "budget_exceeded_throttle_percentage",
+    # Every field editable from the Admin UI (proxy_server._GENERAL_SETTINGS_UI_LITELLM_FIELDS)
+    # must be listed here so a DB write from one worker overrides the live litellm attribute on
+    # the others when config reloads; otherwise peer workers stay on their startup value.
+    # test_general_settings_ui_fields_are_db_overridable enforces that pairing.
+    "enable_anthropic_prompt_caching",
+    "anthropic_prompt_caching_ttl",
 ]
 SPECIAL_LITELLM_AUTH_TOKEN = ["ui-token"]
 DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL = int(os.getenv("DEFAULT_MANAGEMENT_OBJECT_IN_MEMORY_CACHE_TTL", 60))

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1011,10 +1011,10 @@ class LiteLLM_ObjectPermissionBase(LiteLLMPydanticObjectBase):
     mcp_tool_search_enabled: Optional[bool] = None
 
 
+from litellm.models.team import BudgetLimitEntry as BudgetLimitEntry  # noqa: E402
 from litellm.types.object_permission import (  # noqa: E402
     ObjectPermissionDict as ObjectPermissionDict,
 )
-from litellm.models.team import BudgetLimitEntry as BudgetLimitEntry  # noqa: E402
 
 
 class GenerateRequestBase(LiteLLMPydanticObjectBase):
@@ -2122,6 +2122,7 @@ class ConfigList(LiteLLMPydanticObjectBase):
     field_default_value: Any
     premium_field: bool = False
     nested_fields: Optional[List[FieldDetail]] = None  # For nested dictionary or Pydantic fields
+    field_options: Optional[list[str]] = None  # Allowed values, for field_type == "Select"
 
 
 class UserHeaderMapping(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2123,6 +2123,7 @@ class ConfigList(LiteLLMPydanticObjectBase):
     premium_field: bool = False
     nested_fields: Optional[List[FieldDetail]] = None  # For nested dictionary or Pydantic fields
     field_options: Optional[list[str]] = None  # Allowed values, for field_type == "Select"
+    field_tab: Optional[str] = None  # Admin UI sub-tab this field renders under; None groups it with the rest
 
 
 class UserHeaderMapping(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -14826,7 +14826,11 @@ _GENERAL_SETTINGS_UI_LITELLM_FIELDS: dict[str, GeneralSettingsUILiteLLMFieldSpec
             "Automatically add Anthropic cache_control breakpoints to the system prompt and the "
             "trailing turn, for Anthropic and Bedrock Claude models that support prompt caching. "
             "Lets clients that never set cache_control themselves still get cached prompts. "
-            "Requests that already carry their own cache_control are left untouched."
+            "Requests that already carry their own cache_control are left untouched. "
+            "The provider caches a prefix against the upstream credentials that sent it, not per "
+            "end user, so this makes every caller's prompts cacheable on that shared account. "
+            "Leave this off if callers sharing a set of credentials must not learn whether "
+            "another caller recently sent a given prompt."
         ),
     },
     "anthropic_prompt_caching_ttl": {

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -14825,25 +14825,15 @@ _GENERAL_SETTINGS_UI_LITELLM_FIELDS: dict[str, GeneralSettingsUILiteLLMFieldSpec
         "type": "Boolean",
         "tab": "prompt_caching",
         "description": (
-            "Automatically add Anthropic cache_control breakpoints to the system prompt and the "
-            "trailing turn, for Anthropic and Bedrock Claude models that support prompt caching. "
-            "Lets clients that never set cache_control themselves still get cached prompts. "
-            "Requests that already carry their own cache_control are left untouched. "
-            "The provider caches a prefix against the upstream credentials that sent it, not per "
-            "end user, so this makes every caller's prompts cacheable on that shared account. "
-            "Leave this off if callers sharing a set of credentials must not learn whether "
-            "another caller recently sent a given prompt."
+            "Auto-adds cache_control to the system prompt and trailing turn for supported Anthropic "
+            "and Bedrock Claude models. The cache is shared across callers on the same upstream credentials."
         ),
     },
     "anthropic_prompt_caching_ttl": {
         "type": "Select",
         "options": ("5m", "1h"),
         "tab": "prompt_caching",
-        "description": (
-            "Cache lifetime for the breakpoints added by 'enable_anthropic_prompt_caching'. "
-            "Leave empty for Anthropic's 5m default. 1h suits long agentic sessions but doubles "
-            "the cache write premium."
-        ),
+        "description": "Empty uses Anthropic's 5m default. 1h suits long sessions but doubles the cache write cost.",
     },
 }
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -28,6 +28,7 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    TypedDict,
     Union,
     cast,
     get_args,
@@ -39,6 +40,7 @@ import anyio
 import websockets
 import websockets.exceptions
 from pydantic import BaseModel, Json, JsonValue
+from typing_extensions import NotRequired, assert_never
 
 from litellm._uuid import uuid
 from litellm.constants import (
@@ -363,14 +365,14 @@ from litellm.proxy.management_endpoints.cache_settings_endpoints import (
 from litellm.proxy.management_endpoints.callback_management_endpoints import (
     router as callback_management_endpoints_router,
 )
-from litellm.proxy.management_endpoints.coordination_redis_endpoints import (
-    get_persisted_coordination_redis_settings,
-    router as coordination_redis_settings_router,
-)
 from litellm.proxy.management_endpoints.common_utils import (
     _user_has_admin_privileges,
     _user_has_admin_view,
     admin_can_invite_user,
+)
+from litellm.proxy.management_endpoints.coordination_redis_endpoints import (
+    get_persisted_coordination_redis_settings,
+    router as coordination_redis_settings_router,
 )
 from litellm.proxy.management_endpoints.cost_tracking_settings import (
     router as cost_tracking_settings_router,
@@ -14800,7 +14802,16 @@ async def get_config_general_settings(
             )
 
 
-_GENERAL_SETTINGS_UI_LITELLM_FIELDS: dict[str, dict[str, str]] = {
+GeneralSettingsUILiteLLMValue = Union[float, bool, str, None]
+
+
+class GeneralSettingsUILiteLLMFieldSpec(TypedDict):
+    type: Literal["Float", "Boolean", "Select"]
+    description: str
+    options: NotRequired[tuple[str, ...]]
+
+
+_GENERAL_SETTINGS_UI_LITELLM_FIELDS: dict[str, GeneralSettingsUILiteLLMFieldSpec] = {
     "budget_exceeded_throttle_percentage": {
         "type": "Float",
         "description": (
@@ -14809,18 +14820,64 @@ _GENERAL_SETTINGS_UI_LITELLM_FIELDS: dict[str, dict[str, str]] = {
             "over-budget keys."
         ),
     },
+    "enable_anthropic_prompt_caching": {
+        "type": "Boolean",
+        "description": (
+            "Automatically add Anthropic cache_control breakpoints to the system prompt and the "
+            "trailing turn, for Anthropic and Bedrock Claude models that support prompt caching. "
+            "Lets clients that never set cache_control themselves still get cached prompts. "
+            "Requests that already carry their own cache_control are left untouched."
+        ),
+    },
+    "anthropic_prompt_caching_ttl": {
+        "type": "Select",
+        "options": ("5m", "1h"),
+        "description": (
+            "Cache lifetime for the breakpoints added by 'enable_anthropic_prompt_caching'. "
+            "Leave empty for Anthropic's 5m default. 1h suits long agentic sessions but doubles "
+            "the cache write premium."
+        ),
+    },
 }
 
 
-def _validate_general_settings_ui_litellm_value(field_name: str, value: Any) -> Optional[float]:
+def _general_settings_ui_litellm_default(
+    field_type: Literal["Float", "Boolean", "Select"],
+) -> GeneralSettingsUILiteLLMValue:
+    """The value a field falls back to when it is cleared or reset."""
+    return False if field_type == "Boolean" else None
+
+
+def _validate_general_settings_ui_litellm_value(field_name: str, value: Any) -> GeneralSettingsUILiteLLMValue:
+    spec = _GENERAL_SETTINGS_UI_LITELLM_FIELDS[field_name]
+    field_type = spec["type"]
     if value is None or value == "":
-        return None
-    if isinstance(value, bool) or not isinstance(value, (int, float)) or not (0 < float(value) <= 1):
-        raise HTTPException(
-            status_code=400,
-            detail={"error": f"{field_name} must be a number in (0, 1] or empty"},
-        )
-    return float(value)
+        return _general_settings_ui_litellm_default(field_type)
+    match field_type:
+        case "Boolean":
+            if not isinstance(value, bool):
+                raise HTTPException(
+                    status_code=400,
+                    detail={"error": f"{field_name} must be true or false"},
+                )
+            return value
+        case "Select":
+            options = spec.get("options", ())
+            if value not in options:
+                raise HTTPException(
+                    status_code=400,
+                    detail={"error": f"{field_name} must be one of: {', '.join(options)}, or empty"},
+                )
+            return cast(str, value)  # cast-ok: membership in options proves it is one of the option strings
+        case "Float":
+            if isinstance(value, bool) or not isinstance(value, (int, float)) or not (0 < float(value) <= 1):
+                raise HTTPException(
+                    status_code=400,
+                    detail={"error": f"{field_name} must be a number in (0, 1] or empty"},
+                )
+            return float(value)
+        case _:
+            assert_never(field_type)
 
 
 async def _persist_general_settings_ui_litellm_field(
@@ -14841,11 +14898,12 @@ async def _persist_general_settings_ui_litellm_field(
 async def _reset_general_settings_ui_litellm_field(field_name: str, user_api_key_dict: UserAPIKeyAuth) -> dict:
     config = await proxy_config.get_config()
     before_value = config.get("litellm_settings", {}).get(field_name)
-    setattr(litellm, field_name, None)
+    default_value = _general_settings_ui_litellm_default(_GENERAL_SETTINGS_UI_LITELLM_FIELDS[field_name]["type"])
+    setattr(litellm, field_name, default_value)
     if "litellm_settings" in config:
         config["litellm_settings"].pop(field_name, None)
     await proxy_config.save_config(new_config=config)
-    asyncio.create_task(create_config_audit_log(field_name, "deleted", before_value, None, user_api_key_dict))
+    asyncio.create_task(create_config_audit_log(field_name, "deleted", before_value, default_value, user_api_key_dict))
     return {"message": f"Field {field_name} reset", "status": "success"}
 
 
@@ -15013,11 +15071,12 @@ async def get_config_list(
         else {}
     )
     for litellm_field_name, spec in _GENERAL_SETTINGS_UI_LITELLM_FIELDS.items():
-        current_value: Optional[float] = getattr(litellm, litellm_field_name, None)
+        current_value: GeneralSettingsUILiteLLMValue = getattr(litellm, litellm_field_name, None)
+        default_value = _general_settings_ui_litellm_default(spec["type"])
         stored_in_db_litellm: Optional[bool]
         if litellm_field_name in db_litellm_settings:
             stored_in_db_litellm = True
-        elif current_value is not None:
+        elif current_value != default_value:
             stored_in_db_litellm = False
         else:
             stored_in_db_litellm = None
@@ -15028,7 +15087,8 @@ async def get_config_list(
                 field_description=spec["description"],
                 field_value=current_value,
                 stored_in_db=stored_in_db_litellm,
-                field_default_value=None,
+                field_default_value=default_value,
+                field_options=list(spec.get("options", ())) or None,
                 nested_fields=None,
             )
         )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -14809,6 +14809,7 @@ class GeneralSettingsUILiteLLMFieldSpec(TypedDict):
     type: Literal["Float", "Boolean", "Select"]
     description: str
     options: NotRequired[tuple[str, ...]]
+    tab: NotRequired[str]  # Admin UI sub-tab this field renders under; None groups it with the rest
 
 
 _GENERAL_SETTINGS_UI_LITELLM_FIELDS: dict[str, GeneralSettingsUILiteLLMFieldSpec] = {
@@ -14822,6 +14823,7 @@ _GENERAL_SETTINGS_UI_LITELLM_FIELDS: dict[str, GeneralSettingsUILiteLLMFieldSpec
     },
     "enable_anthropic_prompt_caching": {
         "type": "Boolean",
+        "tab": "prompt_caching",
         "description": (
             "Automatically add Anthropic cache_control breakpoints to the system prompt and the "
             "trailing turn, for Anthropic and Bedrock Claude models that support prompt caching. "
@@ -14836,6 +14838,7 @@ _GENERAL_SETTINGS_UI_LITELLM_FIELDS: dict[str, GeneralSettingsUILiteLLMFieldSpec
     "anthropic_prompt_caching_ttl": {
         "type": "Select",
         "options": ("5m", "1h"),
+        "tab": "prompt_caching",
         "description": (
             "Cache lifetime for the breakpoints added by 'enable_anthropic_prompt_caching'. "
             "Leave empty for Anthropic's 5m default. 1h suits long agentic sessions but doubles "
@@ -15093,6 +15096,7 @@ async def get_config_list(
                 stored_in_db=stored_in_db_litellm,
                 field_default_value=default_value,
                 field_options=list(spec.get("options", ())) or None,
+                field_tab=spec.get("tab"),
                 nested_fields=None,
             )
         )

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -8984,6 +8984,210 @@ async def test_update_config_field_throttle_persists_to_litellm_settings(monkeyp
     assert saved["litellm_settings"]["budget_exceeded_throttle_percentage"] == 0.1
 
 
+def test_get_config_list_includes_anthropic_prompt_caching_fields(monkeypatch):
+    """The auto prompt caching flag and its ttl are litellm_settings globals surfaced on the
+    General Settings table, so an admin can turn caching on without hand-writing config. The
+    ttl is a Select and must ship its allowed values, or the table renders no editor for it."""
+    import types
+    from unittest.mock import AsyncMock, MagicMock
+
+    from fastapi.testclient import TestClient
+
+    import litellm.proxy.proxy_server as ps
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.proxy_server import app
+
+    mock_prisma = MagicMock()
+    mock_config_table = MagicMock()
+    mock_config_table.find_first = AsyncMock(return_value=None)
+    mock_prisma.db = types.SimpleNamespace(litellm_config=mock_config_table)
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+    monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", True)
+    monkeypatch.setattr(litellm, "anthropic_prompt_caching_ttl", "1h")
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN
+    )
+    try:
+        client = TestClient(app)
+        resp = client.get("/config/list", params={"config_type": "general_settings"})
+        assert resp.status_code == 200, resp.text
+        fields = {item["field_name"]: item for item in resp.json()}
+
+        assert fields["enable_anthropic_prompt_caching"]["field_type"] == "Boolean"
+        assert fields["enable_anthropic_prompt_caching"]["field_value"] is True
+
+        assert fields["anthropic_prompt_caching_ttl"]["field_type"] == "Select"
+        assert fields["anthropic_prompt_caching_ttl"]["field_value"] == "1h"
+        assert fields["anthropic_prompt_caching_ttl"]["field_options"] == ["5m", "1h"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_get_config_list_marks_untouched_prompt_caching_flag_as_not_set(monkeypatch):
+    """The flag defaults to False rather than None, so a plain 'is not None' check would
+    report the default as 'In Config' and imply an admin had set it."""
+    import types
+    from unittest.mock import AsyncMock, MagicMock
+
+    from fastapi.testclient import TestClient
+
+    import litellm.proxy.proxy_server as ps
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.proxy_server import app
+
+    mock_prisma = MagicMock()
+    mock_config_table = MagicMock()
+    mock_config_table.find_first = AsyncMock(return_value=None)
+    mock_prisma.db = types.SimpleNamespace(litellm_config=mock_config_table)
+    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
+    monkeypatch.setattr(litellm, "enable_anthropic_prompt_caching", False)
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN
+    )
+    try:
+        client = TestClient(app)
+        resp = client.get("/config/list", params={"config_type": "general_settings"})
+        fields = {item["field_name"]: item for item in resp.json()}
+        assert fields["enable_anthropic_prompt_caching"]["stored_in_db"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.parametrize(
+    "field_name, field_value",
+    [
+        ("enable_anthropic_prompt_caching", True),
+        ("enable_anthropic_prompt_caching", False),
+        ("anthropic_prompt_caching_ttl", "5m"),
+        ("anthropic_prompt_caching_ttl", "1h"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_update_config_field_prompt_caching_persists_to_litellm_settings(monkeypatch, field_name, field_value):
+    """Toggling either row must set litellm.<attr> live and persist under litellm_settings,
+    so the running proxy caches immediately and still does after a restart."""
+    from unittest.mock import MagicMock
+
+    import litellm.proxy.proxy_server as ps
+    from litellm.proxy._types import (
+        ConfigFieldUpdate,
+        LitellmUserRoles,
+        UserAPIKeyAuth,
+    )
+    from litellm.proxy.proxy_server import update_config_general_settings
+
+    saved: dict = {}
+
+    async def fake_get_config():
+        return {"litellm_settings": {}}
+
+    async def fake_save_config(new_config=None):
+        saved.update(new_config or {})
+
+    monkeypatch.setattr(ps.proxy_config, "get_config", fake_get_config)
+    monkeypatch.setattr(ps.proxy_config, "save_config", fake_save_config)
+    monkeypatch.setattr(ps, "prisma_client", MagicMock())
+    monkeypatch.setattr(litellm, "store_audit_logs", False)
+    monkeypatch.setattr(litellm, field_name, None)
+
+    admin = UserAPIKeyAuth(api_key="k", user_id="a", user_role=LitellmUserRoles.PROXY_ADMIN)
+    await update_config_general_settings(
+        data=ConfigFieldUpdate(field_name=field_name, field_value=field_value, config_type="general_settings"),
+        user_api_key_dict=admin,
+    )
+
+    assert getattr(litellm, field_name) == field_value
+    assert saved["litellm_settings"][field_name] == field_value
+
+
+@pytest.mark.parametrize(
+    "field_name, bad_value",
+    [
+        ("enable_anthropic_prompt_caching", "yes"),
+        ("enable_anthropic_prompt_caching", 1),
+        ("anthropic_prompt_caching_ttl", "10m"),
+        ("anthropic_prompt_caching_ttl", "1H"),
+        ("anthropic_prompt_caching_ttl", 3600),
+    ],
+)
+@pytest.mark.asyncio
+async def test_update_config_field_prompt_caching_rejects_invalid(monkeypatch, field_name, bad_value):
+    """An unsupported ttl must be refused here rather than reaching Anthropic verbatim."""
+    from unittest.mock import MagicMock
+
+    from fastapi import HTTPException
+
+    import litellm.proxy.proxy_server as ps
+    from litellm.proxy._types import (
+        ConfigFieldUpdate,
+        LitellmUserRoles,
+        UserAPIKeyAuth,
+    )
+    from litellm.proxy.proxy_server import update_config_general_settings
+
+    async def fake_get_config():
+        return {"litellm_settings": {}}
+
+    monkeypatch.setattr(ps.proxy_config, "get_config", fake_get_config)
+    monkeypatch.setattr(ps, "prisma_client", MagicMock())
+    monkeypatch.setattr(litellm, field_name, None)
+
+    admin = UserAPIKeyAuth(api_key="k", user_id="a", user_role=LitellmUserRoles.PROXY_ADMIN)
+    with pytest.raises(HTTPException) as exc:
+        await update_config_general_settings(
+            data=ConfigFieldUpdate(field_name=field_name, field_value=bad_value, config_type="general_settings"),
+            user_api_key_dict=admin,
+        )
+    assert exc.value.status_code == 400
+    assert getattr(litellm, field_name) is None
+
+
+@pytest.mark.parametrize(
+    "field_name, expected_default",
+    [
+        ("enable_anthropic_prompt_caching", False),
+        ("anthropic_prompt_caching_ttl", None),
+        ("budget_exceeded_throttle_percentage", None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_reset_config_field_restores_type_default(monkeypatch, field_name, expected_default):
+    """Reset must restore each field's own default. Blanket None would leave the boolean flag
+    set to None, which is not a bool and would read as neither on nor off."""
+    from unittest.mock import MagicMock
+
+    import litellm.proxy.proxy_server as ps
+    from litellm.proxy._types import (
+        ConfigFieldDelete,
+        LitellmUserRoles,
+        UserAPIKeyAuth,
+    )
+    from litellm.proxy.proxy_server import delete_config_general_settings
+
+    saved: dict = {}
+
+    async def fake_get_config():
+        return {"litellm_settings": {field_name: "stale"}}
+
+    async def fake_save_config(new_config=None):
+        saved.update(new_config or {})
+
+    monkeypatch.setattr(ps.proxy_config, "get_config", fake_get_config)
+    monkeypatch.setattr(ps.proxy_config, "save_config", fake_save_config)
+    monkeypatch.setattr(ps, "prisma_client", MagicMock())
+    monkeypatch.setattr(litellm, "store_audit_logs", False)
+    monkeypatch.setattr(litellm, field_name, "stale")
+
+    admin = UserAPIKeyAuth(api_key="k", user_id="a", user_role=LitellmUserRoles.PROXY_ADMIN)
+    await delete_config_general_settings(
+        data=ConfigFieldDelete(field_name=field_name, config_type="general_settings"),
+        user_api_key_dict=admin,
+    )
+
+    assert getattr(litellm, field_name) is expected_default
+    assert field_name not in saved["litellm_settings"]
+
+
 @pytest.mark.parametrize("bad_value", [0, -0.1, 1.5, True])
 @pytest.mark.asyncio
 async def test_update_config_field_throttle_rejects_invalid(monkeypatch, bad_value):

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -9019,6 +9019,12 @@ def test_get_config_list_includes_anthropic_prompt_caching_fields(monkeypatch):
         assert fields["anthropic_prompt_caching_ttl"]["field_type"] == "Select"
         assert fields["anthropic_prompt_caching_ttl"]["field_value"] == "1h"
         assert fields["anthropic_prompt_caching_ttl"]["field_options"] == ["5m", "1h"]
+
+        # Both caching fields carry their sub-tab so the Admin UI can render them on a
+        # dedicated Prompt Caching tab, while ungrouped fields stay on General.
+        assert fields["enable_anthropic_prompt_caching"]["field_tab"] == "prompt_caching"
+        assert fields["anthropic_prompt_caching_ttl"]["field_tab"] == "prompt_caching"
+        assert fields["budget_exceeded_throttle_percentage"]["field_tab"] is None
     finally:
         app.dependency_overrides.clear()
 

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -9029,6 +9029,51 @@ def test_get_config_list_includes_anthropic_prompt_caching_fields(monkeypatch):
         app.dependency_overrides.clear()
 
 
+def test_general_settings_ui_fields_are_db_overridable():
+    """Every field the Admin UI can edit is a `litellm.<attr>` set via setattr on the handling
+    worker (`_persist_general_settings_ui_litellm_field`). Unless it is also in
+    LITELLM_SETTINGS_SAFE_DB_OVERRIDES, a config reload on a peer worker merges the DB value but
+    never applies it to the live attribute, so peer workers stay on their startup value.
+
+    This invariant is the guard against the two registries drifting: adding a UI-editable field
+    without enrolling it in the DB-override allowlist silently breaks cross-worker propagation.
+    """
+    from litellm.constants import LITELLM_SETTINGS_SAFE_DB_OVERRIDES
+    from litellm.proxy.proxy_server import _GENERAL_SETTINGS_UI_LITELLM_FIELDS
+
+    missing = set(_GENERAL_SETTINGS_UI_LITELLM_FIELDS) - set(LITELLM_SETTINGS_SAFE_DB_OVERRIDES)
+    assert not missing, (
+        f"UI-editable litellm_settings fields missing from LITELLM_SETTINGS_SAFE_DB_OVERRIDES: {sorted(missing)}. "
+        "Add them, or they will not propagate to other workers when changed from the UI."
+    )
+
+
+@pytest.mark.parametrize(
+    "field_name, db_value",
+    [
+        ("enable_anthropic_prompt_caching", True),
+        ("anthropic_prompt_caching_ttl", "1h"),
+    ],
+)
+def test_prompt_caching_settings_propagate_on_config_reload(monkeypatch, field_name, db_value):
+    """A UI toggle on one worker persists to the DB; a peer worker picks it up only when the
+    config reload applies the safe-override allowlist. Regression for the fields being absent
+    from that allowlist, which left peer workers stale."""
+    import litellm.proxy.proxy_server as ps
+
+    # peer worker booted with the opposite/absent value
+    monkeypatch.setattr(litellm, field_name, False if isinstance(db_value, bool) else None)
+
+    pc = ps.ProxyConfig()
+    pc._update_config_fields(
+        current_config={"litellm_settings": {}},
+        param_name="litellm_settings",
+        db_param_value={field_name: db_value},
+    )
+
+    assert getattr(litellm, field_name) == db_value
+
+
 def test_get_config_list_marks_untouched_prompt_caching_flag_as_not_set(monkeypatch):
     """The flag defaults to False rather than None, so a plain 'is not None' check would
     report the default as 'In Config' and imply an admin had set it."""

--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -1079,7 +1079,7 @@
   },
   "src/app/(dashboard)/router-settings/_components/general_settings.tsx": {
     "no-nested-ternary": {
-      "count": 3
+      "count": 1
     },
     "no-restricted-imports": {
       "count": 2

--- a/ui/litellm-dashboard/src/app/(dashboard)/router-settings/_components/general_settings.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/router-settings/_components/general_settings.tsx
@@ -14,7 +14,7 @@ import {
 } from "@tremor/react";
 import { TabPanel, TabPanels, TabGroup, TabList, Tab } from "@tremor/react";
 import { getGeneralSettingsCall, updateConfigFieldSetting, deleteConfigFieldSetting } from "@/components/networking";
-import { InputNumber } from "antd";
+import { InputNumber, Select as AntdSelect } from "antd";
 import { TrashIcon } from "@heroicons/react/outline";
 import { StatusBadge } from "@/components/shared/table_cells";
 
@@ -33,6 +33,7 @@ interface generalSettingsItem {
   field_value: any;
   field_description: string;
   stored_in_db: boolean | null;
+  field_options?: string[] | null;
 }
 
 const GeneralSettings: React.FC<GeneralSettingsPageProps> = ({ accessToken, userRole, userID }) => {
@@ -168,6 +169,18 @@ const GeneralSettings: React.FC<GeneralSettingsPageProps> = ({ accessToken, user
                               step={0.05}
                               value={value.field_value}
                               onChange={(newValue) => handleInputChange(value.field_name, newValue)}
+                            />
+                          ) : value.field_type == "Select" ? (
+                            <AntdSelect
+                              allowClear
+                              style={{ minWidth: "8rem" }}
+                              placeholder="Default"
+                              value={value.field_value || undefined}
+                              options={(value.field_options ?? []).map((option) => ({
+                                label: option,
+                                value: option,
+                              }))}
+                              onChange={(newValue) => handleInputChange(value.field_name, newValue ?? "")}
                             />
                           ) : null}
                         </TableCell>

--- a/ui/litellm-dashboard/src/app/(dashboard)/router-settings/_components/general_settings.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/router-settings/_components/general_settings.tsx
@@ -7,6 +7,7 @@ import {
   TableHeaderCell,
   TableCell,
   TableBody,
+  Title,
   Text,
   Button,
   Icon,
@@ -21,6 +22,11 @@ import { StatusBadge } from "@/components/shared/table_cells";
 import RouterSettings from "@/components/router_settings";
 import Fallbacks from "@/components/Settings/RouterSettings/Fallbacks/Fallbacks";
 import RoutingGroups from "@/components/routing_groups";
+
+const PROMPT_CACHING_TAB = "prompt_caching";
+const ENABLE_ANTHROPIC_PROMPT_CACHING = "enable_anthropic_prompt_caching";
+const ANTHROPIC_PROMPT_CACHING_TTL = "anthropic_prompt_caching_ttl";
+
 interface GeneralSettingsPageProps {
   accessToken: string | null;
   userRole: string | null;
@@ -34,6 +40,7 @@ interface generalSettingsItem {
   field_description: string;
   stored_in_db: boolean | null;
   field_options?: string[] | null;
+  field_tab?: string | null;
 }
 
 const SettingValueEditor: React.FC<{
@@ -81,6 +88,71 @@ const SettingValueEditor: React.FC<{
     );
   }
   return null;
+};
+
+const PromptCachingPanel: React.FC<{
+  accessToken: string;
+  settings: generalSettingsItem[];
+  onChange: (fieldName: string, newValue: any) => void;
+}> = ({ accessToken, settings, onChange }) => {
+  const enableSetting = settings.find((s) => s.field_name === ENABLE_ANTHROPIC_PROMPT_CACHING);
+  const ttlSetting = settings.find((s) => s.field_name === ANTHROPIC_PROMPT_CACHING_TTL);
+
+  // The two rows come from the same registry the General tab reads; if they
+  // are not loaded yet there is nothing to render.
+  if (!enableSetting) {
+    return null;
+  }
+
+  const enabled = enableSetting.field_value === true || enableSetting.field_value === "true";
+
+  // Apply immediately: a toggle and a dropdown are direct controls, so there is
+  // no separate Update button. Clearing the ttl resets it to the provider default.
+  const persist = (fieldName: string, value: any) => {
+    onChange(fieldName, value);
+    if (value === "" || value === null || value === undefined) {
+      deleteConfigFieldSetting(accessToken, fieldName);
+    } else {
+      updateConfigFieldSetting(accessToken, fieldName, value);
+    }
+  };
+
+  return (
+    <Card>
+      <Title>Prompt Caching</Title>
+      <Text className="mt-2">
+        Automatically inject Anthropic prompt caching for every Anthropic and Bedrock Claude model, so clients that
+        never set <span className="font-mono">cache_control</span> themselves still get cached prompts. This is a single
+        gateway-wide switch; there is no per-model setup.
+      </Text>
+
+      <div className="mt-6 flex items-start justify-between gap-8">
+        <div className="max-w-2xl">
+          <Text className="font-medium">Automatic Anthropic prompt caching</Text>
+          <p className="mt-1 text-xs text-gray-500">{enableSetting.field_description}</p>
+        </div>
+        <Switch checked={enabled} onChange={(checked) => persist(ENABLE_ANTHROPIC_PROMPT_CACHING, checked)} />
+      </div>
+
+      {ttlSetting && (
+        <div className="mt-6 flex items-start justify-between gap-8">
+          <div className="max-w-2xl">
+            <Text className={`font-medium ${enabled ? "" : "text-gray-400"}`}>Cache lifetime (TTL)</Text>
+            <p className="mt-1 text-xs text-gray-500">{ttlSetting.field_description}</p>
+          </div>
+          <AntdSelect
+            allowClear
+            disabled={!enabled}
+            style={{ minWidth: "10rem" }}
+            placeholder="5m (default)"
+            value={ttlSetting.field_value || undefined}
+            options={(ttlSetting.field_options ?? []).map((option) => ({ label: option, value: option }))}
+            onChange={(newValue) => persist(ANTHROPIC_PROMPT_CACHING_TTL, newValue ?? "")}
+          />
+        </div>
+      )}
+    </Card>
+  );
 };
 
 const GeneralSettings: React.FC<GeneralSettingsPageProps> = ({ accessToken, userRole, userID }) => {
@@ -156,6 +228,7 @@ const GeneralSettings: React.FC<GeneralSettingsPageProps> = ({ accessToken, user
           <Tab value="1">Loadbalancing</Tab>
           <Tab value="2">Routing Groups</Tab>
           <Tab value="3">Fallbacks</Tab>
+          <Tab value="5">Prompt Caching</Tab>
           <Tab value="4">General</Tab>
         </TabList>
         <TabPanels className="px-8 py-6">
@@ -167,6 +240,9 @@ const GeneralSettings: React.FC<GeneralSettingsPageProps> = ({ accessToken, user
           </TabPanel>
           <TabPanel>
             <Fallbacks accessToken={accessToken} userRole={userRole} userID={userID} />
+          </TabPanel>
+          <TabPanel>
+            <PromptCachingPanel accessToken={accessToken} settings={generalSettings} onChange={handleInputChange} />
           </TabPanel>
           <TabPanel>
             <Card>
@@ -181,7 +257,7 @@ const GeneralSettings: React.FC<GeneralSettingsPageProps> = ({ accessToken, user
                 </TableHead>
                 <TableBody>
                   {generalSettings
-                    .filter((value) => value.field_type !== "TypedDictionary")
+                    .filter((value) => value.field_type !== "TypedDictionary" && value.field_tab !== PROMPT_CACHING_TAB)
                     .map((value, index) => (
                       <TableRow key={index}>
                         <TableCell>

--- a/ui/litellm-dashboard/src/app/(dashboard)/router-settings/_components/general_settings.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/router-settings/_components/general_settings.tsx
@@ -36,6 +36,53 @@ interface generalSettingsItem {
   field_options?: string[] | null;
 }
 
+const SettingValueEditor: React.FC<{
+  setting: generalSettingsItem;
+  onChange: (fieldName: string, newValue: any) => void;
+}> = ({ setting, onChange }) => {
+  if (setting.field_type === "Integer") {
+    return (
+      <InputNumber
+        step={1}
+        value={setting.field_value}
+        onChange={(newValue) => onChange(setting.field_name, newValue)}
+      />
+    );
+  }
+  if (setting.field_type === "Boolean") {
+    return (
+      <Switch
+        checked={setting.field_value === true || setting.field_value === "true"}
+        onChange={(checked) => onChange(setting.field_name, checked)}
+      />
+    );
+  }
+  if (setting.field_type === "Float") {
+    return (
+      <InputNumber
+        min={0}
+        max={1}
+        step={0.05}
+        value={setting.field_value}
+        onChange={(newValue) => onChange(setting.field_name, newValue)}
+      />
+    );
+  }
+  if (setting.field_type === "Select") {
+    return (
+      <AntdSelect
+        allowClear
+        style={{ minWidth: "8rem" }}
+        placeholder="Default"
+        value={setting.field_value || undefined}
+        options={(setting.field_options ?? []).map((option) => ({ label: option, value: option }))}
+        onChange={(newValue) => onChange(setting.field_name, newValue ?? "")}
+      />
+    );
+  }
+  return null;
+};
+
 const GeneralSettings: React.FC<GeneralSettingsPageProps> = ({ accessToken, userRole, userID }) => {
   const [generalSettings, setGeneralSettings] = useState<generalSettingsItem[]>([]);
 
@@ -151,38 +198,7 @@ const GeneralSettings: React.FC<GeneralSettingsPageProps> = ({ accessToken, user
                           </p>
                         </TableCell>
                         <TableCell>
-                          {value.field_type == "Integer" ? (
-                            <InputNumber
-                              step={1}
-                              value={value.field_value}
-                              onChange={(newValue) => handleInputChange(value.field_name, newValue)}
-                            />
-                          ) : value.field_type == "Boolean" ? (
-                            <Switch
-                              checked={value.field_value === true || value.field_value === "true"}
-                              onChange={(checked) => handleInputChange(value.field_name, checked)}
-                            />
-                          ) : value.field_type == "Float" ? (
-                            <InputNumber
-                              min={0}
-                              max={1}
-                              step={0.05}
-                              value={value.field_value}
-                              onChange={(newValue) => handleInputChange(value.field_name, newValue)}
-                            />
-                          ) : value.field_type == "Select" ? (
-                            <AntdSelect
-                              allowClear
-                              style={{ minWidth: "8rem" }}
-                              placeholder="Default"
-                              value={value.field_value || undefined}
-                              options={(value.field_options ?? []).map((option) => ({
-                                label: option,
-                                value: option,
-                              }))}
-                              onChange={(newValue) => handleInputChange(value.field_name, newValue ?? "")}
-                            />
-                          ) : null}
+                          <SettingValueEditor setting={value} onChange={handleInputChange} />
                         </TableCell>
                         <TableCell>
                           {value.stored_in_db == true ? (

--- a/ui/litellm-dashboard/src/app/(dashboard)/router-settings/_components/general_settings.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/router-settings/_components/general_settings.tsx
@@ -120,11 +120,6 @@ const PromptCachingPanel: React.FC<{
   return (
     <Card>
       <Title>Prompt Caching</Title>
-      <Text className="mt-2">
-        Automatically inject Anthropic prompt caching for every Anthropic and Bedrock Claude model, so clients that
-        never set <span className="font-mono">cache_control</span> themselves still get cached prompts. This is a single
-        gateway-wide switch; there is no per-model setup.
-      </Text>
 
       <div className="mt-6 flex items-start justify-between gap-8">
         <div className="max-w-2xl">

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -22713,6 +22713,8 @@ export interface components {
             field_name: string;
             /** Field Options */
             field_options?: string[] | null;
+            /** Field Tab */
+            field_tab?: string | null;
             /** Field Type */
             field_type: string;
             /** Field Value */

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -22711,6 +22711,8 @@ export interface components {
             field_description: string;
             /** Field Name */
             field_name: string;
+            /** Field Options */
+            field_options?: string[] | null;
             /** Field Type */
             field_type: string;
             /** Field Value */


### PR DESCRIPTION
## Relevant issues

- The issue: `enable_anthropic_prompt_caching` and its ttl are `litellm_settings` globals, so the only way to turn automatic Anthropic prompt caching on was to hand-write config, which is the recipe the flag set out to replace. Support has been filing tickets to flip caching settings on customer instances because there is no equivalent surface in the UI.
- The fix: a dedicated Prompt Caching tab under Router Settings, with a labeled toggle for the flag and a dropdown for the ttl, so an admin turns caching on and picks the ttl from the UI. The existing update, persist and reset plumbing carries both into `litellm_settings` and onto the live `litellm.<attr>`, so caching starts on the next request without a restart. Each field carries a `tab` in the registry (surfaced as `field_tab` on `ConfigList`) so the General tab shows the ungrouped fields and the caching fields render on their own tab; `field_options` on `ConfigList` gives the ttl dropdown its allowed values

Stacked on #33573, which adds the flag itself. Merge that first; this PR only exposes it

## Linear ticket

Resolves LIT-4478

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix
https://github.com/user-attachments/assets/0843458c-da41-42cb-b386-962668aa7847

Live proxy on localhost:4000 against the real Anthropic API, backed by a real DB so the config endpoints are live. The flag is set nowhere: not in the config file, not in the environment. Everything below drives the exact endpoints the Prompt Caching tab calls

Both settings arrive from the config list, the ttl carrying its allowed values so the tab can render its dropdown

```bash
curl -s "http://localhost:4000/config/list?config_type=general_settings" -H "Authorization: Bearer sk-1234" \
  | jq -c '.[] | select(.field_name|test("anthropic_prompt_caching")) | {field_name, field_type, field_value, field_options, stored_in_db}'
{"field_name":"enable_anthropic_prompt_caching","field_type":"Boolean","field_value":false,"field_options":null,"stored_in_db":null}
{"field_name":"anthropic_prompt_caching_ttl","field_type":"Select","field_value":null,"field_options":["5m","1h"],"stored_in_db":null}
```

Toggling the switch on caches immediately, in the same proxy process, with no restart. A ~13.6k token prefix goes from full price to cached

```bash
# before, flag off as shipped
curl -s http://localhost:4000/v1/messages -H "x-api-key: sk-1234" -H "anthropic-version: 2023-06-01" \
  -H "Content-Type: application/json" -d @msg.json | jq -c '.usage | {input_tokens, cache_creation_input_tokens}'
{"input_tokens":13669,"cache_creation_input_tokens":0}

# the switch, i.e. what the Update button posts
curl -s -X POST http://localhost:4000/config/field/update -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"field_name":"enable_anthropic_prompt_caching","field_value":true,"config_type":"general_settings"}'
{"message":"Field enable_anthropic_prompt_caching updated","status":"success"}

# after, same process, no restart
{"input_tokens":2,"cache_creation_input_tokens":13667}
```

Picking `1h` in the ttl Select moves the write onto Anthropic's 1 hour cache rather than the 5 minute one, which is the knob long agentic sessions actually need

```bash
curl -s -X POST http://localhost:4000/config/field/update -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"field_name":"anthropic_prompt_caching_ttl","field_value":"1h","config_type":"general_settings"}'
{"cache_creation_input_tokens":13667,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":13667}}
```

An unsupported ttl is refused at the gateway instead of reaching Anthropic verbatim

```bash
curl -s -X POST http://localhost:4000/config/field/update -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"field_name":"anthropic_prompt_caching_ttl","field_value":"10m","config_type":"general_settings"}'
{"detail":{"error":"anthropic_prompt_caching_ttl must be one of: 5m, 1h, or empty"}}
```

Reset returns the flag to its real default, rather than leaving the boolean as `None`

```bash
curl -s -X POST http://localhost:4000/config/field/delete -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"field_name":"enable_anthropic_prompt_caching","config_type":"general_settings"}'
{"message":"Field enable_anthropic_prompt_caching reset","status":"success"}
{"field_value":false,"stored_in_db":null}
```

In the Admin UI these same endpoints are driven from a dedicated Prompt Caching tab under Router Settings (http://localhost:4000/ui/?page=router-settings): a toggle for the flag and a ttl dropdown that is disabled until the toggle is on. The click-through is in the QA runbook below.

(Earlier screenshots in this PR showed the first design, where these lived as rows on the General settings table with In DB / In Config / Not Set badges; that was replaced by the dedicated tab, so those images have been removed as stale.)

## Type

🆕 New Feature

## Changes

`enable_anthropic_prompt_caching` and its `anthropic_prompt_caching_ttl` are `litellm_settings` globals, so today the only way to turn automatic Anthropic prompt caching on is to hand-write config, which is the recipe this whole feature set out to replace. Support has been filing tickets to flip caching settings on customer instances because there was no equivalent surface in the UI

Both are registered in `_GENERAL_SETTINGS_UI_LITELLM_FIELDS`, tagged with a `tab` so they render on a dedicated Prompt Caching tab (a purpose-built toggle and dropdown, not the generic settings table) rather than mixed in with the other global limits. The existing update, persist and reset plumbing carries them into `litellm_settings` and onto the live `litellm.<attr>`, so caching starts on the next request, with no restart. `ConfigList` gains an optional `field_tab` that the frontend uses to route each field to its tab, and `field_options` that gives the ttl dropdown its allowed values

The flag is a Boolean and the table already renders that as a switch. The ttl is an enum, and the table only knew Integer, Boolean and Float, falling through to no editor at all for anything else. Rather than special casing this one field, `ConfigList` now carries an optional `field_options` and the table renders a `Select` for `field_type == "Select"`, so any future enum setting gets an editor for free. Clearing it sends an empty value, which resolves back to the provider default

Three things the registry could not previously express, all of which this needed:

`_validate_general_settings_ui_litellm_value` was hardcoded to a float in (0, 1], the shape of the one field that existed. It now dispatches on the field's declared type, so a Boolean rejects `"yes"` and `1`, and a Select rejects any value outside its options. The Float path is unchanged and its existing tests still pass

`_reset_general_settings_ui_litellm_field` set every field to `None`. For a boolean flag that is not a bool and reads as neither on nor off, so reset now restores each field's own declared default, `False` for a Boolean and `None` otherwise

The listing reported `stored_in_db=False`, rendered as "In Config", for any field whose value was not `None`. A boolean that defaults to `False` would therefore always claim an admin had configured it. It now compares against the field's default, which is equivalent to the old check for the existing Float field and correct for the new ones

## Cross-worker propagation

These two settings are set as live `litellm.<attr>` values on the worker that handles the UI save, the same way `budget_exceeded_throttle_percentage` is. That sibling field is in `LITELLM_SETTINGS_SAFE_DB_OVERRIDES`, which is what makes a config reload apply the DB value to the live attribute on other workers; these two were missing from it, so a peer worker merged the DB value but stayed on its startup value. This PR adds both to that allowlist so they behave like the sibling, and adds `test_general_settings_ui_fields_are_db_overridable`, which asserts every UI-editable field is enrolled so the two lists cannot drift again (that drift is exactly what caused the bug).

One pre-existing gap remains, shared with `budget_exceeded_throttle_percentage` and not specific to caching: the safe-override reapply runs on `get_config`, not on the periodic worker poll, so allowlisted `litellm_settings` converge when a worker next reloads config rather than on a timer. Config-file and env-var configuration are unaffected (applied to every worker at boot). Tracked in LIT-4567.

## QA runbook

1. Point a config at any Anthropic or Bedrock Claude model, leave `enable_anthropic_prompt_caching` out of the config and the environment entirely, and start the proxy with a DB
2. Open http://localhost:4000/ui/?page=router-settings and select the Prompt Caching tab. Confirm a toggle for automatic Anthropic prompt caching and a ttl dropdown offering only `5m` and `1h` (the dropdown is disabled until the toggle is on). Confirm these two settings no longer appear on the General tab
3. Send a large prompt (it must clear the provider's minimum cacheable prefix, up to 4k tokens on current Anthropic models, or nothing will cache) to `/v1/messages` and confirm `cache_creation_input_tokens` is 0
4. Turn the toggle on (the tab applies immediately; there is no separate Update button) and, without restarting, confirm `cache_creation_input_tokens` is now greater than 0; a second identical call reports `cache_read_input_tokens`
5. Set the ttl dropdown to `1h` and confirm `usage.cache_creation.ephemeral_1h_input_tokens` is what moves. Clear it and confirm the write returns to `ephemeral_5m_input_tokens`
6. Turn the toggle off and confirm caching stops
7. Confirm the `budget_exceeded_throttle_percentage` row still accepts a value in (0, 1] and still rejects 0 and 1.5

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


Link to Devin session: https://app.devin.ai/sessions/58dc3285dc2b44bbbebffc4ecfc41362



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global `litellm_settings` and live `litellm` attributes that affect Anthropic/Bedrock caching on all requests; multi-worker behavior depends on the safe-override allowlist staying in sync with UI fields.
> 
> **Overview**
> Adds **Admin UI control** for `enable_anthropic_prompt_caching` and `anthropic_prompt_caching_ttl`, wired through the same general-settings persist/reset flow so changes apply live on `litellm.<attr>` and in `litellm_settings` without a restart.
> 
> The proxy **general-settings registry** grows typed specs (Boolean, Float, Select) with optional `tab` and `options`; `/config/list` exposes `field_tab` and `field_options`, validation is type-aware, reset restores per-type defaults (e.g. `False` for booleans), and `stored_in_db` compares against those defaults. Both caching fields are added to **`LITELLM_SETTINGS_SAFE_DB_OVERRIDES`** so peer workers pick up UI saves on config reload, with a test that UI fields stay enrolled in that allowlist.
> 
> The dashboard gets a **Prompt Caching** tab under Router Settings (toggle + TTL select with immediate save), a shared `SettingValueEditor` including Select support, and caching fields are hidden from the General table via `field_tab`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47ba9e76121dd7dbf572e112d7df5ebad5414bac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

