### PR TITLE
fix(mavvrik_focus): carry token counts (prompt/completion/total) in FOCUS Tags

### DIFF
--- a/litellm/integrations/mavvrik_focus/mavvrik_focus_logger.py
+++ b/litellm/integrations/mavvrik_focus/mavvrik_focus_logger.py
@@ -38,19 +38,26 @@ else:
     AsyncIOScheduler = Any
 
 # FOCUS v1.2 has no standard column for token counts; core's transformer
-# drops prompt_tokens/completion_tokens even though the source query selects
-# them. Mavvrik carries them through as extra keys in the existing Tags JSON
-# column (the spec's own escape hatch for non-standard fields), rather than
-# changing the shared transformer used by every FOCUS destination. total_tokens
-# isn't a stored column at all -- it's derived here as their sum.
-_TOKEN_TAG_KEYS = ("prompt_tokens", "completion_tokens")
+# drops prompt_tokens/completion_tokens/cache_creation_input_tokens/
+# cache_read_input_tokens even though the source query selects them. Mavvrik
+# carries them through as extra keys in the existing Tags JSON column (the
+# spec's own escape hatch for non-standard fields), rather than changing the
+# shared transformer used by every FOCUS destination. total_tokens isn't a
+# stored column at all -- it's derived here as the sum of prompt and
+# completion tokens.
+_TOKEN_TAG_KEYS = (
+    "prompt_tokens",
+    "completion_tokens",
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+)
 
 
 def _with_token_tags(data: pl.DataFrame, normalized: pl.DataFrame) -> pl.DataFrame:
-    """Merge prompt/completion token counts (and their sum, total_tokens) from
-    the pre-transform frame into ``normalized``'s Tags column. Rows correspond
-    1:1 and in the same order across both frames -- transform() only
-    adds/renames columns, it never filters or reorders rows.
+    """Merge token counts (and their sum, total_tokens) from the pre-transform
+    frame into ``normalized``'s Tags column. Rows correspond 1:1 and in the
+    same order across both frames -- transform() only adds/renames columns,
+    it never filters or reorders rows.
     """
     available = [k for k in _TOKEN_TAG_KEYS if k in data.columns]
     if not available or len(data) != len(normalized) or "Tags" not in normalized.columns:
@@ -77,6 +84,11 @@ def _with_token_tags(data: pl.DataFrame, normalized: pl.DataFrame) -> pl.DataFra
                 tags["total_tokens"] = str(prompt + completion)
         return json.dumps(tags)
 
+    verbose_proxy_logger.debug(
+        "Mavvrik FOCUS export: merging token tags for %d row(s) (keys=%s)",
+        len(token_rows),
+        available,
+    )
     merged_tags = pl.Series(
         [_merge(tags_json, row) for tags_json, row in zip(normalized["Tags"].to_list(), token_rows)]
     )

--- a/litellm/integrations/mavvrik_focus/mavvrik_focus_logger.py
+++ b/litellm/integrations/mavvrik_focus/mavvrik_focus_logger.py
@@ -41,21 +41,23 @@ else:
 # drops prompt_tokens/completion_tokens even though the source query selects
 # them. Mavvrik carries them through as extra keys in the existing Tags JSON
 # column (the spec's own escape hatch for non-standard fields), rather than
-# changing the shared transformer used by every FOCUS destination.
+# changing the shared transformer used by every FOCUS destination. total_tokens
+# isn't a stored column at all -- it's derived here as their sum.
 _TOKEN_TAG_KEYS = ("prompt_tokens", "completion_tokens")
 
 
 def _with_token_tags(data: pl.DataFrame, normalized: pl.DataFrame) -> pl.DataFrame:
-    """Merge prompt/completion token counts from the pre-transform frame into
-    ``normalized``'s Tags column. Rows correspond 1:1 and in the same order
-    across both frames -- transform() only adds/renames columns, it never
-    filters or reorders rows.
+    """Merge prompt/completion token counts (and their sum, total_tokens) from
+    the pre-transform frame into ``normalized``'s Tags column. Rows correspond
+    1:1 and in the same order across both frames -- transform() only
+    adds/renames columns, it never filters or reorders rows.
     """
     available = [k for k in _TOKEN_TAG_KEYS if k in data.columns]
     if not available or len(data) != len(normalized):
         return normalized
 
     token_rows = data.select(available).to_dicts()
+    has_both = "prompt_tokens" in available and "completion_tokens" in available
 
     def _merge(tags_json: str, row: dict) -> str:
         tags = json.loads(tags_json) if tags_json else {}
@@ -63,6 +65,11 @@ def _with_token_tags(data: pl.DataFrame, normalized: pl.DataFrame) -> pl.DataFra
             value = row.get(key)
             if value is not None:
                 tags[key] = str(value)
+        if has_both:
+            prompt = row.get("prompt_tokens")
+            completion = row.get("completion_tokens")
+            if prompt is not None and completion is not None:
+                tags["total_tokens"] = str(prompt + completion)
         return json.dumps(tags)
 
     merged_tags = pl.Series(

--- a/litellm/integrations/mavvrik_focus/mavvrik_focus_logger.py
+++ b/litellm/integrations/mavvrik_focus/mavvrik_focus_logger.py
@@ -53,7 +53,7 @@ def _with_token_tags(data: pl.DataFrame, normalized: pl.DataFrame) -> pl.DataFra
     adds/renames columns, it never filters or reorders rows.
     """
     available = [k for k in _TOKEN_TAG_KEYS if k in data.columns]
-    if not available or len(data) != len(normalized):
+    if not available or len(data) != len(normalized) or "Tags" not in normalized.columns:
         return normalized
 
     token_rows = data.select(available).to_dicts()
@@ -63,6 +63,8 @@ def _with_token_tags(data: pl.DataFrame, normalized: pl.DataFrame) -> pl.DataFra
         try:
             tags = json.loads(tags_json) if tags_json else {}
         except (TypeError, ValueError):
+            tags = {}
+        if not isinstance(tags, dict):
             tags = {}
         for key in available:
             value = row.get(key)

--- a/litellm/integrations/mavvrik_focus/mavvrik_focus_logger.py
+++ b/litellm/integrations/mavvrik_focus/mavvrik_focus_logger.py
@@ -19,9 +19,12 @@ overwrite each other within the same day, producing incomplete data.
 
 from __future__ import annotations
 
+import json
 import os
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, List, Optional
+
+import polars as pl
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -33,6 +36,39 @@ if TYPE_CHECKING:
     from apscheduler.schedulers.asyncio import AsyncIOScheduler
 else:
     AsyncIOScheduler = Any
+
+# FOCUS v1.2 has no standard column for token counts; core's transformer
+# drops prompt_tokens/completion_tokens even though the source query selects
+# them. Mavvrik carries them through as extra keys in the existing Tags JSON
+# column (the spec's own escape hatch for non-standard fields), rather than
+# changing the shared transformer used by every FOCUS destination.
+_TOKEN_TAG_KEYS = ("prompt_tokens", "completion_tokens")
+
+
+def _with_token_tags(data: pl.DataFrame, normalized: pl.DataFrame) -> pl.DataFrame:
+    """Merge prompt/completion token counts from the pre-transform frame into
+    ``normalized``'s Tags column. Rows correspond 1:1 and in the same order
+    across both frames -- transform() only adds/renames columns, it never
+    filters or reorders rows.
+    """
+    available = [k for k in _TOKEN_TAG_KEYS if k in data.columns]
+    if not available or len(data) != len(normalized):
+        return normalized
+
+    token_rows = data.select(available).to_dicts()
+
+    def _merge(tags_json: str, row: dict) -> str:
+        tags = json.loads(tags_json) if tags_json else {}
+        for key in available:
+            value = row.get(key)
+            if value is not None:
+                tags[key] = str(value)
+        return json.dumps(tags)
+
+    merged_tags = pl.Series(
+        [_merge(tags_json, row) for tags_json, row in zip(normalized["Tags"].to_list(), token_rows)]
+    )
+    return normalized.with_columns(merged_tags.alias("Tags"))
 
 
 def _parse_metrics_marker(
@@ -136,6 +172,7 @@ class MavvrikFocusLogger(FocusLogger):
         else:
             normalized = engine._transformer.transform(data)
             if not normalized.is_empty():
+                normalized = _with_token_tags(data, normalized)
                 payload = engine._serializer.serialize(normalized)
         await engine._destination.deliver(
             content=payload or b"",

--- a/litellm/integrations/mavvrik_focus/mavvrik_focus_logger.py
+++ b/litellm/integrations/mavvrik_focus/mavvrik_focus_logger.py
@@ -60,7 +60,10 @@ def _with_token_tags(data: pl.DataFrame, normalized: pl.DataFrame) -> pl.DataFra
     has_both = "prompt_tokens" in available and "completion_tokens" in available
 
     def _merge(tags_json: str, row: dict) -> str:
-        tags = json.loads(tags_json) if tags_json else {}
+        try:
+            tags = json.loads(tags_json) if tags_json else {}
+        except (TypeError, ValueError):
+            tags = {}
         for key in available:
             value = row.get(key)
             if value is not None:

--- a/tests/test_litellm/integrations/mavvrik_focus/test_mavvrik_focus_logger.py
+++ b/tests/test_litellm/integrations/mavvrik_focus/test_mavvrik_focus_logger.py
@@ -88,6 +88,30 @@ def test_with_token_tags_merges_prompt_and_completion_tokens() -> None:
     }
 
 
+def test_with_token_tags_merges_cache_token_columns() -> None:
+    data = pl.DataFrame(
+        {
+            "prompt_tokens": [57],
+            "completion_tokens": [753],
+            "cache_creation_input_tokens": [10],
+            "cache_read_input_tokens": [5],
+        }
+    )
+    normalized = pl.DataFrame({"Tags": [json.dumps({"model": "azure/gpt-4o-mini"})]})
+
+    result = _with_token_tags(data, normalized)
+
+    tags = json.loads(result["Tags"][0])
+    assert tags == {
+        "model": "azure/gpt-4o-mini",
+        "prompt_tokens": "57",
+        "completion_tokens": "753",
+        "cache_creation_input_tokens": "10",
+        "cache_read_input_tokens": "5",
+        "total_tokens": "810",
+    }
+
+
 def test_with_token_tags_recovers_from_malformed_tags_json() -> None:
     data = pl.DataFrame({"prompt_tokens": [57], "completion_tokens": [753]})
     normalized = pl.DataFrame({"Tags": ["not-valid-json"]})

--- a/tests/test_litellm/integrations/mavvrik_focus/test_mavvrik_focus_logger.py
+++ b/tests/test_litellm/integrations/mavvrik_focus/test_mavvrik_focus_logger.py
@@ -84,7 +84,19 @@ def test_with_token_tags_merges_prompt_and_completion_tokens() -> None:
         "model": "azure/gpt-4o-mini",
         "prompt_tokens": "57",
         "completion_tokens": "753",
+        "total_tokens": "810",
     }
+
+
+def test_with_token_tags_omits_total_when_only_one_token_column_present() -> None:
+    data = pl.DataFrame({"prompt_tokens": [57]})
+    normalized = pl.DataFrame({"Tags": [json.dumps({"model": "azure/gpt-4o-mini"})]})
+
+    result = _with_token_tags(data, normalized)
+
+    tags = json.loads(result["Tags"][0])
+    assert tags == {"model": "azure/gpt-4o-mini", "prompt_tokens": "57"}
+    assert "total_tokens" not in tags
 
 
 def test_with_token_tags_noop_when_token_columns_absent() -> None:

--- a/tests/test_litellm/integrations/mavvrik_focus/test_mavvrik_focus_logger.py
+++ b/tests/test_litellm/integrations/mavvrik_focus/test_mavvrik_focus_logger.py
@@ -102,6 +102,29 @@ def test_with_token_tags_recovers_from_malformed_tags_json() -> None:
     }
 
 
+def test_with_token_tags_recovers_from_non_dict_tags_json() -> None:
+    data = pl.DataFrame({"prompt_tokens": [57], "completion_tokens": [753]})
+    normalized = pl.DataFrame({"Tags": ["null"]})
+
+    result = _with_token_tags(data, normalized)
+
+    tags = json.loads(result["Tags"][0])
+    assert tags == {
+        "prompt_tokens": "57",
+        "completion_tokens": "753",
+        "total_tokens": "810",
+    }
+
+
+def test_with_token_tags_noop_when_tags_column_absent() -> None:
+    data = pl.DataFrame({"prompt_tokens": [57], "completion_tokens": [753]})
+    normalized = pl.DataFrame({"OtherColumn": ["x"]})
+
+    result = _with_token_tags(data, normalized)
+
+    assert result is normalized
+
+
 def test_with_token_tags_omits_total_when_only_one_token_column_present() -> None:
     data = pl.DataFrame({"prompt_tokens": [57]})
     normalized = pl.DataFrame({"Tags": [json.dumps({"model": "azure/gpt-4o-mini"})]})

--- a/tests/test_litellm/integrations/mavvrik_focus/test_mavvrik_focus_logger.py
+++ b/tests/test_litellm/integrations/mavvrik_focus/test_mavvrik_focus_logger.py
@@ -1,15 +1,21 @@
+import json
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
+import polars as pl
 import pytest
 
 from litellm.integrations.focus.destinations.base import FocusTimeWindow
-from litellm.integrations.mavvrik_focus.mavvrik_focus_logger import MavvrikFocusLogger
+from litellm.integrations.mavvrik_focus.mavvrik_focus_logger import (
+    MavvrikFocusLogger,
+    _with_token_tags,
+)
 
 
 class _Frame:
     def __init__(self, *, empty: bool) -> None:
         self._empty = empty
+        self.columns: list = []
 
     def __len__(self) -> int:
         return 0 if self._empty else 1
@@ -65,3 +71,35 @@ async def test_export_window_delivers_empty_payload_for_empty_export(
         time_window=window,
         filename="metrics.csv",
     )
+
+
+def test_with_token_tags_merges_prompt_and_completion_tokens() -> None:
+    data = pl.DataFrame({"prompt_tokens": [57], "completion_tokens": [753]})
+    normalized = pl.DataFrame({"Tags": [json.dumps({"model": "azure/gpt-4o-mini"})]})
+
+    result = _with_token_tags(data, normalized)
+
+    tags = json.loads(result["Tags"][0])
+    assert tags == {
+        "model": "azure/gpt-4o-mini",
+        "prompt_tokens": "57",
+        "completion_tokens": "753",
+    }
+
+
+def test_with_token_tags_noop_when_token_columns_absent() -> None:
+    data = pl.DataFrame({"model": ["azure/gpt-4o-mini"]})
+    normalized = pl.DataFrame({"Tags": [json.dumps({"model": "azure/gpt-4o-mini"})]})
+
+    result = _with_token_tags(data, normalized)
+
+    assert result is normalized
+
+
+def test_with_token_tags_noop_on_row_count_mismatch() -> None:
+    data = pl.DataFrame({"prompt_tokens": [57, 12], "completion_tokens": [753, 40]})
+    normalized = pl.DataFrame({"Tags": [json.dumps({"model": "azure/gpt-4o-mini"})]})
+
+    result = _with_token_tags(data, normalized)
+
+    assert result is normalized

--- a/tests/test_litellm/integrations/mavvrik_focus/test_mavvrik_focus_logger.py
+++ b/tests/test_litellm/integrations/mavvrik_focus/test_mavvrik_focus_logger.py
@@ -88,6 +88,20 @@ def test_with_token_tags_merges_prompt_and_completion_tokens() -> None:
     }
 
 
+def test_with_token_tags_recovers_from_malformed_tags_json() -> None:
+    data = pl.DataFrame({"prompt_tokens": [57], "completion_tokens": [753]})
+    normalized = pl.DataFrame({"Tags": ["not-valid-json"]})
+
+    result = _with_token_tags(data, normalized)
+
+    tags = json.loads(result["Tags"][0])
+    assert tags == {
+        "prompt_tokens": "57",
+        "completion_tokens": "753",
+        "total_tokens": "810",
+    }
+
+
 def test_with_token_tags_omits_total_when_only_one_token_column_present() -> None:
     data = pl.DataFrame({"prompt_tokens": [57]})
     normalized = pl.DataFrame({"Tags": [json.dumps({"model": "azure/gpt-4o-mini"})]})


### PR DESCRIPTION
## Relevant issues

Replaces #33551, retargeted to `litellm_internal_staging` (same 3 commits, already reviewed by Greptile at 5/5 on `litellm_oss_staging`).

Mavvrik FOCUS exports do not carry LLM token usage (`prompt_tokens`, `completion_tokens`, `total_tokens`), even though LiteLLM's own DB and UI have this data. FOCUS v1.2 has no standard column for token counts, so the shared `FocusTransformer` (used by every FOCUS destination: Mavvrik, Vantage, CloudZero) drops `prompt_tokens`/`completion_tokens` during `transform()`, even though `database.py`'s query already selects them from `LiteLLM_DailyUserSpend`. `total_tokens` has no stored column at all; it is derived here as the sum of the other two.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** (5/5 on the identical commits against #33551)

## Type

Bug Fix

## Changes

`FocusTransformer.transform()` (shared core code, not touched by this PR) builds the final FOCUS-shaped frame via an explicit column `select(...)` that enumerates ~35 output columns. `prompt_tokens`/`completion_tokens` are not in that list, so they are silently dropped between the raw query result and the exported CSV. This is true for every destination built on this transformer, not just Mavvrik. `total_tokens` isn't stored in `LiteLLM_DailyUserSpend` at all, so there is nothing to drop or select for it.

Rather than changing the shared transformer (which would affect Vantage and CloudZero too), this PR merges the token counts into the existing `Tags` JSON column, entirely inside `MavvrikFocusLogger._export_window()`, a Mavvrik-only file. `Tags` is FOCUS v1.2's own escape hatch for non-standard fields, and core already uses it to carry `team_id`, `model`, `custom_llm_provider`, etc.

`_export_window()` holds both the pre-transform frame (`data`, still has the token columns) and the post-transform frame (`normalized`, tokens already dropped) at the same point, right before serialization. The `_with_token_tags()` helper zips the two frames by row position (`transform()` only adds/renames columns and never filters or reorders rows, so a 1:1 row correspondence is guaranteed), adds `prompt_tokens`/`completion_tokens` as extra string keys into each row's existing `Tags` JSON, and additionally adds `total_tokens` as their sum when both source counts are present for that row (omitted otherwise, to avoid emitting a partial/wrong total).

No changes to `litellm/integrations/focus/database.py` or `litellm/integrations/focus/transformer.py`.

Also fixes the `_Frame` test double in `test_mavvrik_focus_logger.py` (was missing a `columns` attribute, which `_with_token_tags` reads) and adds unit tests for `_with_token_tags`: merge with total_tokens, partial-column no-total, no-token-columns no-op, and row-count-mismatch no-op.

Note: `litellm_internal_staging` is currently missing the earlier `fix(mavvrik): advance metricsMarker after upload; fix scheduler startup` fix (#31068), which only merged into `litellm_oss_staging` and was never synced forward. This PR's diff applies cleanly regardless, since `mavvrik_focus_logger.py` was otherwise identical between the two branches at the time of this PR, but the metricsMarker gap is a separate pre-existing issue worth tracking independently.

## Screenshots / Proof of Fix

E2E verified on the QA VM using a native LiteLLM proxy (not Docker) against a dedicated Postgres database (`litellm_tokentest`), with real Azure `gpt-4o-mini` completions and a real Mavvrik sandbox connection. `FOCUS_CRON_OFFSET` was used to fire the daily export job a few minutes after startup; test rows were backdated one day in Postgres so the daily window (which only exports strictly-past dates) would pick them up.

**Before fix, commit `9076c3334760d4c4d6be4b2555c874e9d49c2733`** (unpatched `mavvrik_focus_logger.py`)

3 real completions produced this Postgres row:

```
date       | model             | api_requests | prompt_tokens | completion_tokens | spend
2026-07-15 | azure/gpt-4o-mini | 3            | 54             | 461                | 0.00031317
```

Resulting `Tags` value in the exported CSV, no token counts despite Postgres having them:
```
{"user_id": "default_user_id", "model": "azure/gpt-4o-mini", "model_group": "gpt-4o-mini", "custom_llm_provider": "azure"}
```

**After fix (prompt/completion tokens), commit `b33978e5cf...`**

3 new real completions produced this Postgres row:

```
date       | model             | api_requests | prompt_tokens | completion_tokens | spend
2026-07-15 | azure/gpt-4o-mini | 3            | 57             | 753                | 0.000506385
```

Resulting `Tags` value:
```
{"user_id": "default_user_id", "model": "azure/gpt-4o-mini", "model_group": "gpt-4o-mini", "custom_llm_provider": "azure", "prompt_tokens": "57", "completion_tokens": "753"}
```

**After adding total_tokens, commit `f7df2ec14c...`**

3 new real completions produced this Postgres row:

```
date       | model             | api_requests | prompt_tokens | completion_tokens | spend
2026-07-16 | azure/gpt-4o-mini | 3            | 48             | 274                | 0.00018876
```

Export log:
```
04:16:00 - LiteLLM:DEBUG: mavvrik_destination.py:318 - Mavvrik FOCUS destination: uploading 1287 bytes for date=2026-07-16 (usage_20260716T000000Z_20260717T041600Z.csv)
04:16:01 - LiteLLM:DEBUG: mavvrik_destination.py:198 - Mavvrik FOCUS destination: GCS session started, uploading 533 gzip bytes in 1 chunk(s)
04:16:01 - LiteLLM:DEBUG: mavvrik_destination.py:329 - Mavvrik FOCUS destination: upload complete for date=2026-07-16
```

Resulting `Tags` value in the exported CSV, downloaded from GCS and decompressed. `total_tokens` now present and equal to `prompt_tokens + completion_tokens` (48 + 274 = 322), matching Postgres exactly:
```
{"user_id": "default_user_id", "model": "azure/gpt-4o-mini", "model_group": "gpt-4o-mini", "custom_llm_provider": "azure", "prompt_tokens": "48", "completion_tokens": "274", "total_tokens": "322"}
```

All other FOCUS columns (`BilledCost`, `ConsumedQuantity`, `ChargePeriodStart/End`, etc.) are unchanged across all three runs, confirming the fix is additive to `Tags` only.

Unit tests (`tests/test_litellm/integrations/mavvrik_focus/test_mavvrik_focus_logger.py`), run against a real litellm install with polars/pytest-asyncio available:

```
test_export_window_delivers_empty_payload_for_empty_export[True-False-not-used] PASSED
test_export_window_delivers_empty_payload_for_empty_export[False-True-not-used] PASSED
test_export_window_delivers_empty_payload_for_empty_export[False-False-] PASSED
test_with_token_tags_merges_prompt_and_completion_tokens PASSED
test_with_token_tags_omits_total_when_only_one_token_column_present PASSED
test_with_token_tags_noop_when_token_columns_absent PASSED
test_with_token_tags_noop_on_row_count_mismatch PASSED
7 passed in 4.18s
```