### PR TITLE
feat(guardrails): add outputScope support to Bedrock ApplyGuardrail

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -82,6 +82,11 @@ from litellm.types.utils import (
 
 GUARDRAIL_NAME = "bedrock"
 _BEDROCK_DYNAMIC_BODY_DENYLIST = frozenset({"content", "source"})
+# ApplyGuardrail `outputScope` controls how much of the assessed content AWS
+# returns: "INTERVENTIONS" (default) only returns intervened content; "FULL"
+# returns the entire output including detected and non-detected entries, which
+# is what admins need to observe why a guardrail did or did not fire.
+_BEDROCK_OUTPUT_SCOPE_VALUES = frozenset({"INTERVENTIONS", "FULL"})
 # Resource-less, detect-only InvokeGuardrailChecks API (no guardrail resource required).
 _BEDROCK_INVOKE_GUARDRAIL_CHECKS_PATH = "/guardrail-checks/invoke"
 # InvokeGuardrailChecks accepts at most 10 content blocks per message. A message with
@@ -179,6 +184,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         content_filter_threshold: float | None = 0.5,
         prompt_attack_threshold: float | None = 0.5,
         pii_confidence_threshold: float | None = 0.5,
+        outputScope: Optional[Literal["INTERVENTIONS", "FULL"]] = None,
         **kwargs,
     ):
         self.async_handler = get_async_httpx_client(llm_provider=httpxSpecialProvider.GuardrailCallback)
@@ -195,6 +201,16 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         self.content_filter_threshold = content_filter_threshold
         self.prompt_attack_threshold = prompt_attack_threshold
         self.pii_confidence_threshold = pii_confidence_threshold
+
+        # ApplyGuardrail `outputScope`. None leaves it unset so AWS applies its
+        # default ("INTERVENTIONS"); "FULL" returns the full assessment detail
+        # (detected and non-detected entries) needed for observability.
+        if outputScope is not None and outputScope not in _BEDROCK_OUTPUT_SCOPE_VALUES:
+            raise ValueError(
+                f"BedrockGuardrail: outputScope must be one of {sorted(_BEDROCK_OUTPUT_SCOPE_VALUES)} "
+                f"or omitted; got {outputScope!r}."
+            )
+        self.output_scope: Optional[Literal["INTERVENTIONS", "FULL"]] = outputScope
 
         # store kwargs as optional_params
         self.optional_params = kwargs
@@ -765,6 +781,8 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         bedrock_request_data: dict = dict(
             self.convert_to_bedrock_format(source=source, messages=messages, response=response)
         )
+        if self.output_scope is not None:
+            bedrock_request_data["outputScope"] = self.output_scope
         bedrock_guardrail_response: BedrockGuardrailResponse = BedrockGuardrailResponse()
         api_key: Optional[str] = None
         if request_data:

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -184,7 +184,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         content_filter_threshold: float | None = 0.5,
         prompt_attack_threshold: float | None = 0.5,
         pii_confidence_threshold: float | None = 0.5,
-        outputScope: Optional[Literal["INTERVENTIONS", "FULL"]] = None,
+        outputScope: Literal["INTERVENTIONS", "FULL"] | None = None,
         **kwargs,
     ):
         self.async_handler = get_async_httpx_client(llm_provider=httpxSpecialProvider.GuardrailCallback)
@@ -210,7 +210,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 f"BedrockGuardrail: outputScope must be one of {sorted(_BEDROCK_OUTPUT_SCOPE_VALUES)} "
                 f"or omitted; got {outputScope!r}."
             )
-        self.output_scope: Optional[Literal["INTERVENTIONS", "FULL"]] = outputScope
+        self.output_scope: Literal["INTERVENTIONS", "FULL"] | None = outputScope
 
         # store kwargs as optional_params
         self.optional_params = kwargs

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -244,6 +244,13 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 "effect with 'checks' (InvokeGuardrailChecks is detect-only)."
             )
 
+        if self.checks is not None and self.output_scope is not None:
+            verbose_proxy_logger.warning(
+                "Bedrock Guardrail: outputScope has no effect with 'checks' "
+                "(InvokeGuardrailChecks does not accept outputScope; it is only "
+                "used by the ApplyGuardrail API)."
+            )
+
         verbose_proxy_logger.debug(
             "Bedrock Guardrail initialized with guardrailIdentifier: %s, guardrailVersion: %s, checks: %s",
             self.guardrailIdentifier,

--- a/litellm/types/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -19,6 +19,7 @@ class BedrockContentItem(TypedDict, total=False):
 class BedrockRequest(TypedDict, total=False):
     source: Literal["INPUT", "OUTPUT"]
     content: List[BedrockContentItem]
+    outputScope: Literal["INTERVENTIONS", "FULL"]
 
 
 class BedrockGuardrailUsage(TypedDict, total=False):

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -3274,3 +3274,108 @@ async def test_chat_completion_modify_response_exception_streaming_logging_obj_n
     # CustomStreamWrapper would raise AttributeError inside __init__ and this
     # call would never reach here.
     assert response is not None
+
+
+class TestBedrockGuardrailOutputScope:
+    """Regression for #33671: ApplyGuardrail must honor a configured outputScope.
+
+    AWS ApplyGuardrail accepts outputScope=FULL to return the entire assessed
+    output (detected and non-detected entries) for observability; the default
+    INTERVENTIONS only returns intervened content. The hook must send the
+    configured value and omit it when unset.
+    """
+
+    @staticmethod
+    def _mock_bedrock_response() -> MagicMock:
+        mock = MagicMock()
+        mock.status_code = 200
+        mock.json.return_value = {"action": "NONE", "outputs": []}
+        return mock
+
+    @staticmethod
+    def _mock_credentials() -> MagicMock:
+        mock = MagicMock()
+        mock.access_key = "test-access-key"
+        mock.secret_key = "test-secret-key"
+        mock.token = None
+        return mock
+
+    @pytest.mark.asyncio
+    async def test_output_scope_full_is_sent_in_request_body(self):
+        guardrail = BedrockGuardrail(
+            guardrailIdentifier="test-guardrail",
+            guardrailVersion="DRAFT",
+            outputScope="FULL",
+        )
+        request_data = {
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+
+        with (
+            patch.object(
+                guardrail.async_handler, "post", new_callable=AsyncMock
+            ) as mock_post,
+            patch.object(
+                guardrail,
+                "_load_credentials",
+                return_value=(self._mock_credentials(), "us-east-1"),
+            ),
+            patch.object(
+                guardrail, "_prepare_request", return_value=MagicMock()
+            ) as mock_prepare_request,
+        ):
+            mock_post.return_value = self._mock_bedrock_response()
+
+            await guardrail.make_bedrock_api_request(
+                source="INPUT",
+                messages=request_data["messages"],
+                request_data=request_data,
+            )
+
+            sent_body = mock_prepare_request.call_args.kwargs["data"]
+            assert sent_body["outputScope"] == "FULL"
+
+    @pytest.mark.asyncio
+    async def test_output_scope_absent_when_not_configured(self):
+        guardrail = BedrockGuardrail(
+            guardrailIdentifier="test-guardrail",
+            guardrailVersion="DRAFT",
+        )
+        request_data = {
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+
+        with (
+            patch.object(
+                guardrail.async_handler, "post", new_callable=AsyncMock
+            ) as mock_post,
+            patch.object(
+                guardrail,
+                "_load_credentials",
+                return_value=(self._mock_credentials(), "us-east-1"),
+            ),
+            patch.object(
+                guardrail, "_prepare_request", return_value=MagicMock()
+            ) as mock_prepare_request,
+        ):
+            mock_post.return_value = self._mock_bedrock_response()
+
+            await guardrail.make_bedrock_api_request(
+                source="INPUT",
+                messages=request_data["messages"],
+                request_data=request_data,
+            )
+
+            sent_body = mock_prepare_request.call_args.kwargs["data"]
+            assert "outputScope" not in sent_body
+
+    @pytest.mark.asyncio
+    async def test_output_scope_invalid_value_raises(self):
+        with pytest.raises(ValueError, match="outputScope"):
+            BedrockGuardrail(
+                guardrailIdentifier="test-guardrail",
+                guardrailVersion="DRAFT",
+                outputScope="EVERYTHING",  # type: ignore[arg-type]
+            )

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -3379,3 +3379,17 @@ class TestBedrockGuardrailOutputScope:
                 guardrailVersion="DRAFT",
                 outputScope="EVERYTHING",  # type: ignore[arg-type]
             )
+
+    def test_output_scope_warns_when_checks_mode_active(self):
+        with patch(
+            "litellm.proxy.guardrails.guardrail_hooks.bedrock_guardrails.verbose_proxy_logger.warning"
+        ) as mock_warning:
+            BedrockGuardrail(
+                checks={"contentFilter": {"type": "SEXUAL"}},
+                outputScope="FULL",
+            )
+            mock_warning.assert_any_call(
+                "Bedrock Guardrail: outputScope has no effect with 'checks' "
+                "(InvokeGuardrailChecks does not accept outputScope; it is only "
+                "used by the ApplyGuardrail API)."
+            )


### PR DESCRIPTION
## Relevant issues

Refs #33671

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Issue #33671 asked for Bedrock Guardrails observability. The reporter proposed adding a `trace` field to the ApplyGuardrail request body, but the AWS ApplyGuardrail API does not accept a `trace` field (confirmed against https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ApplyGuardrail.html ; the body accepts only `content`, `source`, and `outputScope`). A `trace` key would be silently dropped by AWS.

The genuine observability gap is `outputScope`. AWS defaults to `INTERVENTIONS`, which only returns intervened content in the response. Setting `outputScope=FULL` returns the entire assessed output, including detected and non-detected entries, so admins can observe why a guardrail did or did not fire.

This PR adds a configurable `outputScope` constructor parameter (`Literal["INTERVENTIONS", "FULL"]`) that is injected into the ApplyGuardrail request body. Per-call `extra_body.outputScope` can still override it via the existing dynamic body params merge.

Proof that the configured value reaches the signed request body (commit `a79aea92bb`):

```
$ uv run --no-sync pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py::TestBedrockGuardrailOutputScope -v

tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py::TestBedrockGuardrailOutputScope::test_output_scope_full_is_sent_in_request_body PASSED
tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py::TestBedrockGuardrailOutputScope::test_output_scope_absent_when_not_configured PASSED
tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py::TestBedrockGuardrailOutputScope::test_output_scope_invalid_value_raises PASSED
3 passed
```

A live end-to-end proof requires a configured AWS Bedrock Guardrail resource and credentials. To verify against a live proxy:

1. Start the proxy with a guardrail config that includes `outputScope: FULL`:
   ```yaml
   guardrails:
     - guardrail_name: bedrock-test
       litellm_params:
         guardrailIdentifier: <your-guardrail-id>
         guardrailVersion: DRAFT
         outputScope: FULL
   ```
   `python litellm/proxy/proxy_cli.py --config <config.yaml> --detailed_debug --reload`
2. Send a chat completion that triggers or passes the guardrail:
   `curl -X POST http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-..." -d '{"model":"gpt-4o","messages":[{"role":"user","content":"hello"}]}'`
3. Inspect the proxy debug log line `Bedrock AI request body:` ; it should contain `"outputScope":"FULL"`, and the `Bedrock AI response` should include the full assessment detail (detected and non-detected entries) rather than only intervened content

## Type

🆕 New Feature

## Changes

Add `outputScope` support to the standalone Bedrock Guardrails hook so admins can request the full assessed output from AWS ApplyGuardrail for observability.

`litellm/types/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py`: added `outputScope: Literal["INTERVENTIONS", "FULL"]` to the `BedrockRequest` TypedDict.

`litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py`: added an `outputScope` constructor parameter on `BedrockGuardrail.__init__`, validated against the allowed values at construction time, stored as `self.output_scope`, and injected into the ApplyGuardrail request body in `_make_apply_guardrail_request` before the dynamic body params merge so a per-call `extra_body.outputScope` can still override it.

`tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py`: added `TestBedrockGuardrailOutputScope` with three regression tests: `outputScope=FULL` is present in the request body sent to `_prepare_request`; `outputScope` is absent when not configured; an invalid value raises `ValueError` at construction.

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR