### PR TITLE
fix(ui): show all teams in policy attachment form for admins

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/add_attachment_form.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/add_attachment_form.test.tsx
@@ -18,6 +18,10 @@ vi.mock("./impact_preview_alert", () => ({
     React.createElement("div", { "data-testid": "impact-preview" }, `${impactResult.affected_keys_count} keys`),
 }));
 
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
+  default: () => ({ userId: "admin-user-id", userRole: "Admin", accessToken: "test-token" }),
+}));
+
 const makePolicy = (overrides: Partial<Policy> = {}): Policy => ({
   policy_id: "policy-id-1",
   policy_name: "test-policy",
@@ -69,6 +73,12 @@ describe("AddAttachmentForm", () => {
       expect(networking.keyListCall).toHaveBeenCalled();
       expect(networking.modelAvailableCall).toHaveBeenCalled();
     });
+  });
+
+  it("fetches all teams, not just teams the caller is a member of (LIT-4199)", async () => {
+    renderWithProviders(<AddAttachmentForm {...defaultProps} />);
+    await waitFor(() => expect(networking.teamListCall).toHaveBeenCalled());
+    expect(networking.teamListCall).toHaveBeenCalledWith("test-token", null, null);
   });
 
   it("should not fetch teams, keys, or models when accessToken is null", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/add_attachment_form.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/add_attachment_form.tsx
@@ -56,7 +56,7 @@ const AddAttachmentForm: React.FC<AddAttachmentFormProps> = ({
     setIsLoadingTeams(true);
     setTeamsLoaded(false);
     try {
-      const teamsResponse = await teamListCall(accessToken, null, userId);
+      const teamsResponse = await teamListCall(accessToken, null, null);
       const teamsArray = Array.isArray(teamsResponse) ? teamsResponse : teamsResponse?.data || [];
       const teamAliases = teamsArray.map((t: any) => t.team_alias).filter(Boolean);
       setAvailableTeams(teamAliases);


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4199

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

UI change; verified against a live proxy plus the dashboard dev server. Before captured at `224fe67f10` (litellm_internal_staging), after captured at `598a578cab` (this branch). Two teams were created: `team-lit4199-a` (the proxy admin is a member) and `team-lit4199-b` (the proxy admin is NOT a member)

1. Start the proxy (`python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug`) and the dashboard (`npm run dev` in `ui/litellm-dashboard`)
2. Create a team the admin is not a member of: `curl -X POST http://localhost:4000/team/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"team_alias": "team-lit4199-b"}'` (do not add yourself as a member)
3. Log in to the UI as the proxy admin, open http://localhost:3000/?page=policies, create a policy if none exists, switch to the Attachments tab and click "+ Add New Attachment"
4. Select Scope Type "Specific" and open the Teams dropdown

Before the fix: `team-lit4199-b` is missing from the dropdown, and typing it shows the validation error "These teams don't exist"

![before - team-lit4199-b missing from dropdown](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvMjI5ZWY2NjUtOWYxMi00MWVkLTkyZjktNDIzOTY3YjlhMTJjIiwiaWF0IjoxNzg0MjUyMzY5LCJleHAiOjE3ODQ4NTcxNjksImZpbGVuYW1lIjoiYmVmb3JlLndlYnAifQ.d7YOMRp6Unpq7iXEClGWJEPlfPemspzKgmwVNPke7RM)

After the fix: `team-lit4199-b` appears in the dropdown, is selectable, and the attachment is created successfully

![after - team-lit4199-b now selectable and attachment created](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvMzA5Zjc5NjItNTYwMi00ZjJjLWI3MjgtZmUwNDM2NmQ5ZDBjIiwiaWF0IjoxNzg0MjUyMzY5LCJleHAiOjE3ODQ4NTcxNjksImZpbGVuYW1lIjoiYWZ0ZXIud2VicCJ9.Z06fC97eBv57H_9JXQl_3C8VBIBpu1sLfZrW7rzPSOU)

## Type

🐛 Bug Fix

## Changes

The Create Policy Attachment form loaded its Teams dropdown with `teamListCall(accessToken, null, userId)`, which hits `GET /team/list?user_id=<caller>`. The backend treats a non-null `user_id` as a membership filter for every role, proxy admins included (`_authorize_and_filter_teams` in `team_endpoints.py`), so admins only saw teams they were personally a member of. Teams created by other admins or via SSO silently vanished from the dropdown

This compounded with the client-side scope validation from #32131: typed entries are checked against that same member-filtered list, so valid team aliases were rejected with "These teams don't exist". Only wildcard patterns like `team-*` slipped through, since wildcards skip the existence check

The fix drops the `user_id` filter from the call. The policies page is gated to admin roles in the nav (`all_admin_roles`), and `/team/list` without `user_id` returns all teams for both `PROXY_ADMIN` and `PROXY_ADMIN_VIEW_ONLY` while still scoping org admins to their organizations server side

The regression test mocks `useAuthorized` with a concrete `userId` and asserts the team fetch passes no user filter; it fails on the previous code

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


Link to Devin session: https://app.devin.ai/sessions/63337648882841d38357c44156757609