### PR TITLE
feat: add openrouter/kwaipilot/kat-coder-air-v2.5 and kat-coder-pro-v2.5 pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -31104,6 +31104,38 @@
         "output_cost_per_token": 1.875e-06,
         "supports_tool_choice": true
     },
+    "openrouter/kwaipilot/kat-coder-air-v2.5": {
+        "cache_read_input_token_cost": 3e-08,
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 80000,
+        "max_tokens": 80000,
+        "mode": "chat",
+        "output_cost_per_token": 6e-07,
+        "source": "https://openrouter.ai/kwaipilot/kat-coder-air-v2.5",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
+    "openrouter/kwaipilot/kat-coder-pro-v2.5": {
+        "cache_read_input_token_cost": 1.5e-07,
+        "input_cost_per_token": 7.4e-07,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 80000,
+        "max_tokens": 80000,
+        "mode": "chat",
+        "output_cost_per_token": 2.96e-06,
+        "source": "https://openrouter.ai/kwaipilot/kat-coder-pro-v2.5",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
     "openrouter/mancer/weaver": {
         "input_cost_per_token": 5.625e-06,
         "litellm_provider": "openrouter",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -31179,6 +31179,38 @@
         "output_cost_per_token": 1.875e-06,
         "supports_tool_choice": true
     },
+    "openrouter/kwaipilot/kat-coder-air-v2.5": {
+        "cache_read_input_token_cost": 3e-08,
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 80000,
+        "max_tokens": 80000,
+        "mode": "chat",
+        "output_cost_per_token": 6e-07,
+        "source": "https://openrouter.ai/kwaipilot/kat-coder-air-v2.5",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
+    "openrouter/kwaipilot/kat-coder-pro-v2.5": {
+        "cache_read_input_token_cost": 1.5e-07,
+        "input_cost_per_token": 7.4e-07,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 256000,
+        "max_output_tokens": 80000,
+        "max_tokens": 80000,
+        "mode": "chat",
+        "output_cost_per_token": 2.96e-06,
+        "source": "https://openrouter.ai/kwaipilot/kat-coder-pro-v2.5",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
     "openrouter/mancer/weaver": {
         "input_cost_per_token": 5.625e-06,
         "litellm_provider": "openrouter",

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -3538,3 +3538,42 @@ def test_completion_cost_prices_anthropic_shaped_cache_read_tokens():
     )
 
     assert cost == pytest.approx(3 * 5e-6 + 4014 * 5e-7 + 5 * 3e-5, rel=1e-9)
+
+
+@pytest.mark.parametrize(
+    "model_name, expected_input, expected_output, expected_cache_read",
+    [
+        ("openrouter/kwaipilot/kat-coder-air-v2.5", 1.5e-07, 6e-07, 3e-08),
+        ("openrouter/kwaipilot/kat-coder-pro-v2.5", 7.4e-07, 2.96e-06, 1.5e-07),
+    ],
+)
+def test_openrouter_kat_coder_v2_5_pricing(
+    model_name, expected_input, expected_output, expected_cache_read
+):
+    """
+    KAT-Coder-Air V2.5 and KAT-Coder-Pro V2.5 (Kwaipilot, launched 2026-07-14) are
+    served on OpenRouter but had no openrouter/ pricing entries, so cost tracking
+    could not price either model. Prices verified against the OpenRouter models API
+    (https://openrouter.ai/api/v1/models): air $0.15/M in, $0.60/M out, $0.03/M
+    cache read; pro $0.74/M in, $2.96/M out, $0.15/M cache read; both 256k context
+    and 80k max output tokens.
+    """
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    model_info = litellm.model_cost.get(model_name)
+    assert model_info is not None, f"Missing model pricing entry: {model_name}"
+    assert model_info["litellm_provider"] == "openrouter"
+    assert model_info["input_cost_per_token"] == expected_input
+    assert model_info["output_cost_per_token"] == expected_output
+    assert model_info["cache_read_input_token_cost"] == expected_cache_read
+    assert model_info["max_input_tokens"] == 256000
+    assert model_info["max_output_tokens"] == 80000
+
+    prompt_cost, completion_cost_value = cost_per_token(
+        model=model_name,
+        prompt_tokens=1000,
+        completion_tokens=100,
+    )
+    assert prompt_cost == pytest.approx(1000 * expected_input)
+    assert completion_cost_value == pytest.approx(100 * expected_output)


### PR DESCRIPTION
## Relevant issues

No open issue for this. Kwaipilot released KAT-Coder-Air V2.5 and KAT-Coder-Pro V2.5 on July 14 and OpenRouter serves both, but neither has an `openrouter/` pricing entry, so any proxy routing them tracks the spend as $0

## Linear ticket

External contributor; no Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests (`test_openrouter_kat_coder_v2_5_pricing` in `tests/test_litellm/test_cost_calculator.py`; verified it fails on the base branch without the new entries and passes with them)
- [x] My PR passes all CI/CD checks (locally: `make lint` fully green, `make test-unit-root` 1923 passed, `make pre-commit` clean; note that whole-suite `make test-unit` currently fails to collect on the base branch itself because `tests/test_litellm/models/test_models.py` and `tests/test_litellm/proxy/client/test_models.py` share a basename, reproduced with this PR's changes stashed, so it is pre-existing and unrelated)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem (two missing pricing entries for one model family)
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile returned Confidence Score: 5/5 on its automatic review of this PR)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy started from this branch with the local cost map, using a minimal config pointing at both models:

```yaml
model_list:
  - model_name: kat-coder-air
    litellm_params:
      model: openrouter/kwaipilot/kat-coder-air-v2.5
      api_key: sk-or-v1-dummy
  - model_name: kat-coder-pro
    litellm_params:
      model: openrouter/kwaipilot/kat-coder-pro-v2.5
      api_key: sk-or-v1-dummy
general_settings:
  master_key: sk-1234
```

```
LITELLM_LOCAL_MODEL_COST_MAP=True uv run litellm --config config.yaml --port 4000
```

**Before** (base branch, `69a476f791`): the proxy has no pricing for either model and silently bills them at zero

```
$ curl -s http://localhost:4000/v1/model/info -H "Authorization: Bearer sk-1234" | jq '.data[] | {model_name, input_cost_per_token: .model_info.input_cost_per_token, output_cost_per_token: .model_info.output_cost_per_token}'
{ "model_name": "kat-coder-air", "input_cost_per_token": 0, "output_cost_per_token": 0 }
{ "model_name": "kat-coder-pro", "input_cost_per_token": 0, "output_cost_per_token": 0 }

$ curl -s -X POST http://localhost:4000/spend/calculate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"completion_response": {"model": "openrouter/kwaipilot/kat-coder-pro-v2.5", "usage": {"prompt_tokens": 100000, "completion_tokens": 10000, "total_tokens": 110000}, "choices": [{"message": {"role": "assistant", "content": "x"}}]}}'
{"cost":0.0}
```

**After** (this PR, `0a0e9ab0bd`): same curls return the real prices and the right math, pro at 100000 x $0.74/M + 10000 x $2.96/M = $0.1036 and air at $0.021

```
$ curl -s http://localhost:4000/v1/model/info -H "Authorization: Bearer sk-1234" | jq '.data[] | {model_name, litellm_model: .litellm_params.model, input_cost_per_token: .model_info.input_cost_per_token, output_cost_per_token: .model_info.output_cost_per_token, cache_read_input_token_cost: .model_info.cache_read_input_token_cost, max_input_tokens: .model_info.max_input_tokens, max_output_tokens: .model_info.max_output_tokens}'
{
  "model_name": "kat-coder-air",
  "litellm_model": "openrouter/kwaipilot/kat-coder-air-v2.5",
  "input_cost_per_token": 1.5E-7,
  "output_cost_per_token": 6E-7,
  "cache_read_input_token_cost": 3E-8,
  "max_input_tokens": 256000,
  "max_output_tokens": 80000
}
{
  "model_name": "kat-coder-pro",
  "litellm_model": "openrouter/kwaipilot/kat-coder-pro-v2.5",
  "input_cost_per_token": 7.4E-7,
  "output_cost_per_token": 0.00000296,
  "cache_read_input_token_cost": 1.5E-7,
  "max_input_tokens": 256000,
  "max_output_tokens": 80000
}

$ curl -s -X POST http://localhost:4000/spend/calculate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"completion_response": {"model": "openrouter/kwaipilot/kat-coder-pro-v2.5", "usage": {"prompt_tokens": 100000, "completion_tokens": 10000, "total_tokens": 110000}, "choices": [{"message": {"role": "assistant", "content": "x"}}]}}'
{"cost":0.1036}

$ curl -s -X POST http://localhost:4000/spend/calculate ... (same body with kat-coder-air-v2.5)
{"cost":0.020999999999999998}
```

Every figure verified against OpenRouter's public models API, which is the pricing source for these two models:

```
$ curl -s https://openrouter.ai/api/v1/models | jq '[.data[] | select(.id | test("kat-coder.*v2.5")) | {id, context_length, pricing, max_completion_tokens: .top_provider.max_completion_tokens}]'
[
  { "id": "kwaipilot/kat-coder-air-v2.5", "context_length": 256000, "pricing": { "prompt": "0.00000015", "completion": "0.0000006", "input_cache_read": "0.00000003" }, "max_completion_tokens": 80000 },
  { "id": "kwaipilot/kat-coder-pro-v2.5", "context_length": 256000, "pricing": { "prompt": "0.00000074", "completion": "0.00000296", "input_cache_read": "0.00000015" }, "max_completion_tokens": 80000 }
]
```

One honest caveat: I don't have OpenRouter credits on this machine, so I didn't run a paid completion through these models. The entries only feed the pricing and cost tracking surfaces, and those are exactly what the before/after above exercises end to end on a live proxy

## Type

🆕 New Feature

## Changes

Adds `openrouter/kwaipilot/kat-coder-air-v2.5` and `openrouter/kwaipilot/kat-coder-pro-v2.5` to `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json`, inserted alphabetically next to the other `openrouter/` entries. Both carry prices from the OpenRouter listing (air $0.15/M input, $0.60/M output, $0.03/M cache read; pro $0.74/M input, $2.96/M output, $0.15/M cache read), 256k context, 80k max output, and capability flags matching OpenRouter's supported parameters for these models (tools, tool_choice, structured outputs, prompt caching). The `source` field on each entry points at the OpenRouter model page

The regression test asserts the pricing fields and the computed cost via `cost_per_token` for both models, so a future accidental removal or price drift on these entries fails CI

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

---

small note: I'm a freshman in college trying to contribute for the greater good, so apologies in advance if anything here has an obvious error. I picked the target and checked every number against OpenRouter's models API myself, and built the change with Claude Code's help. if something's off I'd honestly love to learn :)


