### PR TITLE
fix(bedrock): replace invalid apac. geo inference ID for Nova 2 Lite with jp.

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -293,7 +293,7 @@ class AmazonConverseConfig(BaseConfig):
         - amazon.nova-2-pro-preview-20251202-v1:0
         - us.amazon.nova-2-lite-v1:0
         - eu.amazon.nova-2-lite-v1:0
-        - apac.amazon.nova-2-lite-v1:0
+        - jp.amazon.nova-2-lite-v1:0
         - (and other regional variants)
 
         Args:
@@ -322,8 +322,8 @@ class AmazonConverseConfig(BaseConfig):
                 model_without_region = model_without_region[len(routing_prefix) :]
                 break
 
-        # Remove regional prefix if present (us., eu., apac.)
-        for prefix in ["us.", "eu.", "apac."]:
+        # Remove regional prefix if present (us., eu., apac., jp.)
+        for prefix in ["us.", "eu.", "apac.", "jp."]:
             if model_without_region.startswith(prefix):
                 model_without_region = model_without_region[len(prefix) :]
                 break

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -394,7 +394,7 @@
         "supports_video_input": true,
         "supports_vision": true
     },
-    "apac.amazon.nova-2-lite-v1:0": {
+    "jp.amazon.nova-2-lite-v1:0": {
         "cache_read_input_token_cost": 8.25e-08,
         "input_cost_per_token": 3.3e-07,
         "litellm_provider": "bedrock_converse",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -394,7 +394,7 @@
         "supports_video_input": true,
         "supports_vision": true
     },
-    "apac.amazon.nova-2-lite-v1:0": {
+    "jp.amazon.nova-2-lite-v1:0": {
         "cache_read_input_token_cost": 8.25e-08,
         "input_cost_per_token": 3.3e-07,
         "litellm_provider": "bedrock_converse",

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -3311,7 +3311,7 @@ def test_is_nova_2_model():
     # Test with regional variants
     assert config._is_nova_2_model("us.amazon.nova-2-lite-v1:0") is True
     assert config._is_nova_2_model("eu.amazon.nova-2-lite-v1:0") is True
-    assert config._is_nova_2_model("apac.amazon.nova-2-lite-v1:0") is True
+    assert config._is_nova_2_model("jp.amazon.nova-2-lite-v1:0") is True
 
     # Test with other Nova 2 variants (pro, micro)
     assert config._is_nova_2_model("amazon.nova-pro-1-5-v1:0") is False

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation_nova_2.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation_nova_2.py
@@ -202,11 +202,11 @@ class TestNova2ParameterMapping:
         assert result["reasoningConfig"]["type"] == "enabled"
         assert result["reasoningConfig"]["maxReasoningEffort"] == "low"
 
-    def test_nova_2_regional_variant_apac(self):
-        """Test that APAC regional variant of Nova 2 works correctly."""
+    def test_nova_2_regional_variant_jp(self):
+        """Test that JP regional variant of Nova 2 works correctly."""
         config = AmazonConverseConfig()
 
-        model = "apac.amazon.nova-2-lite-v1:0"
+        model = "jp.amazon.nova-2-lite-v1:0"
         non_default_params = {"reasoning_effort": "high"}
         optional_params = {}
 
@@ -295,11 +295,11 @@ class TestNova15SupportedParameters:
         # Verify thinking is NOT in supported params
         assert "thinking" not in supported_params
 
-    def test_nova_2_regional_variant_apac_supported_params(self):
-        """Test that APAC regional variant returns same supported params."""
+    def test_nova_2_regional_variant_jp_supported_params(self):
+        """Test that JP regional variant returns same supported params."""
         config = AmazonConverseConfig()
 
-        model = "apac.amazon.nova-2-lite-v1:0"
+        model = "jp.amazon.nova-2-lite-v1:0"
         supported_params = config.get_supported_openai_params(model)
 
         # Verify reasoning_effort is in supported params
@@ -605,6 +605,31 @@ class TestNova2EndToEndResponse:
 # ---------------------------------------------------------------------------
 # Multi-turn — reasoning_content round-trips back to Bedrock format
 # ---------------------------------------------------------------------------
+
+
+class TestNova2GeoInferenceIds:
+    """Regression tests for Bedrock geo inference profile IDs for Nova 2 Lite.
+
+    Covers https://github.com/BerriAI/litellm/issues/33211: the jp. prefix is the
+    correct AWS geo inference ID for the Japan region; apac. does not exist for
+    Nova 2 Lite and causes a BadRequestError from Bedrock.
+    """
+
+    def test_jp_nova_2_lite_in_model_cost(self) -> None:
+        assert "jp.amazon.nova-2-lite-v1:0" in litellm.model_cost, (
+            "jp.amazon.nova-2-lite-v1:0 must be a recognised model ID; "
+            "it is the correct Geo: JP inference profile per the AWS model card"
+        )
+
+    def test_apac_nova_2_lite_not_in_model_cost(self) -> None:
+        assert "apac.amazon.nova-2-lite-v1:0" not in litellm.model_cost, (
+            "apac.amazon.nova-2-lite-v1:0 is an invalid AWS model ID for Nova 2 Lite; "
+            "Bedrock rejects it with 'The provided model identifier is invalid'"
+        )
+
+    def test_jp_nova_2_lite_is_detected_as_nova_2(self) -> None:
+        config = AmazonConverseConfig()
+        assert config._is_nova_2_model("jp.amazon.nova-2-lite-v1:0") is True
 
 
 class TestNova2MultiTurnMessageTranslation:


### PR DESCRIPTION
## Relevant issues

Fixes #33211

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

No AWS credentials needed to reproduce the data error. Before this PR:

```python
import litellm
print("apac.amazon.nova-2-lite-v1:0" in litellm.model_cost)  # True  (wrong)
print("jp.amazon.nova-2-lite-v1:0" in litellm.model_cost)    # False (wrong)
```

After this PR:

```python
print("apac.amazon.nova-2-lite-v1:0" in litellm.model_cost)  # False
print("jp.amazon.nova-2-lite-v1:0" in litellm.model_cost)    # True
```

Callers who used `bedrock/apac.amazon.nova-2-lite-v1:0` received `BadRequestError: BedrockException - {"message":"The provided model identifier is invalid."}` from AWS. `jp.amazon.nova-2-lite-v1:0` is the correct geo inference profile per the [AWS Nova 2 Lite model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-amazon-nova-2-lite.html).

## Type

Bug Fix

## Changes

AWS Bedrock has no `apac.` cross-region inference profile for `amazon.nova-2-lite-v1:0`. The documented geo tiers are `us.`, `eu.`, `jp.`, and `global.` only. Calling `bedrock/apac.amazon.nova-2-lite-v1:0` returns a `BadRequestError` from Bedrock.

- Renamed `apac.amazon.nova-2-lite-v1:0` -> `jp.amazon.nova-2-lite-v1:0` in `model_prices_and_context_window.json` and the bundled backup JSON (same pricing data, corrected key).
- Added `jp.` to the regional prefix list in `AmazonConverseConfig._is_nova_2_model` so that `jp.amazon.nova-2-lite-v1:0` is correctly identified as a Nova 2 model.
- Updated the docstring example in `_is_nova_2_model` to use the correct ID.
- Updated two test methods in `test_converse_transformation_nova_2.py` that used the wrong model ID, and added a `TestNova2GeoInferenceIds` class with three regression tests (checking presence/absence in `model_cost` and correct Nova 2 detection via `_is_nova_2_model`).
- Updated one assertion in `test_converse_transformation.py` that used the wrong model ID.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR