### PR TITLE
fix(logging): stabilize StandardLoggingPayload.model across success and failure paths

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5322,7 +5322,8 @@ def get_standard_logging_object_payload(
         # This ensures Bedrock models like "us.anthropic.claude-3-5-sonnet-20240620-v1:0"
         # are logged as "bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0"
         custom_llm_provider = cast(Optional[str], kwargs.get("custom_llm_provider"))
-        model_name = reconstruct_model_name(kwargs.get("model", "") or "", custom_llm_provider, metadata)
+        stable_model = litellm_params.get("model") or kwargs.get("model", "") or ""
+        model_name = reconstruct_model_name(stable_model, custom_llm_provider, metadata)
         response_model_name: Optional[str] = None
         if isinstance(final_response_obj, dict):
             response_model_name = final_response_obj.get("model")

--- a/tests/logging_callback_tests/test_standard_logging_payload.py
+++ b/tests/logging_callback_tests/test_standard_logging_payload.py
@@ -1169,3 +1169,162 @@ def test_merge_litellm_metadata_bedrock_passthrough_scenario():
 
     # Verify total number of fields (9 user fields + 4 model fields = 13)
     assert len(result) == 13
+
+
+
+def test_standard_logging_payload_failure_uses_litellm_params_model_not_alias():
+    """Regression test for #33572: on the failure path, the router resets
+    kwargs["model"] back to the model-group alias so retries can re-route,
+    while litellm_params["model"] retains the backend deployment model that
+    actually failed. The payload must carry the backend deployment model, not
+    the alias, so dashboards aggregating by payload["model"] do not split a
+    single deployment's traffic across two keys."""
+    from datetime import datetime
+
+    from litellm.litellm_core_utils.litellm_logging import (
+        Logging,
+        get_standard_logging_object_payload,
+    )
+
+    logging_obj = Logging(
+        model="ssg/anthropic-claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        call_type="completion",
+        start_time=datetime.now(),
+        litellm_call_id="test-failure-stable-model",
+        function_id="test-fn",
+    )
+
+    kwargs = {
+        "model": "ssg/anthropic-claude-sonnet-4-6",
+        "messages": [{"role": "user", "content": "hi"}],
+        "custom_llm_provider": "anthropic",
+        "litellm_params": {
+            "model": "anthropic/claude-sonnet-4-6",
+            "api_base": "https://api.anthropic.com",
+            "metadata": {
+                "model_group": "ssg/anthropic-claude-sonnet-4-6",
+            },
+        },
+    }
+
+    payload = get_standard_logging_object_payload(
+        kwargs=kwargs,
+        init_response_obj={},
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+        logging_obj=logging_obj,
+        status="failure",
+        error_str="overloaded_error",
+    )
+
+    assert payload is not None
+    assert payload["model"] == "anthropic/claude-sonnet-4-6"
+    assert payload["model"] != "ssg/anthropic-claude-sonnet-4-6"
+
+
+def test_standard_logging_payload_failure_falls_back_to_kwargs_model_when_no_litellm_params_model():
+    """Backwards-compat: direct litellm.completion() calls without a router do
+    not populate litellm_params["model"]. The payload must still carry
+    kwargs["model"] unchanged so non-router callers see no behavior change."""
+    from datetime import datetime
+
+    from litellm.litellm_core_utils.litellm_logging import (
+        Logging,
+        get_standard_logging_object_payload,
+    )
+
+    logging_obj = Logging(
+        model="anthropic/claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        call_type="completion",
+        start_time=datetime.now(),
+        litellm_call_id="test-failure-no-router-fallback",
+        function_id="test-fn",
+    )
+
+    kwargs = {
+        "model": "anthropic/claude-sonnet-4-6",
+        "messages": [{"role": "user", "content": "hi"}],
+        "custom_llm_provider": "anthropic",
+        "litellm_params": {},
+    }
+
+    payload = get_standard_logging_object_payload(
+        kwargs=kwargs,
+        init_response_obj={},
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+        logging_obj=logging_obj,
+        status="failure",
+        error_str="overloaded_error",
+    )
+
+    assert payload is not None
+    assert payload["model"] == "anthropic/claude-sonnet-4-6"
+
+
+def test_standard_logging_payload_success_prefers_litellm_params_model():
+    """Symmetry guard: on the success path, when both kwargs["model"] (the
+    router's post-dispatch value) and litellm_params["model"] (the stable
+    deployment identifier) are set, the payload must carry
+    litellm_params["model"]. This pins the success/failure invariant so a
+    future router change cannot silently regress it by re-introducing
+    divergence."""
+    from datetime import datetime
+
+    from litellm.litellm_core_utils.litellm_logging import (
+        Logging,
+        get_standard_logging_object_payload,
+    )
+
+    logging_obj = Logging(
+        model="ssg/anthropic-claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        call_type="completion",
+        start_time=datetime.now(),
+        litellm_call_id="test-success-stable-model",
+        function_id="test-fn",
+    )
+
+    kwargs = {
+        "model": "ssg/anthropic-claude-sonnet-4-6",
+        "messages": [{"role": "user", "content": "hi"}],
+        "custom_llm_provider": "anthropic",
+        "litellm_params": {
+            "model": "anthropic/claude-sonnet-4-6",
+            "api_base": "https://api.anthropic.com",
+            "metadata": {
+                "model_group": "ssg/anthropic-claude-sonnet-4-6",
+            },
+        },
+    }
+    mock_response = {
+        "id": "chatcmpl-success-stable",
+        "object": "chat.completion",
+        "model": "anthropic/claude-sonnet-4-6",
+        "usage": {"prompt_tokens": 5, "completion_tokens": 10, "total_tokens": 15},
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hello"},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+
+    payload = get_standard_logging_object_payload(
+        kwargs=kwargs,
+        init_response_obj=mock_response,
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+        logging_obj=logging_obj,
+        status="success",
+    )
+
+    assert payload is not None
+    assert payload["model"] == "anthropic/claude-sonnet-4-6"
+    assert payload["model"] != "ssg/anthropic-claude-sonnet-4-6"


### PR DESCRIPTION
## Relevant issues

Fixes #33572

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The bug is in `StandardLoggingPayload.model` construction inside `get_standard_logging_object_payload()`, which is not observable through the proxy HTTP response surface. It only surfaces in the logging payload emitted to spend logging backends (Langfuse, S3, Datadog, etc.). The natural test level is therefore a direct call to `get_standard_logging_object_payload()` with mock kwargs, which is the pattern the existing tests in `tests/logging_callback_tests/test_standard_logging_payload.py` already use (see `test_standard_logging_payload_uses_deployment_when_no_base_model` at line 349 and `test_standard_logging_payload_uses_actual_model_for_azure_router` at line 893).

### Before the fix

Pre-fix behavior (issue scenario, status `failure`, router has reset `kwargs["model"]` to the alias while `litellm_params["model"]` retains the backend deployment):

```
kwargs["model"]              = "ssg/anthropic-claude-sonnet-4-6"          # model-group alias
litellm_params["model"]      = "anthropic/claude-sonnet-4-6"              # backend deployment
metadata["deployment"]       = unset                                       # not always populated on failure path

payload["model"]             = "ssg/anthropic-claude-sonnet-4-6"          # WRONG: alias leaks in
```

For the same deployment on the success path, `payload["model"]` is the backend deployment model. Dashboards that group by `payload["model"]` then split a single deployment's traffic across two keys, breaking error-rate math and mislabeling failures during incidents when accurate logs matter most.

### After the fix

Post-fix behavior, same scenario:

```
kwargs["model"]              = "ssg/anthropic-claude-sonnet-4-6"          # alias (unchanged input)
litellm_params["model"]      = "anthropic/claude-sonnet-4-6"              # backend deployment (unchanged input)
metadata["deployment"]       = unset

payload["model"]             = "anthropic/claude-sonnet-4-6"              # CORRECT: stable backend deployment
```

The success and failure paths now produce the same `payload["model"]` for the same deployment, since both read from `litellm_params["model"]` (the stable deployment identifier set by the router when it picks a deployment) instead of `kwargs["model"]` (which the router resets to the alias on the failure path so retries can re-route).

The before/after behavior is asserted by the new regression test `test_standard_logging_payload_failure_uses_litellm_params_model_not_alias`, which fails on the pre-fix code and passes after. Commit hash for both runs is `4b49d97c` (this PR's only commit).

## Type

🐛 Bug Fix

## Changes

`litellm/litellm_core_utils/litellm_logging.py`: in `get_standard_logging_object_payload()`, prefer `litellm_params.get("model")` over `kwargs.get("model", "")` when constructing the `model_name` passed to `reconstruct_model_name()`. Falls back to `kwargs.get("model", "")` when `litellm_params["model"]` is absent, so direct `litellm.completion()` calls without a router preserve the existing behavior.

```python
# Before:
custom_llm_provider = cast(Optional[str], kwargs.get("custom_llm_provider"))
model_name = reconstruct_model_name(kwargs.get("model", "") or "", custom_llm_provider, metadata)

# After:
custom_llm_provider = cast(Optional[str], kwargs.get("custom_llm_provider"))
stable_model = litellm_params.get("model") or kwargs.get("model", "") or ""
model_name = reconstruct_model_name(stable_model, custom_llm_provider, metadata)
```

`litellm_params["model"]` is the deployment's stable backend model identifier (a TypedDict field on `LiteLLMParamsTypedDict` at `litellm/types/router.py:361`). It is set by the router once a deployment is selected and is not reverted on failure, unlike `kwargs["model"]` which is reset to the model-group alias so retries can re-route through the model group. Reading the stable identifier at the logging-payload constructor is what makes the payload stable across success and failure paths.

The Azure Model Router opt-in block immediately below is unchanged. It still keys off `kwargs["model"]` for its `"model_router"` / `"model-router"` substring check, which is the correct field for that opt-in (the user explicitly opts in by passing a model name containing that substring). The existing tests `test_standard_logging_payload_uses_actual_model_for_azure_router` and `test_standard_logging_payload_uses_actual_model_for_azure_router_with_underscore` continue to pass.

`tests/logging_callback_tests/test_standard_logging_payload.py`: three regression tests appended.

1. `test_standard_logging_payload_failure_uses_litellm_params_model_not_alias` reproduces the reported case. Status `failure`, `kwargs["model"]` set to the alias, `litellm_params["model"]` set to the backend deployment, `metadata["deployment"]` unset. Asserts `payload["model"]` equals the backend deployment model. This test fails on the pre-fix code.

2. `test_standard_logging_payload_failure_falls_back_to_kwargs_model_when_no_litellm_params_model` covers backwards compatibility for direct `litellm.completion()` calls without a router. No `litellm_params["model"]`, no `metadata["deployment"]`. Asserts `payload["model"]` equals `kwargs["model"]` so non-router callers see no behavior change.

3. `test_standard_logging_payload_success_prefers_litellm_params_model` pins the success/failure invariant. Both `kwargs["model"]` (alias) and `litellm_params["model"]` (backend) set on the success path. Asserts `payload["model"]` equals `litellm_params["model"]`. This guards against a future router change silently regressing the invariant by re-introducing divergence on the success path.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
