### PR TITLE
fix(e2e): recover llm_translation/realtime suite; error-event fail-fast, gemini defer-setup, pipecat pin

### DIFF
--- a/litellm/llms/gemini/realtime/transformation.py
+++ b/litellm/llms/gemini/realtime/transformation.py
@@ -1103,7 +1103,11 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
         key: str,
         value: Any,
         current_delta_type: Optional[ALL_DELTA_TYPES],
-    ) -> Union[OpenAIRealtimeEventTypes, ResponsesAPIStreamEvents]:
+    ) -> Union[OpenAIRealtimeEventTypes, ResponsesAPIStreamEvents, None]:
+        """Map a Gemini top-level key to the OpenAI event it produces. Returns None
+        for a ``generationComplete`` with no preceding content deltas (a toolCall-only
+        or empty generation): there is no text/audio "done" to emit for it, and
+        raising here used to make the caller drop the entire backend frame."""
         if isinstance(value, dict):
             model_turn_event = value.get("modelTurn")
             generation_complete_event = value.get("generationComplete")
@@ -1114,6 +1118,8 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
         if model_turn_event:  # check if model turn event
             openai_event = self.map_model_turn_event(model_turn_event)
         elif generation_complete_event:
+            if current_delta_type is None:
+                return None
             openai_event = self.map_generation_complete_event(delta_type=current_delta_type)
         else:
             # Check if this key or any nested key matches our mapping. Use a
@@ -1237,6 +1243,7 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
             server_content_handled = False
 
         tool_call_handled = False
+        generation_complete_handled = False
         for key, value in list(json_message.items()):  # snapshot: handlers may mutate json_message
             # Skip sibling metadata keys (e.g. ``usageMetadata``) that can
             # accompany a primary payload like ``toolCall`` or ``serverContent``.
@@ -1255,6 +1262,9 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
                 value=value,
                 current_delta_type=current_delta_type,
             )
+            if openai_event is None:
+                generation_complete_handled = True
+                continue
 
             if openai_event == OpenAIRealtimeEventTypes.SESSION_CREATED:
                 transformed_message = self.transform_session_created_event(
@@ -1498,6 +1508,7 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
                 for key in json_message
                 if key in _KNOWN_GEMINI_TOP_LEVEL_KEYS
                 and not (key == "serverContent" and server_content_handled)
+                and not (key == "serverContent" and generation_complete_handled)
                 and not (key == "toolCall" and tool_call_handled)
             ]
             standalone_usage_metadata = json_message.get("usageMetadata")

--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -135,6 +135,7 @@ services:
     environment:
       LITELLM_MASTER_KEY: sk-1234
       STORE_MODEL_IN_DB: "True"
+      LITELLM_GEMINI_LIVE_DEFER_SETUP: "true"
       DD_API_KEY: local-sink-noauth
       DD_SITE: datadoghq.com
       DD_BASE_URL: http://dd-sink:8080

