### PR TITLE
fix(anthropic): send the MCP connector beta on /v1/messages

### DIFF
--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -18,6 +18,7 @@ from litellm.litellm_core_utils.prompt_templates.factory import (
 from litellm.llms.base_llm.base_utils import BaseLLMModelInfo, BaseTokenCounter
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.types.llms.anthropic import (
+    ANTHROPIC_BETA_HEADER_VALUES,
     ANTHROPIC_HOSTED_TOOLS,
     ANTHROPIC_OAUTH_BETA_HEADER,
     ANTHROPIC_OAUTH_TOKEN_PREFIX,
@@ -551,7 +552,7 @@ class AnthropicModelInfo(BaseLLMModelInfo):
             betas.append("code-execution-2025-05-22")
 
         if mcp_server_used:
-            betas.append("mcp-client-2025-04-04")
+            betas.append(ANTHROPIC_BETA_HEADER_VALUES.MCP_CLIENT_2025_04_04.value)
 
         return list(set(betas))
 
@@ -599,7 +600,7 @@ class AnthropicModelInfo(BaseLLMModelInfo):
             betas.add("files-api-2025-04-14")
             betas.add("code-execution-2025-05-22")
         if mcp_server_used:
-            betas.add("mcp-client-2025-04-04")
+            betas.add(ANTHROPIC_BETA_HEADER_VALUES.MCP_CLIENT_2025_04_04.value)
         # Tool search, programmatic tool calling, and input_examples all use the same beta header
         if tool_search_used or programmatic_tool_calling_used or input_examples_used:
             from litellm.types.llms.anthropic import ANTHROPIC_TOOL_SEARCH_BETA_HEADER
@@ -642,8 +643,6 @@ class AnthropicModelInfo(BaseLLMModelInfo):
         if is_vertex_request is True:
             # Vertex AI requires web search beta header for web search to work
             if web_search_tool_used:
-                from litellm.types.llms.anthropic import ANTHROPIC_BETA_HEADER_VALUES
-
                 headers["anthropic-beta"] = ANTHROPIC_BETA_HEADER_VALUES.WEB_SEARCH_2025_03_05.value
         elif len(betas) > 0:
             headers["anthropic-beta"] = ",".join(betas)

--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -592,6 +592,10 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         if optional_params.get("speed") == "fast":
             beta_values.add(ANTHROPIC_BETA_HEADER_VALUES.FAST_MODE_2026_02_01.value)
 
+        # Check for Anthropic's MCP connector
+        if AnthropicModelInfo().is_mcp_server_used(mcp_servers=optional_params.get("mcp_servers")):
+            beta_values.add(ANTHROPIC_BETA_HEADER_VALUES.MCP_CLIENT_2025_04_04.value)
+
         # Check for advisor tool
         tools = optional_params.get("tools")
         if tools:

--- a/litellm/types/llms/anthropic.py
+++ b/litellm/types/llms/anthropic.py
@@ -702,6 +702,7 @@ class ANTHROPIC_BETA_HEADER_VALUES(str, Enum):
 
     WEB_FETCH_2025_09_10 = "web-fetch-2025-09-10"
     WEB_SEARCH_2025_03_05 = "web-search-2025-03-05"
+    MCP_CLIENT_2025_04_04 = "mcp-client-2025-04-04"
     CONTEXT_MANAGEMENT_2025_06_27 = "context-management-2025-06-27"
     COMPACT_2026_01_12 = "compact-2026-01-12"
     STRUCTURED_OUTPUT_2025_09_25 = "structured-outputs-2025-11-13"

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_native_mcp.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_native_mcp.py
@@ -1,0 +1,51 @@
+from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+    AnthropicMessagesConfig,
+)
+from litellm.types.llms.anthropic import ANTHROPIC_BETA_HEADER_VALUES
+
+MCP_SERVERS = [{"type": "url", "url": "https://mcp.deepwiki.com/mcp", "name": "deepwiki"}]
+
+
+def test_messages_injects_the_mcp_beta_when_mcp_servers_is_set():
+    """
+    Regression test: /v1/messages must send the MCP connector beta header.
+
+    Given: A request carrying Anthropic's native mcp_servers
+    When:  Beta headers are computed for the request
+    Then:  mcp-client-2025-04-04 is present
+
+    Anthropic refuses mcp_servers without this beta ("mcp_servers: Extra inputs are
+    not permitted"), so the whole connector was unusable on this route while working
+    on /chat/completions, which gets the same header from AnthropicConfig.
+    """
+    headers = AnthropicMessagesConfig._update_headers_with_anthropic_beta(
+        headers={},
+        optional_params={"mcp_servers": MCP_SERVERS},
+    )
+
+    assert ANTHROPIC_BETA_HEADER_VALUES.MCP_CLIENT_2025_04_04.value in headers["anthropic-beta"]
+
+
+def test_messages_does_not_inject_the_mcp_beta_without_mcp_servers():
+    """The beta is opt-in; a request with no MCP connector must not advertise it."""
+    headers = AnthropicMessagesConfig._update_headers_with_anthropic_beta(headers={}, optional_params={})
+
+    assert ANTHROPIC_BETA_HEADER_VALUES.MCP_CLIENT_2025_04_04.value not in headers.get("anthropic-beta", "")
+
+
+def test_messages_mcp_beta_preserves_caller_and_sibling_betas():
+    """
+    The header is a comma-joined set, so injecting must not drop what is already there.
+
+    A caller-supplied beta and a second feature's beta both have to survive alongside
+    the MCP one, otherwise enabling MCP silently disables another feature.
+    """
+    headers = AnthropicMessagesConfig._update_headers_with_anthropic_beta(
+        headers={"anthropic-beta": "some-caller-beta"},
+        optional_params={"mcp_servers": MCP_SERVERS, "speed": "fast"},
+    )
+
+    betas = {value.strip() for value in headers["anthropic-beta"].split(",")}
+    assert ANTHROPIC_BETA_HEADER_VALUES.MCP_CLIENT_2025_04_04.value in betas
+    assert ANTHROPIC_BETA_HEADER_VALUES.FAST_MODE_2026_02_01.value in betas
+    assert "some-caller-beta" in betas


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

One proxy, real `anthropic/claude-sonnet-4-5` calls, deepwiki as a publicly reachable MCP server that Anthropic fetches itself

```yaml
model_list:
  - model_name: claude
    litellm_params:
      model: anthropic/claude-sonnet-4-5
      api_key: os.environ/ANTHROPIC_API_KEY

general_settings:
  master_key: sk-1234
```

```bash
curl -sS http://localhost:4144/v1/messages \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"claude","max_tokens":300,
       "messages":[{"role":"user","content":"Use deepwiki to tell me what BerriAI/litellm is, one sentence."}],
       "mcp_servers":[{"type":"url","url":"https://mcp.deepwiki.com/mcp","name":"deepwiki"}]}'
```

Before, captured at ecef9e6c9b (`litellm_internal_staging`). Anthropic refuses the param because the request never advertises the beta

```
HTTP:400
{"type":"error","error":{"type":"invalid_request_error","message":"mcp_servers: Extra inputs are not permitted"}}
```

After, captured at 6f70838af4. The connector runs; the `mcp_tool_use` and `mcp_tool_result` blocks are Anthropic calling deepwiki on its own

```
HTTP:200
blocks: ['mcp_tool_use', 'mcp_tool_result', 'text']
text: BerriAI/litellm is a library that simplifies interactions with over 100 different LLM API providers using a unified ...
```

Controls, both at 6f70838af4. The same request with the beta supplied by hand behaved identically before this change, which is what identifies the header as the only missing piece

```
curl ... -H "anthropic-beta: mcp-client-2025-04-04" ... -> HTTP:200, blocks: ['mcp_tool_use', 'mcp_tool_result', 'text']
```

and a plain `/v1/messages` call with no MCP is untouched, so the beta stays opt-in

```
curl ... -d '{"model":"claude","max_tokens":40,"messages":[{"role":"user","content":"say hi"}]}' -> HTTP:200
```

## Type

🐛 Bug Fix

## Changes

`AnthropicConfig` adds `mcp-client-2025-04-04` whenever `mcp_servers` is set, so the connector works on `/chat/completions`. The messages transformation computes its beta headers in its own `_update_headers_with_anthropic_beta`, which handles context management, tool search, structured outputs, fast mode and the advisor tool, and never learned about MCP. The param itself is forwarded either way, so the request reached Anthropic and was rejected for advertising no beta

The check reuses `AnthropicModelInfo.is_mcp_server_used` rather than testing `mcp_servers` again locally, so both routes answer "is the connector in play" from one predicate. The header value was a bare `"mcp-client-2025-04-04"` string at two call sites in `common_utils`; it moves into `ANTHROPIC_BETA_HEADER_VALUES` beside every other beta, so this third caller does not add a third literal to keep in sync. Removing the local re-import of that enum inside `get_anthropic_headers` follows from it, since the module-level import now covers the whole function and the shadowed name would otherwise be read before assignment

Scope: this is the provider-native half. Servers Anthropic can reach itself now work on `/v1/messages` through the connector. Gateway-hosted servers, referenced as `litellm_proxy/mcp/<name>`, resolve only inside litellm and are handled separately in #33631

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
