### PR TITLE
fix(mcp-semantic-filter): fall back to no MCP tools on context overfl…

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
+++ b/litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
@@ -17,22 +17,6 @@ if TYPE_CHECKING:
     from litellm.router import Router
 
 
-class SemanticToolFilterContextWindowError(Exception):
-    """Raised when the embedding model exceeds its context window, so semantic filtering cannot run."""
-
-    def __init__(self, embedding_model: str, stage: str, original_error: str):
-        self.embedding_model = embedding_model
-        self.stage = stage
-        self.original_error = original_error
-        super().__init__(
-            f"MCP semantic tool filtering could not run: embedding model '{embedding_model}' "
-            f"exceeded its context window while embedding {stage}. "
-            f"The request was blocked instead of silently passing all tools through. "
-            f"Switch to an embedding model with a larger context window, or disable "
-            f"semantic tool filtering."
-        )
-
-
 def _is_context_window_error(error: Optional[BaseException], max_depth: int = 5) -> bool:
     """Detect a context-window overflow anywhere in an exception's cause chain."""
     current = error
@@ -120,9 +104,17 @@ class SemanticMCPToolFilter:
         description: str
 
         if isinstance(tool, dict):
-            # OpenAI function format
-            name = tool.get("name", "")
-            description = tool.get("description", name)
+            function_spec = tool.get("function")
+            if isinstance(function_spec, dict):
+                # Chat Completions nested format:
+                # {"type": "function", "function": {"name": ..., "description": ...}}
+                name = function_spec.get("name", "")
+                description = function_spec.get("description", name)
+            else:
+                # Flat format (legacy OpenAI functions / Responses API):
+                # {"type": "function", "name": ..., "description": ...}
+                name = tool.get("name", "")
+                description = tool.get("description", name)
         else:
             # MCPTool object
             name = str(tool.name)
@@ -207,11 +199,17 @@ class SemanticMCPToolFilter:
             return available_tools
 
         if self.context_window_error is not None:
