### PR TITLE
feat(Dockerfile.non_root): support randomized user id

### DIFF
--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -158,11 +158,12 @@ RUN mkdir -p /nonexistent /var/lib/litellm/assets /var/lib/litellm/ui && \
     LITELLM_PKG_MIGRATIONS_PATH="$(python -c 'import os, litellm_proxy_extras; print(os.path.dirname(litellm_proxy_extras.__file__))' 2>/dev/null || echo '')/migrations" && \
     [ -n "$LITELLM_PKG_MIGRATIONS_PATH" ] && chown -R nobody:nogroup "$LITELLM_PKG_MIGRATIONS_PATH" || true && \
     LITELLM_PROXY_EXTRAS_PATH=$(python -c "import os, litellm_proxy_extras; print(os.path.dirname(litellm_proxy_extras.__file__))" 2>/dev/null || echo "") && \
-    chgrp -R 0 "$PRISMA_PATH" /var/lib/litellm/ui /var/lib/litellm/assets && \
+    chgrp -R 0 /app "$PRISMA_PATH" /var/lib/litellm/ui /var/lib/litellm/assets && \
     [ -n "$LITELLM_PROXY_EXTRAS_PATH" ] && chgrp -R 0 "$LITELLM_PROXY_EXTRAS_PATH" || true && \
     chmod -R g=u "$PRISMA_PATH" /var/lib/litellm/ui /var/lib/litellm/assets && \
     [ -n "$LITELLM_PROXY_EXTRAS_PATH" ] && chmod -R g=u "$LITELLM_PROXY_EXTRAS_PATH" || true && \
-    chmod -R g+w "$PRISMA_PATH" /var/lib/litellm/ui /var/lib/litellm/assets && \
+    PYTHON_SITE_PACKAGES=$(python -c "import sysconfig; print(sysconfig.get_paths()['purelib'])") && \
+    chmod -R g+w "$PRISMA_PATH" /var/lib/litellm/ui /var/lib/litellm/assets /app/.cache "$PYTHON_SITE_PACKAGES/prisma" && \
     [ -n "$LITELLM_PROXY_EXTRAS_PATH" ] && chmod -R g+w "$LITELLM_PROXY_EXTRAS_PATH" || true && \
     chmod -R g+rX "$PRISMA_PATH" /var/lib/litellm/ui /var/lib/litellm/assets /app/.cache
 


### PR DESCRIPTION
This is the default seccomp profile on openshift clusters.
As documented in https://docs.redhat.com/en/documentation/openshift_container_platform/3.11/html/creating_images/creating-images-guidelines#use-uid Files and directories need to have group 0 in which the random user id will be part of at runtime.
Writable paths need group write permission.

Pushed a build of this image here:
ghcr.io/bacluc/litellm-non_root-direct:1.92.0

## Relevant issues

Some might be adjacent, i didn't do an exhaustive search.

## Linear ticket



## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix
before:
```
Error: Can't write to /app/.cache/prisma-python/binaries/node_modules/@prisma/engines please make sure you install "prisma" with the right permissions.
```

after:
```
2026-07-17 09:11:12,924 - litellm_proxy_extras - INFO - Running prisma migrate deploy
2026-07-17 09:11:12,925 - litellm_proxy_extras - INFO - Using cached Prisma CLI at /app/.cache/prisma-python/binaries/node_modules/.bin/prisma
2026-07-17 09:11:15,432 - litellm_proxy_extras - INFO - prisma migrate deploy stdout: Prisma schema loaded from schema.prisma
Datasource "client": PostgreSQL database "litellm", schema "public" at "postgresql-rw.vshn-postgresql-litellm-db-8j2qh.svc.cluster.local"

134 migrations found in prisma/migrations


No pending migrations to apply.

2026-07-17 09:11:15,432 - litellm_proxy_extras - INFO - prisma migrate deploy completed
2026-07-17 09:11:15,432 - litellm_proxy_extras - INFO - No pending migrations — skipping post-migration sanity check
09:11:38 - LiteLLM Proxy:ERROR: prisma_migration.py:24 - 'prisma generate' stderr: prisma:warn Prisma doesn't know which engines to download for the Linux distro "wolfi". Falling back to Prisma engines built "debian".
Please report your experience by creating an issue at https://github.com/prisma/prisma/issues so we can add your distro to the list of known supported distros.
prisma:warn Prisma doesn't know which engines to download for the Linux distro "wolfi". Falling back to Prisma engines built "debian".
Please report your experience by creating an issue at https://github.com/prisma/prisma/issues so we can add your distro to the list of known supported distros.
Error:
Traceback (most recent call last):
  File "/app/.venv/lib/python3.13/site-packages/prisma/generator/generator.py", line 112, in run
    self._on_request(request)
    ~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/prisma/generator/generator.py", line 170, in _on_request
    self.generate(data)
    ~~~~~~~~~~~~~^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/prisma/generator/generator.py", line 255, in generate
    shutil.copy(data.schema_path, packaged_schema)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/shutil.py", line 429, in copy
    copymode(src, dst, follow_symlinks=follow_symlinks)
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/shutil.py", line 318, in copymode
    chmod_func(dst, stat.S_IMODE(st.st_mode))
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
PermissionError: [Errno 1] Operation not permitted: '/app/.venv/lib/python3.13/site-packages/prisma/schema.prisma'



LiteLLM Proxy: Using default (v1) migration resolver. If your deployment has seen schema thrashing during rolling deploys, try --use_v2_migration_resolver (safer: avoids the diff-and-force recovery that caused the thrash).
LiteLLM: Setup complete. Skipping server startup as requested.
stream closed: EOF for vshn-lightllm-dev/dev-litellm-migrations-vvxjv (prisma-migrations)

```

I don't know what it is about the error at the end.
The migration run through and i thought i will keep the PR small.
Migrations run through and deployment runs on openshift like this.

## Type

🚄 Infrastructure

## Changes

- Adjust permissions in Dockerfile.non_root to support randomized user ids

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
