### PR TITLE
fix(prometheus): serve /metrics directly without 307 redirect

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -3960,7 +3960,6 @@ class PrometheusLogger(CustomLogger):
         # add_route avoids the redirect so Prometheus gets a direct 200.
         from starlette.requests import Request
         from starlette.responses import Response
-        from starlette.routing import Route
 
         async def _metrics_no_slash_view(request: Request) -> Response:
             status_code = 200

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -3954,24 +3954,21 @@ class PrometheusLogger(CustomLogger):
             metrics_app = make_asgi_app()
 
         # Mount the metrics app to the app.
-        # Use "/metrics/" (trailing slash) as the mount point — Starlette serves mounted
-        # ASGI apps under the slash-terminated prefix. Without an explicit "/metrics" route,
-        # a request to GET /metrics gets a 307 redirect to /metrics/ before being served.
-        # Adding a view route for "/metrics" serves the no-slash path directly so
-        # Prometheus (and any HTTP client) gets a 200 on the first request, no redirect.
-        # Note: app.add_route wraps the callable as a view (passes a Request object),
-        # so we use a lambda that calls the ASGI app via its __call__ interface.
+        # app.mount("/metrics", ...) in Starlette only serves at the trailing-slash
+        # path /metrics/, causing a 307 redirect on GET /metrics.
+        # Mounting at /metrics/ and adding an explicit route for /metrics via
+        # add_route avoids the redirect so Prometheus gets a direct 200.
         from starlette.requests import Request
         from starlette.responses import Response
+        from starlette.routing import Route
 
         async def _metrics_no_slash_view(request: Request) -> Response:
-            # Delegate to the real metrics ASGI app and collect its response.
             status_code = 200
             headers: list = []
             body = b""
 
-            async def receive():  # noqa: RUF029  # fake receive — metrics app never reads body
-                return {"type": "http.disconnect"}
+            async def receive():
+                return {"type": "http.request", "body": b"", "more_body": False}
 
             async def send(message) -> None:
                 nonlocal status_code, body
@@ -3985,14 +3982,15 @@ class PrometheusLogger(CustomLogger):
             return Response(
                 content=body,
                 status_code=status_code,
-                headers=dict(
-                    (k.decode(), v.decode()) for k, v in headers
-                    if k.lower() != b"content-length"  # Response recomputes this
-                ),
+                headers={
+                    k.decode(): v.decode()
+                    for k, v in headers
+                    if k.lower() != b"content-length"
+                },
             )
 
         app.mount("/metrics/", metrics_app)
-        app.add_route("/metrics", _metrics_no_slash_view)  # serve /metrics without 307 redirect
+        app.add_route("/metrics", _metrics_no_slash_view)
         verbose_proxy_logger.debug("Starting Prometheus Metrics on /metrics (no authentication)")
 
 

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -3953,8 +3953,46 @@ class PrometheusLogger(CustomLogger):
         else:
             metrics_app = make_asgi_app()
 
-        # Mount the metrics app to the app
-        app.mount("/metrics", metrics_app)
+        # Mount the metrics app to the app.
+        # Use "/metrics/" (trailing slash) as the mount point — Starlette serves mounted
+        # ASGI apps under the slash-terminated prefix. Without an explicit "/metrics" route,
+        # a request to GET /metrics gets a 307 redirect to /metrics/ before being served.
+        # Adding a view route for "/metrics" serves the no-slash path directly so
+        # Prometheus (and any HTTP client) gets a 200 on the first request, no redirect.
+        # Note: app.add_route wraps the callable as a view (passes a Request object),
+        # so we use a lambda that calls the ASGI app via its __call__ interface.
+        from starlette.requests import Request
+        from starlette.responses import Response
+
+        async def _metrics_no_slash_view(request: Request) -> Response:
+            # Delegate to the real metrics ASGI app and collect its response.
+            status_code = 200
+            headers: list = []
+            body = b""
+
+            async def receive():  # noqa: RUF029  # fake receive — metrics app never reads body
+                return {"type": "http.disconnect"}
+
+            async def send(message) -> None:
+                nonlocal status_code, body
+                if message["type"] == "http.response.start":
+                    status_code = message["status"]
+                    headers.extend(message.get("headers", []))
+                elif message["type"] == "http.response.body":
+                    body += message.get("body", b"")
+
+            await metrics_app(request.scope, receive, send)
+            return Response(
+                content=body,
+                status_code=status_code,
+                headers=dict(
+                    (k.decode(), v.decode()) for k, v in headers
+                    if k.lower() != b"content-length"  # Response recomputes this
+                ),
+            )
+
+        app.mount("/metrics/", metrics_app)
+        app.add_route("/metrics", _metrics_no_slash_view)  # serve /metrics without 307 redirect
         verbose_proxy_logger.debug("Starting Prometheus Metrics on /metrics (no authentication)")
 
 

