### PR TITLE
fix(bedrock): recognize jp and global geo prefixes in Nova 2 model detection

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -293,8 +293,9 @@ class AmazonConverseConfig(BaseConfig):
         - amazon.nova-2-pro-preview-20251202-v1:0
         - us.amazon.nova-2-lite-v1:0
         - eu.amazon.nova-2-lite-v1:0
-        - apac.amazon.nova-2-lite-v1:0
-        - (and other regional variants)
+        - jp.amazon.nova-2-lite-v1:0
+        - global.amazon.nova-2-lite-v1:0
+        - (and other regional / geo variants; legacy apac. prefix still stripped)
 
         Args:
             model: The model identifier
@@ -322,8 +323,8 @@ class AmazonConverseConfig(BaseConfig):
                 model_without_region = model_without_region[len(routing_prefix) :]
                 break
 
-        # Remove regional prefix if present (us., eu., apac.)
-        for prefix in ["us.", "eu.", "apac."]:
+        # Remove regional / geo inference prefix if present
+        for prefix in ["us.", "eu.", "apac.", "jp.", "global."]:
             if model_without_region.startswith(prefix):
                 model_without_region = model_without_region[len(prefix) :]
                 break

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -293,7 +293,9 @@ class AmazonConverseConfig(BaseConfig):
         - amazon.nova-2-pro-preview-20251202-v1:0
         - us.amazon.nova-2-lite-v1:0
         - eu.amazon.nova-2-lite-v1:0
-        - apac.amazon.nova-2-lite-v1:0
+        - jp.amazon.nova-2-lite-v1:0
+        - global.amazon.nova-2-lite-v1:0
+        - (legacy apac. prefix still stripped)
         - (and other regional variants)
 
         Args:
@@ -323,7 +325,7 @@ class AmazonConverseConfig(BaseConfig):
                 break
 
         # Remove regional prefix if present (us., eu., apac.)
-        for prefix in ["us.", "eu.", "apac."]:
+        for prefix in ["us.", "eu.", "apac.", "jp.", "global."]:
             if model_without_region.startswith(prefix):
                 model_without_region = model_without_region[len(prefix) :]
                 break

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -3311,7 +3311,10 @@ def test_is_nova_2_model():
     # Test with regional variants
     assert config._is_nova_2_model("us.amazon.nova-2-lite-v1:0") is True
     assert config._is_nova_2_model("eu.amazon.nova-2-lite-v1:0") is True
-    assert config._is_nova_2_model("apac.amazon.nova-2-lite-v1:0") is True
+    assert config._is_nova_2_model("jp.amazon.nova-2-lite-v1:0") is True
+    assert config._is_nova_2_model("global.amazon.nova-2-lite-v1:0") is True
+    # legacy apac. strip still works for other Nova 2 SKUs
+    assert config._is_nova_2_model("apac.amazon.nova-2-pro-preview-20251202-v1:0") is True
 
     # Test with other Nova 2 variants (pro, micro)
     assert config._is_nova_2_model("amazon.nova-pro-1-5-v1:0") is False

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation_nova_2.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation_nova_2.py
@@ -202,11 +202,11 @@ class TestNova2ParameterMapping:
         assert result["reasoningConfig"]["type"] == "enabled"
         assert result["reasoningConfig"]["maxReasoningEffort"] == "low"
 
-    def test_nova_2_regional_variant_apac(self):
-        """Test that APAC regional variant of Nova 2 works correctly."""
+    def test_nova_2_regional_variant_jp(self):
+        """Test that JP geo inference variant of Nova 2 works correctly."""
         config = AmazonConverseConfig()
 
-        model = "apac.amazon.nova-2-lite-v1:0"
+        model = "jp.amazon.nova-2-lite-v1:0"
         non_default_params = {"reasoning_effort": "high"}
         optional_params = {}
 
@@ -295,11 +295,11 @@ class TestNova15SupportedParameters:
         # Verify thinking is NOT in supported params
         assert "thinking" not in supported_params
 
-    def test_nova_2_regional_variant_apac_supported_params(self):
-        """Test that APAC regional variant returns same supported params."""
+    def test_nova_2_regional_variant_jp_supported_params(self):
+        """Test that JP geo inference variant returns same supported params."""
         config = AmazonConverseConfig()
 
-        model = "apac.amazon.nova-2-lite-v1:0"
+        model = "jp.amazon.nova-2-lite-v1:0"
         supported_params = config.get_supported_openai_params(model)
 
         # Verify reasoning_effort is in supported params
@@ -470,6 +470,10 @@ class TestNova2ModelDetection:
             "us.amazon.nova-2-pro-preview-20251202-v1:0",
             "eu.amazon.nova-2-lite-v1:0",
             "apac.amazon.nova-2-pro-preview-20251202-v1:0",
+            "jp.amazon.nova-2-lite-v1:0",
+            "global.amazon.nova-2-lite-v1:0",
+            "bedrock/converse/jp.amazon.nova-2-lite-v1:0",
+            "bedrock/converse/global.amazon.nova-2-lite-v1:0",
             "bedrock/converse/amazon.nova-2-lite-v1:0",
             "bedrock/converse/us.amazon.nova-2-pro-preview-20251202-v1:0",
             "bedrock/amazon.nova-2-lite-v1:0",

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation_nova_2.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation_nova_2.py
@@ -687,3 +687,37 @@ class TestNova2MultiTurnMessageTranslation:
         ]
         assert len(rc_blocks) >= 1
         assert any("Hello!" in b["text"] for b in text_blocks)
+
+    def test_nova_2_regional_variant_jp(self):
+        """Test that JP geo inference variant of Nova 2 works correctly."""
+        config = AmazonConverseConfig()
+
+        model = "jp.amazon.nova-2-lite-v1:0"
+        non_default_params = {"reasoning_effort": "high"}
+        optional_params = {}
+
+        result = config.map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model=model,
+            drop_params=False,
+        )
+
+        # Verify reasoningConfig is in result
+        assert "reasoningConfig" in result
+        assert result["reasoningConfig"]["type"] == "enabled"
+        assert result["reasoningConfig"]["maxReasoningEffort"] == "high"
+
+    def test_nova_2_regional_variant_jp_supported_params(self):
+        """Test that JP geo inference variant returns same supported params."""
+        config = AmazonConverseConfig()
+
+        model = "jp.amazon.nova-2-lite-v1:0"
+        supported_params = config.get_supported_openai_params(model)
+
+        # Verify reasoning_effort is in supported params
+        assert "reasoning_effort" in supported_params
+
+        # Verify thinking is NOT in supported params
+        assert "thinking" not in supported_params
+


### PR DESCRIPTION
Successor of #33469. Related #33211. Extend _is_nova_2_model for jp./global. prefixes + tests.