### PR TITLE
feat(mcp): support MCP servers on the Anthropic /v1/messages API

### DIFF
--- a/litellm/experimental_mcp_client/tools.py
+++ b/litellm/experimental_mcp_client/tools.py
@@ -9,6 +9,7 @@ from openai.types.chat import ChatCompletionToolParam
 from openai.types.responses.function_tool_param import FunctionToolParam
 from openai.types.shared_params.function_definition import FunctionDefinition
 
+from litellm.types.llms.anthropic import AnthropicInputSchema, AnthropicMessagesTool
 from litellm.types.utils import ChatCompletionMessageToolCall
 
 
@@ -72,6 +73,18 @@ def transform_mcp_tool_to_openai_responses_api_tool(
         strict=False,
         type="function",
         description=mcp_tool.description or "",
+    )
+
+
+def transform_mcp_tool_to_anthropic_tool(mcp_tool: MCPTool) -> AnthropicMessagesTool:
+    """Convert an MCP tool to an Anthropic Messages API tool."""
+    normalized_parameters = _normalize_mcp_input_schema(mcp_tool.inputSchema)
+
+    return AnthropicMessagesTool(
+        name=mcp_tool.name,
+        description=mcp_tool.description or "",
+        input_schema=AnthropicInputSchema(**normalized_parameters),
+        type="custom",
     )
 
 

--- a/litellm/experimental_mcp_client/tools.py
+++ b/litellm/experimental_mcp_client/tools.py
@@ -9,7 +9,7 @@ from openai.types.chat import ChatCompletionToolParam
 from openai.types.responses.function_tool_param import FunctionToolParam
 from openai.types.shared_params.function_definition import FunctionDefinition
 
-from litellm.types.llms.anthropic import AnthropicInputSchema, AnthropicMessagesTool
+from litellm.types.llms.anthropic import AnthropicMessagesTool
 from litellm.types.utils import ChatCompletionMessageToolCall
 
 
@@ -78,12 +78,14 @@ def transform_mcp_tool_to_openai_responses_api_tool(
 
 def transform_mcp_tool_to_anthropic_tool(mcp_tool: MCPTool) -> AnthropicMessagesTool:
     """Convert an MCP tool to an Anthropic Messages API tool."""
-    normalized_parameters = _normalize_mcp_input_schema(mcp_tool.inputSchema)
+    from litellm.litellm_core_utils.prompt_templates.common_utils import (
+        sanitize_input_schema_for_anthropic,
+    )
 
     return AnthropicMessagesTool(
         name=mcp_tool.name,
         description=mcp_tool.description or "",
-        input_schema=AnthropicInputSchema(**normalized_parameters),
+        input_schema=sanitize_input_schema_for_anthropic(mcp_tool.inputSchema),
         type="custom",
     )
 

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -42,6 +42,7 @@ from litellm.types.utils import (
 )
 
 if TYPE_CHECKING:  # newer pattern to avoid importing pydantic objects on __init__.py
+    from litellm.types.llms.anthropic import AnthropicInputSchema
     from litellm.types.llms.openai import ChatCompletionImageObject
 
 DEFAULT_USER_CONTINUE_MESSAGE = ChatCompletionUserMessage(content="Please continue.", role="user")
@@ -1044,6 +1045,31 @@ def unpack_legacy_defs(
     defs.update(schema.pop("definitions", None) or {})
     unpack_defs(schema, defs, max_inlined_bytes=max_inlined_bytes)
     return schema
+
+
+def sanitize_input_schema_for_anthropic(input_schema: dict) -> "AnthropicInputSchema":
+    """Coerce an arbitrary tool input_schema into the shape Anthropic accepts.
+
+    Anthropic requires ``type == "object"``, only recognises ``$defs`` (legacy
+    ``definitions`` / OpenAPI ``components.schemas`` refs must be inlined first),
+    and rejects keys outside ``AnthropicInputSchema``. Both the chat
+    (``AnthropicConfig._map_tool_helper``) and Anthropic Messages MCP paths run
+    a schema through here so an external MCP schema cannot succeed on one route
+    and 400 on the other.
+    """
+    from litellm.types.llms.anthropic import AnthropicInputSchema
+
+    normalized = dict(input_schema) if input_schema else {}
+    if normalized.get("type") != "object":
+        normalized["type"] = "object"
+    if "properties" not in normalized:
+        normalized["properties"] = {}
+
+    normalized = unpack_legacy_defs(normalized, copy=True)
+
+    allowed_keys = set(AnthropicInputSchema.__annotations__.keys())
+    filtered = {key: value for key, value in normalized.items() if key in allowed_keys}
+    return AnthropicInputSchema(**filtered)
 
 
 def _get_image_mime_type_from_url(url: str) -> Optional[str]:

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -29,7 +29,9 @@ from litellm.constants import (
     RESPONSE_FORMAT_TOOL_NAME,
 )
 from litellm.litellm_core_utils.core_helpers import map_finish_reason
-from litellm.litellm_core_utils.prompt_templates.common_utils import unpack_legacy_defs
+from litellm.litellm_core_utils.prompt_templates.common_utils import (
+    sanitize_input_schema_for_anthropic,
+)
 from litellm.llms.base_llm.base_utils import type_to_response_format_param
 from litellm.llms.base_llm.chat.transformation import BaseConfig, BaseLLMException
 from litellm.types.llms.anthropic import (
@@ -634,7 +636,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         mcp_server: Optional[AnthropicMcpServerTool] = None
 
         if tool["type"] == "function" or tool["type"] == "custom":
-            _input_schema: dict = tool["function"].get(
+            _input_schema = tool["function"].get(
                 "parameters",
                 {
                     "type": "object",
@@ -642,28 +644,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 },
             )
 
-            # Anthropic requires input_schema.type to be "object". Normalize
-            # schemas from external sources (MCP servers, OpenAI callers) that
-            # may omit the type field or use a non-object type.
-            if _input_schema.get("type") != "object":
-                litellm.verbose_logger.debug(
-                    "_map_tool_helper: coercing input_schema type from %r to "
-                    "'object' for Anthropic compatibility (tool: %s)",
-                    _input_schema.get("type"),
-                    tool["function"].get("name"),
-                )
-                _input_schema = dict(_input_schema)  # avoid mutating caller's dict
-                _input_schema["type"] = "object"
-                if "properties" not in _input_schema:
-                    _input_schema["properties"] = {}
-
-            # Inline legacy / OpenAPI $refs before the allow-list filter strips
-            # their backing def blocks (https://github.com/BerriAI/litellm/issues/26692).
-            _input_schema = unpack_legacy_defs(_input_schema, copy=True)
-
-            _allowed_properties = set(AnthropicInputSchema.__annotations__.keys())
-            input_schema_filtered = {k: v for k, v in _input_schema.items() if k in _allowed_properties}
-            input_anthropic_schema: AnthropicInputSchema = AnthropicInputSchema(**input_schema_filtered)
+            input_anthropic_schema = sanitize_input_schema_for_anthropic(_input_schema)
 
             _tool = AnthropicMessagesTool(
                 name=tool["function"]["name"],

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -477,6 +477,41 @@ def anthropic_messages_handler(
             mock_response=litellm_params.mock_response,
         )
 
+    # Expand litellm_proxy MCP references through the MCP gateway before dispatch, so every
+    # downstream path (native passthrough and both bridges) gets real tools rather than a
+    # reference the provider cannot resolve. Popped from kwargs so it never reaches the provider.
+    skip_mcp_handler = kwargs.pop("_skip_mcp_handler", False)
+    if not skip_mcp_handler and tools:
+        from litellm.llms.anthropic.experimental_pass_through.messages.mcp_handler import (
+            anthropic_messages_with_mcp,
+        )
+        from litellm.responses.mcp.litellm_proxy_mcp_handler import (
+            LiteLLM_Proxy_MCP_Handler,
+        )
+
+        if LiteLLM_Proxy_MCP_Handler._should_use_litellm_mcp_gateway(tools=tools):
+            return anthropic_messages_with_mcp(
+                max_tokens=max_tokens,
+                messages=messages,
+                model=model,
+                metadata=metadata,
+                stop_sequences=stop_sequences,
+                stream=stream,
+                system=system,
+                temperature=temperature,
+                thinking=thinking,
+                tool_choice=tool_choice,
+                tools=tools,
+                top_k=top_k,
+                top_p=top_p,
+                container=container,
+                api_key=api_key,
+                api_base=api_base,
+                client=client,
+                custom_llm_provider=custom_llm_provider,
+                **kwargs,
+            )
+
     anthropic_messages_provider_config: Optional[BaseAnthropicMessagesConfig] = None
 
     if custom_llm_provider is not None and custom_llm_provider in [provider.value for provider in LlmProviders]:

--- a/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
@@ -1,0 +1,174 @@
+"""
+MCP gateway support for the Anthropic `/v1/messages` API.
+
+Mirrors ``litellm.responses.mcp.chat_completions_handler`` but speaks the
+Anthropic Messages shapes: tools carry an ``input_schema``, the model asks for a
+tool through a ``tool_use`` content block, and results are fed back as
+``tool_result`` blocks in a user message.
+"""
+
+from typing import Any, AsyncIterator, Mapping, Sequence, Union
+
+from litellm._logging import verbose_logger
+from litellm.types.llms.anthropic import (
+    AnthropicMessagesTool,
+    AnthropicMessagesToolResultParam,
+    AnthropicMessagesUserMessageParam,
+)
+from litellm.types.llms.anthropic_messages.anthropic_response import (
+    AnthropicMessagesResponse,
+)
+
+MAX_MCP_TOOL_USE_ITERATIONS = 10
+
+
+def _get_response_content(response: AnthropicMessagesResponse) -> Sequence[Mapping[str, Any]]:
+    content = response.get("content")
+    if not isinstance(content, list):
+        return ()
+    return tuple(block for block in content if isinstance(block, dict))
+
+
+def _extract_tool_use_blocks(response: AnthropicMessagesResponse) -> Sequence[Mapping[str, Any]]:
+    """Return the ``tool_use`` content blocks the model emitted."""
+    return tuple(block for block in _get_response_content(response) if block.get("type") == "tool_use")
+
+
+def _get_stop_reason(response: AnthropicMessagesResponse) -> Union[str, None]:
+    stop_reason = response.get("stop_reason")
+    return stop_reason if isinstance(stop_reason, str) else None
+
+
+def _build_tool_result_message(tool_results: Sequence[Mapping[str, Any]]) -> AnthropicMessagesUserMessageParam:
+    """Turn executed tool results into the user message Anthropic expects."""
+    return AnthropicMessagesUserMessageParam(
+        role="user",
+        content=tuple(
+            AnthropicMessagesToolResultParam(
+                type="tool_result",
+                tool_use_id=str(result.get("tool_call_id") or ""),
+                content=str(result.get("result") or ""),
+            )
+            for result in tool_results
+        ),
+    )
+
+
+def _resolve_user_api_key_auth(
+    kwargs: Mapping[str, Any],
+) -> Any:  # any-ok: UserAPIKeyAuth is proxy-only, importing it here would create a cycle
+    """`/v1/messages` is a LITELLM_METADATA_ROUTE, so the auth object rides in litellm_metadata."""
+    litellm_metadata = kwargs.get("litellm_metadata") or {}
+    metadata = kwargs.get("metadata") or {}
+    return (
+        kwargs.get("user_api_key_auth")
+        or litellm_metadata.get("user_api_key_auth")
+        or metadata.get("user_api_key_auth")
+    )
+
+
+async def anthropic_messages_with_mcp(
+    max_tokens: int,
+    messages: Sequence[Mapping[str, Any]],
+    model: str,
+    tools: Union[Sequence[Mapping[str, Any]], None] = None,
+    **kwargs: Any,  # kwargs-ok: forwarded verbatim to litellm.anthropic_messages, which owns the param contract
+) -> Union[AnthropicMessagesResponse, AsyncIterator[Any]]:
+    """
+    Expand litellm_proxy MCP references for `/v1/messages` and run the tool loop.
+
+    The MCP gateway owns the expansion so the reference resolves against the
+    caller's own credentials and access control, rather than being handed to the
+    upstream provider as a url it cannot reach.
+    """
+    import litellm
+    from litellm.experimental_mcp_client.tools import (
+        transform_mcp_tool_to_anthropic_tool,
+    )
+    from litellm.responses.mcp.litellm_proxy_mcp_handler import (
+        LiteLLM_Proxy_MCP_Handler,
+    )
+
+    mcp_references, other_tools = LiteLLM_Proxy_MCP_Handler._parse_mcp_tools(tools)
+
+    if not mcp_references:
+        return await litellm.anthropic_messages(
+            max_tokens=max_tokens,
+            messages=list(messages),
+            model=model,
+            tools=list(tools) if tools else None,
+            _skip_mcp_handler=True,
+            **kwargs,
+        )
+
+    user_api_key_auth = _resolve_user_api_key_auth(kwargs)
+
+    (
+        deduplicated_mcp_tools,
+        tool_server_map,
+    ) = await LiteLLM_Proxy_MCP_Handler._process_mcp_tools_without_openai_transform(
+        user_api_key_auth,
+        mcp_references,
+        litellm_trace_id=kwargs.get("litellm_trace_id"),
+    )
+
+    anthropic_tools: Sequence[AnthropicMessagesTool] = tuple(
+        transform_mcp_tool_to_anthropic_tool(mcp_tool) for mcp_tool in deduplicated_mcp_tools
+    )
+    all_tools = [*anthropic_tools, *(other_tools or ())]
+
+    should_auto_execute = LiteLLM_Proxy_MCP_Handler._should_auto_execute_tools(
+        mcp_tools_with_litellm_proxy=mcp_references
+    )
+    stream = bool(kwargs.pop("stream", False))
+
+    base_call_args: Mapping[str, Any] = {
+        "max_tokens": max_tokens,
+        "model": model,
+        "tools": all_tools or None,
+        "_skip_mcp_handler": True,
+        **kwargs,
+    }
+
+    if not should_auto_execute:
+        return await litellm.anthropic_messages(messages=list(messages), stream=stream, **base_call_args)
+
+    working_messages: Sequence[Mapping[str, Any]] = tuple(messages)
+    response: AnthropicMessagesResponse = await litellm.anthropic_messages(
+        messages=list(working_messages), stream=False, **base_call_args
+    )
+
+    for _ in range(MAX_MCP_TOOL_USE_ITERATIONS):
+        if _get_stop_reason(response) != "tool_use":
+            break
+
+        tool_use_blocks = _extract_tool_use_blocks(response)
+        if not tool_use_blocks:
+            break
+
+        tool_results = await LiteLLM_Proxy_MCP_Handler._execute_tool_calls(
+            tool_server_map=tool_server_map,
+            tool_calls=list(tool_use_blocks),
+            user_api_key_auth=user_api_key_auth,
+            litellm_trace_id=kwargs.get("litellm_trace_id"),
+        )
+
+        working_messages = (
+            *working_messages,
+            {"role": "assistant", "content": list(_get_response_content(response))},
+            _build_tool_result_message(tool_results),
+        )
+        response = await litellm.anthropic_messages(messages=list(working_messages), stream=False, **base_call_args)
+    else:
+        verbose_logger.warning(
+            f"MCP tool loop hit its {MAX_MCP_TOOL_USE_ITERATIONS} iteration cap for model {model}; "
+            "returning the last response"
+        )
+
+    if stream:
+        from litellm.llms.anthropic.experimental_pass_through.messages.fake_stream_iterator import (
+            FakeAnthropicMessagesStreamIterator,
+        )
+
+        return FakeAnthropicMessagesStreamIterator(response)
+    return response

--- a/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/mcp_handler.py
@@ -10,6 +10,7 @@ tool through a ``tool_use`` content block, and results are fed back as
 from typing import Any, AsyncIterator, Mapping, Sequence, Union
 
 from litellm._logging import verbose_logger
+from litellm.responses.mcp.request_context import MCPRequestContext
 from litellm.types.llms.anthropic import (
     AnthropicMessagesTool,
     AnthropicMessagesToolResultParam,
@@ -54,19 +55,6 @@ def _build_tool_result_message(tool_results: Sequence[Mapping[str, Any]]) -> Ant
     )
 
 
-def _resolve_user_api_key_auth(
-    kwargs: Mapping[str, Any],
-) -> Any:  # any-ok: UserAPIKeyAuth is proxy-only, importing it here would create a cycle
-    """`/v1/messages` is a LITELLM_METADATA_ROUTE, so the auth object rides in litellm_metadata."""
-    litellm_metadata = kwargs.get("litellm_metadata") or {}
-    metadata = kwargs.get("metadata") or {}
-    return (
-        kwargs.get("user_api_key_auth")
-        or litellm_metadata.get("user_api_key_auth")
-        or metadata.get("user_api_key_auth")
-    )
-
-
 async def anthropic_messages_with_mcp(
     max_tokens: int,
     messages: Sequence[Mapping[str, Any]],
@@ -101,15 +89,18 @@ async def anthropic_messages_with_mcp(
             **kwargs,
         )
 
-    user_api_key_auth = _resolve_user_api_key_auth(kwargs)
+    context = MCPRequestContext.resolve(kwargs=dict(kwargs), tools=tools)
 
     (
         deduplicated_mcp_tools,
         tool_server_map,
     ) = await LiteLLM_Proxy_MCP_Handler._process_mcp_tools_without_openai_transform(
-        user_api_key_auth,
+        context.user_api_key_auth,
         mcp_references,
-        litellm_trace_id=kwargs.get("litellm_trace_id"),
+        litellm_trace_id=context.litellm_trace_id,
+        mcp_auth_header=context.mcp_auth_header,
+        mcp_server_auth_headers=context.mcp_server_auth_headers,
+        request_tags=list(context.request_tags) if context.request_tags else None,
     )
 
     anthropic_tools: Sequence[AnthropicMessagesTool] = tuple(
@@ -149,9 +140,20 @@ async def anthropic_messages_with_mcp(
         tool_results = await LiteLLM_Proxy_MCP_Handler._execute_tool_calls(
             tool_server_map=tool_server_map,
             tool_calls=list(tool_use_blocks),
-            user_api_key_auth=user_api_key_auth,
-            litellm_trace_id=kwargs.get("litellm_trace_id"),
+            user_api_key_auth=context.user_api_key_auth,
+            mcp_auth_header=context.mcp_auth_header,
+            mcp_server_auth_headers=context.mcp_server_auth_headers,
+            oauth2_headers=context.oauth2_headers,
+            raw_headers=context.raw_headers,
+            litellm_call_id=context.litellm_call_id,
+            litellm_trace_id=context.litellm_trace_id,
+            request_tags=list(context.request_tags) if context.request_tags else None,
         )
+
+        # Every tool call was skipped, so there is nothing to feed back; a
+        # tool_result message with empty content is rejected by Anthropic.
+        if not tool_results:
+            break
 
         working_messages = (
             *working_messages,

--- a/litellm/responses/mcp/chat_completions_handler.py
+++ b/litellm/responses/mcp/chat_completions_handler.py
@@ -12,7 +12,7 @@ from typing import (
 from litellm.responses.mcp.litellm_proxy_mcp_handler import (
     LiteLLM_Proxy_MCP_Handler,
 )
-from litellm.responses.utils import ResponsesAPIRequestUtils
+from litellm.responses.mcp.request_context import MCPRequestContext
 from litellm.types.utils import ModelResponse
 from litellm.utils import CustomStreamWrapper
 
@@ -114,20 +114,13 @@ async def acompletion_with_mcp(
             **kwargs,
         )
 
-    # Extract user_api_key_auth from metadata or kwargs
-    user_api_key_auth = kwargs.get("user_api_key_auth") or ((kwargs.get("metadata", {}) or {}).get("user_api_key_auth"))
-    request_tags = LiteLLM_Proxy_MCP_Handler._get_parent_request_tags(kwargs)
-
-    # Extract MCP auth headers before fetching tools (needed for dynamic auth)
-    (
-        mcp_auth_header,
-        mcp_server_auth_headers,
-        oauth2_headers,
-        raw_headers,
-    ) = ResponsesAPIRequestUtils.extract_mcp_headers_from_request(
-        secret_fields=kwargs.get("secret_fields"),
-        tools=tools,
-    )
+    context = MCPRequestContext.resolve(kwargs=kwargs, tools=tools)
+    user_api_key_auth = context.user_api_key_auth
+    request_tags = list(context.request_tags) if context.request_tags else None
+    mcp_auth_header = context.mcp_auth_header
+    mcp_server_auth_headers = context.mcp_server_auth_headers
+    oauth2_headers = context.oauth2_headers
+    raw_headers = context.raw_headers
 
     # Process MCP tools (pass auth headers for dynamic auth)
     (

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -478,17 +478,25 @@ class LiteLLM_Proxy_MCP_Handler:
     ) -> bool:
         """Check if we should auto-execute tool calls.
 
-        Only auto-execute tools if user passed a MCP tool with require_approval set to "never".
-
-
+        Auto-execution requires EVERY MCP reference to opt in with
+        ``require_approval="never"``. A single reference that requires approval
+        ("always", "manual", the object form, or an unset value) disables
+        auto-execution for the whole request. This fails closed: when an
+        approval-required reference shares a request with a "never" one, the
+        model's tool calls are returned to the caller instead of being run, so
+        an approval-gated tool can never be invoked without approval. Returns
+        False for an empty list.
         """
-        for tool in mcp_tools_with_litellm_proxy:
-            if isinstance(tool, dict):
-                if tool.get("require_approval") == "never":
-                    return True
-            elif getattr(tool, "require_approval", None) == "never":
-                return True
-        return False
+        references = list(mcp_tools_with_litellm_proxy or [])
+        if not references:
+            return False
+        for tool in references:
+            approval = (
+                tool.get("require_approval") if isinstance(tool, dict) else getattr(tool, "require_approval", None)
+            )
+            if approval != "never":
+                return False
+        return True
 
     @staticmethod
     def _extract_tool_calls_from_response(response: ResponsesAPIResponse) -> List[Any]:

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -541,7 +541,10 @@ class LiteLLM_Proxy_MCP_Handler:
                 tool_arguments = function_block.get("arguments")
             else:
                 tool_name = tool_call.get("name")
+                # Anthropic tool_use blocks carry the arguments under `input`
                 tool_arguments = tool_call.get("arguments")
+                if tool_arguments is None:
+                    tool_arguments = tool_call.get("input")
         else:
             tool_call_id = getattr(tool_call, "call_id", None) or getattr(tool_call, "id", None)
 
@@ -552,6 +555,8 @@ class LiteLLM_Proxy_MCP_Handler:
             else:
                 tool_name = getattr(tool_call, "name", None)
                 tool_arguments = getattr(tool_call, "arguments", None)
+                if tool_arguments is None:
+                    tool_arguments = getattr(tool_call, "input", None)
 
         return tool_name, tool_arguments, tool_call_id
 

--- a/litellm/responses/mcp/request_context.py
+++ b/litellm/responses/mcp/request_context.py
@@ -1,0 +1,73 @@
+"""
+The per-request context an MCP gateway handler needs.
+
+Listing and executing MCP tools both need the caller's identity, their MCP auth
+headers, and the request's trace/tag identifiers. Every gateway surface resolves
+the same set from its own kwargs, so resolving it in one place keeps a new
+surface from silently dropping a field: omitting the auth headers, for instance,
+still executes the tool, just with no credentials.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Sequence, Union
+
+
+@dataclass(frozen=True, slots=True)
+class MCPRequestContext:
+    """Everything a gateway handler must forward to MCP tool listing and execution."""
+
+    user_api_key_auth: Any  # any-ok: UserAPIKeyAuth is proxy-only; importing it here would create a cycle
+    mcp_auth_header: Union[str, None] = None
+    mcp_server_auth_headers: Union[Mapping[str, Mapping[str, str]], None] = None
+    oauth2_headers: Union[Mapping[str, str], None] = None
+    raw_headers: Union[Mapping[str, str], None] = None
+    request_tags: Union[Sequence[str], None] = None
+    litellm_trace_id: Union[str, None] = None
+    litellm_call_id: Union[str, None] = None
+
+    @classmethod
+    def resolve(
+        cls,
+        kwargs: Mapping[str, Any],
+        tools: Union[Iterable[Any], None],
+    ) -> "MCPRequestContext":
+        """
+        Build the context from a gateway handler's kwargs.
+
+        ``user_api_key_auth`` is read from both metadata keys because routes differ:
+        LITELLM_METADATA_ROUTES (``/v1/messages``, ``/responses``) carry it in
+        ``litellm_metadata`` while ``/chat/completions`` uses ``metadata``.
+        """
+        from litellm.responses.mcp.litellm_proxy_mcp_handler import (
+            LiteLLM_Proxy_MCP_Handler,
+        )
+        from litellm.responses.utils import ResponsesAPIRequestUtils
+
+        litellm_metadata = kwargs.get("litellm_metadata") or {}
+        metadata = kwargs.get("metadata") or {}
+        user_api_key_auth = (
+            kwargs.get("user_api_key_auth")
+            or litellm_metadata.get("user_api_key_auth")
+            or metadata.get("user_api_key_auth")
+        )
+
+        (
+            mcp_auth_header,
+            mcp_server_auth_headers,
+            oauth2_headers,
+            raw_headers,
+        ) = ResponsesAPIRequestUtils.extract_mcp_headers_from_request(
+            secret_fields=kwargs.get("secret_fields"),
+            tools=tools,
+        )
+
+        return cls(
+            user_api_key_auth=user_api_key_auth,
+            mcp_auth_header=mcp_auth_header,
+            mcp_server_auth_headers=mcp_server_auth_headers,
+            oauth2_headers=oauth2_headers,
+            raw_headers=raw_headers,
+            request_tags=LiteLLM_Proxy_MCP_Handler._get_parent_request_tags(dict(kwargs)),
+            litellm_trace_id=kwargs.get("litellm_trace_id"),
+            litellm_call_id=kwargs.get("litellm_call_id"),
+        )

--- a/tests/mcp_tests/test_aresponses_api_with_mcp.py
+++ b/tests/mcp_tests/test_aresponses_api_with_mcp.py
@@ -86,6 +86,15 @@ async def test_mcp_helper_methods():
         LiteLLM_Proxy_MCP_Handler._should_auto_execute_tools(mcp_tools_always) == False
     )
 
+    # A single approval-required reference must disable auto-execution for the
+    # whole request; otherwise a "never" reference alongside an "always" one
+    # would let the approval-gated tool run without approval.
+    mcp_tools_mixed = [{"require_approval": "never"}, {"require_approval": "always"}]
+    assert LiteLLM_Proxy_MCP_Handler._should_auto_execute_tools(mcp_tools_mixed) == False
+    mcp_tools_manual = [{"require_approval": "never"}, {"require_approval": "manual"}]
+    assert LiteLLM_Proxy_MCP_Handler._should_auto_execute_tools(mcp_tools_manual) == False
+    assert LiteLLM_Proxy_MCP_Handler._should_auto_execute_tools([]) == False
+
     print("✓ MCP helper methods test passed!")
 
 

--- a/tests/test_litellm/experimental_mcp_client/test_tools.py
+++ b/tests/test_litellm/experimental_mcp_client/test_tools.py
@@ -18,6 +18,7 @@ from mcp.types import (
 from mcp.types import Tool as MCPTool
 
 from litellm.experimental_mcp_client.tools import (
+    transform_mcp_tool_to_anthropic_tool,
     _get_function_arguments,
     _normalize_mcp_input_schema,
     call_mcp_tool,
@@ -250,3 +251,51 @@ def test_transform_mcp_tool_to_openai_responses_api_tool():
     assert "query" in openai_tool["parameters"]["properties"]
     assert openai_tool["parameters"]["required"] == ["query"]
     assert openai_tool["parameters"]["additionalProperties"] == False
+
+
+def test_transform_mcp_tool_to_anthropic_tool():
+    """
+    Regression test (LIT-4517): MCP tools must reach /v1/messages in Anthropic's
+    own tool shape.
+
+    Given: An MCP tool
+    When:  It is transformed for the Anthropic Messages API
+    Then:  It carries name/description/input_schema, the shape that endpoint
+           accepts, rather than an OpenAI function block
+
+    /v1/messages rejects an OpenAI-shaped tool outright ("Input tag 'function'
+    does not match any of the expected tags"), so reusing either OpenAI
+    transform here loses every MCP tool.
+    """
+    tool = MCPTool(
+        name="read_wiki_structure",
+        description="Get a list of documentation topics",
+        inputSchema={
+            "type": "object",
+            "properties": {"repoName": {"type": "string"}},
+            "required": ["repoName"],
+        },
+    )
+
+    anthropic_tool = transform_mcp_tool_to_anthropic_tool(tool)
+
+    assert anthropic_tool["name"] == "read_wiki_structure"
+    assert anthropic_tool["description"] == "Get a list of documentation topics"
+    assert anthropic_tool["type"] == "custom"
+    assert anthropic_tool["input_schema"]["type"] == "object"
+    assert "repoName" in anthropic_tool["input_schema"]["properties"]
+    assert anthropic_tool["input_schema"]["required"] == ["repoName"]
+    assert "function" not in anthropic_tool, "Anthropic tools must not carry an OpenAI function block"
+    assert "parameters" not in anthropic_tool, "Anthropic names the schema input_schema, not parameters"
+
+
+def test_transform_mcp_tool_to_anthropic_tool_normalizes_empty_schema():
+    """A tool with no declared arguments must still present a valid object schema."""
+    anthropic_tool = transform_mcp_tool_to_anthropic_tool(
+        MCPTool(name="noargs", description=None, inputSchema={})
+    )
+
+    assert anthropic_tool["name"] == "noargs"
+    assert anthropic_tool["description"] == ""
+    assert anthropic_tool["input_schema"]["type"] == "object"
+    assert anthropic_tool["input_schema"]["properties"] == {}

--- a/tests/test_litellm/experimental_mcp_client/test_tools.py
+++ b/tests/test_litellm/experimental_mcp_client/test_tools.py
@@ -299,3 +299,45 @@ def test_transform_mcp_tool_to_anthropic_tool_normalizes_empty_schema():
     assert anthropic_tool["description"] == ""
     assert anthropic_tool["input_schema"]["type"] == "object"
     assert anthropic_tool["input_schema"]["properties"] == {}
+
+
+def test_transform_mcp_tool_to_anthropic_tool_strips_keys_anthropic_rejects():
+    """
+    Regression test (LIT-4517): an MCP schema with keys Anthropic does not accept
+    must be sanitized, so the same tool cannot succeed on /chat/completions and 400
+    on /v1/messages.
+
+    Given: An MCP tool whose inputSchema carries $schema, legacy definitions and oneOf
+    When:  It is transformed for the Anthropic Messages API
+    Then:  Only keys in AnthropicInputSchema survive, matching the chat path
+
+    The chat path runs the schema through the same sanitizer, so before this the two
+    routes diverged: a clean-schema server (deepwiki) worked on both, but a server
+    with a richer schema would be rejected only on messages.
+    """
+    from litellm.types.llms.anthropic import AnthropicInputSchema
+
+    tool = MCPTool(
+        name="rich",
+        description="tool with a dirty schema",
+        inputSchema={
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": ["q"],
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "definitions": {"D": {"type": "string"}},
+            "oneOf": [{"required": ["q"]}],
+        },
+    )
+
+    anthropic_tool = transform_mcp_tool_to_anthropic_tool(tool)
+    schema_keys = set(anthropic_tool["input_schema"].keys())
+
+    assert schema_keys <= set(AnthropicInputSchema.__annotations__.keys()), (
+        f"schema must only carry keys Anthropic accepts, got {schema_keys}"
+    )
+    assert "$schema" not in schema_keys
+    assert "definitions" not in schema_keys
+    assert "oneOf" not in schema_keys
+    assert anthropic_tool["input_schema"]["properties"] == {"q": {"type": "string"}}
+    assert anthropic_tool["input_schema"]["required"] == ["q"]

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_mcp_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_mcp_handler.py
@@ -120,3 +120,124 @@ def test_build_tool_result_message_uses_anthropic_tool_result_blocks():
     assert list(message["content"]) == [
         {"type": "tool_result", "tool_use_id": "toolu_1", "content": "9 sections"}
     ]
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_with_mcp_forwards_the_callers_mcp_credentials():
+    """
+    Regression test (LIT-4517): the caller's MCP auth must reach both tool listing
+    and tool execution on /v1/messages.
+
+    Given: A request carrying MCP auth headers and request tags
+    When:  The gateway lists and then executes an MCP tool
+    Then:  Both calls receive the caller's credentials, tags and trace ids
+
+    Dropping them does not fail loudly; the tool still executes, just with no
+    credentials, so every auth-requiring MCP server (interactive OAuth, bearer
+    token, per-user env) silently returns nothing while the model claims it has
+    no access. Only a no-auth server would look healthy.
+    """
+    from litellm.llms.anthropic.experimental_pass_through.messages import mcp_handler
+    from litellm.responses.mcp.request_context import MCPRequestContext
+
+    context = MCPRequestContext(
+        user_api_key_auth="auth-object",
+        mcp_auth_header="legacy-header",
+        mcp_server_auth_headers={"deepwiki": {"authorization": "Bearer per-server"}},
+        oauth2_headers={"authorization": "Bearer oauth"},
+        raw_headers={"x-trace": "abc"},
+        request_tags=["team-a"],
+        litellm_trace_id="trace-123",
+        litellm_call_id="call-456",
+    )
+
+    process = AsyncMock(return_value=([], {}))
+    execute = AsyncMock(return_value=[{"tool_call_id": "toolu_1", "result": "ok", "name": "t"}])
+    responses = [
+        {"stop_reason": "tool_use", "content": [{"type": "tool_use", "id": "toolu_1", "name": "t", "input": {}}]},
+        {"stop_reason": "end_turn", "content": [{"type": "text", "text": "done"}]},
+    ]
+
+    with patch.object(MCPRequestContext, "resolve", return_value=context), patch.object(
+        mcp_handler.LiteLLM_Proxy_MCP_Handler
+        if hasattr(mcp_handler, "LiteLLM_Proxy_MCP_Handler")
+        else __import__(
+            "litellm.responses.mcp.litellm_proxy_mcp_handler", fromlist=["LiteLLM_Proxy_MCP_Handler"]
+        ).LiteLLM_Proxy_MCP_Handler,
+        "_process_mcp_tools_without_openai_transform",
+        new=process,
+    ), patch(
+        "litellm.responses.mcp.litellm_proxy_mcp_handler.LiteLLM_Proxy_MCP_Handler._execute_tool_calls",
+        new=execute,
+    ), patch(
+        "litellm.anthropic_messages", new=AsyncMock(side_effect=responses)
+    ):
+        await mcp_handler.anthropic_messages_with_mcp(
+            max_tokens=100,
+            messages=[{"role": "user", "content": "hi"}],
+            model="claude-sonnet-4-5",
+            tools=[MCP_REFERENCE],
+        )
+
+    listing = process.call_args.kwargs
+    assert listing["mcp_auth_header"] == "legacy-header", "tool listing must use the caller's MCP auth"
+    assert listing["mcp_server_auth_headers"] == {"deepwiki": {"authorization": "Bearer per-server"}}
+    assert listing["request_tags"] == ["team-a"]
+    assert listing["litellm_trace_id"] == "trace-123"
+
+    execution = execute.call_args.kwargs
+    assert execution["user_api_key_auth"] == "auth-object"
+    assert execution["mcp_auth_header"] == "legacy-header", "tool execution must use the caller's MCP auth"
+    assert execution["mcp_server_auth_headers"] == {"deepwiki": {"authorization": "Bearer per-server"}}
+    assert execution["oauth2_headers"] == {"authorization": "Bearer oauth"}
+    assert execution["raw_headers"] == {"x-trace": "abc"}
+    assert execution["litellm_call_id"] == "call-456"
+    assert execution["litellm_trace_id"] == "trace-123"
+    assert execution["request_tags"] == ["team-a"]
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_with_mcp_stops_when_every_tool_call_is_skipped():
+    """
+    Regression test (LIT-4517): a tool_use turn whose calls all get skipped must
+    end the loop, not send an empty tool_result message.
+
+    Given: The model asks for a tool but the executor skips it (unresolvable name)
+    When:  The gateway loop handles the empty result set
+    Then:  It returns the last response instead of calling the model again
+
+    _build_tool_result_message([]) produces a user message with empty content, and
+    Anthropic rejects that, so the caller would get an unhandled 400 from the middle
+    of the loop rather than the model's own answer.
+    """
+    from litellm.llms.anthropic.experimental_pass_through.messages import mcp_handler
+    from litellm.responses.mcp.request_context import MCPRequestContext
+
+    tool_use_response = {
+        "stop_reason": "tool_use",
+        "content": [{"type": "tool_use", "id": "toolu_1", "name": "gone", "input": {}}],
+    }
+    anthropic_messages_mock = AsyncMock(return_value=tool_use_response)
+
+    with patch.object(
+        MCPRequestContext, "resolve", return_value=MCPRequestContext(user_api_key_auth="auth")
+    ), patch(
+        "litellm.responses.mcp.litellm_proxy_mcp_handler.LiteLLM_Proxy_MCP_Handler._process_mcp_tools_without_openai_transform",
+        new=AsyncMock(return_value=([], {})),
+    ), patch(
+        "litellm.responses.mcp.litellm_proxy_mcp_handler.LiteLLM_Proxy_MCP_Handler._execute_tool_calls",
+        new=AsyncMock(return_value=[]),
+    ), patch(
+        "litellm.anthropic_messages", new=anthropic_messages_mock
+    ):
+        result = await mcp_handler.anthropic_messages_with_mcp(
+            max_tokens=100,
+            messages=[{"role": "user", "content": "hi"}],
+            model="claude-sonnet-4-5",
+            tools=[MCP_REFERENCE],
+        )
+
+    assert anthropic_messages_mock.await_count == 1, (
+        "With no tool results there is nothing to send back, so the loop must not call the model again"
+    )
+    assert result == tool_use_response

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_mcp_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_mcp_handler.py
@@ -1,0 +1,122 @@
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../../../.."))
+
+from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+    anthropic_messages_handler,
+)
+from litellm.llms.anthropic.experimental_pass_through.messages.mcp_handler import (
+    _build_tool_result_message,
+    _extract_tool_use_blocks,
+)
+
+MCP_REFERENCE = {
+    "type": "mcp",
+    "server_label": "litellm",
+    "server_url": "litellm_proxy/mcp/deepwiki",
+    "require_approval": "never",
+}
+
+
+def test_anthropic_messages_handler_routes_litellm_proxy_mcp_to_the_gateway():
+    """
+    Regression test (LIT-4517): /v1/messages must expand a litellm_proxy MCP
+    reference through the MCP gateway.
+
+    Given: A /v1/messages request whose tools carry a litellm_proxy MCP reference
+    When:  The handler dispatches
+    Then:  It hands off to the MCP gateway instead of the provider
+
+    Without this hook the reference is forwarded to Anthropic verbatim and the API
+    rejects the request ("Input tag 'mcp' found using 'type' does not match any of
+    the expected tags"), because only /v1/chat/completions and /v1/responses ever
+    had a gateway entry point. This pins the wiring, not the helper: deleting the
+    dispatch makes the whole feature unreachable while every unit test still passes.
+    """
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.mcp_handler.anthropic_messages_with_mcp",
+        new=AsyncMock(return_value={"routed": True}),
+    ) as routed:
+        result = anthropic_messages_handler(
+            max_tokens=100,
+            messages=[{"role": "user", "content": "hi"}],
+            model="claude-sonnet-4-5",
+            tools=[MCP_REFERENCE],
+            custom_llm_provider="anthropic",
+        )
+
+    assert routed.called, "A litellm_proxy MCP reference must be dispatched to the MCP gateway"
+    assert routed.call_args.kwargs["tools"] == [MCP_REFERENCE]
+    assert routed.call_args.kwargs["model"] == "claude-sonnet-4-5"
+    assert result is not None
+
+
+def test_anthropic_messages_handler_skips_the_gateway_on_recursion():
+    """The gateway's own follow-up call must not re-enter the gateway."""
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.mcp_handler.anthropic_messages_with_mcp",
+        new=AsyncMock(return_value={"routed": True}),
+    ) as routed:
+        with pytest.raises(Exception):
+            anthropic_messages_handler(
+                max_tokens=100,
+                messages=[{"role": "user", "content": "hi"}],
+                model="claude-sonnet-4-5",
+                tools=[MCP_REFERENCE],
+                custom_llm_provider="anthropic",
+                _skip_mcp_handler=True,
+            )
+
+    assert not routed.called, "_skip_mcp_handler must stop the gateway from recursing"
+
+
+def test_anthropic_messages_handler_leaves_native_tools_alone():
+    """A plain Anthropic tool is not an MCP reference and must not reach the gateway."""
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.mcp_handler.anthropic_messages_with_mcp",
+        new=AsyncMock(return_value={"routed": True}),
+    ) as routed:
+        with pytest.raises(Exception):
+            anthropic_messages_handler(
+                max_tokens=100,
+                messages=[{"role": "user", "content": "hi"}],
+                model="claude-sonnet-4-5",
+                tools=[{"name": "get_weather", "input_schema": {"type": "object"}}],
+                custom_llm_provider="anthropic",
+            )
+
+    assert not routed.called, "Only litellm_proxy MCP references belong to the gateway"
+
+
+def test_extract_tool_use_blocks_ignores_text_blocks():
+    """Only tool_use blocks drive the loop; text blocks are the model's prose."""
+    response = {
+        "content": [
+            {"type": "text", "text": "let me look that up"},
+            {"type": "tool_use", "id": "toolu_1", "name": "read_wiki_structure", "input": {"repoName": "a/b"}},
+        ]
+    }
+
+    blocks = _extract_tool_use_blocks(response)
+
+    assert len(blocks) == 1
+    assert blocks[0]["name"] == "read_wiki_structure"
+
+
+def test_build_tool_result_message_uses_anthropic_tool_result_blocks():
+    """
+    Results must go back as tool_result blocks in a user message.
+
+    Anthropic pairs each result to its request by tool_use_id; the OpenAI shape
+    (a role="tool" message keyed by tool_call_id) is rejected here.
+    """
+    message = _build_tool_result_message([{"tool_call_id": "toolu_1", "result": "9 sections", "name": "read_wiki"}])
+
+    assert message["role"] == "user"
+    assert list(message["content"]) == [
+        {"type": "tool_result", "tool_use_id": "toolu_1", "content": "9 sections"}
+    ]

--- a/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
+++ b/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
@@ -605,3 +605,45 @@ def test_completion_with_function_tools_works_without_fastapi_installed():
         timeout=120,
     )
     assert result.returncode == 0, result.stderr
+
+
+def test_extract_tool_call_details_reads_anthropic_tool_use_input():
+    """
+    Regression test (LIT-4517): an Anthropic tool_use block carries its arguments
+    under `input`, not `arguments`.
+
+    Given: A tool_use content block as /v1/messages returns it
+    When:  The shared extractor reads it
+    Then:  The arguments come back, so the MCP tool is called with them
+
+    Reading only `arguments` fails silently rather than loudly: _parse_tool_arguments
+    turns the resulting None into {}, so the tool still executes, just with every
+    argument dropped.
+    """
+    tool_use_block = {
+        "type": "tool_use",
+        "id": "toolu_01ABC",
+        "name": "read_wiki_structure",
+        "input": {"repoName": "BerriAI/litellm"},
+    }
+
+    name, arguments, call_id = LiteLLM_Proxy_MCP_Handler._extract_tool_call_details(tool_use_block)
+
+    assert name == "read_wiki_structure"
+    assert call_id == "toolu_01ABC"
+    assert arguments == {"repoName": "BerriAI/litellm"}
+    assert LiteLLM_Proxy_MCP_Handler._parse_tool_arguments(arguments) == {"repoName": "BerriAI/litellm"}
+
+
+def test_extract_tool_call_details_still_prefers_openai_arguments():
+    """The OpenAI chat shape must keep winning; `input` is only the fallback."""
+    openai_tool_call = {
+        "id": "call_123",
+        "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+    }
+
+    name, arguments, call_id = LiteLLM_Proxy_MCP_Handler._extract_tool_call_details(openai_tool_call)
+
+    assert name == "get_weather"
+    assert call_id == "call_123"
+    assert arguments == '{"city": "Paris"}'

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -98,7 +98,12 @@ interface ChatUIProps {
   fixedModel?: string;
 }
 
-const MCP_SUPPORTED_ENDPOINTS = new Set<EndpointType>([EndpointType.CHAT, EndpointType.RESPONSES, EndpointType.MCP]);
+const MCP_SUPPORTED_ENDPOINTS = new Set<EndpointType>([
+  EndpointType.CHAT,
+  EndpointType.RESPONSES,
+  EndpointType.MCP,
+  EndpointType.ANTHROPIC_MESSAGES,
+]);
 
 const CUSTOM_MODEL_DEBOUNCE_WAIT_MS = 500;
 
@@ -870,8 +875,11 @@ const ChatUI: React.FC<ChatUIProps> = ({
             selectedVectorStores.length > 0 ? selectedVectorStores : undefined,
             selectedGuardrails.length > 0 ? selectedGuardrails : undefined,
             selectedPolicies.length > 0 ? selectedPolicies : undefined,
-            selectedMCPServers, // Pass the selected tools array
+            selectedMCPServers,
             customProxyBaseUrl || undefined,
+            mcpServers,
+            mcpServerToolRestrictions,
+            mcpToolsets,
           );
         } else if (endpointType === EndpointType.EMBEDDINGS) {
           await makeOpenAIEmbeddingsRequest(

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/llm_calls/anthropic_messages.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/llm_calls/anthropic_messages.tsx
@@ -1,6 +1,8 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { MessageType } from "@/components/chat_ui/types";
 import { TokenUsage } from "@/components/chat_ui/ResponseMetrics";
+import { buildMcpToolBlocks } from "@/components/llm_calls/mcp_tool_blocks";
+import { MCPServer, MCPToolset } from "@/components/mcp_tools/types";
 import { getProxyBaseUrl } from "@/components/networking";
 import NotificationManager from "@/components/molecules/notifications_manager";
 
@@ -18,8 +20,11 @@ export async function makeAnthropicMessagesRequest(
   vector_store_ids?: string[],
   guardrails?: string[],
   policies?: string[],
-  selectedMCPTools?: string[],
+  selectedMCPServers?: string[],
   customBaseUrl?: string,
+  mcpServers?: MCPServer[],
+  mcpServerToolRestrictions?: Record<string, string[]>,
+  mcpToolsets?: MCPToolset[],
 ) {
   if (!accessToken) {
     throw new Error("Virtual Key is required");
@@ -58,6 +63,13 @@ export async function makeAnthropicMessagesRequest(
       litellm_trace_id: traceId,
     };
 
+    const tools = buildMcpToolBlocks({
+      selectedMCPServers,
+      mcpServers,
+      mcpToolsets,
+      mcpServerToolRestrictions,
+    });
+    if (tools.length > 0) requestBody.tools = tools;
     if (vector_store_ids) requestBody.vector_store_ids = vector_store_ids;
     if (guardrails) requestBody.guardrails = guardrails;
     if (policies) requestBody.policies = policies;

--- a/ui/litellm-dashboard/src/components/llm_calls/mcp_tool_blocks.test.ts
+++ b/ui/litellm-dashboard/src/components/llm_calls/mcp_tool_blocks.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { buildMcpToolBlocks } from "./mcp_tool_blocks";
+import { MCPServer, MCPToolset } from "@/components/mcp_tools/types";
+
+const server = (over: Partial<MCPServer>): MCPServer =>
+  ({
+    server_id: "id-1",
+    server_name: "deepwiki",
+    alias: "wiki",
+    url: "",
+    transport: "http",
+    auth_type: "none",
+    ...over,
+  }) as any;
+
+describe("buildMcpToolBlocks", () => {
+  it("returns no blocks when nothing is selected", () => {
+    expect(buildMcpToolBlocks({ selectedMCPServers: [] })).toEqual([]);
+    expect(buildMcpToolBlocks({ selectedMCPServers: undefined })).toEqual([]);
+  });
+
+  it("routes by server_name, not alias, so colliding aliases cannot cross-route", () => {
+    const [block] = buildMcpToolBlocks({
+      selectedMCPServers: ["id-1"],
+      mcpServers: [server({})],
+    });
+    expect(block.server_url).toBe("litellm_proxy/mcp/deepwiki");
+    expect(block.server_label).toBe("deepwiki");
+  });
+
+  it("does not percent-encode the name; the gateway splits the raw path and never decodes", () => {
+    const [block] = buildMcpToolBlocks({
+      selectedMCPServers: ["id-1"],
+      mcpServers: [server({ server_name: "my server" }) as any],
+    });
+    expect(block.server_url).toBe("litellm_proxy/mcp/my server");
+    expect(block.server_url).not.toContain("%20");
+  });
+
+  it("passes per-server tool restrictions through as allowed_tools", () => {
+    const [block] = buildMcpToolBlocks({
+      selectedMCPServers: ["id-1"],
+      mcpServers: [server({})],
+      mcpServerToolRestrictions: { "id-1": ["read_wiki_structure"] },
+    });
+    expect(block.allowed_tools).toEqual(["read_wiki_structure"]);
+  });
+
+  it("collapses the all-servers sentinel to a single proxy-wide block", () => {
+    expect(buildMcpToolBlocks({ selectedMCPServers: ["__all__", "id-1"] })).toEqual([
+      { type: "mcp", server_label: "litellm", server_url: "litellm_proxy/mcp", require_approval: "never" },
+    ]);
+  });
+
+  it("routes a toolset by its name", () => {
+    const toolset = { toolset_id: "ts-1", toolset_name: "docs" } as MCPToolset;
+    const [block] = buildMcpToolBlocks({
+      selectedMCPServers: ["toolset:ts-1"],
+      mcpToolsets: [toolset],
+    });
+    expect(block.server_url).toBe("litellm_proxy/mcp/docs");
+  });
+});

--- a/ui/litellm-dashboard/src/components/llm_calls/mcp_tool_blocks.ts
+++ b/ui/litellm-dashboard/src/components/llm_calls/mcp_tool_blocks.ts
@@ -29,6 +29,10 @@ export interface BuildMcpToolBlocksArgs {
  * server_name is used for both routing and labelling because it is the unique
  * registered identifier; aliases can collide across servers, and a duplicated
  * server_label causes silent tool-routing failures.
+ *
+ * The name is not percent-encoded: the gateway resolves it with a raw
+ * `server_url.split("/")[-1]` and never url-decodes, so an encoded name would
+ * fail server lookup rather than round-trip.
  */
 export function buildMcpToolBlocks({
   selectedMCPServers,
@@ -59,7 +63,7 @@ export function buildMcpToolBlocks({
       return {
         type: "mcp",
         server_label: toolsetName,
-        server_url: `litellm_proxy/mcp/${encodeURIComponent(toolsetName)}`,
+        server_url: `litellm_proxy/mcp/${toolsetName}`,
         require_approval: "never",
       };
     }
@@ -71,7 +75,7 @@ export function buildMcpToolBlocks({
     return {
       type: "mcp",
       server_label: routeName,
-      server_url: `litellm_proxy/mcp/${encodeURIComponent(routeName)}`,
+      server_url: `litellm_proxy/mcp/${routeName}`,
       require_approval: "never",
       ...(allowedTools.length > 0 ? { allowed_tools: allowedTools } : {}),
     };

--- a/ui/litellm-dashboard/src/components/llm_calls/mcp_tool_blocks.ts
+++ b/ui/litellm-dashboard/src/components/llm_calls/mcp_tool_blocks.ts
@@ -1,0 +1,79 @@
+import { MCPServer, MCPToolset } from "@/components/mcp_tools/types";
+
+export const ALL_MCP_SERVERS_SENTINEL = "__all__";
+const TOOLSET_PREFIX = "toolset:";
+
+export interface McpToolBlock {
+  type: "mcp";
+  server_label: string;
+  server_url: string;
+  require_approval: "never";
+  allowed_tools?: string[];
+}
+
+export interface BuildMcpToolBlocksArgs {
+  selectedMCPServers?: string[];
+  mcpServers?: MCPServer[];
+  mcpToolsets?: MCPToolset[];
+  mcpServerToolRestrictions?: Record<string, string[]>;
+}
+
+/**
+ * Build the litellm_proxy MCP reference blocks for a playground request.
+ *
+ * Every endpoint that supports MCP sends the same reference shape; the gateway
+ * expands it server side and each endpoint's own transformation decides the
+ * final tool shape. Keeping one builder here stops the endpoints from drifting
+ * apart on routing name, label uniqueness, or escaping.
+ *
+ * server_name is used for both routing and labelling because it is the unique
+ * registered identifier; aliases can collide across servers, and a duplicated
+ * server_label causes silent tool-routing failures.
+ */
+export function buildMcpToolBlocks({
+  selectedMCPServers,
+  mcpServers,
+  mcpToolsets,
+  mcpServerToolRestrictions,
+}: BuildMcpToolBlocksArgs): McpToolBlock[] {
+  if (!selectedMCPServers || selectedMCPServers.length === 0) {
+    return [];
+  }
+
+  if (selectedMCPServers.includes(ALL_MCP_SERVERS_SENTINEL)) {
+    return [
+      {
+        type: "mcp",
+        server_label: "litellm",
+        server_url: "litellm_proxy/mcp",
+        require_approval: "never",
+      },
+    ];
+  }
+
+  return selectedMCPServers.map((serverId) => {
+    if (serverId.startsWith(TOOLSET_PREFIX)) {
+      const toolsetId = serverId.slice(TOOLSET_PREFIX.length);
+      const toolset = mcpToolsets?.find((t) => t.toolset_id === toolsetId);
+      const toolsetName = toolset?.toolset_name || toolsetId;
+      return {
+        type: "mcp",
+        server_label: toolsetName,
+        server_url: `litellm_proxy/mcp/${encodeURIComponent(toolsetName)}`,
+        require_approval: "never",
+      };
+    }
+
+    const server = mcpServers?.find((s) => s.server_id === serverId);
+    const routeName = server?.server_name || serverId;
+    const allowedTools = mcpServerToolRestrictions?.[serverId] || [];
+
+    return {
+      type: "mcp",
+      server_label: routeName,
+      server_url: `litellm_proxy/mcp/${encodeURIComponent(routeName)}`,
+      require_approval: "never",
+      ...(allowedTools.length > 0 ? { allowed_tools: allowedTools } : {}),
+    };
+  });
+}


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4517
Resolves LIT-4518

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

One proxy, one MCP server, real `anthropic/claude-sonnet-4-5` calls; only the commit changes

```yaml
model_list:
  - model_name: claude
    litellm_params:
      model: anthropic/claude-sonnet-4-5
      api_key: os.environ/ANTHROPIC_API_KEY

mcp_servers:
  deepwiki:
    transport: "http"
    url: "https://mcp.deepwiki.com/mcp"

general_settings:
  master_key: sk-1234
```

```bash
curl -sS http://localhost:4143/v1/messages \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"claude","max_tokens":400,
       "messages":[{"role":"user","content":"Use deepwiki: call read_wiki_structure for repoName BerriAI/litellm and summarize in 2 sentences."}],
       "tools":[{"type":"mcp","server_label":"litellm","server_url":"litellm_proxy/mcp/deepwiki","require_approval":"never"}]}'
```

Before, captured at 224fe67f10 (`litellm_internal_staging`). The reference reaches Anthropic verbatim and the API refuses it

```
HTTP:400
{"type":"error","error":{"type":"invalid_request_error","message":"tools.0: Input tag 'mcp' found using 'type' does not match any of the expected tags: 'bash_20250124', 'code_execution_20250522', 'custom', 'memory_20250818', 'text_editor_20250124', 'tool_search_tool_bm25', 'web_fetch_20250910', 'web_search_20250305'"}}
```

After, captured at ae952ce971. The gateway expands the reference, the model calls the tool and answers from the result

```
HTTP:200
  stop_reason: end_turn
  answer: The BerriAI/litellm repository wiki is comprehensively structured into 9 major sections covering everything from core SDK functionality (completion AP...
```

Streaming, which is what the playground sends, at ae952ce971

```bash
curl -sS -N http://localhost:4143/v1/messages \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"claude","max_tokens":400,"stream":true,
       "messages":[{"role":"user","content":"Use deepwiki: call read_wiki_structure for repoName BerriAI/litellm and summarize in 2 sentences."}],
       "tools":[{"type":"mcp","server_label":"litellm","server_url":"litellm_proxy/mcp/deepwiki","require_approval":"never"}]}'
```

```
events: ['message_start', 'content_block_start', 'content_block_delta', 'content_block_stop', 'message_delta', 'message_stop']
streamed chars: 518
```

Two controls, both at ae952ce971. A native Anthropic tool still works on the same endpoint, which is what proves the 400 above was the MCP reference rather than tool support in general

```
tool_use fired: True | tool: get_weather | stop_reason: tool_use
```

and `/v1/chat/completions` with the same MCP reference is unchanged

```
mcp_list_tools: 3 | auto-executed: True
```

## Type

🆕 New Feature

## Changes

Only `/v1/chat/completions` (`litellm/main.py`) and `/v1/responses` (`litellm/responses/main.py`) call `_should_use_litellm_mcp_gateway`, so `/v1/messages` had no way to expand a `litellm_proxy` MCP reference. `AnthropicMessagesConfig.transform_anthropic_messages_request` is a passthrough, so the reference went to Anthropic inside `tools` exactly as the caller wrote it and the API rejected the request. `_map_openai_mcp_server_tool` does translate an MCP reference into Anthropic's native connector, but it is only reachable from `map_openai_params` on the chat path, so it never applied here

Scope: this covers gateway-hosted servers, meaning a `server_url` of `litellm_proxy/mcp/<name>` or `http(s)://<host>/mcp/<name>`. An external MCP url passed as a `{"type": "mcp"}` tools entry still fails on this route, unchanged by this PR: the gateway check does not match it, `mcp_servers` is not in `get_supported_anthropic_messages_params` so Anthropic's own connector param is dropped, and the messages transformation never adds the `mcp-client-2025-04-04` beta. Supporting that is the provider-native half and belongs with the Anthropic messages transformation rather than the MCP gateway, so it is filed separately

The hook goes in `anthropic_messages_handler` ahead of the provider branch, which is the one point covering the native path and both the responses and completion bridges. It sits after `local_vars = locals()` and pops `_skip_mcp_handler` before `local_vars.update(kwargs)`, so neither the flag nor the guard reaches the provider params

`/v1/messages` wants Anthropic's own tool shape, so `transform_mcp_tool_to_anthropic_tool` joins the two OpenAI transforms in `experimental_mcp_client/tools.py` and reuses `_normalize_mcp_input_schema`. The loop in the new `messages/mcp_handler.py` reads `tool_use` content blocks, executes them through the existing `_execute_tool_calls`, and feeds results back as `tool_result` blocks in a user message, bounded at 10 iterations. Streaming reuses `FakeAnthropicMessagesStreamIterator`, the same convert-and-re-stream pattern the websearch interception already uses on this route, so no second SSE buffering path was needed

`_extract_tool_call_details` gained one branch rather than a per-surface parser: an Anthropic `tool_use` block carries its arguments under `input`, and reading only `arguments` failed silently because `_parse_tool_arguments` turns the resulting None into `{}` and the tool still runs with every argument dropped

On the frontend `makeAnthropicMessagesRequest` declared `selectedMCPTools` and never read it; `requestBody` had no `tools` key, so the playground dropped the selection. It now builds the reference through a shared `buildMcpToolBlocks`, and `EndpointType.ANTHROPIC_MESSAGES` joins `MCP_SUPPORTED_ENDPOINTS`, which is the set that was rendering the selector disabled (LIT-4518)

Deliberately left out. `anthropic_messages` is not added to the semantic filter's `call_type` gate: with the filter on, messages passes through unfiltered and the gateway still expands it, and wiring it in would pull query extraction over Anthropic content blocks into this change untested. `chat_completion.tsx` and `responses_api.tsx` keep their own inline builders; they diverge today on routing name, label uniqueness and escaping, and consolidating them onto the shared builder rewrites two shipped surfaces and the tests that pin them, which belongs in its own PR

Security: `_should_auto_execute_tools` gated auto-execution on the first reference with `require_approval="never"`, so a request that mixed a `never` reference with an `always`/`manual` one auto-ran every tool call the model produced, including the approval-gated ones. It now fails closed, auto-executing only when every reference opts in with `never`; a single approval-required reference returns the model tool calls to the caller instead. This is the shared decision behind chat completions, responses, the streaming iterator and this messages path, so all four harden from one change and the common all-`never` case is unchanged

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared MCP auto-execution and tool-argument parsing used by chat, responses, and messages; the approval gate change hardens security but alters behavior when MCP references mix approval settings. New gateway loop on `/v1/messages` adds credential forwarding and iteration bounds that must stay correct to avoid silent tool failures or API errors.
> 
> **Overview**
> Adds **MCP gateway support for `/v1/messages`**, matching chat completions and responses: `litellm_proxy` MCP references are expanded server-side instead of being forwarded to Anthropic (which rejects `type: "mcp"`).
> 
> **Backend:** `anthropic_messages_handler` routes gateway-eligible tools to new `anthropic_messages_with_mcp`, which lists MCP tools, maps them via `transform_mcp_tool_to_anthropic_tool`, optionally auto-executes `tool_use` blocks (with `tool_result` follow-ups), and re-streams via `FakeAnthropicMessagesStreamIterator`. Shared **`sanitize_input_schema_for_anthropic`** centralizes schema coercion for chat and messages MCP paths. **`MCPRequestContext.resolve`** unifies auth/trace/tag extraction for chat and messages handlers. **`_should_auto_execute_tools`** now requires **every** MCP reference to use `require_approval="never"` (fail-closed on mixed approval). **`_extract_tool_call_details`** reads Anthropic **`input`** as well as OpenAI **`arguments`**.
> 
> **Dashboard:** Anthropic Messages is MCP-enabled in the playground; requests attach tools built by shared **`buildMcpToolBlocks`** (routing by `server_name`, toolsets, restrictions, `__all__` sentinel).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf23df94313ae308484a41772e1e8aab23ded4d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

