### PR TITLE
fix(responses): bound spend-log rows fetched for previous_response_id session reconstruction

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1302,6 +1302,10 @@ STANDARD_CUSTOMER_ID_HEADERS = [
 MAX_SPENDLOG_ROWS_TO_QUERY = int(
     os.getenv("MAX_SPENDLOG_ROWS_TO_QUERY", 1_000_000)
 )  # if spendLogs has more than 1M rows, do not query the DB
+# Max spend-log rows fetched to reconstruct a single Responses API session
+# (previous_response_id). Bounds how much the Prisma query engine buffers when a
+# session_id maps to a large number of rows; keeps the most recent N.
+MAX_RESPONSES_API_SESSION_SPEND_LOGS = int(os.getenv("MAX_RESPONSES_API_SESSION_SPEND_LOGS", 1000))
 DEFAULT_SOFT_BUDGET = float(
     os.getenv("DEFAULT_SOFT_BUDGET", 50.0)
 )  # by default all litellm proxy keys have a soft budget of 50.0

--- a/litellm/responses/litellm_completion_transformation/session_handler.py
+++ b/litellm/responses/litellm_completion_transformation/session_handler.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
 
 import litellm
 from litellm._logging import verbose_proxy_logger
+from litellm.constants import MAX_RESPONSES_API_SESSION_SPEND_LOGS
 from litellm.proxy._types import SpendLogsPayload
 from litellm.proxy.spend_tracking.cold_storage_handler import ColdStorageHandler
 from litellm.responses.utils import ResponsesAPIRequestUtils
@@ -268,19 +269,28 @@ class ResponsesSessionHandler:
         if prisma_client is None:
             return []
 
+        # Bounded to the most recent MAX_RESPONSES_API_SESSION_SPEND_LOGS rows. Without
+        # a LIMIT this SELECT * over LiteLLM_SpendLogs pulls the entire session, which
+        # can make the Prisma query engine buffer a very large session into memory when
+        # a session_id maps to many rows. The inner query takes the most recent N
+        # (ORDER BY endTime DESC LIMIT); the outer re-sorts them ASC for replay.
         query = """
             WITH matching_session AS (
                 SELECT session_id
                 FROM "LiteLLM_SpendLogs"
                 WHERE request_id = $1
             )
-            SELECT *
-            FROM "LiteLLM_SpendLogs"
-            WHERE session_id IN (SELECT session_id FROM matching_session)
+            SELECT * FROM (
+                SELECT *
+                FROM "LiteLLM_SpendLogs"
+                WHERE session_id IN (SELECT session_id FROM matching_session)
+                ORDER BY "endTime" DESC
+                LIMIT $2
+            ) recent_session_logs
             ORDER BY "endTime" ASC;
         """
 
-        spend_logs = await prisma_client.db.query_raw(query, previous_response_id)
+        spend_logs = await prisma_client.db.query_raw(query, previous_response_id, MAX_RESPONSES_API_SESSION_SPEND_LOGS)
 
         verbose_proxy_logger.debug(
             "Found the following spend logs for previous response id %s: %s",

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py
@@ -435,3 +435,35 @@ async def test_get_chat_completion_message_history_empty_response_dict():
 
         # Verify the session was still created correctly
         assert result["litellm_session_id"] == "test-session"
+
+
+@pytest.mark.asyncio
+async def test_get_all_spend_logs_for_previous_response_id_is_bounded():
+    """The session-reconstruction query must be bounded by
+    LIMIT $2 = MAX_RESPONSES_API_SESSION_SPEND_LOGS so a session_id mapping to a very
+    large number of rows cannot make the query engine buffer the whole session."""
+    captured = {}
+
+    class _MockDB:
+        async def query_raw(self, query, *params):
+            captured["query"] = query
+            captured["params"] = params
+            return []
+
+    class _MockPrisma:
+        db = _MockDB()
+
+    with patch("litellm.proxy.proxy_server.prisma_client", _MockPrisma()):
+        result = await ResponsesSessionHandler.get_all_spend_logs_for_previous_response_id(
+            "resp_test_123"
+        )
+
+    assert result == []
+    # inner LIMIT $2 bounds the fetch; outer query re-sorts ASC for chronological replay
+    assert "LIMIT $2" in captured["query"]
+    assert 'ORDER BY "endTime" ASC' in captured["query"]
+    # the row cap is passed as the last positional param to query_raw
+    assert (
+        captured["params"][-1]
+        == session_handler.MAX_RESPONSES_API_SESSION_SPEND_LOGS
+    )


### PR DESCRIPTION
## Relevant issues

Fixes #33666

## Linear ticket

<!-- external contributor -->

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (validated locally: `ruff 0.15.3 format --check` and `ruff check` clean on the changed `litellm/` files; the session-handler unit tests pass — leaving CI to confirm the full suite)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 (Greptile reviews automatically once the PR is opened)

## What this changes

`ResponsesSessionHandler.get_all_spend_logs_for_previous_response_id` reconstructs a Responses API session with an **unbounded** `SELECT *` over `LiteLLM_SpendLogs`, filtered only by `session_id`:

```sql
SELECT *
FROM "LiteLLM_SpendLogs"
WHERE session_id IN (SELECT session_id FROM matching_session)
ORDER BY "endTime" ASC;
```

When a `session_id` maps to many rows — a long-running `previous_response_id` chain, a reused `litellm_trace_id`, or tool/MCP fan-out — the Prisma query engine buffers the **entire session** (with the large `messages`/`response`/`proxy_server_request`/`metadata` blob columns) into memory. In production this grew the query-engine process to 12–16 GB RSS and OOM'd pods. Full root-cause details in #33666.

This bounds the reconstruction to the most-recent `MAX_RESPONSES_API_SESSION_SPEND_LOGS` rows (default **1000**, env-configurable), preserving chronological replay order:

- the inner query takes the most recent N (`ORDER BY "endTime" DESC LIMIT $2`);
- the outer query re-sorts them `ASC` for replay.

**Behavioral impact:** none for normal conversations (fewer than N rows). For pathological/very-long sessions the oldest rows are dropped from replay — those would already exceed the model context window. Session-id chaining is unaffected (`litellm_session_id` is still read from the returned rows' shared `session_id`).

## Changes

- `litellm/constants.py`: add `MAX_RESPONSES_API_SESSION_SPEND_LOGS` (next to `MAX_SPENDLOG_ROWS_TO_QUERY`).
- `litellm/responses/litellm_completion_transformation/session_handler.py`: bound the reconstruction query with `LIMIT $2` and pass the cap.
- `tests/test_litellm/responses/litellm_completion_transformation/test_session_handler.py`: add `test_get_all_spend_logs_for_previous_response_id_is_bounded`.

## Out of scope (noted as follow-ups in #33666)

- The query is not scoped by user/key, so a `session_id` collision across users is a latent cross-tenant read.
- Preserving the first turn (system prompt) when truncating a very long session.

## Type

🐛 Bug Fix

## Screenshots / Proof of Fix

Unit test (at `891b177`) asserting the reconstruction query is now bounded:

```
tests/.../test_session_handler.py::test_get_all_spend_logs_for_previous_response_id_is_bounded PASSED
7 passed
```

Before/after of the generated SQL:

```diff
- SELECT * FROM "LiteLLM_SpendLogs"
- WHERE session_id IN (SELECT session_id FROM matching_session)
- ORDER BY "endTime" ASC;
+ SELECT * FROM (
+     SELECT * FROM "LiteLLM_SpendLogs"
+     WHERE session_id IN (SELECT session_id FROM matching_session)
+     ORDER BY "endTime" DESC
+     LIMIT $2
+ ) recent_session_logs
+ ORDER BY "endTime" ASC;
```

Production evidence of the bug (before the fix): a query-engine process holding ~12 GB dropped ~7.3 GB in a single step the moment one such reconstruction query completed — ~100% `RssAnon`, `RssFile` flat — confirming a single query buffering a multi-GB session result set.

Note: a full real-$ e2e requires a populated `LiteLLM_SpendLogs` and live Responses API traffic to force a large session; the unit test plus the SQL diff demonstrate the bound. Happy to add a specific repro if a maintainer wants one.
