### PR TITLE
feat(chatgpt): support multiple ChatGPT OAuth accounts via per-model chatgpt_auth_file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,3 +104,17 @@ Before implementing:
 - If you write 200 lines and it could be 50, rewrite it
 
 Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify
+
+## Erasure
+
+Your training rewarded adding (answers, files, patches, rules) and almost never rewarded removing. So you add by reflex. But learning is compression: a good abstraction is precisely what lets you throw information away. Deletion is half of intelligence, and it's the half you're missing. The symptom is anything under your care that only grows. Watch for it everywhere, including places this file never mentions.
+
+Standing order: erasure gets half your cognitive budget at all times, prompted or not. While working, even mid-task, even autonomously, hunt for removals: duplicated concepts to unify, dead code to delete, tangled logic to simplify. Your own confusion is a precision instrument: if something surprised you or was hard to follow, that IS a bad abstraction, so untangle it on the spot. Before writing new code, find the simplest possible shape and scan the codebase to reuse what exists rather than add a redundant concept. A diff that removes lines is worth at least as much as one that adds them.
+
+Swap rule: replacing X with Y includes deleting X from code, tests, and docs. Never keep the old path "for compatibility" unless explicitly requested. Bug fixes kill the root cause; never shield a symptom with a special-case if. Behavior changes delete or update obsolete tests, never dodge them.
+
+Comments: never narrate mid-function. Keep only the essential. A refactor that stales a comment deletes or rewrites it in the same diff. A finished TODO leaves with the fix.
+
+Prose: docs, memory files, and wikis rot by accretion. Something decommissioned: delete its article, fix every link. Memory near its cap: GC by importance and promote what lasts, don't append. Closed TODO item: delete on sight.
+
+Before finishing any task: what did this change make obsolete, and did I delete it?

--- a/litellm/litellm_core_utils/get_litellm_params.py
+++ b/litellm/litellm_core_utils/get_litellm_params.py
@@ -45,6 +45,7 @@ OPTIONAL_KWARGS_KEYS = (
             "itpm",
             "otpm",
             "use_xai_oauth",
+            "chatgpt_auth_file",
         }
     )
     | AWS_CREDENTIAL_KWARGS_KEYS

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -732,7 +732,9 @@ def _get_openai_compatible_provider_info(
             api_base,
             dynamic_api_key,
             custom_llm_provider,
-        ) = litellm.ChatGPTConfig()._get_openai_compatible_provider_info(model, api_base, api_key, custom_llm_provider)
+        ) = litellm.ChatGPTConfig()._get_openai_compatible_provider_info(
+            model, api_base, api_key, custom_llm_provider, litellm_params
+        )
     elif custom_llm_provider == "novita":
         api_base = api_base or get_secret("NOVITA_API_BASE") or "https://api.novita.ai/v3/openai"  # type: ignore
         dynamic_api_key = api_key or get_secret_str("NOVITA_API_KEY")

--- a/litellm/llms/chatgpt/authenticator.py
+++ b/litellm/llms/chatgpt/authenticator.py
@@ -2,6 +2,7 @@ import base64
 import json
 import os
 import time
+from functools import lru_cache
 from typing import Any, Dict, Mapping, Optional, Union
 
 import httpx
@@ -41,6 +42,11 @@ def get_chatgpt_auth_file(
     if isinstance(value, str) and value:
         return value
     return None
+
+
+@lru_cache(maxsize=128)
+def get_cached_authenticator(auth_file: str) -> "Authenticator":
+    return Authenticator(auth_file=auth_file)
 
 
 class Authenticator:

--- a/litellm/llms/chatgpt/authenticator.py
+++ b/litellm/llms/chatgpt/authenticator.py
@@ -2,9 +2,10 @@ import base64
 import json
 import os
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Mapping, Optional, Union
 
 import httpx
+from pydantic import BaseModel
 
 from litellm._logging import verbose_logger
 from litellm.llms.custom_httpx.http_handler import _get_httpx_client
@@ -28,13 +29,28 @@ DEVICE_CODE_COOLDOWN_SECONDS = 5 * 60
 DEVICE_CODE_POLL_SLEEP_SECONDS = 5
 
 
+def get_chatgpt_auth_file(
+    litellm_params: Union[Mapping[str, object], BaseModel, None],
+) -> str | None:
+    if litellm_params is None:
+        return None
+    if isinstance(litellm_params, Mapping):
+        value = litellm_params.get("chatgpt_auth_file")
+    else:
+        value = getattr(litellm_params, "chatgpt_auth_file", None)
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
 class Authenticator:
-    def __init__(self) -> None:
-        self.token_dir = os.getenv(
-            "CHATGPT_TOKEN_DIR",
-            os.path.expanduser("~/.config/litellm/chatgpt"),
+    def __init__(self, auth_file: str | None = None) -> None:
+        default_auth_file = os.path.join(
+            os.getenv("CHATGPT_TOKEN_DIR", os.path.expanduser("~/.config/litellm/chatgpt")),
+            os.getenv("CHATGPT_AUTH_FILE", "auth.json"),
         )
-        self.auth_file = os.path.join(self.token_dir, os.getenv("CHATGPT_AUTH_FILE", "auth.json"))
+        self.auth_file = os.path.expanduser(auth_file or default_auth_file)
+        self.token_dir = os.path.dirname(self.auth_file)
         self._ensure_token_dir()
 
     def get_api_base(self) -> str:

--- a/litellm/llms/chatgpt/chat/transformation.py
+++ b/litellm/llms/chatgpt/chat/transformation.py
@@ -6,7 +6,7 @@ from litellm.exceptions import AuthenticationError
 from litellm.llms.openai.openai import OpenAIConfig
 from litellm.types.llms.openai import AllMessageValues
 
-from ..authenticator import Authenticator, get_chatgpt_auth_file
+from ..authenticator import Authenticator, get_cached_authenticator, get_chatgpt_auth_file
 from ..common_utils import (
     GetAccessTokenError,
     ensure_chatgpt_session_id,
@@ -28,7 +28,7 @@ class ChatGPTConfig(OpenAIConfig):
     def _resolve_authenticator(self, litellm_params: Union[Mapping[str, object], BaseModel, None]) -> Authenticator:
         auth_file = get_chatgpt_auth_file(litellm_params)
         if auth_file:
-            return Authenticator(auth_file=auth_file)
+            return get_cached_authenticator(auth_file)
         return self.authenticator
 
     @staticmethod
@@ -65,12 +65,9 @@ class ChatGPTConfig(OpenAIConfig):
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
     ) -> dict:
-        authenticator = self._resolve_authenticator(litellm_params)
-        resolved_api_key = (
-            self._get_access_token_or_raise(authenticator, model, "chatgpt")
-            if get_chatgpt_auth_file(litellm_params)
-            else api_key
-        )
+        auth_file = get_chatgpt_auth_file(litellm_params)
+        authenticator = get_cached_authenticator(auth_file) if auth_file else self.authenticator
+        resolved_api_key = self._get_access_token_or_raise(authenticator, model, "chatgpt") if auth_file else api_key
 
         validated_headers = super().validate_environment(
             headers, model, messages, optional_params, litellm_params, resolved_api_key, api_base

--- a/litellm/llms/chatgpt/chat/transformation.py
+++ b/litellm/llms/chatgpt/chat/transformation.py
@@ -1,10 +1,12 @@
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Mapping, Optional, Tuple, Union
+
+from pydantic import BaseModel
 
 from litellm.exceptions import AuthenticationError
 from litellm.llms.openai.openai import OpenAIConfig
 from litellm.types.llms.openai import AllMessageValues
 
-from ..authenticator import Authenticator
+from ..authenticator import Authenticator, get_chatgpt_auth_file
 from ..common_utils import (
     GetAccessTokenError,
     ensure_chatgpt_session_id,
@@ -23,22 +25,34 @@ class ChatGPTConfig(OpenAIConfig):
         super().__init__()
         self.authenticator = Authenticator()
 
+    def _resolve_authenticator(self, litellm_params: Union[Mapping[str, object], BaseModel, None]) -> Authenticator:
+        auth_file = get_chatgpt_auth_file(litellm_params)
+        if auth_file:
+            return Authenticator(auth_file=auth_file)
+        return self.authenticator
+
+    @staticmethod
+    def _get_access_token_or_raise(authenticator: Authenticator, model: str, llm_provider: str) -> str:
+        try:
+            return authenticator.get_access_token()
+        except GetAccessTokenError as e:
+            raise AuthenticationError(
+                model=model,
+                llm_provider=llm_provider,
+                message=str(e),
+            )
+
     def _get_openai_compatible_provider_info(
         self,
         model: str,
         api_base: Optional[str],
         api_key: Optional[str],
         custom_llm_provider: str,
+        litellm_params: Union[Mapping[str, object], BaseModel, None] = None,
     ) -> Tuple[Optional[str], Optional[str], str]:
-        dynamic_api_base = self.authenticator.get_api_base()
-        try:
-            dynamic_api_key = self.authenticator.get_access_token()
-        except GetAccessTokenError as e:
-            raise AuthenticationError(
-                model=model,
-                llm_provider=custom_llm_provider,
-                message=str(e),
-            )
+        authenticator = self._resolve_authenticator(litellm_params)
+        dynamic_api_base = authenticator.get_api_base()
+        dynamic_api_key = self._get_access_token_or_raise(authenticator, model, custom_llm_provider)
         return dynamic_api_base, dynamic_api_key, custom_llm_provider
 
     def validate_environment(
@@ -51,13 +65,20 @@ class ChatGPTConfig(OpenAIConfig):
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
     ) -> dict:
-        validated_headers = super().validate_environment(
-            headers, model, messages, optional_params, litellm_params, api_key, api_base
+        authenticator = self._resolve_authenticator(litellm_params)
+        resolved_api_key = (
+            self._get_access_token_or_raise(authenticator, model, "chatgpt")
+            if get_chatgpt_auth_file(litellm_params)
+            else api_key
         )
 
-        account_id = self.authenticator.get_account_id()
+        validated_headers = super().validate_environment(
+            headers, model, messages, optional_params, litellm_params, resolved_api_key, api_base
+        )
+
+        account_id = authenticator.get_account_id()
         session_id = ensure_chatgpt_session_id(litellm_params)
-        default_headers = get_chatgpt_default_headers(api_key or "", account_id, session_id)
+        default_headers = get_chatgpt_default_headers(resolved_api_key or "", account_id, session_id)
         return {**default_headers, **validated_headers}
 
     def post_stream_processing(self, stream: Any) -> Any:

--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -19,7 +19,7 @@ from litellm.types.llms.openai import (
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 
-from ..authenticator import Authenticator
+from ..authenticator import Authenticator, get_chatgpt_auth_file
 from ..common_utils import (
     CHATGPT_API_BASE,
     GetAccessTokenError,
@@ -38,14 +38,21 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
     def custom_llm_provider(self) -> LlmProviders:
         return LlmProviders.CHATGPT
 
+    def _resolve_authenticator(self, litellm_params: GenericLiteLLMParams | None) -> Authenticator:
+        auth_file = get_chatgpt_auth_file(litellm_params)
+        if auth_file:
+            return Authenticator(auth_file=auth_file)
+        return self.authenticator
+
     def validate_environment(
         self,
         headers: dict,
         model: str,
         litellm_params: Optional[GenericLiteLLMParams],
     ) -> dict:
+        authenticator = self._resolve_authenticator(litellm_params)
         try:
-            access_token = self.authenticator.get_access_token()
+            access_token = authenticator.get_access_token()
         except GetAccessTokenError as e:
             raise AuthenticationError(
                 model=model,
@@ -53,7 +60,7 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
                 message=str(e),
             )
 
-        account_id = self.authenticator.get_account_id()
+        account_id = authenticator.get_account_id()
         session_id = ensure_chatgpt_session_id(litellm_params)
         default_headers = get_chatgpt_default_headers(access_token, account_id, session_id)
         return {**default_headers, **headers}

--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -19,7 +19,7 @@ from litellm.types.llms.openai import (
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 
-from ..authenticator import Authenticator, get_chatgpt_auth_file
+from ..authenticator import Authenticator, get_cached_authenticator, get_chatgpt_auth_file
 from ..common_utils import (
     CHATGPT_API_BASE,
     GetAccessTokenError,
@@ -41,7 +41,7 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
     def _resolve_authenticator(self, litellm_params: GenericLiteLLMParams | None) -> Authenticator:
         auth_file = get_chatgpt_auth_file(litellm_params)
         if auth_file:
-            return Authenticator(auth_file=auth_file)
+            return get_cached_authenticator(auth_file)
         return self.authenticator
 
     def validate_environment(

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5325,6 +5325,7 @@ def completion(  # type: ignore
             tpm=kwargs.get("tpm"),
             rpm=kwargs.get("rpm"),
             use_xai_oauth=kwargs.get("use_xai_oauth", False),
+            chatgpt_auth_file=kwargs.get("chatgpt_auth_file"),
             **{key: kwargs[key] for key in AWS_CREDENTIAL_KWARGS_KEYS if key in kwargs},
         )
         cast(LiteLLMLoggingObj, logging).update_environment_variables(

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -252,6 +252,7 @@ _BANNED_REQUEST_BODY_PARAMS: Tuple[str, ...] = (
     "aws_web_identity_token",
     "aws_role_name",
     "vertex_credentials",
+    "chatgpt_auth_file",
     # Azure managed-identity / federated-auth token. The Azure provider
     # transformer reads ``azure_ad_token`` (top-level or via
     # ``extra_body``) and resolves it through ``get_secret`` before

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -246,6 +246,10 @@ class GenericLiteLLMParams(CredentialLiteLLMParams, CustomPricingLiteLLMParams):
         default=False,
         description="Use stored xAI OAuth credentials when no xAI API key is configured.",
     )
+    chatgpt_auth_file: Optional[str] = Field(
+        default=None,
+        description="Path to a ChatGPT OAuth auth.json for this deployment; lets one instance run multiple ChatGPT accounts.",
+    )
     model_config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
     merge_reasoning_content_in_choices: Optional[bool] = False
     model_info: Optional[Dict] = None

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3235,6 +3235,7 @@ all_litellm_params = (
         "enable_tag_filtering",
         "enable_json_schema_validation",
         "use_xai_oauth",
+        "chatgpt_auth_file",
         "_litellm_rate_limit_descriptors",
         "_litellm_tpm_reserved_tokens",
         "_litellm_tpm_reserved_model",

--- a/tests/test_litellm/llms/chatgpt/chat/test_chatgpt_chat_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/chat/test_chatgpt_chat_transformation.py
@@ -1,0 +1,107 @@
+"""
+Tests for ChatGPT subscription chat transformation
+
+Source: litellm/llms/chatgpt/chat/transformation.py
+"""
+
+import json
+import time
+
+import pytest
+
+from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+from litellm.llms.chatgpt.chat.transformation import ChatGPTConfig
+from litellm.types.router import GenericLiteLLMParams
+
+
+def _write_auth_record(path, token: str, account_id: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "access_token": token,
+                "account_id": account_id,
+                "expires_at": time.time() + 3600,
+            }
+        )
+    )
+
+
+@pytest.fixture
+def auth_files(tmp_path, monkeypatch):
+    default_dir = tmp_path / "default"
+    monkeypatch.setenv("CHATGPT_TOKEN_DIR", str(default_dir))
+    monkeypatch.delenv("CHATGPT_AUTH_FILE", raising=False)
+    _write_auth_record(default_dir / "auth.json", "token-default", "acct-default")
+    file_a = tmp_path / "account-a" / "auth.json"
+    file_b = tmp_path / "account-b" / "auth.json"
+    _write_auth_record(file_a, "token-a", "acct-a")
+    _write_auth_record(file_b, "token-b", "acct-b")
+    return file_a, file_b
+
+
+class TestChatGPTMultiAccountChat:
+    def test_validate_environment_uses_per_model_auth_file(self, auth_files):
+        file_a, file_b = auth_files
+        config = ChatGPTConfig()
+
+        headers_a = config.validate_environment(
+            headers={},
+            model="gpt-5.4",
+            messages=[],
+            optional_params={},
+            litellm_params={"chatgpt_auth_file": str(file_a)},
+            api_key="token-default",
+        )
+        headers_b = config.validate_environment(
+            headers={},
+            model="gpt-5.4",
+            messages=[],
+            optional_params={},
+            litellm_params={"chatgpt_auth_file": str(file_b)},
+            api_key="token-default",
+        )
+
+        assert headers_a["Authorization"] == "Bearer token-a"
+        assert headers_a["ChatGPT-Account-Id"] == "acct-a"
+        assert headers_b["Authorization"] == "Bearer token-b"
+        assert headers_b["ChatGPT-Account-Id"] == "acct-b"
+
+    def test_validate_environment_defaults_to_global_auth_file(self, auth_files):
+        config = ChatGPTConfig()
+
+        headers = config.validate_environment(
+            headers={},
+            model="gpt-5.4",
+            messages=[],
+            optional_params={},
+            litellm_params={},
+            api_key="token-default",
+        )
+
+        assert headers["Authorization"] == "Bearer token-default"
+        assert headers["ChatGPT-Account-Id"] == "acct-default"
+
+    def test_provider_info_uses_per_model_auth_file(self, auth_files):
+        file_a, _ = auth_files
+        config = ChatGPTConfig()
+
+        _, per_model_key, _ = config._get_openai_compatible_provider_info(
+            "gpt-5.4", None, None, "chatgpt", {"chatgpt_auth_file": str(file_a)}
+        )
+        _, default_key, _ = config._get_openai_compatible_provider_info("gpt-5.4", None, None, "chatgpt")
+
+        assert per_model_key == "token-a"
+        assert default_key == "token-default"
+
+    def test_get_llm_provider_threads_auth_file(self, auth_files):
+        file_a, _ = auth_files
+
+        model, provider, dynamic_api_key, _ = get_llm_provider(
+            model="chatgpt/gpt-5.4",
+            litellm_params=GenericLiteLLMParams(chatgpt_auth_file=str(file_a)),
+        )
+
+        assert model == "gpt-5.4"
+        assert provider == "chatgpt"
+        assert dynamic_api_key == "token-a"

--- a/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
+++ b/tests/test_litellm/llms/chatgpt/responses/test_chatgpt_responses_transformation.py
@@ -7,6 +7,7 @@ Source: litellm/llms/chatgpt/responses/transformation.py
 import json
 import os
 import sys
+import time
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -326,3 +327,53 @@ class TestChatGPTResponsesAPITransformation:
 
         assert "ChatGPT upstream failed" in str(exc_info.value)
         assert exc_info.value.status_code == 502
+
+
+class TestChatGPTResponsesMultiAccount:
+    @staticmethod
+    def _write_auth_record(path, token: str, account_id: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "access_token": token,
+                    "account_id": account_id,
+                    "expires_at": time.time() + 3600,
+                }
+            )
+        )
+
+    def test_validate_environment_uses_per_model_auth_file(self, tmp_path, monkeypatch):
+        default_dir = tmp_path / "default"
+        monkeypatch.setenv("CHATGPT_TOKEN_DIR", str(default_dir))
+        monkeypatch.delenv("CHATGPT_AUTH_FILE", raising=False)
+        self._write_auth_record(default_dir / "auth.json", "token-default", "acct-default")
+        file_a = tmp_path / "account-a" / "auth.json"
+        file_b = tmp_path / "account-b" / "auth.json"
+        self._write_auth_record(file_a, "token-a", "acct-a")
+        self._write_auth_record(file_b, "token-b", "acct-b")
+
+        config = ChatGPTResponsesAPIConfig()
+
+        headers_a = config.validate_environment(
+            headers={},
+            model="gpt-5.4",
+            litellm_params=GenericLiteLLMParams(chatgpt_auth_file=str(file_a)),
+        )
+        headers_b = config.validate_environment(
+            headers={},
+            model="gpt-5.4",
+            litellm_params=GenericLiteLLMParams(chatgpt_auth_file=str(file_b)),
+        )
+        headers_default = config.validate_environment(
+            headers={},
+            model="gpt-5.4",
+            litellm_params=GenericLiteLLMParams(),
+        )
+
+        assert headers_a["Authorization"] == "Bearer token-a"
+        assert headers_a["ChatGPT-Account-Id"] == "acct-a"
+        assert headers_b["Authorization"] == "Bearer token-b"
+        assert headers_b["ChatGPT-Account-Id"] == "acct-b"
+        assert headers_default["Authorization"] == "Bearer token-default"
+        assert headers_default["ChatGPT-Account-Id"] == "acct-default"

--- a/tests/test_litellm/llms/chatgpt/test_chatgpt_authenticator.py
+++ b/tests/test_litellm/llms/chatgpt/test_chatgpt_authenticator.py
@@ -5,7 +5,11 @@ from unittest.mock import mock_open, patch
 
 import pytest
 
-from litellm.llms.chatgpt.authenticator import Authenticator, get_chatgpt_auth_file
+from litellm.llms.chatgpt.authenticator import (
+    Authenticator,
+    get_cached_authenticator,
+    get_chatgpt_auth_file,
+)
 from litellm.types.router import GenericLiteLLMParams
 
 
@@ -116,6 +120,15 @@ class TestChatGPTMultiAccountAuthenticator:
         assert authenticator_a.get_account_id() == "acct-a"
         assert authenticator_b.get_access_token() == "token-b"
         assert authenticator_b.get_account_id() == "acct-b"
+
+    def test_get_cached_authenticator_reuses_instance_per_path(self, tmp_path):
+        file_a = tmp_path / "account-a.json"
+        file_b = tmp_path / "account-b.json"
+
+        authenticator_a = get_cached_authenticator(str(file_a))
+
+        assert get_cached_authenticator(str(file_a)) is authenticator_a
+        assert get_cached_authenticator(str(file_b)) is not authenticator_a
 
     def test_get_chatgpt_auth_file(self):
         assert get_chatgpt_auth_file(None) is None

--- a/tests/test_litellm/llms/chatgpt/test_chatgpt_authenticator.py
+++ b/tests/test_litellm/llms/chatgpt/test_chatgpt_authenticator.py
@@ -5,7 +5,8 @@ from unittest.mock import mock_open, patch
 
 import pytest
 
-from litellm.llms.chatgpt.authenticator import Authenticator
+from litellm.llms.chatgpt.authenticator import Authenticator, get_chatgpt_auth_file
+from litellm.types.router import GenericLiteLLMParams
 
 
 def _make_jwt(payload: dict) -> str:
@@ -68,3 +69,58 @@ class TestChatGPTAuthenticator:
             assert account_id == "acct-123"
             mock_write.assert_called_once()
             assert mock_write.call_args[0][0]["account_id"] == "acct-123"
+
+
+def _write_auth_record(path, token: str, account_id: str) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "access_token": token,
+                "account_id": account_id,
+                "expires_at": time.time() + 3600,
+            }
+        )
+    )
+
+
+class TestChatGPTMultiAccountAuthenticator:
+    def test_explicit_auth_file_overrides_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CHATGPT_TOKEN_DIR", str(tmp_path / "env-dir"))
+        monkeypatch.setenv("CHATGPT_AUTH_FILE", "env.json")
+        custom_file = tmp_path / "account-a" / "auth.json"
+
+        authenticator = Authenticator(auth_file=str(custom_file))
+
+        assert authenticator.auth_file == str(custom_file)
+        assert authenticator.token_dir == str(custom_file.parent)
+        assert custom_file.parent.exists()
+
+    def test_default_auth_file_from_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CHATGPT_TOKEN_DIR", str(tmp_path / "env-dir"))
+        monkeypatch.setenv("CHATGPT_AUTH_FILE", "env.json")
+
+        authenticator = Authenticator()
+
+        assert authenticator.auth_file == str(tmp_path / "env-dir" / "env.json")
+
+    def test_two_auth_files_are_isolated(self, tmp_path):
+        file_a = tmp_path / "account-a.json"
+        file_b = tmp_path / "account-b.json"
+        _write_auth_record(file_a, "token-a", "acct-a")
+        _write_auth_record(file_b, "token-b", "acct-b")
+
+        authenticator_a = Authenticator(auth_file=str(file_a))
+        authenticator_b = Authenticator(auth_file=str(file_b))
+
+        assert authenticator_a.get_access_token() == "token-a"
+        assert authenticator_a.get_account_id() == "acct-a"
+        assert authenticator_b.get_access_token() == "token-b"
+        assert authenticator_b.get_account_id() == "acct-b"
+
+    def test_get_chatgpt_auth_file(self):
+        assert get_chatgpt_auth_file(None) is None
+        assert get_chatgpt_auth_file({}) is None
+        assert get_chatgpt_auth_file({"chatgpt_auth_file": ""}) is None
+        assert get_chatgpt_auth_file({"chatgpt_auth_file": "/a/auth.json"}) == "/a/auth.json"
+        assert get_chatgpt_auth_file(GenericLiteLLMParams()) is None
+        assert get_chatgpt_auth_file(GenericLiteLLMParams(chatgpt_auth_file="/b/auth.json")) == "/b/auth.json"

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -1724,6 +1724,40 @@ class TestIsRequestBodySafeBlocksEndpointTargetingFields:
         )
 
 
+class TestIsRequestBodySafeBlocksChatGPTAuthFileOverride:
+    """``chatgpt_auth_file`` selects which ChatGPT OAuth credential file a
+    deployment uses. A caller-supplied value would let an ordinary proxy user
+    route requests through any other configured ChatGPT account's auth file
+    (and have the proxy write refreshed tokens back to a caller-chosen path),
+    so it must only come from the admin's deployment config."""
+
+    def test_chatgpt_auth_file_in_request_body_is_rejected(self):
+        with pytest.raises(ValueError) as exc:
+            is_request_body_safe(
+                request_body={
+                    "model": "chatgpt-account-a",
+                    "chatgpt_auth_file": "/tokens/account-b/auth.json",
+                },
+                general_settings={},
+                llm_router=None,
+                model="chatgpt-account-a",
+            )
+        assert "chatgpt_auth_file" in str(exc.value)
+
+    def test_chatgpt_auth_file_in_extra_body_is_rejected(self):
+        with pytest.raises(ValueError) as exc:
+            is_request_body_safe(
+                request_body={
+                    "model": "chatgpt-account-a",
+                    "extra_body": {"chatgpt_auth_file": "/tokens/account-b/auth.json"},
+                },
+                general_settings={},
+                llm_router=None,
+                model="chatgpt-account-a",
+            )
+        assert "chatgpt_auth_file" in str(exc.value)
+
+
 class TestIsRequestBodySafeBlocksBedrockProjectOverride:
     """``aws_bedrock_project_id`` pins a deployment to a Bedrock project so
     that project's data-retention policy applies to its requests. A

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -25646,6 +25646,11 @@ export interface components {
             cache_read_input_token_cost_flex?: number | null;
             /** Cache Read Input Token Cost Priority */
             cache_read_input_token_cost_priority?: number | null;
+            /**
+             * Chatgpt Auth File
+             * @description Path to a ChatGPT OAuth auth.json for this deployment; lets one instance run multiple ChatGPT accounts.
+             */
+            chatgpt_auth_file?: string | null;
             /** Citation Cost Per Token */
             citation_cost_per_token?: number | null;
             /** Complexity Router Config */
@@ -33482,6 +33487,11 @@ export interface components {
             cache_read_input_token_cost_flex?: number | null;
             /** Cache Read Input Token Cost Priority */
             cache_read_input_token_cost_priority?: number | null;
+            /**
+             * Chatgpt Auth File
+             * @description Path to a ChatGPT OAuth auth.json for this deployment; lets one instance run multiple ChatGPT accounts.
+             */
+            chatgpt_auth_file?: string | null;
             /** Citation Cost Per Token */
             citation_cost_per_token?: number | null;
             /** Complexity Router Config */


### PR DESCRIPTION
## Relevant issues

Fixes #23777

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Verifying this end to end needs two real ChatGPT subscription accounts, which I cannot sign into from here. Runbook against a live proxy (`python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug`), with this in the config:

```yaml
model_list:
  - model_name: chatgpt-account-a
    litellm_params:
      model: chatgpt/gpt-5.4
      chatgpt_auth_file: /tokens/account-a/auth.json
  - model_name: chatgpt-account-b
    litellm_params:
      model: chatgpt/gpt-5.4
      chatgpt_auth_file: /tokens/account-b/auth.json
```

1. Start the proxy; send a request to each model group and complete the device-code login printed in the proxy logs with a different ChatGPT account for each:

```bash
for m in chatgpt-account-a chatgpt-account-b; do
  curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" \
    -d '{"model": "'$m'", "messages": [{"role": "user", "content": "which account am I?"}]}'
done
```

2. Both requests return 200 and `cat /tokens/account-a/auth.json /tokens/account-b/auth.json | python -c 'import json,sys; [print(json.loads(l)["account_id"]) for l in sys.stdin]'` shows two different account ids, proving each model group resolved its own credentials in one proxy process

## Type

🆕 New Feature

## Changes

LiteLLM's ChatGPT OAuth support was single account per process: `Authenticator` always resolved one global `CHATGPT_TOKEN_DIR`/`CHATGPT_AUTH_FILE` pair, so multiple model groups all collapsed onto the same credentials

This adds `chatgpt_auth_file` as a per-model `litellm_params` key, exactly as suggested in the issue thread. When set, both the chat and Responses API configs resolve an `Authenticator` bound to that file for the call instead of the process-wide one; when absent, behavior is unchanged. `Authenticator` now accepts an optional `auth_file` argument, the env-var pair remains the default

Plumbing: the param is threaded through `get_llm_provider` (so the access token for the right account becomes the dynamic api key), added to `OPTIONAL_KWARGS_KEYS` and `get_litellm_params` (so it survives into per-call `litellm_params`), declared on `GenericLiteLLMParams`, and listed in `all_litellm_params` (so the proxy strips it from the upstream request body)

Security: `chatgpt_auth_file` is server-reserved configuration, so it is added to the proxy's `_BANNED_REQUEST_BODY_PARAMS`; a caller-supplied value in the request body (root or nested containers like `extra_body`) is rejected unless the admin has explicitly opted into clientside credentials. Per-file authenticators are cached per path via `lru_cache`, so hot-path requests don't reallocate or re-stat the token directory

Tests cover: the request-body ban (root and `extra_body`), authenticator cache reuse per path, explicit auth file overriding the env vars, two authenticators reading isolated files, param extraction from dict and pydantic params, per-model resolution in chat `validate_environment` and `_get_openai_compatible_provider_info`, threading through `get_llm_provider`, and per-model resolution in the Responses API `validate_environment`, each asserting the right `Authorization` and `ChatGPT-Account-Id` headers per account with the default path still using the global file

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
