### PR TITLE
fix(secret_redaction): make connection-string pattern linear to stop ReDoS

### DIFF
--- a/litellm/litellm_core_utils/secret_redaction.py
+++ b/litellm/litellm_core_utils/secret_redaction.py
@@ -49,7 +49,9 @@ def _build_secret_patterns() -> "re.Pattern[str]":
         r"(?:^|(?<=\W))\w*(?:password|passwd|client_secret|secret_key|_secret)"
         r"['\"]?\s*[:=]\s*['\"]?[^\s,'\"})\]{}>]+",
         # Database connection string credentials (scheme://user:pass@host)
-        r"(?<=://)[^\s'\"]*:[^\s'\"@]+(?=@)",
+        # Userinfo cannot contain ':' (the delimiter), '/' or '@'; excluding them keeps
+        # this linear instead of O(n^2) backtracking on colon-heavy URLs with no '@'.
+        r"(?<=://)[^\s'\"/@:]*:[^\s'\"/@]+(?=@)",
         # Databricks personal access tokens
         r"dapi[0-9a-f]{32}",
         # Module-level provider keys logged as litellm.<provider>_key=<value>

--- a/tests/test_litellm/test_secret_redaction.py
+++ b/tests/test_litellm/test_secret_redaction.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import time
 from io import StringIO
 from unittest.mock import patch
 
@@ -381,3 +382,40 @@ def test_non_pem_private_key_value_redacted():
 def test_normal_vertex_log_not_redacted():
     msg = "Vertex: Loading vertex credentials, is_file_path=True, current dir /app"
     assert redact_string(msg) == msg
+
+
+def test_connection_string_pattern_does_not_backtrack_on_colon_heavy_url():
+    """Regression test for #32353: redact_string must stay linear on colon-heavy URLs.
+
+    The connection-string pattern matched userinfo as `[^\\s'\"]*`, which permits ':',
+    '/' and '@'. On a `scheme://` URL followed by a long colon-heavy run containing no
+    '@', the engine retried the username/password split at every colon, giving O(n^2)
+    behaviour: this 80k payload took roughly 14s before the fix and a multi-MB provider
+    error string took minutes. Since redact_string runs synchronously on the event loop
+    when exception_type() stringifies a failed request, that is client-triggerable.
+
+    URL userinfo cannot contain ':' (the delimiter), '/' or '@', so excluding them makes
+    the split unambiguous and the scan linear.
+    """
+    payload = "postgres://" + "seg:" * 20000
+
+    start = time.perf_counter()
+    redact_string(payload)
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 2.0, (
+        f"redact_string took {elapsed:.1f}s on an 80k colon-heavy URL; "
+        "the connection-string pattern is backtracking again"
+    )
+
+
+def test_connection_string_credentials_still_redacted():
+    """The linear pattern must still redact the credentials it is there to catch."""
+    for url, secret in (
+        ("postgresql://admin:s3cretpass@db.example.com:5432/mydb", "s3cretpass"),
+        ("redis://:secretpw@cache:6379", "secretpw"),
+        ("mysql://root:hunter2@10.0.0.1:3306/x", "hunter2"),
+    ):
+        result = redact_string("connecting to " + url)
+        assert secret not in result, f"{url!r} credentials were not redacted"
+        assert "REDACTED" in result


### PR DESCRIPTION
## Relevant issues

Fixes #32353

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The regression is entirely inside `redact_string`, which is a pure string function, so this reproduces without a provider or a proxy. Both runs below are against the real module; the only difference is this patch

Before (on `litellm_oss_daily_2026_07_16`):

```
$ python -c "
import time
from litellm.litellm_core_utils.secret_redaction import redact_string
p = 'postgres://' + 'seg:' * 20000
t = time.perf_counter(); redact_string(p); print(f'{len(p):,} chars -> {time.perf_counter()-t:.3f}s')"
80,011 chars -> 14.106s
```

After:

```
$ python -c "
import time
from litellm.litellm_core_utils.secret_redaction import redact_string
p = 'postgres://' + 'seg:' * 20000
t = time.perf_counter(); redact_string(p); print(f'{len(p):,} chars -> {time.perf_counter()-t:.5f}s')"
80,011 chars -> 0.00215s
```

Scaling before the patch is exactly quadratic; each doubling of input quadruples the time, which is what turns a multi-MB error string into a multi-minute stall

```
len=  10,008     0.434s
len=  20,008     1.755s   (4.04x)
len=  40,008     7.114s   (4.05x)
len=  80,008    28.486s   (4.00x)
```

After the patch the same growth is linear, and a 2 MB payload finishes in 0.65s

```
len=   40,011 -> 0.0143s
len=  160,011 -> 0.0519s
len=  640,011 -> 0.2039s
len=2,000,011 -> 0.6546s
```

I could not produce the end-to-end proxy repro because it needs a backend returning a multi-MB error and I do not have provider credentials to spend against. The QA runbook below is what I would run with keys; happy to add the output if someone can run it

## Type

🐛 Bug Fix

## Changes

The issue attributes the stall to the service-account pattern and its nested quantifier `(?:\{[^{}]*\}[^{}]*)*`. That attribution does not hold up; the reporter's own minimal repro completes in 0.024s on 2M chars, because the inner `\{` forces a deterministic split and the group cannot backtrack ambiguously. The py-spy evidence in the issue is solid, so I timed every pattern in `_build_secret_patterns` separately against inputs shaped for each construct. Only one blows up

The actual culprit is the database connection-string pattern, `(?<=://)[^\s'"]*:[^\s'"@]+(?=@)`. It matches userinfo as `[^\s'"]*`, which permits `:`, `/` and `@`. Given a `scheme://` URL followed by a long colon-heavy run with no `@`, the engine retries the username/password split at every colon and rescans forward each time, which is O(n^2). It needs three things together: a `://` scheme, many colons, and no `@`. With an `@` present it matches immediately; with a single colon it returns in 0.001s

That combination is reachable in production. A stack with Postgres and Redis attached puts connection strings into error text, and `postgres://` plus a colon-heavy 60k run already takes 8s

The fix narrows the character classes to what a URL can actually contain. Userinfo cannot hold `:` (it is the delimiter), `/` or `@`, so excluding them makes the split unambiguous and the scan linear. Redaction output is unchanged; I verified the existing cases including empty usernames (`redis://:pw@host`) and host ports (`10.0.0.1:3306`) produce identical results

I added two lines of comment above the pattern against the repo convention of not adding comments, because the file already carries an equivalent note two patterns up (`# Word boundary prevents O(n^2) backtracking on long word-char runs`) and because the character classes look arbitrary without it; a future simplification back to `[^\s'"]*` would silently reintroduce this. Happy to drop them if you would rather keep the rule strict

Not addressed here, deliberately, to keep scope isolated: the issue also suggests bounding input size to `redact_string`, and notes `SecretRedactionFilter` applies the same regex to every log record. A size bound is a sensible defence in depth but it is a separate behavioural decision; this patch removes the quadratic blowup itself

## QA runbook

1. `python -c "import time; from litellm.litellm_core_utils.secret_redaction import redact_string; p='postgres://'+'seg:'*20000; t=time.perf_counter(); redact_string(p); print(time.perf_counter()-t)"` returns in milliseconds rather than ~14s
2. `pytest tests/test_litellm/test_secret_redaction.py` passes; 25 tests
3. With provider credentials, run the proxy with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug`, point a model at a backend that rejects large requests, curl `/v1/chat/completions` with a multi-MB prompt, and confirm `/health/liveliness` keeps answering while the error is mapped

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

`test_connection_string_pattern_does_not_backtrack_on_colon_heavy_url` asserts the 80k payload completes under 2s; it fails at 15.5s on the unpatched pattern and passes at 2ms with it, so the specific regression is pinned. `test_connection_string_credentials_still_redacted` covers the credential shapes the pattern exists to catch, so a mutation that makes it fast by matching nothing would fail