-            raise SemanticToolFilterContextWindowError(
-                embedding_model=self.embedding_model,
-                stage="the MCP tool descriptions during semantic router build",
-                original_error=self.context_window_error,
+            # Build-time overflow: tool descriptions exceeded the embedding
+            # model's context window. Log and return no MCP tools instead of
+            # raising; native tools are preserved by the hook.
+            verbose_logger.warning(
+                f"MCP semantic tool filter: embedding model '{self.embedding_model}' "
+                f"exceeded its context window while embedding tool descriptions at "
+                f"startup. Returning 0 MCP tools (native tools preserved). "
+                f"Switch to a larger-context embedding model or disable semantic "
+                f"filtering. Original error: {self.context_window_error}"
             )
+            return []
 
         if not query or not query.strip():
             return available_tools
@@ -234,15 +232,19 @@ class SemanticMCPToolFilter:
 
         except Exception as e:
             if _is_context_window_error(e):
-                verbose_logger.error(
-                    f"Semantic tool filter embedding exceeded its context window: {e}",
-                    exc_info=True,
+                # Query-time overflow: the user query exceeded the embedding
+                # model's context window. Log and return no MCP tools instead
+                # of raising; native tools are preserved by the hook.
+                # Intentionally no exc_info: the cause is already inlined and
+                # litellm.Router logs the full upstream error separately.
+                verbose_logger.warning(
+                    f"MCP semantic tool filter: embedding model '{self.embedding_model}' "
+                    f"exceeded its context window while embedding the user query. "
+                    f"Returning 0 MCP tools (native tools preserved). "
+                    f"Switch to a larger-context embedding model or disable "
+                    f"semantic filtering. Original error: {e}"
                 )
-                raise SemanticToolFilterContextWindowError(
-                    embedding_model=self.embedding_model,
-                    stage="the user query",
-                    original_error=str(e),
-                ) from e
+                return []
             verbose_logger.error(f"Semantic tool filter failed: {e}", exc_info=True)
             return available_tools
 
@@ -319,6 +321,16 @@ class SemanticMCPToolFilter:
             client_name, _ = self._extract_tool_info(tool)
             if client_name and client_name not in available_by_name:
                 available_by_name[client_name] = tool
+
+        if available_tools and not available_by_name:
+            # Couldn't extract a usable name from any tool in the list, so
+            # there's nothing to safely map the router's matches back onto.
+            # Fail open instead of silently returning zero tools.
+            verbose_logger.warning(
+                f"Semantic tool filter: could not extract names from any of "
+                f"{len(available_tools)} available tool(s); returning tools unfiltered"
+            )
+            return available_tools
 
         matched: List[Any] = []
         used_ids: set = set()

--- a/litellm/proxy/hooks/mcp_semantic_filter/hook.py
+++ b/litellm/proxy/hooks/mcp_semantic_filter/hook.py
@@ -7,8 +7,6 @@ Reduces context window size and improves tool selection accuracy.
 
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
-from fastapi import HTTPException
-
 from litellm._logging import verbose_proxy_logger
 from litellm.constants import (
     DEFAULT_MCP_SEMANTIC_FILTER_EMBEDDING_MODEL,
@@ -16,9 +14,6 @@ from litellm.constants import (
     DEFAULT_MCP_SEMANTIC_FILTER_TOP_K,
 )
 from litellm.integrations.custom_logger import CustomLogger
-from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
-    SemanticToolFilterContextWindowError,
-)
 
 if TYPE_CHECKING:
     from litellm.caching.caching import DualCache
@@ -160,16 +155,24 @@ class SemanticToolFilterHook(CustomLogger):
         Check whether *tool* is registered in the MCP semantic router.
 
         Classification strategy (shape-first, lookup-second):
-        1. Chat Completions format dicts are always native.
-        2. Responses API function tools are always native.
-        3. Everything else is looked up by name in the MCP registry.
+        1. Responses API function tools are always native.
+        2. Everything else is looked up by name in the MCP registry,
+           with tolerant suffix matching for client-side namespace prefixes.
         """
-        if isinstance(tool, dict) and tool.get("type") == "function" and isinstance(tool.get("function"), dict):
-            return False
+        from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+            SemanticMCPToolFilter,
+        )
+
         if isinstance(tool, dict) and tool.get("type") == "function" and isinstance(tool.get("name"), str):
             return False
         name, _ = self.filter._extract_tool_info(tool)
-        return bool(name) and name in self.filter._tool_map
+        if not name:
+            return False
+        if name in self.filter._tool_map:
+            return True
+        return any(
+            SemanticMCPToolFilter._name_matches_canonical(name, canonical) for canonical in self.filter._tool_map
+        )
 
     def _get_metadata_variable_name(self, data: dict) -> str:
         if "litellm_metadata" in data:
@@ -299,8 +302,6 @@ class SemanticToolFilterHook(CustomLogger):
                 )
                 return data
 
-            except SemanticToolFilterContextWindowError as e:
-                raise HTTPException(status_code=400, detail={"error": str(e)}) from e
             except Exception as e:
                 verbose_proxy_logger.error(f"Failed to expand MCP references: {e}", exc_info=True)
                 return None
@@ -373,8 +374,6 @@ class SemanticToolFilterHook(CustomLogger):
 
             return data
 
-        except SemanticToolFilterContextWindowError as e:
-            raise HTTPException(status_code=400, detail={"error": str(e)}) from e
         except Exception as e:
             verbose_proxy_logger.warning(f"Semantic tool filter hook failed: {e}. Proceeding with all tools.")
             return None

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -993,21 +993,6 @@ async def proxy_startup_event(app: FastAPI):
         redis_usage_cache=transaction_buffer_redis_cache,
     )
 
-    ## SEMANTIC TOOL FILTER ##
-    # Read litellm_settings from config for semantic filter initialization
-    try:
-        verbose_proxy_logger.debug("About to initialize semantic tool filter")
-        _config = proxy_config.get_config_state()
-        _litellm_settings = _config.get("litellm_settings", {})
-        verbose_proxy_logger.debug(f"litellm_settings keys = {list(_litellm_settings.keys())}")
-        await ProxyStartupEvent._initialize_semantic_tool_filter(
-            llm_router=llm_router,
-            litellm_settings=_litellm_settings,
-        )
-        verbose_proxy_logger.debug("After semantic tool filter initialization")
-    except Exception as e:
-        verbose_proxy_logger.error(f"Semantic filter init failed: {e}", exc_info=True)
-
     ## JWT AUTH ##
     ProxyStartupEvent._initialize_jwt_auth(
         general_settings=general_settings,
@@ -1044,6 +1029,24 @@ async def proxy_startup_event(app: FastAPI):
 
         ## SYNC UI SETTINGS ##
         await ProxyStartupEvent._sync_ui_settings_to_general_settings()
+
+    ## SEMANTIC TOOL FILTER ##
+    # Initialized after `initialize_scheduled_background_jobs` so DB-stored
+    # model deployments (store_model_in_db) are registered in the router before
+    # the semantic router eagerly embeds tool descriptions. Running this earlier
+    # fails for embedding models that only exist in the DB, not in config.yaml.
+    try:
+        verbose_proxy_logger.debug("About to initialize semantic tool filter")
+        _config = proxy_config.get_config_state()
+        _litellm_settings = _config.get("litellm_settings", {})
+        verbose_proxy_logger.debug(f"litellm_settings keys = {list(_litellm_settings.keys())}")
+        await ProxyStartupEvent._initialize_semantic_tool_filter(
+            llm_router=llm_router,
+            litellm_settings=_litellm_settings,
+        )
+        verbose_proxy_logger.debug("After semantic tool filter initialization")
+    except Exception as e:
+        verbose_proxy_logger.error(f"Semantic filter init failed: {e}", exc_info=True)
 
     # Start background health checks AFTER models are loaded and index is built
     if use_background_health_checks:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -5,10 +5,9 @@ Tests the core filtering logic that takes a long list of tools and returns
 an ordered set of top K tools based on semantic similarity.
 """
 
-import asyncio
 import os
 import sys
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -122,26 +121,18 @@ async def test_semantic_filter_basic_filtering():
     )
 
     # Assertions - validate filtering mechanics work
-    assert (
-        len(filtered) <= 3
-    ), f"Should return at most 3 tools (top_k), got {len(filtered)}"
+    assert len(filtered) <= 3, f"Should return at most 3 tools (top_k), got {len(filtered)}"
     assert len(filtered) > 0, "Should return at least some tools"
-    assert len(filtered) < len(
-        tools
-    ), f"Should filter down from {len(tools)} tools, got {len(filtered)}"
+    assert len(filtered) < len(tools), f"Should filter down from {len(tools)} tools, got {len(filtered)}"
 
     # Validate tools are actual MCPTool objects
     for tool in filtered:
         assert hasattr(tool, "name"), "Filtered result should be MCPTool with name"
-        assert hasattr(
-            tool, "description"
-        ), "Filtered result should be MCPTool with description"
+        assert hasattr(tool, "description"), "Filtered result should be MCPTool with description"
 
     filtered_names = [t.name for t in filtered]
-    print(
-        f"✅ Successfully filtered {len(tools)} tools down to top {len(filtered)}: {filtered_names}"
-    )
-    print(f"   Filter respects top_k parameter correctly")
+    print(f"✅ Successfully filtered {len(tools)} tools down to top {len(filtered)}: {filtered_names}")
+    print("   Filter respects top_k parameter correctly")
 
 
 @pytest.mark.asyncio
@@ -218,12 +209,7 @@ async def test_semantic_filter_disabled():
         SemanticMCPToolFilter,
     )
 
-    tools = [
-        MCPTool(
-            name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"}
-        )
-        for i in range(10)
-    ]
+    tools = [MCPTool(name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"}) for i in range(10)]
 
     mock_router = Mock()
 
@@ -243,9 +229,7 @@ async def test_semantic_filter_disabled():
     )
 
     # Should return all tools when disabled
-    assert len(filtered) == len(
-        tools
-    ), f"Expected all {len(tools)} tools, got {len(filtered)}"
+    assert len(filtered) == len(tools), f"Expected all {len(tools)} tools, got {len(filtered)}"
 
 
 @pytest.mark.asyncio
@@ -364,12 +348,7 @@ async def test_semantic_filter_hook_triggers_on_completion():
     )
 
     # Prepare data - completion request with tools
-    tools = [
-        MCPTool(
-            name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"}
-        )
-        for i in range(10)
-    ]
+    tools = [MCPTool(name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"}) for i in range(10)]
 
     # Build router with the tools before filtering
     filter_instance._build_router(tools)
@@ -399,9 +378,7 @@ async def test_semantic_filter_hook_triggers_on_completion():
     # Assertions
     assert result is not None, "Hook should return modified data"
     assert "tools" in result, "Result should contain tools"
-    assert len(result["tools"]) < len(
-        tools
-    ), f"Hook should filter tools, got {len(result['tools'])}/{len(tools)}"
+    assert len(result["tools"]) < len(tools), f"Hook should filter tools, got {len(result['tools'])}/{len(tools)}"
 
     print(f"✅ Hook triggered correctly: {len(tools)} -> {len(result['tools'])} tools")
 
@@ -547,18 +524,12 @@ async def test_semantic_filter_hook_preserves_native_tools():
     filtered = result["tools"]
 
     # Native tools must survive
-    native_in_result = [
-        t for t in filtered if isinstance(t, dict) and t.get("type") == "function"
-    ]
-    assert (
-        len(native_in_result) == 2
-    ), f"Both native tools must survive, got {len(native_in_result)}"
+    native_in_result = [t for t in filtered if isinstance(t, dict) and t.get("type") == "function"]
+    assert len(native_in_result) == 2, f"Both native tools must survive, got {len(native_in_result)}"
 
     # MCP tools should be filtered (top_k=2)
     mcp_in_result = [t for t in filtered if not isinstance(t, dict)]
-    assert (
-        len(mcp_in_result) <= 2
-    ), f"MCP tools should be filtered to top_k=2, got {len(mcp_in_result)}"
+    assert len(mcp_in_result) <= 2, f"MCP tools should be filtered to top_k=2, got {len(mcp_in_result)}"
 
     # Total should be native + filtered MCP
     assert len(filtered) <= 4, f"Expected at most 4 tools, got {len(filtered)}"
@@ -569,12 +540,8 @@ async def test_semantic_filter_hook_preserves_native_tools():
     # Stats should report MCP-only counts, not inflated with native tools
     stats = result["metadata"]["litellm_semantic_filter_stats"]
     mcp_before, mcp_after = stats.split("->")
-    assert (
-        int(mcp_before) == 5
-    ), f"Stats 'from' should be MCP count (5), got {mcp_before}"
-    assert int(mcp_after) == len(
-        mcp_in_result
-    ), f"Stats 'to' should match filtered MCP count, got {mcp_after}"
+    assert int(mcp_before) == 5, f"Stats 'from' should be MCP count (5), got {mcp_before}"
+    assert int(mcp_after) == len(mcp_in_result), f"Stats 'to' should match filtered MCP count, got {mcp_after}"
 
     print(
         f"✅ Hook preserves native tools: {len(all_tools)} -> {len(filtered)} "
@@ -668,19 +635,14 @@ async def test_semantic_filter_hook_all_native_tools():
     filtered = result["tools"]
 
     # All native tools must pass through
-    assert (
-        len(filtered) == 3
-    ), f"All 3 native tools must pass through, got {len(filtered)}"
+    assert len(filtered) == 3, f"All 3 native tools must pass through, got {len(filtered)}"
 
     # No spurious semantic filter stats (P2 fix)
-    assert (
-        "litellm_semantic_filter_stats" not in result["metadata"]
-    ), "Should NOT emit semantic filter stats for all-native-tool requests"
-
-    print(
-        f"✅ Hook passes through all {len(filtered)} native tools, "
-        f"no spurious filter headers emitted"
+    assert "litellm_semantic_filter_stats" not in result["metadata"], (
+        "Should NOT emit semantic filter stats for all-native-tool requests"
     )
+
+    print(f"✅ Hook passes through all {len(filtered)} native tools, no spurious filter headers emitted")
 
 
 @pytest.mark.asyncio
@@ -746,8 +708,7 @@ async def test_semantic_filter_hook_responses_api_name_collision():
 
     # Verify classification: should be native, not MCP
     assert not hook._is_mcp_tool(responses_api_tool), (
-        "Responses API tool with type=function + top-level name "
-        "should be classified as native, not MCP"
+        "Responses API tool with type=function + top-level name should be classified as native, not MCP"
     )
 
     # Full hook test: all-native request should preserve tools
@@ -874,9 +835,9 @@ async def test_semantic_filter_hook_filters_expanded_litellm_proxy_tools():
     for tool in filtered:
         assert tool in expanded_tools, "Filtered tools must be the original expanded tool dicts"
 
-    assert (
-        "litellm_semantic_filter_stats" in result["metadata"]
-    ), "Filter stats must be emitted for the litellm_proxy expansion path"
+    assert "litellm_semantic_filter_stats" in result["metadata"], (
+        "Filter stats must be emitted for the litellm_proxy expansion path"
+    )
     stats = result["metadata"]["litellm_semantic_filter_stats"]
     total, selected = stats.split("->")
     assert int(total) == 5, f"Stats 'from' should be pre-filter expanded count (5), got {total}"
@@ -1011,9 +972,9 @@ async def test_semantic_filter_hook_expansion_skips_filter_when_disabled():
 
     assert result is not None, "Hook should still expand MCP references when the filter is disabled"
     assert len(result["tools"]) == 5, f"All expanded tools must be forwarded when disabled, got {len(result['tools'])}"
-    assert (
-        "litellm_semantic_filter_stats" not in result["metadata"]
-    ), "No filter stats may be emitted when the filter is disabled"
+    assert "litellm_semantic_filter_stats" not in result["metadata"], (
+        "No filter stats may be emitted when the filter is disabled"
+    )
 
     print("✅ Disabled filter: expansion preserved, no spurious stats")
 
@@ -1116,9 +1077,7 @@ async def test_semantic_filter_hook_preserves_tool_order():
     assert filtered[1] is native_tool, "Second tool should be native_tool"
     assert filtered[2] is mcp_tool_b, "Third tool should be mcp_tool_b"
 
-    print(
-        "✅ Tool ordering preserved: [mcp_A, native, mcp_B] maintained after filtering"
-    )
+    print("✅ Tool ordering preserved: [mcp_A, native, mcp_B] maintained after filtering")
 
 
 class TestGetToolsByNames:
@@ -1228,9 +1187,7 @@ class TestGetToolsByNames:
         filter_instance = self._make_filter()
         available_tools = [{"name": "litellm_api-fs-read_file", "description": "read"}]
 
-        matched = filter_instance._get_tools_by_names(
-            ["fs-read_file", "api-fs-read_file"], available_tools
-        )
+        matched = filter_instance._get_tools_by_names(["fs-read_file", "api-fs-read_file"], available_tools)
 
         assert len(matched) == 1
 
@@ -1261,9 +1218,7 @@ class TestGetToolsByNames:
             {"name": "litellm_fs-delete", "description": "delete"},
         ]
 
-        matched = filter_instance._get_tools_by_names(
-            ["fs-write", "fs-delete", "fs-read"], available_tools
-        )
+        matched = filter_instance._get_tools_by_names(["fs-write", "fs-delete", "fs-read"], available_tools)
 
         names = [t["name"] for t in matched]
         assert names == [
@@ -1295,6 +1250,121 @@ class TestGetToolsByNames:
         )
 
         assert matched == []
+
+    def test_nested_chat_completions_format_matches_by_name(self):
+        """
+        Regression test (issue #31909): tools in the standard chat/completions
+        nested shape (``{"type": "function", "function": {"name": ...}}``)
+        must be name-matchable like the flat format, not invisible to the
+        filter.
+        """
+        filter_instance = self._make_filter()
+        available_tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "my_mcp-search",
+                    "description": "Search the web",
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "pkb_search",
+                    "description": "Search notes",
+                },
+            },
+        ]
+
+        matched = filter_instance._get_tools_by_names(["my_mcp-search"], available_tools)
+
+        assert len(matched) == 1
+        assert matched[0]["function"]["name"] == "my_mcp-search"
+
+    def test_fail_open_when_no_names_extractable(self):
+        """
+        Regression test (issue #31909): if the filter cannot extract a
+        usable name from any tool in ``available_tools``, it must fail
+        open and return the tools unchanged instead of silently
+        collapsing the request to zero tools.
+        """
+        filter_instance = self._make_filter()
+        available_tools = [
+            {"type": "mcp", "server_label": "x"},
+            {"type": "mcp", "server_label": "y"},
+        ]
+
+        matched = filter_instance._get_tools_by_names(["search"], available_tools)
+
+        assert matched == available_tools
+
+
+class TestExtractToolInfo:
+    """
+    Regression coverage for SemanticMCPToolFilter._extract_tool_info
+    (issue #31909): the nested chat/completions tool schema was silently
+    unparseable, returning an empty name for every such tool.
+    """
+
+    def _make_filter(self):
+        from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+            SemanticMCPToolFilter,
+        )
+
+        return SemanticMCPToolFilter(
+            embedding_model="text-embedding-3-small",
+            litellm_router_instance=Mock(),
+            top_k=5,
+            similarity_threshold=0.3,
+            enabled=True,
+        )
+
+    def test_nested_chat_completions_format(self):
+        filter_instance = self._make_filter()
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "my_mcp-search",
+                "description": "Search the web for pages relevant to a query",
+            },
+        }
+
+        name, description = filter_instance._extract_tool_info(tool)
+
+        assert name == "my_mcp-search"
+        assert description == "Search the web for pages relevant to a query"
+
+    def test_nested_format_missing_description_falls_back_to_name(self):
+        filter_instance = self._make_filter()
+        tool = {"type": "function", "function": {"name": "my_mcp-search"}}
+
+        name, description = filter_instance._extract_tool_info(tool)
+
+        assert name == "my_mcp-search"
+        assert description == "my_mcp-search"
+
+    def test_flat_format_unchanged(self):
+        """The legacy flat/Responses-API shape must keep working."""
+        filter_instance = self._make_filter()
+        tool = {"name": "send_email", "description": "send mail"}
+
+        name, description = filter_instance._extract_tool_info(tool)
+
+        assert name == "send_email"
+        assert description == "send mail"
+
+    def test_mcp_tool_object_unchanged(self):
+        filter_instance = self._make_filter()
+        tool = MCPTool(
+            name="scrape_url",
+            description="Fetch a URL",
+            inputSchema={"type": "object"},
+        )
+
+        name, description = filter_instance._extract_tool_info(tool)
+
+        assert name == "scrape_url"
+        assert description == "Fetch a URL"
 
 
 @pytest.mark.asyncio
