### PR TITLE
fix(bedrock): honor explicit aws_session_name when already running as target role

### DIFF
--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -286,9 +286,12 @@ class BaseAWSLLM:
         elif self._is_auth_with_aws_role(aws_role_name):
             # Same role (IRSA/ECS/EC2): ambient creds via _get_or_set_cached_credentials like the
             # default env branch; never pre-read cache (must run _is_already_running_as_role first).
-            if self._is_already_running_as_role(cast(str, aws_role_name), ssl_verify=ssl_verify):
+            if aws_session_name is None and self._is_already_running_as_role(
+                cast(str, aws_role_name), ssl_verify=ssl_verify
+            ):
                 verbose_logger.debug(
-                    "Already running as target role %s, using ambient credentials",
+                    "Already running as target role %s and no explicit session name requested; "
+                    "using ambient credentials",
                     aws_role_name,
                 )
                 return self._get_or_set_cached_credentials(args, self._auth_with_env_vars)

--- a/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
+++ b/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
@@ -2355,7 +2355,7 @@ def test_get_credentials_same_role_explicit_session_name_assumes_role():
             base_aws_llm,
             "_is_already_running_as_role",
             return_value=True,
-        ):
+        ) as mock_already_running:
             with patch.object(
                 base_aws_llm,
                 "_auth_with_env_vars",
@@ -2371,6 +2371,7 @@ def test_get_credentials_same_role_explicit_session_name_assumes_role():
                         RoleArn="arn:aws:iam::123456789012:role/MyEcsTaskRole",
                         RoleSessionName="caller-attribution-session",
                     )
+                    mock_already_running.assert_not_called()
                     mock_env_auth.assert_not_called()
                     assert credentials.access_key == "assumed-access-key"
 

--- a/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
+++ b/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
@@ -1909,7 +1909,7 @@ def test_auth_with_aws_role_irsa_environment():
 
 
 def test_auth_with_aws_role_same_role_irsa():
-    """Test that when IRSA role matches the requested role, we skip assumption"""
+    """Test that when IRSA role matches the requested role and no explicit session name is given, we skip assumption"""
     base_llm = BaseAWSLLM()
 
     # Set IRSA environment variables
@@ -1935,7 +1935,7 @@ def test_auth_with_aws_role_same_role_irsa():
                 aws_access_key_id=None,
                 aws_secret_access_key=None,
                 aws_role_name="arn:aws:iam::111111111111:role/LitellmRole",  # Same as AWS_ROLE_ARN
-                aws_session_name="test-session",
+                aws_session_name=None,
                 aws_region_name="us-east-1",
             )
 
@@ -1944,6 +1944,46 @@ def test_auth_with_aws_role_same_role_irsa():
 
             # Verify the returned credentials
             assert creds.access_key == "irsa-access-key"
+
+
+def test_get_credentials_same_role_irsa_explicit_session_name_assumes_role():
+    """When IRSA role matches the requested role but an explicit session name is given,
+    the role must be assumed so RoleSessionName reflects the caller's request."""
+    base_llm = BaseAWSLLM()
+
+    with patch.dict(
+        os.environ,
+        {
+            "AWS_ROLE_ARN": "arn:aws:iam::111111111111:role/LitellmRole",
+            "AWS_WEB_IDENTITY_TOKEN_FILE": "/var/run/secrets/eks.amazonaws.com/serviceaccount/token",
+        },
+    ):
+        mock_sts_client = MagicMock()
+        mock_sts_client.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "assumed-access-key",
+                "SecretAccessKey": "assumed-secret-key",
+                "SessionToken": "assumed-session-token",
+                "Expiration": datetime.now(timezone.utc) + timedelta(hours=1),
+            }
+        }
+
+        with patch.object(base_llm, "_auth_with_env_vars") as mock_env_auth:
+            with patch("boto3.client", return_value=mock_sts_client):
+                creds = base_llm.get_credentials(
+                    aws_access_key_id=None,
+                    aws_secret_access_key=None,
+                    aws_role_name="arn:aws:iam::111111111111:role/LitellmRole",
+                    aws_session_name="caller-attribution-session",
+                    aws_region_name="us-east-1",
+                )
+
+                mock_sts_client.assume_role.assert_called_once_with(
+                    RoleArn="arn:aws:iam::111111111111:role/LitellmRole",
+                    RoleSessionName="caller-attribution-session",
+                )
+                mock_env_auth.assert_not_called()
+                assert creds.access_key == "assumed-access-key"
 
 
 def test_assume_role_with_external_id():
@@ -2284,6 +2324,55 @@ def test_get_credentials_ecs_same_role_skips_assume_role():
                 mock_env_auth.assert_called_once()
                 mock_role_auth.assert_not_called()
                 assert credentials.access_key == "ecs-access-key"
