### PR TITLE
fix(utils): report missing API keys in validate_environment for sambanova, hyperbolic, and lambda_ai

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -6149,6 +6149,21 @@ def validate_environment(
                 keys_in_environment = True
             else:
                 missing_keys.append("MOONSHOT_API_KEY")
+        elif custom_llm_provider == "sambanova":
+            if "SAMBANOVA_API_KEY" in os.environ:
+                keys_in_environment = True
+            else:
+                missing_keys.append("SAMBANOVA_API_KEY")
+        elif custom_llm_provider == "hyperbolic":
+            if "HYPERBOLIC_API_KEY" in os.environ:
+                keys_in_environment = True
+            else:
+                missing_keys.append("HYPERBOLIC_API_KEY")
+        elif custom_llm_provider == "lambda_ai":
+            if "LAMBDA_API_KEY" in os.environ:
+                keys_in_environment = True
+            else:
+                missing_keys.append("LAMBDA_API_KEY")
     else:
         ## openai - chatcompletion + text completion
         if (

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4765,6 +4765,59 @@ class TestVertexEmbeddingEncodingFormat:
             custom_llm_provider="vertex_ai",
         )
         assert optional_params.get("outputDimensionality") == 256
+class TestValidateEnvironmentMissingProviders:
+    """Regression: sambanova/hyperbolic/lambda_ai must not false-positive all-clear."""
+
+    def test_sambanova_reports_key_present(self):
+        with patch.dict(os.environ, {"SAMBANOVA_API_KEY": "test-key"}, clear=True):
+            result = litellm.validate_environment(
+                model="sambanova/Meta-Llama-3.1-8B-Instruct"
+            )
+        assert result["keys_in_environment"] is True
+        assert "SAMBANOVA_API_KEY" not in result["missing_keys"]
+
+    def test_sambanova_reports_key_missing(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = litellm.validate_environment(
+                model="sambanova/Meta-Llama-3.1-8B-Instruct"
+            )
+        assert result["keys_in_environment"] is False
+        assert "SAMBANOVA_API_KEY" in result["missing_keys"]
+
+    def test_hyperbolic_reports_key_present(self):
+        with patch.dict(
+            os.environ, {"HYPERBOLIC_API_KEY": "test-key"}, clear=True
+        ):
+            result = litellm.validate_environment(
+                model="hyperbolic/meta-llama/Meta-Llama-3.1-70B-Instruct"
+            )
+        assert result["keys_in_environment"] is True
+        assert "HYPERBOLIC_API_KEY" not in result["missing_keys"]
+
+    def test_hyperbolic_reports_key_missing(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = litellm.validate_environment(
+                model="hyperbolic/meta-llama/Meta-Llama-3.1-70B-Instruct"
+            )
+        assert result["keys_in_environment"] is False
+        assert "HYPERBOLIC_API_KEY" in result["missing_keys"]
+
+    def test_lambda_ai_reports_key_present(self):
+        with patch.dict(os.environ, {"LAMBDA_API_KEY": "test-key"}, clear=True):
+            result = litellm.validate_environment(
+                model="lambda_ai/llama3.1-70b-instruct-fp8"
+            )
+        assert result["keys_in_environment"] is True
+        assert "LAMBDA_API_KEY" not in result["missing_keys"]
+
+    def test_lambda_ai_reports_key_missing(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = litellm.validate_environment(
+                model="lambda_ai/llama3.1-70b-instruct-fp8"
+            )
+        assert result["keys_in_environment"] is False
+        assert "LAMBDA_API_KEY" in result["missing_keys"]
+
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4863,3 +4863,55 @@ def test_is_prompt_caching_valid_prompt_explicit_min_token_count_overrides_model
         is_prompt_caching_valid_prompt(model="claude-opus-4-8", messages=PROMPT_CACHE_MESSAGES, min_token_count=8192)
         is False
     )
+
+
+class TestValidateEnvironmentProviderKeys:
+    def test_sambanova_reports_key_present(self):
+        with patch.dict(os.environ, {"SAMBANOVA_API_KEY": "test-key"}, clear=True):
+            result = litellm.validate_environment(
+                model="sambanova/Meta-Llama-3.1-8B-Instruct"
+            )
+        assert result["keys_in_environment"] is True
+        assert "SAMBANOVA_API_KEY" not in result["missing_keys"]
+
+    def test_sambanova_reports_key_missing(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = litellm.validate_environment(
+                model="sambanova/Meta-Llama-3.1-8B-Instruct"
+            )
+        assert result["keys_in_environment"] is False
+        assert "SAMBANOVA_API_KEY" in result["missing_keys"]
+
+    def test_hyperbolic_reports_key_present(self):
+        with patch.dict(
+            os.environ, {"HYPERBOLIC_API_KEY": "test-key"}, clear=True
+        ):
+            result = litellm.validate_environment(
+                model="hyperbolic/meta-llama/Meta-Llama-3.1-70B-Instruct"
+            )
+        assert result["keys_in_environment"] is True
+        assert "HYPERBOLIC_API_KEY" not in result["missing_keys"]
+
+    def test_hyperbolic_reports_key_missing(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = litellm.validate_environment(
+                model="hyperbolic/meta-llama/Meta-Llama-3.1-70B-Instruct"
+            )
+        assert result["keys_in_environment"] is False
+        assert "HYPERBOLIC_API_KEY" in result["missing_keys"]
+
+    def test_lambda_ai_reports_key_present(self):
+        with patch.dict(os.environ, {"LAMBDA_API_KEY": "test-key"}, clear=True):
+            result = litellm.validate_environment(
+                model="lambda_ai/llama3.1-70b-instruct-fp8"
+            )
+        assert result["keys_in_environment"] is True
+        assert "LAMBDA_API_KEY" not in result["missing_keys"]
+
+    def test_lambda_ai_reports_key_missing(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = litellm.validate_environment(
+                model="lambda_ai/llama3.1-70b-instruct-fp8"
+            )
+        assert result["keys_in_environment"] is False
+        assert "LAMBDA_API_KEY" in result["missing_keys"]


### PR DESCRIPTION
Successor of #33467. validate_environment reports SAMBANOVA_API_KEY / HYPERBOLIC_API_KEY / LAMBDA_API_KEY when missing. Tests included.