--- a/tests/e2e/llm_translation/realtime/REALTIME_COVERAGE_MATRIX.md
+++ b/tests/e2e/llm_translation/realtime/REALTIME_COVERAGE_MATRIX.md
@@ -22,7 +22,9 @@ appears). That raw-websocket tool path is the source of truth for tool calling.
 `test_pipecat_tool_smoke` is a realism layer through pipecat for openai, azure,
 and gemini only (not vertex_ai: native-audio live is flaky under pipecat tool
 calling while raw-ws tools pass; see pipecat-ai/pipecat#2544). Assertions are
-coarse; raw-ws remains authoritative. Requires `pipecat-ai`.
+coarse; raw-ws remains authoritative. Requires `pipecat-ai[openai]<1.5`:
+1.5.0 broke the azure/gemini/vertex realtime paths through the proxy
+(`pipecat_service.py` fails loudly on >=1.5).
 
 Pipecat audio coverage lives in `test_realtime_pipecat_audio_e2e.py` (VAD / audio
 I/O).
@@ -57,7 +59,12 @@ to turn its tests green.
 ## Running
 
 Start a proxy with the provider keys set in its environment (the suite registers
-the deployments itself), then
+the deployments itself). The proxy must also run with
+`LITELLM_GEMINI_LIVE_DEFER_SETUP=true` (the `tests/e2e` compose stack sets it):
+the suite configures sessions through the client's first `session.update`, and
+without deferred setup the Gemini Live bridge sends its own `setup` at connect,
+ignores that `session.update`, and never echoes `session.updated`, so every
+gemini and vertex_ai case times out. Then
 
 ```
 uv run pytest tests/e2e/llm_translation/realtime/ -v

--- a/tests/e2e/llm_translation/realtime/pipecat_service.py
+++ b/tests/e2e/llm_translation/realtime/pipecat_service.py
@@ -9,16 +9,28 @@ three overrides from bot.py needed to talk to the proxy, the keepalive-disabling
 
 Importing this module skips the collecting test when pipecat is not installed:
 
-    uv pip install "pipecat-ai[openai]"
+    uv pip install "pipecat-ai[openai]<1.5"
+
+pipecat 1.5.0 broke the azure/gemini/vertex realtime paths through the proxy
+(openai still passes; raw-ws passes for every provider), so imports fail loudly
+on >=1.5 instead of letting the suites fail as opaque no-response timeouts.
 """
 
 # pipecat is an optional, dynamically typed dependency loaded behind importorskip,
 # so its symbols are Unknown to the type checker; relax those rules for this file.
 # pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportUnknownParameterType=false, reportMissingParameterType=false
 
+from importlib.metadata import version as _distribution_version
+
 import pytest
 
 pytest.importorskip("pipecat", reason="pipecat-ai not installed")
+
+_PIPECAT_VERSION = _distribution_version("pipecat-ai")
+assert tuple(int(part) for part in _PIPECAT_VERSION.split(".")[:2]) < (1, 5), (
+    f"pipecat-ai {_PIPECAT_VERSION} is installed, but >=1.5 breaks the "
+    'azure/gemini/vertex realtime paths; install "pipecat-ai[openai]<1.5"'
+)
 
 from pipecat.services.openai.realtime.llm import (  # noqa: E402
     OpenAIRealtimeLLMService,

--- a/tests/e2e/llm_translation/realtime/realtime_client.py
+++ b/tests/e2e/llm_translation/realtime/realtime_client.py
@@ -307,6 +307,11 @@ class RealtimeSession:
     def collect_until(
         self, stop_type: str, *, timeout: float
     ) -> tuple[ReceivedEvent, ...]:
+        """Collect events until `stop_type` arrives. A server `error` event fails
+        immediately with the error payload instead of burning the rest of the
+        timeout: upstream failures (bad key, exhausted quota) arrive as an `error`
+        event on an otherwise-open socket, and waiting out the timeout used to
+        bury the cause in a bare "no session.created; got ['error']" (LIT-4482)."""
         deadline = time.monotonic() + timeout
         collected: list[ReceivedEvent] = []
         while time.monotonic() < deadline:
@@ -322,6 +327,10 @@ class RealtimeSession:
             collected.append(event)
             if event.type == stop_type:
                 return tuple(collected)
+            if event.type == "error":
+                raise AssertionError(
+                    f"server sent 'error' while waiting for {stop_type!r}: {event.payload}"
+                )
         raise TimeoutError(
             f"no {stop_type!r} within {timeout}s; got {[e.type for e in collected]}"
         )

--- a/tests/e2e/llm_translation/realtime/test_realtime_pipecat_e2e.py
+++ b/tests/e2e/llm_translation/realtime/test_realtime_pipecat_e2e.py
@@ -10,7 +10,7 @@ the raw-websocket suite is the source of truth.
 The harness is synchronous, so each test stays a normal sync function and drives
 the async pipecat pipeline with asyncio.run. Skips unless pipecat is installed:
 
-    uv pip install "pipecat-ai[openai]"
+    uv pip install "pipecat-ai[openai]<1.5"
 
 Known caveat: pipecat tool calling over the realtime service has been flaky
 upstream (pipecat-ai/pipecat#2544). A failure here with the matching raw-ws tool
@@ -103,7 +103,18 @@ async def _run_pipeline(key: str, model: str) -> tuple[bool, bool]:
     )
     llm.register_function("get_weather", get_weather)
 
-    context = LLMContext(tools=WEATHER_TOOL)
+    context = LLMContext(
+        messages=[
+            {
+                "role": "system",
+                "content": (
+                    "Use the get_weather tool whenever the user asks about weather. "
+                    "After receiving the result, state the temperature."
+                ),
+            }
+        ],
+        tools=WEATHER_TOOL,
+    )
     aggregator = LLMContextAggregatorPair(context)
     capture = _CaptureText()
     task = PipelineTask(

--- a/tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py
+++ b/tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py
@@ -311,6 +311,37 @@ def test_gemini_realtime_transformation_generation_complete():
     assert contains_audio_done_event, "Expected audio done event"
 
 
+def test_gemini_realtime_transformation_generation_complete_without_deltas():
+    config = GeminiRealtimeConfig()
+
+    session_configuration_request_str = json.dumps(
+        {
+            "setup": {
+                "model": "gemini-1.5-flash",
+                "generationConfig": {"responseModalities": ["AUDIO"]},
+            }
+        }
+    )
+
+    result = config.transform_realtime_response(
+        json.dumps({"serverContent": {"generationComplete": True}}),
+        "gemini-1.5-flash",
+        MagicMock(),
+        realtime_response_transform_input={
+            "session_configuration_request": session_configuration_request_str,
+            "current_output_item_id": None,
+            "current_response_id": None,
+            "current_conversation_id": None,
+            "current_delta_chunks": [],
+            "current_item_chunks": [],
+            "current_delta_type": None,
+        },
+    )
+
+    assert result["response"] == []
+    assert result["current_delta_type"] is None
+
+
 def test_gemini_3_1_flash_live_preview_model_cost_map_entry():
     for key in (
         "gemini-3.1-flash-live-preview",


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4482

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All before proofs were captured at fba7ac4428, all after proofs at 94add306ad, against the tests/e2e compose stack (published main-latest image with this PR's gemini realtime transformation mounted in, real provider APIs, real $)

**Root cause 1, the three cells in the ticket: the OpenAI key on the gateway ran out of quota.** Probing the realtime websocket directly with the key the gateway had (before):

```
$ python probe_realtime.py gpt-realtime-2   # wss://api.openai.com/v1/realtime, key from .env
EVENT: error
{"type": "error", "error": {"type": "insufficient_quota", "code": "insufficient_quota",
 "message": "You exceeded your current quota, ..."}}