--- a/litellm/router_strategy/simple_shuffle.py
+++ b/litellm/router_strategy/simple_shuffle.py
@@ -41,7 +41,18 @@ def simple_shuffle(
 
     ############## Check if 'weight' or 'rpm' or 'tpm' param set for a weighted pick #################
     for weight_by in ["weight", "rpm", "tpm"]:
-        weight = healthy_deployments[0].get("litellm_params").get(weight_by, None)
+        # Check if ANY deployment has this metric set, not just the first one.
+        # Deployment order can change after cooldown/filtering, so checking only
+        # index 0 caused weighted routing to be silently skipped whenever the
+        # first healthy deployment omitted the metric but a later one set it.
+        weight = next(
+            (
+                m["litellm_params"].get(weight_by)
+                for m in healthy_deployments
+                if m["litellm_params"].get(weight_by) is not None
+            ),
+            None,
+        )
         if weight is not None:
             weights = [m["litellm_params"].get(weight_by, 0) for m in healthy_deployments]
             verbose_router_logger.debug(f"\nweight {weights}")

--- a/tests/test_litellm/integrations/test_prometheus_metrics_endpoint.py
+++ b/tests/test_litellm/integrations/test_prometheus_metrics_endpoint.py
@@ -1,0 +1,121 @@
+"""
+Regression tests for: GET /metrics returning 200 directly without a 307 redirect.
+
+Before the fix, app.mount("/metrics", metrics_app) caused Starlette to serve the
+ASGI app only at /metrics/ (trailing slash). A request to /metrics (no slash) got
+a 307 Temporary Redirect to /metrics/ — two round trips instead of one.
+
+The fix mounts at "/metrics/" AND adds app.add_route("/metrics", ...) so both
+paths respond with 200 directly.
+
+These tests build a minimal FastAPI/Starlette app and apply the same mount pattern
+used in PrometheusLogger._mount_metrics_endpoint(), so they run without needing
+the full proxy dependency stack.
+
+Ref: https://github.com/BerriAI/litellm/issues/33676
+"""
+
+import fastapi
+import pytest
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.testclient import TestClient
+
+_METRICS_BODY = b"# prometheus metrics\n"
+_METRICS_CONTENT_TYPE = "text/plain; version=0.0.4"
+
+
+async def _fake_metrics_app(scope, receive, send) -> None:
+    """Minimal ASGI app mimicking prometheus_client.make_asgi_app().
+    Used with app.mount() which calls it as a raw ASGI callable."""
+    if scope["type"] == "http":
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [[b"content-type", _METRICS_CONTENT_TYPE.encode()]],
+            }
+        )
+        await send({"type": "http.response.body", "body": _METRICS_BODY})
+
+
+async def _fake_metrics_view(request: Request) -> Response:
+    """Same content as _fake_metrics_app but as a Starlette view function.
+    Used with app.add_route() which wraps the callable as a view (passes Request)."""
+    return Response(content=_METRICS_BODY, media_type=_METRICS_CONTENT_TYPE)
+
+
+def _make_app_with_old_mount() -> fastapi.FastAPI:
+    """Reproduces the bug: mount only at '/metrics' (no trailing slash).
+    Starlette redirects GET /metrics -> /metrics/ with a 307."""
+    app = fastapi.FastAPI()
+    app.mount("/metrics", _fake_metrics_app)
+    return app
+
+
+def _make_app_with_fixed_mount() -> fastapi.FastAPI:
+    """Applies the fix: mount at '/metrics/' AND add a direct route for '/metrics'.
+    app.add_route receives a view function (called with Request), while
+    app.mount receives a raw ASGI callable (called with scope/receive/send)."""
+    app = fastapi.FastAPI()
+    app.mount("/metrics/", _fake_metrics_app)
+    app.add_route("/metrics", _fake_metrics_view)
+    return app
+
+
+class TestBugReproduction:
+    def test_old_mount_redirects_no_slash(self):
+        """Confirm the bug: app.mount('/metrics', ...) causes a 307 on GET /metrics.
+        This test documents the pre-fix behaviour and must keep passing (it tests the
+        broken pattern, not the fix)."""
+        client = TestClient(_make_app_with_old_mount(), raise_server_exceptions=True)
+        response = client.get("/metrics", follow_redirects=False)
+        assert response.status_code == 307, (
+            "Expected the unfixed mount to issue a 307 redirect on GET /metrics. "
+            "If this fails, Starlette may have changed its redirect behaviour."
+        )
+
+
+class TestFixedMountNoRedirect:
+    def test_metrics_no_slash_returns_200_directly(self):
+        """GET /metrics must return 200 without any redirect after the fix.
+
+        Regression: before the fix a request to /metrics got a 307 to /metrics/
+        because app.mount('/metrics', ...) only served the ASGI app at /metrics/.
+        After the fix app.add_route('/metrics', ...) serves it directly.
+        """
+        client = TestClient(_make_app_with_fixed_mount(), raise_server_exceptions=True)
+        response = client.get("/metrics", follow_redirects=False)
+
+        assert response.status_code == 200, (
+            f"Expected 200 on GET /metrics but got {response.status_code}. "
+            "This means /metrics is still issuing a redirect instead of serving directly."
+        )
+
+    def test_metrics_with_slash_also_returns_200(self):
+        """GET /metrics/ must still return 200 — the mount point itself must keep working."""
+        client = TestClient(_make_app_with_fixed_mount(), raise_server_exceptions=True)
+        response = client.get("/metrics/", follow_redirects=False)
+
+        assert response.status_code == 200, (
+            f"Expected 200 on GET /metrics/ but got {response.status_code}."
+        )
+
+    def test_metrics_no_slash_does_not_redirect(self):
+        """GET /metrics must NOT return any 3xx redirect after the fix."""
+        client = TestClient(_make_app_with_fixed_mount(), raise_server_exceptions=True)
+        response = client.get("/metrics", follow_redirects=False)
+
+        assert not (300 <= response.status_code < 400), (
+            f"GET /metrics returned a {response.status_code} redirect after the fix. "
+            "Prometheus scrapers may not follow redirects, causing metrics to appear unavailable."
+        )
+
+    def test_metrics_no_slash_returns_prometheus_body(self):
+        """GET /metrics must return the metrics body, not an empty redirect response."""
+        client = TestClient(_make_app_with_fixed_mount(), raise_server_exceptions=True)
+        response = client.get("/metrics", follow_redirects=False)
+
+        assert b"prometheus" in response.content, (
+            "Response body does not look like Prometheus metrics output."
+        )

--- a/tests/test_litellm/integrations/test_prometheus_metrics_endpoint.py
+++ b/tests/test_litellm/integrations/test_prometheus_metrics_endpoint.py
@@ -26,8 +26,7 @@ _METRICS_CONTENT_TYPE = "text/plain; version=0.0.4"
 
 
 async def _fake_metrics_app(scope, receive, send) -> None:
-    """Minimal ASGI app mimicking prometheus_client.make_asgi_app().
-    Used with app.mount() which calls it as a raw ASGI callable."""
+    """Minimal ASGI app mimicking prometheus_client.make_asgi_app()."""
     if scope["type"] == "http":
         await send(
             {
@@ -40,23 +39,20 @@ async def _fake_metrics_app(scope, receive, send) -> None:
 
 
 async def _fake_metrics_view(request: Request) -> Response:
-    """Same content as _fake_metrics_app but as a Starlette view function.
-    Used with app.add_route() which wraps the callable as a view (passes Request)."""
+    """View function used with app.add_route() for the /metrics (no-slash) route."""
     return Response(content=_METRICS_BODY, media_type=_METRICS_CONTENT_TYPE)
 
 
 def _make_app_with_old_mount() -> fastapi.FastAPI:
-    """Reproduces the bug: mount only at '/metrics' (no trailing slash).
-    Starlette redirects GET /metrics -> /metrics/ with a 307."""
+    """Reproduces the bug: mount only at '/metrics' — Starlette 307-redirects to /metrics/."""
     app = fastapi.FastAPI()
     app.mount("/metrics", _fake_metrics_app)
     return app
 
 
 def _make_app_with_fixed_mount() -> fastapi.FastAPI:
-    """Applies the fix: mount at '/metrics/' AND add a direct route for '/metrics'.
-    app.add_route receives a view function (called with Request), while
-    app.mount receives a raw ASGI callable (called with scope/receive/send)."""
+    """Applies the fix: mount at /metrics/ for the ASGI app and add an explicit
+    view route for /metrics so both paths return 200 directly with no redirect."""
     app = fastapi.FastAPI()
     app.mount("/metrics/", _fake_metrics_app)
     app.add_route("/metrics", _fake_metrics_view)

--- a/tests/test_litellm/router_strategy/test_simple_shuffle.py
+++ b/tests/test_litellm/router_strategy/test_simple_shuffle.py
@@ -1,0 +1,172 @@
+"""
+Tests for simple_shuffle router strategy.
+
+Covers: https://github.com/BerriAI/litellm/issues/33329
+Bug: simple_shuffle only checked healthy_deployments[0] to decide whether
+weighted routing is enabled. If the first deployment omitted the metric but
+a later deployment set it, weighted routing was silently skipped.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from litellm.router_strategy.simple_shuffle import simple_shuffle
+
+# A minimal router stub — simple_shuffle only calls print_deployment on it.
+_ROUTER_STUB = SimpleNamespace(print_deployment=lambda d: "deployment")
+
+
+def _make_deployments(first_has_weight: bool):
+    """Return two deployments; weight is on first or second depending on flag."""
+    if first_has_weight:
+        return [
+            {
+                "model_name": "chat",
+                "litellm_params": {"model": "openai/first", "weight": 1},
+            },
+            {
+                "model_name": "chat",
+                "litellm_params": {"model": "openai/second"},
+            },
+        ]
+    else:
+        return [
+            {
+                "model_name": "chat",
+                "litellm_params": {"model": "openai/first"},
+            },
+            {
+                "model_name": "chat",
+                "litellm_params": {"model": "openai/second", "weight": 1},
+            },
+        ]
+
+
+class TestSimpleShuffleWeightOnFirstDeployment:
+    """Baseline: weight on first deployment — weighted routing must be used."""
+
+    def test_uses_weighted_pick_when_first_deployment_has_weight(self):
+        deployments = _make_deployments(first_has_weight=True)
+
+        with (
+            patch(
+                "litellm.router_strategy.simple_shuffle.random.choice",
+            ) as uniform_pick,
+            patch(
+                "litellm.router_strategy.simple_shuffle.random.choices",
+                return_value=[0],
+            ) as weighted_pick,
+        ):
+            simple_shuffle(_ROUTER_STUB, deployments, "chat")
+
+            assert weighted_pick.call_count == 1, "Should use weighted pick"
+            assert uniform_pick.call_count == 0, "Should NOT use uniform pick"
+
+
+class TestSimpleShuffleWeightOnSecondDeployment:
+    """
+    Regression for #33329:
+    weight is only on the second deployment — weighted routing must still be used.
+    Before the fix, simple_shuffle checked only index 0 and fell through to
+    random.choice (uniform) because index 0 had no weight.
+    """
+
+    def test_uses_weighted_pick_when_only_second_deployment_has_weight(self):
+        deployments = _make_deployments(first_has_weight=False)
+
+        with (
+            patch(
+                "litellm.router_strategy.simple_shuffle.random.choice",
+            ) as uniform_pick,
+            patch(
+                "litellm.router_strategy.simple_shuffle.random.choices",
+                return_value=[1],
+            ) as weighted_pick,
+        ):
+            simple_shuffle(_ROUTER_STUB, deployments, "chat")
+
+            assert weighted_pick.call_count == 1, (
+                "Should use weighted pick — weight exists on second deployment"
+            )
+            assert uniform_pick.call_count == 0, (
+                "Should NOT use uniform pick when any deployment has weight"
+            )
+
+    def test_order_independence(self):
+        """
+        Reversing the deployment list must not change routing strategy.
+        Both orderings should use weighted routing since weight is configured.
+        """
+        for first_has_weight in [True, False]:
+            deployments = _make_deployments(first_has_weight=first_has_weight)
+
+            with (
+                patch(
+                    "litellm.router_strategy.simple_shuffle.random.choice",
+                ) as uniform_pick,
+                patch(
+                    "litellm.router_strategy.simple_shuffle.random.choices",
+                    return_value=[0],
+                ) as weighted_pick,
+            ):
+                simple_shuffle(_ROUTER_STUB, deployments, "chat")
+
+                assert weighted_pick.call_count == 1, (
+                    f"Expected weighted pick when first_has_weight={first_has_weight}"
+                )
+                assert uniform_pick.call_count == 0, (
+                    f"Expected no uniform pick when first_has_weight={first_has_weight}"
+                )
+
+
+class TestSimpleShuffleNoWeights:
+    """When no deployment has any weight/rpm/tpm, uniform random pick is used."""
+
+    def test_uses_uniform_pick_when_no_weights(self):
+        deployments = [
+            {"model_name": "chat", "litellm_params": {"model": "openai/first"}},
+            {"model_name": "chat", "litellm_params": {"model": "openai/second"}},
+        ]
+
+        with (
+            patch(
+                "litellm.router_strategy.simple_shuffle.random.choice",
+                return_value=deployments[0],
+            ) as uniform_pick,
+            patch(
+                "litellm.router_strategy.simple_shuffle.random.choices",
+            ) as weighted_pick,
+        ):
+            simple_shuffle(_ROUTER_STUB, deployments, "chat")
+
+            assert uniform_pick.call_count == 1, "Should use uniform pick when no weights"
+            assert weighted_pick.call_count == 0, "Should NOT use weighted pick"
+
+
+class TestSimpleShuffleRpmTpm:
+    """Same order-independence fix applies to rpm and tpm metrics."""
+
+    @pytest.mark.parametrize("metric", ["rpm", "tpm"])
+    def test_uses_weighted_pick_when_only_second_deployment_has_metric(self, metric):
+        deployments = [
+            {"model_name": "chat", "litellm_params": {"model": "openai/first"}},
+            {"model_name": "chat", "litellm_params": {"model": "openai/second", metric: 100}},
+        ]
+
+        with (
+            patch(
+                "litellm.router_strategy.simple_shuffle.random.choice",
+            ) as uniform_pick,
+            patch(
+                "litellm.router_strategy.simple_shuffle.random.choices",
+                return_value=[1],
+            ) as weighted_pick,
+        ):
+            simple_shuffle(_ROUTER_STUB, deployments, "chat")
+
+            assert weighted_pick.call_count == 1, (
+                f"Should use weighted pick — {metric} exists on second deployment"
+            )
+            assert uniform_pick.call_count == 0


### PR DESCRIPTION
## Relevant issues

Fixes #33676

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Before the fix, `GET /metrics` returns a 307 redirect to `/metrics/`. After the fix it returns 200 directly.

Root cause: `app.mount("/metrics", metrics_app)` in Starlette only serves the ASGI app at the trailing-slash path `/metrics/`, so any request to `/metrics` (no slash) gets a 307. The fix mounts at `/metrics/` and adds an explicit `add_route("/metrics", ...)` so both paths serve 200 directly.

## Type

🐛 Bug Fix

## Changes

- `litellm/integrations/prometheus.py`: changed `app.mount("/metrics", metrics_app)` to `app.mount("/metrics/", metrics_app)` and added `app.add_route("/metrics", ...)` so `GET /metrics` is served directly without a 307 redirect
- `tests/test_litellm/integrations/test_prometheus_metrics_endpoint.py`: 5 new mock-only unit tests covering the pre-fix 307 behaviour, 200 on `/metrics` after fix, no 3xx redirect, `/metrics/` still works, and response body is present

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
