### PR TITLE
fix(proxy): preserve body trace and session IDs

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -971,8 +971,24 @@ class LiteLLMProxyRequestSetup:
         if chain_id:
         if chain_id:
             request_metadata = data.get(_metadata_variable_name) or {}
-            session_id = data.get("litellm_session_id") or request_metadata.get("session_id") or chain_id
-            trace_id = data.get("litellm_trace_id") or request_metadata.get("trace_id") or chain_id
+            body_session_id = data.get("litellm_session_id")
+            body_trace_id = data.get("litellm_trace_id")
+            metadata_session_id = request_metadata.get("session_id")
+            metadata_trace_id = request_metadata.get("trace_id")
+            session_id = (
+                body_session_id
+                if body_session_id is not None
+                else metadata_session_id
+                if metadata_session_id is not None
+                else chain_id
+            )
+            trace_id = (
+                body_trace_id
+                if body_trace_id is not None
+                else metadata_trace_id
+                if metadata_trace_id is not None
+                else chain_id
+            )
             metadata_from_headers["trace_id"] = trace_id
             metadata_from_headers["session_id"] = session_id
             data["litellm_session_id"] = session_id

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -969,26 +969,13 @@ class LiteLLMProxyRequestSetup:
             verbose_proxy_logger.debug(f"Extracted agent_id from header: {agent_id_from_header}")
 
         if chain_id:
-        if chain_id:
             request_metadata = data.get(_metadata_variable_name) or {}
             body_session_id = data.get("litellm_session_id")
             body_trace_id = data.get("litellm_trace_id")
             metadata_session_id = request_metadata.get("session_id")
             metadata_trace_id = request_metadata.get("trace_id")
-            session_id = (
-                body_session_id
-                if body_session_id is not None
-                else metadata_session_id
-                if metadata_session_id is not None
-                else chain_id
-            )
-            trace_id = (
-                body_trace_id
-                if body_trace_id is not None
-                else metadata_trace_id
-                if metadata_trace_id is not None
-                else chain_id
-            )
+            session_id = body_session_id or metadata_session_id or chain_id
+            trace_id = body_trace_id or metadata_trace_id or chain_id
             metadata_from_headers["trace_id"] = trace_id
             metadata_from_headers["session_id"] = session_id
             data["litellm_session_id"] = session_id

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -961,7 +961,7 @@ class LiteLLMProxyRequestSetup:
         #########################################################################################
 
         agent_id_from_header = headers.get("x-litellm-agent-id")
-        # Explicit litellm headers take precedence; fall back to any x-*-session-id header.
+        # Use the header chain ID only for values the request body did not provide.
         chain_id = get_chain_id_from_headers(dict(headers))
 
         if agent_id_from_header:
@@ -969,11 +969,18 @@ class LiteLLMProxyRequestSetup:
             verbose_proxy_logger.debug(f"Extracted agent_id from header: {agent_id_from_header}")
 
         if chain_id:
-            metadata_from_headers["trace_id"] = chain_id
-            metadata_from_headers["session_id"] = chain_id
-            data["litellm_session_id"] = chain_id
-            data["litellm_trace_id"] = chain_id
-            verbose_proxy_logger.debug(f"Extracted chain_id from header (trace-id/session-id): {chain_id}")
+        if chain_id:
+            request_metadata = data.get(_metadata_variable_name) or {}
+            session_id = data.get("litellm_session_id") or request_metadata.get("session_id") or chain_id
+            trace_id = data.get("litellm_trace_id") or request_metadata.get("trace_id") or chain_id
+            metadata_from_headers["trace_id"] = trace_id
+            metadata_from_headers["session_id"] = session_id
+            data["litellm_session_id"] = session_id
+            data["litellm_trace_id"] = trace_id
+            verbose_proxy_logger.debug(
+                "Applied chain ID from header to missing trace/session IDs: "
+                f"session_id={session_id}, trace_id={trace_id}"
+            )
         else:
             body_metadata = data.get("metadata")
             session_id = _get_anthropic_session_id_from_metadata(body_metadata)

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -2537,8 +2537,8 @@ def test_add_litellm_metadata_from_request_headers_preserves_body_chain_ids():
     assert data["metadata"]["trace_id"] == "body-trace-id"
 
 
-def test_add_litellm_metadata_from_request_headers_preserves_empty_body_chain_ids():
-    """An explicitly empty body ID must not be replaced by the header chain ID."""
+def test_add_litellm_metadata_from_request_headers_falls_back_from_empty_body_chain_ids():
+    """Empty body IDs must fall back to the header chain ID for session limit enforcement."""
     headers = {"x-litellm-trace-id": "header-trace-id"}
     data = {
         "metadata": {},
@@ -2549,10 +2549,10 @@ def test_add_litellm_metadata_from_request_headers_preserves_empty_body_chain_id
         headers=headers, data=data, _metadata_variable_name="metadata"
     )
 
-    assert data["litellm_session_id"] == ""
-    assert data["litellm_trace_id"] == ""
-    assert data["metadata"]["session_id"] == ""
-    assert data["metadata"]["trace_id"] == ""
+    assert data["litellm_session_id"] == "header-trace-id"
+    assert data["litellm_trace_id"] == "header-trace-id"
+    assert data["metadata"]["session_id"] == "header-trace-id"
+    assert data["metadata"]["trace_id"] == "header-trace-id"
 
 
 def test_add_litellm_metadata_from_request_headers_preserves_metadata_chain_ids():
@@ -2572,6 +2572,25 @@ def test_add_litellm_metadata_from_request_headers_preserves_metadata_chain_ids(
     assert data["litellm_trace_id"] == "metadata-trace-id"
     assert data["metadata"]["session_id"] == "metadata-session-id"
     assert data["metadata"]["trace_id"] == "metadata-trace-id"
+
+
+def test_add_litellm_metadata_from_request_headers_falls_back_from_empty_metadata_chain_ids():
+    """Empty metadata IDs must fall back to the header chain ID for session limit enforcement."""
+    headers = {"x-litellm-trace-id": "header-trace-id"}
+    data = {
+        "metadata": {
+            "session_id": "",
+            "trace_id": "",
+        }
+    }
+    LiteLLMProxyRequestSetup.add_litellm_metadata_from_request_headers(
+        headers=headers, data=data, _metadata_variable_name="metadata"
+    )
+
+    assert data["litellm_session_id"] == "header-trace-id"
+    assert data["litellm_trace_id"] == "header-trace-id"
+    assert data["metadata"]["session_id"] == "header-trace-id"
+    assert data["metadata"]["trace_id"] == "header-trace-id"
 
 
 def test_add_litellm_metadata_from_request_headers_x_litellm_session_id_sets_chain_id():

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -2519,6 +2519,24 @@ def test_add_litellm_metadata_from_request_headers_x_litellm_trace_id_sets_chain
     assert data["litellm_trace_id"] == "foo"
 
 
+def test_add_litellm_metadata_from_request_headers_preserves_body_chain_ids():
+    """A header chain ID must not overwrite distinct body session and trace IDs."""
+    headers = {"x-litellm-trace-id": "header-trace-id"}
+    data = {
+        "metadata": {},
+        "litellm_session_id": "body-session-id",
+        "litellm_trace_id": "body-trace-id",
+    }
+    LiteLLMProxyRequestSetup.add_litellm_metadata_from_request_headers(
+        headers=headers, data=data, _metadata_variable_name="metadata"
+    )
+
+    assert data["litellm_session_id"] == "body-session-id"
+    assert data["litellm_trace_id"] == "body-trace-id"
+    assert data["metadata"]["session_id"] == "body-session-id"
+    assert data["metadata"]["trace_id"] == "body-trace-id"
+
+
 def test_add_litellm_metadata_from_request_headers_x_litellm_session_id_sets_chain_id():
     """x-litellm-session-id sets both metadata and top-level litellm_session_id/litellm_trace_id for call chaining."""
     headers = {"x-litellm-session-id": "bar"}

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -2537,6 +2537,43 @@ def test_add_litellm_metadata_from_request_headers_preserves_body_chain_ids():
     assert data["metadata"]["trace_id"] == "body-trace-id"
 
 
+def test_add_litellm_metadata_from_request_headers_preserves_empty_body_chain_ids():
+    """An explicitly empty body ID must not be replaced by the header chain ID."""
+    headers = {"x-litellm-trace-id": "header-trace-id"}
+    data = {
+        "metadata": {},
+        "litellm_session_id": "",
+        "litellm_trace_id": "",
+    }
+    LiteLLMProxyRequestSetup.add_litellm_metadata_from_request_headers(
+        headers=headers, data=data, _metadata_variable_name="metadata"
+    )
+
+    assert data["litellm_session_id"] == ""
+    assert data["litellm_trace_id"] == ""
+    assert data["metadata"]["session_id"] == ""
+    assert data["metadata"]["trace_id"] == ""
+
+
+def test_add_litellm_metadata_from_request_headers_preserves_metadata_chain_ids():
+    """A header chain ID must not overwrite IDs supplied through metadata."""
+    headers = {"x-litellm-trace-id": "header-trace-id"}
+    data = {
+        "metadata": {
+            "session_id": "metadata-session-id",
+            "trace_id": "metadata-trace-id",
+        }
+    }
+    LiteLLMProxyRequestSetup.add_litellm_metadata_from_request_headers(
+        headers=headers, data=data, _metadata_variable_name="metadata"
+    )
+
+    assert data["litellm_session_id"] == "metadata-session-id"
+    assert data["litellm_trace_id"] == "metadata-trace-id"
+    assert data["metadata"]["session_id"] == "metadata-session-id"
+    assert data["metadata"]["trace_id"] == "metadata-trace-id"
+
+
 def test_add_litellm_metadata_from_request_headers_x_litellm_session_id_sets_chain_id():
     """x-litellm-session-id sets both metadata and top-level litellm_session_id/litellm_trace_id for call chaining."""
     headers = {"x-litellm-session-id": "bar"}


### PR DESCRIPTION
## Summary
- preserve explicit body trace and session IDs when a chain-ID header is present
- populate only missing IDs from the header chain ID
- add regression coverage for distinct body IDs

## Testing
- `uv run pytest tests/test_litellm/proxy/test_litellm_pre_call_utils.py -k 'chain_id or preserves_body_chain_ids'`