### PR TITLE
feat(mcp): surface upstream tools/call response headers on the result _meta

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260716000000_add_allowed_response_headers_to_mcp_server_table/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260716000000_add_allowed_response_headers_to_mcp_server_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "LiteLLM_MCPServerTable" ADD COLUMN IF NOT EXISTS "allowed_response_headers" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -311,6 +311,7 @@ model LiteLLM_MCPServerTable {
   tool_name_to_display_name Json? @default("{}")
   tool_name_to_description   Json? @default("{}")
   extra_headers String[]    @default([])
+  allowed_response_headers String[] @default([])
   static_headers Json?        @default("{}")
   // Admin-configured environment variables interpolated into static_headers
   // via ${NAME} syntax. Stored as an array of

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -121,6 +121,25 @@ MCP_TOOL_LISTING_TIMEOUT = float(os.getenv("LITELLM_MCP_TOOL_LISTING_TIMEOUT", "
 MCP_METADATA_TIMEOUT = float(os.getenv("LITELLM_MCP_METADATA_TIMEOUT", "10.0"))
 MCP_HEALTH_CHECK_TIMEOUT = float(os.getenv("LITELLM_MCP_HEALTH_CHECK_TIMEOUT", "10.0"))
 
+MCP_RESPONSE_HEADERS_META_KEY = "ai.litellm/responseHeaders"
+MCP_RESPONSE_HEADER_DENYLIST = frozenset(
+    {
+        "authorization",
+        "proxy-authorization",
+        "www-authenticate",
+        "proxy-authenticate",
+        "set-cookie",
+        "cookie",
+        "mcp-session-id",
+        "connection",
+        "keep-alive",
+        "transfer-encoding",
+        "upgrade",
+        "te",
+        "trailer",
+    }
+)
+
 # Allowlist of commands permitted for MCP stdio transport.
 # Prevents arbitrary command execution via /mcp-rest/test/* endpoints or server creation.
 # Note: allowlisted runtimes can still execute code via args (e.g. python -c "...").

--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -4,6 +4,7 @@ LiteLLM Proxy uses this MCP Client to connnect to other MCP servers.
 
 import asyncio
 import base64
+import json
 import os
 from typing import (
     Any,
@@ -41,7 +42,12 @@ from mcp.types import (
 from mcp.types import Tool as MCPTool
 from pydantic import AnyUrl
 from litellm._logging import verbose_logger
-from litellm.constants import MCP_CLIENT_TIMEOUT, MCP_NPM_CACHE_DIR
+from litellm.constants import (
+    MCP_CLIENT_TIMEOUT,
+    MCP_NPM_CACHE_DIR,
+    MCP_RESPONSE_HEADER_DENYLIST,
+    MCP_RESPONSE_HEADERS_META_KEY,
+)
 from litellm.llms.custom_httpx.http_handler import get_ssl_configuration
 from litellm.types.llms.custom_http import VerifyTypes
 from litellm.types.mcp import (
@@ -56,6 +62,35 @@ from litellm.types.mcp import (
 def to_basic_auth(auth_value: str) -> str:
     """Convert auth value to Basic Auth format."""
     return base64.b64encode(auth_value.encode("utf-8")).decode()
+
+
+def normalize_allowed_response_headers(names: list[str] | None) -> frozenset[str]:
+    """Lowercase the configured upstream response-header allowlist, dropping blanks and denylisted names.
+
+    Normalizing in one place keeps a single notion of "blank" (None, "", whitespace) and guarantees a
+    denylisted header can never be surfaced to the caller even when an admin configures it explicitly.
+    """
+    if not names:
+        return frozenset()
+    return frozenset(
+        stripped
+        for stripped in (name.strip().lower() for name in names if isinstance(name, str))
+        if stripped and stripped not in MCP_RESPONSE_HEADER_DENYLIST
+    )
+
+
+def _is_tool_call_request(request: httpx.Request) -> bool:
+    """True when this HTTP request carries the JSON-RPC ``tools/call`` that produced the response.
+
+    A streamable-HTTP session also POSTs ``initialize`` and notifications, and may DELETE the session
+    on close, so the tool call is identified by its JSON-RPC method rather than by being the last
+    response observed on the connection.
+    """
+    try:
+        payload = json.loads(request.content)
+    except (httpx.RequestNotRead, ValueError, TypeError):
+        return False
+    return isinstance(payload, dict) and payload.get("method") == "tools/call"
 
 
 def _strip_header_whitespace(headers: Dict[str, str]) -> Dict[str, str]:
@@ -217,6 +252,7 @@ class MCPClient:
         sampling_callback: Optional[Callable] = None,
         elicitation_callback: Optional[Callable] = None,
         logging_callback: Optional[Callable] = None,
+        allowed_response_headers: list[str] | None = None,
     ):
         self.server_url: str = server_url
         self.transport_type: MCPTransport = transport_type
@@ -234,9 +270,34 @@ class MCPClient:
         self._sampling_callback: Optional[Callable] = sampling_callback
         self._elicitation_callback: Optional[Callable] = elicitation_callback
         self._logging_callback: Optional[Callable] = logging_callback
+        self._allowed_response_headers: frozenset[str] = normalize_allowed_response_headers(allowed_response_headers)
+        self._tool_call_response_headers: dict[str, str] | None = None
         # handle the basic auth value if provided
         if auth_value:
             self.update_auth_value(auth_value)
+
+    def _response_event_hooks(
+        self,
+    ) -> dict[str, list[Callable[[httpx.Response], Awaitable[None]]]] | None:
+        """An httpx response hook recording the allowlisted upstream ``tools/call`` headers, when configured.
+
+        This is the only seam that sees the upstream HTTP response: the MCP SDK's transport keeps just
+        the session id and content-type and hands back a headerless ``CallToolResult``. Reading only
+        ``response.headers`` leaves the (possibly streamed) body untouched.
+        """
+        if not self._allowed_response_headers:
+            return None
+
+        async def _capture(response: httpx.Response) -> None:
+            if not _is_tool_call_request(response.request):
+                return
+            self._tool_call_response_headers = {
+                name.lower(): value
+                for name, value in response.headers.items()
+                if name.lower() in self._allowed_response_headers
+            }
+
+        return {"response": [_capture]}
 
     def _create_transport_context(
         self,
@@ -278,6 +339,7 @@ class MCPClient:
         http_client = httpx_client_factory(
             headers=headers,
             timeout=httpx.Timeout(self.timeout),
+            event_hooks=self._response_event_hooks(),
         )
         transport_ctx = streamable_http_client(
             url=self.server_url,
@@ -396,6 +458,7 @@ class MCPClient:
         http_client: Optional[httpx.AsyncClient] = None
         try:
             self._last_initialize_instructions = None
+            self._tool_call_response_headers = None
             transport_ctx, http_client = self._create_transport_context()
             return await self._execute_session_operation(transport_ctx, operation)
         except Exception:
@@ -465,6 +528,7 @@ class MCPClient:
             headers: Optional[Dict[str, str]] = None,
             timeout: Optional[httpx.Timeout] = None,
             auth: Optional[httpx.Auth] = None,
+            event_hooks: dict[str, list[Callable[[httpx.Response], Awaitable[None]]]] | None = None,
         ) -> httpx.AsyncClient:
             """Create an httpx.AsyncClient with LiteLLM's SSL configuration."""
             # Get unified SSL configuration using the same logic as http_handler.py
@@ -481,6 +545,7 @@ class MCPClient:
                 auth=effective_auth,
                 verify=ssl_config,
                 follow_redirects=True,
+                event_hooks=event_hooks,
             )
 
         return factory
@@ -537,6 +602,20 @@ class MCPClient:
             # Return empty list instead of raising to allow graceful degradation
             return []
 
+    def _with_response_headers_meta(self, result: MCPCallToolResult) -> MCPCallToolResult:
+        """Surface the captured upstream response headers on the result's MCP ``_meta``.
+
+        ``_meta`` is the protocol's reserved slot for out-of-band metadata and the only channel that
+        reaches the caller, since the gateway re-serializes the result over its own transport and
+        commits its HTTP headers before the tool runs. The key carries litellm's reverse-DNS prefix
+        because the spec reserves ``mcp``/``modelcontextprotocol`` prefixes for protocol use.
+        """
+        headers = self._tool_call_response_headers
+        if not headers:
+            return result
+        merged_meta = {**(result.meta or {}), MCP_RESPONSE_HEADERS_META_KEY: headers}
+        return result.model_copy(update={"meta": merged_meta})
+
     @staticmethod
     def error_tool_result(exc: Exception) -> MCPCallToolResult:
         """The error result ``call_tool`` returns when it swallows a failure (no re-execution)."""
@@ -586,7 +665,7 @@ class MCPClient:
         try:
             tool_result = await self.run_with_session(_call_tool_operation, quiet_on_error=raise_on_error)
             verbose_logger.info(f"MCP client tool call '{call_tool_request_params.name}' completed successfully")
-            return tool_result
+            return self._with_response_headers_meta(tool_result)
         except asyncio.CancelledError:
             verbose_logger.warning(f"MCP client tool call timed out after {self.timeout}s for {self.server_url}")
             raise

--- a/litellm/models/mcp_server.py
+++ b/litellm/models/mcp_server.py
@@ -67,6 +67,7 @@ class LiteLLM_MCPServerTable(LiteLLMPydanticObjectBase):
     tool_name_to_display_name: Optional[Dict[str, str]] = None
     tool_name_to_description: Optional[Dict[str, str]] = None
     extra_headers: List[str] = Field(default_factory=list)
+    allowed_response_headers: list[str] = Field(default_factory=list)
     mcp_info: Optional[MCPInfo] = None
     static_headers: Optional[Dict[str, str]] = None
     env_vars: Optional[List[MCPEnvVar]] = None

--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -289,8 +289,9 @@ def _prepare_mcp_server_data(
             data_dict.pop("alias", None)
         # Prisma ``allowed_tools`` is a required String[]; ``null`` is invalid.
         # The UI sends null to clear a whitelist — treat that as ``[]``.
-        if "allowed_tools" in data_dict and data_dict["allowed_tools"] is None:
-            data_dict["allowed_tools"] = []
+        for list_field in ("allowed_tools", "allowed_response_headers"):
+            if list_field in data_dict and data_dict[list_field] is None:
+                data_dict[list_field] = []
         # Json map fields use ``@default("{}")``; explicit null means clear overrides.
         for json_map_field in (
             "tool_name_to_display_name",

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1768,6 +1768,7 @@ class MCPServerManager:
             authentication_token=auth_value,
             mcp_info=mcp_info,
             extra_headers=getattr(mcp_server, "extra_headers", None),
+            allowed_response_headers=getattr(mcp_server, "allowed_response_headers", None),
             static_headers=static_headers_dict,
             env_vars=env_vars_list,
             client_id=client_id_value or getattr(mcp_server, "client_id", None),
@@ -1825,6 +1826,7 @@ class MCPServerManager:
             max_concurrent_requests=getattr(mcp_server, "max_concurrent_requests", None),
         )
         _warn_internal_delegate_pkce_if_applicable(new_server, source="database")
+        _warn_response_headers_unsupported_transport_if_applicable(new_server, source="database")
         if persist_discovered_endpoints:
             await self._persist_discovered_obo_token_url(
                 server_id=mcp_server.server_id,

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1323,6 +1323,7 @@ class MCPServerManager:
                 allowed_params=server_config.get("allowed_params", None),
                 access_groups=server_config.get("access_groups", None),
                 static_headers=server_config.get("static_headers", None),
+                allowed_response_headers=server_config.get("allowed_response_headers", None),
                 env_vars=server_config.get("env_vars", None),
                 allow_all_keys=bool(server_config.get("allow_all_keys", False)),
                 available_on_public_internet=bool(server_config.get("available_on_public_internet", True)),
@@ -2864,6 +2865,7 @@ class MCPServerManager:
                     resolved_auth=resolved_auth,
                     sampling_callback=sampling_cb,
                     elicitation_callback=elicitation_cb,
+                    allowed_response_headers=server.allowed_response_headers,
                 )
 
             # Create SigV4 auth if configured
@@ -2889,6 +2891,7 @@ class MCPServerManager:
                 aws_auth=aws_auth,
                 sampling_callback=sampling_cb,
                 elicitation_callback=elicitation_cb,
+                allowed_response_headers=server.allowed_response_headers,
             )
 
     async def _get_tools_from_server(

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -726,6 +726,30 @@ def _warn_internal_delegate_pkce_if_applicable(server: MCPServer, *, source: str
     )
 
 
+def _warn_response_headers_unsupported_transport_if_applicable(server: MCPServer, *, source: str) -> None:
+    """Surface an ``allowed_response_headers`` config that the server's transport cannot honor.
+
+    Only the streamable-HTTP transport exposes the upstream ``tools/call`` HTTP response. stdio has no
+    HTTP at all, and the SSE transport delivers the result over a stream whose headers are committed
+    before the tool runs (its POST returns only an ack), so on both the setting is inert. Without this
+    line an operator would see no headers, no error, and no explanation.
+    """
+    if not server.allowed_response_headers:
+        return
+    if server.transport == MCPTransport.http:
+        return
+    label = get_server_prefix(server)
+    verbose_logger.warning(
+        "MCP server %r (id=%s, source=%s): allowed_response_headers is set but the transport is %s. "
+        "Upstream response headers are only observable on the streamable-HTTP transport, so no headers "
+        "will be surfaced on the tool result's _meta.",
+        label,
+        server.server_id,
+        source,
+        server.transport,
+    )
+
+
 def _deserialize_json_dict(data: Any) -> Optional[dict[str, str]]:
     """
     Deserialize optional JSON mappings stored in the database.
@@ -1354,6 +1378,7 @@ class MCPServerManager:
             )
             self._assign_unique_short_prefix(new_server)
             _warn_internal_delegate_pkce_if_applicable(new_server, source="config")
+            _warn_response_headers_unsupported_transport_if_applicable(new_server, source="config")
             self.config_mcp_servers[server_id] = new_server
 
             # Check if this is an OpenAPI-based server

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1256,6 +1256,7 @@ class NewMCPServerRequest(LiteLLMPydanticObjectBase):
     tool_name_to_display_name: Optional[Dict[str, str]] = None
     tool_name_to_description: Optional[Dict[str, str]] = None
     extra_headers: Optional[List[str]] = None
+    allowed_response_headers: list[str] | None = None
     static_headers: Optional[Dict[str, str]] = None
     env_vars: Optional[List[MCPEnvVar]] = None
     instructions: Optional[str] = None
@@ -1362,6 +1363,7 @@ class UpdateMCPServerRequest(LiteLLMPydanticObjectBase):
     tool_name_to_display_name: Optional[Dict[str, str]] = None
     tool_name_to_description: Optional[Dict[str, str]] = None
     extra_headers: Optional[List[str]] = None
+    allowed_response_headers: list[str] | None = None
     static_headers: Optional[Dict[str, str]] = None
     env_vars: Optional[List[MCPEnvVar]] = None
     instructions: Optional[str] = None

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -533,6 +533,7 @@ if MCP_AVAILABLE:
         sanitized.spec_path = None
         sanitized.static_headers = None
         sanitized.extra_headers = []
+        sanitized.allowed_response_headers = []
         sanitized.env = {}
         sanitized.command = None
         sanitized.args = []
@@ -577,6 +578,7 @@ if MCP_AVAILABLE:
         sanitized.command = None
         sanitized.args = []
         sanitized.extra_headers = []
+        sanitized.allowed_response_headers = []
         sanitized.allowed_tools = []
         sanitized.mcp_access_groups = []
         sanitized.teams = []
@@ -683,6 +685,7 @@ if MCP_AVAILABLE:
             mcp_access_groups=payload.mcp_access_groups,
             allowed_tools=payload.allowed_tools or [],
             extra_headers=payload.extra_headers or [],
+            allowed_response_headers=payload.allowed_response_headers or [],
             mcp_info=payload.mcp_info,
             static_headers=payload.static_headers,
             command=payload.command,

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -311,6 +311,7 @@ model LiteLLM_MCPServerTable {
   tool_name_to_display_name Json? @default("{}")
   tool_name_to_description   Json? @default("{}")
   extra_headers String[]    @default([])
+  allowed_response_headers String[] @default([])
   static_headers Json?        @default("{}")
   // Admin-configured environment variables interpolated into static_headers
   // via ${NAME} syntax. Stored as an array of

--- a/litellm/types/mcp_server/mcp_server_manager.py
+++ b/litellm/types/mcp_server/mcp_server_manager.py
@@ -58,6 +58,13 @@ class MCPServer(BaseModel):
     tool_name_to_description: Optional[Dict[str, str]] = None
     allowed_params: Optional[Dict[str, List[str]]] = None  # map of tool names to allowed parameter lists
     static_headers: Optional[Dict[str, str]] = None  # static headers to forward to the MCP server
+    allowed_response_headers: Optional[List[str]] = None
+    """Upstream ``tools/call`` response headers to surface to the caller on the MCP result's ``_meta``.
+
+    Opt-in allowlist of header names; empty or unset forwards nothing. The gateway answers the caller
+    over a stream whose HTTP headers are already committed before the tool runs, so these are relayed
+    as protocol metadata rather than as HTTP response headers. Credential, cookie, upstream-session and
+    hop-by-hop headers are never forwarded (see ``MCP_RESPONSE_HEADER_DENYLIST``)."""
     # Admin-configured env vars. Each entry is {name, value, scope, description}.
     # scope=="global" values are interpolated into static_headers using ${NAME}.
     # scope=="user" values must be supplied per-user.

--- a/litellm/types/mcp_server/mcp_server_manager.py
+++ b/litellm/types/mcp_server/mcp_server_manager.py
@@ -64,7 +64,12 @@ class MCPServer(BaseModel):
     Opt-in allowlist of header names; empty or unset forwards nothing. The gateway answers the caller
     over a stream whose HTTP headers are already committed before the tool runs, so these are relayed
     as protocol metadata rather than as HTTP response headers. Credential, cookie, upstream-session and
-    hop-by-hop headers are never forwarded (see ``MCP_RESPONSE_HEADER_DENYLIST``)."""
+    hop-by-hop headers are never forwarded (see ``MCP_RESPONSE_HEADER_DENYLIST``).
+
+    Honored only on the ``http`` (streamable-HTTP) transport, the one that exposes the upstream
+    ``tools/call`` HTTP response. stdio carries no HTTP, and SSE returns only an ack on its POST and
+    delivers the result over a pre-committed stream, so on those the setting is inert and loading a
+    server configured this way logs a warning."""
     # Admin-configured env vars. Each entry is {name, value, scope, description}.
     # scope=="global" values are interpolated into static_headers using ${NAME}.
     # scope=="user" values must be supplied per-user.

--- a/schema.prisma
+++ b/schema.prisma
@@ -311,6 +311,7 @@ model LiteLLM_MCPServerTable {
   tool_name_to_display_name Json? @default("{}")
   tool_name_to_description   Json? @default("{}")
   extra_headers String[]    @default([])
+  allowed_response_headers String[] @default([])
   static_headers Json?        @default("{}")
   // Admin-configured environment variables interpolated into static_headers
   // via ${NAME} syntax. Stored as an array of

--- a/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
+++ b/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
@@ -9,10 +9,15 @@ import pytest
 # Add the parent directory to the path so we can import litellm
 sys.path.insert(0, "../../../")
 
+from mcp.types import CallToolRequestParams, CallToolResult, TextContent
+
 import litellm.experimental_mcp_client.client as mcp_client_module
+from litellm.constants import MCP_RESPONSE_HEADERS_META_KEY
 from litellm.experimental_mcp_client.client import (
     MCPClient,
     _first_non_cancelled_cause,
+    _is_tool_call_request,
+    normalize_allowed_response_headers,
 )
 from litellm.types.mcp import MCPAuth, MCPStdioConfig, MCPTransport
 
@@ -695,3 +700,191 @@ async def test_run_with_session_quiet_on_error_demotes_warning_to_debug():
                 assert any("run_with_session failed" in m for m in warning_msgs), (
                     "the default path must keep the operator-visible warning"
                 )
+
+
+def _jsonrpc_response(method: str, headers: dict) -> httpx.Response:
+    """An upstream HTTP response to the given JSON-RPC method, carrying ``headers``."""
+    request = httpx.Request("POST", "http://upstream/mcp", json={"jsonrpc": "2.0", "id": 1, "method": method})
+    return httpx.Response(200, headers=headers, request=request)
+
+
+class TestNormalizeAllowedResponseHeaders:
+    """The allowlist normalizer: one notion of blank, case, and never-forward."""
+
+    def test_unset_forwards_nothing(self):
+        assert normalize_allowed_response_headers(None) == frozenset()
+        assert normalize_allowed_response_headers([]) == frozenset()
+
+    def test_lowercases_and_strips(self):
+        assert normalize_allowed_response_headers(["  X-Example-Header  ", "X-Request-Id"]) == frozenset(
+            {"x-example-header", "x-request-id"}
+        )
+
+    def test_blank_entries_dropped(self):
+        assert normalize_allowed_response_headers(["", "   ", "\t", "X-Ok"]) == frozenset({"x-ok"})
+
+    def test_denylisted_headers_never_forwarded_even_when_configured(self):
+        """An admin cannot opt a credential, cookie, upstream session or hop-by-hop header into the result."""
+        configured = [
+            "Authorization",
+            "Proxy-Authorization",
+            "Set-Cookie",
+            "Cookie",
+            "MCP-Session-Id",
+            "WWW-Authenticate",
+            "Connection",
+            "Transfer-Encoding",
+            "X-Keep",
+        ]
+        assert normalize_allowed_response_headers(configured) == frozenset({"x-keep"})
+
+
+class TestIsToolCallRequest:
+    """Only the tools/call response may be captured, never a sibling message on the same connection."""
+
+    def test_tool_call_matches(self):
+        assert _is_tool_call_request(_jsonrpc_response("tools/call", {}).request) is True
+
+    @pytest.mark.parametrize("method", ["initialize", "tools/list", "notifications/initialized"])
+    def test_other_methods_do_not_match(self, method):
+        assert _is_tool_call_request(_jsonrpc_response(method, {}).request) is False
+
+    def test_non_json_body_does_not_match(self):
+        assert _is_tool_call_request(httpx.Request("DELETE", "http://upstream/mcp")) is False
+
+
+class TestMCPResponseHeaderCapture:
+    """Capturing the upstream tools/call response headers off the httpx seam."""
+
+    def test_no_allowlist_installs_no_hook(self):
+        """Unconfigured servers keep the stock client: no hook, no capture, no behavior change."""
+        client = MCPClient(server_url="http://upstream/mcp", transport_type=MCPTransport.http)
+        assert client._response_event_hooks() is None
+
+    @pytest.mark.asyncio
+    async def test_captures_only_allowlisted_headers_from_tool_call(self):
+        client = MCPClient(
+            server_url="http://upstream/mcp",
+            transport_type=MCPTransport.http,
+            allowed_response_headers=["X-Example-Header"],
+        )
+        hook = client._response_event_hooks()["response"][0]
+
+        await hook(_jsonrpc_response("tools/call", {"X-Example-Header": "hello", "X-Other": "dropped"}))
+
+        assert client._tool_call_response_headers == {"x-example-header": "hello"}
+
+    @pytest.mark.asyncio
+    async def test_ignores_non_tool_call_responses(self):
+        """initialize and the session teardown share the connection; taking the last response would be wrong."""
+        client = MCPClient(
+            server_url="http://upstream/mcp",
+            transport_type=MCPTransport.http,
+            allowed_response_headers=["X-Example-Header"],
+        )
+        hook = client._response_event_hooks()["response"][0]
+
+        await hook(_jsonrpc_response("initialize", {"X-Example-Header": "from-initialize"}))
+
+        assert client._tool_call_response_headers is None
+
+    @pytest.mark.asyncio
+    async def test_tool_call_headers_survive_a_later_sibling_response(self):
+        client = MCPClient(
+            server_url="http://upstream/mcp",
+            transport_type=MCPTransport.http,
+            allowed_response_headers=["X-Example-Header"],
+        )
+        hook = client._response_event_hooks()["response"][0]
+
+        await hook(_jsonrpc_response("tools/call", {"X-Example-Header": "hello"}))
+        await hook(_jsonrpc_response("tools/list", {"X-Example-Header": "later"}))
+
+        assert client._tool_call_response_headers == {"x-example-header": "hello"}
+
+
+class TestWithResponseHeadersMeta:
+    """Surfacing captured headers on the result's MCP ``_meta``."""
+
+    def _client(self):
+        return MCPClient(
+            server_url="http://upstream/mcp",
+            transport_type=MCPTransport.http,
+            allowed_response_headers=["X-Example-Header"],
+        )
+
+    def test_nothing_captured_leaves_result_untouched(self):
+        client = self._client()
+        result = CallToolResult(content=[TextContent(type="text", text="ok")])
+
+        assert client._with_response_headers_meta(result).meta is None
+
+    def test_captured_headers_land_under_the_litellm_meta_key(self):
+        client = self._client()
+        client._tool_call_response_headers = {"x-example-header": "hello"}
+        result = CallToolResult(content=[TextContent(type="text", text="ok")])
+
+        assert client._with_response_headers_meta(result).meta == {
+            MCP_RESPONSE_HEADERS_META_KEY: {"x-example-header": "hello"}
+        }
+
+    def test_preserves_meta_the_upstream_server_already_set(self):
+        """The upstream's own ``_meta`` is the caller's data; header surfacing must merge, not clobber."""
+        client = self._client()
+        client._tool_call_response_headers = {"x-example-header": "hello"}
+        result = CallToolResult(content=[TextContent(type="text", text="ok")], _meta={"upstream/trace": "abc123"})
+
+        assert client._with_response_headers_meta(result).meta == {
+            "upstream/trace": "abc123",
+            MCP_RESPONSE_HEADERS_META_KEY: {"x-example-header": "hello"},
+        }
+
+    def test_does_not_mutate_the_original_result(self):
+        client = self._client()
+        client._tool_call_response_headers = {"x-example-header": "hello"}
+        result = CallToolResult(content=[TextContent(type="text", text="ok")])
+
+        client._with_response_headers_meta(result)
+
+        assert result.meta is None
+
+    @pytest.mark.asyncio
+    async def test_call_tool_surfaces_captured_headers_on_its_result(self):
+        """The wiring that makes the feature reachable: call_tool must surface what the session captured."""
+        client = self._client()
+
+        async def _session_that_captures(operation, *, quiet_on_error=False):
+            client._tool_call_response_headers = {"x-example-header": "hello"}
+            return CallToolResult(content=[TextContent(type="text", text="ok")])
+
+        with patch.object(client, "run_with_session", side_effect=_session_that_captures):
+            result = await client.call_tool(CallToolRequestParams(name="echo", arguments={}))
+
+        assert result.meta == {MCP_RESPONSE_HEADERS_META_KEY: {"x-example-header": "hello"}}
+
+    @pytest.mark.asyncio
+    async def test_call_tool_leaves_result_alone_when_nothing_captured(self):
+        client = self._client()
+
+        async def _session_without_capture(operation, *, quiet_on_error=False):
+            return CallToolResult(content=[TextContent(type="text", text="ok")])
+
+        with patch.object(client, "run_with_session", side_effect=_session_without_capture):
+            result = await client.call_tool(CallToolRequestParams(name="echo", arguments={}))
+
+        assert result.meta is None
+
+    @pytest.mark.asyncio
+    async def test_opening_a_session_clears_a_previous_calls_headers(self):
+        """Without this reset a reused client would replay the prior call's headers onto a later result."""
+        client = self._client()
+        client._tool_call_response_headers = {"x-example-header": "stale"}
+
+        async def _op(session):
+            return "unused"
+
+        with patch.object(client, "_create_transport_context", side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError):
+                await client.run_with_session(_op)
+
+        assert client._tool_call_response_headers is None

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_db_credentials.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_db_credentials.py
@@ -958,6 +958,44 @@ def test_prepare_mcp_server_data_create_carries_token_exchange_columns():
     assert data["token_exchange_profile"] == "entra_obo"
 
 
+def test_prepare_mcp_server_data_create_carries_allowed_response_headers():
+    """The create path must emit allowed_response_headers as a column value, or a server registered
+    through the REST API / dashboard could never surface upstream response headers."""
+    request = NewMCPServerRequest(
+        server_name="hdr_write",
+        url="https://upstream.example.com/mcp",
+        transport=MCPTransport.http,
+        allowed_response_headers=["X-Example-Header"],
+    )
+
+    data = _prepare_mcp_server_data(request)
+
+    assert data["allowed_response_headers"] == ["X-Example-Header"]
+
+
+def test_prepare_mcp_server_data_update_maps_cleared_allowed_response_headers_to_empty_list():
+    """The column is a Prisma String[], which rejects null. The edit form clears the field to null,
+    so an explicit null must become [] rather than reaching the DB and failing the update."""
+    request = UpdateMCPServerRequest(
+        server_id="hdr-1",
+        allowed_response_headers=None,
+    )
+
+    data = _prepare_mcp_server_data(request, exclude_unset=True)
+
+    assert data["allowed_response_headers"] == []
+
+
+def test_prepare_mcp_server_data_update_omits_allowed_response_headers_when_untouched():
+    """A partial update that never mentions the field must not write it, so an edit to an unrelated
+    field cannot silently wipe a configured allowlist."""
+    request = UpdateMCPServerRequest(server_id="hdr-1", alias="renamed")
+
+    data = _prepare_mcp_server_data(request, exclude_unset=True)
+
+    assert "allowed_response_headers" not in data
+
+
 def test_prepare_mcp_server_data_update_carries_token_exchange_columns():
     """The partial-update path (PUT /v1/mcp/server, exclude_unset) must carry the three
     token-exchange columns when the caller provides them."""

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -6560,6 +6560,57 @@ class TestWarnResponseHeadersUnsupportedTransport:
 
         assert not any("allowed_response_headers" in m for m in caplog.messages)
 
+    @pytest.mark.asyncio
+    async def test_loading_such_a_server_from_the_database_emits_the_warning(self, caplog):
+        """The field is DB-backed, so the dashboard can create the same misconfiguration as config.yaml."""
+        manager = MCPServerManager()
+        table_record = LiteLLM_MCPServerTable(
+            server_id="hdr-sse-db",
+            server_name="hdr_sse_db",
+            url="https://example.com/sse",
+            transport=MCPTransport.sse,
+            allowed_response_headers=["X-Example-Header"],
+        )
+
+        with caplog.at_level(logging.WARNING, logger="LiteLLM"):
+            await manager.build_mcp_server_from_table(table_record)
+
+        assert any("allowed_response_headers is set but the transport is" in m for m in caplog.messages)
+
+
+class TestAllowedResponseHeadersFromDatabase:
+    """The DB row is the dashboard's storage, so the field must survive the row -> MCPServer build."""
+
+    @pytest.mark.asyncio
+    async def test_build_mcp_server_from_table_carries_allowed_response_headers(self):
+        """Without this the dashboard could save the allowlist and the gateway would silently ignore it."""
+        manager = MCPServerManager()
+        table_record = LiteLLM_MCPServerTable(
+            server_id="hdr-db-1",
+            server_name="hdr_db",
+            url="https://example.com/mcp",
+            transport=MCPTransport.http,
+            allowed_response_headers=["X-Example-Header"],
+        )
+
+        mcp_server = await manager.build_mcp_server_from_table(table_record)
+
+        assert mcp_server.allowed_response_headers == ["X-Example-Header"]
+
+    @pytest.mark.asyncio
+    async def test_build_mcp_server_from_table_defaults_to_no_headers(self):
+        manager = MCPServerManager()
+        table_record = LiteLLM_MCPServerTable(
+            server_id="hdr-db-2",
+            server_name="hdr_db_none",
+            url="https://example.com/mcp",
+            transport=MCPTransport.http,
+        )
+
+        mcp_server = await manager.build_mcp_server_from_table(table_record)
+
+        assert not mcp_server.allowed_response_headers
+
 
 class TestHasClientCredentialsOAuth2Flow:
     """

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -6482,6 +6482,85 @@ class TestInternalDelegatePkceWarningLog:
         assert "internal-only" not in combined
 
 
+class TestWarnResponseHeadersUnsupportedTransport:
+    """allowed_response_headers is inert off streamable-HTTP, so loading such a server must say so."""
+
+    def _server(self, transport, allowed):
+        return MCPServer(
+            server_id="hdr-1",
+            name="hdr_server",
+            url="https://example.com/mcp",
+            transport=transport,
+            allowed_response_headers=allowed,
+        )
+
+    def _warn(self, server, caplog):
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            _warn_response_headers_unsupported_transport_if_applicable,
+        )
+
+        _warn_response_headers_unsupported_transport_if_applicable(server, source="test")
+        return " ".join(r.getMessage() for r in caplog.records)
+
+    @pytest.mark.parametrize("transport", [MCPTransport.sse, MCPTransport.stdio])
+    def test_warns_on_every_non_http_transport(self, caplog, transport):
+        caplog.set_level(logging.WARNING, logger="LiteLLM")
+
+        combined = self._warn(self._server(transport, ["X-Example-Header"]), caplog)
+
+        assert "allowed_response_headers is set but the transport is" in combined
+        assert "hdr-1" in combined
+        assert transport.value in combined
+
+    def test_no_warning_on_http_where_the_feature_works(self, caplog):
+        caplog.set_level(logging.WARNING, logger="LiteLLM")
+
+        combined = self._warn(self._server(MCPTransport.http, ["X-Example-Header"]), caplog)
+
+        assert "allowed_response_headers" not in combined
+
+    @pytest.mark.parametrize("allowed", [None, []])
+    def test_no_warning_when_the_feature_is_not_configured(self, caplog, allowed):
+        caplog.set_level(logging.WARNING, logger="LiteLLM")
+
+        combined = self._warn(self._server(MCPTransport.sse, allowed), caplog)
+
+        assert "allowed_response_headers" not in combined
+
+    @pytest.mark.asyncio
+    async def test_loading_such_a_server_from_config_emits_the_warning(self, caplog):
+        """Pins the call site: the check is only useful if config load actually runs it."""
+        manager = MCPServerManager()
+        config = {
+            "sse_server": {
+                "url": "https://example.com/sse",
+                "transport": MCPTransport.sse,
+                "allowed_response_headers": ["X-Example-Header"],
+            }
+        }
+
+        with caplog.at_level(logging.WARNING, logger="LiteLLM"):
+            await manager.load_servers_from_config(config)
+
+        assert any("allowed_response_headers is set but the transport is" in m for m in caplog.messages)
+
+    @pytest.mark.asyncio
+    async def test_loading_an_http_server_from_config_stays_quiet(self, caplog):
+        manager = MCPServerManager()
+        config = {
+            "http_server": {
+                "url": "https://example.com/mcp",
+                "transport": MCPTransport.http,
+                "allowed_response_headers": ["X-Example-Header"],
+            }
+        }
+
+        with caplog.at_level(logging.WARNING, logger="LiteLLM"):
+            await manager.load_servers_from_config(config)
+
+        assert not any("allowed_response_headers" in m for m in caplog.messages)
+
+
 class TestHasClientCredentialsOAuth2Flow:
     """
     Regression tests for the M2M auto-detection bug.

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -5376,3 +5376,30 @@ async def test_edit_mcp_server_snapshot_failure_skips_purge_but_edit_succeeds():
 
     assert result.server_id == server_id
     mock_purge.assert_not_awaited()
+
+
+def test_temporary_mcp_server_record_carries_allowed_response_headers():
+    """The pre-save 'test this server' flow builds an unpersisted record; dropping the field there
+    would make a temporary server behave differently from the one the admin is about to save."""
+    payload = NewMCPServerRequest(
+        server_name="hdr_tmp",
+        url="https://upstream.example.com/mcp",
+        transport=MCPTransport.http,
+        allowed_response_headers=["X-Example-Header"],
+    )
+
+    record = mgmt_endpoints._build_temporary_mcp_server_record(payload, created_by="tester")
+
+    assert record.allowed_response_headers == ["X-Example-Header"]
+
+
+def test_temporary_mcp_server_record_defaults_allowed_response_headers_to_empty():
+    payload = NewMCPServerRequest(
+        server_name="hdr_tmp_none",
+        url="https://upstream.example.com/mcp",
+        transport=MCPTransport.http,
+    )
+
+    record = mgmt_endpoints._build_temporary_mcp_server_record(payload, created_by="tester")
+
+    assert record.allowed_response_headers == []

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPPermissionManagement.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPPermissionManagement.tsx
@@ -282,6 +282,36 @@ const MCPPermissionManagement: React.FC<MCPPermissionManagementProps> = ({
           <Form.Item
             label={
               <span className="text-sm font-medium text-gray-700 flex items-center">
+                Allowed Response Headers
+                <Tooltip title="Surface these response headers from this MCP server back to the caller, on the tool result's _meta under 'ai.litellm/responseHeaders'. Streamable HTTP transport only. Credential, cookie, session and hop-by-hop headers are never forwarded.">
+                  <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
+                </Tooltip>
+                {mcpServer?.allowed_response_headers && mcpServer.allowed_response_headers.length > 0 && (
+                  <span className="ml-2 text-xs bg-blue-100 text-blue-700 px-2 py-1 rounded-full">
+                    {mcpServer.allowed_response_headers.length} configured
+                  </span>
+                )}
+              </span>
+            }
+            name="allowed_response_headers"
+          >
+            <Select
+              mode="tags"
+              placeholder={
+                mcpServer?.allowed_response_headers && mcpServer.allowed_response_headers.length > 0
+                  ? `Currently: ${mcpServer.allowed_response_headers.join(", ")}`
+                  : "Enter header names (e.g., X-Request-Id, X-RateLimit-Remaining)"
+              }
+              className="rounded-lg"
+              size="large"
+              tokenSeparators={[","]}
+              allowClear
+            />
+          </Form.Item>
+
+          <Form.Item
+            label={
+              <span className="text-sm font-medium text-gray-700 flex items-center">
                 Static Headers
                 <Tooltip title="Send these key-value headers with every request to this MCP server.">
                   <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.tsx
@@ -295,6 +295,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
       static_headers: initialStaticHeaders,
       env_vars: initialEnvVars,
       extra_headers: mcpServer.extra_headers || [],
+      allowed_response_headers: mcpServer.allowed_response_headers || [],
       oauth_flow_type: oauth2FlowToFormValue(mcpServer.oauth2_flow),
       dcr_bridge: Boolean(mcpServer.dcr_bridge),
       token_validation_json: mcpServer.token_validation
@@ -867,6 +868,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         alias: restValues.alias,
         // Include permission management fields
         extra_headers: restValues.extra_headers || [],
+        allowed_response_headers: restValues.allowed_response_headers || [],
         ...(toolAllowlistEnforced
           ? {
               allowed_tools: allowedTools,

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_view.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_view.tsx
@@ -294,6 +294,16 @@ export const MCPServerView: React.FC<MCPServerViewProps> = ({
                     </div>
                   </div>
                   <div className="py-3 grid grid-cols-3 gap-4">
+                    <Text className="text-sm font-medium text-gray-500">Allowed Response Headers</Text>
+                    <div className="col-span-2 text-sm text-gray-900">
+                      {mcpServer.allowed_response_headers && mcpServer.allowed_response_headers.length > 0 ? (
+                        mcpServer.allowed_response_headers.join(", ")
+                      ) : (
+                        <span className="text-gray-400">—</span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="py-3 grid grid-cols-3 gap-4">
                     <Text className="text-sm font-medium text-gray-500">Allow All Keys</Text>
                     <div className="col-span-2">
                       {mcpServer.allow_all_keys ? (

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
@@ -356,6 +356,7 @@ export interface MCPServer {
   updated_at: string;
   updated_by: string;
   extra_headers?: string[] | null;
+  allowed_response_headers?: string[] | null;
   static_headers?: Record<string, string> | null;
   status?: "healthy" | "unhealthy" | "unknown";
   last_health_check?: string | null;


### PR DESCRIPTION
## Relevant issues

Closes #33447

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

A downstream streamable-HTTP MCP server that sets `X-Example-Header: hello` on its `tools/call` response, registered under `mcp_servers` twice against the same upstream; `hdr_on` opts in, `hdr_off` does not

```yaml
mcp_servers:
  hdr_on:
    url: http://127.0.0.1:8933/mcp/
    transport: http
    allowed_response_headers: ["X-Example-Header", "Authorization"]
  hdr_off:
    url: http://127.0.0.1:8933/mcp/
    transport: http
```

`Authorization` is listed on purpose throughout: it is denylisted, so it must never reach the caller even though an admin asked for it

1. The downstream server really does emit the header; calling it directly, bypassing the proxy

```bash
curl -sS -i -L -X POST http://127.0.0.1:8933/mcp \
  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hi"}}}'
```
```
HTTP/1.1 200 OK
content-type: text/event-stream
x-example-header: hello
data: {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"echo: hi"}],"structuredContent":{"result":"echo: hi"},"isError":false}}
```

2. Before, on unfixed code, through the gateway on `localhost:4000`; the body is correct and the header is gone, with no `_meta`. The allowlist above is already in the config, so this also shows configuration alone does nothing without the fix

```bash
curl -sS -L -X POST http://127.0.0.1:4000/mcp/ \
  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
  -H 'x-litellm-api-key: Bearer sk-1234' \
  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"hdr_on-echo","arguments":{"text":"hi"}}}'
```
```
data: {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"echo: hi"}],"structuredContent":{"result":"echo: hi"},"isError":false}}
```

3. After, same command against the fixed proxy; the upstream header reaches the caller on `_meta`. `Authorization` was listed in the allowlist on purpose and is still withheld, so an upstream credential cannot be opted into the caller's result

```
data: {"jsonrpc":"2.0","id":4,"result":{"_meta":{"ai.litellm/responseHeaders":{"x-example-header":"hello"}},"content":[{"type":"text","text":"echo: hi"}],"structuredContent":{"result":"echo: hi"},"isError":false}}
```

4. After, the server that did not opt in; unchanged, so this is inert for everyone who does not configure it

```bash
curl -sS -L -X POST http://127.0.0.1:4000/mcp/ \
  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
  -H 'x-litellm-api-key: Bearer sk-1234' \
  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"hdr_off-echo","arguments":{"text":"hi"}}}'
```
```
data: {"jsonrpc":"2.0","id":4,"result":{"content":[{"type":"text","text":"echo: hi"}],"structuredContent":{"result":"echo: hi"},"isError":false}}
```

5. The same field set through the REST API, which is what the dashboard form posts, so a server created in the UI behaves identically

```bash
curl -sS -X POST http://127.0.0.1:4141/v1/mcp/server \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"server_name":"hdr_db","alias":"hdr_db","url":"http://127.0.0.1:8933/mcp/","transport":"http","allowed_response_headers":["X-Example-Header","Authorization"]}'

docker exec litellm-mcphdr-pg psql -U postgres -c 'SELECT server_name, allowed_response_headers FROM "LiteLLM_MCPServerTable";'
```
```
 server_name |     allowed_response_headers
-------------+----------------------------------
 hdr_db      | {X-Example-Header,Authorization}
```

6. Calling the tool on that database-created server; the upstream header reaches the caller and the denylisted `Authorization` still does not

```
data: {"jsonrpc":"2.0","id":2,"result":{"_meta":{"ai.litellm/responseHeaders":{"x-example-header":"hello"}},"content":[{"type":"text","text":"echo: hi"}],"structuredContent":{"result":"echo: hi"},"isError":false}}
```

7. Editing the allowlist, then clearing it the way the edit form does; a Prisma `String[]` rejects null, so the cleared case must land as `{}` rather than a 500

```bash
curl -sS -X PUT http://127.0.0.1:4141/v1/mcp/server -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' -d '{"server_id":"'"$SID"'","allowed_response_headers":null}'
```
```
HTTP 202
 allowed_response_headers
--------------------------
 {}
```

## Type

🆕 New Feature

## Changes

The SDK's streamable-HTTP client transport reads only the session id and content-type off an upstream response and hands back a `CallToolResult`, which has no HTTP headers, so a downstream server's custom `tools/call` response headers were gone from every object the gateway holds

This adds an opt-in per-server `allowed_response_headers` allowlist. When set, the client captures those headers off the upstream `tools/call` response through the one seam litellm owns, the httpx client it builds and passes into the SDK transport, and surfaces them on the MCP result's `_meta`. Reading only `response.headers` leaves the streamed body untouched

`_meta` is the right target rather than a real response header. The gateway answers the caller over a stream whose HTTP headers are committed when the stream opens, strictly before the tool handler runs, so no downstream header can be copied onto the gateway's own response; `_meta` is the protocol's reserved slot for out-of-band result metadata and the only channel that survives the gateway re-serializing the result. The key carries a reverse-DNS prefix, `ai.litellm/responseHeaders`, because the spec reserves `mcp` and `modelcontextprotocol` prefixes for protocol use

The capture is scoped to the JSON-RPC `tools/call` rather than to whichever response happened to arrive last, since a session also POSTs `initialize` and notifications and may DELETE the session on close. Credential, cookie, upstream-session and hop-by-hop headers are never forwarded even when an admin lists them explicitly, and the allowlist is normalized once so casing and blank entries are handled in a single place. Unset means no hook is installed and the result is returned untouched

Configurable from config.yaml, the REST API and the dashboard. The column is on all three prisma schemas with a migration, and is carried through the create, edit and temporary-record paths, the row to `MCPServer` build, and the dashboard's edit form and detail view. Because a Prisma `String[]` rejects null and the edit form clears a field to null, an explicit null normalizes to `[]` alongside `allowed_tools`. The unsupported-transport warning fires for database-loaded servers too, since the dashboard can create the same misconfiguration as config.yaml

Docs live in the separate docs repo and would be a follow-up there

## QA runbook

Run a streamable-HTTP MCP server whose `tools/call` handler sets `X-Example-Header: hello`, register it under `mcp_servers` with `allowed_response_headers: ["X-Example-Header"]`, then run the calls above in order. Expect the header on the direct call, absent through the gateway before the change, and present under `result._meta["ai.litellm/responseHeaders"]` after; a second server without the field must return a result with no `_meta`

For the dashboard, go to http://localhost:4000/ui/?page=mcp-servers and either add a server or edit an existing streamable-HTTP one. The field is `Allowed Response Headers` in the permissions section, under `Extra Headers`; enter `X-Example-Header` and save, then reopen the server's detail view and confirm the value renders in the `Allowed Response Headers` row. Calling that server's tool should then return it on `result._meta`. Clearing the field and saving must succeed and leave the row empty

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in feature with header denylisting, but it still forwards admin-chosen upstream response metadata to MCP callers on tool results; misconfiguration on non-HTTP transports is warned but inert.
> 
> **Overview**
> Adds an opt-in per-MCP-server **`allowed_response_headers`** allowlist so callers can receive selected upstream HTTP response headers from **`tools/call`** on streamable-HTTP transports.
> 
> **Persistence & config:** New `allowed_response_headers` column (Prisma migration + API/types/models), wired through config load, DB row → `MCPServer`, REST create/update/temporary records, and dashboard edit/view/permissions UI. Cleared UI values normalize `null` → `[]` for Prisma `String[]`.
> 
> **Runtime:** `MCPClient` installs an httpx response hook only when the allowlist is non-empty, captures headers from JSON-RPC **`tools/call`** responses (not other session traffic), applies a credential/cookie/session/hop-by-hop **denylist**, and merges allowed headers into tool result **`_meta`** under **`ai.litellm/responseHeaders`**. Servers on SSE/stdio with this field set log a warning that the setting is ignored.
> 
> **Tests** cover normalization, capture scoping, `_meta` merging, DB prep, and transport warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8ef01bfbeddf29b871cfc65efa42b38d8433c26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->