### PR TITLE
Team member add/delete loses members on concurrent requests

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -118,7 +118,7 @@ from litellm.repositories.verification_token_repository import (
 )
 from litellm.router import Router
 from litellm.types.proxy.management_endpoints.common_daily_activity import (
-    SpendAnalyticsPaginatedResponse,
+    CommonDailyActivity,
 )
 from litellm.types.proxy.management_endpoints.team_endpoints import (
     BulkTeamMemberAddRequest,
@@ -128,10 +128,74 @@ from litellm.types.proxy.management_endpoints.team_endpoints import (
     GetTeamMemberPermissionsResponse,
     TeamListItem,
     TeamListResponse,
+    TeamMemberAddRequest,
     TeamMemberAddResult,
     TeamMemberInfoResponse,
     UpdateTeamMemberPermissionsRequest,
 )
+
+# Locks for preventing race conditions when modifying team members concurrently.
+# Keyed by team_id to allow parallel operations on different teams while
+# serializing operations on the same team.
+_team_member_locks: Dict[str, asyncio.Lock] = {}
+_team_member_locks_lock = asyncio.Lock()
+
+# Maximum number of team locks to keep in memory before triggering cleanup.
+# This prevents unbounded memory growth in long-running proxy servers.
+_MAX_TEAM_MEMBER_LOCKS = 10000
+
+
+async def _get_team_member_lock(team_id: str) -> asyncio.Lock:
+    """
+    Get or create an asyncio.Lock for a specific team_id.
+
+    This ensures that concurrent requests to add/remove members from the same
+    team are serialized, preventing the read-modify-write race condition where
+    multiple requests read the same member list, modify it independently, and
+    overwrite each other's changes.
+
+    Args:
+        team_id: The ID of the team to lock
+
+    Returns:
+        An asyncio.Lock specific to this team_id
+    """
+    async with _team_member_locks_lock:
+        # Cleanup old locks if we've exceeded the maximum
+        if len(_team_member_locks) >= _MAX_TEAM_MEMBER_LOCKS:
+            _cleanup_team_member_locks()
+
+        if team_id not in _team_member_locks:
+            _team_member_locks[team_id] = asyncio.Lock()
+        return _team_member_locks[team_id]
+
+
+def _cleanup_team_member_locks() -> None:
+    """
+    Remove unlocked locks from the lock dictionary to prevent memory leaks.
+
+    This function removes locks that are not currently held. Locks that are
+    actively being used (locked) are preserved. This is called automatically
+    when the lock dictionary exceeds _MAX_TEAM_MEMBER_LOCKS entries.
+
+    Note: This function is not async-safe by design - it must be called while
+    holding _team_member_locks_lock to ensure thread safety.
+    """
+    # Create a list of team_ids to remove (unlocked locks)
+    to_remove = [
+        team_id
+        for team_id, lock in _team_member_locks.items()
+        if not lock.locked()
+    ]
+
+    # Remove unlocked locks
+    for team_id in to_remove:
+        del _team_member_locks[team_id]
+
+    verbose_proxy_logger.debug(
+        f"Cleaned up {len(to_remove)} unlocked team member locks. "
+        f"Remaining locks: {len(_team_member_locks)}"
+    )
 
 router = APIRouter()
 
@@ -2487,72 +2551,79 @@ async def team_member_add(
 
     prisma_client = cast(PrismaClient, prisma_client)
 
-    existing_team_row = await get_team_object(
-        team_id=data.team_id,
-        prisma_client=prisma_client,
-        user_api_key_cache=user_api_key_cache,
-        parent_otel_span=None,
-        proxy_logging_obj=proxy_logging_obj,
-        check_cache_only=False,
-        check_db_only=True,
-    )
-    if existing_team_row is None:
-        raise HTTPException(
-            status_code=404,
-            detail={
-                "error": f"Team not found for team_id={getattr(data, 'team_id', None)}"
-            },
-        )
+    # Acquire a lock for this team_id to prevent race conditions when
+    # multiple concurrent requests try to add members to the same team.
+    # Without this lock, two requests could read the same member list,
+    # modify it independently, and overwrite each other's changes.
+    team_member_lock = await _get_team_member_lock(data.team_id)
 
-    complete_team_data = LiteLLM_TeamTable(**existing_team_row.model_dump())
-
-    team_member_add_duplication_check(
-        data=data,
-        existing_team_row=complete_team_data,
-    )
-
-    # Validate permissions
-    await _validate_team_member_add_permissions(
-        user_api_key_dict=user_api_key_dict,
-        complete_team_data=complete_team_data,
-        data=data,
-    )
-
-    # Validate and populate user_email/user_id for members before processing
-    if isinstance(data.member, Member):
-        await _validate_and_populate_member_user_info(
-            member=data.member,
+    async with team_member_lock:
+        existing_team_row = await get_team_object(
+            team_id=data.team_id,
             prisma_client=prisma_client,
+            user_api_key_cache=user_api_key_cache,
+            parent_otel_span=None,
+            proxy_logging_obj=proxy_logging_obj,
+            check_cache_only=False,
+            check_db_only=True,
         )
-    elif isinstance(data.member, List):
-        for m in data.member:
-            await _validate_and_populate_member_user_info(
-                member=m,
-                prisma_client=prisma_client,
+        if existing_team_row is None:
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "error": f"Team not found for team_id={getattr(data, 'team_id', None)}"
+                },
             )
 
-    (
-        updated_team,
-        updated_users,
-        updated_team_memberships,
-    ) = await _add_team_members_to_team(
-        data=data,
-        complete_team_data=complete_team_data,
-        prisma_client=prisma_client,
-        user_api_key_dict=user_api_key_dict,
-        litellm_proxy_admin_name=litellm_proxy_admin_name,
-    )
+        complete_team_data = LiteLLM_TeamTable(**existing_team_row.model_dump())
 
-    # Check if updated_team is None
-    if updated_team is None:
-        raise HTTPException(
-            status_code=404, detail={"error": f"Team with id {data.team_id} not found"}
+        team_member_add_duplication_check(
+            data=data,
+            existing_team_row=complete_team_data,
         )
-    return TeamAddMemberResponse(
-        **updated_team.model_dump(),
-        updated_users=updated_users,
-        updated_team_memberships=updated_team_memberships,
-    )
+
+        # Validate permissions
+        await _validate_team_member_add_permissions(
+            user_api_key_dict=user_api_key_dict,
+            complete_team_data=complete_team_data,
+            data=data,
+        )
+
+        # Validate and populate user_email/user_id for members before processing
+        if isinstance(data.member, Member):
+            await _validate_and_populate_member_user_info(
+                member=data.member,
+                prisma_client=prisma_client,
+            )
+        elif isinstance(data.member, List):
+            for m in data.member:
+                await _validate_and_populate_member_user_info(
+                    member=m,
+                    prisma_client=prisma_client,
+                )
+
+        (
+            updated_team,
+            updated_users,
+            updated_team_memberships,
+        ) = await _add_team_members_to_team(
+            data=data,
+            complete_team_data=complete_team_data,
+            prisma_client=prisma_client,
+            user_api_key_dict=user_api_key_dict,
+            litellm_proxy_admin_name=litellm_proxy_admin_name,
+        )
+
+        # Check if updated_team is None
+        if updated_team is None:
+            raise HTTPException(
+                status_code=404, detail={"error": f"Team with id {data.team_id} not found"}
+            )
+        return TeamAddMemberResponse(
+            **updated_team.model_dump(),
+            updated_users=updated_users,
+            updated_team_memberships=updated_team_memberships,
+        )
 
 
 def _cleanup_members_with_roles(
@@ -2624,96 +2695,101 @@ async def team_member_delete(
             detail={"error": "Either user_id or user_email needs to be passed in"},
         )
 
-    _existing_team_row = await TeamRepository(prisma_client).table.find_unique(
-        where={"team_id": data.team_id}
-    )
+    # Acquire a lock for this team_id to prevent race conditions when
+    # multiple concurrent requests try to modify members of the same team.
+    team_member_lock = await _get_team_member_lock(data.team_id)
 
-    if _existing_team_row is None:
-        raise HTTPException(
-            status_code=400,
-            detail={"error": "Team id={} does not exist in db".format(data.team_id)},
+    async with team_member_lock:
+        _existing_team_row = await TeamRepository(prisma_client).table.find_unique(
+            where={"team_id": data.team_id}
         )
-    existing_team_row = LiteLLM_TeamTable(**_existing_team_row.model_dump())
 
-    ## CHECK IF USER IS PROXY ADMIN OR TEAM ADMIN OR ORG ADMIN
+        if _existing_team_row is None:
+            raise HTTPException(
+                status_code=400,
+                detail={"error": "Team id={} does not exist in db".format(data.team_id)},
+            )
+        existing_team_row = LiteLLM_TeamTable(**_existing_team_row.model_dump())
 
-    if (
-        user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN.value
-        and not _is_user_team_admin(
-            user_api_key_dict=user_api_key_dict, team_obj=existing_team_row
+        ## CHECK IF USER IS PROXY ADMIN OR TEAM ADMIN OR ORG ADMIN
+
+        if (
+            user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN.value
+            and not _is_user_team_admin(
+                user_api_key_dict=user_api_key_dict, team_obj=existing_team_row
+            )
+            and not await _is_user_org_admin_for_team(
+                user_api_key_dict=user_api_key_dict, team_obj=existing_team_row
+            )
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": "Call not allowed. User not proxy admin OR team admin. route={}, team_id={}".format(
+                        "/team/member_delete", existing_team_row.team_id
+                    )
+                },
+            )
+
+        ## DELETE MEMBER FROM TEAM
+        is_member_in_team, new_team_members = _cleanup_members_with_roles(
+            existing_team_row=existing_team_row,
+            data=data,
         )
-        and not await _is_user_org_admin_for_team(
-            user_api_key_dict=user_api_key_dict, team_obj=existing_team_row
-        )
-    ):
-        raise HTTPException(
-            status_code=403,
-            detail={
-                "error": "Call not allowed. User not proxy admin OR team admin. route={}, team_id={}".format(
-                    "/team/member_delete", existing_team_row.team_id
-                )
+
+        if not is_member_in_team:
+            raise HTTPException(status_code=400, detail={"error": "User not found in team"})
+
+        existing_team_row.members_with_roles = new_team_members
+
+        _db_new_team_members: List[dict] = [m.model_dump() for m in new_team_members]
+
+        _ = await TeamRepository(prisma_client).table.update(
+            where={
+                "team_id": data.team_id,
             },
+            data={"members_with_roles": json.dumps(_db_new_team_members)},  # type: ignore
         )
 
-    ## DELETE MEMBER FROM TEAM
-    is_member_in_team, new_team_members = _cleanup_members_with_roles(
-        existing_team_row=existing_team_row,
-        data=data,
-    )
-
-    if not is_member_in_team:
-        raise HTTPException(status_code=400, detail={"error": "User not found in team"})
-
-    existing_team_row.members_with_roles = new_team_members
-
-    _db_new_team_members: List[dict] = [m.model_dump() for m in new_team_members]
-
-    _ = await TeamRepository(prisma_client).table.update(
-        where={
-            "team_id": data.team_id,
-        },
-        data={"members_with_roles": json.dumps(_db_new_team_members)},  # type: ignore
-    )
-
-    ## DELETE TEAM ID from USER ROW, IF EXISTS ##
-    # get user row
-    key_val = {}
-    if data.user_id is not None:
-        key_val["user_id"] = data.user_id
-    elif data.user_email is not None:
-        key_val["user_email"] = data.user_email
-    existing_user_rows = await UserRepository(prisma_client).table.find_many(
-        where=key_val  # type: ignore
-    )
-
-    if existing_user_rows is not None and (
-        isinstance(existing_user_rows, list) and len(existing_user_rows) > 0
-    ):
-        for existing_user in existing_user_rows:
-            team_list = []
-            if data.team_id in existing_user.teams:
-                team_list = existing_user.teams
-                team_list.remove(data.team_id)
-                await UserRepository(prisma_client).table.update(
-                    where={
-                        "user_id": existing_user.user_id,
-                    },
-                    data={"teams": {"set": team_list}},
-                )
-
-    # Also clean up any existing team membership rows for this user and team
-    user_ids_to_delete = set()
-    if data.user_id is not None:
-        user_ids_to_delete.add(data.user_id)
-    if existing_user_rows is not None and isinstance(existing_user_rows, list):
-        for existing_user in existing_user_rows:
-            if getattr(existing_user, "user_id", None):
-                user_ids_to_delete.add(existing_user.user_id)
-
-    for _uid in user_ids_to_delete:
-        await TeamMembershipRepository(prisma_client).table.delete_many(
-            where={"team_id": data.team_id, "user_id": _uid}
+        ## DELETE TEAM ID from USER ROW, IF EXISTS ##
+        # get user row
+        key_val = {}
+        if data.user_id is not None:
+            key_val["user_id"] = data.user_id
+        elif data.user_email is not None:
+            key_val["user_email"] = data.user_email
+        existing_user_rows = await UserRepository(prisma_client).table.find_many(
+            where=key_val  # type: ignore
         )
+
+        if existing_user_rows is not None and (
+            isinstance(existing_user_rows, list) and len(existing_user_rows) > 0
+        ):
+            for existing_user in existing_user_rows:
+                team_list = []
+                if data.team_id in existing_user.teams:
+                    team_list = existing_user.teams
+                    team_list.remove(data.team_id)
+                    await UserRepository(prisma_client).table.update(
+                        where={
+                            "user_id": existing_user.user_id,
+                        },
+                        data={"teams": {"set": team_list}},
+                    )
+
+        # Also clean up any existing team membership rows for this user and team
+        user_ids_to_delete = set()
+        if data.user_id is not None:
+            user_ids_to_delete.add(data.user_id)
+        if existing_user_rows is not None and isinstance(existing_user_rows, list):
+            for existing_user in existing_user_rows:
+                if getattr(existing_user, "user_id", None):
+                    user_ids_to_delete.add(existing_user.user_id)
+
+        for _uid in user_ids_to_delete:
+            await TeamMembershipRepository(prisma_client).table.delete_many(
+                where={"team_id": data.team_id, "user_id": _uid}
+            )
 
     ## DELETE KEYS CREATED BY USER FOR THIS TEAM
     if user_ids_to_delete:

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -8404,3 +8404,259 @@ async def test_update_team_blocks_non_admin_passthrough_routes(mock_db_client):
             )
     assert str(exc.value.code) == "403"
     assert "allowed_passthrough_routes" in str(exc.value.message)
+
+
+@pytest.mark.asyncio
+async def test_get_team_member_lock_creates_lock_for_team():
+    """
+    Test that _get_team_member_lock creates and returns a lock for a team_id
+    """
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _get_team_member_lock,
+        _team_member_locks,
+    )
+
+    # Clear any existing locks
+    _team_member_locks.clear()
+
+    # Get lock for a team
+    lock1 = await _get_team_member_lock("team-123")
+    assert lock1 is not None
+    assert isinstance(lock1, asyncio.Lock)
+
+    # Getting lock for same team should return the same lock
+    lock2 = await _get_team_member_lock("team-123")
+    assert lock2 is lock1
+
+    # Getting lock for different team should return a different lock
+    lock3 = await _get_team_member_lock("team-456")
+    assert lock3 is not lock1
+
+
+@pytest.mark.asyncio
+async def test_get_team_member_lock_concurrent_access():
+    """
+    Test that _get_team_member_lock is thread-safe and handles concurrent access
+    """
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _get_team_member_lock,
+        _team_member_locks,
+    )
+
+    # Clear any existing locks
+    _team_member_locks.clear()
+
+    # Create multiple concurrent requests for the same team
+    async def get_lock():
+        return await _get_team_member_lock("concurrent-team")
+
+    # Run 10 concurrent requests
+    locks = await asyncio.gather(*[get_lock() for _ in range(10)])
+
+    # All should return the same lock instance
+    first_lock = locks[0]
+    for lock in locks:
+        assert lock is first_lock
+
+
+@pytest.mark.asyncio
+async def test_team_member_lock_serializes_concurrent_requests():
+    """
+    Test that the team member lock properly serializes concurrent requests
+    to prevent race conditions in read-modify-write operations.
+    """
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _get_team_member_lock,
+        _team_member_locks,
+    )
+
+    # Clear any existing locks
+    _team_member_locks.clear()
+
+    team_id = "test-race-team"
+    lock = await _get_team_member_lock(team_id)
+
+    # Track execution order
+    execution_order = []
+
+    async def worker(worker_id: int, delay: float):
+        async with lock:
+            execution_order.append(f"start-{worker_id}")
+            await asyncio.sleep(delay)
+            execution_order.append(f"end-{worker_id}")
+
+    # Start 3 workers with different delays
+    await asyncio.gather(
+        worker(1, 0.05),
+        worker(2, 0.01),
+        worker(3, 0.03),
+    )
+
+    # Verify that workers executed serially (each start is followed by its end)
+    assert len(execution_order) == 6
+    for i in range(0, 6, 2):
+        start = execution_order[i]
+        end = execution_order[i + 1]
+        # Each start should be immediately followed by its corresponding end
+        worker_id = start.split("-")[1]
+        assert end == f"end-{worker_id}", f"Worker {worker_id} was interleaved"
+
+
+@pytest.mark.asyncio
+async def test_team_member_lock_allows_parallel_different_teams():
+    """
+    Test that locks for different teams allow parallel execution
+    """
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _get_team_member_lock,
+        _team_member_locks,
+    )
+
+    # Clear any existing locks
+    _team_member_locks.clear()
+
+    lock_team_a = await _get_team_member_lock("team-a")
+    lock_team_b = await _get_team_member_lock("team-b")
+
+    # Verify they are different locks
+    assert lock_team_a is not lock_team_b
+
+    # Track execution
+    execution_log = []
+
+    async def worker_team_a():
+        async with lock_team_a:
+            execution_log.append("a-start")
+            await asyncio.sleep(0.05)
+            execution_log.append("a-end")
+
+    async def worker_team_b():
+        async with lock_team_b:
+            execution_log.append("b-start")
+            await asyncio.sleep(0.01)
+            execution_log.append("b-end")
+
+    # Run both workers concurrently
+    await asyncio.gather(worker_team_a(), worker_team_b())
+
+    # Team B should finish before team A (different locks allow parallel execution)
+    assert execution_log == ["a-start", "b-start", "b-end", "a-end"]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_team_member_locks_removes_unlocked():
+    """
+    Test that _cleanup_team_member_locks removes unlocked locks
+    """
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _cleanup_team_member_locks,
+        _get_team_member_lock,
+        _team_member_locks,
+    )
+
+    # Clear any existing locks
+    _team_member_locks.clear()
+
+    # Create some locks
+    lock1 = await _get_team_member_lock("team-1")
+    lock2 = await _get_team_member_lock("team-2")
+    lock3 = await _get_team_member_lock("team-3")
+
+    assert len(_team_member_locks) == 3
+
+    # Hold one lock
+    async with lock2:
+        # Cleanup should remove lock1 and lock3 (unlocked), but keep lock2 (locked)
+        _cleanup_team_member_locks()
+
+    # lock1 and lock3 should be removed, lock2 should remain
+    assert len(_team_member_locks) == 1
+    assert "team-2" in _team_member_locks
+    assert "team-1" not in _team_member_locks
+    assert "team-3" not in _team_member_locks
+
+
+@pytest.mark.asyncio
+async def test_cleanup_team_member_locks_empty_dict():
+    """
+    Test that _cleanup_team_member_locks handles empty dictionary gracefully
+    """
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _cleanup_team_member_locks,
+        _team_member_locks,
+    )
+
+    # Clear any existing locks
+    _team_member_locks.clear()
+
+    # Should not raise any errors
+    _cleanup_team_member_locks()
+    assert len(_team_member_locks) == 0
+
+
+@pytest.mark.asyncio
+async def test_cleanup_team_member_locks_all_locked():
+    """
+    Test that _cleanup_team_member_locks preserves all locks when all are locked
+    """
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _cleanup_team_member_locks,
+        _get_team_member_lock,
+        _team_member_locks,
+    )
+
+    # Clear any existing locks
+    _team_member_locks.clear()
+
+    # Create locks and hold all of them
+    locks = []
+    for i in range(5):
+        lock = await _get_team_member_lock(f"team-{i}")
+        await lock.acquire()
+        locks.append(lock)
+
+    assert len(_team_member_locks) == 5
+
+    # Cleanup should not remove any locks (all are locked)
+    _cleanup_team_member_locks()
+
+    assert len(_team_member_locks) == 5
+
+    # Release all locks
+    for lock in locks:
+        lock.release()
+
+
+@pytest.mark.asyncio
+async def test_get_team_member_lock_triggers_cleanup_when_full():
+    """
+    Test that _get_team_member_lock triggers cleanup when max locks is reached
+    """
+    from litellm.proxy.management_endpoints import team_endpoints
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _get_team_member_lock,
+        _team_member_locks,
+    )
+
+    # Clear any existing locks and temporarily reduce max for testing
+    _team_member_locks.clear()
+    original_max = team_endpoints._MAX_TEAM_MEMBER_LOCKS
+    team_endpoints._MAX_TEAM_MEMBER_LOCKS = 5
+
+    try:
+        # Create 5 locks (at max capacity)
+        for i in range(5):
+            await _get_team_member_lock(f"team-{i}")
+
+        assert len(_team_member_locks) == 5
+
+        # Creating one more should trigger cleanup (but all are unlocked, so they'll be removed)
+        await _get_team_member_lock("team-new")
+
+        # After cleanup, only the new lock should remain
+        assert len(_team_member_locks) == 1
+        assert "team-new" in _team_member_locks
+
+    finally:
+        # Restore original max
+        team_endpoints._MAX_TEAM_MEMBER_LOCKS = original_max


### PR DESCRIPTION
Was debugging a Terraform deployment that was creating teams and adding members. Noticed that only about half the members were actually showing up in the team even though all the API calls returned 200.

Took a while to track down but the issue is in `/team/member_add` (and same pattern in `/team/member_delete`). It does a classic read-modify-write without any locking:

1. Reads `members_with_roles` from the team row
2. Appends the new member in memory
3. Writes the whole list back

When two requests hit at the same time:
- Request A reads [alice, bob]
- Request B reads [alice, bob] (same snapshot)
- Request A writes [alice, bob, carol]
- Request B writes [alice, bob, dave] -> carol is gone

The last write wins and the other members are silently dropped. The API returns 200 for both so there's no error to catch.

I added per-team asyncio locks to serialize concurrent requests to the same team. Different teams can still be modified in parallel. Also added a cleanup mechanism so the lock dictionary doesn't grow unbounded over time.

The lock is acquired before reading the team data and held through the update, which closes the race window. Tested with concurrent requests and all members are now persisted correctly.

For now the workaround is to use `-parallelism=1` with Terraform but that's obviously not ideal.

Fixes #25951
