### PR TITLE
fix(router): stop deep-copying model_info in pattern-matched deployments

### DIFF
--- a/litellm/router_utils/pattern_match_deployments.py
+++ b/litellm/router_utils/pattern_match_deployments.py
@@ -98,16 +98,19 @@ class PatternMatchRouter:
         return re.escape(pattern).replace(r"\*", "(.*)")
 
     def _return_pattern_matched_deployments(self, matched_pattern: Match, deployments: List[Dict]) -> List[Dict]:
-        new_deployments = []
-        for deployment in deployments:
-            new_deployment = copy.deepcopy(deployment)
-            new_deployment["litellm_params"]["model"] = PatternMatchRouter.set_deployment_model_name(
-                matched_pattern=matched_pattern,
-                litellm_deployment_litellm_model=deployment["litellm_params"]["model"],
-            )
-            new_deployments.append(new_deployment)
-
-        return new_deployments
+        return [
+            {
+                **deployment,
+                "litellm_params": {
+                    **copy.deepcopy(deployment["litellm_params"]),
+                    "model": PatternMatchRouter.set_deployment_model_name(
+                        matched_pattern=matched_pattern,
+                        litellm_deployment_litellm_model=deployment["litellm_params"]["model"],
+                    ),
+                },
+            }
+            for deployment in deployments
+        ]
 
     def route(self, request: Optional[str], filtered_model_names: Optional[List[str]] = None) -> Optional[List[Dict]]:
         """

--- a/tests/test_litellm/router_utils/test_pattern_match_deployments.py
+++ b/tests/test_litellm/router_utils/test_pattern_match_deployments.py
@@ -1,0 +1,74 @@
+import pytest
+
+from litellm.router_utils.pattern_match_deployments import PatternMatchRouter
+
+
+@pytest.fixture
+def wildcard_deployment() -> dict:
+    return {
+        "model_name": "bedrock/*",
+        "litellm_params": {
+            "model": "bedrock/*",
+            "extra_headers": {"x-pool": "pool-1"},
+        },
+        "model_info": {
+            "id": "wildcard-bedrock-1",
+            "large_metadata": {f"k{i}": {"v": i} for i in range(100)},
+        },
+    }
+
+
+class TestReturnPatternMatchedDeployments:
+    def test_rewrites_model_name_without_mutating_source(self, wildcard_deployment):
+        pattern_router = PatternMatchRouter()
+        pattern_router.add_pattern("bedrock/*", wildcard_deployment)
+
+        result = pattern_router.route("bedrock/anthropic.claude-v2")
+
+        assert result is not None
+        assert result[0]["litellm_params"]["model"] == "bedrock/anthropic.claude-v2"
+        assert wildcard_deployment["litellm_params"]["model"] == "bedrock/*"
+
+    def test_does_not_deepcopy_model_info(self, wildcard_deployment):
+        """Regression test for https://github.com/BerriAI/litellm/issues/33636
+
+        Deployments can carry large model_info blobs (tens of KB of JSON for
+        DB-stored models). Deep-copying model_info on every route() call made
+        GET /v1/models cost minutes of event-loop CPU under wildcard configs.
+        Only litellm_params is rewritten, so model_info must be shared.
+        """
+        pattern_router = PatternMatchRouter()
+        pattern_router.add_pattern("bedrock/*", wildcard_deployment)
+
+        result = pattern_router.route("bedrock/anthropic.claude-v2")
+
+        assert result is not None
+        assert result[0]["model_info"] is wildcard_deployment["model_info"]
+
+    def test_returned_litellm_params_are_isolated_from_source(self, wildcard_deployment):
+        pattern_router = PatternMatchRouter()
+        pattern_router.add_pattern("bedrock/*", wildcard_deployment)
+
+        result = pattern_router.route("bedrock/anthropic.claude-v2")
+
+        assert result is not None
+        result[0]["litellm_params"]["api_key"] = "sk-request-scoped"
+        result[0]["litellm_params"]["extra_headers"]["x-pool"] = "mutated"
+        assert "api_key" not in wildcard_deployment["litellm_params"]
+        assert wildcard_deployment["litellm_params"]["extra_headers"]["x-pool"] == "pool-1"
+
+    def test_multiple_deployments_under_one_pattern(self, wildcard_deployment):
+        second = {
+            "model_name": "bedrock/*",
+            "litellm_params": {"model": "bedrock/*"},
+            "model_info": {"id": "wildcard-bedrock-2"},
+        }
+        pattern_router = PatternMatchRouter()
+        pattern_router.add_pattern("bedrock/*", wildcard_deployment)
+        pattern_router.add_pattern("bedrock/*", second)
+
+        result = pattern_router.route("bedrock/amazon.titan-text-express-v1")
+
+        assert result is not None
+        assert len(result) == 2
+        assert all(d["litellm_params"]["model"] == "bedrock/amazon.titan-text-express-v1" for d in result)


### PR DESCRIPTION
## Relevant issues

Fixes #33636

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Reproduction config: six wildcard deployments (three pooled under the same `model_name`, mirroring provider credential pools), each carrying a ~79KB object-dense `model_info` blob like DB-stored models do. Generated with:

```python
import json

blob = {"entries": {f"k{i}": {"v": i, "f": [i, True]} for i in range(2000)}}

def dep(provider, i):
    return {
        "model_name": f"{provider}/*",
        "litellm_params": {"model": f"{provider}/*"},
        "model_info": {"id": f"wildcard-{provider}-{i}", **blob},
    }

config = {
    "model_list": [
        dep("bedrock", 0), dep("bedrock", 1), dep("bedrock", 2),
        dep("anthropic", 3), dep("openai", 4), dep("gemini", 5),
    ],
    "general_settings": {"master_key": "sk-mastertestkey123456789"},
}
with open("proof-config.yaml", "w") as f:
    json.dump(config, f)
```

Before, at base commit 69a476f791 (`litellm --port 41930 --config proof-config.yaml`):

```
$ curl -s -o /dev/null -H "Authorization: Bearer sk-mastertestkey123456789" -w 'http=%{http_code} time_total=%{time_total}s\n' http://127.0.0.1:41930/v1/models
http=200 time_total=7.721557s
```

After, at 68f8e7485a (same config, same command, port 41931):

```
$ curl -s -o /dev/null -H "Authorization: Bearer sk-mastertestkey123456789" -w 'http=%{http_code} time_total=%{time_total}s size=%{size_download}\n' http://127.0.0.1:41931/v1/models
http=200 time_total=0.174506s size=158621
```

The 7.7s is one request on an otherwise idle proxy, all of it CPU on the event loop; nothing else is served while it runs. The response body is unchanged by the fix (identical size and content; the endpoint output does not include model_info). In the production deployment where this was found (litellm v1.92.0, real ~66KB model_info rows), a single `GET /models` measured 7 minutes 25 seconds and took the container out of the load balancer for the duration; full py-spy stacks and measurements are in #33636

## Type

🐛 Bug Fix

## Changes

`PatternMatchRouter._return_pattern_matched_deployments` deep-copied the entire deployment dict for every wildcard match, although the only thing it rewrites is `litellm_params["model"]`. Deployments can carry large `model_info` blobs (tens of KB for DB-stored models), and `GET /v1/models` calls `get_model_group_info` once per listed model, so one listing request performed `listing_length x deployments_per_pattern` deepcopies of those blobs synchronously on the event loop. The large `model_info` in our production case turned out to be litellm-generated: the `access_via_team_ids` list computed for the dashboard's team-access display gets persisted to the DB by the UI's edit-model save (filed as #33722), so any deployment with a realistic team count reproduces this organically after one admin model edit

The shared-`model_info` approach here matches the existing precedent in `Router._get_all_deployments`, which already returns shallow copies that share `model_info` ("Use shallow copy since we only modify top-level model_name"). The two proxy endpoints that mutate `model_info` on listing results (`_populate_team_access_on_models`) operate on request-private deep copies of `model_list` (proxy_server.py:12409 and 11620 at v1.92.0), so sharing `model_info` on the pattern-route path does not expose router state to those writes

This change builds the rewritten deployment as a shallow merge that shares `model_info` and deep-copies only `litellm_params`, preserving the isolation that callers relied on (mutating a returned deployment's `litellm_params`, including nested values, cannot affect the router's stored deployment) while no longer paying for `model_info`

New tests in `tests/test_litellm/router_utils/test_pattern_match_deployments.py`: the model_info identity assertion fails without this fix; the others lock the semantics the deepcopy used to provide (source deployment not mutated, returned `litellm_params` isolated including nested dicts, multi-deployment pattern expansion). Existing suites pass: `tests/test_litellm/test_router.py` (119), `tests/test_litellm/proxy/test_proxy_utils.py` (46), `tests/local_testing/test_router_pattern_matching.py` (14 passed, 1 pre-existing failure requiring a real `OPENAI_API_KEY`, identical without this change)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

