### PR TITLE
fix(proxy): bill partial streamed spend when the client disconnects mid-stream

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -2649,8 +2649,8 @@ class ProxyBaseLLMRequestProcessing:
         response: Any,
         stream_completed: bool = False,
         client_disconnected: bool = False,
-        user_api_key_dict: Optional[UserAPIKeyAuth] = None,
-        proxy_logging_obj: Optional[ProxyLogging] = None,
+        user_api_key_dict: UserAPIKeyAuth | None = None,
+        proxy_logging_obj: ProxyLogging | None = None,
     ) -> None:
         with anyio.CancelScope(shield=True):
             should_record_client_disconnect = client_disconnected or (not stream_completed)

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -161,7 +161,7 @@ def _deferred_stream_logging_is_armed(request_data: dict) -> bool:
     )
 
 
-def _bill_partial_streamed_spend_on_disconnect(request_data: dict, response: object) -> None:
+async def _bill_partial_streamed_spend_on_disconnect(request_data: dict, response: object) -> None:
     """
     A client disconnect throws GeneratorExit/CancelledError into the streaming
     generator, so neither the success nor the failure logging callback fires
@@ -170,6 +170,10 @@ def _bill_partial_streamed_spend_on_disconnect(request_data: dict, response: obj
     response from the wrapper's collected chunks and dispatch success logging
     for it; dispatch_success_handlers dedups against a natural end-of-stream
     dispatch via has_dispatched_final_stream_success.
+
+    Awaited directly by the shielded cleanup rather than scheduled with
+    create_task: the client is already gone so the extra latency is harmless,
+    and an unrooted task could be garbage-collected before it bills.
     """
     if litellm.disable_streaming_logging is True:
         return
