### PR TITLE
feat(router): add router plugin reference catalog

### DIFF
--- a/router_plugins.json
+++ b/router_plugins.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "TEMPLATE: copy this block for a new plugin, then delete this entry",
+    "description": "One line on what the plugin does and the routing signal it publishes.",
+    "author": "Plugin author's name.",
+    "repo": "https://github.com/<owner>/<repo> (public source repository).",
+    "commit": "Full 40-char git SHA to pin when the plugin is not yet on PyPI; omit once 'pypi' is set.",
+    "version": "Plugin release version, e.g. 1.0.0.",
+    "pypi": "PyPI spec pinned to a version, e.g. my-plugin==1.0.0, or null if unpublished.",
+    "litellm_version": "Minimum compatible litellm version, e.g. >=1.94.0.",
+    "entrypoint": "Dotted import path to the plugin instance, e.g. my_plugin.plugin.instance.",
+    "license": "SPDX license id, e.g. MIT.",
+    "tags": ["searchable", "keywords"]
+  },
+  {
+    "name": "language-detector",
+    "description": "Detects the user's language and publishes a routing signal.",
+    "author": "Jean Nuñez",
+    "repo": "https://github.com/jeann2013/language-detector",
+    "commit": "9e712819269173fc25a16f59ca3e9890f7864ac1",
+    "version": "1.0.0",
+    "pypi": null,
+    "litellm_version": ">=1.94.0",
+    "entrypoint": "litellm_plugin_language_detector.plugin.language_detector_plugin",
+    "license": "MIT",
+    "tags": ["language", "classification", "routing"]
+  }
+]


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Static JSON reference catalog, so live proxy proof is not applicable. Syntax proof:

```bash
python -m json.tool router_plugins.json >/dev/null
```

Output:

```text
(no output, exit code 0)
```

## Type

New Feature

## Changes

Adds `router_plugins.json` as a root-level, machine-readable reference catalog for routing plugins. The catalog is a plain JSON array of plugin entries so users can decide whether a plugin fits without opening its repository

Each entry carries lightweight, evaluation-focused metadata: `name`, `description`, `author`, `repo`, `commit`, `version`, `pypi`, `litellm_version`, `entrypoint`, `license`, and `tags`. `version` supports update tracking, `litellm_version` guards compatibility, `entrypoint` gives a deterministic dotted path to load the plugin, `license` helps orgs evaluate third-party plugins, and `tags` enable filtering

Seeded with one entry for Jean's language detector plugin. `pypi` is null for this entry because the package is not published on PyPI yet; advertising a `pip install` of an unclaimed name is a namesquatting risk (flagged by Veria), so the entry pins the reviewed `repo` at an immutable `commit` as the trustworthy source until a release is published from a trusted account

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