websockets.exceptions.ConnectionClosedError: received 1013 (try again later) insufficient_quota
```

The upstream sends one `error` event and closes 1013; through the proxy the suite saw `TimeoutError: no 'session.created' within 20s; got ['error']`. After rotating to the funded key the same probe completes a full round trip (`session.created` -> `response.done` with usage), and the three cells pass (full suite run below)

**Root cause 2, harness: the error payload was thrown away.** `collect_until` waited out the full timeout after the server had already said why it failed. Now it fails immediately with the payload. Demo against the live proxy with a deliberately broken deployment (before: 20s of silence then the bare timeout above; after):

```
$ curl -X POST http://localhost:47210/model/new -H "Authorization: Bearer sk-1234" \
    -d '{"model_name": "badkey-realtime-proof", "litellm_params": {"model": "openai/gpt-realtime-2", "api_key": "sk-invalid-proof"}, "model_info": {"mode": "realtime"}}'
$ python - <<'EOF'   # connect through the proxy with the suite's own client
from realtime_client import build_client
with build_client().connect(key="sk-1234", model="badkey-realtime-proof") as session:
    session.collect_until("session.created", timeout=20)
EOF
failed fast after 0.3s:
AssertionError: server sent 'error' while waiting for 'session.created': {"type": "error",
 "event_id": "event_E2Ogrja2slAhlq27odlDj", "error": {"type": "invalid_request_error",
 "code": "invalid_api_key", "message": "Incorrect API key provided: sk-inval****roof. ...", ...}}
```

**Root cause 3, gemini/vertex hang silently without deferred setup.** With `LITELLM_GEMINI_LIVE_DEFER_SETUP` unset, the bridge sends its own Gemini `setup` at connect and drops the client's first `session.update` without ever echoing `session.updated`, so all four gemini/vertex raw-ws cells timed out on the compose stack (before, at fba7ac4428):

```
FAILED test_realtime_e2e.py::test_text_conversation[gemini]      TimeoutError: no 'session.updated' within 20s; got []
FAILED test_realtime_e2e.py::test_text_conversation[vertex_ai]   TimeoutError: no 'session.updated' within 20s; got []
FAILED test_realtime_e2e.py::test_tool_call_round_trip[gemini]   TimeoutError: no 'session.updated' within 20s; got []
FAILED test_realtime_e2e.py::test_tool_call_round_trip[vertex_ai] TimeoutError: no 'session.updated' within 20s; got []
```

After adding the flag to the compose stack all four pass in 10s total

**Root cause 4, product: toolCall-only and empty Gemini generations crashed the frame handler.** Every gemini/vertex tool-call turn logged this on the proxy and dropped the frame (before):

```
21:54:06 - LiteLLM:ERROR - realtime_streaming.py:984 - Error processing backend message, skipping: Unexpected delta type: None
ValueError: Unexpected delta type: None
```

`generationComplete` with no preceding content deltas hit `map_generation_complete_event(None)` which raised, and the caller skipped the whole backend frame; on the vertex server-VAD path that intermittently stalled the client. After the fix the same workloads produce zero occurrences:

```
$ docker logs --since 90m <litellm> 2>&1 | grep -c "Unexpected delta type"
0
```

**Full suite after (94add306ad):**

```
$ LITELLM_PROXY_URL=http://localhost:47210 uv run pytest tests/e2e/llm_translation/realtime -v --timeout=300
test_realtime_e2e.py::test_text_conversation[openai|azure|gemini|vertex_ai]         4 PASSED
test_realtime_e2e.py::test_tool_call_round_trip[openai|azure|gemini|vertex_ai]      4 PASSED
test_realtime_pipecat_audio_e2e.py::test_pipecat_server_vad[all 4 providers]        4 PASSED
test_realtime_pipecat_audio_e2e.py::test_pipecat_audio_output[all 4 providers]      4 PASSED
test_realtime_pipecat_audio_e2e.py::test_pipecat_server_vad_audio_input[openai|azure|gemini] 3 PASSED
test_realtime_pipecat_audio_e2e.py::test_pipecat_server_vad_audio_input[vertex_ai]    FAILED
test_realtime_pipecat_e2e.py::test_pipecat_tool_smoke[openai|azure|gemini]          3 PASSED
============ 1 failed, 22 passed, 49 warnings in 695.06s (0:11:35) =============
```

The one red cell, `test_pipecat_server_vad_audio_input[vertex_ai]`, is the documented vertex native-audio flake (passes 2 of 3 isolated reruns; the suite already excludes vertex_ai from `test_pipecat_tool_smoke` for the same reason, see pipecat-ai/pipecat#2544)

## Type

🐛 Bug Fix
✅ Test

## Changes

Recovers the `tests/e2e/llm_translation/realtime` suite failures from the stage e2e logs of 2026-07-15 and the additional problems found while reproducing them

The gateway-side cause of the three cells in the ticket was the OpenAI key running out of quota (confirmed by probing `wss://api.openai.com/v1/realtime` directly: one `error` event then a 1013 close). That is a credentials rotation, not a code change; the stage gateway secret still needs the funded key (see handoff in the Linear ticket)

Code changes, all small:

`realtime_client.py::collect_until` now fails immediately when the server sends an `error` event, quoting the full payload, instead of sitting out the timeout and reporting the opaque `no 'session.created' within 20s; got ['error']` that made the stage logs undiagnosable

`tests/e2e/docker-compose.yml` now sets `LITELLM_GEMINI_LIVE_DEFER_SETUP=true`. The suite configures sessions through the client's first `session.update` (tools, instructions, VAD), which only reaches Gemini in deferred-setup mode; without it the bridge ignores that update and never echoes `session.updated`, so every gemini/vertex raw-ws cell times out. REALTIME_COVERAGE_MATRIX.md documents the requirement

`litellm/llms/gemini/realtime/transformation.py::map_openai_event` returns None for a `generationComplete` with no preceding content deltas (toolCall-only or empty generations) instead of raising `ValueError: Unexpected delta type: None`, which made the caller drop the entire backend frame. This fired on every gemini/vertex tool-call turn and intermittently stalled the vertex server-VAD path. Regression test added in tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py

`test_realtime_pipecat_e2e.py::test_pipecat_tool_smoke` now seeds the context with the same tool-use instruction the raw-ws tool test uses, so the smoke no longer depends on the model spontaneously deciding to call the tool

`pipecat_service.py` pins `pipecat-ai[openai]<1.5` and fails imports loudly on >=1.5: pipecat 1.5.0 broke the azure/gemini/vertex realtime paths through the proxy (openai still passes, raw-ws passes for every provider; verified by downgrading to 1.4.0, which turns those exact cells green). The underlying >=1.5 incompatibility is a product gap that deserves its own ticket

## QA runbook

- tests/e2e/llm_translation/realtime/test_realtime_e2e.py::test_text_conversation[gemini] (and [vertex_ai]) - a GA client's session.update is acknowledged and a text conversation completes through the Gemini Live bridge
  - [ ] Start the compose stack: `docker compose -f tests/e2e/docker-compose.yml up -d` with OPENAI/AZURE/GEMINI/VERTEXAI creds in tests/e2e/.env (the stack now sets LITELLM_GEMINI_LIVE_DEFER_SETUP=true)
  - [ ] Register a deployment: `curl -X POST http://localhost:4000/model/new -H "Authorization: Bearer sk-1234" -d '{"model_name": "gemini-rt", "litellm_params": {"model": "gemini/gemini-3.1-flash-live-preview", "api_key": "os.environ/GEMINI_API_KEY"}, "model_info": {"mode": "realtime"}}'`
  - [ ] Connect `wscat -c "ws://localhost:4000/v1/realtime?model=gemini-rt" -H "Authorization: Bearer sk-1234"` and expect a `session.created` event
  - [ ] Send `{"type": "session.update", "session": {"modalities": ["text"], "instructions": "You are a terse assistant."}}` and expect a `session.updated` echo (this is the step that hangs forever without the compose flag)
  - [ ] Send `{"type": "conversation.item.create", "item": {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Say the single word hello."}]}}` then `{"type": "response.create"}` and expect `response.created`, deltas, and `response.done` with usage
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/realtime/test_realtime_e2e.py::test_tool_call_round_trip[gemini] (and [vertex_ai]) - a tool call round-trips and the proxy no longer logs `Unexpected delta type: None` on the toolCall turn
  - [ ] In the same wscat session, send a session.update declaring the get_weather tool, ask "What's the weather in Paris right now?", send response.create, and expect `response.function_call_arguments.done`
  - [ ] Reply with `conversation.item.create` (function_call_output, `{"city": "Paris", "temperature_f": 72}`) plus `response.create`, and expect a follow-up response quoting 72
  - [ ] Confirm `docker logs <litellm> 2>&1 | grep -c "Unexpected delta type"` prints 0 (before this PR it incremented on every tool-call turn)
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/realtime/test_realtime_pipecat_e2e.py::test_pipecat_tool_smoke[openai|azure|gemini] - a pipecat voice-bot pipeline against the proxy invokes get_weather and speaks the result
  - [ ] `uv pip install "pipecat-ai[openai]<1.5"` (1.5.0 fails the import guard on purpose; installing it and running any pipecat test should print the guard's message naming the pin)
  - [ ] `LITELLM_PROXY_URL=http://localhost:4000 uv run pytest tests/e2e/llm_translation/realtime/test_realtime_pipecat_e2e.py -v`
  - [ ] Expect all three providers to pass; the system instruction now pins tool use, so a run where the model never calls get_weather indicates a real regression rather than model whim
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

Environment prerequisites: OPENAI_API_KEY must have Realtime quota (probe `POST https://api.openai.com/v1/chat/completions` directly with the key first; an insufficient_quota 429 there reproduces the exact `got ['error']` timeouts from the ticket), AZURE_API_BASE/AZURE_API_KEY need a `gpt-realtime` deployment, and vertex needs VERTEXAI_CREDENTIALS readable inside the container

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
