### PR TITLE
test(e2e): a user's max_budget follows the person across personal and team keys

### DIFF
--- a/tests/e2e/quota_management/budgets/test_budget_enforcement_e2e.py
+++ b/tests/e2e/quota_management/budgets/test_budget_enforcement_e2e.py
@@ -119,12 +119,36 @@ class TeamBudgetCase(_BudgetCase):
 
 
 class InternalUserBudgetCase(_BudgetCase):
+    """A user's max_budget follows the person, not the key. The capped user holds
+    two personal keys (no team, no key budgets) plus a team-member key on an
+    uncapped team; once the first personal key is refused, the other two must be
+    refused as well - a second key is not a fresh allowance, and since #32005 the
+    user budget draws down team keys too. All refusals must be 429 budget_exceeded."""
+
     def init(self) -> None:
         user_id = self.client.create_user(max_budget=3e-6)
         self._undo.append(lambda: self.client.delete_user(user_id))
-        # personal key (no team) -> the user budget governs
         self.key = self.client.generate_key(user_id=user_id)
         self._undo.append(lambda: self.client.delete_key(self.key))
+        self._second_key = self.client.generate_key(user_id=user_id)
+        self._undo.append(lambda: self.client.delete_key(self._second_key))
+        team_id = self.client.create_team(alias=f"e2e-budget-team-{unique_marker()}")
+        self._undo.append(lambda: self.client.delete_team(team_id))
+        self.client.add_team_member(team_id, user_id)
+        self._team_key = self.client.generate_key(team_id=team_id, user_id=user_id)
+        self._undo.append(lambda: self.client.delete_key(self._team_key))
+
+    def run(self) -> None:
+        blocked = _assert_budget_blocks(self.client, self.key)
+        assert blocked.status_code == 429, (
+            f"budget refusal must be 429, got {blocked.status_code}: {blocked.body[:200]}"
+        )
+        for label, key in (("second personal key", self._second_key), ("team-member key", self._team_key)):
+            result = self.client.chat(key, "claude-haiku-4-5", f"spend {unique_marker()}", max_tokens=16)
+            assert is_budget_block(result) and result.status_code == 429, (
+                f"the {label} of a user over budget must get the same 429 budget_exceeded, "
+                f"got {result.status_code}: {result.body[:200]}"
+            )
 
 
 class EndUserBudgetCase(_BudgetCase):


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured at cdc5deb5f3, before the branch was rebased onto litellm_internal_staging once #33632 squash-merged (the identical change now sits at c9249ec6f1), against a live proxy (docker compose stack in tests/e2e) with real paid llama-3.3-70b-versatile calls through the `claude-haiku-4-5` model group. A user with max_budget 3e-06 holding two personal keys (user_id only) and one team-member key on an uncapped team:

```
--- personal key 1, call 1 ---
... "usage":{"completion_tokens":16,"prompt_tokens":40,"total_tokens":56, ...
HTTP 200
--- personal key 1, call 2 ---
{"error":{"message":"ExceededBudget: User=8ef70057-dee8-4d89-96a2-445b35e8df6e over budget. Spend=3.624e-05, Budget=3e-06","type":"budget_exceeded","param":null,"code":"429"}}
HTTP 429
--- personal key 2, first call ---
{"error":{"message":"ExceededBudget: User=8ef70057-dee8-4d89-96a2-445b35e8df6e over budget. Spend=3.624e-05, Budget=3e-06","type":"budget_exceeded","param":null,"code":"429"}}
HTTP 429
--- team-member key on uncapped team, first call ---
{"error":{"message":"ExceededBudget: User=8ef70057-dee8-4d89-96a2-445b35e8df6e over budget. Spend=3.624e-05, Budget=3e-06","type":"budget_exceeded","param":null,"code":"429"}}
HTTP 429
```

One key's spend exhausts the user's budget and every key the person holds is refused, including the team-member key on a team with no budget of its own. All 6 enforcement cases pass against the same live proxy (6 passed in 14.83s) and `basedpyright tests/e2e` reports 0 errors

## Type

✅ Test

## Changes

The internal-user budget case in `tests/e2e/quota_management/budgets/test_budget_enforcement_e2e.py` (covering `quota_management.budget.internal_user.blocks_over_limit`) proved a user's `max_budget` blocks a single personal key. What nothing asserted is the property that makes a user budget a user budget: the cap follows the person, not the key. `InternalUserBudgetCase` now gives the capped user two personal keys plus a team-member key on an uncapped team; after the first personal key is driven to a refusal, one call on each of the other two keys must also be refused. The second personal key proves a fresh key is not a fresh allowance; the team-member key proves the user budget draws down team keys as well (the behavior introduced by #32005). All refusals must be HTTP 429 with error type `budget_exceeded`

Targets litellm_internal_staging directly; the `_assert_budget_blocks` return value it builds on landed with #33632. The diff here is only the internal-user case

## QA runbook

- tests/e2e/quota_management/budgets/test_budget_enforcement_e2e.py::test_budget_enforcement[InternalUserBudgetCase] - a user's max_budget pools across every key the person holds: a second personal key and a team-member key on an uncapped team are refused once the user is over budget
  - [x] POST /user/new with `{"max_budget":0.000003}` and save the user_id
  - [x] POST /key/generate with `{"user_id":"<user_id>"}` twice (personal keys 1 and 2)
  - [x] POST /team/new with `{"team_alias":"qa-uncapped"}`, POST /team/member_add for the user, then POST /key/generate with `{"team_id":"<team_id>","user_id":"<user_id>"}`
  - [x] Send short chat completions with personal key 1 a couple of seconds apart until one is refused and confirm a 429 whose body has type budget_exceeded naming the user
  - [x] Send 1 chat completion with personal key 2 and confirm the same 429 on its first call
  - [x] Send 1 chat completion with the team-member key and confirm the same 429
  - [x] POST /key/delete, /team/delete, /user/delete to clean up

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

