### PR TITLE
test(e2e): a member's team budget cuts off only that member's key

### DIFF
--- a/tests/e2e/quota_management/budgets/test_budget_enforcement_e2e.py
+++ b/tests/e2e/quota_management/budgets/test_budget_enforcement_e2e.py
@@ -168,18 +168,44 @@ class OrganizationBudgetCase(_BudgetCase):
 
 
 class TeamMemberBudgetCase(_BudgetCase):
+    """Member A's per-team budget is tiny while the team and both members' user
+    budgets are roomy (100.0), so the only cap that can trip is A's: the refusal
+    must be a 429 budget_exceeded quoting the tiny member cap as the binding
+    budget. Teammate B, uncapped on the same team, must keep serving after A is
+    cut off, proving the member cap does not leak onto the team or its members."""
+
     def init(self) -> None:
-        # Member's per-team budget is tiny while the team has a large budget, so a
-        # block proves member-level (not team-level) enforcement.
-        team_id = self.client.create_team(
+        self._team_id = self.client.create_team(
             alias=f"e2e-budget-team-{unique_marker()}", max_budget=100.0
         )
-        self._undo.append(lambda: self.client.delete_team(team_id))
-        user_id = self.client.create_user(max_budget=100.0)
-        self._undo.append(lambda: self.client.delete_user(user_id))
-        self.client.add_team_member(team_id, user_id, max_budget_in_team=3e-6)
-        self.key = self.client.generate_key(team_id=team_id, user_id=user_id)
+        self._undo.append(lambda: self.client.delete_team(self._team_id))
+        self._member_id = self.client.create_user(max_budget=100.0)
+        self._undo.append(lambda: self.client.delete_user(self._member_id))
+        self.client.add_team_member(self._team_id, self._member_id, max_budget_in_team=3e-6)
+        self.key = self.client.generate_key(team_id=self._team_id, user_id=self._member_id)
         self._undo.append(lambda: self.client.delete_key(self.key))
+        teammate_id = self.client.create_user(max_budget=100.0)
+        self._undo.append(lambda: self.client.delete_user(teammate_id))
+        self.client.add_team_member(self._team_id, teammate_id)
+        self._teammate_key = self.client.generate_key(team_id=self._team_id, user_id=teammate_id)
+        self._undo.append(lambda: self.client.delete_key(self._teammate_key))
+
+    def run(self) -> None:
+        blocked = _assert_budget_blocks(self.client, self.key)
+        assert blocked.status_code == 429, (
+            f"budget refusal must be 429, got {blocked.status_code}: {blocked.body[:200]}"
+        )
+        assert "Max budget: 3e-06" in blocked.body, (
+            f"refusal must quote the member's tiny cap as the binding budget "
+            f"(team and user budgets are 100.0), got: {blocked.body[:200]}"
+        )
+        teammate = self.client.chat(
+            self._teammate_key,
+            "claude-haiku-4-5",
+            f"spend {unique_marker()}",
+            max_tokens=16,
+        )
+        require_successful_call(teammate)
 
 
 def _case_id(case_cls: Type[_BudgetCase]) -> str:

--- a/tests/e2e/quota_management/budgets/test_budget_enforcement_e2e.py
+++ b/tests/e2e/quota_management/budgets/test_budget_enforcement_e2e.py
@@ -169,10 +169,10 @@ class OrganizationBudgetCase(_BudgetCase):
 
 class TeamMemberBudgetCase(_BudgetCase):
     """Member A's per-team budget is tiny while the team and both members' user
-    budgets are roomy (100.0), so the only cap that can trip is A's: the refusal
-    must be a 429 budget_exceeded quoting the tiny member cap as the binding
-    budget. Teammate B, uncapped on the same team, must keep serving after A is
-    cut off, proving the member cap does not leak onto the team or its members."""
+    budgets are roomy (100.0), so the only cap that can trip is A's: a block
+    proves member-level enforcement and must be a 429 budget_exceeded. Teammate
+    B, uncapped on the same team, must keep serving after A is cut off, proving
+    the member cap does not leak onto the team or its members."""
 
     def init(self) -> None:
         self._team_id = self.client.create_team(
@@ -194,10 +194,6 @@ class TeamMemberBudgetCase(_BudgetCase):
         blocked = _assert_budget_blocks(self.client, self.key)
         assert blocked.status_code == 429, (
             f"budget refusal must be 429, got {blocked.status_code}: {blocked.body[:200]}"
-        )
-        assert "Max budget: 3e-06" in blocked.body, (
-            f"refusal must quote the member's tiny cap as the binding budget "
-            f"(team and user budgets are 100.0), got: {blocked.body[:200]}"
         )
         teammate = self.client.chat(
             self._teammate_key,


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured at f83b5153df, before the branch was rebased onto litellm_internal_staging once #33632 squash-merged; the same assertions now sit at e9ab6849c0 and the member case re-ran green after each revision against a live proxy (docker compose stack in tests/e2e) with real paid llama-3.3-70b-versatile calls through the `claude-haiku-4-5` model group. A team with a roomy max_budget (100.0), members A and B (both users with roomy 100.0 budgets), A capped with max_budget_in_team 3e-06, B uncapped, one team-member key each (team_id + user_id):

```
--- member A key, call 1 ---
... "usage":{"completion_tokens":16,"prompt_tokens":39,"total_tokens":55, ...
HTTP 200
--- member A key, call 2 ---
{"error":{"message":"Budget has been exceeded! Current cost: 3.565e-05, Max budget: 3e-06","type":"budget_exceeded","param":null,"code":"429"}}
HTTP 429
--- member A key, call 3 ---
{"error":{"message":"Budget has been exceeded! Current cost: 3.565e-05, Max budget: 3e-06","type":"budget_exceeded","param":null,"code":"429"}}
HTTP 429
--- member B key, first call ---
... "usage":{"completion_tokens":16,"prompt_tokens":39,"total_tokens":55, ...
HTTP 200
```

With team and user budgets at 100.0 and the key uncapped, only A's member cap can block, and B keeps serving after A is cut off. All 6 enforcement cases pass against the same live proxy (6 passed in 14.82s) and `basedpyright tests/e2e` reports 0 errors

## Type

✅ Test

## Changes

The team-member budget case in `tests/e2e/quota_management/budgets/test_budget_enforcement_e2e.py` (covering `quota_management.budget.team_member.blocks_over_limit`) already proved the enforcement half: member A with a tiny `max_budget_in_team` under a roomy team gets blocked. What nothing asserted is the isolation half of the same customer story: when A burns through their member cap, their teammates must keep working. `TeamMemberBudgetCase` now adds an uncapped member B with their own team-member key; after A's key is refused, one call on B's key must return a successful completion, proving A's cap did not leak onto the team or its other members

The refusal shape is also pinned: A's block must be HTTP 429 `budget_exceeded`. Attribution to the member cap is structural rather than message-based: with the team and both user budgets at 100.0 and the key uncapped, no other cap can block. An earlier revision also matched the cap value in the error message, but that couples the test to the proxy's float formatting, so it was dropped

Targets litellm_internal_staging directly; the `_assert_budget_blocks` return value it builds on landed with #33632. The diff here is only the team-member case

## QA runbook

- tests/e2e/quota_management/budgets/test_budget_enforcement_e2e.py::test_budget_enforcement[TeamMemberBudgetCase] - a member's per-team budget cuts off that member's key while an uncapped teammate's key on the same team keeps serving
  - [x] POST /team/new with `{"team_alias":"qa-member-budget","max_budget":100.0}` and save the team_id
  - [x] POST /user/new with `{"max_budget":100.0}` twice and save user_a and user_b
  - [x] POST /team/member_add with `{"team_id":"<team_id>","member":{"role":"user","user_id":"<user_a>"},"max_budget_in_team":0.000003}`, then again for user_b without max_budget_in_team
  - [x] POST /key/generate with `{"team_id":"<team_id>","user_id":"<user_a>"}`, then the same for user_b
  - [x] Send short chat completions with A's key a couple of seconds apart until one is refused and confirm a 429 whose body has type budget_exceeded
  - [x] Send 1 chat completion with B's key and confirm 200
  - [x] POST /key/delete, /user/delete, /team/delete to clean up

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

