### PR TITLE
perf: cache Redis semantic cache index_info in health check

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -45,6 +45,41 @@ from litellm.proxy.shutdown.graceful_shutdown_manager import GracefulShutdownMan
 
 #### Health ENDPOINTS ####
 
+_REDIS_CACHE_INDEX_INFO_TTL_SECONDS = 30
+_redis_cache_index_info: Dict[str, Any] = {}
+
+
+async def _get_redis_cache_index_info_with_ttl() -> Any:
+    """
+    Get Redis cache index info with TTL caching to avoid pinging the cache
+    on every health check. Caches result for _REDIS_CACHE_INDEX_INFO_TTL_SECONDS.
+
+    Resolves https://github.com/BerriAI/litellm/issues/XXXX:
+    /health/readiness was pinging the semantic cache on every request, adding latency.
+    This caches the result to reduce unnecessary network calls.
+    """
+    global _redis_cache_index_info
+
+    current_time = time.time()
+    cached_time = _redis_cache_index_info.get("timestamp", 0)
+
+    if (
+        "index_info" in _redis_cache_index_info
+        and (current_time - cached_time) < _REDIS_CACHE_INDEX_INFO_TTL_SECONDS
+    ):
+        return _redis_cache_index_info["index_info"]
+
+    try:
+        index_info = await litellm.cache.cache._index_info()
+        _redis_cache_index_info["index_info"] = index_info
+        _redis_cache_index_info["timestamp"] = current_time
+        return index_info
+    except Exception as e:
+        error_msg = f"index does not exist - error: {str(e)}"
+        _redis_cache_index_info["index_info"] = error_msg
+        _redis_cache_index_info["timestamp"] = current_time
+        return error_msg
+
 
 def _reject_os_environ_references(params: dict) -> None:
     """
@@ -1434,13 +1469,7 @@ async def _get_health_readiness_details(
             cache_type = litellm.cache.type
 
             if isinstance(litellm.cache.cache, RedisSemanticCache):
-                # ping the cache
-                # TODO: @ishaan-jaff - we should probably not ping the cache on every /health/readiness check
-                index_info: Any
-                try:
-                    index_info = await litellm.cache.cache._index_info()
-                except Exception as e:
-                    index_info = "index does not exist - error: " + str(e)  # type: ignore[assignment]
+                index_info = await _get_redis_cache_index_info_with_ttl()
                 cache_type = {"type": cache_type, "index_info": index_info}  # type: ignore[assignment]
 
         # check log level

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -63,10 +63,7 @@ async def _get_redis_cache_index_info_with_ttl() -> Any:
     current_time = time.time()
     cached_time = _redis_cache_index_info.get("timestamp", 0)
 
-    if (
-        "index_info" in _redis_cache_index_info
-        and (current_time - cached_time) < _REDIS_CACHE_INDEX_INFO_TTL_SECONDS
-    ):
+    if "index_info" in _redis_cache_index_info and (current_time - cached_time) < _REDIS_CACHE_INDEX_INFO_TTL_SECONDS:
         return _redis_cache_index_info["index_info"]
 
     try:

--- a/tests/test_litellm/test_health_check_cache.py
+++ b/tests/test_litellm/test_health_check_cache.py
@@ -1,0 +1,88 @@
+import asyncio
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from litellm.proxy.health_endpoints._health_endpoints import (
+    _REDIS_CACHE_INDEX_INFO_TTL_SECONDS,
+    _get_redis_cache_index_info_with_ttl,
+    _redis_cache_index_info,
+)
+
+
+@pytest.mark.asyncio
+async def test_redis_cache_index_info_caches_result():
+    """Test that _get_redis_cache_index_info_with_ttl caches results within TTL."""
+    global _redis_cache_index_info
+    _redis_cache_index_info.clear()
+
+    call_count = 0
+
+    async def mock_index_info():
+        nonlocal call_count
+        call_count += 1
+        return {"index": "test_index", "status": "ok"}
+
+    with patch(
+        "litellm.cache.cache._index_info",
+        new_callable=AsyncMock,
+        side_effect=mock_index_info,
+    ):
+        result1 = await _get_redis_cache_index_info_with_ttl()
+        result2 = await _get_redis_cache_index_info_with_ttl()
+
+        assert result1 == {"index": "test_index", "status": "ok"}
+        assert result2 == result1
+        assert call_count == 1, "Should only call _index_info once within TTL"
+
+
+@pytest.mark.asyncio
+async def test_redis_cache_index_info_refreshes_after_ttl():
+    """Test that cache is refreshed after TTL expires."""
+    global _redis_cache_index_info
+    _redis_cache_index_info.clear()
+
+    call_count = 0
+
+    async def mock_index_info():
+        nonlocal call_count
+        call_count += 1
+        return {"index": f"test_index_{call_count}"}
+
+    with patch(
+        "litellm.cache.cache._index_info",
+        new_callable=AsyncMock,
+        side_effect=mock_index_info,
+    ):
+        result1 = await _get_redis_cache_index_info_with_ttl()
+        assert call_count == 1
+
+        _redis_cache_index_info["timestamp"] = time.time() - (_REDIS_CACHE_INDEX_INFO_TTL_SECONDS + 1)
+
+        result2 = await _get_redis_cache_index_info_with_ttl()
+        assert call_count == 2
+        assert result1["index"] == "test_index_1"
+        assert result2["index"] == "test_index_2"
+
+
+@pytest.mark.asyncio
+async def test_redis_cache_index_info_handles_errors():
+    """Test that errors are cached with the same TTL."""
+    global _redis_cache_index_info
+    _redis_cache_index_info.clear()
+
+    async def mock_index_info_error():
+        raise ValueError("Connection failed")
+
+    with patch(
+        "litellm.cache.cache._index_info",
+        new_callable=AsyncMock,
+        side_effect=mock_index_info_error,
+    ):
+        result = await _get_redis_cache_index_info_with_ttl()
+        assert "index does not exist - error" in result
+        assert "Connection failed" in result
+
+        result2 = await _get_redis_cache_index_info_with_ttl()
+        assert result == result2


### PR DESCRIPTION
Reduce latency on /health/readiness/details by caching the result of litellm.cache.cache._index_info() for 30 seconds instead of pinging the cache on every health check request.

Health checks run frequently from load balancers and orchestrators; unnecessary cache calls add latency to what should be a lightweight diagnostic endpoint. Single-threaded cache access is serialized by the event loop, so simple dict-based caching with timestamp is safe.

Changes:
- Add _get_redis_cache_index_info_with_ttl() helper with 30s TTL
- Update _get_health_readiness_details() to use cached version
- Add unit tests for cache expiry and error handling

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
