### PR TITLE
fix(mcp): stop preemptively 401-challenging client_credentials (M2M) MCP servers

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -3577,6 +3577,11 @@ if MCP_AVAILABLE:
         """
         for server_name in mcp_servers or []:
             server = global_mcp_server_manager.get_mcp_server_by_name(server_name, client_ip=client_ip)
+            if server is not None:
+                # Same request-time oauth2_flow backstop the listing and tool-call
+                # paths apply, so the challenge classifies a null-flow M2M-shape row
+                # exactly as egress will.
+                server = MCPServerManager.resolve_oauth2_flow_for_request(server)
             if server is not None and allowed_server_ids is not None and server.server_id not in allowed_server_ids:
                 # Caller's narrowed scope excludes this server — skip the
                 # preemptive challenge and let downstream authorization
@@ -3587,25 +3592,26 @@ if MCP_AVAILABLE:
                 # a stored token actually exists for this user+server pair.
                 # If no stored token exists, fail fast with 401 so clients can
                 # kick off PKCE/interactive OAuth flow immediately.
-                if server.needs_user_oauth_token:
-                    if getattr(server, "delegate_auth_to_upstream", False) is True:
-                        # Delegate-auth servers run upstream PKCE: challenge with
-                        # the proxied resource_metadata (RFC 9728), not the
-                        # gateway authorization_uri below which would authorize
-                        # against the gateway instead of the upstream IdP.
-                        www_authenticate = _get_passthrough_www_authenticate(
-                            scope=scope,
-                            server_name=server_name,
-                        )
-                        raise HTTPException(
-                            status_code=401,
-                            detail="Unauthorized",
-                            headers={"www-authenticate": www_authenticate},
-                        )
-                    # The v2 resolver owns the existence check, so every authorization_code
-                    # resolution (egress and this discovery challenge) runs through it.
-                    if await global_mcp_server_manager.has_user_oauth_token(server, user_api_key_auth):
-                        continue
+                if not server.needs_user_oauth_token:
+                    continue
+                if getattr(server, "delegate_auth_to_upstream", False) is True:
+                    # Delegate-auth servers run upstream PKCE: challenge with
+                    # the proxied resource_metadata (RFC 9728), not the
+                    # gateway authorization_uri below which would authorize
+                    # against the gateway instead of the upstream IdP.
+                    www_authenticate = _get_passthrough_www_authenticate(
+                        scope=scope,
+                        server_name=server_name,
+                    )
+                    raise HTTPException(
+                        status_code=401,
+                        detail="Unauthorized",
+                        headers={"www-authenticate": www_authenticate},
+                    )
+                # The v2 resolver owns the existence check, so every authorization_code
+                # resolution (egress and this discovery challenge) runs through it.
+                if await global_mcp_server_manager.has_user_oauth_token(server, user_api_key_auth):
+                    continue
 
                 request = StarletteRequest(scope)
                 base_url = get_request_base_url(request)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_stale_session.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_stale_session.py
@@ -665,6 +665,101 @@ async def test_per_user_oauth_missing_stored_token_returns_preemptive_401():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "m2m_fields",
+    [
+        {"oauth2_flow": "client_credentials"},
+        {"client_id": "cid", "client_secret": "csec", "token_url": "https://idp.example.com/token"},
+    ],
+    ids=["stamped", "unstamped_m2m_shape"],
+)
+async def test_client_credentials_server_is_not_preemptively_challenged(m2m_fields):
+    """
+    An OAuth2 client_credentials (M2M) server mints its own upstream token;
+    there is no user OAuth flow to bootstrap. The connect-time gate must let
+    the request through to the session manager rather than pushing the client
+    into an interactive OAuth flow it can never complete (the per-user token
+    store is never even consulted for M2M). Covers both a stamped row and a
+    legacy null-flow row with the M2M field shape: the gate must classify the
+    flow through the same request-time backstop egress uses, or the two
+    disagree and the unstamped server is challenged for a token egress would
+    never look for.
+    """
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            handle_streamable_http_mcp,
+            session_manager_stateless,
+        )
+        from litellm.proxy._types import MCPTransport
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/mcp",
+        "scheme": "http",
+        "query_string": b"",
+        "root_path": "",
+        "server": ("localhost", 8000),
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"host", b"localhost:8000"),
+        ],
+    }
+    receive = AsyncMock(
+        return_value={
+            "type": "http.request",
+            "body": b'{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}',
+            "more_body": False,
+        }
+    )
+    send = AsyncMock()
+    user_auth = MagicMock()
+    user_auth.user_id = "test-user-id"
+    m2m_server = MCPServer(
+        server_id="m2m-server-id",
+        name="m2m_server",
+        server_name="m2m_server",
+        alias="m2m_server",
+        url="https://upstream.example.com/mcp",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2,
+        **m2m_fields,
+    )
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.extract_mcp_auth_context",
+            new_callable=AsyncMock,
+            return_value=(user_auth, None, ["m2m_server"], None, None, None),
+        ),
+        patch("litellm.proxy._experimental.mcp_server.server.set_auth_context"),
+        patch("litellm.proxy._experimental.mcp_server.server._SESSION_MANAGERS_INITIALIZED", True),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server._handle_stale_mcp_session",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager.has_user_oauth_token",
+            new_callable=AsyncMock,
+        ) as mock_has_token,
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager.get_mcp_server_by_name",
+            return_value=m2m_server,
+        ),
+        patch.object(session_manager_stateless, "handle_request", new_callable=AsyncMock) as mock_handle_request,
+        patch.object(session_manager_stateless, "_server_instances", {}),
+    ):
+        await handle_streamable_http_mcp(scope, receive, send)
+
+    assert mock_handle_request.await_count == 1
+    assert mock_has_token.await_count == 0
+
+
+@pytest.mark.asyncio
 async def test_handle_streamable_http_mcp_delegated_server_surfaces_upstream_challenge():
     """
     OAuth2 server with ``delegate_auth_to_upstream=True`` where the client


### PR DESCRIPTION
## Relevant issues

Ships the product fix that PR #33263 documents as a known failure against current main: its `test_gateway_exchanges_client_credentials_and_sends_minted_token` e2e test is the protocol-level regression guard for this bug and goes green once this lands

## Linear ticket

Part of LIT-4263 (migrate client_credentials M2M into v2); this ships the connect-time gate fix that track requires

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Rig: a local stub serving an OAuth token endpoint (client_credentials grant, counts every mint) plus an MCP streamable-HTTP mount that 401s any request whose bearer is not a token that endpoint minted. A served MCP call is therefore proof the gateway ran the grant and attached the minted token. Proxy runs against local Postgres with `--port 4001`

Register the M2M server the way a production host does:

```
curl -s -X POST http://127.0.0.1:4001/v1/mcp/server -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{
  "alias": "m2mrig", "url": "http://127.0.0.1:8765/mcp", "transport": "http", "allow_all_keys": true,
  "auth_type": "oauth2", "oauth2_flow": "client_credentials", "token_url": "http://127.0.0.1:8765/token",
  "credentials": {"client_id": "m2m-rig-client-id", "client_secret": "m2m-rig-client-secret"}}'

{"server_id": "e314c2f6-43a3-43d8-8231-0206615fdf65", "alias": "m2mrig", "auth_type": "oauth2", "oauth2_flow": "client_credentials", ...}
```

Before the fix, connecting over the MCP protocol path is dead on arrival on both routes; the gateway pushes the client into an interactive OAuth flow it can never complete, and the stub IdP records zero mint attempts:

```
curl -si -X POST http://127.0.0.1:4001/m2mrig/mcp -H "x-litellm-api-key: Bearer sk-1234" \
  -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{...}}'

HTTP/1.1 401 Unauthorized
www-authenticate: Bearer authorization_uri="http://127.0.0.1:4001/.well-known/oauth-authorization-server/m2mrig"

curl -si -X POST http://127.0.0.1:4001/mcp/ -H "x-litellm-api-key: Bearer sk-1234" -H "x-mcp-servers: m2mrig" ...same initialize...

HTTP/1.1 401 Unauthorized
www-authenticate: Bearer authorization_uri="http://127.0.0.1:4001/.well-known/oauth-authorization-server/m2mrig"
```

After the fix, the same commands complete the full flow. initialize returns a session, tools list, a tool call round-trips, and the stub proves the gateway minted exactly one token and attached it (the caller's virtual key never crossed the gateway boundary):

```
curl -si -X POST http://127.0.0.1:4001/m2mrig/mcp ...same initialize...
HTTP/1.1 200 OK
mcp-session-id: a47f24bfebdb4f19928b50e66bb63a65

curl -s ... -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
"name":"m2mrig-echo"
"name":"m2mrig-last_auth"

curl -s ... -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"m2mrig-echo","arguments":{"text":"live-m2m-proof"}}}'
data: {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"echo:live-m2m-proof"}],...,"isError":false}}

curl -s http://127.0.0.1:8765/stats
{"mints":2,"last_mcp_auth":"Bearer m2m-token-2","denied":12}   # was mints:1 before the flow; exactly one gateway mint

curl -s -X POST http://127.0.0.1:4001/mcp/ -H "x-mcp-servers: m2mrig" ...initialize... -w "%{http_code}"
200                                                            # aggregate route; mints stays 2, cached token reused
```

The interactive flow is untouched; a per-user oauth2 server with no stored token still gets the challenge:

```
curl -si -X POST http://127.0.0.1:4001/interactiverig/mcp ...same initialize...
HTTP/1.1 401 Unauthorized
www-authenticate: Bearer authorization_uri="http://127.0.0.1:4001/.well-known/oauth-authorization-server/interactiverig"
```

Legacy rows are covered too. Nulling the stored flow on an M2M-shape row (`UPDATE "LiteLLM_MCPServerTable" SET oauth2_flow = NULL WHERE alias = 'm2mlegacy'`) and restarting the proxy, initialize on `/m2mlegacy/mcp` returns 200 instead of the spurious challenge

## Type

🐛 Bug Fix

## Changes

`_raise_preemptive_401_for_unauthenticated_servers` in `litellm/proxy/_experimental/mcp_server/server.py` raised the interactive OAuth 401 for every `oauth2` server that received no per-request oauth header. The interactive logic (delegate challenge, stored-token check) was correctly nested under `needs_user_oauth_token`, but the raise sat at the outer level, so a `client_credentials` (M2M) server, for which the gateway mints its own upstream token and no user flow exists, fell through into a challenge it can never satisfy. Both the `/{alias}/mcp` route and the `/mcp` aggregate go through this function, so M2M servers were unusable over the MCP protocol path

Two changes, one invariant: a server whose credential mode requires no user participation is never preemptively challenged for user auth, and the challenge classifies a server's flow exactly as egress does. First, the `needs_user_oauth_token` branch is inverted into an early `continue`, so the 401 raise is only reachable for flows that actually need a user token. Second, the loop now applies `MCPServerManager.resolve_oauth2_flow_for_request` right after resolving the server, the same request-time backstop the listing and tool-call paths already apply, so a legacy null-flow row with the M2M field shape is treated as M2M at the challenge gate instead of being pushed into a user OAuth flow that egress would never look for

The regression test (`test_client_credentials_server_is_not_preemptively_challenged` in `tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_stale_session.py`) drives `handle_streamable_http_mcp` with a real `MCPServer` object, parametrized over a stamped `oauth2_flow="client_credentials"` row and an unstamped M2M-shape row; both must reach the session manager without the per-user token store ever being consulted. Both cases fail on the unfixed code (the stamped case with the exact 401 from the bug, the unstamped case by consulting the per-user store) and pass with the fix. The pre-existing tests pinning the interactive, delegate, and passthrough challenges all still pass

## QA runbook

1. Start a proxy with a Postgres-backed config and register an MCP server with `auth_type: oauth2`, `oauth2_flow: client_credentials`, a `token_url`, and client credentials for a real M2M upstream (any IdP-guarded MCP server works)
2. As a regular virtual key, POST an MCP `initialize` to `/{alias}/mcp` with `x-litellm-api-key: Bearer <key>`; expect HTTP 200 and an `mcp-session-id` header, not a 401 with a gateway `authorization_uri`
3. Complete the handshake (`notifications/initialized`), then `tools/list` and a `tools/call`; both must succeed and the upstream must receive the gateway-minted bearer, never your virtual key
4. Repeat step 2 against the aggregate `/mcp/` route with `x-mcp-servers: <alias>`; expect 200
5. Register a second oauth2 server with `oauth2_flow: authorization_code` and repeat step 2 against it without authorizing first; expect the 401 challenge with `authorization_uri` (interactive flow unchanged)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
