### PR TITLE
fix(meta): normalize generic image data-URL mime types for muse-spark vision requests

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -2,6 +2,7 @@
 Common utility functions used for translating messages across providers
 """
 
+import base64
 import io
 import json
 import mimetypes
@@ -31,6 +32,7 @@ from litellm.types.llms.openai import (
     ChatCompletionResponseMessage,
     ChatCompletionToolParam,
     ChatCompletionUserMessage,
+    OpenAIMessageContentListBlock,
 )
 from litellm.types.utils import (
     Choices,
@@ -1202,6 +1204,86 @@ def infer_content_type_from_url_and_content(
 
     # If all fallbacks failed, raise error
     raise ValueError(f"Unable to determine content type from URL: {url}. Response content-type: {current_content_type}")
+
+
+_GENERIC_DATA_URL_MIME_TYPES = frozenset({"", "binary/octet-stream", "application/octet-stream"})
+
+_SNIFFED_IMAGE_TYPE_TO_MIME_TYPE: Mapping[str, str] = {
+    "png": "image/png",
+    "jpeg": "image/jpeg",
+    "gif": "image/gif",
+    "webp": "image/webp",
+    "heic": "image/heic",
+}
+
+
+def _sniff_base64_image_mime_type(base64_payload: str) -> str | None:
+    from litellm.litellm_core_utils.token_counter import get_image_type
+
+    prefix = base64_payload[:64]
+    aligned_prefix = prefix[: len(prefix) - len(prefix) % 4]
+    if not aligned_prefix:
+        return None
+    try:
+        decoded_prefix = base64.b64decode(aligned_prefix)
+    except ValueError:
+        return None
+    sniffed_image_type = get_image_type(decoded_prefix)
+    if sniffed_image_type is None:
+        return None
+    return _SNIFFED_IMAGE_TYPE_TO_MIME_TYPE.get(sniffed_image_type)
+
+
+def normalize_image_data_url_mime_type(url: str) -> str:
+    if not url.startswith("data:") or ";base64," not in url:
+        return url
+    header, payload = url.split(";base64,", 1)
+    declared_mime_type = header[len("data:") :]
+    if declared_mime_type.lower() not in _GENERIC_DATA_URL_MIME_TYPES:
+        return url
+    sniffed_mime_type = _sniff_base64_image_mime_type(payload)
+    if sniffed_mime_type is None:
+        return url
+    return f"data:{sniffed_mime_type};base64,{payload}"
+
+
+def _normalize_image_mime_type_in_content_item(
+    content_item: OpenAIMessageContentListBlock,
+) -> OpenAIMessageContentListBlock:
+    if content_item["type"] != "image_url":
+        return content_item
+    image_url = content_item.get("image_url")
+    if isinstance(image_url, str):
+        normalized_item = content_item.copy()
+        normalized_item["image_url"] = normalize_image_data_url_mime_type(image_url)
+        return normalized_item
+    if not isinstance(image_url, dict) or "url" not in image_url:
+        return content_item
+    url = image_url["url"]
+    if not isinstance(url, str):
+        return content_item
+    normalized_image_url = image_url.copy()
+    normalized_image_url["url"] = normalize_image_data_url_mime_type(url)
+    normalized_item = content_item.copy()
+    normalized_item["image_url"] = normalized_image_url
+    return normalized_item
+
+
+def _normalize_image_mime_types_in_message(message: AllMessageValues) -> AllMessageValues:
+    if message["role"] != "user":
+        return message
+    content = message.get("content")
+    if not isinstance(content, list):
+        return message
+    normalized_message = message.copy()
+    normalized_message["content"] = [_normalize_image_mime_type_in_content_item(item) for item in content]
+    return normalized_message
+
+
+def normalize_image_data_url_mime_types_in_messages(
+    messages: list[AllMessageValues],
+) -> list[AllMessageValues]:
+    return [_normalize_image_mime_types_in_message(message) for message in messages]
 
 
 def get_tool_call_names(tools: List[ChatCompletionToolParam]) -> List[str]:

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1250,7 +1250,7 @@ def normalize_image_data_url_mime_type(url: str) -> str:
 def _normalize_image_mime_type_in_content_item(
     content_item: OpenAIMessageContentListBlock,
 ) -> OpenAIMessageContentListBlock:
-    if content_item["type"] != "image_url":
+    if content_item.get("type") != "image_url":
         return content_item
     image_url = content_item.get("image_url")
     if isinstance(image_url, str):
@@ -1270,7 +1270,7 @@ def _normalize_image_mime_type_in_content_item(
 
 
 def _normalize_image_mime_types_in_message(message: AllMessageValues) -> AllMessageValues:
-    if message["role"] != "user":
+    if message.get("role") != "user":
         return message
     content = message.get("content")
     if not isinstance(content, list):

--- a/litellm/llms/openai_like/dynamic_config.py
+++ b/litellm/llms/openai_like/dynamic_config.py
@@ -7,6 +7,7 @@ from typing import Any, Coroutine, List, Literal, Optional, Tuple, Union, overlo
 from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     handle_messages_with_content_list_to_str_conversion,
+    normalize_image_data_url_mime_types_in_messages,
 )
 from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
 from litellm.llms.openai_like.chat.transformation import OpenAILikeChatConfig
@@ -44,6 +45,9 @@ def create_config_class(provider: SimpleProviderConfig):
             # Handle content list to string conversion if configured
             if provider.special_handling.get("convert_content_list_to_string"):
                 messages = handle_messages_with_content_list_to_str_conversion(messages)
+
+            if provider.special_handling.get("normalize_image_mime_type"):
+                messages = normalize_image_data_url_mime_types_in_messages(messages)
 
             if is_async:
                 return super()._transform_messages(messages=messages, model=model, is_async=True)

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -173,7 +173,10 @@
     "api_key_env": "META_API_KEY",
     "api_base_env": "META_API_BASE",
     "base_class": "openai_gpt",
-    "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/messages"]
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/messages"],
+    "special_handling": {
+      "normalize_image_mime_type": true
+    }
   },
   "pinstripes": {
     "base_url": "https://pinstripes.io/v1",

--- a/tests/test_litellm/llms/openai_like/test_meta_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_meta_provider.py
@@ -275,6 +275,38 @@ class TestMetaImageMimeNormalization:
         out = asyncio.run(cfg._transform_messages(messages=messages, model="muse-spark-1.1", is_async=True))
         assert out[0]["content"][0]["image_url"]["url"] == f"data:image/png;base64,{PNG_BASE64}"
 
+    def test_content_item_without_type_passthrough(self):
+        cfg = litellm.ProviderConfigManager.get_provider_chat_config(
+            model="muse-spark-1.1", provider=litellm.LlmProviders.META
+        )
+        assert cfg is not None
+        out = cfg.transform_request(
+            model="muse-spark-1.1",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"text": "hi"},
+                        {"type": "image_url", "image_url": {"url": f"data:binary/octet-stream;base64,{PNG_BASE64}"}},
+                    ],
+                }
+            ],
+            optional_params={},
+            litellm_params={},
+            headers={},
+        )
+        content = out["messages"][0]["content"]
+        assert content[0] == {"text": "hi"}
+        assert content[1]["image_url"]["url"] == f"data:image/png;base64,{PNG_BASE64}"
+
+    def test_message_without_role_passthrough(self):
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            normalize_image_data_url_mime_types_in_messages,
+        )
+
+        messages = [{"content": [{"type": "text", "text": "hi"}]}]
+        assert normalize_image_data_url_mime_types_in_messages(messages) == messages
+
     def test_string_content_passthrough(self):
         cfg = litellm.ProviderConfigManager.get_provider_chat_config(
             model="muse-spark-1.1", provider=litellm.LlmProviders.META

--- a/tests/test_litellm/llms/openai_like/test_meta_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_meta_provider.py
@@ -2,6 +2,9 @@
 Tests for the Meta Model API (Muse Spark) provider configuration and integration.
 """
 
+import asyncio
+import base64
+
 import litellm
 
 
@@ -190,6 +193,101 @@ class TestMetaAnthropicMessages:
         )
         assert headers["authorization"] == "Bearer sk-env-key"
         assert headers["anthropic-version"] == "2023-06-01"
+
+
+PNG_BASE64 = base64.b64encode(b"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a" + b"\x00" * 32).decode()
+JPEG_BASE64 = base64.b64encode(b"\xff\xd8\xff\xe0" + b"\x00" * 32).decode()
+
+
+def _transform_image_url_through_provider(url: str, provider: litellm.LlmProviders) -> str:
+    cfg = litellm.ProviderConfigManager.get_provider_chat_config(model="muse-spark-1.1", provider=provider)
+    assert cfg is not None
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is in this image?"},
+                {"type": "image_url", "image_url": {"url": url}},
+            ],
+        }
+    ]
+    out = cfg.transform_request(
+        model="muse-spark-1.1",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+    return out["messages"][0]["content"][1]["image_url"]["url"]
+
+
+class TestMetaImageMimeNormalization:
+    def test_meta_config_has_normalize_flag(self):
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        meta = JSONProviderRegistry.get("meta")
+        assert meta is not None
+        assert meta.special_handling.get("normalize_image_mime_type") is True
+
+    def test_octet_stream_png_rewritten(self):
+        url = _transform_image_url_through_provider(
+            f"data:binary/octet-stream;base64,{PNG_BASE64}", litellm.LlmProviders.META
+        )
+        assert url == f"data:image/png;base64,{PNG_BASE64}"
+
+    def test_application_octet_stream_jpeg_rewritten(self):
+        url = _transform_image_url_through_provider(
+            f"data:application/octet-stream;base64,{JPEG_BASE64}", litellm.LlmProviders.META
+        )
+        assert url == f"data:image/jpeg;base64,{JPEG_BASE64}"
+
+    def test_valid_mime_untouched(self):
+        original = f"data:image/jpeg;base64,{JPEG_BASE64}"
+        assert _transform_image_url_through_provider(original, litellm.LlmProviders.META) == original
+
+    def test_mismatched_but_valid_mime_untouched(self):
+        original = f"data:image/jpeg;base64,{PNG_BASE64}"
+        assert _transform_image_url_through_provider(original, litellm.LlmProviders.META) == original
+
+    def test_undecodable_payload_untouched(self):
+        original = "data:binary/octet-stream;base64,!!!not-base64!!!"
+        assert _transform_image_url_through_provider(original, litellm.LlmProviders.META) == original
+
+    def test_http_url_untouched(self):
+        original = "https://example.com/image.png"
+        assert _transform_image_url_through_provider(original, litellm.LlmProviders.META) == original
+
+    def test_provider_without_flag_untouched(self):
+        original = f"data:binary/octet-stream;base64,{PNG_BASE64}"
+        assert _transform_image_url_through_provider(original, litellm.LlmProviders.TENSORMESH) == original
+
+    def test_async_transform_rewrites_octet_stream_png(self):
+        cfg = litellm.ProviderConfigManager.get_provider_chat_config(
+            model="muse-spark-1.1", provider=litellm.LlmProviders.META
+        )
+        assert cfg is not None
+        messages = [
+            {
+                "role": "user",
+                "content": [{"type": "image_url", "image_url": {"url": f"data:binary/octet-stream;base64,{PNG_BASE64}"}}],
+            }
+        ]
+        out = asyncio.run(cfg._transform_messages(messages=messages, model="muse-spark-1.1", is_async=True))
+        assert out[0]["content"][0]["image_url"]["url"] == f"data:image/png;base64,{PNG_BASE64}"
+
+    def test_string_content_passthrough(self):
+        cfg = litellm.ProviderConfigManager.get_provider_chat_config(
+            model="muse-spark-1.1", provider=litellm.LlmProviders.META
+        )
+        assert cfg is not None
+        out = cfg.transform_request(
+            model="muse-spark-1.1",
+            messages=[{"role": "user", "content": "hello"}],
+            optional_params={},
+            litellm_params={},
+            headers={},
+        )
+        assert out["messages"][0]["content"] == "hello"
 
 
 class TestMuseSparkModelInfo:


### PR DESCRIPTION
## Relevant issues

Pylon #5974

## Linear ticket

Resolves LIT-4494

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

A customer sends multimodal requests to `meta/muse-spark-1.1` with image data URLs tagged `data:binary/octet-stream;base64,...`. LiteLLM forwarded that generic mime verbatim and Meta's API rejected the request with a 400

Both runs below hit the real Meta API through a live local proxy started with `python litellm/proxy/proxy_cli.py --config lit4494_config.yaml --port 41879`, where the config maps `model_name: muse-spark` to `model: meta/muse-spark-1.1` with a real `META_API_KEY`. The image is a real 64x64 solid red PNG, base64'd and deliberately tagged with the customer's generic mime

```bash
B64=$(base64 -i red.png | tr -d '\n')
curl -sS http://localhost:41879/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d "{\"model\":\"muse-spark\",\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"What is in this image? Answer in one short sentence.\"},{\"type\":\"image_url\",\"image_url\":{\"url\":\"data:binary/octet-stream;base64,${B64}\"}}]}]}" \
  -w "\nHTTP %{http_code}\n"
```

Before, at commit a7d01cb1ac (origin/litellm_internal_staging):

```
{"error":{"message":"litellm.BadRequestError: MetaException - unsupported media type at messages[0].content[1]: `binary/octet-stream`. Supported: JPEG, PNG, GIF, WebP, ICO.. Received Model Group=muse-spark\nAvailable Model Group Fallbacks=None","type":"invalid_request_error","param":null,"code":"400"}}
HTTP 400
```

After, at commit a5be3867ad (this PR), same curl:

```
{"id":"chatcmpl-2e015b70-2789-4390-9ab4-4c29ecf71238","created":1784310926,"model":"muse-spark","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"The image is a solid, bright red field.","role":"assistant","provider_specific_fields":{"refusal":null}},"provider_specific_fields":{}}],"usage":{"completion_tokens":361,"prompt_tokens":30,"total_tokens":391,"completion_tokens_details":{"reasoning_tokens":341},"prompt_tokens_details":{"cached_tokens":0}}}
HTTP 200
```

Also at a5be3867ad, the same image sent with an already-correct `data:image/png;base64,...` header still works, confirming valid mimes pass through untouched:

```
{"id":"chatcmpl-dea25feb-1339-47b6-99fc-6e29babd93bb","created":1784310936,"model":"muse-spark","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Red","role":"assistant","provider_specific_fields":{"refusal":null}},"provider_specific_fields":{}}],"usage":{"completion_tokens":533,"prompt_tokens":27,"total_tokens":560,"completion_tokens_details":{"reasoning_tokens":522},"prompt_tokens_details":{"cached_tokens":0}}}
HTTP 200
```

A review pass flagged that the new normalization helpers indexed `content_item["type"]` and `message["role"]` directly, so commit 033ba88d7e switches both lookups to `.get`. The crash was only reachable below litellm's top-level message validation: `validate_and_fix_openai_messages` (called for every provider in `litellm.completion`) defaults a missing `role` and rejects content items whose `type` is missing or unrecognized before any provider transform runs, so at the proxy boundary a type-less content item gets the same pre-existing validator error on every provider, meta included, both before and after this PR. Live proxy run at 033ba88d7e with `{"text": "hi"}` (no `type`) in the content list:

```
{"error":{"message":"litellm.APIConnectionError: APIConnectionError: MetaException - Invalid user message at index 0. Please ensure all user messages are valid OpenAI chat completion messages.. Received Model Group=muse-spark\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"500"}}
HTTP 500
```

The identical response comes back at a5be3867ad, so proxy behavior is unchanged. Below that boundary the defect was real: calling the meta chat config's `transform_request` directly with that same message raises `KeyError: 'type'` at a5be3867ad and returns the message cleanly at 033ba88d7e, with the type-less item passed through untouched and the sibling octet-stream image still rewritten to `data:image/png`. Two regression tests pin this down and fail without the `.get` fix

Re-run of the main proof at 033ba88d7e, same curl as above against a live proxy on port 52233 hitting the real Meta API, confirming the mime rewrite still works after the hardening:

```
{"id":"chatcmpl-26a9ef08-d040-4ab4-ab84-2375a6bed174","created":1784312273,"model":"muse-spark","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"The image is a solid field of bright red color.","role":"assistant","provider_specific_fields":{"refusal":null}},"provider_specific_fields":{}}],"usage":{"completion_tokens":335,"prompt_tokens":30,"total_tokens":365,"completion_tokens_details":{"reasoning_tokens":314},"prompt_tokens_details":{"cached_tokens":0}}}
HTTP 200
```

## Type

🐛 Bug Fix

## Changes

Meta's API rejects image data URLs whose mime header is generic (`binary/octet-stream` or `application/octet-stream`), which is what some client stacks emit when they base64 image bytes without sniffing the format. The meta provider is JSON-defined in `litellm/llms/openai_like/providers.json`, so this PR adds a `normalize_image_mime_type` special_handling flag to its entry and implements it in the shared JSON provider transform in `litellm/llms/openai_like/dynamic_config.py`, covering both the sync and async `_transform_messages` paths

The normalization itself lives in `litellm/litellm_core_utils/prompt_templates/common_utils.py` as shared helpers: when a user message carries an image data URL whose declared mime is missing or generic, the base64 payload's magic bytes are sniffed with the existing `get_image_type` helper (png, jpeg, gif, webp, heic) and the header is rewritten to the detected image mime. Data URLs that already declare a concrete mime pass through byte-identical, and http(s) URLs, undecodable payloads, and unrecognized formats are left untouched. Providers without the flag are unaffected

Regression tests in `tests/test_litellm/llms/openai_like/test_meta_provider.py` cover the rewrite for octet-stream PNG and JPEG payloads (sync and async), byte-identical passthrough for valid mimes, garbage payload passthrough, and flag gating via a provider without the flag. The rewrite tests fail on `origin/litellm_internal_staging` and pass with this change

Following review, the `type` and `role` lookups in the normalization helpers now use `.get` instead of direct indexing, matching the sibling transforms in `gpt_transformation.py`, so a content item without a `type` key or a message without a `role` key passes through untouched instead of raising `KeyError` when the transform is invoked outside litellm's top-level message validation. Two added regression tests cover a type-less content item through the full meta `transform_request` and a role-less message through `normalize_image_data_url_mime_types_in_messages`; both fail without the `.get` change

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

