### PR TITLE
fix(azure_ai): recognize real Search doc endpoints so teams can read/write via passthrough

### DIFF
--- a/litellm/llms/azure_ai/vector_stores/transformation.py
+++ b/litellm/llms/azure_ai/vector_stores/transformation.py
@@ -38,8 +38,8 @@ class AzureAIVectorStoreConfig(BaseVectorStoreConfig, BaseAzureLLM):
 
     def get_vector_store_endpoints_by_type(self) -> VectorStoreIndexEndpoints:
         return {
-            "read": [("GET", "/docs/search"), ("POST", "/docs/search")],
-            "write": [("PUT", "/docs")],
+            "read": [("GET", "/indexes/"), ("POST", "/docs/search")],
+            "write": [("POST", "/docs/index")],
         }
 
     def get_auth_credentials(self, litellm_params: dict) -> BaseVectorStoreAuthCredentials:

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
@@ -2840,3 +2840,95 @@ class TestUpdateVectorStoreAccessControlAndRedaction:
         params = response["vector_store"]["litellm_params"]
         assert params["api_key"] == REDACTED_BY_LITELM_STRING
         assert params["api_base"] == "https://api.openai.com/v1"
+
+
+class TestAzureAIDocumentWritePassthroughPermission:
+    """Regression tests for the Azure AI Search passthrough write mapping.
+
+    Azure's batch document write/merge/delete endpoint is
+    ``POST /indexes/{name}/docs/index``. A non-admin team holding a ``write``
+    grant on the index must be allowed to call it, while index lifecycle
+    (create / update / delete the index itself) stays proxy-admin only.
+
+    These exercise the real ``AzureAIVectorStoreConfig`` endpoint map on
+    purpose (no mocked provider config), so reverting the map to the old
+    ``("PUT", "/docs")`` entry makes ``test_team_with_write_grant_can_upload``
+    fail.
+    """
+
+    INDEX = "my-index"
+
+    def _request(self, method: str, path: str) -> MagicMock:
+        request = MagicMock(spec=Request)
+        request.method = method
+        request.url.path = path
+        return request
+
+    def _team_member(self, permissions: list) -> MagicMock:
+        user = MagicMock(spec=UserAPIKeyAuth)
+        user.user_role = None
+        user.metadata = {"allowed_vector_store_indexes": [{"index_name": self.INDEX, "index_permissions": permissions}]}
+        user.team_metadata = None
+        return user
+
+    def test_team_with_write_grant_can_upload(self):
+        result = is_allowed_to_call_vector_store_endpoint(
+            provider=LlmProviders.AZURE_AI,
+            index_name=self.INDEX,
+            request=self._request("POST", f"/azure_ai/indexes/{self.INDEX}/docs/index"),
+            user_api_key_dict=self._team_member(["read", "write"]),
+        )
+        assert result is True
+
+    def test_team_without_write_grant_cannot_upload(self):
+        with pytest.raises(HTTPException) as exc_info:
+            is_allowed_to_call_vector_store_endpoint(
+                provider=LlmProviders.AZURE_AI,
+                index_name=self.INDEX,
+                request=self._request("POST", f"/azure_ai/indexes/{self.INDEX}/docs/index"),
+                user_api_key_dict=self._team_member(["read"]),
+            )
+        assert exc_info.value.status_code == 403
+
+    def test_team_with_read_grant_can_search(self):
+        result = is_allowed_to_call_vector_store_endpoint(
+            provider=LlmProviders.AZURE_AI,
+            index_name=self.INDEX,
+            request=self._request("POST", f"/azure_ai/indexes/{self.INDEX}/docs/search"),
+            user_api_key_dict=self._team_member(["read"]),
+        )
+        assert result is True
+
+    def test_team_with_read_grant_can_get_index_details(self):
+        result = is_allowed_to_call_vector_store_endpoint(
+            provider=LlmProviders.AZURE_AI,
+            index_name=self.INDEX,
+            request=self._request("GET", f"/azure_ai/indexes/{self.INDEX}"),
+            user_api_key_dict=self._team_member(["read"]),
+        )
+        assert result is True
+
+    def test_team_without_read_grant_cannot_get_index_details(self):
+        with pytest.raises(HTTPException) as exc_info:
+            is_allowed_to_call_vector_store_endpoint(
+                provider=LlmProviders.AZURE_AI,
+                index_name=self.INDEX,
+                request=self._request("GET", f"/azure_ai/indexes/{self.INDEX}"),
+                user_api_key_dict=self._team_member(["write"]),
+            )
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.parametrize(
+        "method, operation",
+        [("PUT", "update"), ("DELETE", "delete")],
+    )
+    def test_team_cannot_manage_index_lifecycle_even_with_write_grant(self, method, operation):
+        with pytest.raises(HTTPException) as exc_info:
+            is_allowed_to_call_vector_store_endpoint(
+                provider=LlmProviders.AZURE_AI,
+                index_name=self.INDEX,
+                request=self._request(method, f"/azure_ai/indexes/{self.INDEX}?api-version=2024-07-01"),
+                user_api_key_dict=self._team_member(["read", "write"]),
+            )
+        assert exc_info.value.status_code == 403
+        assert f"Only proxy admins can {operation}" in exc_info.value.detail


### PR DESCRIPTION
## Relevant issues

Non-admin teams cannot upload documents to, or read the details of, an Azure AI Search index through the passthrough, even when an admin has granted them access

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The bug is in how the Azure passthrough classifies a request as read vs write. `is_allowed_to_call_vector_store_endpoint` matches the incoming route against the provider's read/write endpoint lists, and a route matching neither resolves to `permission_type = None`, which raises a 403 before the caller's `allowed_vector_store_indexes` grant is ever consulted

Before, on a deployed proxy running the current code, a non-admin team token that holds a read+write grant on the index is refused on both document upload and get-index-details

```
# team document upload -> POST /azure_ai/indexes/{idx}/docs/index
{"detail":"User does not have permission to call vector store endpoint <idx>. Ask your administrator to add the necessary permissions to your API key/Team."}

# team get index details -> GET /azure_ai/indexes/{idx}
{"detail":"User does not have permission to call vector store endpoint <idx>. Ask your administrator to add the necessary permissions to your API key/Team."}
```

The reproduction is that `POST /docs/index` (Azure's real batch write endpoint) was not in the write list, which held only `PUT /docs` (an endpoint Azure does not use), and `GET /indexes/{name}` (get details) was not covered by the read list, which held only `/docs/search`

After this change (`39794dac6a`), the same team token with the same grant is expected to return 200 on both. To capture this against a proxy running this branch: register the index as admin, grant a team `allowed_vector_store_indexes` with read and write on it, mint that team's token, then

```
# upload -> HTTP 200, each doc {"status": true, "statusCode": 201}
curl -sS -X POST "$PROXY/azure_ai/indexes/$IDX/docs/index?api-version=2024-07-01" \
  -H "Authorization: Bearer $TEAM_TOKEN" -H 'Content-Type: application/json' -d @doc.json

# get index details -> HTTP 200, index schema returned
curl -sS "$PROXY/azure_ai/indexes/$IDX?api-version=2024-07-01" -H "Authorization: Bearer $TEAM_TOKEN"
```

Index lifecycle stays admin-only, verified in the same run

```
# team PUT/DELETE on the index itself -> still 403 "Only proxy admins can update/delete vector store indexes"
```

## Type

🐛 Bug Fix

## Changes

`AzureAIVectorStoreConfig.get_vector_store_endpoints_by_type` now returns read = any `GET` under `/indexes/` (get details, stats, count, and the GET form of search) plus `POST /docs/search`, and write = `POST /docs/index`. The old map declared write as `PUT /docs` and read as only `/docs/search`, so the two real routes above fell through the classifier and 403'd non-admins regardless of grant

Index create, update, and delete remain proxy-admin only. Those are caught earlier by the separate lifecycle check (`_is_vector_store_index_lifecycle_request` on POST/PUT/DELETE/PATCH of the index itself), so widening the document read/write map does not let a team manage indexes. Because the classifier only decides read vs write, the per-index grant check still runs afterward, so a team can only reach an index it was explicitly granted

Regression tests in `tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py` exercise the real `AzureAIVectorStoreConfig` map rather than a mock, so reverting to `("PUT", "/docs")` or dropping the GET-on-index read makes them fail. They cover a write-granted team uploading, a read-granted team searching and reading index details, a team missing the matching grant still being denied, and a team being unable to manage index lifecycle even with a write grant

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
