### PR TITLE
fix(mcp): expand toolset grants in shared permission primitives so tools/call honors them

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -1220,9 +1220,27 @@ class MCPRequestHandler:
                 global_mcp_server_manager,
             )
 
-            key_tools = (
+            key_direct_tools = (
                 global_mcp_server_manager.expand_tool_permissions(key_obj_perm.mcp_tool_permissions).get(server_id)
                 if key_obj_perm
+                else None
+            )
+
+            # Tools granted through the key's toolsets restrict this server exactly
+            # as direct tool permissions do; union with any direct grants so the
+            # tool-level check sees the key's full effective tool scope
+            key_toolset_ids = (key_obj_perm.mcp_toolsets or []) if key_obj_perm else []
+            key_toolset_tools = (
+                (await global_mcp_server_manager.resolve_toolset_tool_permissions(toolset_ids=key_toolset_ids)).get(
+                    server_id
+                )
+                if key_toolset_ids
+                else None
+            )
+
+            key_tools = (
+                list(set(key_direct_tools or []) | set(key_toolset_tools or []))
+                if key_direct_tools is not None or key_toolset_tools is not None
                 else None
             )
             team_tools = (
@@ -1430,8 +1448,18 @@ class MCPRequestHandler:
                 global_mcp_server_manager.expand_tool_permissions(key_object_permission.mcp_tool_permissions).keys()
             )
 
+            # servers referenced by the key's toolset grants are part of the key's
+            # scope on every path (list, call, REST), subject to the same team/org
+            # ceilings as any other key-level grant
+            toolset_ids = key_object_permission.mcp_toolsets or []
+            toolset_servers = (
+                list((await global_mcp_server_manager.resolve_toolset_tool_permissions(toolset_ids=toolset_ids)).keys())
+                if toolset_ids
+                else []
+            )
+
             # Combine all lists
-            all_servers = direct_mcp_servers + access_group_servers + tool_perm_servers
+            all_servers = direct_mcp_servers + access_group_servers + tool_perm_servers + toolset_servers
             return list(set(all_servers))
         except Exception as e:
             verbose_logger.warning(f"Failed to get allowed MCP servers for key: {str(e)}")

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -515,20 +515,19 @@ if MCP_AVAILABLE:
         # enforced even when no allowlist is set (matches the SSE/HTTP path).
         tools = filter_tools_by_allowed_tools(tools, server)
 
-        # Filter tools based on user_api_key_auth.object_permission.mcp_tool_permissions
-        # This provides per-key/team/org control over which tools can be accessed
-        if (
-            user_api_key_auth
-            and user_api_key_auth.object_permission
-            and user_api_key_auth.object_permission.mcp_tool_permissions
-        ):
-            # Dict keys may be server_ids OR names/aliases; normalize so lookup
-            # by concrete server_id resolves name-keyed restrictions too.
-            allowed_tools_for_server = global_mcp_server_manager.expand_tool_permissions(
-                user_api_key_auth.object_permission.mcp_tool_permissions
-            ).get(server.server_id)
-            if allowed_tools_for_server is not None and len(allowed_tools_for_server) > 0:
-                # Filter tools to only include those in the allowed list
+        # Filter by the key's effective tool permissions through the same
+        # primitive the MCP protocol path uses (direct grants, toolset grants,
+        # and team/agent/org ceilings), so REST listing cannot drift from it
+        if user_api_key_auth:
+            from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
+                MCPRequestHandler,
+            )
+
+            allowed_tools_for_server = await MCPRequestHandler.get_allowed_tools_for_server(
+                server_id=server.server_id,
+                user_api_key_auth=user_api_key_auth,
+            )
+            if allowed_tools_for_server is not None:
                 tools = [tool for tool in tools if _tool_name_matches(tool.name, allowed_tools_for_server)]
 
         return _create_tool_response_objects(tools, server)

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2218,43 +2218,6 @@ if MCP_AVAILABLE:
         server = global_mcp_server_manager.get_mcp_server_by_id(server_id)
         return [t for t in tools if strip_known_server_prefix(t.name, server) in allowed_tool_names]
 
-    async def _merge_toolset_permissions(
-        user_api_key_auth: Optional[UserAPIKeyAuth],
-    ) -> Optional[UserAPIKeyAuth]:
-        """
-        Resolve mcp_toolsets on the key's object_permission into tool-level permissions
-        and merge them (union) into object_permission.mcp_tool_permissions.
-
-        Returns the (possibly mutated copy of) user_api_key_auth.
-        """
-        if user_api_key_auth is None:
-            return None
-        op = user_api_key_auth.object_permission
-        if op is None:
-            return user_api_key_auth
-        toolset_ids = getattr(op, "mcp_toolsets", None) or []
-        if not toolset_ids:
-            return user_api_key_auth
-
-        toolset_perms = await global_mcp_server_manager.resolve_toolset_tool_permissions(toolset_ids=toolset_ids)
-        if not toolset_perms:
-            return user_api_key_auth
-
-        # Merge toolset_perms into existing mcp_tool_permissions (union)
-        existing = dict(op.mcp_tool_permissions or {})
-        for server_id, tool_names in toolset_perms.items():
-            existing_tools = existing.get(server_id, [])
-            merged = list(set(existing_tools) | set(tool_names))
-            existing[server_id] = merged
-
-        # Build updated object_permission with merged tool permissions and server IDs.
-        # Union the toolset's server IDs into mcp_servers so downstream server-level
-        # filtering doesn't silently drop servers that the toolset references but that
-        # aren't already in the key's explicit mcp_servers list.
-        merged_servers = list(set(op.mcp_servers or []) | set(existing.keys()))
-        updated_op = op.model_copy(update={"mcp_servers": merged_servers, "mcp_tool_permissions": existing})
-        return user_api_key_auth.model_copy(update={"object_permission": updated_op})
-
     async def _list_mcp_tools(
         user_api_key_auth: Optional[UserAPIKeyAuth] = None,
         mcp_auth_header: Optional[str] = None,
@@ -2281,10 +2244,6 @@ if MCP_AVAILABLE:
         """
         if not MCP_AVAILABLE:
             return []
-
-        # Resolve toolset permissions and merge into the key's object_permission
-        # so that the existing filter_tools_by_key_team_permissions logic picks them up.
-        user_api_key_auth = await _merge_toolset_permissions(user_api_key_auth)
 
         # Get tools from managed MCP servers with error handling
         managed_tools = []

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -376,6 +376,35 @@ class TestMCPRequestHandler:
 
         assert result == ["server-a"]
 
+    async def test_toolset_servers_stay_capped_by_team_ceiling(self):
+        """Toolset grants expand the KEY's scope, which the team ceiling still
+        intersects; a toolset must never grant a server the team does not allow.
+        Pins that toolset expansion lives in the intersected key scope, not the
+        additive access-group path"""
+        user_api_key_auth = UserAPIKeyAuth(api_key="test-key", user_id="test-user", team_id="test-team")
+        key_object_permission = self._toolset_only_object_permission(["toolset-1"])
+        mock_manager = self._mock_manager_with_toolsets(
+            {"server-in-team": ["lookup_status"], "server-outside-team": ["other_tool"]}
+        )
+
+        with (
+            patch.object(MCPRequestHandler, "_get_key_object_permission", return_value=key_object_permission),
+            patch(
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+                mock_manager,
+            ),
+            patch.object(MCPRequestHandler, "_get_mcp_servers_from_access_groups", AsyncMock(return_value=[])),
+            patch.object(
+                MCPRequestHandler,
+                "_get_allowed_mcp_servers_for_team",
+                AsyncMock(return_value=["server-in-team", "server-unrelated"]),
+            ),
+            patch.object(MCPRequestHandler, "_get_key_access_group_mcp_server_extras", AsyncMock(return_value=[])),
+        ):
+            result = await MCPRequestHandler.get_allowed_mcp_servers(user_api_key_auth)
+
+        assert result == ["server-in-team"]
+
     async def test_get_allowed_tools_for_server_unions_toolset_and_direct_tools(self):
         user_api_key_auth = UserAPIKeyAuth(api_key="test-key", user_id="test-user")
         key_object_permission = self._toolset_only_object_permission(["toolset-1"])

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -301,6 +301,158 @@ class TestMCPRequestHandler:
 
         assert result == [SpecialMCPServerNames.no_mcp_servers.value]
 
+    def _toolset_only_object_permission(self, toolset_ids):
+        key_object_permission = MagicMock()
+        key_object_permission.mcp_servers = []
+        key_object_permission.mcp_access_groups = []
+        key_object_permission.mcp_tool_permissions = None
+        key_object_permission.mcp_toolsets = toolset_ids
+        return key_object_permission
+
+    def _mock_manager_with_toolsets(self, toolset_perms):
+        mock_manager = MagicMock()
+        mock_manager.expand_permission_list = MagicMock(side_effect=lambda servers: servers)
+        mock_manager.expand_tool_permissions = MagicMock(side_effect=lambda perms: perms or {})
+        mock_manager.resolve_toolset_tool_permissions = AsyncMock(return_value=toolset_perms)
+        return mock_manager
+
+    async def test_get_allowed_mcp_servers_for_key_includes_toolset_servers(self):
+        """A key granted only mcp_toolsets must reach the toolset's servers on
+        every path (list, call, REST); regression for the list-ok/call-403 bug"""
+        user_api_key_auth = UserAPIKeyAuth(api_key="test-key", user_id="test-user")
+        key_object_permission = self._toolset_only_object_permission(["toolset-1"])
+        mock_manager = self._mock_manager_with_toolsets({"server-a": ["lookup_status"]})
+
+        with (
+            patch.object(MCPRequestHandler, "_get_key_object_permission", return_value=key_object_permission),
+            patch(
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+                mock_manager,
+            ),
+            patch.object(MCPRequestHandler, "_get_mcp_servers_from_access_groups", AsyncMock(return_value=[])),
+        ):
+            result = await MCPRequestHandler._get_allowed_mcp_servers_for_key(user_api_key_auth)
+
+        assert result == ["server-a"]
+        mock_manager.resolve_toolset_tool_permissions.assert_awaited_once_with(toolset_ids=["toolset-1"])
+
+    async def test_get_allowed_mcp_servers_for_key_skips_toolset_resolution_when_none_granted(self):
+        user_api_key_auth = UserAPIKeyAuth(api_key="test-key", user_id="test-user")
+        key_object_permission = self._toolset_only_object_permission([])
+        key_object_permission.mcp_servers = ["server-direct"]
+        mock_manager = self._mock_manager_with_toolsets({})
+
+        with (
+            patch.object(MCPRequestHandler, "_get_key_object_permission", return_value=key_object_permission),
+            patch(
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+                mock_manager,
+            ),
+            patch.object(MCPRequestHandler, "_get_mcp_servers_from_access_groups", AsyncMock(return_value=[])),
+        ):
+            result = await MCPRequestHandler._get_allowed_mcp_servers_for_key(user_api_key_auth)
+
+        assert result == ["server-direct"]
+        mock_manager.resolve_toolset_tool_permissions.assert_not_awaited()
+
+    async def test_get_allowed_mcp_servers_toolset_only_key_end_to_end_inheritance(self):
+        """The full get_allowed_mcp_servers flow (key/team inheritance, no team
+        restriction) surfaces toolset-granted servers for a toolset-only key"""
+        user_api_key_auth = UserAPIKeyAuth(api_key="test-key", user_id="test-user")
+        key_object_permission = self._toolset_only_object_permission(["toolset-1"])
+        mock_manager = self._mock_manager_with_toolsets({"server-a": ["lookup_status"]})
+
+        with (
+            patch.object(MCPRequestHandler, "_get_key_object_permission", return_value=key_object_permission),
+            patch(
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+                mock_manager,
+            ),
+            patch.object(MCPRequestHandler, "_get_mcp_servers_from_access_groups", AsyncMock(return_value=[])),
+            patch.object(MCPRequestHandler, "_get_allowed_mcp_servers_for_team", AsyncMock(return_value=[])),
+            patch.object(MCPRequestHandler, "_get_key_access_group_mcp_server_extras", AsyncMock(return_value=[])),
+        ):
+            result = await MCPRequestHandler.get_allowed_mcp_servers(user_api_key_auth)
+
+        assert result == ["server-a"]
+
+    async def test_get_allowed_tools_for_server_unions_toolset_and_direct_tools(self):
+        user_api_key_auth = UserAPIKeyAuth(api_key="test-key", user_id="test-user")
+        key_object_permission = self._toolset_only_object_permission(["toolset-1"])
+        key_object_permission.mcp_tool_permissions = {"server-a": ["direct_tool"]}
+        mock_manager = self._mock_manager_with_toolsets({"server-a": ["lookup_status"]})
+
+        with (
+            patch.object(MCPRequestHandler, "_get_key_object_permission", return_value=key_object_permission),
+            patch.object(MCPRequestHandler, "_get_team_object_permission", AsyncMock(return_value=None)),
+            patch(
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+                mock_manager,
+            ),
+        ):
+            result = await MCPRequestHandler.get_allowed_tools_for_server(
+                server_id="server-a",
+                user_api_key_auth=user_api_key_auth,
+            )
+
+        assert result is not None
+        assert set(result) == {"direct_tool", "lookup_status"}
+
+    async def test_get_allowed_tools_for_server_toolset_only_key_restricts_to_toolset_tools(self):
+        """A toolset grant must RESTRICT the server's tools, not fall through to
+        the allow-all default; otherwise merging servers alone would over-grant
+        every tool on a toolset-referenced server"""
+        user_api_key_auth = UserAPIKeyAuth(api_key="test-key", user_id="test-user")
+        key_object_permission = self._toolset_only_object_permission(["toolset-1"])
+        mock_manager = self._mock_manager_with_toolsets({"server-a": ["lookup_status"]})
+
+        with (
+            patch.object(MCPRequestHandler, "_get_key_object_permission", return_value=key_object_permission),
+            patch.object(MCPRequestHandler, "_get_team_object_permission", AsyncMock(return_value=None)),
+            patch(
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+                mock_manager,
+            ),
+        ):
+            allowed = await MCPRequestHandler.get_allowed_tools_for_server(
+                server_id="server-a",
+                user_api_key_auth=user_api_key_auth,
+            )
+            is_granted_tool_allowed = await MCPRequestHandler.is_tool_allowed_for_server(
+                tool_name="lookup_status",
+                server_id="server-a",
+                user_api_key_auth=user_api_key_auth,
+            )
+            is_other_tool_allowed = await MCPRequestHandler.is_tool_allowed_for_server(
+                tool_name="delete_everything",
+                server_id="server-a",
+                user_api_key_auth=user_api_key_auth,
+            )
+
+        assert allowed == ["lookup_status"]
+        assert is_granted_tool_allowed is True
+        assert is_other_tool_allowed is False
+
+    async def test_get_allowed_tools_for_server_without_restrictions_stays_allow_all(self):
+        user_api_key_auth = UserAPIKeyAuth(api_key="test-key", user_id="test-user")
+        key_object_permission = self._toolset_only_object_permission([])
+        mock_manager = self._mock_manager_with_toolsets({})
+
+        with (
+            patch.object(MCPRequestHandler, "_get_key_object_permission", return_value=key_object_permission),
+            patch.object(MCPRequestHandler, "_get_team_object_permission", AsyncMock(return_value=None)),
+            patch(
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+                mock_manager,
+            ),
+        ):
+            result = await MCPRequestHandler.get_allowed_tools_for_server(
+                server_id="server-a",
+                user_api_key_auth=user_api_key_auth,
+            )
+
+        assert result is None
+
     async def test_permission_inheritance_edge_cases(self):
         """Test edge cases in permission inheritance"""
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -8496,3 +8496,34 @@ def test_build_mcp_server_table_carries_null_oauth2_flow():
     table = manager._build_mcp_server_table(server)
 
     assert table.oauth2_flow is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_toolset_tool_permissions_single_db_fetch_across_checks():
+    """The server-level and tool-level permission primitives each resolve the
+    key's toolsets during one request; the shared cache must dedupe the DB
+    fetch so the request costs a single toolset query however many checks run"""
+    from litellm.caching.caching import DualCache
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        MCPServerManager,
+    )
+
+    manager = MCPServerManager()
+    toolset = MagicMock()
+    toolset.tools = [{"server_id": "server-a", "tool_name": "lookup_status"}]
+    list_toolsets_mock = AsyncMock(return_value=[toolset])
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.toolset_db.list_mcp_toolsets",
+            list_toolsets_mock,
+        ),
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", DualCache()),
+    ):
+        first = await manager.resolve_toolset_tool_permissions(toolset_ids=["ts-1"])
+        second = await manager.resolve_toolset_tool_permissions(toolset_ids=["ts-1"])
+
+    assert first == {"server-a": ["lookup_status"]}
+    assert second == first
+    list_toolsets_mock.assert_awaited_once()

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -2654,3 +2654,74 @@ class TestToolResponseMcpInfoEnrichment:
             "server_id": "server-uuid",
             "alias": None,
         }
+
+
+class TestRestListToolsetFiltering:
+    @pytest.mark.asyncio
+    async def test_rest_list_filters_toolset_only_key_to_toolset_tools(self, monkeypatch):
+        """A toolset-only key reaching a toolset server via REST list must see
+        only the toolset's tools; the raw catalog leaked every tool on the
+        server when the filter read object_permission directly instead of the
+        shared toolset-aware primitive"""
+        from unittest.mock import patch
+
+        from mcp.types import Tool as MCPTool
+
+        from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
+            MCPRequestHandler,
+        )
+        from litellm.proxy._experimental.mcp_server.server import MCPServer
+        from litellm.types.mcp import MCPTransport
+
+        stub_server = MCPServer(
+            server_id="server-a",
+            name="stubtools",
+            transport=MCPTransport.http,
+        )
+        stub_server.alias = "stubtools"
+        stub_server.server_name = "stubtools"
+        stub_server.allowed_tools = None
+        stub_server.disallowed_tools = None
+        stub_server.mcp_info = {"server_name": "stubtools"}
+
+        upstream_tools = [
+            MCPTool(name="lookup_status", inputSchema={"type": "object"}),
+            MCPTool(name="delete_everything", inputSchema={"type": "object"}),
+        ]
+
+        key_object_permission = MagicMock()
+        key_object_permission.mcp_servers = []
+        key_object_permission.mcp_access_groups = []
+        key_object_permission.mcp_tool_permissions = None
+        key_object_permission.mcp_toolsets = ["toolset-1"]
+
+        user_auth = UserAPIKeyAuth(api_key="test-key", user_id="test-user")
+
+        mock_manager = MagicMock()
+        mock_manager.expand_tool_permissions = MagicMock(side_effect=lambda perms: perms or {})
+        mock_manager.resolve_toolset_tool_permissions = AsyncMock(
+            return_value={"server-a": ["lookup_status"]}
+        )
+
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "_get_tools_from_server",
+            AsyncMock(return_value=upstream_tools),
+        )
+
+        with (
+            patch.object(MCPRequestHandler, "_get_key_object_permission", return_value=key_object_permission),
+            patch.object(MCPRequestHandler, "_get_team_object_permission", AsyncMock(return_value=None)),
+            patch(
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+                mock_manager,
+            ),
+        ):
+            result = await rest_endpoints._get_tools_for_single_server(
+                server=stub_server,
+                server_auth_header=None,
+                raw_headers=None,
+                user_api_key_auth=user_auth,
+            )
+
+        assert [tool.name for tool in result] == ["lookup_status"]


### PR DESCRIPTION
## Relevant issues

Customer report (Pylon #4335): a key granted access through a toolset can list the toolset's tools but calling any of them returns 403

## Linear ticket

Part of LIT-4448 (prerequisite for the entitlement enforcement point; does not resolve the ticket)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on localhost:4012, fresh Postgres, stub streamable-HTTP MCP server ("stubtools") exposing two tools: `lookup_status` and `delete_everything`. Fixture: a toolset containing ONLY `{stubtools, lookup_status}`, and a key whose object_permission grants ONLY that toolset (`mcp_toolsets: [<toolset_id>]`, no mcp_servers, no tool permissions)

Before (unfixed, captured at `669ef389b9`): the key can list the tool but not call it, on both the MCP protocol path and the REST path

```
# streamable /mcp with x-litellm-api-key: Bearer <toolset-only key>
tools/list  -> tools: ['stubtools-lookup_status']
tools/call stubtools-lookup_status
            -> {"result":{"content":[{"type":"text","text":"Error: User not allowed to call this tool."}],"isError":true}}

# REST call path
POST /mcp-rest/tools/call {"server_id":"<id>","name":"lookup_status",...}
            -> {"detail":{"error":"access_denied","message":"The key is not allowed to access server <id>"}}
```

After (fixed, captured at `e25cab6ed5`): same fixture, same curls

```
tools/list  -> tools: ['stubtools-lookup_status']                      # list unchanged
tools/call stubtools-lookup_status
            -> {"content":[{"type":"text","text":"status of abc: OK"}],"isError":false}

# negative control: tool on the SAME server but NOT in the toolset stays blocked
tools/call stubtools-delete_everything
            -> {"content":[{"type":"text","text":"Error: {'error': \"Tool 'delete_everything' is not allowed for your key/team on server 'stubtools'...\"}"}],"isError":true}

# REST call path now matches
POST /mcp-rest/tools/call name=lookup_status      -> {"content":[{"text":"status of rest: OK"}],"isError":false}
POST /mcp-rest/tools/call name=delete_everything  -> {"detail":{"error":"Tool 'delete_everything' is not allowed for your key/team on server 'stubtools'..."}}

# admin sanity: master key still calls anything
POST /mcp-rest/tools/call name=delete_everything (master key) -> {"content":[{"text":"deleted everything (yes)"}],"isError":false}
```

## Type

🐛 Bug Fix

## Changes

A key granted MCP access only through toolsets could list the granted tools but not call them. tools/list ran a toolset expansion step (`_merge_toolset_permissions`) before filtering, but `call_mcp_tool` computed allowed servers from the raw auth object, so the server-level check saw an empty server list and returned 403 before execution. The REST `/mcp-rest/tools/call` endpoint had the same gap through its own resolver

Rather than bolting the expansion onto each remaining entry point (there were already four near-duplicate toolset expansion wrappers, and any new entry point would re-introduce the bug), this PR moves toolset awareness into the two shared permission primitives every path already consults: `_get_allowed_mcp_servers_for_key` now unions the servers referenced by the key's toolsets into the key's scope (subject to the same team/org ceilings as any other key-level grant), and `get_allowed_tools_for_server` unions the toolset's tool list into the key's per-server tool restrictions. The second half is what prevents over-granting: the call path's tool-level check defaults to allow-all when a server has no restrictions, so expanding servers without tools would have exposed every tool on a toolset-referenced server. With both in place, a toolset key reaches exactly the toolset's tools and nothing else

The list path's `_merge_toolset_permissions` wrapper is deleted; tools/list now gets identical behavior from the shared primitives, so list and call can no longer drift. A review round surfaced the one remaining path still reading raw object_permission for tool filtering: the REST tools list helper, which would have listed every tool on a toolset server; it now consults the same get_allowed_tools_for_server primitive, which also applies the team/agent/org tool ceilings the raw read ignored and fails closed on an empty allowed list, matching the protocol path. `/toolset/{name}/mcp` scoping (`_apply_toolset_scope`) replaces the object_permission and empties `mcp_toolsets` before the primitives run, so toolset-scoped routes are unaffected; the Responses API MCP handler does its own equivalent merge and is likewise unaffected. Team-level `mcp_toolsets` remains a key-creation ceiling only, matching its behavior on every path before this change

Tests: six new cases in the mapped auth test file covering server expansion for a toolset-only key, the no-toolsets fast path (no resolver round-trip), end-to-end inheritance through `get_allowed_mcp_servers`, direct+toolset tool union, the over-grant negative control (granted tool allowed, sibling tool on the same server denied), and preservation of allow-all when no restrictions exist. Mutation-checked: dropping the server union, the tool union, or the union gate each fails at least one test. A follow-up commit pins the scope semantics explicitly: toolset grants expand the KEY scope (union within a level) and the team ceiling still intersects it (intersection across levels), killing the mutant where toolset servers escape into the additive grant path. Full MCP suite (393 pre-existing tests) passes with the wrapper removed

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP authorization for keys using toolsets across list, call, and REST; incorrect union/intersection logic could over-grant tools or block valid access, but behavior is heavily regression-tested.
> 
> **Overview**
> Fixes **toolset-only API keys** that could **list** granted MCP tools but got **403 on call** (and inconsistent REST behavior) because toolset expansion lived only on the list path.
> 
> **`mcp_toolsets` is now resolved inside shared auth primitives** instead of a one-off merge before `tools/list`. `_get_allowed_mcp_servers_for_key` unions servers from the key’s toolsets into allowed servers (still capped by team/org ceilings). `get_allowed_tools_for_server` unions toolset tools with direct `mcp_tool_permissions` so tool-level checks see the full key scope and toolset-only keys are restricted to toolset tools, not allow-all on the server.
> 
> **`_merge_toolset_permissions` is removed** from the protocol list path; list and call both use the same primitives. REST `_get_tools_for_single_server` stops reading raw `object_permission` and calls `get_allowed_tools_for_server` so REST listing matches protocol paths and team ceilings.
> 
> Tests cover toolset-only server access, team intersection, tool union/over-grant guards, REST list filtering, and toolset resolution caching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5d38b84e0d5641bb3ce991bc70eb737a614a0e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

