### PR TITLE
fix(azure_ai): recognize real Search doc endpoints so teams can read/write via passthrough

### DIFF
--- a/litellm/llms/azure_ai/vector_stores/transformation.py
+++ b/litellm/llms/azure_ai/vector_stores/transformation.py
@@ -38,8 +38,8 @@ class AzureAIVectorStoreConfig(BaseVectorStoreConfig, BaseAzureLLM):
 
     def get_vector_store_endpoints_by_type(self) -> VectorStoreIndexEndpoints:
         return {
-            "read": [("GET", "/docs/search"), ("POST", "/docs/search")],
-            "write": [("PUT", "/docs")],
+            "read": [("GET", "/indexes/"), ("POST", "/docs/search")],
+            "write": [("POST", "/docs/index")],
         }
 
     def get_auth_credentials(self, litellm_params: dict) -> BaseVectorStoreAuthCredentials:

--- a/litellm/llms/azure_ai/vector_stores/transformation.py
+++ b/litellm/llms/azure_ai/vector_stores/transformation.py
@@ -37,8 +37,28 @@ class AzureAIVectorStoreConfig(BaseVectorStoreConfig, BaseAzureLLM):
         super().__init__()
 
     def get_vector_store_endpoints_by_type(self) -> VectorStoreIndexEndpoints:
+        """
+        Every ``GET`` under ``/indexes/`` is a read: get details, stats, and the
+        document reads (GET-form search, ``$count``, point lookup, and the
+        GET forms of suggest and autocomplete).
+
+        ``POST`` splits by endpoint. Search, suggest, autocomplete, and analyze
+        are query endpoints, so they read; ``/docs/index`` is the batch endpoint
+        carrying upload, merge, mergeOrUpload, and delete actions, so it writes.
+
+        Patterns stay literal rather than ``{placeholder}`` templates because the
+        matcher falls back to the substring before a ``{``, which here is always
+        ``/indexes/`` -- broad enough that a templated read, matched first, would
+        shadow the ``/docs/index`` write.
+        """
         return {
-            "read": [("GET", "/indexes/"), ("POST", "/docs/search")],
+            "read": [
+                ("GET", "/indexes/"),
+                ("POST", "/docs/search"),
+                ("POST", "/docs/suggest"),
+                ("POST", "/docs/autocomplete"),
+                ("POST", "/analyze"),
+            ],
             "write": [("POST", "/docs/index")],
         }
 

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -1233,6 +1233,22 @@ async def assemblyai_proxy_route(
     return received_value
 
 
+def get_azure_ai_search_index_from_endpoint(endpoint: str) -> str | None:
+    """Return the index name in the ``/indexes/{name}`` position of an Azure AI
+    Search passthrough path, or ``None`` when the path targets no index.
+
+    Only the segment immediately after ``indexes`` is the operable target. Any
+    other segment (for example the trailing ``index`` in ``.../docs/index``) must
+    never be treated as the index, otherwise a caller authorized on one index
+    could have Azure apply the operation to a different index on the same service.
+    """
+    segments: Final = endpoint.split("?", 1)[0].strip("/").split("/")
+    for position, segment in enumerate(segments):
+        if segment == "indexes" and position + 1 < len(segments):
+            return segments[position + 1] or None
+    return None
+
+
 @router.api_route(
     "/azure_ai/{endpoint:path}",
     methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
@@ -1262,6 +1278,8 @@ async def azure_proxy_route(
         "/"
     )  # azure model is in the url - e.g. https://{endpoint}/openai/deployments/{deployment-id}/completions?api-version=2024-10-21
 
+    search_index_name: Final = get_azure_ai_search_index_from_endpoint(endpoint)
+
     if len(parts) > 1 and llm_router:
         for part in parts:
             # check if LLM MODEL
@@ -1270,9 +1288,9 @@ async def azure_proxy_route(
             )
             # check if vector store index
             is_vector_store_index = (
-                (litellm.vector_store_index_registry.is_vector_store_index(vector_store_index_name=part))
-                if litellm.vector_store_index_registry is not None
-                else False
+                part == search_index_name
+                and litellm.vector_store_index_registry is not None
+                and litellm.vector_store_index_registry.is_vector_store_index(vector_store_index_name=part)
             )
 
             if is_router_model:

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -44,6 +44,7 @@ from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
 )
 from litellm.proxy.utils import is_known_model
 from litellm.proxy.vector_store_endpoints.utils import (
+    assert_proxy_admin_for_vector_store_index_management,
     assert_user_can_access_vector_store,
     get_litellm_managed_vector_store,
     is_allowed_to_call_vector_store_endpoint,
@@ -1249,6 +1250,21 @@ def get_azure_ai_search_index_from_endpoint(endpoint: str) -> str | None:
     return None
 
 
+def is_azure_ai_search_service_level_index_create(method: str, endpoint: str) -> bool:
+    """Return True for ``POST /indexes``, Azure AI Search's service-level index create.
+
+    No index name appears in that path, so ``get_azure_ai_search_index_from_endpoint``
+    yields None and the managed-index branch can never claim the request. Without an
+    explicit guard it reaches the generic Azure passthrough on the proxy's own
+    credential, so a non-admin could create an index whenever ``AZURE_API_BASE``
+    points at the Search service.
+    """
+    if method != "POST":
+        return False
+    path: Final = endpoint.split("?", 1)[0].strip("/")
+    return path == "indexes" or path.endswith("/indexes")
+
+
 @router.api_route(
     "/azure_ai/{endpoint:path}",
     methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
@@ -1273,6 +1289,9 @@ async def azure_proxy_route(
     Checks if the deployment id in the url is a litellm model name. If so, it will route using the llm_router.allm_passthrough_route.
     """
     from litellm.proxy.proxy_server import llm_router
+
+    if is_azure_ai_search_service_level_index_create(method=request.method, endpoint=endpoint):
+        assert_proxy_admin_for_vector_store_index_management(user_api_key_dict, operation="create")
 
     parts: Final = endpoint.split(
         "/"

--- a/litellm/proxy/vector_store_endpoints/utils.py
+++ b/litellm/proxy/vector_store_endpoints/utils.py
@@ -86,7 +86,7 @@ def _is_vector_store_index_lifecycle_request(
             return True
 
     # POST /indexes (create index at service level; no index name in path).
-    normalized: Final = request_path.rstrip("/")
+    normalized: Final = request_path.split("?", 1)[0].rstrip("/")
     if request_method == "POST" and normalized.endswith("/indexes"):
         return True
 

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import httpx
 import pytest
-from fastapi import Request, Response
+from fastapi import HTTPException, Request, Response
 from fastapi.testclient import TestClient
 
 sys.path.insert(
@@ -24,6 +24,7 @@ from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
     cursor_proxy_route,
     get_azure_ai_search_index_from_endpoint,
     get_vertex_base_url,
+    is_azure_ai_search_service_level_index_create,
     llm_passthrough_factory_proxy_route,
     milvus_proxy_route,
     mistral_proxy_route,
@@ -32,7 +33,7 @@ from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
     vertex_proxy_route,
     vllm_proxy_route,
 )
-from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
 from litellm.types.passthrough_endpoints.vertex_ai import VertexPassThroughCredentials
 
 
@@ -3323,3 +3324,91 @@ class TestAzureProxyRouteCrossIndexAuthorization:
             mock_is_allowed.assert_not_called()
             mock_handler.assert_awaited_once()
             assert mock_handler.await_args.kwargs["custom_llm_provider"] == litellm.LlmProviders.AZURE
+
+
+class TestAzureProxyRouteServiceLevelIndexCreate:
+    """``POST /indexes`` carries no index name, so the managed-index branch cannot
+    claim it and it would otherwise reach the generic Azure passthrough on the
+    proxy's own credential. The admin-only index management guard has to be
+    enforced on the route itself, not just on the permission gate the route skips.
+    """
+
+    def _request(self, method: str, path: str) -> MagicMock:
+        request = MagicMock(spec=Request)
+        request.method = method
+        request.headers = {"content-type": "application/json"}
+        request.url = MagicMock()
+        request.url.path = path
+        return request
+
+    @pytest.mark.parametrize(
+        "method, endpoint, expected",
+        [
+            ("POST", "indexes", True),
+            ("POST", "indexes?api-version=2024-07-01", True),
+            ("POST", "/indexes/", True),
+            ("POST", "indexes/my-index", False),
+            ("POST", "indexes/my-index/docs/index", False),
+            ("GET", "indexes", False),
+            ("POST", "openai/deployments/gpt-4o/chat/completions", False),
+        ],
+    )
+    def test_recognizes_service_level_create(self, method, endpoint, expected):
+        assert is_azure_ai_search_service_level_index_create(method=method, endpoint=endpoint) is expected
+
+    @pytest.mark.asyncio
+    async def test_non_admin_cannot_create_an_index(self):
+        with (
+            patch("litellm.proxy.proxy_server.llm_router", MagicMock()),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.get_secret_str",
+                return_value="https://svc.search.windows.net",
+            ),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.BaseOpenAIPassThroughHandler._base_openai_pass_through_handler",
+                new=AsyncMock(return_value=Response()),
+            ) as mock_handler,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await azure_proxy_route(
+                    endpoint="indexes?api-version=2024-07-01",
+                    request=self._request("POST", "/azure_ai/indexes"),
+                    fastapi_response=MagicMock(spec=Response),
+                    user_api_key_dict=UserAPIKeyAuth(
+                        token="sk-team-token",
+                        user_role=LitellmUserRoles.INTERNAL_USER,
+                    ),
+                )
+
+            assert exc_info.value.status_code == 403
+            assert "Only proxy admins can create" in exc_info.value.detail
+            mock_handler.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_admin_can_still_create_an_index(self):
+        with (
+            patch("litellm.proxy.proxy_server.llm_router", MagicMock()),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.get_secret_str",
+                return_value="https://svc.search.windows.net",
+            ),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
+                return_value="azure-key",
+            ),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.BaseOpenAIPassThroughHandler._base_openai_pass_through_handler",
+                new=AsyncMock(return_value=Response()),
+            ) as mock_handler,
+        ):
+            await azure_proxy_route(
+                endpoint="indexes?api-version=2024-07-01",
+                request=self._request("POST", "/azure_ai/indexes"),
+                fastapi_response=MagicMock(spec=Response),
+                user_api_key_dict=UserAPIKeyAuth(
+                    token="sk-admin-token",
+                    user_role=LitellmUserRoles.PROXY_ADMIN,
+                ),
+            )
+
+            mock_handler.assert_awaited_once()

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -18,9 +18,11 @@ import litellm
 from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
     BaseOpenAIPassThroughHandler,
     RouteChecks,
+    azure_proxy_route,
     bedrock_llm_proxy_route,
     create_pass_through_route,
     cursor_proxy_route,
+    get_azure_ai_search_index_from_endpoint,
     get_vertex_base_url,
     llm_passthrough_factory_proxy_route,
     milvus_proxy_route,
@@ -3191,3 +3193,133 @@ def test_is_passthrough_request_streaming_tolerates_non_object_bodies(request_bo
     )
 
     assert is_passthrough_request_streaming(request_body) is expected
+
+
+class TestGetAzureAISearchIndexFromEndpoint:
+    """The operable index is only the segment right after ``indexes``.
+
+    A doc-write path ends in ``.../docs/index``; the trailing ``index`` must not
+    be mistaken for the target, otherwise a caller could be authorized on one
+    index while Azure applies the write to another.
+    """
+
+    @pytest.mark.parametrize(
+        "endpoint, expected",
+        [
+            ("indexes/my-index/docs/index", "my-index"),
+            ("indexes/my-index/docs/search", "my-index"),
+            ("indexes/my-index", "my-index"),
+            ("indexes/my-index?api-version=2024-07-01", "my-index"),
+            ("/indexes/my-index/docs/index", "my-index"),
+            ("indexes/victim/docs/index", "victim"),
+            ("openai/deployments/gpt-4o/chat/completions", None),
+            ("indexes", None),
+            ("indexes/", None),
+        ],
+    )
+    def test_extracts_positional_index_only(self, endpoint, expected):
+        assert get_azure_ai_search_index_from_endpoint(endpoint) == expected
+
+
+class TestAzureProxyRouteCrossIndexAuthorization:
+    """Regression tests: the passthrough must authorize the index that the request
+    actually targets (the ``/indexes/{name}`` segment), never a different segment
+    that merely happens to match a managed index the caller can access.
+    """
+
+    def _request(self, method: str, path: str) -> MagicMock:
+        request = MagicMock(spec=Request)
+        request.method = method
+        request.headers = {"content-type": "application/json"}
+        request.url = MagicMock()
+        request.url.path = path
+        return request
+
+    @pytest.mark.asyncio
+    async def test_authorizes_the_targeted_index(self):
+        index_object = MagicMock()
+        index_object.litellm_params.vector_store_name = "my-store"
+        vector_store = {"litellm_params": {"api_base": "https://svc.search.windows.net"}}
+
+        with (
+            patch("litellm.proxy.proxy_server.llm_router", MagicMock()),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.is_passthrough_request_using_router_model",
+                return_value=False,
+            ),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.ProviderConfigManager.get_provider_vector_stores_config"
+            ) as mock_get_config,
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.is_allowed_to_call_vector_store_endpoint"
+            ) as mock_is_allowed,
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.assert_user_can_access_vector_store",
+                new=AsyncMock(),
+            ),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.BaseOpenAIPassThroughHandler._base_openai_pass_through_handler",
+                new=AsyncMock(return_value=Response()),
+            ),
+            patch.object(litellm, "vector_store_index_registry") as mock_index_registry,
+            patch.object(litellm, "vector_store_registry") as mock_vector_registry,
+        ):
+            mock_get_config.return_value.get_auth_credentials.return_value = {"headers": {"api-key": "k"}}
+            mock_index_registry.is_vector_store_index.side_effect = lambda vector_store_index_name: (
+                vector_store_index_name == "my-index"
+            )
+            mock_index_registry.get_vector_store_index_by_name.return_value = index_object
+            mock_vector_registry.get_litellm_managed_vector_store_from_registry_by_name.return_value = vector_store
+
+            await azure_proxy_route(
+                endpoint="indexes/my-index/docs/index",
+                request=self._request("POST", "/azure_ai/indexes/my-index/docs/index"),
+                fastapi_response=MagicMock(spec=Response),
+                user_api_key_dict=MagicMock(spec=UserAPIKeyAuth),
+            )
+
+            mock_is_allowed.assert_called_once()
+            assert mock_is_allowed.call_args.kwargs["index_name"] == "my-index"
+            mock_index_registry.get_vector_store_index_by_name.assert_called_once_with(
+                vector_store_index_name="my-index"
+            )
+
+    @pytest.mark.asyncio
+    async def test_trailing_index_segment_does_not_authorize_a_different_index(self):
+        with (
+            patch("litellm.proxy.proxy_server.llm_router", MagicMock()),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.is_passthrough_request_using_router_model",
+                return_value=False,
+            ),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.is_allowed_to_call_vector_store_endpoint"
+            ) as mock_is_allowed,
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.get_secret_str",
+                return_value="https://azure-openai.example.com",
+            ),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.passthrough_endpoint_router.get_credentials",
+                return_value="azure-key",
+            ),
+            patch(
+                "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints.BaseOpenAIPassThroughHandler._base_openai_pass_through_handler",
+                new=AsyncMock(return_value=Response()),
+            ) as mock_handler,
+            patch.object(litellm, "vector_store_index_registry") as mock_index_registry,
+        ):
+            mock_index_registry.is_vector_store_index.side_effect = lambda vector_store_index_name: (
+                vector_store_index_name == "index"
+            )
+
+            await azure_proxy_route(
+                endpoint="indexes/victim/docs/index",
+                request=self._request("POST", "/azure_ai/indexes/victim/docs/index"),
+                fastapi_response=MagicMock(spec=Response),
+                user_api_key_dict=MagicMock(spec=UserAPIKeyAuth),
+            )
+
+            mock_is_allowed.assert_not_called()
+            mock_handler.assert_awaited_once()
+            assert mock_handler.await_args.kwargs["custom_llm_provider"] == litellm.LlmProviders.AZURE

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
@@ -2919,15 +2919,19 @@ class TestAzureAIDocumentWritePassthroughPermission:
         assert exc_info.value.status_code == 403
 
     @pytest.mark.parametrize(
-        "method, operation",
-        [("PUT", "update"), ("DELETE", "delete")],
+        "method, operation, path",
+        [
+            ("PUT", "update", f"/azure_ai/indexes/{INDEX}?api-version=2024-07-01"),
+            ("DELETE", "delete", f"/azure_ai/indexes/{INDEX}?api-version=2024-07-01"),
+            ("POST", "create", "/azure_ai/indexes?api-version=2024-07-01"),
+        ],
     )
-    def test_team_cannot_manage_index_lifecycle_even_with_write_grant(self, method, operation):
+    def test_team_cannot_manage_index_lifecycle_even_with_write_grant(self, method, operation, path):
         with pytest.raises(HTTPException) as exc_info:
             is_allowed_to_call_vector_store_endpoint(
                 provider=LlmProviders.AZURE_AI,
                 index_name=self.INDEX,
-                request=self._request(method, f"/azure_ai/indexes/{self.INDEX}?api-version=2024-07-01"),
+                request=self._request(method, path),
                 user_api_key_dict=self._team_member(["read", "write"]),
             )
         assert exc_info.value.status_code == 403

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
@@ -2840,3 +2840,95 @@ class TestUpdateVectorStoreAccessControlAndRedaction:
         params = response["vector_store"]["litellm_params"]
         assert params["api_key"] == REDACTED_BY_LITELM_STRING
         assert params["api_base"] == "https://api.openai.com/v1"
+
+
+class TestAzureAIDocumentWritePassthroughPermission:
+    """Regression tests for the Azure AI Search passthrough write mapping.
+
+    Azure's batch document write/merge/delete endpoint is
+    ``POST /indexes/{name}/docs/index``. A non-admin team holding a ``write``
+    grant on the index must be allowed to call it, while index lifecycle
+    (create / update / delete the index itself) stays proxy-admin only.
+
+    These exercise the real ``AzureAIVectorStoreConfig`` endpoint map on
+    purpose (no mocked provider config), so reverting the map to the old
+    ``("PUT", "/docs")`` entry makes ``test_team_with_write_grant_can_upload``
+    fail.
+    """
+
+    INDEX = "my-index"
+
+    def _request(self, method: str, path: str) -> MagicMock:
+        request = MagicMock(spec=Request)
+        request.method = method
+        request.url.path = path
+        return request
+
+    def _team_member(self, permissions: list) -> MagicMock:
+        user = MagicMock(spec=UserAPIKeyAuth)
+        user.user_role = None
+        user.metadata = {"allowed_vector_store_indexes": [{"index_name": self.INDEX, "index_permissions": permissions}]}
+        user.team_metadata = None
+        return user
+
+    def test_team_with_write_grant_can_upload(self):
+        result = is_allowed_to_call_vector_store_endpoint(
+            provider=LlmProviders.AZURE_AI,
+            index_name=self.INDEX,
+            request=self._request("POST", f"/azure_ai/indexes/{self.INDEX}/docs/index"),
+            user_api_key_dict=self._team_member(["read", "write"]),
+        )
+        assert result is True
+
+    def test_team_without_write_grant_cannot_upload(self):
+        with pytest.raises(HTTPException) as exc_info:
+            is_allowed_to_call_vector_store_endpoint(
+                provider=LlmProviders.AZURE_AI,
+                index_name=self.INDEX,
+                request=self._request("POST", f"/azure_ai/indexes/{self.INDEX}/docs/index"),
+                user_api_key_dict=self._team_member(["read"]),
+            )
+        assert exc_info.value.status_code == 403
+
+    def test_team_with_read_grant_can_search(self):
+        result = is_allowed_to_call_vector_store_endpoint(
+            provider=LlmProviders.AZURE_AI,
+            index_name=self.INDEX,
+            request=self._request("POST", f"/azure_ai/indexes/{self.INDEX}/docs/search"),
+            user_api_key_dict=self._team_member(["read"]),
+        )
+        assert result is True
+
+    def test_team_with_read_grant_can_get_index_details(self):
+        result = is_allowed_to_call_vector_store_endpoint(
+            provider=LlmProviders.AZURE_AI,
+            index_name=self.INDEX,
+            request=self._request("GET", f"/azure_ai/indexes/{self.INDEX}"),
+            user_api_key_dict=self._team_member(["read"]),
+        )
+        assert result is True
+
+    def test_team_without_read_grant_cannot_get_index_details(self):
+        with pytest.raises(HTTPException) as exc_info:
+            is_allowed_to_call_vector_store_endpoint(
+                provider=LlmProviders.AZURE_AI,
+                index_name=self.INDEX,
+                request=self._request("GET", f"/azure_ai/indexes/{self.INDEX}"),
+                user_api_key_dict=self._team_member(["write"]),
+            )
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.parametrize(
+        "method, operation",
+        [("PUT", "update"), ("DELETE", "delete")],
+    )
+    def test_team_cannot_manage_index_lifecycle_even_with_write_grant(self, method, operation):
+        with pytest.raises(HTTPException) as exc_info:
+            is_allowed_to_call_vector_store_endpoint(
+                provider=LlmProviders.AZURE_AI,
+                index_name=self.INDEX,
+                request=self._request(method, f"/azure_ai/indexes/{self.INDEX}?api-version=2024-07-01"),
+                user_api_key_dict=self._team_member(["read", "write"]),
+            )
+        assert exc_info.value.status_code == 403
+        assert f"Only proxy admins can {operation}" in exc_info.value.detail

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
@@ -2858,6 +2858,21 @@ class TestAzureAIDocumentWritePassthroughPermission:
 
     INDEX = "my-index"
 
+    # Every non-lifecycle read Azure exposes for an index. The GET forms are all
+    # covered by the ("GET", "/indexes/") entry; the POST query endpoints each
+    # need their own, since the write entry also matches on POST.
+    READ_ROUTES = [
+        ("GET", f"/azure_ai/indexes/{INDEX}/stats"),
+        ("GET", f"/azure_ai/indexes/{INDEX}/docs"),
+        ("GET", f"/azure_ai/indexes/{INDEX}/docs/$count"),
+        ("GET", f"/azure_ai/indexes/{INDEX}/docs/seed-doc-1"),
+        ("GET", f"/azure_ai/indexes/{INDEX}/docs/suggest"),
+        ("GET", f"/azure_ai/indexes/{INDEX}/docs/autocomplete"),
+        ("POST", f"/azure_ai/indexes/{INDEX}/docs/suggest"),
+        ("POST", f"/azure_ai/indexes/{INDEX}/docs/autocomplete"),
+        ("POST", f"/azure_ai/indexes/{INDEX}/analyze"),
+    ]
+
     def _request(self, method: str, path: str) -> MagicMock:
         request = MagicMock(spec=Request)
         request.method = method
@@ -2914,6 +2929,27 @@ class TestAzureAIDocumentWritePassthroughPermission:
                 provider=LlmProviders.AZURE_AI,
                 index_name=self.INDEX,
                 request=self._request("GET", f"/azure_ai/indexes/{self.INDEX}"),
+                user_api_key_dict=self._team_member(["write"]),
+            )
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.parametrize("method, path", READ_ROUTES)
+    def test_team_with_read_grant_can_call_every_read_route(self, method, path):
+        result = is_allowed_to_call_vector_store_endpoint(
+            provider=LlmProviders.AZURE_AI,
+            index_name=self.INDEX,
+            request=self._request(method, path),
+            user_api_key_dict=self._team_member(["read"]),
+        )
+        assert result is True
+
+    @pytest.mark.parametrize("method, path", READ_ROUTES)
+    def test_team_without_read_grant_cannot_call_read_routes(self, method, path):
+        with pytest.raises(HTTPException) as exc_info:
+            is_allowed_to_call_vector_store_endpoint(
+                provider=LlmProviders.AZURE_AI,
+                index_name=self.INDEX,
+                request=self._request(method, path),
                 user_api_key_dict=self._team_member(["write"]),
             )
         assert exc_info.value.status_code == 403


### PR DESCRIPTION
## Relevant issues

Non-admin teams cannot upload documents to, read the details of, or run most of the query endpoints on an Azure AI Search index through the passthrough, even when an admin has granted them access

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Captured against a local proxy on `:4000` wired to a real Azure AI Search service, no mocks, every call hitting the Search data plane. Setup: the admin master key registered the index and created it physically over the passthrough, then a team was granted `allowed_vector_store_indexes` with `read` and `write` on that index and a non-admin virtual key was minted for that team. Every call below runs as that team key. Service hostnames are redacted.

Before, at `4d33964898`, the commit this branch starts from, the team key is refused on nine of the ten non-lifecycle routes despite holding a grant on the index. Only `POST /docs/search` was classified by the endpoint map, so only it worked

```
upload documents        -> HTTP 403
get index details       -> HTTP 403
index stats             -> HTTP 403
document count          -> HTTP 403
document lookup by key  -> HTTP 403
search (GET form)       -> HTTP 403
search (POST form)      -> HTTP 200
suggest                 -> HTTP 403
autocomplete            -> HTTP 403
analyze                 -> HTTP 403
```

Every refusal is the pre-grant rejection, raised before `allowed_vector_store_indexes` is consulted. The reported upload failure, verbatim

```
$ curl -sS -X POST "$PROXY/azure_ai/indexes/$IDX/docs/index?api-version=2024-07-01" \
    -H "Authorization: Bearer $TEAM_KEY" -H 'Content-Type: application/json' \
    -d '{"value":[{"@search.action":"mergeOrUpload","id":"1","content":"Azure AI Search supports vector similarity search using HNSW indexes."}]}'
HTTP 403
{"detail":"User does not have permission to call vector store endpoint litellm-pr33757-proof. Ask your administrator to add the necessary permissions to your API key/Team."}
```

After, at `5fa5d96cf3`, the same key with the same grant against the same index

```
upload documents        -> HTTP 200
get index details       -> HTTP 200
index stats             -> HTTP 200
document count          -> HTTP 200
document lookup by key  -> HTTP 200
search (GET form)       -> HTTP 200
search (POST form)      -> HTTP 200
suggest                 -> HTTP 200
autocomplete            -> HTTP 200
analyze                 -> HTTP 200
```

The same upload, now accepted by Azure, and the document readable straight after

```
$ curl -sS -X POST "$PROXY/azure_ai/indexes/$IDX/docs/index?api-version=2024-07-01" \
    -H "Authorization: Bearer $TEAM_KEY" -H 'Content-Type: application/json' \
    -d '{"value":[{"@search.action":"mergeOrUpload","id":"1","content":"Azure AI Search supports vector similarity search using HNSW indexes."}]}'
HTTP 200
{"value":[{"key":"1","status":true,"errorMessage":null,"statusCode":201}]}

$ curl -sS "$PROXY/azure_ai/indexes/$IDX/docs/1?api-version=2024-07-01" -H "Authorization: Bearer $TEAM_KEY"
HTTP 200
{"id":"1","content":"Azure AI Search supports vector similarity search using HNSW indexes."}

$ curl -sS "$PROXY/azure_ai/indexes/$IDX/docs/\$count?api-version=2024-07-01" -H "Authorization: Bearer $TEAM_KEY"
HTTP 200
1
```

Index lifecycle stays admin-only for the team at both commits on update and delete

```
$ curl -sS -X PUT "$PROXY/azure_ai/indexes/$IDX?api-version=2024-07-01" -H "Authorization: Bearer $TEAM_KEY" ...
HTTP 403
{"detail":"Only proxy admins can update vector store indexes. Contact your LiteLLM administrator."}

$ curl -sS -X DELETE "$PROXY/azure_ai/indexes/$IDX?api-version=2024-07-01" -H "Authorization: Bearer $TEAM_KEY"
HTTP 403
{"detail":"Only proxy admins can delete vector store indexes. Contact your LiteLLM administrator."}
```

Service-level create was the one that was not gated. At `4d33964898` the team key's request was forwarded upstream on the proxy's own credential and Azure created the index

```
$ curl -sS -X POST "$PROXY/azure_ai/indexes?api-version=2024-07-01" \
    -H "Authorization: Bearer $TEAM_KEY" -H 'Content-Type: application/json' \
    -d '{"name":"litellm-pr33757-escalation","fields":[{"name":"id","type":"Edm.String","key":true}]}'
HTTP 201
{"name":"litellm-pr33757-escalation", ...}
```

At `5fa5d96cf3` the identical call is refused, while an admin can still create

```
$ curl -sS -X POST "$PROXY/azure_ai/indexes?api-version=2024-07-01" -H "Authorization: Bearer $TEAM_KEY" -d '{"name":"litellm-pr33757-escalation2","fields":[{"name":"id","type":"Edm.String","key":true}]}'
HTTP 403
{"detail":"Only proxy admins can create vector store indexes. Contact your LiteLLM administrator."}

$ curl -sS -X POST "$PROXY/azure_ai/indexes?api-version=2024-07-01" -H "Authorization: Bearer $MASTER_KEY" -d '{"name":"litellm-pr33757-admincreate","fields":[{"name":"id","type":"Edm.String","key":true}]}'
HTTP 201
{"name":"litellm-pr33757-admincreate", ...}
```

Every index created during these runs was deleted afterward.

## Type

🐛 Bug Fix

## Changes

`AzureAIVectorStoreConfig.get_vector_store_endpoints_by_type` now returns read = any `GET` under `/indexes/` (get details, stats, count, point lookup, and the GET forms of search, suggest, and autocomplete) plus the `POST` query endpoints `/docs/search`, `/docs/suggest`, `/docs/autocomplete`, and `/analyze`, with write = `POST /docs/index`. The old map declared write as `PUT /docs` and read as only `/docs/search`, so every real route above fell through the classifier and 403'd non-admins regardless of grant

Every pattern stays a literal path fragment rather than a `{placeholder}` template. `_does_endpoint_match` falls back to the substring preceding a `{`, which for these routes is always `/indexes/`, and reads are matched before writes, so a templated read would shadow the `/docs/index` write and let a read-only team upload documents. The classification is otherwise driven by HTTP semantics: `GET` never mutates a Search index, and among the `POST` routes only `/docs/index` carries `upload`, `merge`, `mergeOrUpload`, and `delete` actions

Index create, update, and delete remain proxy-admin only. Those are caught earlier by the separate lifecycle check (`_is_vector_store_index_lifecycle_request` on POST/PUT/DELETE/PATCH of the index itself), so widening the document read/write map does not let a team manage indexes. Because the classifier only decides read vs write, the per-index grant check still runs afterward, so a team can only reach an index it was explicitly granted

The same lifecycle check had a latent bug the new create-path test surfaced: the service-level `POST /indexes` create branch matched on `normalized.endswith("/indexes")` without stripping the query string, so Azure's real `POST /indexes?api-version=...` was never classified as lifecycle and fell through to the generic permission check instead of the explicit admin-only guard. Non-admins were still denied by the catch-all, but the guard meant to own create was bypassed. It now strips the query string before the suffix check, matching how the PUT/DELETE index paths already tolerate a trailing `?`

That admin-only create guard was still unreachable from the route, so it is now enforced there too. `POST /azure_ai/indexes` carries no index name, so `get_azure_ai_search_index_from_endpoint` returns `None`, no segment matches a managed index, and the request falls through to the generic Azure passthrough on the proxy's own `AZURE_API_BASE` and `AZURE_API_KEY` without ever reaching `is_allowed_to_call_vector_store_endpoint`. A non-admin could therefore create a Search index whenever `AZURE_API_BASE` points at the Search service, and the lifecycle test above hid it by exercising the gate directly rather than the route that skips it. `azure_proxy_route` now calls `assert_proxy_admin_for_vector_store_index_management` before the segment loop, scoped to `POST` on a path whose last segment is `indexes`, mirroring the `endswith("/indexes")` branch the lifecycle helper already uses so managed-index paths and ordinary Azure OpenAI traffic are untouched

The passthrough route resolver (`azure_proxy_route`) is also hardened. It previously scanned every URL segment for one matching a registered index, authorized against that, then forwarded the original path, so a caller holding a grant on a managed index named `index` or `docs` could send `POST /azure_ai/indexes/{victim}/docs/index` and have Azure apply the batch write to `{victim}` on the same Search service while the trailing segment supplied the authorized grant. This is a preexisting weakness that was already reachable for cross-index search reads; recognizing `POST /docs/index` as a write extends it to document writes, so it is fixed here. The resolver now takes the index positionally from the `/indexes/{name}` segment and authorizes and credentials against exactly that name, so the authorized index and the physical target cannot diverge

Regression tests in `tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py` exercise the real `AzureAIVectorStoreConfig` map rather than a mock, so reverting to `("PUT", "/docs")`, dropping the GET-on-index read, or dropping any of the `POST` query endpoints makes them fail. They cover a write-granted team uploading, a read-granted team reaching the full read surface (index details, stats, `$count`, point lookup, search, and both forms of suggest and autocomplete, plus analyze), a team holding only the opposite grant still being denied on each of those routes, and a team being unable to create, update, or delete an index even with a write grant. Route-level tests in `tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py` cover the positional index extraction, the cross-index write attempt, and the service-level create, asserting a non-admin is refused with the admin-only message and never reaches the passthrough handler while an admin still creates; removing the route guard makes that first case fail

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
