### PR TITLE
fix(e2e): stage UI base, complexity router registration, classifier prompt

### DIFF
--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -56,11 +56,13 @@ class TierClassification(BaseModel):
 
 _CLASSIFICATION_PROMPT_TEMPLATE = """Classify the complexity of the following user request into exactly one tier.
 
+Judge the intellectual difficulty of answering correctly, not how short the request is.
+
 Tiers:
-- SIMPLE: factual lookups, greetings, short direct questions with no reasoning or code involved.
-- MEDIUM: everyday requests needing some explanation or minor code/technical content.
-- COMPLEX: requests involving non-trivial code, architecture, or multi-step technical work.
-- REASONING: requests explicitly requiring step-by-step reasoning, analysis, or weighing tradeoffs.
+- SIMPLE: greetings, chitchat, or factual lookups with a short known answer. Do not use SIMPLE for unsolved problems, proofs, deep theory, multi-step analysis, or non-trivial code, even if the request is only one sentence.
+- MEDIUM: everyday requests that need some explanation, light reasoning, or minor code/technical content.
+- COMPLEX: non-trivial code, architecture, multi-step technical work, or specialized domain depth.
+- REASONING: open-ended analysis, proofs, famous hard problems, step-by-step reasoning, tradeoffs, or anything where a correct answer requires careful thought rather than a quick lookup.
 
 {system_context}Request:
 {prompt}"""

--- a/tests/e2e/e2e_config.py
+++ b/tests/e2e/e2e_config.py
@@ -24,8 +24,9 @@ CONTROL_PLANE_BASE_URL = os.environ.get(
 UI_USERNAME = os.environ.get("E2E_UI_USERNAME", "admin")
 UI_PASSWORD = os.environ.get("E2E_UI_PASSWORD", MASTER_KEY)
 
-# Dashboard base URL. On split deployments the Next.js Admin UI is a separate
-# service (e.g. litellm-ui:3000); the data-plane gateway often 404s /ui.
+# Dashboard base URL for playwright. On split stage the ingress ALB routes
+# /ui to the litellm-ui pod; the data-plane gateway ClusterIP 404s /ui. Set
+# E2E_UI_BASE_URL to the ALB (or any host that path-routes /ui to the UI).
 # Defaults to PROXY_BASE_URL so compose/monolith (proxy-served /ui) still works.
 UI_BASE_URL = os.environ.get("E2E_UI_BASE_URL", PROXY_BASE_URL).rstrip("/")
 

--- a/tests/e2e/e2e_config.py
+++ b/tests/e2e/e2e_config.py
@@ -24,6 +24,11 @@ CONTROL_PLANE_BASE_URL = os.environ.get(
 UI_USERNAME = os.environ.get("E2E_UI_USERNAME", "admin")
 UI_PASSWORD = os.environ.get("E2E_UI_PASSWORD", MASTER_KEY)
 
+# Dashboard base URL. On split deployments the Next.js Admin UI is a separate
+# service (e.g. litellm-ui:3000); the data-plane gateway often 404s /ui.
+# Defaults to PROXY_BASE_URL so compose/monolith (proxy-served /ui) still works.
+UI_BASE_URL = os.environ.get("E2E_UI_BASE_URL", PROXY_BASE_URL).rstrip("/")
+
 CHEAP_ANTHROPIC_MODEL = os.environ.get("E2E_CHEAP_ANTHROPIC_MODEL", "claude-haiku-4-5")
 CHEAP_OPENAI_MODEL = os.environ.get("E2E_CHEAP_OPENAI_MODEL", "gpt-5.5")
 

--- a/tests/e2e/e2e_config.py
+++ b/tests/e2e/e2e_config.py
@@ -10,13 +10,10 @@ import uuid
 PROXY_BASE_URL = os.environ.get("LITELLM_PROXY_URL", "http://localhost:4000").rstrip("/")
 MASTER_KEY = os.environ.get("LITELLM_MASTER_KEY", "sk-1234")
 
-# Control-plane (management/admin) base URL. In a split control-plane/data-plane
-# deployment the LLM data plane (PROXY_BASE_URL: /chat, /embeddings, native
-# passthrough) and the management API (keys, users, teams, orgs, budgets, spend,
-# model info, /openapi.json) are served by *different* services. The suite drives
-# both through one Transport that routes by path (see transport.SplitTransport).
-# Defaults to PROXY_BASE_URL so a monolithic proxy serving everything on one URL
-# behaves exactly as before.
+# Control-plane (management/admin) base URL. Defaults to PROXY_BASE_URL so a
+# single path-routing host (stage ALB, compose monolith) works for both planes.
+# Set LITELLM_CONTROL_PLANE_URL only when management is a different base than
+# the LLM host and you are not going through an ingress that path-routes.
 CONTROL_PLANE_BASE_URL = os.environ.get(
     "LITELLM_CONTROL_PLANE_URL", PROXY_BASE_URL
 ).rstrip("/")
@@ -24,10 +21,8 @@ CONTROL_PLANE_BASE_URL = os.environ.get(
 UI_USERNAME = os.environ.get("E2E_UI_USERNAME", "admin")
 UI_PASSWORD = os.environ.get("E2E_UI_PASSWORD", MASTER_KEY)
 
-# Dashboard base URL for playwright. On split stage the ingress ALB routes
-# /ui to the litellm-ui pod; the data-plane gateway ClusterIP 404s /ui. Set
-# E2E_UI_BASE_URL to the ALB (or any host that path-routes /ui to the UI).
-# Defaults to PROXY_BASE_URL so compose/monolith (proxy-served /ui) still works.
+# Dashboard base for playwright. Defaults to PROXY_BASE_URL so one ALB/monolith
+# host covers /ui as well. Override E2E_UI_BASE_URL only if the UI is elsewhere.
 UI_BASE_URL = os.environ.get("E2E_UI_BASE_URL", PROXY_BASE_URL).rstrip("/")
 
 CHEAP_ANTHROPIC_MODEL = os.environ.get("E2E_CHEAP_ANTHROPIC_MODEL", "claude-haiku-4-5")

--- a/tests/e2e/management/conftest.py
+++ b/tests/e2e/management/conftest.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Iterator
 
 import pytest
 
-from e2e_config import PROXY_BASE_URL, UI_PASSWORD, UI_USERNAME
+from e2e_config import UI_BASE_URL, UI_PASSWORD, UI_USERNAME
 from management_client import ManagementClient, build_client
 
 if TYPE_CHECKING:
@@ -47,13 +47,17 @@ def ui_page(browser: "Browser") -> "Iterator[Page]":
     context = browser.new_context()
     try:
         page = context.new_page()
-        page.goto(f"{PROXY_BASE_URL}/ui/")
-        page.fill("#username", UI_USERNAME)
-        page.fill("#password", UI_PASSWORD)
-        page.click('button[type="submit"]')
-        page.wait_for_function(
-            "() => document.cookie.includes('token=') || !document.querySelector('#username')"
-        )
+        # Split deploys serve the Next.js dashboard on the UI service, not the
+        # data-plane gateway (which 404s /ui). Login is a client-rendered form
+        # that appears after LoadingScreen; wait on the placeholder, not #id
+        # (Ant Design Input does not always set id="username").
+        page.goto(f"{UI_BASE_URL}/ui/login")
+        username = page.get_by_placeholder("Enter your username")
+        username.wait_for(state="visible", timeout=30_000)
+        username.fill(UI_USERNAME)
+        page.get_by_placeholder("Enter your password").fill(UI_PASSWORD)
+        page.get_by_role("button", name="Login").click()
+        page.wait_for_function("() => document.cookie.includes('token=')")
         yield page
     finally:
         context.close()

--- a/tests/e2e/management/conftest.py
+++ b/tests/e2e/management/conftest.py
@@ -56,7 +56,7 @@ def ui_page(browser: "Browser") -> "Iterator[Page]":
         username.wait_for(state="visible", timeout=30_000)
         username.fill(UI_USERNAME)
         page.get_by_placeholder("Enter your password").fill(UI_PASSWORD)
-        page.get_by_role("button", name="Login").click()
+        page.get_by_role("button", name="Login", exact=True).click()
         page.wait_for_function("() => document.cookie.includes('token=')")
         yield page
     finally:

--- a/tests/e2e/management/test_key_models_dropdown_e2e.py
+++ b/tests/e2e/management/test_key_models_dropdown_e2e.py
@@ -14,7 +14,7 @@ proxy under test does not serve it.
 
 import pytest
 
-from e2e_config import PROXY_BASE_URL, unique_marker
+from e2e_config import UI_BASE_URL, unique_marker
 from lifecycle import ResourceManager
 from management_client import ManagementClient
 from models import KeyGenerateBody, TeamNewBody
@@ -46,7 +46,7 @@ def _models_dropdown_texts(page: Page, must_contain: str) -> list[str]:
 
 
 def _open_create_key_modal(page: Page) -> None:
-    page.goto(f"{PROXY_BASE_URL}/ui/api-keys/?create=true")
+    page.goto(f"{UI_BASE_URL}/ui/api-keys/?create=true")
     expect(page.locator(".ant-modal").first).to_be_visible()
 
 
@@ -69,7 +69,7 @@ def _submit_create_modal(page: Page, sentinel_label: str) -> str:
 
 
 def _open_key_edit_form(page: Page, key_alias: str) -> None:
-    page.goto(f"{PROXY_BASE_URL}/ui/api-keys/")
+    page.goto(f"{UI_BASE_URL}/ui/api-keys/")
     page.get_by_text(key_alias).first.click()
     page.get_by_role("tab", name="Settings").click()
     page.get_by_role("button", name="Edit Settings").click()

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -442,6 +442,7 @@ class LiteLLMParamsBody(BaseModel):
     output_cost_per_token: float | None = None
     extra_headers: dict[str, str] | None = None
     use_in_pass_through: bool | None = None
+    complexity_router_config: dict[str, object] | None = None
 
 
 ModelMode = Literal["batch", "realtime", "image_generation"]

--- a/tests/e2e/router/conftest.py
+++ b/tests/e2e/router/conftest.py
@@ -3,13 +3,80 @@
 The shared lifecycle (resources/scoped_key), proxy liveness skip, and e2e marker
 live in the parent tests/e2e/conftest.py. ComplexityRouterClient holds the shared
 Gateway, so the `resources` fixture cleans up keys this suite creates.
+
+Also registers `complexity-smart-router` via management /model/new when the
+proxy does not already list it (compose has it in static config; stage does not).
 """
 
+from __future__ import annotations
+
+from collections.abc import Iterator
+
 import pytest
+from requests import RequestException
 
 from complexity_router_client import ComplexityRouterClient, build_client
+from e2e_gateway import Gateway
+from e2e_http import NoBody, Success
+from models import LiteLLMParamsBody, ModelsListResponse
+
+ROUTER_MODEL = "complexity-smart-router"
+ROUTER_PARAMS = LiteLLMParamsBody(
+    model="auto_router/complexity_router",
+    complexity_router_config={
+        "classifier_type": "llm",
+        "classifier_llm_config": {"model": "gpt-5.5"},
+        "tiers": {
+            "SIMPLE": "gpt-5.5",
+            "MEDIUM": "claude-haiku-4-5",
+            "COMPLEX": "claude-haiku-4-5",
+            "REASONING": "claude-haiku-4-5",
+        },
+    },
+)
 
 
 @pytest.fixture(scope="session")
 def client() -> ComplexityRouterClient:
     return build_client()
+
+
+def _model_is_servable(gateway: Gateway, model_name: str) -> bool:
+    result = gateway.transport.get(
+        "/v1/models",
+        headers=gateway.transport.master,
+        params=NoBody(),
+        response_type=ModelsListResponse,
+    )
+    return isinstance(result, Success) and any(entry.id == model_name for entry in result.data.data)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _ensure_complexity_smart_router(  # pyright: ignore[reportUnusedFunction]  # pytest autouse session fixture, wired by name
+    client: ComplexityRouterClient,
+) -> Iterator[None]:
+    """Ensure the complexity router virtual model exists for this session.
+
+    Compose already declares it in docker-compose.yml; stage does not. Register
+    via /model/new when missing and tear down only what we created.
+    """
+    gateway = client.gateway
+    if _model_is_servable(gateway, ROUTER_MODEL):
+        yield
+        return
+
+    try:
+        model_id = gateway.create_model(ROUTER_MODEL, ROUTER_PARAMS)
+    except (AssertionError, RequestException) as exc:
+        if _model_is_servable(gateway, ROUTER_MODEL):
+            yield
+            return
+        raise AssertionError(
+            f"failed to register {ROUTER_MODEL!r} for the complexity router e2e "
+            f"(not listed on /v1/models and /model/new failed): {exc}"
+        ) from exc
+
+    try:
+        yield
+    finally:
+        gateway.delete_model(model_id)

--- a/tests/e2e/router/conftest.py
+++ b/tests/e2e/router/conftest.py
@@ -10,6 +10,7 @@ proxy does not already list it (compose has it in static config; stage does not)
 
 from __future__ import annotations
 
+import time
 from collections.abc import Iterator
 
 import pytest
@@ -17,8 +18,14 @@ from requests import RequestException
 
 from complexity_router_client import ComplexityRouterClient, build_client
 from e2e_gateway import Gateway
-from e2e_http import NoBody, Success
-from models import LiteLLMParamsBody, ModelsListResponse
+from e2e_http import NoBody, Success, unwrap
+from models import (
+    LiteLLMParamsBody,
+    ModelInfoBody,
+    ModelNewBody,
+    ModelNewResponse,
+    ModelsListResponse,
+)
 
 ROUTER_MODEL = "complexity-smart-router"
 ROUTER_PARAMS = LiteLLMParamsBody(
@@ -51,6 +58,38 @@ def _model_is_servable(gateway: Gateway, model_name: str) -> bool:
     return isinstance(result, Success) and any(entry.id == model_name for entry in result.data.data)
 
 
+def _register_router_model(gateway: Gateway) -> str:
+    """POST /model/new only; returns the proxy model_id before data-plane wait.
+
+    Split from create_model so a slow control→data propagation timeout still
+    leaves us a model_id for teardown (avoids orphaning complexity-smart-router).
+    """
+    return unwrap(
+        gateway.transport.post(
+            "/model/new",
+            headers=gateway.transport.master,
+            json=ModelNewBody(
+                model_name=ROUTER_MODEL,
+                litellm_params=ROUTER_PARAMS,
+                model_info=ModelInfoBody(),
+            ),
+            response_type=ModelNewResponse,
+        )
+    ).model_id
+
+
+def _await_router_model_servable(gateway: Gateway) -> None:
+    deadline = time.monotonic() + gateway.poll_timeout
+    while time.monotonic() < deadline:
+        if _model_is_servable(gateway, ROUTER_MODEL):
+            return
+        time.sleep(gateway.poll_interval)
+    raise AssertionError(
+        f"model {ROUTER_MODEL!r} was created but never became servable on the data "
+        f"plane within {gateway.poll_timeout}s of /model/new"
+    )
+
+
 @pytest.fixture(scope="session", autouse=True)
 def _ensure_complexity_smart_router(  # pyright: ignore[reportUnusedFunction]  # pytest autouse session fixture, wired by name
     client: ComplexityRouterClient,
@@ -66,7 +105,7 @@ def _ensure_complexity_smart_router(  # pyright: ignore[reportUnusedFunction]  #
         return
 
     try:
-        model_id = gateway.create_model(ROUTER_MODEL, ROUTER_PARAMS)
+        model_id = _register_router_model(gateway)
     except (AssertionError, RequestException) as exc:
         if _model_is_servable(gateway, ROUTER_MODEL):
             yield
@@ -77,6 +116,7 @@ def _ensure_complexity_smart_router(  # pyright: ignore[reportUnusedFunction]  #
         ) from exc
 
     try:
+        _await_router_model_servable(gateway)
         yield
     finally:
         gateway.delete_model(model_id)


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Local e2e proxy (`e2e-litellm-1` on `:4000`) after patching only the classifier prompt into the running image (workspace change is `a224dbb777`)

Before (old prompt; LLM path was running but returned SIMPLE):

```
ComplexityRouter: routing decision cause=complexity_scorer, tier=SIMPLE, score=1.000,
signals=['llm-classifier:SIMPLE'], routed_model=gpt-5.5
```

After (same request `"Is P equal to NP?"`):

```
ComplexityRouter: routing decision cause=complexity_scorer, tier=REASONING, score=1.000,
signals=['llm-classifier:REASONING'], routed_model=claude-haiku-4-5
```

Spend log for the key:

```
model=claude-haiku-4-5 call_type=acompletion
```

Live e2e (no mocks):

```
cd tests/e2e && LITELLM_MASTER_KEY=sk-1234 uv run pytest router/test_complexity_router_e2e.py -q --tb=short
# 1 passed in 10.18s
# E2E_RESULT ... outcome=passed covers=reliability.routing.complexity_llm_classifier.routes_by_llm_tier
```

UI login path: Playwright now uses `E2E_UI_BASE_URL` and `get_by_role("button", name="Login", exact=True)` so "Login with SSO" is not matched

## Type

Bug Fix
Test

## Changes

Stage e2e still failed the key-models dropdown suite and the complexity router classifier test after Claude CLI work landed

Gateway `/ui` returns 404 on the componentized stage chart; the Admin UI is `litellm-ui:3000`. Playwright was hitting the data plane, so `#username` never appeared. Tests now use `E2E_UI_BASE_URL` (defaults to `LITELLM_PROXY_URL` for compose), open `/ui/login`, wait on the Ant Design placeholders after the loading screen, and click the exact Login button so the SSO control is not matched under Playwright strict mode

`complexity-smart-router` only exists in docker-compose `model_list`. Router conftest registers it via management `/model/new` when `/v1/models` does not list it, awaits the data plane, and deletes only what it created. `/model/new` is split from the wait so a propagation timeout still has a model_id for teardown

The LLM complexity classifier was already running on stage/local (signals `llm-classifier:SIMPLE`), but the classification prompt treated short wording as SIMPLE. `"Is P equal to NP?"` stayed on the SIMPLE backend and the e2e looked like the old silent heuristic fallback. The prompt now scores intellectual difficulty so short hard questions land above SIMPLE while greetings and short factual lookups stay SIMPLE

Companion wiring (same env name, separate repos):
- litellm-auto chart: `litellm.uiHost` -> `E2E_UI_BASE_URL`
- litellm-ops e2e app: prefer one ALB path-routing host when possible

## QA runbook

- tests/e2e/router/test_complexity_router_e2e.py::TestComplexityRouterLlmClassifier::test_llm_classifier_runs_and_routes_by_semantic_tier - LLM classifier runs and routes a short hard prompt above SIMPLE (anthropic/claude-haiku-4-5 in the spend log)
  - [ ] Ensure proxy has `gpt-5.5`, `claude-haiku-4-5`, and either compose config or `/model/new` for `complexity-smart-router` with `classifier_type: llm` and `classifier_llm_config.model: gpt-5.5`
  - [ ] Generate a key scoped to those models: `curl -sS -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"models":["complexity-smart-router","gpt-5.5","claude-haiku-4-5"],"max_budget":10}'`
  - [ ] Chat: `curl -sS -X POST http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{"model":"complexity-smart-router","messages":[{"role":"user","content":"Is P equal to NP?"}],"max_tokens":16}'`
  - [ ] Expect proxy log `signals=['llm-classifier:REASONING']` (or MEDIUM/COMPLEX) and `routed_model=claude-haiku-4-5`, not `gpt-5.5`
  - [ ] Expect `/spend/logs?api_key=$KEY` to show the higher-tier backend model (not the SIMPLE openai deployment)
  - [ ] Sanity check: this fails if the classifier crashes and falls back to heuristic (SIMPLE) OR if the prompt still scores short hard questions as SIMPLE

- tests/e2e/management/test_key_models_dropdown_e2e.py (create-key UI paths) - Admin UI login and model multi-select work against the dashboard host
  - [ ] Set `E2E_UI_BASE_URL` to the dashboard origin (compose: same as proxy; stage: ALB or `http://litellm-ui...:3000` when ingress splits)
  - [ ] Open `$E2E_UI_BASE_URL/ui/login`, sign in as admin, create a virtual key with model multi-select
  - [ ] Expect no timeout on `#username` and no strict-mode dual match on Login vs Login with SSO
  - [ ] Sanity check: this is about reaching the real Admin UI, not grepping a gateway 404 page

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
