### PR TITLE
fix(transcription): accept token usage without input_token_details

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/usage_object_transformation.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/usage_object_transformation.py
@@ -24,13 +24,19 @@ class TranscriptionUsageObjectTransformation:
         if isinstance(usage_object, TranscriptionUsageDurationObject):
             return None
         elif isinstance(usage_object, TranscriptionUsageTokensObject):
+            input_token_details = usage_object.input_token_details
+            prompt_tokens_details = (
+                PromptTokensDetailsWrapper(
+                    text_tokens=input_token_details.text_tokens,
+                    audio_tokens=input_token_details.audio_tokens,
+                )
+                if input_token_details is not None
+                else None
+            )
             return Usage(
                 prompt_tokens=usage_object.input_tokens,
                 completion_tokens=usage_object.output_tokens,
                 total_tokens=usage_object.total_tokens,
-                prompt_tokens_details=PromptTokensDetailsWrapper(
-                    text_tokens=usage_object.input_token_details.text_tokens,
-                    audio_tokens=usage_object.input_token_details.audio_tokens,
-                ),
+                prompt_tokens_details=prompt_tokens_details,
             )
         return None

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2368,7 +2368,7 @@ class TranscriptionUsageTokensObject(BaseModel):
     input_tokens: int
     output_tokens: int
     total_tokens: int
-    input_token_details: TranscriptionUsageInputTokenDetailsObject
+    input_token_details: Optional[TranscriptionUsageInputTokenDetailsObject] = None
 
 
 class TranscriptionResponse(OpenAIObject):

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_usage_object_transformation.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_usage_object_transformation.py
@@ -1,0 +1,51 @@
+"""
+Tests for ``TranscriptionUsageObjectTransformation`` in
+``litellm.litellm_core_utils.llm_cost_calc.usage_object_transformation``.
+"""
+
+from litellm.litellm_core_utils.llm_cost_calc.usage_object_transformation import (
+    TranscriptionUsageObjectTransformation,
+)
+from litellm.types.utils import (
+    TranscriptionUsageInputTokenDetailsObject,
+    TranscriptionUsageTokensObject,
+)
+
+
+def test_transform_transcription_tokens_without_input_token_details():
+    """Token usage without the per-modality input_token_details breakdown must still
+    produce a Usage (token counts drive cost), not crash on None.
+
+    Regression for https://github.com/BerriAI/litellm/issues/33764
+    """
+    usage_object = TranscriptionUsageTokensObject(
+        type="tokens",
+        input_tokens=14,
+        output_tokens=45,
+        total_tokens=59,
+        input_token_details=None,
+    )
+
+    usage = TranscriptionUsageObjectTransformation.transform_transcription_usage_object(usage_object)
+
+    assert usage is not None
+    assert usage.prompt_tokens == 14
+    assert usage.completion_tokens == 45
+    assert usage.total_tokens == 59
+    assert usage.prompt_tokens_details is None
+
+
+def test_transform_transcription_tokens_with_input_token_details():
+    """When the breakdown is present it is carried into prompt_tokens_details."""
+    usage_object = TranscriptionUsageTokensObject(
+        type="tokens",
+        input_tokens=14,
+        output_tokens=45,
+        total_tokens=59,
+        input_token_details=TranscriptionUsageInputTokenDetailsObject(audio_tokens=14, text_tokens=0),
+    )
+
+    usage = TranscriptionUsageObjectTransformation.transform_transcription_usage_object(usage_object)
+
+    assert usage.prompt_tokens_details.audio_tokens == 14
+    assert usage.prompt_tokens_details.text_tokens == 0

--- a/tests/test_litellm/litellm_core_utils/llm_response_utils/test_convert_dict_to_response.py
+++ b/tests/test_litellm/litellm_core_utils/llm_response_utils/test_convert_dict_to_response.py
@@ -1,0 +1,58 @@
+"""
+Tests for ``convert_to_model_response_object`` transcription usage handling in
+``litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response``.
+"""
+
+from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
+    convert_to_model_response_object,
+)
+
+
+def test_transcription_usage_tokens_allows_none_input_token_details():
+    """Servers like llama.cpp (response_format=json) return token usage without the
+    per-modality input_token_details breakdown, so it must be accepted as None.
+
+    Regression for https://github.com/BerriAI/litellm/issues/33764
+    """
+    response_object = {
+        "text": "the transcription text",
+        "usage": {
+            "type": "tokens",
+            "input_tokens": 14,
+            "output_tokens": 45,
+            "total_tokens": 59,
+            "input_token_details": None,
+        },
+    }
+
+    result = convert_to_model_response_object(
+        response_object=response_object,
+        response_type="audio_transcription",
+    )
+
+    assert result.text == "the transcription text"
+    assert result.usage.type == "tokens"
+    assert result.usage.total_tokens == 59
+    assert result.usage.input_token_details is None
+
+
+def test_transcription_usage_tokens_preserves_input_token_details():
+    """When the server does provide input_token_details, it is still parsed."""
+    response_object = {
+        "text": "hello",
+        "usage": {
+            "type": "tokens",
+            "input_tokens": 14,
+            "output_tokens": 45,
+            "total_tokens": 59,
+            "input_token_details": {"audio_tokens": 14, "text_tokens": 0},
+        },
+    }
+
+    result = convert_to_model_response_object(
+        response_object=response_object,
+        response_type="audio_transcription",
+    )
+
+    assert result.usage.input_token_details.audio_tokens == 14
+    assert result.usage.input_token_details.text_tokens == 0


### PR DESCRIPTION
## Relevant issues

Fixes #33764

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a pure-SDK response-parsing bug (no provider call needed to trigger it), so the reproduction below drives the real `convert_to_model_response_object` with the token usage shape a server like llama.cpp returns for `response_format=json` (token usage without the per-modality `input_token_details` breakdown)

before, base at `1ebf2a78a9`

```
RAISED Exception: Invalid response object Traceback (most recent call last):
  ...
  tr_usage_object = TranscriptionUsageTokensObject(**response_object["usage"])
  pydantic_core._pydantic_core.ValidationError: 1 validation error for TranscriptionUsageTokensObject
  input_token_details
    Input should be a valid dictionary or instance of TranscriptionUsageInputTokenDetailsObject [input_value=None]
```

after, this PR at `0c8c0cedd9`

```
OK  text = 'the transcription text'
OK  usage.type = tokens  input_token_details = None
```

Reproduction script:

```python
from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
    convert_to_model_response_object,
)

response_object = {
    "text": "the transcription text",
    "usage": {
        "type": "tokens",
        "input_tokens": 14,
        "output_tokens": 45,
        "total_tokens": 59,
        "input_token_details": None,
    },
}
result = convert_to_model_response_object(response_object=response_object, response_type="audio_transcription")
print(result.text, result.usage.input_token_details)
```

## Type

🐛 Bug Fix

## Changes

Transcription responses from OpenAI-compatible servers return token usage where the per-modality `input_token_details` breakdown is absent. OpenAI itself always includes it, but servers such as llama.cpp (which only supports `response_format=json`) return `input_token_details: None`. `TranscriptionUsageTokensObject.input_token_details` was declared as a required `TranscriptionUsageInputTokenDetailsObject`, so pydantic rejected the `None` and `convert_to_model_response_object` raised `Invalid response object` on an otherwise valid transcription; the same request works with the openai client directly

The field is now `Optional[TranscriptionUsageInputTokenDetailsObject] = None`, matching that the breakdown is not guaranteed across providers. The pydantic error reported only this field, so `input_tokens`, `output_tokens`, and `total_tokens` are unaffected, and the change is backward compatible for providers that do send the breakdown

The cost path is updated to match. `transform_transcription_usage_object` in `llm_cost_calc/usage_object_transformation.py` dereferenced `input_token_details.text_tokens` / `.audio_tokens` unconditionally, so once the field can be `None` a transcription would raise `AttributeError` during cost calculation. It now sets `prompt_tokens_details` to `None` when the breakdown is absent, so token-based cost still comes from `prompt_tokens` / `completion_tokens` / `total_tokens` (which are always present) and spend is decremented normally

Tests are in two new mapped files. `test_convert_dict_to_response.py` asserts a `type: tokens` usage with `input_token_details: None` now parses through `convert_to_model_response_object` (fails on the pre-fix code) and that a populated breakdown is still parsed. `test_usage_object_transformation.py` asserts the cost transform produces a `Usage` with the right token counts and `prompt_tokens_details=None` for the no-breakdown case (fails with `AttributeError` on the pre-fix code) and preserves the breakdown when present
