### PR TITLE
fix(streaming): keep think tags balanced for interleaved reasoning and exact-match the SSE done marker

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1033,7 +1033,7 @@ class CustomStreamWrapper:
             visible_content or not reasoning_content
         )
 
-    def _consume_pending_think_close_tag(self) -> Optional[str]:
+    def _consume_pending_think_close_tag(self) -> str | None:
         if (
             self.merge_reasoning_content_in_choices
             and self.sent_first_thinking_block

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -989,7 +989,7 @@ class CustomStreamWrapper:
                 )
 
             if _is_delta_empty:
-                model_response.choices[0].delta = Delta(content=None)  # ensure empty delta chunk returned
+                model_response.choices[0].delta = Delta(content=self._consume_pending_think_close_tag())
                 # get any function call arguments
                 model_response.choices[0].finish_reason = map_finish_reason(
                     finish_reason=self.received_finish_reason
@@ -1015,32 +1015,33 @@ class CustomStreamWrapper:
 
 
         """
-        if self.merge_reasoning_content_in_choices is True:
-            reasoning_content = getattr(model_response.choices[0].delta, "reasoning_content", None)
-            if reasoning_content:
-                if self.sent_first_thinking_block is False:
-                    # Ensure content is not None before concatenation
-                    if model_response.choices[0].delta.content is None:
-                        model_response.choices[0].delta.content = ""
-                    model_response.choices[0].delta.content += "<think>" + reasoning_content
-                    self.sent_first_thinking_block = True
-                elif (
-                    self.sent_first_thinking_block is True
-                    and hasattr(model_response.choices[0].delta, "reasoning_content")
-                    and model_response.choices[0].delta.reasoning_content
-                ):
-                    model_response.choices[0].delta.content = reasoning_content
-            elif (
-                self.sent_first_thinking_block is True
-                and not self.sent_last_thinking_block
-                and model_response.choices[0].delta.content
-            ):
-                model_response.choices[0].delta.content = "</think>" + (model_response.choices[0].delta.content or "")
-                self.sent_last_thinking_block = True
+        if self.merge_reasoning_content_in_choices is not True:
+            return
+        delta = model_response.choices[0].delta
+        reasoning_content: str = getattr(delta, "reasoning_content", None) or ""
+        visible_content: str = delta.content or ""
+        if hasattr(delta, "reasoning_content"):
+            del delta.reasoning_content
+        if not reasoning_content and not visible_content:
+            return
+        inside_think_block = self.sent_first_thinking_block and not self.sent_last_thinking_block
+        opening_tag = "<think>" if reasoning_content and not inside_think_block else ""
+        closing_tag = "</think>" if visible_content and (reasoning_content or inside_think_block) else ""
+        delta.content = opening_tag + reasoning_content + closing_tag + visible_content
+        self.sent_first_thinking_block = self.sent_first_thinking_block or bool(reasoning_content)
+        self.sent_last_thinking_block = self.sent_first_thinking_block and bool(
+            visible_content or not reasoning_content
+        )
 
-            if hasattr(model_response.choices[0].delta, "reasoning_content"):
-                del model_response.choices[0].delta.reasoning_content
-        return
+    def _consume_pending_think_close_tag(self) -> Optional[str]:
+        if (
+            self.merge_reasoning_content_in_choices
+            and self.sent_first_thinking_block
+            and not self.sent_last_thinking_block
+        ):
+            self.sent_last_thinking_block = True
+            return "</think>"
+        return None
 
     def _dispatch_provider_chunk(
         self,
@@ -1678,6 +1679,9 @@ class CustomStreamWrapper:
 
     def finish_reason_handler(self):
         model_response = self.model_response_creator()
+        closing_think_tag = self._consume_pending_think_close_tag()
+        if closing_think_tag is not None:
+            model_response.choices[0].delta.content = closing_think_tag
         _finish_reason = self.received_finish_reason or self.intermittent_finish_reason
         if _finish_reason is not None:
             model_response.choices[0].finish_reason = _finish_reason

--- a/litellm/llms/base_llm/base_model_iterator.py
+++ b/litellm/llms/base_llm/base_model_iterator.py
@@ -3,6 +3,7 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING, List, Optional, Union, cast
 
 import litellm
+from litellm._logging import verbose_logger
 
 if TYPE_CHECKING:
     import httpx
@@ -63,12 +64,26 @@ def convert_model_response_to_streaming(
         raise ValueError(f"Failed to convert ModelResponse to ModelResponseStream: {model_response}. Error: {e}")
 
 
+MAX_PARTIAL_JSON_LINE_CHARS = 1_000_000
+
+
+def _try_parse_json_object(payload: str) -> Optional[dict]:
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(parsed, dict):
+        return parsed
+    return None
+
+
 class BaseModelResponseIterator:
     def __init__(self, streaming_response, sync_stream: bool, json_mode: Optional[bool] = False):
         self.streaming_response = streaming_response
         self.response_iterator = self.streaming_response
         self.json_mode = json_mode
         self.http_response: Optional["httpx.Response"] = None
+        self.partial_json_line: str = ""
 
     async def aclose(self) -> None:
         """Close the upstream HTTP response so the provider connection is
@@ -108,10 +123,37 @@ class BaseModelResponseIterator:
             stripped_json_chunk = None
         return stripped_json_chunk
 
+    def _parse_payload_with_rejoin(self, payload: str) -> Optional[dict]:
+        rejoined_line = self.partial_json_line + payload
+        if self.partial_json_line:
+            rejoined_parsed = _try_parse_json_object(rejoined_line)
+            if rejoined_parsed is not None:
+                self.partial_json_line = ""
+                return rejoined_parsed
+        parsed = _try_parse_json_object(payload)
+        if parsed is not None:
+            if self.partial_json_line:
+                verbose_logger.debug("Dropping unparseable stream fragment: %s", self.partial_json_line[:1000])
+                self.partial_json_line = ""
+            return parsed
+        if self.partial_json_line:
+            if len(rejoined_line) > MAX_PARTIAL_JSON_LINE_CHARS:
+                verbose_logger.debug("Dropping unparseable stream fragment: %s", rejoined_line[:1000])
+                self.partial_json_line = ""
+            else:
+                self.partial_json_line = rejoined_line
+            return None
+        if payload.lstrip().startswith("{"):
+            self.partial_json_line = payload
+            return None
+        verbose_logger.debug("Dropping unparseable stream line: %s", payload[:1000])
+        return None
+
     def _handle_string_chunk(self, str_line: str) -> Union[GenericStreamingChunk, ModelResponseStream]:
         # chunk is a str at this point
-        stripped_json_chunk = BaseModelResponseIterator._string_to_dict_parser(str_line=str_line)
-        if "[DONE]" in str_line:
+        payload = litellm.CustomStreamWrapper._strip_sse_data_from_chunk(str_line) or ""
+        if payload.strip().startswith("[DONE]"):
+            self.partial_json_line = ""
             return GenericStreamingChunk(
                 text="",
                 is_finished=True,
@@ -120,17 +162,17 @@ class BaseModelResponseIterator:
                 index=0,
                 tool_use=None,
             )
-        elif stripped_json_chunk:
-            return self.chunk_parser(chunk=stripped_json_chunk)
-        else:
-            return GenericStreamingChunk(
-                text="",
-                is_finished=False,
-                finish_reason="",
-                usage=None,
-                index=0,
-                tool_use=None,
-            )
+        parsed_chunk = self._parse_payload_with_rejoin(payload=payload)
+        if parsed_chunk:
+            return self.chunk_parser(chunk=parsed_chunk)
+        return GenericStreamingChunk(
+            text="",
+            is_finished=False,
+            finish_reason="",
+            usage=None,
+            index=0,
+            tool_use=None,
+        )
 
     def __next__(self):
         while True:

--- a/litellm/llms/base_llm/base_model_iterator.py
+++ b/litellm/llms/base_llm/base_model_iterator.py
@@ -65,9 +65,10 @@ def convert_model_response_to_streaming(
 
 
 MAX_PARTIAL_JSON_LINE_CHARS = 1_000_000
+MAX_PARTIAL_JSON_LINE_FRAGMENTS = 64
 
 
-def _try_parse_json_object(payload: str) -> Optional[dict]:
+def _try_parse_json_object(payload: str) -> dict | None:
     try:
         parsed = json.loads(payload)
     except json.JSONDecodeError:
@@ -84,6 +85,7 @@ class BaseModelResponseIterator:
         self.json_mode = json_mode
         self.http_response: Optional["httpx.Response"] = None
         self.partial_json_line: str = ""
+        self.partial_json_line_fragments: int = 0
 
     async def aclose(self) -> None:
         """Close the upstream HTTP response so the provider connection is
@@ -123,28 +125,36 @@ class BaseModelResponseIterator:
             stripped_json_chunk = None
         return stripped_json_chunk
 
-    def _parse_payload_with_rejoin(self, payload: str) -> Optional[dict]:
-        rejoined_line = self.partial_json_line + payload
+    def _drop_partial_json_line(self) -> None:
         if self.partial_json_line:
+            verbose_logger.debug("Dropping unparseable stream fragment: %s", self.partial_json_line[:1000])
+        self.partial_json_line = ""
+        self.partial_json_line_fragments = 0
+
+    def _parse_payload_with_rejoin(self, payload: str) -> dict | None:
+        rejoined_line = self.partial_json_line + payload
+        if self.partial_json_line and "}" in payload:
             rejoined_parsed = _try_parse_json_object(rejoined_line)
             if rejoined_parsed is not None:
                 self.partial_json_line = ""
+                self.partial_json_line_fragments = 0
                 return rejoined_parsed
         parsed = _try_parse_json_object(payload)
         if parsed is not None:
-            if self.partial_json_line:
-                verbose_logger.debug("Dropping unparseable stream fragment: %s", self.partial_json_line[:1000])
-                self.partial_json_line = ""
+            self._drop_partial_json_line()
             return parsed
         if self.partial_json_line:
-            if len(rejoined_line) > MAX_PARTIAL_JSON_LINE_CHARS:
-                verbose_logger.debug("Dropping unparseable stream fragment: %s", rejoined_line[:1000])
-                self.partial_json_line = ""
-            else:
+            if (
+                len(rejoined_line) <= MAX_PARTIAL_JSON_LINE_CHARS
+                and self.partial_json_line_fragments < MAX_PARTIAL_JSON_LINE_FRAGMENTS
+            ):
                 self.partial_json_line = rejoined_line
-            return None
-        if payload.lstrip().startswith("{"):
+                self.partial_json_line_fragments += 1
+                return None
+            self._drop_partial_json_line()
+        if payload.lstrip().startswith("{") and len(payload) <= MAX_PARTIAL_JSON_LINE_CHARS:
             self.partial_json_line = payload
+            self.partial_json_line_fragments = 1
             return None
         verbose_logger.debug("Dropping unparseable stream line: %s", payload[:1000])
         return None
@@ -153,7 +163,7 @@ class BaseModelResponseIterator:
         # chunk is a str at this point
         payload = litellm.CustomStreamWrapper._strip_sse_data_from_chunk(str_line) or ""
         if payload.strip().startswith("[DONE]"):
-            self.partial_json_line = ""
+            self._drop_partial_json_line()
             return GenericStreamingChunk(
                 text="",
                 is_finished=True,

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -404,6 +404,134 @@ def test_multi_chunk_reasoning_and_content(
     assert initialized_custom_stream_wrapper.sent_last_thinking_block is True
 
 
+def _reasoning_delta_chunk(
+    content: Optional[str], reasoning_content: Optional[str]
+) -> ModelResponseStream:
+    return ModelResponseStream(
+        id="chunk-id",
+        object="chat.completion.chunk",
+        created=1741037890,
+        model="glm-5.2",
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(content=content, reasoning_content=reasoning_content),
+                finish_reason=None,
+            )
+        ],
+    )
+
+
+def _merge_reasoning_delta(
+    wrapper: CustomStreamWrapper,
+    content: Optional[str],
+    reasoning_content: Optional[str],
+) -> Optional[str]:
+    response = _reasoning_delta_chunk(content, reasoning_content)
+    wrapper._optional_combine_thinking_block_in_choices(response)
+    assert not hasattr(response.choices[0].delta, "reasoning_content")
+    return response.choices[0].delta.content
+
+
+def test_interleaved_reasoning_reopens_think_block(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    initialized_custom_stream_wrapper.merge_reasoning_content_in_choices = True
+    deltas_and_expected = [
+        ((None, "plan A"), "<think>plan A"),
+        ((None, " more"), " more"),
+        (("answer part 1", None), "</think>answer part 1"),
+        ((None, "plan B"), "<think>plan B"),
+        (("answer part 2", None), "</think>answer part 2"),
+    ]
+    merged = tuple(
+        _merge_reasoning_delta(initialized_custom_stream_wrapper, content, reasoning)
+        for (content, reasoning), _ in deltas_and_expected
+    )
+    assert merged == tuple(expected for _, expected in deltas_and_expected)
+    assert (
+        "".join(m for m in merged if m)
+        == "<think>plan A more</think>answer part 1<think>plan B</think>answer part 2"
+    )
+    assert initialized_custom_stream_wrapper.sent_last_thinking_block is True
+
+
+def test_mixed_reasoning_and_content_delta_preserves_content(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    initialized_custom_stream_wrapper.merge_reasoning_content_in_choices = True
+    first = _merge_reasoning_delta(
+        initialized_custom_stream_wrapper, None, "thinking"
+    )
+    mixed = _merge_reasoning_delta(
+        initialized_custom_stream_wrapper, "answer", " final thought"
+    )
+    assert first == "<think>thinking"
+    assert mixed == " final thought</think>answer"
+
+
+def test_mixed_first_delta_wraps_reasoning_and_keeps_content(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    initialized_custom_stream_wrapper.merge_reasoning_content_in_choices = True
+    merged = _merge_reasoning_delta(initialized_custom_stream_wrapper, "hi", "think")
+    assert merged == "<think>think</think>hi"
+    assert initialized_custom_stream_wrapper.sent_first_thinking_block is True
+    assert initialized_custom_stream_wrapper.sent_last_thinking_block is True
+
+
+def test_stream_end_mid_reasoning_emits_think_close(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    initialized_custom_stream_wrapper.merge_reasoning_content_in_choices = True
+    opening = _merge_reasoning_delta(
+        initialized_custom_stream_wrapper, None, "half-finished thought"
+    )
+    assert opening == "<think>half-finished thought"
+
+    initialized_custom_stream_wrapper.received_finish_reason = "stop"
+    final_chunk = ModelResponseStream(
+        id="chunk-id",
+        object="chat.completion.chunk",
+        created=1741037891,
+        model="glm-5.2",
+        choices=[
+            StreamingChoices(index=0, delta=Delta(content=None), finish_reason=None)
+        ],
+    )
+    result = initialized_custom_stream_wrapper.return_processed_chunk_logic(
+        completion_obj={"content": ""},
+        model_response=final_chunk,
+        response_obj={},
+    )
+    assert result is not None
+    assert result.choices[0].delta.content == "</think>"
+    assert result.choices[0].finish_reason == "stop"
+    assert initialized_custom_stream_wrapper.sent_last_thinking_block is True
+
+
+def test_finish_reason_handler_closes_open_think_block(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    initialized_custom_stream_wrapper.merge_reasoning_content_in_choices = True
+    _merge_reasoning_delta(initialized_custom_stream_wrapper, None, "dangling thought")
+
+    final_chunk = initialized_custom_stream_wrapper.finish_reason_handler()
+    assert final_chunk.choices[0].delta.content == "</think>"
+    assert final_chunk.choices[0].finish_reason == "stop"
+
+
+def test_finish_chunk_stays_empty_when_think_block_closed(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    initialized_custom_stream_wrapper.merge_reasoning_content_in_choices = True
+    _merge_reasoning_delta(initialized_custom_stream_wrapper, None, "reasoning")
+    _merge_reasoning_delta(initialized_custom_stream_wrapper, "answer", None)
+
+    final_chunk = initialized_custom_stream_wrapper.finish_reason_handler()
+    assert final_chunk.choices[0].delta.content is None
+
+
 def test_strip_sse_data_from_chunk():
     """Test the static method that strips 'data: ' prefix from SSE chunks"""
     # Test with string inputs

--- a/tests/test_litellm/llms/base_llm/test_base_model_iterator.py
+++ b/tests/test_litellm/llms/base_llm/test_base_model_iterator.py
@@ -256,3 +256,104 @@ async def test_aclose_is_noop_without_http_response():
     )
 
     await iterator.aclose()
+
+
+class ContentEchoIterator(BaseModelResponseIterator):
+    def chunk_parser(self, chunk: dict) -> GenericStreamingChunk:
+        choices = chunk.get("choices") or []
+        content = choices[0].get("delta", {}).get("content", "") if choices else ""
+        return GenericStreamingChunk(
+            text=content or "",
+            is_finished=False,
+            finish_reason="",
+            usage=None,
+            index=0,
+            tool_use=None,
+        )
+
+
+class TestDoneMarkerExactMatch:
+    def test_content_containing_done_substring_is_not_treated_as_stream_end(self):
+        lines = [
+            'data: {"id":"1","choices":[{"delta":{"content":"foo [DONE] bar"}}]}',
+            "data: [DONE]",
+        ]
+        iterator = ContentEchoIterator(streaming_response=iter(lines), sync_stream=True)
+
+        chunks = list(iterator)
+
+        assert len(chunks) == 2
+        assert chunks[0]["text"] == "foo [DONE] bar"
+        assert chunks[0]["is_finished"] is False
+        assert chunks[1]["is_finished"] is True
+        assert chunks[1]["finish_reason"] == "stop"
+
+    def test_done_line_variants_still_terminate(self):
+        for line in ["data: [DONE]", "data:[DONE]", "[DONE]", "data:  [DONE]"]:
+            iterator = ContentEchoIterator(
+                streaming_response=iter([line]), sync_stream=True
+            )
+            chunks = list(iterator)
+            assert len(chunks) == 1
+            assert chunks[0]["is_finished"] is True
+
+
+class TestUnicodeLineSeparatorSplitRecovery:
+    def test_line_split_at_unicode_separator_is_rejoined(self):
+        lines = [
+            'data: {"id":"1","choices":[{"delta":{"content":"foo',
+            'bar"}}]}',
+            "data: [DONE]",
+        ]
+        iterator = ContentEchoIterator(streaming_response=iter(lines), sync_stream=True)
+
+        chunks = list(iterator)
+
+        streamed_text = "".join(chunk["text"] for chunk in chunks)
+        assert streamed_text == "foobar"
+        assert all(chunk["is_finished"] is False for chunk in chunks[:-1])
+        assert chunks[-1]["is_finished"] is True
+
+    def test_line_split_into_three_fragments_is_rejoined(self):
+        lines = [
+            'data: {"id":"1","choices":[{"delta":{"content":"a',
+            "b",
+            'c"}}]}',
+            "data: [DONE]",
+        ]
+        iterator = ContentEchoIterator(streaming_response=iter(lines), sync_stream=True)
+
+        chunks = list(iterator)
+
+        assert "".join(chunk["text"] for chunk in chunks) == "abc"
+
+    def test_pending_fragment_does_not_corrupt_next_valid_line(self):
+        lines = [
+            'data: {"broken',
+            'data: {"id":"1","choices":[{"delta":{"content":"ok"}}]}',
+            "data: [DONE]",
+        ]
+        iterator = ContentEchoIterator(streaming_response=iter(lines), sync_stream=True)
+
+        chunks = list(iterator)
+
+        assert "".join(chunk["text"] for chunk in chunks) == "ok"
+        assert chunks[-1]["is_finished"] is True
+
+    @pytest.mark.asyncio
+    async def test_line_split_at_unicode_separator_is_rejoined_async(self):
+        async def async_gen():
+            for line in [
+                'data: {"id":"1","choices":[{"delta":{"content":"foo',
+                'bar"}}]}',
+                "data: [DONE]",
+            ]:
+                yield line
+
+        iterator = ContentEchoIterator(
+            streaming_response=async_gen(), sync_stream=False
+        )
+
+        chunks = [chunk async for chunk in iterator]
+
+        assert "".join(chunk["text"] for chunk in chunks) == "foobar"

--- a/tests/test_litellm/llms/base_llm/test_base_model_iterator.py
+++ b/tests/test_litellm/llms/base_llm/test_base_model_iterator.py
@@ -340,6 +340,61 @@ class TestUnicodeLineSeparatorSplitRecovery:
         assert "".join(chunk["text"] for chunk in chunks) == "ok"
         assert chunks[-1]["is_finished"] is True
 
+    def test_new_json_object_arriving_at_capacity_blowout_is_seeded(self):
+        from litellm.llms.base_llm.base_model_iterator import MAX_PARTIAL_JSON_LINE_CHARS
+
+        oversized_head = 'data: {"pad":"' + "x" * (MAX_PARTIAL_JSON_LINE_CHARS - 8)
+        lines = [
+            oversized_head,
+            'data: {"id":"1","choices":[{"delta":{"content":"after reset',
+            '"}}]}',
+            "data: [DONE]",
+        ]
+        iterator = ContentEchoIterator(streaming_response=iter(lines), sync_stream=True)
+
+        chunks = list(iterator)
+
+        assert "".join(chunk["text"] for chunk in chunks) == "after reset"
+        assert chunks[-1]["is_finished"] is True
+
+    def test_fragment_buffer_is_bounded_by_fragment_count(self):
+        from litellm.llms.base_llm.base_model_iterator import MAX_PARTIAL_JSON_LINE_FRAGMENTS
+
+        lines = (
+            ['data: {"choices":[{"delta":{"content":"runaway']
+            + ["a"] * MAX_PARTIAL_JSON_LINE_FRAGMENTS
+            + [
+                'z"}}]}',
+                'data: {"id":"1","choices":[{"delta":{"content":"ok"}}]}',
+                "data: [DONE]",
+            ]
+        )
+        iterator = ContentEchoIterator(streaming_response=iter(lines), sync_stream=True)
+
+        chunks = list(iterator)
+
+        streamed_text = "".join(chunk["text"] for chunk in chunks)
+        assert "runaway" not in streamed_text
+        assert streamed_text == "ok"
+
+    def test_oversized_object_start_is_not_buffered(self):
+        from litellm.llms.base_llm.base_model_iterator import MAX_PARTIAL_JSON_LINE_CHARS
+
+        oversized_start = 'data: {"choices":[{"delta":{"content":"huge' + "x" * MAX_PARTIAL_JSON_LINE_CHARS
+        lines = [
+            oversized_start,
+            '"}}]}',
+            'data: {"id":"1","choices":[{"delta":{"content":"ok"}}]}',
+            "data: [DONE]",
+        ]
+        iterator = ContentEchoIterator(streaming_response=iter(lines), sync_stream=True)
+
+        chunks = list(iterator)
+
+        streamed_text = "".join(chunk["text"] for chunk in chunks)
+        assert "huge" not in streamed_text
+        assert streamed_text == "ok"
+
     @pytest.mark.asyncio
     async def test_line_split_at_unicode_separator_is_rejoined_async(self):
         async def async_gen():


### PR DESCRIPTION
## Relevant issues

The done-marker portion of this fix was independently proposed by the community in #29262

## Linear ticket

Resolves LIT-4213

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The customer-triggering stream shape (GLM 5.2 on Cloudflare Workers AI emitting interleaved reasoning between tool calls, with unescaped U+2028 inside SSE JSON) needs Cloudflare Workers AI credentials that this environment does not have, so the before repro is pinned by the new unit regressions and the after behavior is proven live against real provider APIs

Before, at base commit 00e0dd1bc1 (fix reverted, new tests only): 9 of the 12 new regression tests fail, reproducing every mechanism (raw reasoning leaked into visible content after the first `</think>`, mixed reasoning+content deltas losing their content, missing `</think>` at stream end, [DONE]-as-substring truncation, split-line fragment drops)

```
FAILED tests/test_litellm/llms/base_llm/test_base_model_iterator.py::TestUnicodeLineSeparatorSplitRecovery::test_line_split_at_unicode_separator_is_rejoined_async
FAILED tests/test_litellm/llms/base_llm/test_base_model_iterator.py::TestUnicodeLineSeparatorSplitRecovery::test_line_split_into_three_fragments_is_rejoined
FAILED tests/test_litellm/litellm_core_utils/test_streaming_handler.py::test_mixed_first_delta_wraps_reasoning_and_keeps_content
FAILED tests/test_litellm/litellm_core_utils/test_streaming_handler.py::test_mixed_reasoning_and_content_delta_preserves_content
FAILED tests/test_litellm/litellm_core_utils/test_streaming_handler.py::test_stream_end_mid_reasoning_emits_think_close
9 failed, 3 passed in 0.46s
```

After, live at fix commit 7ce21e5656, proxy booted with this config on port 52731

```yaml
model_list:
  - model_name: gemini-reasoner
    litellm_params:
      model: gemini/gemini-3.5-flash
      merge_reasoning_content_in_choices: true
  - model_name: openai-compat
    litellm_params:
      model: hosted_vllm/gpt-5.6
      api_base: https://api.openai.com/v1
      api_key: os.environ/OPENAI_API_KEY

litellm_settings:
  drop_params: true

general_settings:
  master_key: sk-1234
```

```bash
.venv/bin/python litellm/proxy/proxy_cli.py --config /tmp/lit4213_proxy_config.yaml --port 52731
```

Real Gemini reasoning stream through the merge path: every reasoning span is tagged, `</think>` lands exactly at the reasoning-to-content transition, and no `reasoning_content` leaks into untagged content

```bash
curl -N -s http://localhost:52731/v1/chat/completions -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
  -d '{"model":"gemini-reasoner","stream":true,"reasoning_effort":"high","messages":[{"role":"user","content":"Prove there are infinitely many primes, in two sentences. Think carefully first."}]}' | cut -c1-400
```

```
data: {"id":"KW1aaubQGeiv1MkPm5O82Qg","object":"chat.completion.chunk","created":1784311084,"model":"gemini-reasoner","choices":[{"index":0,"delta":{"role":"assistant","content":"<think>**Defining the Task**\n\nI've got the task defined. My primary goal is to prove the infinitude of primes, restricted to a concise two-sentence response. ...

data: {"id":"KW1aaubQGeiv1MkPm5O82Qg","object":"chat.completion.chunk","created":1784311084,"model":"gemini-reasoner","choices":[{"index":0,"delta":{"content":"**Refining the Approach**\n\nI'm now refining the proof outline, selecting Euclid's method for its conciseness. ...

data: {"id":"KW1aaubQGeiv1MkPm5O82Qg","object":"chat.completion.chunk","created":1784311084,"model":"gemini-reasoner","choices":[{"index":0,"delta":{"content":"</think>Suppose there are only finitely many primes, $p_1, p_2, \\dots, p"}}]}

data: {"id":"KW1aaubQGeiv1MkPm5O82Qg","object":"chat.completion.chunk","created":1784311084,"model":"gemini-reasoner","choices":[{"index":0,"delta":{"content":"_n$, and define $N = (p_1 \\cdot p_2 \\cdots p_n) +"}}]}
...
data: {"id":"KW1aaubQGeiv1MkPm5O82Qg","object":"chat.completion.chunk","created":1784311084,"model":"gemini-reasoner","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}

data: [DONE]
```

Same result with tools in the request: `<think>` opens, `</think>` closes before the visible text, then the `tool_calls` delta and `finish_reason":"tool_calls"` follow untouched

Real OpenAI stream through `BaseModelResponseIterator` (the same `llm_http_handler` path the `cloudflare/` provider uses) with literal `[DONE]` text in the model output: the stream is not truncated and terminates only on the real `data: [DONE]` line

```bash
curl -N -s http://localhost:52731/v1/chat/completions -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
  -d '{"model":"openai-compat","stream":true,"messages":[{"role":"user","content":"Output exactly this line: alpha [DONE] beta [DONE] gamma. Then on a second line write: stream survived."}]}' | tail -6
```

```
data: {"id":"chatcmpl-E2hJuQ1Bt9Fh1diVeLXWT5D3kw8Rg","object":"chat.completion.chunk","created":1784311886,"model":"openai-compat","choices":[{"index":0,"delta":{"content":" gamma"}}]}
data: {"id":"chatcmpl-E2hJuQ1Bt9Fh1diVeLXWT5D3kw8Rg","object":"chat.completion.chunk","created":1784311886,"model":"openai-compat","choices":[{"index":0,"delta":{"content":".\n"}}]}
data: {"id":"chatcmpl-E2hJuQ1Bt9Fh1diVeLXWT5D3kw8Rg","object":"chat.completion.chunk","created":1784311886,"model":"openai-compat","choices":[{"index":0,"delta":{"content":"stream"}}]}
data: {"id":"chatcmpl-E2hJuQ1Bt9Fh1diVeLXWT5D3kw8Rg","object":"chat.completion.chunk","created":1784311886,"model":"openai-compat","choices":[{"index":0,"delta":{"content":" survived"}}]}
data: {"id":"chatcmpl-E2hJuQ1Bt9Fh1diVeLXWT5D3kw8Rg","object":"chat.completion.chunk","created":1784311886,"model":"openai-compat","choices":[{"index":0,"delta":{"content":"."}}]}
data: {"id":"chatcmpl-E2hJuQ1Bt9Fh1diVeLXWT5D3kw8Rg","object":"chat.completion.chunk","created":1784311886,"model":"openai-compat","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
```

A live before run of the truncation is not showable on OpenAI because its tokenizer splits `[DONE]` across chunks so the old substring check never sees it in one SSE line; Cloudflare batches larger text spans per line, which is where the substring match fired

## Type

🐛 Bug Fix

## Changes

Investigation outcome for the customer report of garbled output from GLM 5.2 on Cloudflare Workers AI after long agentic sessions: the sudden stop after ~1.5h reproduces against Cloudflare directly, so that part is provider side and out of scope; the garbling only reproduces through LiteLLM and is fixed here

`CustomStreamWrapper._optional_combine_thinking_block_in_choices` (the `merge_reasoning_content_in_choices` feature) was a one-shot state machine. Once the first `</think>` was emitted it never reset, so any later reasoning delta was written raw into visible `content` with no `<think>` reopen; GLM 5.2 interleaves reasoning between tool calls inside one response, so longer agentic turns dumped chain of thought into the answer, which is exactly the reported garble. A delta carrying both `content` and `reasoning_content` also had its content overwritten by the reasoning, silently losing text, and a stream that ended mid-reasoning never emitted the closing `</think>`. The method is now a real state machine: it reopens `<think>` after a closed block, preserves content in mixed deltas (`reasoning</think>content`), and a new `_consume_pending_think_close_tag` emits the dangling `</think>` on the final chunk in both terminal paths (empty finish-reason delta and `finish_reason_handler`). Single-block streams produce byte-identical output to before

`BaseModelResponseIterator._handle_string_chunk` treated any line containing the substring `[DONE]` as end of stream, so model content containing that literal text truncated the response mid-stream. Termination now requires the SSE data payload itself to start with `[DONE]`, matching the OpenAI SDK's semantics

The same method silently swallowed any line that failed JSON parsing. httpx's `aiter_lines` splits on the full `str.splitlines()` character set, and U+2028, U+2029 and NEL are legal unescaped inside JSON strings, so a provider emitting them raw (Cloudflare GLM does) had its data line split into two invalid fragments that both vanished, dropping text mid-stream. The iterator now buffers a fragment that looks like a truncated JSON object and rejoins it with following fragments, recovering the surrounding text; the separator character itself is consumed by httpx upstream and cannot be reconstructed at this layer. Genuinely unparseable lines are logged at debug level instead of disappearing without a trace, and a fragment buffer cap prevents unbounded growth on pathological streams

Regression tests cover every mechanism: interleaved reasoning yields balanced tags with zero leakage, mixed deltas keep their content, mid-reasoning stream end still closes the tag, the closed-block finish chunk stays empty, `[DONE]` inside JSON content does not terminate, real done-line variants still terminate, and split lines (two and three fragments, sync and async) are rejoined without corrupting subsequent valid lines

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
