### PR TITLE
fix(mcp): keep the MCP reference intact when the semantic filter narrows tools

### DIFF
--- a/litellm/proxy/hooks/mcp_semantic_filter/hook.py
+++ b/litellm/proxy/hooks/mcp_semantic_filter/hook.py
@@ -169,6 +169,12 @@ class SemanticToolFilterHook(CustomLogger):
         MCP gateway still performs the expansion. That keeps the per-endpoint tool shape
         and tool auto-execution intact. Expansion already applied any caller-supplied
         allowed_tools, so this selection can only narrow a block further.
+
+        Whether an undecidable selection exposes every tool or none is owned by
+        SemanticMCPToolFilter.filter_tools, which returns the full set when nothing
+        matches; the same policy therefore governs references and plain tools. Passing an
+        empty selection through is safe rather than a hidden allow-all: the gateway reads
+        the union of every reference's allowed_tools and treats an empty union as unset.
         """
         from litellm.responses.mcp.litellm_proxy_mcp_handler import (
             LiteLLM_Proxy_MCP_Handler,
@@ -305,10 +311,6 @@ class SemanticToolFilterHook(CustomLogger):
                 filtered_expanded_tools = await self._filter_expanded_tools(data=data, expanded_tools=expanded_tools)
 
                 selected_tool_names = self._selected_tool_names(filtered_expanded_tools)
-                if not selected_tool_names:
-                    verbose_proxy_logger.warning("Semantic filter selected no MCP tools, leaving MCP references intact")
-                    return None
-
                 narrowed_tools = self._narrow_mcp_references(tools, selected_tool_names)
                 data["tools"] = narrowed_tools
                 self._emit_filter_metadata_safe(

--- a/litellm/proxy/hooks/mcp_semantic_filter/hook.py
+++ b/litellm/proxy/hooks/mcp_semantic_filter/hook.py
@@ -155,6 +155,34 @@ class SemanticToolFilterHook(CustomLogger):
 
         return await self.filter.filter_tools(query=user_query, available_tools=expanded_tools)
 
+    def _selected_tool_names(self, filtered_tools: list[dict[str, Any]]) -> list[str]:
+        """Names of the semantically selected tools, as produced by the MCP expansion."""
+        names = (self.filter._extract_tool_info(tool)[0] for tool in filtered_tools)
+        return [name for name in names if name]
+
+    @staticmethod
+    def _narrow_mcp_references(tools: list[Any], selected_tool_names: list[str]) -> list[Any]:
+        """
+        Restrict each litellm_proxy MCP reference to the semantically selected tools.
+
+        The reference block is preserved rather than replaced with expanded tools, so the
+        MCP gateway still performs the expansion. That keeps the per-endpoint tool shape
+        and tool auto-execution intact. Expansion already applied any caller-supplied
+        allowed_tools, so this selection can only narrow a block further.
+        """
+        from litellm.responses.mcp.litellm_proxy_mcp_handler import (
+            LiteLLM_Proxy_MCP_Handler,
+        )
+
+        return [
+            (
+                {**tool, "allowed_tools": selected_tool_names}
+                if isinstance(tool, dict) and LiteLLM_Proxy_MCP_Handler._should_use_litellm_mcp_gateway([tool])
+                else tool
+            )
+            for tool in tools
+        ]
+
     def _is_mcp_tool(self, tool: object) -> bool:
         """
         Check whether *tool* is registered in the MCP semantic router.
@@ -261,36 +289,34 @@ class SemanticToolFilterHook(CustomLogger):
         if self._should_expand_mcp_tools(tools):
             verbose_proxy_logger.debug("Detected litellm_proxy MCP references, expanding before semantic filtering")
 
+            if not self.filter.enabled:
+                verbose_proxy_logger.debug("Semantic filter disabled, leaving MCP references untouched")
+                return None
+
             try:
                 native_tools_before_expand = [t for t in tools if not (isinstance(t, dict) and t.get("type") == "mcp")]
 
                 expanded_tools = await self._expand_mcp_tools(tools, user_api_key_dict)
 
                 if not expanded_tools:
-                    if native_tools_before_expand:
-                        data["tools"] = native_tools_before_expand
-                        verbose_proxy_logger.warning(
-                            f"No MCP tools expanded, preserving {len(native_tools_before_expand)} native tools"
-                        )
-                        return data
                     verbose_proxy_logger.warning("No tools expanded from MCP references")
                     return None
 
-                if not self.filter.enabled:
-                    data["tools"] = native_tools_before_expand + expanded_tools
-                    verbose_proxy_logger.debug("Semantic filter disabled, forwarding expanded MCP tools unfiltered")
-                    return data
-
                 filtered_expanded_tools = await self._filter_expanded_tools(data=data, expanded_tools=expanded_tools)
 
-                combined_tools = native_tools_before_expand + filtered_expanded_tools
-                data["tools"] = combined_tools
+                selected_tool_names = self._selected_tool_names(filtered_expanded_tools)
+                if not selected_tool_names:
+                    verbose_proxy_logger.warning("Semantic filter selected no MCP tools, leaving MCP references intact")
+                    return None
+
+                narrowed_tools = self._narrow_mcp_references(tools, selected_tool_names)
+                data["tools"] = narrowed_tools
                 self._emit_filter_metadata_safe(
                     data=data,
                     mcp_tools=expanded_tools,
                     filtered_mcp_tools=filtered_expanded_tools,
                     native_tools=native_tools_before_expand,
-                    filtered_tools=combined_tools,
+                    filtered_tools=narrowed_tools,
                 )
                 verbose_proxy_logger.info(
                     f"Expanded MCP references to {len(expanded_tools)} tools "

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -865,14 +865,17 @@ async def test_semantic_filter_hook_filters_expanded_litellm_proxy_tools():
     )
 
     assert result is not None, "Hook should return modified data"
-    filtered = result["tools"]
+    mcp_references = [tool for tool in result["tools"] if tool.get("type") == "mcp"]
+    assert len(mcp_references) == 1, "The litellm_proxy MCP reference must be preserved for the MCP gateway to expand"
 
-    assert len(filtered) <= 2, f"Expanded tools should be filtered to top_k=2, got {len(filtered)}"
-    assert len(filtered) < len(expanded_tools), (
-        f"Hook must not forward all {len(expanded_tools)} expanded tools unfiltered, got {len(filtered)}"
+    allowed_tools = mcp_references[0]["allowed_tools"]
+    assert len(allowed_tools) <= 2, f"Expanded tools should be filtered to top_k=2, got {len(allowed_tools)}"
+    assert len(allowed_tools) < len(expanded_tools), (
+        f"Hook must not forward all {len(expanded_tools)} expanded tools unfiltered, got {len(allowed_tools)}"
     )
-    for tool in filtered:
-        assert tool in expanded_tools, "Filtered tools must be the original expanded tool dicts"
+    expanded_names = {tool["name"] for tool in expanded_tools}
+    for name in allowed_tools:
+        assert name in expanded_names, "Selected tool names must come from the expanded tools"
 
     assert (
         "litellm_semantic_filter_stats" in result["metadata"]
@@ -880,9 +883,128 @@ async def test_semantic_filter_hook_filters_expanded_litellm_proxy_tools():
     stats = result["metadata"]["litellm_semantic_filter_stats"]
     total, selected = stats.split("->")
     assert int(total) == 5, f"Stats 'from' should be pre-filter expanded count (5), got {total}"
-    assert int(selected) == len(filtered), f"Stats 'to' should match post-filter count, got {selected}"
+    assert int(selected) == len(allowed_tools), f"Stats 'to' should match post-filter count, got {selected}"
 
-    print(f"✅ Expanded litellm_proxy tools filtered: {len(expanded_tools)} -> {len(filtered)}, stats={stats}")
+    print(f"✅ Expanded litellm_proxy tools filtered: {len(expanded_tools)} -> {len(allowed_tools)}, stats={stats}")
+
+
+@pytest.mark.asyncio
+async def test_semantic_filter_hook_narrows_mcp_reference_for_chat_completions():
+    """
+    Regression test (LIT-4451): the hook must narrow the litellm_proxy MCP
+    reference instead of replacing it with expanded tool definitions.
+
+    Given: A /chat/completions request whose tools are a single
+           {"type": "mcp", "server_url": "litellm_proxy"} reference that
+           expands to 5 tools, with the semantic filter selecting top_k=2
+    When:  The hook processes the request with call_type="acompletion"
+    Then:  The MCP reference survives in data["tools"], carrying the selected
+           tools in allowed_tools, and no expanded function definitions are
+           written into the request.
+
+    Replacing the reference made the hook write Responses-API-shaped tools
+    ({"type": "function", "name": ...}) into /chat/completions, which expects
+    {"type": "function", "function": {...}}. The provider transformation then
+    rejected every MCP tool (Anthropic raised KeyError: 'function') or dropped
+    it silently (Bedrock), so the model saw no MCP tools at all. Replacing the
+    reference also removed the marker the MCP gateway matches on, which
+    disabled tool auto-execution for require_approval="never".
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+    from litellm.types.utils import Embedding, EmbeddingResponse
+
+    mock_router = Mock()
+
+    def mock_embedding_sync(*args, **kwargs):
+        return EmbeddingResponse(
+            data=[Embedding(embedding=[0.1] * 1536, index=0, object="embedding")],
+            model="text-embedding-3-small",
+            object="list",
+            usage={"prompt_tokens": 10, "total_tokens": 10},
+        )
+
+    async def mock_embedding_async(*args, **kwargs):
+        return mock_embedding_sync()
+
+    mock_router.embedding = mock_embedding_sync
+    mock_router.aembedding = mock_embedding_async
+
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=mock_router,
+        top_k=2,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+
+    registry_tools = [
+        MCPTool(
+            name=f"srv-tool_{i}",
+            description=f"Registry tool {i}",
+            inputSchema={"type": "object"},
+        )
+        for i in range(5)
+    ]
+    filter_instance._build_router(registry_tools)
+
+    expanded_tools = [
+        {
+            "type": "function",
+            "name": f"srv-tool_{i}",
+            "description": f"Registry tool {i}",
+            "parameters": {"type": "object", "properties": {}},
+        }
+        for i in range(5)
+    ]
+
+    hook = SemanticToolFilterHook(filter_instance)
+    hook._expand_mcp_tools = AsyncMock(  # type: ignore[method-assign]
+        return_value=expanded_tools
+    )
+
+    mcp_reference = {
+        "type": "mcp",
+        "server_url": "litellm_proxy",
+        "require_approval": "never",
+    }
+    data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "Send an email"}],
+        "tools": [mcp_reference],
+        "metadata": {},
+    }
+
+    result = await hook.async_pre_call_hook(
+        user_api_key_dict=Mock(),
+        cache=Mock(),
+        data=data,
+        call_type="acompletion",
+    )
+
+    assert result is not None, "Hook should return modified data"
+    forwarded = result["tools"]
+
+    assert [tool.get("type") for tool in forwarded] == ["mcp"], (
+        "The MCP reference must be the only forwarded tool; writing expanded function "
+        f"definitions into a chat completion loses every MCP tool. Got: {forwarded}"
+    )
+    assert forwarded[0]["server_url"] == "litellm_proxy", "The MCP reference must keep routing to the gateway"
+    assert forwarded[0]["require_approval"] == "never", "The MCP reference must keep its auto-execute marker"
+
+    allowed_tools = forwarded[0]["allowed_tools"]
+    assert allowed_tools, "The narrowed reference must still carry the selected tools"
+    assert len(allowed_tools) <= 2, f"Selection must narrow the reference to top_k=2, got {allowed_tools}"
+    assert len(allowed_tools) < len(expanded_tools), (
+        f"Hook must not forward all {len(expanded_tools)} expanded tools unfiltered, got {allowed_tools}"
+    )
+    assert set(allowed_tools) <= {tool["name"] for tool in expanded_tools}, (
+        f"Selected names must come from the expanded tools, got {allowed_tools}"
+    )
+
+    print(f"✅ chat completions: MCP reference preserved, narrowed to {allowed_tools}")
 
 
 @pytest.mark.asyncio
@@ -958,8 +1080,9 @@ async def test_semantic_filter_hook_filters_expanded_tools_with_string_input():
 async def test_semantic_filter_hook_expansion_skips_filter_when_disabled():
     """
     When the filter is disabled at runtime (e.g. via the UI toggle), the
-    expansion path must forward all expanded tools and emit NO filter
-    stats, mirroring the generic path's enabled guard.
+    expansion path must leave the MCP reference untouched and emit NO filter
+    stats, mirroring the generic path's enabled guard. The MCP gateway then
+    expands the reference itself, so no tool is narrowed away.
     """
     from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
         SemanticMCPToolFilter,
@@ -1009,13 +1132,19 @@ async def test_semantic_filter_hook_expansion_skips_filter_when_disabled():
         call_type="aresponses",
     )
 
-    assert result is not None, "Hook should still expand MCP references when the filter is disabled"
-    assert len(result["tools"]) == 5, f"All expanded tools must be forwarded when disabled, got {len(result['tools'])}"
+    assert result is None, "Hook must not modify the request when the filter is disabled"
+    assert data["tools"] == [
+        {
+            "type": "mcp",
+            "server_url": "litellm_proxy",
+            "require_approval": "never",
+        }
+    ], "The MCP reference must be left intact for the MCP gateway to expand"
     assert (
-        "litellm_semantic_filter_stats" not in result["metadata"]
+        "litellm_semantic_filter_stats" not in data["metadata"]
     ), "No filter stats may be emitted when the filter is disabled"
 
-    print("✅ Disabled filter: expansion preserved, no spurious stats")
+    print("✅ Disabled filter: MCP reference untouched, no spurious stats")
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -1008,6 +1008,124 @@ async def test_semantic_filter_hook_narrows_mcp_reference_for_chat_completions()
 
 
 @pytest.mark.asyncio
+async def test_semantic_filter_hook_zero_matches_exposes_all_tools_on_both_paths():
+    """
+    A query that matches nothing must expose every MCP tool, whether the request
+    carries a litellm_proxy MCP reference or plain MCP tool objects.
+
+    Given: A router that returns no matches for the query
+    When:  The hook processes an MCP reference request and a plain MCP tool request
+    Then:  Both expose all 3 tools, because filter_tools owns the undecidable-selection
+           policy and returns the full set rather than an empty one
+
+    The two paths narrow through different mechanisms (allowed_tools on the reference
+    versus dropping unmatched entries), so they could drift into opposite fail
+    behaviours. Pinning both here keeps that single policy honest: flipping
+    filter_tools to fail closed must fail this test on both paths at once, instead of
+    silently hard-limiting one surface and not the other.
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+    from litellm.types.utils import Embedding, EmbeddingResponse
+
+    mock_router = Mock()
+
+    def mock_embedding_sync(*args, **kwargs):
+        return EmbeddingResponse(
+            data=[Embedding(embedding=[0.1] * 1536, index=0, object="embedding")],
+            model="text-embedding-3-small",
+            object="list",
+            usage={"prompt_tokens": 10, "total_tokens": 10},
+        )
+
+    async def mock_embedding_async(*args, **kwargs):
+        return mock_embedding_sync()
+
+    mock_router.embedding = mock_embedding_sync
+    mock_router.aembedding = mock_embedding_async
+
+    registry_tools = [
+        MCPTool(
+            name=f"srv-tool_{i}",
+            description=f"Registry tool {i}",
+            inputSchema={"type": "object"},
+        )
+        for i in range(3)
+    ]
+
+    def build_hook():
+        filter_instance = SemanticMCPToolFilter(
+            embedding_model="text-embedding-3-small",
+            litellm_router_instance=mock_router,
+            top_k=2,
+            similarity_threshold=0.3,
+            enabled=True,
+        )
+        filter_instance._build_router(registry_tools)
+        zero_match_router = Mock(return_value=[])
+        zero_match_router.top_k = 2
+        filter_instance.tool_router = zero_match_router
+        return SemanticToolFilterHook(filter_instance)
+
+    expanded_tools = [
+        {
+            "type": "function",
+            "name": f"srv-tool_{i}",
+            "description": f"Registry tool {i}",
+            "parameters": {"type": "object", "properties": {}},
+        }
+        for i in range(3)
+    ]
+
+    reference_hook = build_hook()
+    reference_hook._expand_mcp_tools = AsyncMock(  # type: ignore[method-assign]
+        return_value=expanded_tools
+    )
+    reference_data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "something entirely unrelated"}],
+        "tools": [{"type": "mcp", "server_url": "litellm_proxy", "require_approval": "never"}],
+        "metadata": {},
+    }
+    reference_result = await reference_hook.async_pre_call_hook(
+        user_api_key_dict=Mock(),
+        cache=Mock(),
+        data=reference_data,
+        call_type="acompletion",
+    )
+
+    reference_tools = (reference_result or reference_data)["tools"]
+    mcp_references = [tool for tool in reference_tools if tool.get("type") == "mcp"]
+    assert len(mcp_references) == 1, "The MCP reference must survive a zero-match query"
+    assert set(mcp_references[0].get("allowed_tools") or []) == {tool["name"] for tool in expanded_tools}, (
+        "A zero-match query must leave every expanded tool reachable through the reference"
+    )
+
+    plain_hook = build_hook()
+    plain_data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "something entirely unrelated"}],
+        "tools": list(registry_tools),
+        "metadata": {},
+    }
+    plain_result = await plain_hook.async_pre_call_hook(
+        user_api_key_dict=Mock(),
+        cache=Mock(),
+        data=plain_data,
+        call_type="acompletion",
+    )
+
+    plain_tools = (plain_result or plain_data)["tools"]
+    assert len(plain_tools) == len(registry_tools), (
+        f"A zero-match query must not drop plain MCP tools, got {len(plain_tools)} of {len(registry_tools)}"
+    )
+
+    print("✅ zero matches: both the MCP reference path and the plain tool path expose every tool")
+
+
+@pytest.mark.asyncio
 async def test_semantic_filter_hook_filters_expanded_tools_with_string_input():
     """
     Responses API requests may pass ``input`` as a plain string; the


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4451

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Same proxy, same config, same request throughout; the only variable is the commit. The config enables the semantic tool filter and registers deepwiki, and the model is a real `anthropic/claude-sonnet-4-5` so every run costs real money

```yaml
model_list:
  - model_name: claude
    litellm_params:
      model: anthropic/claude-sonnet-4-5
      api_key: os.environ/ANTHROPIC_API_KEY
  - model_name: text-embedding-3-small
    litellm_params:
      model: openai/text-embedding-3-small

mcp_servers:
  deepwiki:
    transport: "http"
    url: "https://mcp.deepwiki.com/mcp"

general_settings:
  master_key: sk-1234

litellm_settings:
  mcp_semantic_tool_filter:
    enabled: true
    embedding_model: "text-embedding-3-small"
    top_k: 5
    similarity_threshold: 0.3
```

The request is what the Admin UI playground sends when you pick an MCP server

```bash
curl -sS http://localhost:4141/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"claude",
       "messages":[{"role":"user","content":"Use deepwiki: call read_wiki_structure for repoName BerriAI/litellm and summarize."}],
       "tools":[{"type":"mcp","server_label":"litellm","server_url":"litellm_proxy/mcp/deepwiki","require_approval":"never"}],
       "tool_choice":"auto"}'
```

Before, captured at 74ff8d0ff9 (current `litellm_internal_staging`). The filter selected tools, and the request still died in the Anthropic transformation because the tools it wrote were the wrong shape

```
x-litellm-semantic-filter: 3->3

{"error":{"message":"litellm.APIConnectionError: 'function'
Traceback (most recent call last):
  File \"litellm/main.py\", line 5258, in completion
    optional_params = get_optional_params(**optional_param_args, **non_default_params)
  File \"litellm/utils.py\", line 3876, in get_optional_params
    optional_params = litellm.AnthropicConfig().map_openai_params(
  File \"litellm/llms/anthropic/chat/transformation.py\", line 1414, in map_openai_params
    anthropic_tools, mcp_servers = self._map_tools(value)
  File \"litellm/llms/anthropic/chat/transformation.py\", line 910, in _map_tools
    new_tool, mcp_server_tool = self._map_tool_helper(tool)
  File \"litellm/llms/anthropic/chat/transformation.py\", line 637, in _map_tool_helper
    _input_schema: dict = tool[\"function\"].get(
KeyError: 'function'
. Received Model Group=claude"}}
```

On providers that skip unknown tool entries instead of raising, the same shape mismatch is silent: the model just answers as if no MCP server were connected, which is what the playground showed

After, captured at 5421fdfb7e. The filter still runs, and the model now calls the tool and answers from the result

```
x-litellm-semantic-filter: 3->3

prompt_tokens : 2035
mcp_list_tools: 3
auto-executed : True
content head  : ## Summary of BerriAI/litellm Wiki Structure  The **BerriAI/litellm** repository documentation is comprehensively organized into 9 major sections:  ### 1. **Overview** -
```

Streaming, which is what the playground actually uses, at 5421fdfb7e. The `tool_calls` then `stop` pair is the gateway executing the tool and feeding the result back

```bash
curl -sS -N http://localhost:4141/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"claude","stream":true,"stream_options":{"include_usage":true},
       "messages":[{"role":"user","content":"Use deepwiki: call read_wiki_structure for repoName BerriAI/litellm and summarize."}],
       "tools":[{"type":"mcp","server_label":"litellm","server_url":"litellm_proxy/mcp/deepwiki","require_approval":"never"}],
       "tool_choice":"auto"}'
```

```
finish_reasons  : ['tool_calls', 'stop']
tool_call deltas: 7
streamed content: 2133 chars -> "## Summary of BerriAI/litellm Wiki Structure ..."
```

Narrowing still takes effect rather than the filter being bypassed. With `top_k: 1` at 5421fdfb7e the header reports `3->1` and the model is handed only the selected tool

```
x-litellm-semantic-filter: 3->1
x-litellm-semantic-filter-tools: deepwiki-read_wiki_contents
```

### Gateway Playground UI after control at `53e5b22c60`

The authenticated Gateway Playground was run on the exact current head with `/v1/chat/completions`, model `claude`, MCP server `deepwiki`, and the semantic filter settings shown above. The prompt explicitly requested `read_wiki_structure` for `BerriAI/litellm`

| Selected Chat Completions, Claude, and DeepWiki | `List tools` and grounded final answer |
| --- | --- |
| ![Playground setup](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvMmU4N2RlZGYtMjM2YS00ZWJjLWIxYzMtZmZlNzEzYWI5MGM3IiwiaWF0IjoxNzg0MjQwMzI5LCJleHAiOjE3ODQ4NDUxMjksImZpbGVuYW1lIjoiMDEtcGxheWdyb3VuZC1zZXR1cC5wbmcifQ.ofwSe5PKrZlnCPdEOhnsgdYrVIJBahg0Kr_uwm6xgOk) | ![List tools and final answer](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvYmZiM2M2MDQtMzNmMy00OWU1LWIzMDUtM2JiMzdhYzBjMjI0IiwiaWF0IjoxNzg0MjQwMzI5LCJleHAiOjE3ODQ4NDUxMjksImZpbGVuYW1lIjoiMDItbGlzdC10b29scy1maW5hbC1hbnN3ZXIucG5nIn0.mO1w275jVjDX0p5FAwXHbhe7DSFGyLrCaMbGIfwhtJU) |
| Approved call with request and response | Completed stream with timing and token metrics |
| ![Approved DeepWiki call](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvYmM0ZGY0MWQtNTZhNC00YWFkLWEyZTQtZDU2MDllODcyYzE1IiwiaWF0IjoxNzg0MjQwMzMwLCJleHAiOjE3ODQ4NDUxMzAsImZpbGVuYW1lIjoiMDMtdG9vbC1jYWxsLWFwcHJvdmVkLXJlc3BvbnNlLnBuZyJ9.YFM7SDofb1AaKkspgXi_8KVnI1AhsF603Zh7XnhjHlo) | ![Streaming completion metrics](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvYjQzYWE0MDAtOTdmZi00OWRiLWI4NTctZDZjODliMGIwMDJjIiwiaWF0IjoxNzg0MjQwMzMwLCJleHAiOjE3ODQ4NDUxMzAsImZpbGVuYW1lIjoiMDQtc3RyZWFtLW1ldHJpY3MucG5nIn0._iyfeo5HfAM0qqc8xOIRdpmNTxFN3D5GvRPuBSP8O-w) |

The Playground rendered `List tools` with all three DeepWiki tools, then rendered `deepwiki-read_wiki_structure` with `{"repoName":"BerriAI/litellm"}`, status `Approved`, and a non-empty response beginning `Available pages for BerriAI/litellm`. The final answer summarized the nine documentation sections returned by that call

Sanitized proxy evidence showed the MCP reference expanding before filtering, the filter retaining `3->3` tools, the narrowed `type=mcp` reference reaching Anthropic through `allowed_tools`, streamed tool-call argument deltas, real DeepWiki execution, `finish_reason=stop`, and a final usage chunk with 2,661 tokens

[Annotated recording and full runtime report](https://app.devin.ai/sessions/f03da2725ec94d28b3facf766871b102)

This section covers the requested runtime behavior only; PR checks were not all green when inspected

## Type

🐛 Bug Fix

## Changes

The semantic tool filter replaced each `litellm_proxy` MCP reference in `data["tools"]` with the tools it expanded from that reference. `_process_mcp_tools_to_openai_format` defaults to the Responses API tool shape, so a `/chat/completions` request came out carrying flat `{"type": "function", "name": ...}` entries where the provider transformations expect `{"type": "function", "function": {...}}`. Anthropic raised `KeyError: 'function'` and Bedrock skipped every MCP tool silently, so the model answered as if no MCP server were connected

Replacing the reference also removed the marker `_should_use_litellm_mcp_gateway` matches on, so `acompletion_with_mcp` never ran. That disabled tool auto-execution for `require_approval="never"` on `/responses` too, where the tool shape happened to be correct

The filter only ever needed to decide which tools survive, so it now writes that decision into the reference's `allowed_tools` and leaves the reference in place. The MCP gateway keeps ownership of expansion, which is already correct per endpoint, so both the tool shape and auto-execution follow from it rather than being re-derived in the hook. Expansion already applies any caller-supplied `allowed_tools` before the filter selects, so the selection can only narrow a reference further, never widen one

This has been broken since #20296, which introduced the expansion and accepted `completion` and `acompletion` in the hook. It reproduces on any deployment running the filter, which the shipped `proxy_config.yaml` enables

Two existing tests asserted the old contract and now assert the new one. `test_semantic_filter_hook_filters_expanded_litellm_proxy_tools` keeps its LIT-4214 intent, that the reference is genuinely narrowed and real pre/post stats are emitted, expressed through `allowed_tools`. `test_semantic_filter_hook_expansion_skips_filter_when_disabled` now asserts the reference is left untouched when the filter is disabled, which is what lets the gateway expand it

`test_semantic_filter_hook_narrows_mcp_reference_for_chat_completions` is the regression test. It drives a real `{"type": "mcp"}` reference through the hook with `call_type="acompletion"` and asserts the reference survives carrying the selected tools. On `litellm_internal_staging` it fails with `assert ['function'] == ['mcp']`, showing the expanded definition that replaced the reference

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-call tool shaping on completion/responses paths for MCP gateway references; behavior is well covered by regression tests but affects tool availability and auto-execution for real MCP traffic.
> 
> **Overview**
> **Fixes LIT-4451:** semantic filtering for `litellm_proxy` MCP tool references no longer swaps the reference for expanded OpenAI function dicts.
> 
> After expansion and filtering, the hook writes selected tool names onto each gateway MCP reference’s **`allowed_tools`** and leaves **`type: mcp`** entries in `data["tools"]`. The MCP gateway still expands per endpoint, so chat completions keep the nested `function` shape, Anthropic/Bedrock mappings work, and **`require_approval: "never"`** auto-execution still runs.
> 
> When the filter is **disabled**, the hook returns early without mutating tools (no inlined expanded tools). Tests were updated and added for chat completions, zero-match behavior on both reference and plain-tool paths, and the disabled-filter case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53e5b22c609fba2cd45a9dab735c07bc44e41ae3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
