### PR TITLE
fix(docker): pin prisma caches to a UID-independent path so air-gapped and arbitrary-UID deploys work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,9 @@ RUN uv sync --frozen --no-default-groups --no-editable \
     --extra semantic-router \
     --python python3
 
+ENV XDG_CACHE_HOME=/opt/prisma-cache \
+    PRISMA_BINARY_CACHE_DIR=/opt/prisma-cache/prisma-python/binaries
+
 RUN prisma generate --schema=./schema.prisma
 
 RUN sed -i 's/\r$//' docker/entrypoint.sh && chmod +x docker/entrypoint.sh && \
@@ -100,7 +103,9 @@ USER root
 RUN apk add --no-cache bash openssl tzdata nodejs python3 libsndfile
 
 WORKDIR /app
-ENV PATH="/app/.venv/bin:${PATH}"
+ENV PATH="/app/.venv/bin:${PATH}" \
+    XDG_CACHE_HOME=/opt/prisma-cache \
+    PRISMA_BINARY_CACHE_DIR=/opt/prisma-cache/prisma-python/binaries
 
 # Copy only what runtime needs. The application is installed inside the venv;
 # the rest of the builder's /app is source and build metadata that must not
@@ -114,15 +119,19 @@ COPY --from=builder /app/litellm/proxy/prisma_migration.py /app/litellm/proxy/pr
 # working directory on sys.path; litellm/proxy/hooks resolves
 # enterprise.enterprise_hooks from it)
 COPY --from=builder /app/enterprise /app/enterprise
-# Prisma binaries live in $HOME/.cache (default prisma-python location),
-# which is /root/.cache here. Copy only the Prisma subdirs — copying the
-# whole /root/.cache drags in the uv build cache (~660 MB, includes a
-# setuptools wheel that surfaces as a CVE finding even though it's not
-# on the runtime sys.path).
-COPY --from=builder /root/.cache/prisma /root/.cache/prisma
-COPY --from=builder /root/.cache/prisma-python /root/.cache/prisma-python
+# Prisma caches are baked at a fixed, UID-independent path
+# (XDG_CACHE_HOME and PRISMA_BINARY_CACHE_DIR pin them to
+# /opt/prisma-cache in both stages) so the proxy finds them offline under
+# any runtime UID instead of resolving $HOME-relative paths and
+# re-downloading (air-gapped installs, arbitrary-UID pod security
+# contexts). /opt is used rather than /app/.cache because deployments
+# with readOnlyRootFilesystem mount an emptyDir over /app/.cache, which
+# would shadow the baked-in engines. a+rX keeps them readable under any
+# UID. The uv build cache stays in /root/.cache, so it does not ship.
+COPY --from=builder /opt/prisma-cache /opt/prisma-cache
 
-RUN find /app/.venv -type f -path "*/tornado/test/*" -delete && \
+RUN chmod -R a+rX /opt/prisma-cache && \
+    find /app/.venv -type f -path "*/tornado/test/*" -delete && \
     find /app/.venv -type d -path "*/tornado/test" -delete
 
 EXPOSE 4000/tcp

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -84,6 +84,9 @@ RUN uv sync --frozen --no-default-groups --no-editable \
     --extra semantic-router \
     --python python3
 
+ENV XDG_CACHE_HOME=/opt/prisma-cache \
+    PRISMA_BINARY_CACHE_DIR=/opt/prisma-cache/prisma-python/binaries
+
 RUN prisma generate --schema=./schema.prisma
 
 RUN sed -i 's/\r$//' docker/entrypoint.sh && chmod +x docker/entrypoint.sh && \
@@ -97,7 +100,9 @@ USER root
 RUN apk add --no-cache bash openssl tzdata nodejs python3 libsndfile
 
 WORKDIR /app
-ENV PATH="/app/.venv/bin:${PATH}"
+ENV PATH="/app/.venv/bin:${PATH}" \
+    XDG_CACHE_HOME=/opt/prisma-cache \
+    PRISMA_BINARY_CACHE_DIR=/opt/prisma-cache/prisma-python/binaries
 
 # Copy only what runtime needs. The application is installed inside the venv;
 # the rest of the builder's /app is source and build metadata that must not
@@ -111,15 +116,19 @@ COPY --from=builder /app/litellm/proxy/prisma_migration.py /app/litellm/proxy/pr
 # working directory on sys.path; litellm/proxy/hooks resolves
 # enterprise.enterprise_hooks from it)
 COPY --from=builder /app/enterprise /app/enterprise
-# Prisma binaries live in $HOME/.cache (default prisma-python location),
-# which is /root/.cache here. Copy them from the builder so they survive
-# deployments that volume-mount /app/.cache (e.g. readOnlyRootFilesystem
-# + emptyDir) — otherwise the mount would shadow the baked-in query engine.
-# Only the Prisma subdirs: the whole /root/.cache drags in the uv build cache.
-COPY --from=builder /root/.cache/prisma /root/.cache/prisma
-COPY --from=builder /root/.cache/prisma-python /root/.cache/prisma-python
+# Prisma caches are baked at a fixed, UID-independent path
+# (XDG_CACHE_HOME and PRISMA_BINARY_CACHE_DIR pin them to
+# /opt/prisma-cache in both stages) so the proxy finds them offline under
+# any runtime UID instead of resolving $HOME-relative paths and
+# re-downloading (air-gapped installs, arbitrary-UID pod security
+# contexts). /opt keeps them clear of deployments that volume-mount
+# /app/.cache (e.g. readOnlyRootFilesystem + emptyDir) — such a mount
+# would shadow the baked-in query engine. a+rX keeps them readable under
+# any UID. The uv build cache stays in /root/.cache, so it does not ship.
+COPY --from=builder /opt/prisma-cache /opt/prisma-cache
 
-RUN find /app/.venv -type f -path "*/tornado/test/*" -delete && \
+RUN chmod -R a+rX /opt/prisma-cache && \
+    find /app/.venv -type f -path "*/tornado/test/*" -delete && \
     find /app/.venv -type d -path "*/tornado/test" -delete
 
 EXPOSE 4000/tcp


### PR DESCRIPTION
## Relevant issues

Fixes #33365

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests). Every check is green except osv-scan, which fails on the base branch as well (mcp 1.26.0 in uv.lock has three High advisories; #33591 tracks the bump and this PR does not touch uv.lock)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes). Scored 5/5

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Repro environment: `docker network create --internal airgap` (containers can reach each other, zero egress), postgres:16-alpine on it, and the litellm image with `DATABASE_URL` set and a minimal config. `--user 12345:12345` simulates a Kubernetes arbitrary-UID securityContext

Published image (`ghcr.io/berriai/litellm:main-latest`), arbitrary UID, air-gapped:

```
$ docker run -d --name airgap-before --network airgap --user 12345:12345 -e DATABASE_URL=... ghcr.io/berriai/litellm:main-latest --config /app/config.yaml --port 4000
$ docker logs airgap-before
2026-07-17 13:59:15 - litellm_proxy_extras - INFO - prisma db error: Traceback (most recent call last):
FileNotFoundError: [Errno 2] No such file or directory: '/.cache/prisma-python/binaries/5.4.2/ac9d7041ed77bcc8a8dbd2ab6616b39013829574'
  File ".../prisma/cli/prisma.py", line 78, in ensure_cached
    cache_dir.mkdir(parents=True)
PermissionError: [Errno 13] Permission denied: '/.cache'
$ docker ps -a --filter name=airgap-before --format '{{.Status}}'
Exited (3) 4 seconds ago
```

Same image built with this PR, same command, arbitrary UID, air-gapped:

```
$ docker logs airgap-fixed-uid | grep -iE "migrate deploy completed|Uvicorn running"
2026-07-17 14:32:47,271 - litellm_proxy_extras - INFO - prisma migrate deploy completed
INFO:     Uvicorn running on http://0.0.0.0:4000 (Press CTRL+C to quit)
$ docker exec airgap-fixed-uid python3 -c "import urllib.request; print(urllib.request.urlopen('http://localhost:4000/health/liveliness').read().decode())"
"I'm alive!"
```

Root regression check (patched image, default user, air-gapped): migrations complete and the proxy serves identically. The remote model-cost-map fetch logs a warning and falls back to the local backup, which is the expected offline behavior

## Type

🐛 Bug Fix

## Changes

Prisma resolves every cache location relative to $HOME: the python client looks for engines in `~/.cache/prisma-python/binaries/<version>/<hash>` and the node CLI keeps its engines in `~/.cache/prisma`. The published root images bake these caches into `/root/.cache` and rely on the process running as root with HOME=/root. Kubernetes deployments that set an arbitrary runAsUser (standard pod hardening, and the default on OpenShift) get HOME=/ instead, so prisma misses the baked caches, tries to mkdir `/.cache` and re-download the toolchain, and the pod dies; in an air-gapped cluster the download can never succeed, which is the failure in #33365 (and earlier #4915). The same $HOME dependence is why the reporter's traceback shows nodeenv downloading Node into `/.cache/prisma-python/nodeenv`

The fix pins the caches to a fixed, UID-independent path at build time and runtime: XDG_CACHE_HOME and PRISMA_BINARY_CACHE_DIR are set to `/opt/prisma-cache` in both stages of Dockerfile and docker/Dockerfile.database, `prisma generate` in the builder populates that path, the runtime stage copies it and makes it world-readable (a+rX). `/opt` is used rather than `/app/.cache` deliberately: deployments with readOnlyRootFilesystem mount an emptyDir over `/app/.cache`, which would shadow baked-in engines (the old comment in Dockerfile.database documents that trap). The non_root image already ships equivalent env pinning; this brings the two root images in line

No application code changes. Runtime behavior for existing root deployments is unchanged (verified below); arbitrary-UID and air-gapped deployments go from crash-looping to serving

## QA runbook

1. `docker network create --internal airgap` and start postgres on it
2. Run the image on that network with `--user 12345:12345`, DATABASE_URL pointing at the postgres, and any minimal config
3. Before this change the container exits within seconds with `PermissionError: [Errno 13] Permission denied: '/.cache'` after failing to find `/.cache/prisma-python/binaries/...`; after it, migrations run and the proxy serves on :4000 with no egress
4. Repeat without `--user` (root) to confirm the default path still works

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

