### PR TITLE
fix(utils): report missing API keys for compactifai, clarifai, ovhcloud

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -6149,6 +6149,21 @@ def validate_environment(
                 keys_in_environment = True
             else:
                 missing_keys.append("MOONSHOT_API_KEY")
+        elif custom_llm_provider == "compactifai":
+            if "COMPACTIFAI_API_KEY" in os.environ:
+                keys_in_environment = True
+            else:
+                missing_keys.append("COMPACTIFAI_API_KEY")
+        elif custom_llm_provider == "clarifai":
+            if "CLARIFAI_API_KEY" in os.environ:
+                keys_in_environment = True
+            else:
+                missing_keys.append("CLARIFAI_API_KEY")
+        elif custom_llm_provider == "ovhcloud":
+            if "OVHCLOUD_API_KEY" in os.environ:
+                keys_in_environment = True
+            else:
+                missing_keys.append("OVHCLOUD_API_KEY")
     else:
         ## openai - chatcompletion + text completion
         if (

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4863,3 +4863,47 @@ def test_is_prompt_caching_valid_prompt_explicit_min_token_count_overrides_model
         is_prompt_caching_valid_prompt(model="claude-opus-4-8", messages=PROMPT_CACHE_MESSAGES, min_token_count=8192)
         is False
     )
+class TestValidateEnvironmentWave20260716:
+    """compactifai / clarifai / ovhcloud must not false-positive all-clear."""
+
+    def test_compactifai_reports_key_present(self):
+        with patch.dict(os.environ, {"COMPACTIFAI_API_KEY": "test-key"}, clear=True):
+            result = litellm.validate_environment(model="compactifai/test-model")
+        assert result["keys_in_environment"] is True
+        assert "COMPACTIFAI_API_KEY" not in result["missing_keys"]
+
+    def test_compactifai_reports_key_missing(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = litellm.validate_environment(model="compactifai/test-model")
+        assert result["keys_in_environment"] is False
+        assert "COMPACTIFAI_API_KEY" in result["missing_keys"]
+
+    def test_clarifai_reports_key_present(self):
+        with patch.dict(os.environ, {"CLARIFAI_API_KEY": "test-key"}, clear=True):
+            result = litellm.validate_environment(
+                model="clarifai/openai.chat-completion.gpt-4o"
+            )
+        assert result["keys_in_environment"] is True
+        assert "CLARIFAI_API_KEY" not in result["missing_keys"]
+
+    def test_clarifai_reports_key_missing(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = litellm.validate_environment(
+                model="clarifai/openai.chat-completion.gpt-4o"
+            )
+        assert result["keys_in_environment"] is False
+        assert "CLARIFAI_API_KEY" in result["missing_keys"]
+
+    def test_ovhcloud_reports_key_present(self):
+        with patch.dict(os.environ, {"OVHCLOUD_API_KEY": "test-key"}, clear=True):
+            result = litellm.validate_environment(model="ovhcloud/test-model")
+        assert result["keys_in_environment"] is True
+        assert "OVHCLOUD_API_KEY" not in result["missing_keys"]
+
+    def test_ovhcloud_reports_key_missing(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = litellm.validate_environment(model="ovhcloud/test-model")
+        assert result["keys_in_environment"] is False
+        assert "OVHCLOUD_API_KEY" in result["missing_keys"]
+
+

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4863,3 +4863,45 @@ def test_is_prompt_caching_valid_prompt_explicit_min_token_count_overrides_model
         is_prompt_caching_valid_prompt(model="claude-opus-4-8", messages=PROMPT_CACHE_MESSAGES, min_token_count=8192)
         is False
     )
+
+
+class TestValidateEnvironmentProviderKeys:
+    def test_compactifai_reports_key_present(self):
+        with patch.dict(os.environ, {"COMPACTIFAI_API_KEY": "test-key"}, clear=True):
+            result = litellm.validate_environment(model="compactifai/test-model")
+        assert result["keys_in_environment"] is True
+        assert "COMPACTIFAI_API_KEY" not in result["missing_keys"]
+
+    def test_compactifai_reports_key_missing(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = litellm.validate_environment(model="compactifai/test-model")
+        assert result["keys_in_environment"] is False
+        assert "COMPACTIFAI_API_KEY" in result["missing_keys"]
+
+    def test_clarifai_reports_key_present(self):
+        with patch.dict(os.environ, {"CLARIFAI_API_KEY": "test-key"}, clear=True):
+            result = litellm.validate_environment(
+                model="clarifai/openai.chat-completion.gpt-4o"
+            )
+        assert result["keys_in_environment"] is True
+        assert "CLARIFAI_API_KEY" not in result["missing_keys"]
+
+    def test_clarifai_reports_key_missing(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = litellm.validate_environment(
+                model="clarifai/openai.chat-completion.gpt-4o"
+            )
+        assert result["keys_in_environment"] is False
+        assert "CLARIFAI_API_KEY" in result["missing_keys"]
+
+    def test_ovhcloud_reports_key_present(self):
+        with patch.dict(os.environ, {"OVHCLOUD_API_KEY": "test-key"}, clear=True):
+            result = litellm.validate_environment(model="ovhcloud/test-model")
+        assert result["keys_in_environment"] is True
+        assert "OVHCLOUD_API_KEY" not in result["missing_keys"]
+
+    def test_ovhcloud_reports_key_missing(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = litellm.validate_environment(model="ovhcloud/test-model")
+        assert result["keys_in_environment"] is False
+        assert "OVHCLOUD_API_KEY" in result["missing_keys"]


### PR DESCRIPTION
## Relevant issues

Successor of #33614 (closed: GitHub kept a DIRTY merge state / huge file list after rebase even though the tip is a single commit on `main`).

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

- `validate_environment`: report missing `COMPACTIFAI_API_KEY`, `CLARIFAI_API_KEY`, `OVHCLOUD_API_KEY` instead of false all-clear when those providers are selected
- Unit tests for present/missing key for each provider

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR