### PR TITLE
fix(docker): restore litellm-proxy-extras source dir in runtime images

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -51,6 +51,13 @@ jobs:
       - name: Build runtime image
         run: docker build -f docker/Dockerfile.non_root -t litellm-image-scan:${{ github.sha }} .
 
+      - name: Assert prisma migration assets ship at the source path
+        run: |
+          docker run --rm --entrypoint sh litellm-image-scan:${{ github.sha }} -c '
+            test -f /app/litellm-proxy-extras/litellm_proxy_extras/schema.prisma &&
+            find /app/litellm-proxy-extras/litellm_proxy_extras/migrations -name migration.sql | grep -q .
+          '
+
       # Scans the whole shipped artifact: OS/apk plus every language package
       # baked into the image, including ones no lockfile declares (e.g. prisma's
       # vendored node engine) that osv-scan cannot see. osv-scan stays the fast

--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -51,13 +51,6 @@ jobs:
       - name: Build runtime image
         run: docker build -f docker/Dockerfile.non_root -t litellm-image-scan:${{ github.sha }} .
 
-      - name: Assert prisma migration assets ship at the source path
-        run: |
-          docker run --rm --entrypoint sh litellm-image-scan:${{ github.sha }} -c '
-            test -f /app/litellm-proxy-extras/litellm_proxy_extras/schema.prisma &&
-            find /app/litellm-proxy-extras/litellm_proxy_extras/migrations -name migration.sql | grep -q .
-          '
-
       # Scans the whole shipped artifact: OS/apk plus every language package
       # baked into the image, including ones no lockfile declares (e.g. prisma's
       # vendored node engine) that osv-scan cannot see. osv-scan stays the fast

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,7 @@ COPY --from=builder /app/litellm/proxy/prisma_migration.py /app/litellm/proxy/pr
 # working directory on sys.path; litellm/proxy/hooks resolves
 # enterprise.enterprise_hooks from it)
 COPY --from=builder /app/enterprise /app/enterprise
+COPY --from=builder /app/litellm-proxy-extras /app/litellm-proxy-extras
 # Prisma binaries live in $HOME/.cache (default prisma-python location),
 # which is /root/.cache here. Copy only the Prisma subdirs — copying the
 # whole /root/.cache drags in the uv build cache (~660 MB, includes a

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -111,6 +111,7 @@ COPY --from=builder /app/litellm/proxy/prisma_migration.py /app/litellm/proxy/pr
 # working directory on sys.path; litellm/proxy/hooks resolves
 # enterprise.enterprise_hooks from it)
 COPY --from=builder /app/enterprise /app/enterprise
+COPY --from=builder /app/litellm-proxy-extras /app/litellm-proxy-extras
 # Prisma binaries live in $HOME/.cache (default prisma-python location),
 # which is /root/.cache here. Copy them from the builder so they survive
 # deployments that volume-mount /app/.cache (e.g. readOnlyRootFilesystem

--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -137,6 +137,7 @@ COPY --from=builder /app/litellm/proxy/prisma_migration.py /app/litellm/proxy/pr
 # working directory on sys.path; litellm/proxy/hooks resolves
 # enterprise.enterprise_hooks from it)
 COPY --from=builder /app/enterprise /app/enterprise
+COPY --from=builder /app/litellm-proxy-extras /app/litellm-proxy-extras
 COPY --from=builder /app/.cache /app/.cache
 COPY --from=builder /var/lib/litellm/ui /var/lib/litellm/ui
 COPY --from=builder /var/lib/litellm/assets /var/lib/litellm/assets


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Broken behavior, captured on the published `ghcr.io/berriai/litellm:v1.90.4` image (tag commit ae0cfc05fd). The folder is gone:

```
$ docker run --rm --entrypoint sh ghcr.io/berriai/litellm:v1.90.4 -c 'ls /app/litellm-proxy-extras'
ls: /app/litellm-proxy-extras: No such file or directory
$ echo $?
1
```

What makes the breakage silent: pointing prisma at the `/app/schema.prisma` that does still ship exits 0 while applying nothing, so a migration job reports success against an unmigrated database

```
$ docker run --rm -e DATABASE_URL="postgresql://postgres:...@host.docker.internal:55432/mig_before" \
    --entrypoint sh ghcr.io/berriai/litellm:v1.90.4 -c 'prisma migrate deploy --schema /app/schema.prisma'
Datasource "client": PostgreSQL database "mig_before", schema "public" at "host.docker.internal:55432"

No migration found in prisma/migrations

No pending migrations to apply.
$ echo $?
0
$ docker exec pg psql -U postgres -d mig_before -tc "SELECT count(*) FROM pg_tables WHERE schemaname='public';"
     1
```

The single table left behind is prisma's own `_prisma_migrations` bookkeeping table

Fixed behavior, captured at d2a79d8908 on images built locally from each of the three Dockerfiles, each run against a fresh database:

```
$ docker build -t litellm-pe-fix:main -f Dockerfile .
$ docker run --rm -e DATABASE_URL="postgresql://postgres:...@host.docker.internal:55432/mig_after" \
    --entrypoint sh litellm-pe-fix:main -c '
      test -f /app/litellm-proxy-extras/litellm_proxy_extras/schema.prisma && echo "schema: present" &&
      test -d /app/litellm-proxy-extras/litellm_proxy_extras/migrations && echo "migrations dir: present" &&
      diff /app/schema.prisma /app/litellm-proxy-extras/litellm_proxy_extras/schema.prisma && echo "schema matches /app/schema.prisma" &&
      prisma migrate deploy --schema /app/litellm-proxy-extras/litellm_proxy_extras/schema.prisma'
schema: present
migrations dir: present
schema matches /app/schema.prisma
135 migrations found in prisma/migrations

All migrations have been successfully applied.
$ echo $?
0
$ docker exec pg psql -U postgres -d mig_after -tc "SELECT count(*) FROM pg_tables WHERE schemaname='public';"
    66
```

The same flow passes on the database variant and on the non_root variant running as its default uid 65534: migrations dir present and readable, 135 migrations applied to a fresh database, exit 0

Beyond the migration path, the image built at d2a79d8908 was run through a 41-check contract suite covering DB-less and Postgres-backed boots, the migration entrypoint, admin UI serving, key generation, and real completion and streaming calls against the Anthropic API; everything passes except the one hygiene check this change deliberately inverts (it asserted the folder's absence)

## Type

🐛 Bug Fix

## Changes

#30243 narrowed the runtime stage of the three Dockerfiles to an allowlist COPY, which dropped `/app/litellm-proxy-extras` from published images starting v1.90.0. Deployments that run their own pre-deploy migration job (modeled on the helm migration job: pull the same image the app runs, then `prisma migrate deploy` against the schema and migrations shipped at that path) broke on upgrade to 1.90.x, and the breakage is silent because `prisma migrate deploy` exits 0 without applying anything when the schema it is pointed at has no adjacent migrations directory

This restores the `litellm-proxy-extras` folder in the runtime stage of all three Dockerfiles, matching what images up to v1.89.x contained (about 6 MB per image)

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