+
+
+def test_get_credentials_same_role_explicit_session_name_assumes_role():
+    """
+    End-to-end test: even when already running as the target role (ECS/EC2), an
+    explicitly requested aws_session_name must trigger AssumeRole with that
+    RoleSessionName instead of returning ambient credentials.
+    """
+    base_aws_llm = BaseAWSLLM()
+
+    env_without_irsa = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ("AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE")
+    }
+
+    mock_sts_client = MagicMock()
+    mock_sts_client.assume_role.return_value = {
+        "Credentials": {
+            "AccessKeyId": "assumed-access-key",
+            "SecretAccessKey": "assumed-secret-key",
+            "SessionToken": "assumed-session-token",
+            "Expiration": datetime.now(timezone.utc) + timedelta(hours=1),
+        }
+    }
+
+    with patch.dict(os.environ, env_without_irsa, clear=True):
+        with patch.object(
+            base_aws_llm,
+            "_is_already_running_as_role",
+            return_value=True,
+        ):
+            with patch.object(
+                base_aws_llm,
+                "_auth_with_env_vars",
+            ) as mock_env_auth:
+                with patch("boto3.client", return_value=mock_sts_client):
+                    credentials = base_aws_llm.get_credentials(
+                        aws_role_name="arn:aws:iam::123456789012:role/MyEcsTaskRole",
+                        aws_session_name="caller-attribution-session",
+                        aws_region_name="us-east-1",
+                    )
+
+                    mock_sts_client.assume_role.assert_called_once_with(
+                        RoleArn="arn:aws:iam::123456789012:role/MyEcsTaskRole",
+                        RoleSessionName="caller-attribution-session",
+                    )
+                    mock_env_auth.assert_not_called()
+                    assert credentials.access_key == "assumed-access-key"
 
 
 def test_get_credentials_role_second_call_not_same_role_uses_assume_not_env_cache():


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This bug only manifests when the process is already running as the target IAM role (EKS/IRSA or ECS task role), and the machine this PR was authored on has no AWS credentials or role identity, so a live before/after capture could not be taken here. Below is the exact runbook to capture it in any environment whose ambient identity is an IAM role; I will attach the CloudTrail output once run

1. On an EKS pod with IRSA (so `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` are set), configure a Bedrock model with `aws_role_name` set to that same IRSA role ARN and `aws_session_name: proof-session`, then start the proxy: `python litellm/proxy/proxy_cli.py --config config.yaml --detailed_debug`
2. Before the fix (commit 69a476f791): `curl http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -d '{"model": "bedrock-claude", "messages": [{"role": "user", "content": "hi"}]}'` returns 200, and `aws cloudtrail lookup-events --lookup-attributes AttributeKey=EventName,AttributeValue=InvokeModel --max-results 5` shows the Bedrock event's `userIdentity.arn` ending in the default web identity session name (e.g. `.../botocore-session-1699...`); no `AssumeRole` event with `roleSessionName=proof-session` exists
3. After the fix (commit 81bfb99e03): the same curl returns 200, CloudTrail now records an `sts:AssumeRole` event with `requestParameters.roleSessionName: proof-session`, and the Bedrock `InvokeModel` event's `userIdentity.arn` ends in `/proof-session`
4. Regression guard, runnable anywhere: `git checkout 69a476f791 -- litellm/llms/bedrock/base_aws_llm.py && python -m pytest tests/test_litellm/llms/bedrock/test_base_aws_llm.py -k explicit_session_name` fails both new tests; restoring the fix makes all 126 tests in the file pass

## Type

🐛 Bug Fix

## Changes

`BaseAWSLLM.get_credentials()` has a short-circuit in the `aws_role_name` branch: when `_is_already_running_as_role()` detects that the ambient identity already is the requested role (the common EKS/IRSA setup where `AWS_ROLE_ARN` equals the configured `aws_role_name`), it returns ambient credentials and never calls AssumeRole. That short-circuit ignored `aws_session_name`, so an explicitly requested RoleSessionName was silently dropped and CloudTrail/Bedrock logs showed the default `botocore-session-*` / web identity session name instead. This breaks per-caller attribution setups where a proxy running as its own role wants each request's AssumeRole to carry a meaningful session name

The fix guards the short-circuit on `aws_session_name is None`. With no session name requested, behavior is unchanged: ambient credentials, same caching. With an explicit session name, control falls through to the existing `_auth_with_aws_role()` path, which stamps the requested RoleSessionName (via `_handle_irsa_same_account` under IRSA, or a plain `sts:AssumeRole` otherwise) and already contains a safe fallback to ambient credentials if the role is not permitted to assume itself

Tests: `test_get_credentials_same_role_irsa_explicit_session_name_assumes_role` and `test_get_credentials_same_role_explicit_session_name_assumes_role` assert that `sts:AssumeRole` is called with the requested RoleSessionName and that the ambient env path is not used; both fail without the source change. `test_auth_with_aws_role_same_role_irsa` now pins the preserved default: with `aws_session_name=None`, same-role IRSA still uses ambient credentials without any AssumeRole call

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
