### PR TITLE
test(azure): guard the gpt-5 reasoning_effort=none base_model gate at the SDK layer

### DIFF
--- a/tests/test_litellm/llms/azure/chat/test_azure_base_model_routing.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_base_model_routing.py
@@ -170,6 +170,56 @@ class TestGetOptionalParamsWithBaseModel:
                 base_model="azure/gpt-5",
             )
 
+    def test_should_allow_reasoning_effort_none_for_custom_deployment_with_gpt5_base_model(
+        self,
+    ):
+        """GH #31243: the reasoning_effort='none' gate must resolve via base_model."""
+        params = get_optional_params(
+            model="gpt-5.6-sol-e2e",
+            custom_llm_provider="azure",
+            reasoning_effort="none",
+            base_model="azure/gpt-5.6-sol",
+        )
+        assert params.get("reasoning_effort") == "none"
+
+    def test_should_reject_reasoning_effort_none_for_custom_deployment_without_base_model(
+        self,
+    ):
+        """GH #31243: without base_model the 'none' gate fails closed for unknown deployment names."""
+        with pytest.raises(litellm.UnsupportedParamsError):
+            get_optional_params(
+                model="gpt-5.6-sol-e2e",
+                custom_llm_provider="azure",
+                reasoning_effort="none",
+            )
+
+
+class TestCompletionThreadsBaseModelIntoParamGate:
+    """litellm.completion must thread the base_model kwarg into get_optional_params (GH #31243)."""
+
+    def test_should_complete_with_reasoning_effort_none_when_base_model_is_set(self):
+        response = litellm.completion(
+            model="azure/gpt-5.6-sol-e2e",
+            base_model="azure/gpt-5.6-sol",
+            messages=[{"role": "user", "content": "hi"}],
+            reasoning_effort="none",
+            mock_response="ok",
+            api_key="fake-key",
+            api_base="https://fake.openai.azure.com",
+        )
+        assert response.choices[0].message.content == "ok"
+
+    def test_should_raise_for_reasoning_effort_none_without_base_model(self):
+        with pytest.raises(litellm.UnsupportedParamsError):
+            litellm.completion(
+                model="azure/gpt-5.6-sol-e2e",
+                messages=[{"role": "user", "content": "hi"}],
+                reasoning_effort="none",
+                mock_response="ok",
+                api_key="fake-key",
+                api_base="https://fake.openai.azure.com",
+            )
+
 
 # ---------------------------------------------------------------------------
 # Backward compatibility — existing patterns still work


### PR DESCRIPTION
## Relevant issues

Guards #31243 at the SDK layer. The fix itself shipped in PR #28490; live e2e coverage of the same shape is in #33468

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

The guarded behavior is client-side SDK param mapping, so the before/after proof is the same real Azure OpenAI call made through `litellm.completion` on the last release without the fix versus this branch. The deployment `gpt-5.6-sol-e2e` is a real custom-named `gpt-5.6-sol` deployment on the e2e suite Azure resource; the after run reaches Azure and costs real $

Before, captured on `litellm==1.86.7` from PyPI (the fix first shipped in v1.87.0; it entered release branches as a cherry-pick, so `git tag --contains` on the staging commit misleadingly points at v1.91.0):

```bash
$ python - <<'EOF'
import os
import litellm
litellm.completion(
    model="azure/gpt-5.6-sol-e2e",
    base_model="azure/gpt-5.6-sol",
    messages=[{"role": "user", "content": "A farmer has 17 sheep, all but 9 run away, then he buys twice as many as remain minus 3. How many sheep? Reply with just the number."}],
    max_completion_tokens=2000,
    reasoning_effort="none",
    api_base=os.environ["AZURE_API_BASE"],
    api_key=os.environ["AZURE_API_KEY"],
)
EOF
UnsupportedParamsError: litellm.UnsupportedParamsError: Azure OpenAI does not support reasoning_effort='none' for this model. Supported values are: 'low', 'medium', and 'high'. To drop this parameter, set `litellm.drop_params=True` or for proxy:

`litellm_settings:
 drop_params: true`
Issue: https://github.com/BerriAI/litellm/issues/16704
```

The error is raised before any network call, which is exactly why the e2e row in #33468 cannot see it: the proxy's config-file registration resolves capabilities via `base_model` on its own, so a live proxy passes this shape even on images whose SDK path is broken (verified on the v1.86.2 image)

After, captured at commit 2df2c6c165 (same call, printing the response):

```bash
$ python - <<'EOF'
import os
import litellm
r = litellm.completion(
    model="azure/gpt-5.6-sol-e2e",
    base_model="azure/gpt-5.6-sol",
    messages=[{"role": "user", "content": "A farmer has 17 sheep, all but 9 run away, then he buys twice as many as remain minus 3. How many sheep? Reply with just the number."}],
    max_completion_tokens=2000,
    reasoning_effort="none",
    api_base=os.environ["AZURE_API_BASE"],
    api_key=os.environ["AZURE_API_KEY"],
)
print(f"content={r.choices[0].message.content!r} reasoning_tokens={r.usage.completion_tokens_details.reasoning_tokens}")
EOF
content='24' reasoning_tokens=0
```

## Type

✅ Test

## Changes

Adds four tests to `tests/test_litellm/llms/azure/chat/test_azure_base_model_routing.py` (the test file PR #28490 introduced) pinning the exact GH #31243 shape at the SDK layer: `reasoning_effort='none'` against a custom-named Azure deployment whose true model is supplied via `base_model`

Two tests pin `get_optional_params`: with `base_model="azure/gpt-5.6-sol"` the param survives mapping as `reasoning_effort='none'`, and without `base_model` the gate fails closed with `UnsupportedParamsError`, so the positive test cannot pass vacuously. Two tests pin the `litellm.completion` kwarg plumbing in `main.py` using `mock_response`, which short-circuits after `get_optional_params` runs, so they exercise the real param-mapping path with no network

Why this is needed on top of the e2e row in #33468: the proxy's startup registration of config-file models resolves capabilities through `base_model` independently, which masks an SDK-layer regression from any proxy-level test (the v1.86.2 image passes the e2e shape while its own SDK raises). These unit tests are the only guard that fails on an SDK-layer revert

Kill power was verified by mutation: reverting `_azure_detection_model = base_model or model` to `model` in `litellm/utils.py` fails 6 tests in the file including the new ones, and nulling the `base_model` kwarg extraction in `litellm/main.py` fails only the new completion-level test, coverage no existing test provided

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
