### PR TITLE
feat(mcp): record the delegated on-behalf-of user in MCP tool-call spend logs

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2627,6 +2627,13 @@ if MCP_AVAILABLE:
             server_name=server_name,
             session_id=_mcp_session_id_from_headers(raw_headers),
         )
+        # Dual attribution: on a validated delegation the agent key stays the primary
+        # spend/audit identity; record the delegated user it acted on behalf of so
+        # per-user visibility is not lost. This is the single chokepoint both the
+        # streamable and REST call paths funnel through.
+        delegated_user_id = getattr(user_api_key_auth, "delegated_user_id", None) if user_api_key_auth else None
+        if delegated_user_id:
+            standard_logging_mcp_tool_call["mcp_on_behalf_of_user_id"] = delegated_user_id
         litellm_logging_obj: Optional[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj", None)
         if litellm_logging_obj:
             litellm_logging_obj.model_call_details["mcp_tool_call_metadata"] = standard_logging_mcp_tool_call

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2569,6 +2569,14 @@ class StandardLoggingMCPToolCall(TypedDict, total=False):
     Records which upstream received a relayed request; never a credential.
     """
 
+    mcp_on_behalf_of_user_id: str | None
+    """
+    When the call ran under a validated user->agent delegation, the user_id the calling agent
+    acted on behalf of. The agent key remains the primary spend/audit attribution; this records
+    the delegated (triggering) user so N users behind one agent stay distinguishable in the logs.
+    Absent on non-delegated calls.
+    """
+
 
 class StandardLoggingVectorStoreRequest(TypedDict, total=False):
     """

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -7573,3 +7573,99 @@ class TestPreemptive401ModeAware:
             await self._run(delegate, None, has_stored_token=False)
         assert exc.value.status_code == 401
         await self._run(delegate, self.LITELLM_KEY_HEADERS, has_stored_token=False)
+
+
+@pytest.mark.asyncio
+async def test_execute_mcp_tool_records_delegated_user_in_logging_metadata():
+    """A delegated call (user_api_key_auth.delegated_user_id set) records the
+    on-behalf-of user in mcp_tool_call_metadata, in addition to the agent key."""
+    from mcp.types import TextContent
+
+    from litellm.proxy._experimental.mcp_server import server as mcp_module
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    server = MCPServer(
+        server_id="srv",
+        name="echo",
+        server_name="echo",
+        url="http://127.0.0.1:5115/mcp",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.api_key,
+        authentication_token="abc",
+    )
+
+    async def fake_handle_managed_mcp_tool(**kwargs):
+        return mcp_module.CallToolResult(content=[TextContent(type="text", text="ok")], isError=False)
+
+    logging_obj = MagicMock()
+    logging_obj.model_call_details = {}
+
+    agent_auth = UserAPIKeyAuth(api_key="agent-key", user_id="agent-svc-user", delegated_user_id="alice-id")
+
+    with (
+        patch.object(mcp_module.global_mcp_server_manager, "get_registry", return_value={server.server_id: server}),
+        patch.object(mcp_module.global_mcp_server_manager, "_get_mcp_server_from_tool_name", return_value=server),
+        patch.object(mcp_module, "_handle_managed_mcp_tool", new=fake_handle_managed_mcp_tool),
+        patch.object(mcp_module.MCPRequestHandler, "is_tool_allowed", return_value=True),
+        patch.object(mcp_module.global_mcp_tool_registry, "get_tool", return_value=None),
+    ):
+        await mcp_module.execute_mcp_tool(
+            name="echo",
+            arguments={"message": "hi"},
+            allowed_mcp_servers=[server],
+            start_time=datetime.now(),
+            requested_server_id=server.server_id,
+            user_api_key_auth=agent_auth,
+            litellm_logging_obj=logging_obj,
+        )
+
+    meta = logging_obj.model_call_details["mcp_tool_call_metadata"]
+    assert meta["mcp_on_behalf_of_user_id"] == "alice-id"
+
+
+@pytest.mark.asyncio
+async def test_execute_mcp_tool_omits_delegated_user_when_not_delegated():
+    """No delegation -> the on-behalf-of field is absent (payload byte-identical
+    to today for non-delegated calls)."""
+    from mcp.types import TextContent
+
+    from litellm.proxy._experimental.mcp_server import server as mcp_module
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    server = MCPServer(
+        server_id="srv",
+        name="echo",
+        server_name="echo",
+        url="http://127.0.0.1:5115/mcp",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.api_key,
+        authentication_token="abc",
+    )
+
+    async def fake_handle_managed_mcp_tool(**kwargs):
+        return mcp_module.CallToolResult(content=[TextContent(type="text", text="ok")], isError=False)
+
+    logging_obj = MagicMock()
+    logging_obj.model_call_details = {}
+
+    plain_auth = UserAPIKeyAuth(api_key="user-key", user_id="alice-id")
+
+    with (
+        patch.object(mcp_module.global_mcp_server_manager, "get_registry", return_value={server.server_id: server}),
+        patch.object(mcp_module.global_mcp_server_manager, "_get_mcp_server_from_tool_name", return_value=server),
+        patch.object(mcp_module, "_handle_managed_mcp_tool", new=fake_handle_managed_mcp_tool),
+        patch.object(mcp_module.MCPRequestHandler, "is_tool_allowed", return_value=True),
+        patch.object(mcp_module.global_mcp_tool_registry, "get_tool", return_value=None),
+    ):
+        await mcp_module.execute_mcp_tool(
+            name="echo",
+            arguments={"message": "hi"},
+            allowed_mcp_servers=[server],
+            start_time=datetime.now(),
+            requested_server_id=server.server_id,
+            user_api_key_auth=plain_auth,
+            litellm_logging_obj=logging_obj,
+        )
+
+    meta = logging_obj.model_call_details["mcp_tool_call_metadata"]
+    assert "mcp_on_behalf_of_user_id" not in meta


### PR DESCRIPTION
## Relevant issues

- MCP delegation build item 5: record the on-behalf-of user on delegated MCP tool calls
- Stacks on the delegation core (PR #33735); consumes the `delegated_user_id` it stamps
- Base is `litellm_lit4448_obo_delegation` while #33735 is open; retarget to staging once it merges

## Linear ticket

Part of LIT-4448 (build item 5; does not resolve the ticket)

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on localhost:4014 with a stub MCP server (echoes the bearer it received), an authorization_code MCP server, user alice with a stored token, and an agent with `mcp_can_delegate` + an active consent from alice. Query is against the persisted `LiteLLM_SpendLogs` row (`metadata` JSON).

Before (delegation branch, without this change): a delegated tool call records only the agent, the triggering user is lost

```
delegated tools/call (x-litellm-delegated-user: alice@example.com)
  spend log: user_api_key_user_id = "agent-svc-user"
             mcp_tool_call_metadata.mcp_on_behalf_of_user_id = <absent>
```

After: the same call records both principals; a non-delegated call is unchanged

```
delegated tools/call
  spend log: user_api_key_user_id = "agent-svc-user"           # agent, primary attribution
             mcp_tool_call_metadata.mcp_on_behalf_of_user_id = "alice-id"   # delegated user

non-delegated tools/call (no header)
  spend log: user_api_key_user_id = "agent-svc-user"
             mcp_tool_call_metadata.mcp_on_behalf_of_user_id = <absent>     # byte-identical to today
```

## Type

🆕 New Feature

## Changes

- New optional `mcp_on_behalf_of_user_id` key on `StandardLoggingMCPToolCall`; it nests under the existing `metadata.mcp_tool_call_metadata` JSON, so no spend-log column and no migration (matches how every other MCP field except `namespaced_tool_name` is stored)
- Populated once in `execute_mcp_tool` from `user_api_key_auth.delegated_user_id`; that function is the single point both the streamable/SSE and REST `/mcp-rest/tools/call` paths funnel through, so one injection covers both
- The agent key stays the primary attribution (`user`/`team_id`/`api_key` columns unchanged); the delegated user is added, not substituted. When there is no delegation the field is absent and the payload is identical to today

## Things a reviewer will ask about

- Why metadata JSON, not a spend-log column: only `mcp_namespaced_tool_name` is a promoted column; every other MCP field lives in the `mcp_tool_call_metadata` JSON, and adding a column would need a migration plus mirroring in both schema.prisma copies. Promote later only if we need to aggregate spend by on-behalf-of user in SQL
- The Responses-API MCP path (`/v1/responses`) builds its own logging and does not go through `execute_mcp_tool`; it is intentionally not covered because delegation is not validated there either (`resolve_delegated_user_auth` runs only on the streamable and REST MCP endpoints), so `delegated_user_id` can never be set on that path
- Surfacing it in the Logs UI is a separate change; the field is in the raw spend-log metadata today

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
