### PR TITLE
feat(sap):       
 multi-orchestration deployment URL resolution

### DIFF
--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -15,6 +15,7 @@ from typing import (
     FrozenSet,
 )
 from functools import cached_property
+import os
 import httpx
 import litellm
 
@@ -284,8 +285,15 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
         litellm_params: dict,
         stream: Optional[bool] = None,
     ):
-        api_base_ = f"{self.deployment_url}/v2/completion"
-        return api_base_
+        # Step 1: per-request override via optional_params
+        base = optional_params.get("deployment_url")
+        # Step 2: operator-level env var (no discovery needed)
+        if not base:
+            base = os.environ.get("AICORE_ORCHESTRATION_DEPLOYMENT_URL")
+        # Step 3: auto-discovery (cached; one network round-trip per instance)
+        if not base:
+            base = self.deployment_url
+        return f"{base}/v2/completion"
 
     def _build_prompt_module(
         self,

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -62,7 +62,7 @@ def validate_dict(data: dict, model) -> dict:
     return model(**data).model_dump(by_alias=True, exclude_unset=True)
 
 
-def _messages_to_sap_template(messages: list[dict[str, str]]) -> list:  # type: ignore[type-arg]
+def _messages_to_sap_template(messages: list[dict[str, str]]) -> list:  # pyright: ignore[reportMissingTypeArgument]  # SAP template items are heterogeneous dicts; full typing deferred
     template = []
     for message in messages:
         if message["role"] == "user":
@@ -177,7 +177,7 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
     def deployment_url(self) -> str:
         if self._cached_deployment_url is _UNSET:
             self._cached_deployment_url = self._resolve_deployment_url()
-        return self._cached_deployment_url  # type: ignore[return-value]
+        return self._cached_deployment_url  # pyright: ignore[reportReturnType]  # _UNSET is excluded by the guard above
 
     def _resolve_deployment_url(self) -> str:
         """Discover the orchestration deployment URL from SAP AI Core.
@@ -354,7 +354,7 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
     def transform_request(
         self,
         model: str,
-        messages: list[dict[str, str]],  # type: ignore
+        messages: list[dict[str, str]],
         optional_params: dict,
         litellm_params: dict,
         headers: dict,

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -3,16 +3,11 @@ Translate from OpenAI's `/v1/chat/completions` to SAP Generative AI Hub's Orches
 """
 
 from typing import (
-    List,
-    Optional,
     Union,
-    Dict,
-    Tuple,
     Any,
     TYPE_CHECKING,
     Iterator,
     AsyncIterator,
-    FrozenSet,
 )
 import os
 
@@ -52,7 +47,7 @@ from .handler import (
 )
 
 # Keys routed outside SAP orchestration `model.params` (prompt, stream, fallbacks, etc.)
-_SAP_MODEL_PARAMS_EXCLUDED_KEYS: FrozenSet[str] = frozenset(
+_SAP_MODEL_PARAMS_EXCLUDED_KEYS: frozenset[str] = frozenset(
     {
         "tools",
         "tool_choice",
@@ -68,7 +63,7 @@ def validate_dict(data: dict, model) -> dict:
     return model(**data).model_dump(by_alias=True, exclude_unset=True)
 
 
-def _messages_to_sap_template(messages: List[Dict[str, str]]) -> list:  # type: ignore[type-arg]
+def _messages_to_sap_template(messages: list[dict[str, str]]) -> list:  # type: ignore[type-arg]
     template = []
     for message in messages:
         if message["role"] == "user":
@@ -82,7 +77,7 @@ def _messages_to_sap_template(messages: List[Dict[str, str]]) -> list:  # type: 
     return template
 
 
-def _tools_response_format_and_stream(optional_params: dict, model_params: dict) -> Tuple[dict, dict, dict]:
+def _tools_response_format_and_stream(optional_params: dict, model_params: dict) -> tuple[dict, dict, dict]:
     tools_ = optional_params.pop("tools", [])
     tools_ = [validate_dict(tool, ChatCompletionTool) for tool in tools_]
     tools: dict = {"tools": tools_} if tools_ else {}
@@ -109,36 +104,36 @@ def _tools_response_format_and_stream(optional_params: dict, model_params: dict)
 
 
 class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
-    frequency_penalty: Optional[int] = None
-    function_call: Optional[Union[str, dict]] = None
-    functions: Optional[list] = None
-    logit_bias: Optional[dict] = None
-    max_tokens: Optional[int] = None
-    n: Optional[int] = None
-    presence_penalty: Optional[int] = None
-    stop: Optional[Union[str, list]] = None
-    temperature: Optional[int] = None
-    top_p: Optional[int] = None
-    response_format: Optional[dict] = None
-    tools: Optional[list] = None
-    tool_choice: Optional[Union[str, dict]] = None  #
+    frequency_penalty: int | None = None
+    function_call: Union[str, dict] | None = None
+    functions: list | None = None
+    logit_bias: dict | None = None
+    max_tokens: int | None = None
+    n: int | None = None
+    presence_penalty: int | None = None
+    stop: Union[str, list] | None = None
+    temperature: int | None = None
+    top_p: int | None = None
+    response_format: dict | None = None
+    tools: list | None = None
+    tool_choice: Union[str, dict] | None = None  #
     model_version: str = "latest"
 
     def __init__(
         self,
-        frequency_penalty: Optional[int] = None,
-        function_call: Optional[Union[str, dict]] = None,
-        functions: Optional[list] = None,
-        logit_bias: Optional[dict] = None,
-        max_tokens: Optional[int] = None,
-        n: Optional[int] = None,
-        presence_penalty: Optional[int] = None,
-        stop: Optional[Union[str, list]] = None,
-        temperature: Optional[int] = None,
-        top_p: Optional[int] = None,
-        response_format: Optional[dict] = None,
-        tools: Optional[list] = None,
-        tool_choice: Optional[Union[str, dict]] = None,
+        frequency_penalty: int | None = None,
+        function_call: Union[str, dict] | None = None,
+        functions: list | None = None,
+        logit_bias: dict | None = None,
+        max_tokens: int | None = None,
+        n: int | None = None,
+        presence_penalty: int | None = None,
+        stop: Union[str, list] | None = None,
+        temperature: int | None = None,
+        top_p: int | None = None,
+        response_format: dict | None = None,
+        tools: list | None = None,
+        tool_choice: Union[str, dict] | None = None,
     ) -> None:
         locals_ = locals().copy()
         for key, value in locals_.items():
@@ -149,14 +144,14 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
         self._resource_group = None
         self._cached_deployment_url: object = _UNSET  # manual cache; avoids get_config() picking up @cached_property
 
-    def run_env_setup(self, service_key: Optional[str] = None) -> None:
+    def run_env_setup(self, service_key: str | None = None) -> None:
         try:
             self.token_creator, self._base_url, self._resource_group = get_token_creator(service_key)  # type: ignore
         except ValueError as err:
             raise GenAIHubOrchestrationError(status_code=400, message=err.args[0])
 
     @property
-    def headers(self) -> Dict[str, str]:
+    def headers(self) -> dict[str, str]:
         if self.token_creator is None:
             self.run_env_setup()
         access_token = self.token_creator()  # pyright: ignore[reportOptionalCall]  # run_env_setup set it or raised
@@ -195,7 +190,7 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
         """
         client = litellm.module_level_client
         deployments = client.get(f"{self.base_url}/lm/deployments", headers=self.headers).json()
-        valid: List[Tuple[str, str, str]] = []  # (url, createdAt, name)
+        valid: list[tuple[str, str, str]] = []  # (url, createdAt, name)
         for dep in deployments.get("resources", []):
             if dep.get("scenarioId") != "orchestration":
                 continue
@@ -271,11 +266,11 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
         self,
         headers: dict,
         model: str,
-        messages: List[AllMessageValues],
+        messages: list[AllMessageValues],
         optional_params: dict,
         litellm_params: dict,
-        api_key: Optional[str] = None,
-        api_base: Optional[str] = None,
+        api_key: str | None = None,
+        api_base: str | None = None,
     ) -> dict:
         if api_key:
             self.run_env_setup(api_key)
@@ -283,12 +278,12 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
 
     def get_complete_url(
         self,
-        api_base: Optional[str],
-        api_key: Optional[str],
+        api_base: str | None,
+        api_key: str | None,
         model: str,
         optional_params: dict,
         litellm_params: dict,
-        stream: Optional[bool] = None,
+        stream: bool | None = None,
     ):
         # Step 1: per-request override via optional_params
         base = optional_params.get("deployment_url")
@@ -305,7 +300,7 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
     def _build_prompt_module(
         self,
         model_name: str,
-        template_messages: List[Dict[str, str]],
+        template_messages: list[dict[str, str]],
         params: dict,
     ) -> dict:
         # Filter strict for GPT models only - SAP AI Core doesn't accept it as a model param
@@ -360,7 +355,7 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
     def transform_request(
         self,
         model: str,
-        messages: List[Dict[str, str]],  # type: ignore
+        messages: list[dict[str, str]],  # type: ignore
         optional_params: dict,
         litellm_params: dict,
         headers: dict,
@@ -409,13 +404,13 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
                 )
             )
 
-        config_payload: Dict[str, Any] = {
+        config_payload: dict[str, Any] = {
             "modules": modules if len(modules) > 1 else modules[0],
         }
         if stream_config:
             config_payload["stream"] = stream_config
 
-        request_body: Dict[str, Any] = {"config": config_payload}
+        request_body: dict[str, Any] = {"config": config_payload}
         if placeholder_values is not None:
             request_body["placeholder_values"] = placeholder_values
 
@@ -430,12 +425,12 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
         model_response: ModelResponse,
         logging_obj: LiteLLMLoggingObj,
         request_data: dict,
-        messages: List[AllMessageValues],
+        messages: list[AllMessageValues],
         optional_params: dict,
         litellm_params: dict,
         encoding: Any,
-        api_key: Optional[str] = None,
-        json_mode: Optional[bool] = None,
+        api_key: str | None = None,
+        json_mode: bool | None = None,
     ) -> ModelResponse:
         logging_obj.post_call(
             input=messages,
@@ -479,7 +474,7 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
         self,
         streaming_response: Union[Iterator[str], AsyncIterator[str], "ModelResponse"],
         sync_stream: bool,
-        json_mode: Optional[bool] = False,
+        json_mode: bool | None = False,
     ):
         if sync_stream:
             return SAPStreamIterator(response=streaming_response)  # type: ignore

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -15,10 +15,10 @@ from typing import (
     FrozenSet,
 )
 from functools import cached_property
-import litellm
 import httpx
+import litellm
 
-
+from litellm._logging import verbose_logger
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.utils import ModelResponse
 
@@ -177,21 +177,47 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
 
     @cached_property
     def deployment_url(self) -> str:
-        # Keep a short, tight client lifecycle here to avoid fd leaks
+        return self._resolve_deployment_url()
+
+    def _resolve_deployment_url(self) -> str:
+        """Discover the orchestration deployment URL from SAP AI Core.
+
+        Lists all deployments, filters to those with scenarioId and
+        executableId both equal to "orchestration", picks the one with
+        the most recent createdAt timestamp.  Warns when more than one
+        candidate is found.  Raises if none found.
+        """
         client = litellm.module_level_client
-        # with httpx.Client(timeout=30) as client:
         deployments = client.get(f"{self.base_url}/lm/deployments", headers=self.headers).json()
-        valid: List[Tuple[str, str]] = []
+        valid: List[Tuple[str, str, str]] = []  # (url, createdAt, name)
         for dep in deployments.get("resources", []):
-            if dep.get("scenarioId") == "orchestration":
-                cfg = client.get(
-                    f"{self.base_url}/lm/configurations/{dep['configurationId']}",
-                    headers=self.headers,
-                ).json()
-                if cfg.get("executableId") == "orchestration":
-                    valid.append((dep["deploymentUrl"], dep["createdAt"]))
-            # newest first
-        return sorted(valid, key=lambda x: x[1], reverse=True)[0][0]
+            if dep.get("scenarioId") != "orchestration":
+                continue
+            cfg = client.get(
+                f"{self.base_url}/lm/configurations/{dep['configurationId']}",
+                headers=self.headers,
+            ).json()
+            if cfg.get("executableId") == "orchestration":
+                valid.append((dep["deploymentUrl"], dep["createdAt"], cfg.get("name", "")))
+
+        if not valid:
+            raise GenAIHubOrchestrationError(
+                status_code=404,
+                message="No orchestration deployment found in SAP AI Core.",
+            )
+
+        sorted_valid = sorted(valid, key=lambda x: x[1], reverse=True)
+
+        if len(sorted_valid) > 1:
+            chosen = sorted_valid[0]
+            others = [v[2] or v[0] for v in sorted_valid[1:]]
+            verbose_logger.warning(
+                f"SAP: {len(sorted_valid)} orchestration deployments found; "
+                f"using newest (name={chosen[2]!r}, url={chosen[0]!r}). "
+                f"Others ignored: {others}."
+            )
+
+        return sorted_valid[0][0]
 
     @classmethod
     def get_config(cls):

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -2,20 +2,19 @@
 Translate from OpenAI's `/v1/chat/completions` to SAP Generative AI Hub's Orchestration Service`v2/completion`
 """
 
-from typing import (
-    Union,
-    Any,
-    TYPE_CHECKING,
-    Iterator,
-    AsyncIterator,
-)
 import os
-
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncIterator,
+    Iterator,
+    Union,
+)
 
 _UNSET = object()  # sentinel for _cached_deployment_url initialisation
 import httpx
-import litellm
 
+import litellm
 from litellm._logging import verbose_logger
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.utils import ModelResponse
@@ -30,6 +29,11 @@ else:
     LiteLLMLoggingObj = Any
 
 from ..credentials import get_token_creator
+from .handler import (
+    AsyncSAPStreamIterator,
+    GenAIHubOrchestrationError,
+    SAPStreamIterator,
+)
 from .models import (
     ChatCompletionTool,
     OrchestrationRequest,
@@ -39,11 +43,6 @@ from .models import (
     SAPMessage,
     SAPToolChatMessage,
     SAPUserMessage,
-)
-from .handler import (
-    GenAIHubOrchestrationError,
-    AsyncSAPStreamIterator,
-    SAPStreamIterator,
 )
 
 # Keys routed outside SAP orchestration `model.params` (prompt, stream, fallbacks, etc.)

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -14,8 +14,10 @@ from typing import (
     AsyncIterator,
     FrozenSet,
 )
-from functools import cached_property
 import os
+
+
+_UNSET = object()  # sentinel for _cached_deployment_url initialisation
 import httpx
 import litellm
 
@@ -145,6 +147,7 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
         self.token_creator = None
         self._base_url = None
         self._resource_group = None
+        self._cached_deployment_url: object = _UNSET  # manual cache; avoids get_config() picking up @cached_property
 
     def run_env_setup(self, service_key: Optional[str] = None) -> None:
         try:
@@ -176,9 +179,11 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
             self.run_env_setup()
         return self._resource_group  # type: ignore
 
-    @cached_property
+    @property
     def deployment_url(self) -> str:
-        return self._resolve_deployment_url()
+        if self._cached_deployment_url is _UNSET:
+            self._cached_deployment_url = self._resolve_deployment_url()
+        return self._cached_deployment_url  # type: ignore[return-value]
 
     def _resolve_deployment_url(self) -> str:
         """Discover the orchestration deployment URL from SAP AI Core.

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -287,7 +287,9 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
     ):
         # Step 1: per-request override via optional_params
         base = optional_params.get("deployment_url")
-        # Step 2: operator-level env var (no discovery needed)
+        # Step 2: operator-level env var (no discovery needed).
+        # An empty string is treated as unset and falls through to discovery;
+        # export AICORE_ORCHESTRATION_DEPLOYMENT_URL= has no effect.
         if not base:
             base = os.environ.get("AICORE_ORCHESTRATION_DEPLOYMENT_URL")
         # Step 3: auto-discovery (cached; one network round-trip per instance)

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -8,10 +8,13 @@ from typing import (
     Any,
     AsyncIterator,
     Iterator,
-    Union,
 )
 
 _UNSET = object()  # sentinel for _cached_deployment_url initialisation
+
+# Env var an operator can set to pin a specific orchestration deployment URL.
+# An empty string is treated as unset and falls through to auto-discovery.
+_AICORE_ORCHESTRATION_DEPLOYMENT_URL_ENV_VAR = "AICORE_ORCHESTRATION_DEPLOYMENT_URL"
 import httpx
 
 import litellm
@@ -104,35 +107,35 @@ def _tools_response_format_and_stream(optional_params: dict, model_params: dict)
 
 class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
     frequency_penalty: int | None = None
-    function_call: Union[str, dict] | None = None
+    function_call: str | dict | None = None
     functions: list | None = None
     logit_bias: dict | None = None
     max_tokens: int | None = None
     n: int | None = None
     presence_penalty: int | None = None
-    stop: Union[str, list] | None = None
+    stop: str | list | None = None
     temperature: int | None = None
     top_p: int | None = None
     response_format: dict | None = None
     tools: list | None = None
-    tool_choice: Union[str, dict] | None = None  #
+    tool_choice: str | dict | None = None
     model_version: str = "latest"
 
     def __init__(
         self,
         frequency_penalty: int | None = None,
-        function_call: Union[str, dict] | None = None,
+        function_call: str | dict | None = None,
         functions: list | None = None,
         logit_bias: dict | None = None,
         max_tokens: int | None = None,
         n: int | None = None,
         presence_penalty: int | None = None,
-        stop: Union[str, list] | None = None,
+        stop: str | list | None = None,
         temperature: int | None = None,
         top_p: int | None = None,
         response_format: dict | None = None,
         tools: list | None = None,
-        tool_choice: Union[str, dict] | None = None,
+        tool_choice: str | dict | None = None,
     ) -> None:
         locals_ = locals().copy()
         for key, value in locals_.items():
@@ -175,8 +178,20 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
 
     @property
     def deployment_url(self) -> str:
+        """Resolve the orchestration deployment URL, with caching.
+
+        Resolution order:
+        1. ``_AICORE_ORCHESTRATION_URL_ENV_KEY`` env var (operator-level pin).
+           An empty string is treated as unset and falls through to discovery.
+        2. Auto-discovery via ``/lm/deployments`` (one network call, cached).
+
+        A per-request override via ``optional_params["deployment_url"]`` is
+        handled one level up in ``get_complete_url`` before this property
+        is ever called.
+        """
         if self._cached_deployment_url is _UNSET:
-            self._cached_deployment_url = self._resolve_deployment_url()
+            env = os.environ.get(_AICORE_ORCHESTRATION_DEPLOYMENT_URL_ENV_VAR)
+            self._cached_deployment_url = env or self._resolve_deployment_url()
         return self._cached_deployment_url  # pyright: ignore[reportReturnType]  # _UNSET is excluded by the guard above
 
     def _resolve_deployment_url(self) -> str:
@@ -284,16 +299,8 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
         litellm_params: dict,
         stream: bool | None = None,
     ):
-        # Step 1: per-request override via optional_params
-        base = optional_params.get("deployment_url")
-        # Step 2: operator-level env var (no discovery needed).
-        # An empty string is treated as unset and falls through to discovery;
-        # export AICORE_ORCHESTRATION_DEPLOYMENT_URL= has no effect.
-        if not base:
-            base = os.environ.get("AICORE_ORCHESTRATION_DEPLOYMENT_URL")
-        # Step 3: auto-discovery (cached; one network round-trip per instance)
-        if not base:
-            base = self.deployment_url
+        # Per-request override wins; deployment_url handles env var + discovery.
+        base = optional_params.get("deployment_url") or self.deployment_url
         return f"{base}/v2/completion"
 
     def _build_prompt_module(
@@ -471,7 +478,7 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
 
     def get_model_response_iterator(
         self,
-        streaming_response: Union[Iterator[str], AsyncIterator[str], "ModelResponse"],
+        streaming_response: Iterator[str] | AsyncIterator[str] | "ModelResponse",
         sync_stream: bool,
         json_mode: bool | None = False,
     ):

--- a/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
+++ b/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
@@ -650,3 +650,47 @@ class TestDeploymentResolution:
             with pytest.raises(GenAIHubOrchestrationError) as exc:
                 cfg._resolve_deployment_url()
         assert "No orchestration deployment found" in str(exc.value)
+
+
+class TestGetCompleteUrl:
+    def test_optional_params_used_first(self):
+        """Step 1: deployment_url in optional_params skips discovery entirely."""
+        cfg = _make_config()
+        explicit = "https://custom.sap.com/deployments/abc"
+        mock = MagicMock()
+        with patch("litellm.module_level_client", mock):
+            url = cfg.get_complete_url(None, None, "gpt-4o", {"deployment_url": explicit}, {})
+        assert url == f"{explicit}/v2/completion"
+        mock.get.assert_not_called()
+
+    def test_env_var_used_when_no_optional_param(self):
+        """Step 2: AICORE_ORCHESTRATION_DEPLOYMENT_URL skips discovery."""
+        cfg = _make_config()
+        env_url = "https://env.sap.com/deployments/env"
+        mock = MagicMock()
+        with patch("litellm.module_level_client", mock):
+            with patch.dict("os.environ", {"AICORE_ORCHESTRATION_DEPLOYMENT_URL": env_url}):
+                url = cfg.get_complete_url(None, None, "gpt-4o", {}, {})
+        assert url == f"{env_url}/v2/completion"
+        mock.get.assert_not_called()
+
+    def test_optional_params_beats_env_var(self):
+        """Step 1 takes precedence over step 2."""
+        cfg = _make_config()
+        opt_url = "https://opt.sap.com/deployments/opt"
+        env_url = "https://env.sap.com/deployments/env"
+        mock = MagicMock()
+        with patch("litellm.module_level_client", mock):
+            with patch.dict("os.environ", {"AICORE_ORCHESTRATION_DEPLOYMENT_URL": env_url}):
+                url = cfg.get_complete_url(None, None, "gpt-4o", {"deployment_url": opt_url}, {})
+        assert url == f"{opt_url}/v2/completion"
+        mock.get.assert_not_called()
+
+    def test_discovery_used_when_no_override(self):
+        """Step 3: no optional_param, no env var — discovery runs."""
+        cfg = _make_config()
+        env = {"AICORE_ORCHESTRATION_DEPLOYMENT_URL": ""}  # empty = falsy
+        with patch("litellm.module_level_client", _mock_client("orch-a")):
+            with patch.dict("os.environ", env):
+                url = cfg.get_complete_url(None, None, "gpt-4o", {}, {})
+        assert url == "https://deploy-orch-a.sap.com/v2/completion"

--- a/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
+++ b/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
@@ -1,5 +1,6 @@
 import warnings
 import pytest
+from unittest.mock import MagicMock, patch
 from pydantic import ValidationError
 
 
@@ -34,9 +35,7 @@ class TestSAPTransformationIntegration:
 
         result = mock_config.transform_request(model, messages, optional_params, {}, {})
 
-        model_params = result["config"]["modules"]["prompt_templating"]["model"][
-            "params"
-        ]
+        model_params = result["config"]["modules"]["prompt_templating"]["model"]["params"]
 
         assert "temperature" in model_params
         assert "frequency_penalty" in model_params
@@ -44,18 +43,16 @@ class TestSAPTransformationIntegration:
         assert "model_version" not in model_params
         assert "tools" not in model_params
 
-        model_version = result["config"]["modules"]["prompt_templating"]["model"][
-            "version"
-        ]
+        model_version = result["config"]["modules"]["prompt_templating"]["model"]["version"]
         assert model_version == "v1.5"
 
         prompt = result["config"]["modules"]["prompt_templating"]["prompt"]
         if "tools" in prompt:
             assert isinstance(prompt["tools"], list)
             for tool in prompt["tools"]:
-                assert (
-                    tool["function"]["parameters"]["type"] == "object"
-                ), "SAP API requires parameters.type == 'object'"
+                assert tool["function"]["parameters"]["type"] == "object", (
+                    "SAP API requires parameters.type == 'object'"
+                )
                 assert "properties" in tool["function"]["parameters"]
 
     def test_transform_request_parameter_handling_robustness(self, mock_config):
@@ -96,33 +93,25 @@ class TestSAPTransformationIntegration:
 
         for i, test_case in enumerate(test_cases):
             filtered_params = {
-                k: v
-                for k, v in test_case["params"].items()
-                if k not in {"tools", "model_version", "deployment_url"}
+                k: v for k, v in test_case["params"].items() if k not in {"tools", "model_version", "deployment_url"}
             }
 
             for expected_param in test_case["expected_in_model"]:
-                assert (
-                    expected_param in filtered_params
-                ), f"Case {i + 1}: {expected_param} should be in model params"
+                assert expected_param in filtered_params, f"Case {i + 1}: {expected_param} should be in model params"
 
             for excluded_param in test_case["expected_excluded"]:
-                assert (
-                    excluded_param not in filtered_params
-                ), f"Case {i + 1}: {excluded_param} should be excluded from model params"
+                assert excluded_param not in filtered_params, (
+                    f"Case {i + 1}: {excluded_param} should be excluded from model params"
+                )
 
-            result = mock_config.transform_request(
-                model, messages, test_case["params"], {}, {}
-            )
+            result = mock_config.transform_request(model, messages, test_case["params"], {}, {})
             if result and "config" in result:
-                model_params = result["config"]["modules"]["prompt_templating"][
-                    "model"
-                ]["params"]
+                model_params = result["config"]["modules"]["prompt_templating"]["model"]["params"]
 
                 for excluded_param in test_case["expected_excluded"]:
-                    assert (
-                        excluded_param not in model_params
-                    ), f"Case {i + 1}: {excluded_param} should not be in actual model params"
+                    assert excluded_param not in model_params, (
+                        f"Case {i + 1}: {excluded_param} should not be in actual model params"
+                    )
 
     def test_config_transform_with_response_format_json_object(self, mock_config):
         expected_dict = {
@@ -145,9 +134,7 @@ class TestSAPTransformationIntegration:
         }
         config = mock_config.transform_request(
             model="gpt-4o",
-            messages=[
-                {"role": "user", "content": "First man on the moon, answer in json"}
-            ],
+            messages=[{"role": "user", "content": "First man on the moon, answer in json"}],
             optional_params={
                 "response_format": {"type": "json_object"},
                 "deployment_url": "shouldn't be in results",
@@ -189,9 +176,7 @@ class TestSAPTransformationIntegration:
 
         config = mock_config.transform_request(
             model="gpt-4o",
-            messages=[
-                {"role": "user", "content": "First man on the moon, answer in json"}
-            ],
+            messages=[{"role": "user", "content": "First man on the moon, answer in json"}],
             optional_params={
                 "response_format": expected_response_format,
                 "deployment_url": "shouldn't be in results",
@@ -199,27 +184,15 @@ class TestSAPTransformationIntegration:
             litellm_params={},
             headers={},
         )
-        assert (
-            config["config"]["modules"]["prompt_templating"]["prompt"][
-                "response_format"
-            ]
-            == expected_response_format
-        )
-        assert (
-            len(config["config"]["modules"]["prompt_templating"]["model"]["params"])
-            == 0
-        )
+        assert config["config"]["modules"]["prompt_templating"]["prompt"]["response_format"] == expected_response_format
+        assert len(config["config"]["modules"]["prompt_templating"]["model"]["params"]) == 0
 
     def test_config_transform_with_stream(self, mock_config):
         expected_dict = {
             "config": {
                 "modules": {
                     "prompt_templating": {
-                        "prompt": {
-                            "template": [
-                                {"role": "user", "content": "Hello, how are you?"}
-                            ]
-                        },
+                        "prompt": {"template": [{"role": "user", "content": "Hello, how are you?"}]},
                         "model": {
                             "name": "anthropic--claude-4-sonnet",
                             "params": {},
@@ -257,9 +230,7 @@ class TestSAPTransformationIntegration:
             headers={},
         )
 
-        assert config["config"]["modules"]["prompt_templating"]["prompt"][
-            "defaults"
-        ] == {"user_query": "default value"}
+        assert config["config"]["modules"]["prompt_templating"]["prompt"]["defaults"] == {"user_query": "default value"}
         assert config["config"]["modules"]["prompt_templating"]["model"]["params"] == {}
 
     def test_sap_placeholder_values(self, mock_config):
@@ -323,14 +294,8 @@ class TestSAPTransformationIntegration:
         assert config["placeholder_values"] == placeholder_values
         modules = config["config"]["modules"]
         assert modules["grounding"]["type"] == "document_grounding_service"
-        assert (
-            modules["grounding"]["config"]["placeholders"]["output"]
-            == "grounding_response"
-        )
-        assert (
-            modules["grounding"]["config"]["filters"][0]["data_repository_type"]
-            == "vector"
-        )
+        assert modules["grounding"]["config"]["placeholders"]["output"] == "grounding_response"
+        assert modules["grounding"]["config"]["filters"][0]["data_repository_type"] == "vector"
         assert modules["prompt_templating"]["model"]["params"] == {}
 
     def test_grounding_search_config_rejects_both_count_fields(self, mock_config):
@@ -442,10 +407,7 @@ class TestSAPTransformationIntegration:
                 headers={},
             )
 
-        assert (
-            "For using SAP Filtering Module you must provide at least one property"
-            in str(exc_info.value)
-        )
+        assert "For using SAP Filtering Module you must provide at least one property" in str(exc_info.value)
 
     def test_sap_masking(self, mock_config):
         masking_config = {
@@ -509,9 +471,7 @@ class TestSAPTransformationIntegration:
                 headers={},
             )
 
-        assert "must set exactly one of: 'providers' or 'masking_providers'" in str(
-            exc_info.value
-        )
+        assert "must set exactly one of: 'providers' or 'masking_providers'" in str(exc_info.value)
 
     def test_masking_providers_deprecated_emits_warning(self, mock_config):
         masking_config = {
@@ -533,8 +493,7 @@ class TestSAPTransformationIntegration:
                 headers={},
             )
         assert any(
-            issubclass(warning.category, DeprecationWarning)
-            and "masking_providers" in str(warning.message)
+            issubclass(warning.category, DeprecationWarning) and "masking_providers" in str(warning.message)
             for warning in w
         ), "Expected DeprecationWarning for 'masking_providers'"
 
@@ -573,10 +532,7 @@ class TestSAPTransformationIntegration:
                 headers={},
             )
 
-        assert (
-            "TranslationModuleConfig requires at least one of 'input' or 'output'"
-            in str(exc_info.value)
-        )
+        assert "TranslationModuleConfig requires at least one of 'input' or 'output'" in str(exc_info.value)
 
     def test_sap_multiple_modules(self, mock_config):
         translation_config = {
@@ -611,31 +567,86 @@ class TestSAPTransformationIntegration:
             assert translation["input"]["config"]["source_language"] == "en-US"
             assert translation["input"]["config"]["target_language"] == "de-DE"
             assert translation["output"]["config"]["target_language"] == "fr-FR"
+            assert config["config"]["modules"][1]["prompt_templating"]["model"]["name"] == "gpt-5"
+            assert config["config"]["modules"][0]["prompt_templating"]["model"]["name"] == "gpt-4o"
+            assert config["config"]["modules"][0]["prompt_templating"]["model"]["params"] == {}
             assert (
-                config["config"]["modules"][1]["prompt_templating"]["model"]["name"]
-                == "gpt-5"
-            )
-            assert (
-                config["config"]["modules"][0]["prompt_templating"]["model"]["name"]
-                == "gpt-4o"
-            )
-            assert (
-                config["config"]["modules"][0]["prompt_templating"]["model"]["params"]
-                == {}
-            )
-            assert (
-                config["config"]["modules"][1]["prompt_templating"]["prompt"][
-                    "template"
-                ][0]["content"]
+                config["config"]["modules"][1]["prompt_templating"]["prompt"]["template"][0]["content"]
                 == "Hello world!"
             )
-            assert (
-                config["config"]["modules"][0]["prompt_templating"]["prompt"][
-                    "template"
-                ][0]["content"]
-                == "Hello."
-            )
-            assert (
-                config["config"]["modules"][1]["translation"]["input"]["type"]
-                == "sap_document_translation"
-            )
+            assert config["config"]["modules"][0]["prompt_templating"]["prompt"]["template"][0]["content"] == "Hello."
+            assert config["config"]["modules"][1]["translation"]["input"]["type"] == "sap_document_translation"
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by deployment-resolution tests
+# ---------------------------------------------------------------------------
+
+
+def _make_config():
+    from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+    cfg = GenAIHubOrchestrationConfig()
+    cfg.token_creator = lambda: "Bearer TEST"
+    cfg._base_url = "https://api.test-sap.com"
+    cfg._resource_group = "test-group"
+    return cfg
+
+
+def _mock_client(*names: str):
+    """Fake httpx client that returns deployment/config payloads for given names."""
+    resources = [
+        {
+            "scenarioId": "orchestration",
+            "configurationId": f"cfg-{n}",
+            "deploymentUrl": f"https://deploy-{n}.sap.com",
+            "createdAt": f"2024-01-{i + 1:02d}T00:00:00Z",
+        }
+        for i, n in enumerate(names)
+    ]
+    configs = {f"cfg-{n}": {"executableId": "orchestration", "name": n} for n in names}
+
+    def fake_get(url, headers=None):
+        resp = MagicMock()
+        if "/lm/deployments" in url:
+            resp.json.return_value = {"resources": resources}
+        else:
+            cfg_id = url.split("/")[-1]
+            resp.json.return_value = configs.get(cfg_id, {})
+        return resp
+
+    client = MagicMock()
+    client.get.side_effect = fake_get
+    return client
+
+
+class TestDeploymentResolution:
+    def test_single_deployment_returns_url(self):
+        cfg = _make_config()
+        with patch("litellm.module_level_client", _mock_client("orch-a")):
+            url = cfg._resolve_deployment_url()
+        assert url == "https://deploy-orch-a.sap.com"
+
+    def test_multiple_deployments_picks_newest(self):
+        # "older" has createdAt 2024-01-01, "newer" has 2024-01-02
+        cfg = _make_config()
+        with patch("litellm.module_level_client", _mock_client("older", "newer")):
+            url = cfg._resolve_deployment_url()
+        assert url == "https://deploy-newer.sap.com"
+
+    def test_multiple_deployments_emits_warning(self):
+        cfg = _make_config()
+        with patch("litellm.module_level_client", _mock_client("older", "newer")):
+            with patch("litellm.llms.sap.chat.transformation.verbose_logger") as mock_log:
+                cfg._resolve_deployment_url()
+        mock_log.warning.assert_called_once()
+        assert "2" in mock_log.warning.call_args[0][0]
+
+    def test_no_deployments_raises(self):
+        from litellm.llms.sap.chat.handler import GenAIHubOrchestrationError
+
+        cfg = _make_config()
+        with patch("litellm.module_level_client", _mock_client()):
+            with pytest.raises(GenAIHubOrchestrationError) as exc:
+                cfg._resolve_deployment_url()
+        assert "No orchestration deployment found" in str(exc.value)


### PR DESCRIPTION
## Relevant issues                                                                                                                                                          
                                                                                                                                                                             
 <!-- N/A -->                                                                                                                                                                
                                                                                                                                                                             
 ## Linear ticket                                                                                                                                                            
                                                                                                                                                                             
 <!-- N/A -->                                                                                                                                                                
                                                                                                                                                                             
 ## Pre-Submission checklist                                                                                                                                                 
                                                                                                                                                                             
 - [x] I have added meaningful tests                                                                                                                                         
 - [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)                                                                                                        
 - [x] My PR's scope is as isolated as possible; it only solves 1 specific problem                                                                                           
 - [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review                                                                 
                                                                                                                                                                             
 ## Type                                                                                                                                                                     
                                                                                                                                                                             
 🆕 New Feature                                                                                                                                                              
                                                                                                                                                                             
 ## Changes                                                                                                                                                                  
                                                                                                                                                                             
 Improves orchestration deployment URL resolution for SAP AI Core tenants that have more than one orchestration deployment.                                                  
                                                                                                                                                                             
 **Before:** `get_complete_url` always ran auto-discovery on every config instance. If zero deployments existed it crashed with an `IndexError`. If more than one existed it 
 silently picked the newest with no warning and no override path.                                                                                                            
                                                                                                                                                                             
 **After (2 commits):**                                                                                                                                                      
                                                                                                                                                                             
 **commit 1 — extract `_resolve_deployment_url`, warn on multiple, error on zero**                                                                                           
 - Discovery logic moved from `@cached_property deployment_url` into a dedicated `_resolve_deployment_url()` method so it can be unit-tested directly                        
 - Raises `GenAIHubOrchestrationError(404)` when no orchestration deployment is found instead of crashing with `IndexError`                                                  
 - Emits `verbose_logger.warning` when more than one deployment is found, naming the chosen one (newest by `createdAt`) and listing the ignored ones                         
                                                                                                                                                                             
 **commit 2 — 3-step URL resolution in `get_complete_url`**                                                                                                                  
                                                                                                                                                                             
 Resolution order (first match wins; no network call unless step 3 is reached):                                                                                              
                                                                                                                                                                             
 1. `optional_params["deployment_url"]` — per-request override, skips discovery entirely                                                                                     
 2. `AICORE_ORCHESTRATION_DEPLOYMENT_URL` env var — operator-level pin, skips discovery entirely                                                                             
 3. `_resolve_deployment_url()` — auto-discovery (result cached on the instance)                                                                                             
                                                                                                                                                                             
 ## Screenshots / Proof of Fix                                                                                                                                               
                                                                                                                                                                             
 Unit tests, no credentials required:                                                                                                                                        
                                                                                                                                                                             
 ```                                                                                                                                                                         
 tests/test_litellm/llms/sap/chat/test_sap_transformation.py::TestDeploymentResolution                                                                                       
 tests/test_litellm/llms/sap/chat/test_sap_transformation.py::TestGetCompleteUrl                                                                                             
                                                                                                                                                                             
 109 passed                                                                                                                                                                  
 ```                                                                                                                                                                         
                                                                                                                                                                             
 ### Final Attestation                                                                                                                                                       
                                                                                                                                                                             
 - [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR