### PR TITLE
feat(moonshot): add Kimi K3 support

### DIFF
--- a/litellm/llms/moonshot/chat/transformation.py
+++ b/litellm/llms/moonshot/chat/transformation.py
@@ -14,8 +14,21 @@ from litellm.utils import supports_reasoning
 
 from ...openai.chat.gpt_transformation import OpenAIGPTConfig
 
+SERVER_FIXED_SAMPLING_MODEL_FAMILIES: tuple[str, ...] = ("kimi-k3",)
+NATIVE_TOOL_CHOICE_REQUIRED_MODEL_FAMILIES: tuple[str, ...] = ("kimi-k3",)
+
 
 class MoonshotChatConfig(OpenAIGPTConfig):
+    @staticmethod
+    def _model_in_families(model: str, model_families: tuple[str, ...]) -> bool:
+        return model.split("/")[-1] in model_families
+
+    @staticmethod
+    def _supports_max_reasoning_effort(model: str) -> bool:
+        base_model = model.split("/")[-1]
+        model_info = litellm.model_cost.get(f"moonshot/{base_model}") or litellm.model_cost.get(base_model) or {}
+        return bool(model_info.get("supports_max_reasoning_effort"))
+
     @overload
     def _transform_messages(
         self, messages: List[AllMessageValues], model: str, is_async: Literal[True]
@@ -99,11 +112,17 @@ class MoonshotChatConfig(OpenAIGPTConfig):
         if "kimi-thinking-preview" in model:
             excluded_params.extend(["tools", "tool_choice"])
 
+        if self._model_in_families(model, SERVER_FIXED_SAMPLING_MODEL_FAMILIES):
+            excluded_params.extend(["temperature", "top_p", "n", "presence_penalty", "frequency_penalty"])
+
         base_openai_params = super().get_supported_openai_params(model=model)
         final_params: List[str] = []
         for param in base_openai_params:
             if param not in excluded_params:
                 final_params.append(param)
+
+        if self._supports_max_reasoning_effort(model):
+            final_params.append("reasoning_effort")
 
         return final_params
 
@@ -205,7 +224,9 @@ class MoonshotChatConfig(OpenAIGPTConfig):
             dict: The transformed request. Sent as the body of the API call.
         """
         # Add tool_choice="required" message if needed
-        if optional_params.get("tool_choice", None) == "required":
+        if optional_params.get("tool_choice", None) == "required" and not self._model_in_families(
+            model, NATIVE_TOOL_CHOICE_REQUIRED_MODEL_FAMILIES
+        ):
             messages = self._add_tool_choice_required_message(
                 messages=messages,
                 optional_params=optional_params,

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -434,7 +434,7 @@ async def acompletion(
     logprobs: Optional[bool] = None,
     top_logprobs: Optional[int] = None,
     deployment_id=None,
-    reasoning_effort: Optional[Literal["none", "minimal", "low", "medium", "high", "xhigh", "default"]] = None,
+    reasoning_effort: Optional[Literal["none", "minimal", "low", "medium", "high", "xhigh", "max", "default"]] = None,
     verbosity: Optional[Literal["low", "medium", "high"]] = None,
     safety_identifier: Optional[str] = None,
     service_tier: Optional[str] = None,
@@ -4816,7 +4816,7 @@ def completion(  # type: ignore
     logit_bias: Optional[dict] = None,
     user: Optional[str] = None,
     # openai v1.0+ new params
-    reasoning_effort: Optional[Literal["none", "minimal", "low", "medium", "high", "xhigh", "default"]] = None,
+    reasoning_effort: Optional[Literal["none", "minimal", "low", "medium", "high", "xhigh", "max", "default"]] = None,
     verbosity: Optional[Literal["low", "medium", "high"]] = None,
     response_format: Optional[Union[dict, Type[BaseModel]]] = None,
     seed: Optional[int] = None,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -27523,6 +27523,24 @@
         "supports_video_input": true,
         "supports_vision": true
     },
+    "moonshot/kimi-k3": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "moonshot",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://platform.kimi.ai/docs/guide/kimi-k3-quickstart",
+        "supports_function_calling": true,
+        "supports_max_reasoning_effort": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_video_input": true,
+        "supports_vision": true
+    },
     "moonshot/kimi-latest": {
         "cache_read_input_token_cost": 1.5e-07,
         "deprecation_date": "2026-01-28",

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -1781,7 +1781,7 @@ ResponsesAPIStreamingResponse = Annotated[
 ]
 
 
-REASONING_EFFORT = Literal["none", "minimal", "low", "medium", "high", "xhigh"]
+REASONING_EFFORT = Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 
 
 class OpenAIRealtimeStreamSession(TypedDict, total=False):

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27598,6 +27598,24 @@
         "supports_video_input": true,
         "supports_vision": true
     },
+    "moonshot/kimi-k3": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "moonshot",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://platform.kimi.ai/docs/guide/kimi-k3-quickstart",
+        "supports_function_calling": true,
+        "supports_max_reasoning_effort": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_video_input": true,
+        "supports_vision": true
+    },
     "moonshot/kimi-latest": {
         "cache_read_input_token_cost": 1.5e-07,
         "deprecation_date": "2026-01-28",

--- a/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
+++ b/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
@@ -752,6 +752,7 @@ class TestMoonshotResponseSchemaSupport:
     LIVE_MODELS = [
         "moonshot/kimi-k2.5",
         "moonshot/kimi-k2.6",
+        "moonshot/kimi-k3",
         "moonshot/moonshot-v1-8k",
         "moonshot/moonshot-v1-32k",
         "moonshot/moonshot-v1-128k",
@@ -772,3 +773,149 @@ class TestMoonshotResponseSchemaSupport:
     def test_supports_response_schema_utility_reports_true(self, model_cost_map, monkeypatch):
         monkeypatch.setattr(litellm, "model_cost", model_cost_map)
         assert litellm.utils.supports_response_schema(model="moonshot/kimi-k2.5") is True
+
+
+class TestKimiK3ModelRegistry:
+    @pytest.fixture(autouse=True)
+    def model_cost_map(self):
+        return GetModelCostMap.load_local_model_cost_map()
+
+    def test_kimi_k3_in_model_cost_map(self, model_cost_map):
+        assert "moonshot/kimi-k3" in model_cost_map, "moonshot/kimi-k3 not found in model_cost"
+
+    def test_kimi_k3_pricing(self, model_cost_map):
+        model_info = model_cost_map["moonshot/kimi-k3"]
+        assert model_info["input_cost_per_token"] == pytest.approx(3e-06)
+        assert model_info["output_cost_per_token"] == pytest.approx(1.5e-05)
+        assert model_info["cache_read_input_token_cost"] == pytest.approx(3e-07)
+
+    def test_kimi_k3_context_window(self, model_cost_map):
+        model_info = model_cost_map["moonshot/kimi-k3"]
+        assert model_info["max_input_tokens"] == 1048576
+        assert model_info["max_output_tokens"] == 1048576
+        assert model_info["max_tokens"] == 1048576
+
+    def test_kimi_k3_capabilities(self, model_cost_map):
+        model_info = model_cost_map["moonshot/kimi-k3"]
+        assert model_info.get("supports_function_calling") is True
+        assert model_info.get("supports_tool_choice") is True
+        assert model_info.get("supports_vision") is True
+        assert model_info.get("supports_video_input") is True
+        assert model_info.get("supports_reasoning") is True
+        assert model_info.get("supports_max_reasoning_effort") is True
+        assert model_info.get("supports_response_schema") is True
+
+    def test_kimi_k3_provider(self, model_cost_map):
+        model_info = model_cost_map["moonshot/kimi-k3"]
+        assert model_info["litellm_provider"] == "moonshot"
+
+
+class TestKimiK3ParamHandling:
+    def test_k3_supported_params_exclude_fixed_sampling_params(self):
+        config = MoonshotChatConfig()
+        supported_params = config.get_supported_openai_params("kimi-k3")
+
+        for fixed_param in ("temperature", "top_p", "n", "presence_penalty", "frequency_penalty"):
+            assert fixed_param not in supported_params
+
+        assert "tools" in supported_params
+        assert "tool_choice" in supported_params
+
+    def test_k3_supported_params_include_reasoning_effort(self, monkeypatch):
+        monkeypatch.setattr(litellm, "model_cost", GetModelCostMap.load_local_model_cost_map())
+        config = MoonshotChatConfig()
+        assert "reasoning_effort" in config.get_supported_openai_params("kimi-k3")
+
+    def test_non_k3_params_unchanged(self):
+        config = MoonshotChatConfig()
+        supported_params = config.get_supported_openai_params("kimi-k2.5")
+
+        assert "temperature" in supported_params
+        assert "reasoning_effort" not in supported_params
+
+    def test_k3_map_openai_params_drops_fixed_params_keeps_reasoning_effort(self, monkeypatch):
+        monkeypatch.setattr(litellm, "model_cost", GetModelCostMap.load_local_model_cost_map())
+        config = MoonshotChatConfig()
+
+        with patch(
+            "litellm.llms.moonshot.chat.transformation.supports_reasoning",
+            return_value=True,
+        ):
+            optional_params = config.map_openai_params(
+                non_default_params={
+                    "temperature": 0.7,
+                    "top_p": 0.9,
+                    "presence_penalty": 0.5,
+                    "reasoning_effort": "max",
+                    "max_tokens": 4096,
+                },
+                optional_params={},
+                model="kimi-k3",
+                drop_params=True,
+            )
+
+        assert optional_params.get("reasoning_effort") == "max"
+        assert optional_params.get("max_tokens") == 4096
+        assert "temperature" not in optional_params
+        assert "top_p" not in optional_params
+        assert "presence_penalty" not in optional_params
+
+    def test_k3_tool_choice_required_passed_through(self):
+        config = MoonshotChatConfig()
+
+        messages = [{"role": "user", "content": "What is the weather?"}]
+        optional_params = {"tool_choice": "required"}
+
+        with patch(
+            "litellm.llms.moonshot.chat.transformation.supports_reasoning",
+            return_value=True,
+        ):
+            result = config.transform_request(
+                model="kimi-k3",
+                messages=messages,
+                optional_params=optional_params,
+                litellm_params={},
+                headers={},
+            )
+
+        assert len(result["messages"]) == 1
+        assert optional_params.get("tool_choice") == "required"
+
+    def test_non_k3_tool_choice_required_workaround_still_applies(self):
+        config = MoonshotChatConfig()
+
+        messages = [{"role": "user", "content": "What is the weather?"}]
+        optional_params = {"tool_choice": "required"}
+
+        result = config.transform_request(
+            model="kimi-k2.5",
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params={},
+            headers={},
+        )
+
+        assert len(result["messages"]) == 2
+        assert "tool_choice" not in optional_params
+
+
+class TestKimiModelFamilyMatching:
+    @pytest.mark.parametrize(
+        "model,expected",
+        [
+            ("kimi-k3", True),
+            ("moonshot/kimi-k3", True),
+            ("kimi-k3.5", False),
+            ("kimi-k4", False),
+            ("kimi-k2.5", False),
+        ],
+    )
+    def test_family_matching(self, model, expected):
+        assert MoonshotChatConfig._model_in_families(model, ("kimi-k3",)) is expected
+
+    def test_new_generation_does_not_inherit_k3_param_handling(self):
+        config = MoonshotChatConfig()
+        supported_params = config.get_supported_openai_params("kimi-k3.5")
+
+        assert "temperature" in supported_params
+        assert "reasoning_effort" not in supported_params


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live Moonshot API regression run (real calls, real cost) at commit ff45b508e, confirming earlier Kimi generations keep their existing behavior:

```
$ MOONSHOT_API_BASE=https://api.moonshot.cn/v1 LITELLM_LOCAL_MODEL_COST_MAP=True python k2_e2e.py
[PASS] k2.5 t1 basic + temperature          cost=$0.000259
[PASS] k2.5 t2 tool_choice=required workaround still applies
[PASS] k2.5 t3 multi-turn reasoning_content replay
```

K3 request shaping verified against the documented contract (https://platform.kimi.ai/docs/guide/kimi-k3-quickstart):

```
$ LITELLM_LOCAL_MODEL_COST_MAP=True python -c "..."
supports_reasoning('moonshot/kimi-k3') = True
supports_response_schema('moonshot/kimi-k3') = True
get_model_info max_input_tokens = 1048576
get_supported_openai_params('kimi-k3'): 'reasoning_effort' in, 'temperature' not in
```

## Type

🆕 New Feature

## Changes

Registry: adds `moonshot/kimi-k3` (1M context, $3/$15 per 1M tokens, $0.30 cache hit, reasoning, response schema, vision, video input, tool calling). The `supports_reasoning` flag activates the existing reasoning_content replay and temperature drop

Transformation: per the official quickstart, K3 fixes temperature/top_p/n/penalties server-side (excluded from supported params), accepts top-level `reasoning_effort` (passed through), and supports `tool_choice="required"` natively (skips the prompt workaround older models need). Model matching is exact after stripping a provider prefix, so future variants opt in explicitly

Types: adds "max" to the `reasoning_effort` literals in `completion()`, `acompletion()`, and `REASONING_EFFORT`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
