### PR TITLE
chore(release): backport #33592 to stable/1.90.x and cut 1.90.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,7 @@ COPY --from=builder /app/litellm/proxy/prisma_migration.py /app/litellm/proxy/pr
 # working directory on sys.path; litellm/proxy/hooks resolves
 # enterprise.enterprise_hooks from it)
 COPY --from=builder /app/enterprise /app/enterprise
+COPY --from=builder /app/litellm-proxy-extras /app/litellm-proxy-extras
 # Prisma binaries live in $HOME/.cache (default prisma-python location),
 # which is /root/.cache here. Copy only the Prisma subdirs — copying the
 # whole /root/.cache drags in the uv build cache (~660 MB, includes a

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -84,6 +84,7 @@ COPY --from=builder /app/litellm/proxy/prisma_migration.py /app/litellm/proxy/pr
 # working directory on sys.path; litellm/proxy/hooks resolves
 # enterprise.enterprise_hooks from it)
 COPY --from=builder /app/enterprise /app/enterprise
+COPY --from=builder /app/litellm-proxy-extras /app/litellm-proxy-extras
 # Prisma binaries live in $HOME/.cache (default prisma-python location),
 # which is /root/.cache here. Copy them from the builder so they survive
 # deployments that volume-mount /app/.cache (e.g. readOnlyRootFilesystem

--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -109,6 +109,7 @@ COPY --from=builder /app/litellm/proxy/prisma_migration.py /app/litellm/proxy/pr
 # working directory on sys.path; litellm/proxy/hooks resolves
 # enterprise.enterprise_hooks from it)
 COPY --from=builder /app/enterprise /app/enterprise
+COPY --from=builder /app/litellm-proxy-extras /app/litellm-proxy-extras
 COPY --from=builder /app/.cache /app/.cache
 COPY --from=builder /var/lib/litellm/ui /var/lib/litellm/ui
 COPY --from=builder /var/lib/litellm/assets /var/lib/litellm/assets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm"
-version = "1.90.4"
+version = "1.90.5"
 description = "Library to easily interface with LLM API providers"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"
@@ -272,7 +272,7 @@ source-exclude = [
 profile = "black"
 
 [tool.commitizen]
-version = "1.90.4"
+version = "1.90.5"
 version_files = [
     "pyproject.toml:^version",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-08T19:10:40.622802Z"
+exclude-newer = "2026-07-13T22:37:30.905404Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3245,7 +3245,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.90.4"
+version = "1.90.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Relevant issues

Backports [#33592](https://github.com/BerriAI/litellm/pull/33592) onto `stable/1.90.x` and cuts `1.90.5`. #30243 narrowed the runtime stage of the three Dockerfiles to an allowlist COPY, which dropped `/app/litellm-proxy-extras` from published images starting `v1.90.0`. Deployments that run their own pre-deploy migration job (modeled on the helm migration job: pull the same image the app runs, then `prisma migrate deploy` against the schema and migrations shipped at that path) broke on upgrade to 1.90.x, and the breakage is silent because `prisma migrate deploy` exits 0 without applying anything when the schema it is pointed at has no adjacent migrations directory. This restores the folder in the runtime stage of all three Dockerfiles, matching what images up to `v1.89.x` contained (about 6 MB per image)

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## What is included

- #33592 fix(docker): restore litellm-proxy-extras source dir in runtime images (`111d447e1b`), cherry-picked with `-x`
- chore: bump `1.90.4` -> `1.90.5`
- chore: refresh `uv.lock` for `1.90.5`

## Adaptation notes

None. The pick is patch-identical (`git patch-id --stable` matches the staging squash) and applied without conflicts. The change touches no Python, so the line's Black 88-column `format-check` scope is unaffected

## Known noise on this line

The pick adds or modifies no Python or test files, so there is no targeted pytest delta to judge. The claim was verified directly on images built from this branch (below)

## Screenshots / Proof of Fix

Broken behavior, captured on the published `ghcr.io/berriai/litellm:v1.90.4` image (the tip of this line before the pick). The folder is gone, and pointing prisma at the `/app/schema.prisma` that does still ship exits 0 while applying nothing, so a migration job reports success against an unmigrated database:

```
$ docker run --rm --entrypoint sh ghcr.io/berriai/litellm:v1.90.4 -c 'ls /app/litellm-proxy-extras'
ls: /app/litellm-proxy-extras: No such file or directory
$ echo $?
1
$ docker run --rm -e DATABASE_URL="postgresql://postgres:...@host.docker.internal:55433/mig_base" \
    --entrypoint sh ghcr.io/berriai/litellm:v1.90.4 -c 'prisma migrate deploy --schema /app/schema.prisma'
Datasource "client": PostgreSQL database "mig_base", schema "public" at "host.docker.internal:55433"

No migration found in prisma/migrations

No pending migrations to apply.
$ echo $?
0
$ docker exec bp-pe-pg psql -U postgres -d mig_base -tc "SELECT count(*) FROM pg_tables WHERE schemaname='public';"
     1
```

The single table left behind is prisma's own `_prisma_migrations` bookkeeping table

Fixed behavior, on images built locally from this branch from each of the three Dockerfiles, each run against a fresh database:

```
$ docker build -t litellm-190x-fix:main -f Dockerfile .
$ docker run --rm -e DATABASE_URL="postgresql://postgres:...@host.docker.internal:55433/mig_main" \
    --entrypoint sh litellm-190x-fix:main -c '
      test -f /app/litellm-proxy-extras/litellm_proxy_extras/schema.prisma && echo "schema: present" &&
      test -d /app/litellm-proxy-extras/litellm_proxy_extras/migrations && echo "migrations dir: present" &&
      diff /app/schema.prisma /app/litellm-proxy-extras/litellm_proxy_extras/schema.prisma && echo "schema matches /app/schema.prisma" &&
      prisma migrate deploy --schema /app/litellm-proxy-extras/litellm_proxy_extras/schema.prisma'
schema: present
migrations dir: present
schema matches /app/schema.prisma
127 migrations found in prisma/migrations

All migrations have been successfully applied.
$ echo $?
0
$ docker exec bp-pe-pg psql -U postgres -d mig_main -tc "SELECT count(*) FROM pg_tables WHERE schemaname='public';"
    66
```

The same flow passes on the `docker/Dockerfile.database` build (schema present and matching, 127 migrations applied to a fresh database, 66 tables, exit 0) and on the `docker/Dockerfile.non_root` build running as its default uid 65534 (schema present and matching, migrations dir readable, 127 migrations applied, 66 tables, exit 0). 127 is the correct count here: it is this line's own migrations catalog (staging ships 135), which is exactly what a v1.90.5 image should carry

An adversarial verification pass over the pick survived on all three sub-claims: each builder stage provably produces the directory before the new COPY references it (so it cannot land empty), the runtime contract ships it in all three images, and nothing on this line depends on the directory's absence (the non_root recursive chown covers the new folder before the privilege drop to uid 65534, and `.dockerignore` strips nothing from it). The pass also confirmed the restored folder is read only by external pre-deploy migration jobs: every in-repo migration path resolves schema and migrations from the installed `litellm_proxy_extras` package in site-packages, and the helm migration job uses the separate `litellm-migrations` image that always carried the folder. That matches the upstream PR's framing and means the change is inert for in-repo code paths; the risk is presence-only

## Type

🐛 Bug Fix

## Changes

Cherry-pick of #33592 onto `stable/1.90.x`, plus the `1.90.5` version bump and lock refresh. One `COPY --from=builder /app/litellm-proxy-extras /app/litellm-proxy-extras` line in the runtime stage of each of `Dockerfile`, `docker/Dockerfile.database`, and `docker/Dockerfile.non_root`. No schema, dependency, or configuration changes

## QA runbook

1. `git fetch origin && git checkout litellm_backport_1_90_x_bp_proxy_extras_0716`
2. `docker build -t qa-190x:main -f Dockerfile .`
3. `docker run --rm --entrypoint sh qa-190x:main -c 'ls /app/litellm-proxy-extras/litellm_proxy_extras/migrations | head'` and confirm the migrations directory is present and non-empty
4. Point a fresh Postgres at it: `docker run --rm -e DATABASE_URL="postgresql://<user>:<pass>@host.docker.internal:<port>/<fresh-db>" --entrypoint sh qa-190x:main -c 'prisma migrate deploy --schema /app/litellm-proxy-extras/litellm_proxy_extras/schema.prisma'` and confirm 127 migrations apply with exit 0

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