@@ -198,15 +202,16 @@ def _bill_partial_streamed_spend_on_disconnect(request_data: dict, response: obj
         return
     if partial_response is None:
         return
-    asyncio.create_task(
-        logging_obj.dispatch_success_handlers(
+    try:
+        await logging_obj.dispatch_success_handlers(
             partial_response,
             cache_hit=False,
             start_time=None,
             end_time=None,
             prefer_async_handlers=True,
         )
-    )
+    except Exception as e:  # noqa: BLE001  # partial billing is best-effort; never break stream teardown
+        verbose_proxy_logger.debug("Failed to dispatch disconnect billing event: %s", e)
 
 
 async def _cancel_pending_gather_tasks(tasks: list["asyncio.Task[Any]"]) -> None:
@@ -2647,7 +2652,7 @@ class ProxyBaseLLMRequestProcessing:
                 deferred_stream_logging_armed = _deferred_stream_logging_is_armed(request_data)
                 ProxyLogging._fire_deferred_stream_logging(request_data)
                 if not deferred_stream_logging_armed:
-                    _bill_partial_streamed_spend_on_disconnect(request_data, response)
+                    await _bill_partial_streamed_spend_on_disconnect(request_data, response)
 
             if hasattr(response, "aclose"):
                 try:

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -161,7 +161,7 @@ def _deferred_stream_logging_is_armed(request_data: dict) -> bool:
     )
 
 
-async def _bill_partial_streamed_spend_on_disconnect(request_data: dict, response: object) -> None:
+async def _bill_partial_streamed_spend_on_disconnect(request_data: dict, response: object) -> bool:
     """
     A client disconnect throws GeneratorExit/CancelledError into the streaming
     generator, so neither the success nor the failure logging callback fires
@@ -174,17 +174,26 @@ async def _bill_partial_streamed_spend_on_disconnect(request_data: dict, respons
     Awaited directly by the shielded cleanup rather than scheduled with
     create_task: the client is already gone so the extra latency is harmless,
     and an unrooted task could be garbage-collected before it bills.
+
+    Returns True when a disconnect-time success event owns the request's
+    max_parallel_requests slot release (one was dispatched here, or one had
+    already been dispatched for this stream), so the caller can skip the
+    explicit slot release and avoid a double release. Returns False when no
+    success event fired (logging disabled, nothing streamed, or assembly
+    failed) and the caller must release the slot itself.
     """
     if litellm.disable_streaming_logging is True:
-        return
+        return False
     logging_obj = request_data.get("litellm_logging_obj")
     if not isinstance(logging_obj, LiteLLMLoggingObj):
-        return
+        return False
     if logging_obj.model_call_details.get("has_dispatched_final_stream_success"):
-        return
+        # A natural end-of-stream success event already fired and released the
+        # slot; do not bill again, and let the caller skip the slot release.
+        return True
     chunks: object = getattr(response, "chunks", None)
     if not isinstance(chunks, list) or not chunks:
-        return
+        return False
     verbose_proxy_logger.debug(
         "Billing partial streamed spend for %s chunks after client disconnect, litellm_call_id=%s",
         len(chunks),
@@ -199,9 +208,9 @@ async def _bill_partial_streamed_spend_on_disconnect(request_data: dict, respons
         )
     except Exception as e:  # noqa: BLE001  # partial billing is best-effort; never break stream teardown
         verbose_proxy_logger.debug("Failed to assemble partial streamed response for disconnect billing: %s", e)
-        return
+        return False
     if partial_response is None:
-        return
+        return False
     try:
         await logging_obj.dispatch_success_handlers(
             partial_response,
@@ -212,6 +221,8 @@ async def _bill_partial_streamed_spend_on_disconnect(request_data: dict, respons
         )
     except Exception as e:  # noqa: BLE001  # partial billing is best-effort; never break stream teardown
         verbose_proxy_logger.debug("Failed to dispatch disconnect billing event: %s", e)
+        return False
+    return True
 
 
 async def _cancel_pending_gather_tasks(tasks: list["asyncio.Task[Any]"]) -> None:
@@ -2638,6 +2649,8 @@ class ProxyBaseLLMRequestProcessing:
         response: Any,
         stream_completed: bool = False,
         client_disconnected: bool = False,
+        user_api_key_dict: Optional[UserAPIKeyAuth] = None,
+        proxy_logging_obj: Optional[ProxyLogging] = None,
     ) -> None:
         with anyio.CancelScope(shield=True):
             should_record_client_disconnect = client_disconnected or (not stream_completed)
@@ -2651,8 +2664,26 @@ class ProxyBaseLLMRequestProcessing:
             if recorded_client_disconnect:
                 deferred_stream_logging_armed = _deferred_stream_logging_is_armed(request_data)
                 ProxyLogging._fire_deferred_stream_logging(request_data)
+                # A disconnect-time success event (the deferred-guardrail flush
+                # above, or the partial-spend billing below) releases the
+                # request's max_parallel_requests slot through the limiter's
+                # own success callback. Release the slot explicitly only when
+                # no such event fires, so exactly one release happens; two
+                # concurrent releases would race and double-decrement under the
+                # limiter's in-memory fallback.
+                success_event_owns_slot_release = deferred_stream_logging_armed
                 if not deferred_stream_logging_armed:
-                    await _bill_partial_streamed_spend_on_disconnect(request_data, response)
+                    success_event_owns_slot_release = await _bill_partial_streamed_spend_on_disconnect(
+                        request_data, response
+                    )
+                if (
+                    not success_event_owns_slot_release
+                    and proxy_logging_obj is not None
+                    and user_api_key_dict is not None
+                ):
+                    await proxy_logging_obj._arelease_max_parallel_requests_on_disconnect(
+                        user_api_key_dict, request_data
+                    )
 
             if hasattr(response, "aclose"):
                 try:
@@ -2741,12 +2772,13 @@ class ProxyBaseLLMRequestProcessing:
         except (asyncio.CancelledError, GeneratorExit):
             # Client disconnected mid-stream. CancelledError / GeneratorExit
             # are BaseException and bypass the success/failure logging
-            # callbacks that release the pre-call max_parallel_requests +1;
-            # release it here. This is the outermost generator Starlette closes
-            # on disconnect, so the nested iterator hook (which only sees
-            # GeneratorExit on GC) cannot own the refund.
+            # callbacks that release the pre-call max_parallel_requests +1.
+            # Flag the disconnect; the shielded cleanup in `finally` owns the
+            # slot release so it can coordinate with disconnect-time success
+            # billing and release exactly once. This is the outermost generator
+            # Starlette closes on disconnect, so the nested iterator hook (which
+            # only sees GeneratorExit on GC) cannot own the refund.
             if not stream_completed:
-                proxy_logging_obj._release_max_parallel_requests_on_disconnect(user_api_key_dict, request_data)
                 client_disconnected = True
             if not delivered_chunk:
                 from litellm.proxy.spend_tracking.budget_reservation import (
@@ -2789,6 +2821,8 @@ class ProxyBaseLLMRequestProcessing:
                 response=response,
                 stream_completed=stream_completed,
                 client_disconnected=client_disconnected,
+                user_api_key_dict=user_api_key_dict,
+                proxy_logging_obj=proxy_logging_obj,
             )
 
     @staticmethod

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -151,6 +151,64 @@ async def _record_streaming_client_disconnect_if_needed(
     return True
 
 
+def _deferred_stream_logging_is_armed(request_data: dict) -> bool:
+    logging_obj = request_data.get("litellm_logging_obj")
+    if logging_obj is None:
+        return False
+    return (
+        getattr(logging_obj, "_on_deferred_stream_complete", None) is not None
+        and getattr(logging_obj, "_deferred_stream_complete_args", None) is not None
+    )
+
+
+def _bill_partial_streamed_spend_on_disconnect(request_data: dict, response: object) -> None:
+    """
+    A client disconnect throws GeneratorExit/CancelledError into the streaming
+    generator, so neither the success nor the failure logging callback fires
+    and the chunks already streamed (plus any sub-call cost folded into the
+    logging object) would never reach spend tracking. Assemble the partial
+    response from the wrapper's collected chunks and dispatch success logging
+    for it; dispatch_success_handlers dedups against a natural end-of-stream
+    dispatch via has_dispatched_final_stream_success.
+    """
+    if litellm.disable_streaming_logging is True:
+        return
+    logging_obj = request_data.get("litellm_logging_obj")
+    if not isinstance(logging_obj, LiteLLMLoggingObj):
+        return
+    if logging_obj.model_call_details.get("has_dispatched_final_stream_success"):
+        return
+    chunks: object = getattr(response, "chunks", None)
+    if not isinstance(chunks, list) or not chunks:
+        return
+    verbose_proxy_logger.debug(
+        "Billing partial streamed spend for %s chunks after client disconnect, litellm_call_id=%s",
+        len(chunks),
+        request_data.get("litellm_call_id"),
+    )
+    messages: object = getattr(response, "messages", None)
+    try:
+        partial_response = litellm.stream_chunk_builder(
+            chunks=chunks,
+            messages=messages if isinstance(messages, list) else None,
+            logging_obj=logging_obj,
+        )
+    except Exception as e:  # noqa: BLE001  # partial billing is best-effort; never break stream teardown
+        verbose_proxy_logger.debug("Failed to assemble partial streamed response for disconnect billing: %s", e)
+        return
+    if partial_response is None:
+        return
+    asyncio.create_task(
+        logging_obj.dispatch_success_handlers(
+            partial_response,
+            cache_hit=False,
+            start_time=None,
+            end_time=None,
+            prefer_async_handlers=True,
+        )
+    )
+
+
 async def _cancel_pending_gather_tasks(tasks: list["asyncio.Task[Any]"]) -> None:
     pending_tasks = [task for task in tasks if not task.done()]
     for task in pending_tasks:
@@ -2586,7 +2644,10 @@ class ProxyBaseLLMRequestProcessing:
                     client_disconnected,
                 )
             if recorded_client_disconnect:
+                deferred_stream_logging_armed = _deferred_stream_logging_is_armed(request_data)
                 ProxyLogging._fire_deferred_stream_logging(request_data)
+                if not deferred_stream_logging_armed:
+                    _bill_partial_streamed_spend_on_disconnect(request_data, response)
 
             if hasattr(response, "aclose"):
                 try:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7376,12 +7376,13 @@ async def async_data_generator(
     except (asyncio.CancelledError, GeneratorExit):
         # Client disconnected mid-stream. CancelledError / GeneratorExit are
         # BaseException, so they bypass the success/failure logging callbacks
-        # that normally release the pre-call max_parallel_requests +1; release
-        # it here. This is the outermost generator Starlette closes on
+        # that normally release the pre-call max_parallel_requests +1. Flag the
+        # disconnect; the shielded cleanup in `finally` owns the slot release
+        # so it can coordinate with disconnect-time success billing and release
+        # exactly once. This is the outermost generator Starlette closes on
         # disconnect, so it fires reliably regardless of needs_iterator_wrap
         # (a nested iterator hook would only see GeneratorExit on GC).
         if not stream_completed:
-            proxy_logging_obj._release_max_parallel_requests_on_disconnect(user_api_key_dict, request_data)
             client_disconnected = True
         raise
     except Exception as e:
@@ -7427,6 +7428,8 @@ async def async_data_generator(
             response=response,
             stream_completed=stream_completed,
             client_disconnected=client_disconnected,
+            user_api_key_dict=user_api_key_dict,
+            proxy_logging_obj=proxy_logging_obj,
         )
 
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2583,41 +2583,30 @@ class ProxyLogging:
             logging_obj._deferred_stream_complete_args = None
             asyncio.create_task(_deferred_cb(*_args))
 
-    def _release_max_parallel_requests_on_disconnect(
+    async def _arelease_max_parallel_requests_on_disconnect(
         self,
         user_api_key_dict: UserAPIKeyAuth,
         request_data: dict | None = None,
     ) -> None:
         """
         Release the api-key max_parallel_requests slot when a streaming
-        response is cancelled mid-flight (client disconnect). Neither the
-        success nor failure logging callback fires on the resulting
-        CancelledError / GeneratorExit, so the pre-call +1 would otherwise
-        leak.
+        response is cancelled mid-flight (client disconnect) and no logging
+        callback fired for it. Neither the success nor failure callback runs on
+        the resulting CancelledError / GeneratorExit, so the pre-call +1 would
+        otherwise leak.
 
-        Must be called from the outermost streaming generator (the one
-        Starlette drives and closes on disconnect). A nested iterator-hook
-        generator only receives GeneratorExit when it is garbage collected,
-        which is non-deterministic, so the refund cannot live there.
-
-        Scheduled fire-and-forget (no await) because awaiting is not
-        permitted while unwinding a GeneratorExit.
+        Awaited from the shielded streaming cleanup rather than scheduled
+        fire-and-forget, so the caller can make it the single owner of the
+        release: when a disconnect-time success event does fire (partial-spend
+        billing or a deferred-guardrail flush), that event's own limiter
+        callback releases the slot and this is not called at all. Two
+        concurrent releases of the same acquisition would otherwise race and
+        double-decrement under the limiter's in-memory fallback.
         """
         limiter = self.get_proxy_hook("parallel_request_limiter")
         if not isinstance(limiter, _PROXY_MaxParallelRequestsHandler_v3):
             return
-        try:
-            asyncio.create_task(
-                limiter.async_release_max_parallel_requests_on_disconnect(user_api_key_dict, request_data)
-            )
-        except RuntimeError:
-            # No running event loop (e.g. interpreter/loop shutdown); the
-            # counter's window TTL will reclaim the slot.
-            verbose_proxy_logger.warning(
-                "parallel_request_limiter_v3: could not schedule "
-                "max_parallel_requests release on disconnect; no running "
-                "event loop. Slot will be reclaimed when its TTL expires"
-            )
+        await limiter.async_release_max_parallel_requests_on_disconnect(user_api_key_dict, request_data)
 
     def _init_response_taking_too_long_task(self, data: Optional[dict] = None):
         """

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2047,6 +2047,7 @@ class Router:
                     logging_obj=model_response.logging_obj,
                 )
                 self._async_generator = async_generator
+                self.chunks = model_response.chunks
                 # Preserve hidden params (including litellm_overhead_time_ms) from original response
                 if hasattr(model_response, "_hidden_params"):
                     self._hidden_params = model_response._hidden_params.copy()

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2047,7 +2047,9 @@ class Router:
                     logging_obj=model_response.logging_obj,
                 )
                 self._async_generator = async_generator
-                self.chunks = model_response.chunks
+                inner_chunks: object = getattr(model_response, "chunks", None)
+                if isinstance(inner_chunks, list):
+                    self.chunks = inner_chunks
                 # Preserve hidden params (including litellm_overhead_time_ms) from original response
                 if hasattr(model_response, "_hidden_params"):
                     self._hidden_params = model_response._hidden_params.copy()

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -4871,3 +4871,151 @@ class TestPreCallWithFallbacksOnLocalRateLimit:
                     },
                     call_type="acompletion",
                 )
+
+
+class _RecordingSuccessLogger(CustomLogger):
+    def __init__(self):
+        super().__init__()
+        self.success_events = []
+
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        self.success_events.append({"kwargs": kwargs, "response_obj": response_obj})
+
+
+class TestStreamingClientDisconnectBilling:
+    """
+    A client disconnect throws GeneratorExit into the proxy streaming
+    generator; neither the success nor failure logging callback fires from the
+    stream wrapper, so without disconnect-time finalization the chunks already
+    streamed (and any sub-call cost folded into the logging object) never
+    reach spend tracking.
+    """
+
+    async def _start_partial_stream(self):
+        response = await litellm.acompletion(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "tell me a story"}],
+            mock_response="The codename is AZURE-FALCON-42 and the story is long.",
+            stream=True,
+            api_key="test-key",
+        )
+        stream_iter = response.__aiter__()
+        await stream_iter.__anext__()
+        await stream_iter.__anext__()
+        return response
+
+    @pytest.mark.asyncio
+    async def test_disconnect_bills_partial_streamed_spend(self):
+        recorder = _RecordingSuccessLogger()
+        original_callbacks = litellm.callbacks
+        litellm.callbacks = [recorder]
+        try:
+            response = await self._start_partial_stream()
+            logging_obj = response.logging_obj
+            logging_obj.model_call_details["additional_response_cost"] = 0.002
+
+            await ProxyBaseLLMRequestProcessing._finalize_streaming_generator_cleanup(
+                request=None,
+                request_data={"litellm_logging_obj": logging_obj},
+                response=response,
+                stream_completed=False,
+                client_disconnected=True,
+            )
+
+            for _ in range(50):
+                if recorder.success_events:
+                    break
+                await asyncio.sleep(0.1)
+            await asyncio.sleep(0.5)
+        finally:
+            litellm.callbacks = original_callbacks
+
+        assert len(recorder.success_events) == 1
+        standard_logging_object = recorder.success_events[0]["kwargs"]["standard_logging_object"]
+        assert standard_logging_object["total_tokens"] > 0
+        assert standard_logging_object["response_cost"] >= 0.002
+
+    @pytest.mark.asyncio
+    async def test_completed_stream_does_not_double_bill_on_late_disconnect(self):
+        recorder = _RecordingSuccessLogger()
+        original_callbacks = litellm.callbacks
+        litellm.callbacks = [recorder]
+        try:
+            response = await litellm.acompletion(
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": "hi"}],
+                mock_response="hello there",
+                stream=True,
+                api_key="test-key",
+            )
+            async for _ in response:
+                pass
+
+            await ProxyBaseLLMRequestProcessing._finalize_streaming_generator_cleanup(
+                request=None,
+                request_data={"litellm_logging_obj": response.logging_obj},
+                response=response,
+                stream_completed=False,
+                client_disconnected=True,
+            )
+
+            for _ in range(50):
+                if recorder.success_events:
+                    break
+                await asyncio.sleep(0.1)
+            await asyncio.sleep(0.5)
+        finally:
+            litellm.callbacks = original_callbacks
+
+        assert len(recorder.success_events) == 1
+
+    @pytest.mark.asyncio
+    async def test_disconnect_bills_partial_spend_for_router_stream(self):
+        """
+        The router wraps streamed responses in FallbackStreamWrapper, whose
+        __anext__ bypasses the base class, so its own chunk list stays empty
+        unless it aliases the inner stream's chunks; without the alias the
+        disconnect path sees no chunks and bills nothing for router requests,
+        which is every proxy request.
+        """
+        router = litellm.Router(
+            model_list=[
+                {
+                    "model_name": "gpt-4o-mini",
+                    "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "test-key"},
+                }
+            ]
+        )
+        recorder = _RecordingSuccessLogger()
+        original_callbacks = litellm.callbacks
+        litellm.callbacks = [recorder]
+        try:
+            response = await router.acompletion(
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": "tell me a story"}],
+                mock_response="The codename is AZURE-FALCON-42 and the story is long.",
+                stream=True,
+            )
+            stream_iter = response.__aiter__()
+            await stream_iter.__anext__()
+            await stream_iter.__anext__()
+
+            await ProxyBaseLLMRequestProcessing._finalize_streaming_generator_cleanup(
+                request=None,
+                request_data={"litellm_logging_obj": response.logging_obj},
+                response=response,
+                stream_completed=False,
+                client_disconnected=True,
+            )
+
+            for _ in range(50):
+                if recorder.success_events:
+                    break
+                await asyncio.sleep(0.1)
+            await asyncio.sleep(0.5)
+        finally:
+            litellm.callbacks = original_callbacks
+
+        assert len(recorder.success_events) == 1
+        standard_logging_object = recorder.success_events[0]["kwargs"]["standard_logging_object"]
+        assert standard_logging_object["total_tokens"] > 0

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -17,6 +17,7 @@ from litellm.proxy.common_request_processing import (
     ProxyBaseLLMRequestProcessing,
     ProxyConfig,
     _await_llm_call_cancelling_on_disconnect,
+    _bill_partial_streamed_spend_on_disconnect,
     _buffer_first_chunk_honoring_disconnect,
     _cancel_llm_call_on_client_disconnect,
     _ClientDisconnectedBeforeFirstChunk,
@@ -5019,3 +5020,69 @@ class TestStreamingClientDisconnectBilling:
         assert len(recorder.success_events) == 1
         standard_logging_object = recorder.success_events[0]["kwargs"]["standard_logging_object"]
         assert standard_logging_object["total_tokens"] > 0
+
+    @pytest.mark.asyncio
+    async def test_disconnect_billing_does_not_double_release_slot(self):
+        """
+        The disconnect billing fires a success event whose limiter callback
+        already releases the max_parallel_requests slot. The shielded cleanup
+        must therefore NOT also release the slot explicitly; two releases of
+        the same acquisition race and double-decrement under the limiter's
+        in-memory fallback.
+        """
+        import types
+
+        original_callbacks = litellm.callbacks
+        litellm.callbacks = [_RecordingSuccessLogger()]
+        try:
+            response = await self._start_partial_stream()
+            proxy_logging_obj = types.SimpleNamespace(
+                _arelease_max_parallel_requests_on_disconnect=AsyncMock(),
+            )
+
+            billed = await _bill_partial_streamed_spend_on_disconnect(
+                {"litellm_logging_obj": response.logging_obj}, response
+            )
+            assert billed is True
+
+            await ProxyBaseLLMRequestProcessing._finalize_streaming_generator_cleanup(
+                request=None,
+                request_data={"litellm_logging_obj": response.logging_obj},
+                response=response,
+                stream_completed=False,
+                client_disconnected=True,
+                user_api_key_dict=MagicMock(),
+                proxy_logging_obj=proxy_logging_obj,
+            )
+        finally:
+            litellm.callbacks = original_callbacks
+
+        proxy_logging_obj._arelease_max_parallel_requests_on_disconnect.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_without_billable_chunks_releases_slot(self):
+        """
+        When there is nothing to bill (no chunks streamed), no success event
+        fires, so the slot would leak unless the cleanup releases it
+        explicitly. The explicit release must run exactly once in that case.
+        """
+        import types
+
+        response = await self._start_partial_stream()
+        # No chunks to assemble -> billing dispatches no success event.
+        empty_response = types.SimpleNamespace(chunks=[], messages=None)
+        proxy_logging_obj = types.SimpleNamespace(
+            _arelease_max_parallel_requests_on_disconnect=AsyncMock(),
+        )
+
+        await ProxyBaseLLMRequestProcessing._finalize_streaming_generator_cleanup(
+            request=None,
+            request_data={"litellm_logging_obj": response.logging_obj},
+            response=empty_response,
+            stream_completed=False,
+            client_disconnected=True,
+            user_api_key_dict=MagicMock(),
+            proxy_logging_obj=proxy_logging_obj,
+        )
+
+        proxy_logging_obj._arelease_max_parallel_requests_on_disconnect.assert_awaited_once()


### PR DESCRIPTION
## Relevant issues

Follow-up to the security review finding on #32438 ("Client disconnects bypass sub-call billing")

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

All runs against a live proxy (`python litellm/proxy/proxy_cli.py --config config.yaml --port 4245`) backed by a real Postgres, with real `gpt-5.5` calls costing real money. Key setup:

```bash
KEY=$(curl -s -X POST http://127.0.0.1:4245/key/generate \
  -H "Authorization: Bearer sk-litdisc-1234" -H "Content-Type: application/json" \
  -d '{"key_alias": "disconnect-verify"}' | jq -r .key)
```

### Before (base, staging a7d01cb1ac)

A streaming client that disconnects mid-stream pays nothing. The request streams real tokens, curl aborts partway, and no SpendLogs row is ever written:

```bash
curl -s -N --max-time 3 -X POST http://127.0.0.1:4245/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model": "gpt-5.5", "messages": [{"role": "user", "content": "Write a 3000 word story about a lighthouse keeper. Do not stop early."}], "stream": true, "max_tokens": 8000}'
# curl: exit 28 (timed out mid-transfer)
```

```text
 call_type | model | spend | prompt_tokens | completion_tokens | total_tokens
-----------+-------+-------+---------------+-------------------+--------------
(0 rows)

     key_alias     | spend
-------------------+-------
 disconnect-verify |     0
```

### After (commit b6a8582d0e)

Same curl, aborted after 261 streamed chunks (`--max-time 10`). The proxy bills exactly the partial delivered and attributes it to the key:

```text
  call_type  |     model      |  spend   | prompt_tokens | completion_tokens | total_tokens
-------------+----------------+----------+---------------+-------------------+--------------
 acompletion | openai/gpt-5.5 | 0.008045 |            25 |               264 |          289

     key_alias     |  spend
-------------------+----------
 disconnect-verify | 0.008045
```

A second run aborted before the first content token (`--max-time 3`, gpt-5.5 still in TTFT) bills just the prompt side:

```text
  call_type  |     model      |  spend   | prompt_tokens | completion_tokens | total_tokens
-------------+----------------+----------+---------------+-------------------+--------------
 acompletion | openai/gpt-5.5 | 0.000125 |            25 |                 0 |           25
```

A fully drained stream on the same proxy still bills exactly once (single row, no disconnect double-bill), pinned by the regression test as well

## Type

🐛 Bug Fix

## Changes

When a streaming client disconnects mid-stream, Starlette throws GeneratorExit/CancelledError into the proxy's streaming generator. Those are BaseExceptions, so neither the success nor the failure logging callback ever fires for the request; the code already acknowledges this (`_release_max_parallel_requests_on_disconnect` exists precisely to compensate for the leaked concurrency slot). The result is that every token streamed before the disconnect, plus any sub-call cost folded into the logging object (for example the RAG pipeline's vector search and rerank costs from #32438), never reaches SpendLogs, key spend, or budget enforcement. An authenticated caller can stream to 99% completion, disconnect before `[DONE]`, and pay nothing

The fix finalizes streamed spend at disconnect time in `_finalize_streaming_generator_cleanup`, the shielded cleanup that already runs on every disconnect and records the 499 metadata. After the disconnect is recorded, the new `_bill_partial_streamed_spend_on_disconnect` assembles a partial response from the stream wrapper's collected chunks via the existing `stream_chunk_builder` and dispatches success logging for it through `dispatch_success_handlers`. Cost flows through the normal `_response_cost_calculator`, so `additional_response_cost` (sub-call cost) is included, and the standard proxy spend tracking attributes the row to the key with the already-stamped `client_disconnected` metadata. Double billing is impossible by construction: a natural end-of-stream schedules its dispatch before the generator can observe `stream_completed`, and `dispatch_success_handlers` dedups assembled-stream dispatches via `has_dispatched_final_stream_success` whichever side runs first. When post-call guardrails have armed deferred stream logging, that existing path fires instead and the new helper stands down

Live verification surfaced a second gap this fix depends on: the router wraps streamed responses in `FallbackStreamWrapper`, whose `__anext__` bypasses the base `CustomStreamWrapper` iteration, so the wrapper's own `chunks` list stayed permanently empty and the disconnect path saw nothing to bill for router requests, which is every proxy request. The wrapper now aliases the inner stream's `chunks` list. Responses without a `chunks` attribute (raw passthrough generators) are skipped, and `litellm.disable_streaming_logging` is honored

This mirrors the intent of the existing `_record_partial_usage_for_failure`, which already recovers partial usage for streams that break with a provider error; client disconnect was the one abnormal termination with no billing path at all

Tests in `tests/test_litellm/proxy/test_common_request_processing.py`: a disconnect after two streamed chunks produces exactly one billing event carrying real usage plus a seeded `additional_response_cost`; a fully drained stream followed by a late disconnect cleanup still produces exactly one event; and a router-wrapped stream (the `FallbackStreamWrapper` case) bills on disconnect. The first and third fail on the unfixed code

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