@@ -1404,126 +1474,102 @@ def _make_context_window_filter(state, top_k: int = 3):
 
 
 @pytest.mark.asyncio
-async def test_semantic_filter_fails_closed_on_query_time_context_window_error():
+async def test_semantic_filter_returns_empty_on_query_time_context_window_error():
     """
-    Regression test (LIT-4284): a context-window overflow while embedding the
-    user query must fail closed with a typed error instead of silently
-    returning all tools (previously reported as N->N "success").
+    A context-window overflow while embedding the user query must return 0
+    MCP tools (native tools are preserved by the hook) instead of raising or
+    silently passing all tools through.
     """
-    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
-        SemanticToolFilterContextWindowError,
-    )
-
     state = {"raise_context_error": False}
     filter_instance = _make_context_window_filter(state)
 
-    tools = [
-        MCPTool(name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"})
-        for i in range(5)
-    ]
+    tools = [MCPTool(name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"}) for i in range(5)]
     filter_instance._build_router(tools)
     assert filter_instance.tool_router is not None
 
     state["raise_context_error"] = True
-    with pytest.raises(SemanticToolFilterContextWindowError) as exc_info:
-        await filter_instance.filter_tools(query="send an email", available_tools=tools)
+    result = await filter_instance.filter_tools(query="send an email", available_tools=tools)
 
-    message = str(exc_info.value)
-    assert "context window" in message
-    assert "text-embedding-3-small" in message
-    print("✅ Query-time context window overflow fails closed")
+    assert result == [], f"Expected 0 MCP tools on context window overflow, got {len(result)}"
+    print("✅ Query-time context window overflow returns 0 MCP tools")
 
 
 @pytest.mark.asyncio
-async def test_semantic_filter_records_build_time_context_window_error():
+async def test_semantic_filter_returns_empty_on_build_time_context_window_error():
     """
-    Regression test (LIT-4284): a context-window overflow while embedding the
-    tool descriptions at router-build time must be recorded (not raised out of
-    the build, which previously left the hook unregistered and filtering
-    silently disabled) and must fail subsequent filtering closed.
+    A context-window overflow while embedding the tool descriptions at
+    router-build time must be recorded (not raised out of the build) and
+    subsequent filtering must return 0 MCP tools instead of raising.
     """
-    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
-        SemanticToolFilterContextWindowError,
-    )
-
     state = {"raise_context_error": True}
     filter_instance = _make_context_window_filter(state)
 
-    tools = [
-        MCPTool(name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"})
-        for i in range(5)
-    ]
+    tools = [MCPTool(name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"}) for i in range(5)]
     filter_instance._build_router(tools)
 
     assert filter_instance.tool_router is None
     assert filter_instance.context_window_error is not None
 
-    with pytest.raises(SemanticToolFilterContextWindowError) as exc_info:
-        await filter_instance.filter_tools(query="send an email", available_tools=tools)
+    result = await filter_instance.filter_tools(query="send an email", available_tools=tools)
 
-    message = str(exc_info.value)
-    assert "context window" in message
-    assert "tool descriptions" in message
-    print("✅ Build-time context window overflow is recorded and fails closed")
+    assert result == [], f"Expected 0 MCP tools on build-time context window error, got {len(result)}"
+    print("✅ Build-time context window overflow is recorded and returns 0 MCP tools")
 
 
 @pytest.mark.asyncio
-async def test_semantic_filter_hook_fails_closed_on_context_window_error():
+async def test_semantic_filter_hook_drops_mcp_tools_on_context_window_error():
     """
-    Regression test (LIT-4284): the pre-call hook must reject the request with
-    an actionable HTTP 400 when the embedding model overflows its context
-    window, instead of forwarding all tools and emitting an N->N success
-    header.
+    The pre-call hook must preserve all native tools and drop every MCP tool
+    when the embedding model overflows its context window, instead of raising
+    or forwarding all MCP tools.
     """
-    from fastapi import HTTPException
-
     from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
 
     state = {"raise_context_error": False}
     filter_instance = _make_context_window_filter(state)
 
-    tools = [
-        MCPTool(name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"})
-        for i in range(5)
-    ]
-    filter_instance._build_router(tools)
+    mcp_tools = [MCPTool(name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"}) for i in range(5)]
+    filter_instance._build_router(mcp_tools)
     hook = SemanticToolFilterHook(filter_instance)
+
+    native_tools = [
+        {
+            "type": "function",
+            "function": {"name": "local_fn", "description": "A local function", "parameters": {}},
+        }
+    ]
 
     state["raise_context_error"] = True
     data = {
         "model": "gpt-4",
         "messages": [{"role": "user", "content": "Send an email"}],
-        "tools": tools,
+        "tools": mcp_tools + native_tools,
         "metadata": {},
     }
 
-    with pytest.raises(HTTPException) as exc_info:
-        await hook.async_pre_call_hook(
-            user_api_key_dict=Mock(),
-            cache=Mock(),
-            data=data,
-            call_type="completion",
-        )
+    result = await hook.async_pre_call_hook(
+        user_api_key_dict=Mock(),
+        cache=Mock(),
+        data=data,
+        call_type="completion",
+    )
 
-    assert exc_info.value.status_code == 400
-    error_message = exc_info.value.detail["error"]
-    assert "context window" in error_message
-    assert "text-embedding-3-small" in error_message
-    assert "larger context window" in error_message
-    assert "maximum input length" not in error_message
-    print("✅ Hook fails closed with actionable 400 on context window overflow")
+    assert result is not None
+    result_tools = result["tools"]
+    assert len(result_tools) == len(native_tools), (
+        f"Expected only {len(native_tools)} native tool(s) to survive, got {len(result_tools)}"
+    )
+    assert result_tools == native_tools
+    print("✅ Hook drops all MCP tools and preserves native tools on context window overflow")
 
 
 @pytest.mark.asyncio
-async def test_semantic_filter_hook_fails_closed_on_expanded_tools_context_window_error():
+async def test_semantic_filter_hook_drops_mcp_tools_on_expanded_tools_context_window_error():
     """
-    Regression test (LIT-4284): the litellm_proxy MCP expansion path (driven
-    by the dashboard test panel via /v1/responses) must also fail closed with
-    an actionable HTTP 400 instead of being swallowed by the expansion
-    catch-all.
+    The litellm_proxy MCP expansion path (driven by the dashboard test panel
+    via /v1/responses) must also drop all expanded MCP tools on context window
+    overflow instead of raising or being swallowed by the expansion catch-all.
     """
-    from fastapi import HTTPException
-
     from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
 
     state = {"raise_context_error": False}
@@ -1564,20 +1610,19 @@ async def test_semantic_filter_hook_fails_closed_on_expanded_tools_context_windo
         "metadata": {},
     }
 
-    with pytest.raises(HTTPException) as exc_info:
-        await hook.async_pre_call_hook(
-            user_api_key_dict=Mock(),
-            cache=Mock(),
-            data=data,
-            call_type="aresponses",
-        )
+    result = await hook.async_pre_call_hook(
+        user_api_key_dict=Mock(),
+        cache=Mock(),
+        data=data,
+        call_type="aresponses",
+    )
 
-    assert exc_info.value.status_code == 400
-    error_message = exc_info.value.detail["error"]
-    assert "context window" in error_message
-    assert "larger context window" in error_message
-    assert "maximum input length" not in error_message
-    print("✅ Expansion path fails closed with actionable 400 on context window overflow")
+    assert result is not None
+    result_tools = result["tools"]
+    assert result_tools == [], (
+        f"Expected 0 MCP tools after context window overflow on expansion path, got {len(result_tools)}"
+    )
+    print("✅ Expansion path drops all MCP tools on context window overflow")
 
 
 @pytest.mark.asyncio
@@ -1592,10 +1637,7 @@ async def test_semantic_filter_hook_ignores_build_error_for_native_only_tools():
     state = {"raise_context_error": True}
     filter_instance = _make_context_window_filter(state)
 
-    mcp_tools = [
-        MCPTool(name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"})
-        for i in range(3)
-    ]
+    mcp_tools = [MCPTool(name=f"tool_{i}", description=f"Tool {i}", inputSchema={"type": "object"}) for i in range(3)]
     filter_instance._build_router(mcp_tools)
     assert filter_instance.context_window_error is not None
 
@@ -1653,9 +1695,7 @@ def test_is_context_window_error_detection_variants():
 
     try:
         try:
-            raise litellm.ContextWindowExceededError(
-                message="overflow", model="m", llm_provider="openai"
-            )
+            raise litellm.ContextWindowExceededError(message="overflow", model="m", llm_provider="openai")
         except litellm.ContextWindowExceededError:
             raise ValueError("wrapper without explicit chaining")
     except ValueError as implicitly_chained:


### PR DESCRIPTION
Relevant issues
Fixes #31909
And related to PR: https://github.com/BerriAI/litellm/pull/32064


Pre-Submission checklist
Please complete all items before asking a LiteLLM maintainer to review your PR
- I have added meaningful tests
- My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- My PR's scope is as isolated as possible; it only solves 1 specific problem
- I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment @greptileai to re-request a review after pushing changes)
Delays in PR merge?
If you're seeing a delay in your PR being merged, ping the LiteLLM Team on Slack (#pr-review) (https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).
Screenshots / Proof of Fix
Before (commit aa9dcb4, pre-fix): when the embedding model overflowed its context window, the hook raised SemanticToolFilterContextWindowError → HTTPException(400), blocking the entire request — including native (non-MCP) tools — with no recovery path. Reproduction: call /v1/chat/completions with a long user query against an MCP semantic filter configured with text-embedding-3-small; request returns 400 {"error": "MCP semantic tool filtering could not run: embedding model 'text-embedding-3-small' exceeded its context window..."}. Additionally, tools in the nested Chat Completions shape {"type":"function","function":{"name":...}} were silently invisible to the filter (empty extracted name), and the semantic filter init ran before DB-stored model deployments were registered, failing for embedding models that only exist in the DB.
After (commit 1c75729): the same overflow now logs a WARNING and returns [] MCP tools while native tools pass through untouched. The request succeeds. _extract_tool_info parses both nested and flat function formats, and the hook falls back to tolerant suffix matching + fail-open when no tool names can be extracted. Startup init runs after initialize_scheduled_background_jobs, so DB-only embedding models are registered before the semantic router embeds tool descriptions.
$ uv run pytest tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py -v
...
test_semantic_filter_returns_empty_on_query_time_context_window_error PASSED
test_semantic_filter_returns_empty_on_build_time_context_window_error PASSED
test_semantic_filter_hook_drops_mcp_tools_on_context_window_error PASSED
test_semantic_filter_hook_drops_mcp_tools_on_expanded_tools_context_window_error PASSED
test_nested_chat_completions_format_matches_by_name PASSED
test_fail_open_when_no_names_extractable PASSED
...
Type
🐛 Bug Fix
Changes
- litellm/proxy/_experimental/mcp_server/semantic_tool_filter.py
- Removed SemanticToolFilterContextWindowError. Build-time and query-time embedding context-window overflows now log a WARNING and return [] MCP tools (native tools preserved by the hook) instead of raising and blocking the request.
- _extract_tool_info now handles the nested Chat Completions format {"type":"function","function":{"name":...,"description":...}} in addition to the flat {"type":"function","name":...} shape.
- _get_tools_by_names fails open (returns available_tools unfiltered) when no usable name can be extracted from any tool, instead of silently collapsing to zero tools.
- litellm/proxy/hooks/mcp_semantic_filter/hook.py
- Removed HTTPException(400) raising on context-window overflow; the hook now preserves all native tools and drops every MCP tool when the embedding model overflows.
- _is_mcp_tool now uses tolerant suffix matching (SemanticMCPToolFilter._name_matches_canonical) for client-side namespace prefixes (e.g. litellm_api-fs-read_file vs canonical fs-read_file) instead of only exact-match lookup.
- litellm/proxy/proxy_server.py
- Reordered proxy_startup_event so ProxyStartupEvent._initialize_semantic_tool_filter runs after initialize_scheduled_background_jobs and DB-stored model deployments are registered. Previously, init ran early and failed for embedding models that only exist in the DB (not in config.yaml), leaving the hook unregistered and semantic filtering silently disabled.
- tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
- Renamed/rewrote the three fail-closed regression tests (test_semantic_filter_fails_closed_on_query_time_context_window_error, test_semantic_filter_records_build_time_context_window_error, test_semantic_filter_hook_fails_closed_on_context_window_error, test_semantic_filter_hook_fails_closed_on_expanded_tools_context_window_error) to assert the new fail-open behavior: empty MCP-tool result, native tools preserved.
- Added TestExtractToolInfo covering nested Chat Completions, flat, and MCPTool shapes.
- Added test_nested_chat_completions_format_matches_by_name and test_fail_open_when_no_names_extractable under TestGetToolsByNames.
QA runbook
<!-- N/A — no tests/e2e changes -->
Final Attestation
- The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR