### PR TITLE
fix(proxy): reap the killed prisma engine so it doesn't linger as a zombie (#33414)

### DIFF
--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -169,7 +169,7 @@ class PrismaWrapper:
         stuck on TCP close.
 
         Sends SIGTERM for graceful shutdown, waits briefly, then SIGKILL as
-        a backstop.
+        a backstop, then reaps the corpse so it does not linger as a zombie.
         """
         if pid <= 0:
             return
@@ -191,6 +191,47 @@ class PrismaWrapper:
             )
         except (ProcessLookupError, PermissionError, OSError):
             pass  # Exited after SIGTERM — expected
+        await PrismaWrapper._reap_engine_process(pid)
+
+    @staticmethod
+    async def _reap_engine_process(pid: int) -> None:
+        """Reap the killed engine so it doesn't linger as a zombie.
+
+        A signalled child stays in the process table as ``<defunct>`` until its
+        parent wait()s on it. We retire the engine by signalling its PID rather
+        than calling prisma-client-py's ``disconnect()``, so nothing else ever
+        wait()s on that Popen — leaving exactly one zombie per reconnect, which
+        accumulates for the life of the container (#33414, #14739, #10216).
+
+        Note this does NOT reintroduce the blocking `disconnect()` problem this
+        class exists to avoid: that call blocks for 30-120s because it waits on
+        a *live* engine stuck on TCP close. By this point the engine has already
+        been SIGKILLed, so it is dead and WNOHANG collects it on the first poll.
+        The bounded retry only covers the brief window between the signal being
+        delivered and the kernel finishing the exit.
+        """
+        wnohang = getattr(os, "WNOHANG", None)
+        if wnohang is None:
+            return  # Windows: no POSIX zombies, nothing to reap.
+        deadline = time.monotonic() + 2.0
+        while True:
+            try:
+                reaped, _status = os.waitpid(pid, wnohang)
+            except ChildProcessError:
+                return  # Not our child, or already reaped — nothing to do.
+            except OSError:
+                return
+            if reaped == pid:
+                return  # Collected.
+            # reaped == 0: still exiting. Yield rather than spin.
+            if time.monotonic() >= deadline:
+                verbose_proxy_logger.warning(
+                    "prisma-query-engine PID %s did not exit after SIGKILL; "
+                    "leaving it unreaped rather than blocking the event loop.",
+                    pid,
+                )
+                return
+            await asyncio.sleep(0.05)
 
     def _extract_token_from_db_url(self, db_url: str | None) -> str | None:
         """

--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -1,5 +1,6 @@
 """
-This file contains the PrismaWrapper class, which is used to wrap the Prisma client and handle the RDS IAM token.
+This file contains the PrismaWrapper class, which wraps the Prisma client and keeps the
+database token (AWS RDS IAM or Microsoft Entra ID) fresh.
 """
 
 import asyncio
@@ -10,75 +11,141 @@ import subprocess
 import time
 import urllib
 import urllib.parse
-from dataclasses import dataclass
+from collections.abc import Callable
 from datetime import datetime, timedelta
-from typing import Any, Callable, Union
+from typing import Any, Final, Protocol
 
 from litellm._logging import verbose_proxy_logger
+from litellm.proxy.db.token_auth import (
+    DEFAULT_POSTGRES_PORT,
+    DatabaseTokenAuth,
+    IAMEndpoint,
+    RdsIamTokenAuth,
+    mint_database_token,
+    parse_database_token_expiration,
+    parse_iam_endpoint_from_url,
+)
 from litellm.secret_managers.main import str_to_bool
 
-
-@dataclass(frozen=True)
-class IAMEndpoint:
-    """Static parts of an RDS IAM-authenticated Postgres connection.
-
-    The IAM token rotates every ~15 minutes; everything else (host, port, user,
-    database name, schema) stays fixed. We capture the static fields once so
-    refresh just regenerates the token and reassembles the URL.
-    """
-
-    host: str
-    port: str
-    user: str
-    name: str
-    schema: str | None = None
-
-    def build_url(self, token: str) -> str:
-        url = f"postgresql://{self.user}:{token}@{self.host}:{self.port}/{self.name}"
-        if self.schema:
-            url += f"?schema={self.schema}"
-        return url
+__all__ = (
+    "IAMEndpoint",
+    "PrismaManager",
+    "PrismaWrapper",
+    "parse_iam_endpoint_from_url",
+)
 
 
-def parse_iam_endpoint_from_url(url: str) -> IAMEndpoint:
-    """Parse an IAMEndpoint from a Postgres URL.
+class _PrismaProcess(Protocol):
+    pid: object
 
-    Used so a reader URL can drive its own IAM refresh without requiring
-    callers to set parallel DATABASE_HOST_READ_REPLICA / etc. env vars.
-    """
-    parsed = urllib.parse.urlparse(url)
-    if not parsed.hostname or not parsed.username:
-        raise ValueError("Cannot parse IAM endpoint from URL: missing host or username")
-    name = (parsed.path or "/").lstrip("/")
-    if not name:
-        raise ValueError("Cannot parse IAM endpoint from URL: missing database name")
-    port = str(parsed.port) if parsed.port else "5432"
-    schema: str | None = None
-    if parsed.query:
-        qs = urllib.parse.parse_qs(parsed.query)
-        schema_vals = qs.get("schema")
-        if schema_vals:
-            schema = schema_vals[0]
-    return IAMEndpoint(
-        host=parsed.hostname,
-        port=port,
-        user=parsed.username,
-        name=name,
-        schema=schema,
-    )
+
+class _PrismaEngine(Protocol):
+    @property
+    def process(self) -> _PrismaProcess: ...
+
+    async def query(self, content: str, *, tx_id: str | None) -> object: ...
+
+    async def start_transaction(self, *, content: str) -> str: ...
+
+    async def commit_transaction(self, tx_id: str) -> None: ...
+
+    async def rollback_transaction(self, tx_id: str) -> None: ...
+
+
+class _PrismaClient(Protocol):
+    _Prisma__engine: _PrismaEngine
+
+    @property
+    def _engine(self) -> _PrismaEngine: ...
+
+
+class _PrismaDrainTracker:
+    def __init__(self) -> None:
+        self._active_operations = 0
+        self._transactions: frozenset[str] = frozenset()
+        self._drained = asyncio.Event()
+        self._drained.set()
+
+    def begin_operation(self) -> None:
+        if self._active_operations == 0:
+            self._drained.clear()
+        self._active_operations += 1
+
+    def end_operation(self) -> None:
+        self._active_operations -= 1
+        if self._active_operations == 0:
+            self._drained.set()
+
+    def transaction_started(self, transaction_id: str) -> None:
+        self._transactions = self._transactions.union((transaction_id,))
+
+    def transaction_finished(self, transaction_id: str) -> None:
+        if transaction_id not in self._transactions:
+            return
+        self._transactions = self._transactions.difference((transaction_id,))
+        self.end_operation()
+
+    async def wait_until_drained(self) -> None:
+        await self._drained.wait()
+
+
+class _TrackedPrismaEngine:
+    def __init__(self, engine: _PrismaEngine, tracker: _PrismaDrainTracker) -> None:
+        self._engine = engine
+        self.tracker = tracker
+
+    @property
+    def process(self) -> _PrismaProcess:
+        return self._engine.process
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._engine, name)
+
+    async def query(self, content: str, *, tx_id: str | None) -> object:
+        self.tracker.begin_operation()
+        try:
+            return await self._engine.query(content, tx_id=tx_id)
+        finally:
+            self.tracker.end_operation()
+
+    async def start_transaction(self, *, content: str) -> str:
+        self.tracker.begin_operation()
+        try:
+            transaction_id: Final = await self._engine.start_transaction(content=content)
+        except (Exception, asyncio.CancelledError):
+            self.tracker.end_operation()
+            raise
+        self.tracker.transaction_started(transaction_id)
+        return transaction_id
+
+    async def commit_transaction(self, tx_id: str) -> None:
+        self.tracker.begin_operation()
+        try:
+            await self._engine.commit_transaction(tx_id)
+        finally:
+            self.tracker.end_operation()
+            self.tracker.transaction_finished(tx_id)
+
+    async def rollback_transaction(self, tx_id: str) -> None:
+        self.tracker.begin_operation()
+        try:
+            await self._engine.rollback_transaction(tx_id)
+        finally:
+            self.tracker.end_operation()
+            self.tracker.transaction_finished(tx_id)
 
 
 class PrismaWrapper:
     """
-    Wrapper around Prisma client that handles RDS IAM token authentication.
+    Wrapper around Prisma client that handles token-based database authentication.
 
-    When iam_token_db_auth is enabled, this wrapper:
-    1. Proactively refreshes IAM tokens before they expire (background task)
+    When a token strategy is active (AWS RDS IAM or Microsoft Entra ID), this wrapper:
+    1. Proactively refreshes the token before it expires (background task)
     2. Falls back to synchronous refresh if a token is found expired
     3. Uses proper locking to prevent race conditions during reconnection
 
-    RDS IAM tokens are valid for 15 minutes. This wrapper refreshes them
-    3 minutes before expiration to ensure uninterrupted database connectivity.
+    RDS IAM tokens are valid for 15 minutes and Entra tokens for about an hour. This
+    wrapper refreshes 3 minutes before whatever expiry the live token carries.
     """
 
     # Buffer time in seconds before token expiration to trigger refresh
@@ -88,18 +155,28 @@ class PrismaWrapper:
     # Fallback refresh interval if token parsing fails (10 minutes)
     FALLBACK_REFRESH_INTERVAL_SECONDS = 600
 
+    # Floor on the proactive loop's sleep, so a token whose expiry does not advance
+    # (azure-identity hands back its cached token when a renewal attempt fails) costs
+    # one retry every 30 seconds instead of spinning the loop with no sleep at all.
+    TOKEN_REFRESH_MIN_SLEEP_SECONDS = 30
+
+    ENGINE_RETIREMENT_DRAIN_TIMEOUT_SECONDS = 90
+
     def __init__(
         self,
         original_prisma: Any,
-        iam_token_db_auth: bool,
+        iam_token_db_auth: bool = False,
         *,
+        token_auth: DatabaseTokenAuth | None = None,
         db_url_env_var: str = "DATABASE_URL",
         iam_endpoint: IAMEndpoint | None = None,
         recreate_uses_datasource: bool = False,
         log_prefix: str = "",
     ):
+        # Set before `_original_prisma` so the `iam_token_db_auth` property below can
+        # never send `__getattr__` looking for a half-built strategy on the raw client.
+        self._token_auth = token_auth if token_auth is not None else (RdsIamTokenAuth() if iam_token_db_auth else None)
         self._original_prisma = original_prisma
-        self.iam_token_db_auth = iam_token_db_auth
 
         # Per-connection knobs so the same wrapper can be used for the writer
         # (defaults: DATABASE_URL env, IAM endpoint from DATABASE_HOST/etc.,
@@ -119,6 +196,8 @@ class PrismaWrapper:
         self._token_refresh_task: asyncio.Task | None = None
         self._reconnection_lock = asyncio.Lock()
         self._last_refresh_time: datetime | None = None
+        self._active_drain_tracker = self._instrument_prisma_client(original_prisma)
+        self._retirement_tasks: frozenset[asyncio.Task[None]] = frozenset()
 
         # Coordination for planned engine restarts (issue #29176). Every
         # `recreate_prisma_client` SIGTERMs the running query-engine on
@@ -136,7 +215,47 @@ class PrismaWrapper:
         self._engine_generation: int = 0
         self.on_engine_replaced: Callable[[], None] | None = None
 
-    def _get_engine_pid(self) -> int:
+    @property
+    def token_auth(self) -> DatabaseTokenAuth | None:
+        """The active database token strategy, or None for password auth."""
+        return self._token_auth
+
+    @property
+    def token_label(self) -> str:
+        """Human name of the active token kind, for log lines."""
+        return self._token_auth.label if self._token_auth is not None else "database token"
+
+    @property
+    def iam_token_db_auth(self) -> bool:
+        """Whether any token strategy is active.
+
+        Read-only: the kind of token is chosen once, by injection, so there is no way
+        to flip this back on and silently get AWS RDS on an Azure deployment.
+        """
+        return self._token_auth is not None
+
+    @staticmethod
+    def _read_engine(prisma_client: _PrismaClient) -> _PrismaEngine:
+        return prisma_client._engine
+
+    @staticmethod
+    def _write_engine(prisma_client: _PrismaClient, engine: _PrismaEngine) -> None:
+        prisma_client._Prisma__engine = engine
+
+    def _instrument_prisma_client(self, prisma_client: _PrismaClient) -> _PrismaDrainTracker | None:
+        from prisma.errors import ClientNotConnectedError
+
+        try:
+            engine: Final = self._read_engine(prisma_client)
+        except (AttributeError, ClientNotConnectedError):
+            return None
+        if isinstance(engine, _TrackedPrismaEngine):
+            return engine.tracker
+        tracker: Final = _PrismaDrainTracker()
+        self._write_engine(prisma_client, _TrackedPrismaEngine(engine, tracker))
+        return tracker
+
+    def _get_engine_pid(self, prisma_client: _PrismaClient | None = None) -> int:
         """Get the PID of the current Prisma engine subprocess, or 0 if unavailable.
 
         Must never raise: it runs inside the reconnect path, where the client
@@ -145,18 +264,49 @@ class PrismaWrapper:
         escaped here, ``recreate_prisma_client`` would fail before it could
         build a replacement client and the reconnect loop could never recover.
         """
+        from prisma.errors import ClientNotConnectedError
+
         try:
-            if self._original_prisma.is_connected() is not True:
-                return 0
-            engine = self._original_prisma._engine
-            process = getattr(engine, "process", None) if engine is not None else None
-            if process is not None:
-                pid = process.pid
-                if isinstance(pid, int):
-                    return pid
-        except (AttributeError, TypeError):
+            target_prisma: Final = self._original_prisma if prisma_client is None else prisma_client
+            pid: Final = self._read_engine(target_prisma).process.pid
+            if isinstance(pid, int):
+                return pid
+        except (AttributeError, ClientNotConnectedError, TypeError):
             pass
         return 0
+
+    async def _retire_engine_when_drained(self, pid: int, tracker: _PrismaDrainTracker | None) -> None:
+        if tracker is not None:
+            try:
+                await asyncio.wait_for(
+                    tracker.wait_until_drained(),
+                    timeout=self.ENGINE_RETIREMENT_DRAIN_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                verbose_proxy_logger.warning(
+                    "%sReplaced prisma engine PID %s did not drain within %ss; killing it with work still in flight.",
+                    self._log_prefix,
+                    pid,
+                    self.ENGINE_RETIREMENT_DRAIN_TIMEOUT_SECONDS,
+                )
+        await self._kill_engine_process(pid)
+
+    def _schedule_engine_retirement(self, pid: int, tracker: _PrismaDrainTracker | None) -> None:
+        if pid <= 0:
+            return
+        retirement_task: Final = asyncio.create_task(self._retire_engine_when_drained(pid, tracker))
+        self._retirement_tasks = self._retirement_tasks.union((retirement_task,))
+        retirement_task.add_done_callback(self._retirement_finished)
+
+    def _retirement_finished(self, retirement_task: asyncio.Task[None]) -> None:
+        self._retirement_tasks = self._retirement_tasks.difference((retirement_task,))
+
+    async def connect(self, timeout: int | timedelta | None = None) -> None:
+        if timeout is None:
+            await self._original_prisma.connect()
+        else:
+            await self._original_prisma.connect(timeout)
+        self._active_drain_tracker = self._instrument_prisma_client(self._original_prisma)
 
     @staticmethod
     async def _kill_engine_process(pid: int) -> None:
@@ -169,7 +319,7 @@ class PrismaWrapper:
         stuck on TCP close.
 
         Sends SIGTERM for graceful shutdown, waits briefly, then SIGKILL as
-        a backstop, then reaps the corpse so it does not linger as a zombie.
+        a backstop.
         """
         if pid <= 0:
             return
@@ -192,6 +342,7 @@ class PrismaWrapper:
         except (ProcessLookupError, PermissionError, OSError):
             pass  # Exited after SIGTERM — expected
         await PrismaWrapper._reap_engine_process(pid)
+
 
     @staticmethod
     async def _reap_engine_process(pid: int) -> None:
@@ -246,7 +397,7 @@ class PrismaWrapper:
             return None
         try:
             # Parse URL while still encoded to preserve structure
-            parsed = urllib.parse.urlparse(db_url)
+            parsed: Final = urllib.parse.urlparse(db_url)
             if parsed.password:
                 # Now decode just the password/token
                 return urllib.parse.unquote(parsed.password)
@@ -260,30 +411,9 @@ class PrismaWrapper:
 
         Returns the datetime when the token expires, or None if parsing fails.
         """
-        if token is None:
+        if token is None or self._token_auth is None:
             return None
-
-        try:
-            # Token format: ...?X-Amz-Date=YYYYMMDDTHHMMSSZ&X-Amz-Expires=900&...
-            if "?" not in token:
-                return None
-
-            query_string = token.split("?", 1)[1]
-            params = urllib.parse.parse_qs(query_string)
-
-            expires_str = params.get("X-Amz-Expires", [None])[0]
-            date_str = params.get("X-Amz-Date", [None])[0]
-
-            if not expires_str or not date_str:
-                return None
-
-            token_created = datetime.strptime(date_str, "%Y%m%dT%H%M%SZ")
-            expires_in = int(expires_str)
-
-            return token_created + timedelta(seconds=expires_in)
-        except Exception as e:
-            verbose_proxy_logger.debug(f"Failed to parse token expiration: {e}")
-            return None
+        return parse_database_token_expiration(self._token_auth, token)
 
     def _calculate_seconds_until_refresh(self) -> float:
         """
@@ -293,39 +423,42 @@ class PrismaWrapper:
         For a 15-minute (900s) token with 180s buffer, this returns ~720s (12 min).
 
         Returns:
-            Number of seconds to sleep before the next refresh.
-            Returns 0 if token should be refreshed immediately.
+            Number of seconds to sleep before the next refresh, never less than
+            TOKEN_REFRESH_MIN_SLEEP_SECONDS so a token whose expiry never advances
+            cannot spin the loop.
             Returns FALLBACK_REFRESH_INTERVAL_SECONDS if parsing fails.
         """
-        db_url = os.getenv(self._db_url_env_var)
-        token = self._extract_token_from_db_url(db_url)
-        expiration_time = self._parse_token_expiration(token)
+        db_url: Final = os.getenv(self._db_url_env_var)
+        token: Final = self._extract_token_from_db_url(db_url)
+        expiration_time: Final = self._parse_token_expiration(token)
 
         if expiration_time is None:
             # If we can't parse the token, use fallback interval
             verbose_proxy_logger.debug(
-                f"Could not parse token expiration, using fallback interval of "
-                f"{self.FALLBACK_REFRESH_INTERVAL_SECONDS}s"
+                "Could not parse token expiration, using fallback interval of %ss",
+                self.FALLBACK_REFRESH_INTERVAL_SECONDS,
             )
             return self.FALLBACK_REFRESH_INTERVAL_SECONDS
 
         # Calculate when we should refresh (expiration - buffer)
-        refresh_at = expiration_time - timedelta(seconds=self.TOKEN_REFRESH_BUFFER_SECONDS)
+        refresh_at: Final = expiration_time - timedelta(seconds=self.TOKEN_REFRESH_BUFFER_SECONDS)
 
         # How long until refresh time?
-        now = datetime.utcnow()
-        seconds_until_refresh = (refresh_at - now).total_seconds()
+        now: Final = datetime.utcnow()
+        seconds_until_refresh: Final = (refresh_at - now).total_seconds()
 
-        # If already past refresh time, return 0 (refresh immediately)
-        return max(0, seconds_until_refresh)
+        # Past refresh time means refresh as soon as the floor allows, not instantly:
+        # a provider that keeps handing back the same token would otherwise leave the
+        # loop re-minting and recreating the query engine with no sleep between passes.
+        return max(self.TOKEN_REFRESH_MIN_SLEEP_SECONDS, seconds_until_refresh)
 
     def is_token_expired(self, token_url: str | None) -> bool:
         """Check if the token in the given URL is expired."""
         if token_url is None:
             return True
 
-        token = self._extract_token_from_db_url(token_url)
-        expiration_time = self._parse_token_expiration(token)
+        token: Final = self._extract_token_from_db_url(token_url)
+        expiration_time: Final = self._parse_token_expiration(token)
 
         if expiration_time is None:
             # If we can't parse the token, assume it's expired to trigger refresh
@@ -335,45 +468,84 @@ class PrismaWrapper:
         return datetime.utcnow() > expiration_time
 
     def get_rds_iam_token(self) -> str | None:
-        """Generate a new RDS IAM token and update the configured DB URL env var.
+        """Mint a fresh database token and update the configured DB URL env var.
 
         When the wrapper was constructed with an explicit `iam_endpoint`
         (typical for a reader wrapper whose host/port/user came from a parsed
-        URL), use that. Otherwise fall back to the legacy DATABASE_HOST/PORT/
-        USER/NAME/SCHEMA env vars (writer behavior).
+        URL), use that. Otherwise fall back to the DATABASE_HOST/PORT/USER/
+        NAME/SCHEMA env vars (writer behavior).
         """
-        if not self.iam_token_db_auth:
+        auth: Final = self._token_auth
+        if auth is None:
             return None
 
-        from litellm.proxy.auth.rds_iam_token import generate_iam_auth_token
+        endpoint: Final = self._iam_endpoint if self._iam_endpoint is not None else self._endpoint_from_env()
+        db_url: Final = endpoint.build_url(mint_database_token(auth, endpoint))
+        os.environ[self._db_url_env_var] = db_url
+        return db_url
 
-        if self._iam_endpoint is not None:
-            endpoint = self._iam_endpoint
-            token = generate_iam_auth_token(db_host=endpoint.host, db_port=endpoint.port, db_user=endpoint.user)
-            _db_url = endpoint.build_url(token)
-        else:
-            db_host = os.getenv("DATABASE_HOST")
+    @staticmethod
+    def _endpoint_from_env() -> IAMEndpoint:
+        host: Final = os.getenv("DATABASE_HOST")
+        user: Final = os.getenv("DATABASE_USER")
+        name: Final = os.getenv("DATABASE_NAME")
+        if not host or not user or not name:
+            missing: Final = tuple(
+                env
+                for env, value in (("DATABASE_HOST", host), ("DATABASE_USER", user), ("DATABASE_NAME", name))
+                if not value
+            )
+            raise RuntimeError(
+                f"Cannot mint a database token: {', '.join(missing)} unset. Set them so the "
+                "connection URL can be reassembled around a freshly minted token."
+            )
+        return IAMEndpoint(
+            host=host,
             # Default to the Postgres standard port; passing None to
             # `generate_iam_auth_token` makes botocore embed the literal
             # string "None" in the presigned URL, which then fails to parse.
-            db_port = os.getenv("DATABASE_PORT", "5432")
-            db_user = os.getenv("DATABASE_USER")
-            db_name = os.getenv("DATABASE_NAME")
-            db_schema = os.getenv("DATABASE_SCHEMA")
+            port=os.getenv("DATABASE_PORT", DEFAULT_POSTGRES_PORT),
+            user=user,
+            name=name,
+            schema=os.getenv("DATABASE_SCHEMA"),
+        )
 
-            token = generate_iam_auth_token(db_host=db_host, db_port=db_port, db_user=db_user)
+    @property
+    def engine_generation(self) -> int:
+        """How many query-engine replacements have completed on this wrapper.
 
-            _db_url = f"postgresql://{db_user}:{token}@{db_host}:{db_port}/{db_name}"
-            if db_schema:
-                _db_url += f"?schema={db_schema}"
+        Bumped under `_reconnection_lock` only after a replacement engine has
+        connected, so a change across an await proves a *successful* planned
+        replacement happened in between — a replacement that failed (a real
+        outage) leaves it untouched.
+        """
+        return self._engine_generation
 
-        os.environ[self._db_url_env_var] = _db_url
-        return _db_url
+    async def _reconnection_settled(self) -> None:
+        async with self._reconnection_lock:
+            pass
+
+    async def wait_for_planned_engine_replacement(self, timeout_seconds: float) -> None:
+        """Wait, bounded, for an in-flight planned engine replacement to finish.
+
+        Both replacement paths (`recreate_prisma_client` and
+        `_safe_refresh_token`) hold `_reconnection_lock` across their whole
+        kill/connect window, so re-acquiring it means the replacement has
+        settled one way or the other. Gives up silently on timeout: a caller
+        that stopped waiting must treat the replacement as not completed and
+        consult `engine_generation` rather than assume success.
+        """
+        if timeout_seconds <= 0 or not self._reconnection_lock.locked():
+            return
+        try:
+            await asyncio.wait_for(self._reconnection_settled(), timeout=timeout_seconds)
+        except asyncio.TimeoutError:
+            return
 
     async def recreate_prisma_client(
         self,
         new_db_url: str,
-        http_client: Any | None = None,
+        http_client: object | None = None,
         *,
         expected_generation: int | None = None,
     ) -> bool:
@@ -411,7 +583,7 @@ class PrismaWrapper:
     async def _recreate_prisma_client_locked(
         self,
         new_db_url: str,
-        http_client: Any | None = None,
+        http_client: object | None = None,
         *,
         expected_generation: int | None = None,
     ) -> bool:
@@ -421,7 +593,7 @@ class PrismaWrapper:
         `_safe_refresh_token`, which double-checks token freshness under the
         lock) don't re-acquire it — `asyncio.Lock` is not reentrant.
         """
-        from prisma import Prisma  # type: ignore
+        from prisma import Prisma
 
         if expected_generation is not None and expected_generation != self._engine_generation:
             verbose_proxy_logger.info(
@@ -432,7 +604,7 @@ class PrismaWrapper:
             )
             return False
 
-        old_engine_pid = self._get_engine_pid()
+        old_engine_pid: Final = self._get_engine_pid()
         if old_engine_pid > 0:
             # Record BEFORE the kill so the engine-death watcher, which may
             # fire the instant the process dies, recognizes this as a planned
@@ -448,7 +620,7 @@ class PrismaWrapper:
             self._expected_engine_deaths.add(old_engine_pid)
             await self._kill_engine_process(old_engine_pid)
 
-        kwargs: dict[str, Any] = {}
+        kwargs: Final[dict[str, Any]] = {}
         if http_client is not None:
             kwargs["http"] = http_client
         if self._recreate_uses_datasource:
@@ -456,6 +628,7 @@ class PrismaWrapper:
         self._original_prisma = Prisma(**kwargs)
 
         await self._original_prisma.connect()
+        self._active_drain_tracker = self._instrument_prisma_client(self._original_prisma)
         self._engine_generation += 1
 
         # Let the owner (PrismaClient) re-arm its engine-death watcher on the
@@ -466,16 +639,55 @@ class PrismaWrapper:
 
         return True
 
+    async def _replace_prisma_client_for_token_refresh_locked(
+        self,
+        new_db_url: str,
+    ) -> None:
+        from prisma import Prisma
+        from prisma.types import DatasourceOverride
+
+        if self._recreate_uses_datasource:
+            datasource: Final = DatasourceOverride(url=new_db_url)
+            replacement_prisma = Prisma(datasource=datasource)
+        else:
+            replacement_prisma = Prisma()
+
+        old_prisma: Final = self._original_prisma
+        old_engine_pid: Final = self._get_engine_pid(old_prisma)
+        old_drain_tracker = self._active_drain_tracker
+        if old_drain_tracker is None:
+            old_drain_tracker = self._instrument_prisma_client(old_prisma)
+        try:
+            await replacement_prisma.connect()
+        except (Exception, asyncio.CancelledError):
+            self._schedule_engine_retirement(self._get_engine_pid(replacement_prisma), None)
+            raise
+        replacement_drain_tracker: Final = self._instrument_prisma_client(replacement_prisma)
+
+        if old_engine_pid > 0:
+            if len(self._expected_engine_deaths) >= 64:
+                self._expected_engine_deaths.clear()
+            self._expected_engine_deaths.add(old_engine_pid)
+
+        self._original_prisma = replacement_prisma
+        self._active_drain_tracker = replacement_drain_tracker
+        self._engine_generation += 1
+
+        if self.on_engine_replaced is not None:
+            self.on_engine_replaced()
+
+        self._schedule_engine_retirement(old_engine_pid, old_drain_tracker)
+
     async def start_token_refresh_task(self) -> None:
         """
         Start the background token refresh task.
 
-        This task proactively refreshes RDS IAM tokens before they expire,
+        This task proactively refreshes the database token before it expires,
         preventing connection failures. Should be called after the initial
         Prisma client connection is established.
         """
         if not self.iam_token_db_auth:
-            verbose_proxy_logger.debug("IAM token auth not enabled, skipping token refresh task")
+            verbose_proxy_logger.debug("Database token auth not enabled, skipping token refresh task")
             return
 
         if self._token_refresh_task is not None:
@@ -484,8 +696,9 @@ class PrismaWrapper:
 
         self._token_refresh_task = asyncio.create_task(self._token_refresh_loop())
         verbose_proxy_logger.info(
-            "%sStarted RDS IAM token proactive refresh background task",
+            "%sStarted %s proactive refresh background task",
             self._log_prefix,
+            self.token_label,
         )
 
     async def stop_token_refresh_task(self) -> None:
@@ -503,19 +716,25 @@ class PrismaWrapper:
         except asyncio.CancelledError:
             pass
         self._token_refresh_task = None
-        verbose_proxy_logger.info("%sStopped RDS IAM token refresh background task", self._log_prefix)
+        verbose_proxy_logger.info(
+            "%sStopped %s refresh background task",
+            self._log_prefix,
+            self.token_label,
+        )
 
     async def _token_refresh_loop(self) -> None:
         """
-        Background loop that proactively refreshes RDS IAM tokens before expiration.
+        Background loop that proactively refreshes database tokens before expiration.
 
         Uses precise timing: calculates the exact sleep duration until the token
         needs to be refreshed (expiration - 3 minute buffer), then refreshes.
         This is more efficient than polling, requiring only 1 wake-up per token cycle.
         """
         verbose_proxy_logger.info(
-            f"{self._log_prefix}RDS IAM token refresh loop started. "
-            f"Tokens will be refreshed {self.TOKEN_REFRESH_BUFFER_SECONDS}s before expiration."
+            "%s%s refresh loop started. Tokens will be refreshed %ss before expiration.",
+            self._log_prefix,
+            self.token_label,
+            self.TOKEN_REFRESH_BUFFER_SECONDS,
         )
 
         while True:
@@ -525,22 +744,33 @@ class PrismaWrapper:
 
                 if sleep_seconds > 0:
                     verbose_proxy_logger.info(
-                        f"{self._log_prefix}RDS IAM token refresh scheduled in "
+                        f"{self._log_prefix}{self.token_label} refresh scheduled in "
                         f"{sleep_seconds:.0f} seconds ({sleep_seconds / 60:.1f} minutes)"
                     )
                     await asyncio.sleep(sleep_seconds)
 
                 # Refresh the token
-                verbose_proxy_logger.info("%sProactively refreshing RDS IAM token...", self._log_prefix)
+                verbose_proxy_logger.info(
+                    "%sProactively refreshing %s...",
+                    self._log_prefix,
+                    self.token_label,
+                )
                 await self._safe_refresh_token()
 
             except asyncio.CancelledError:
-                verbose_proxy_logger.info("%sRDS IAM token refresh loop cancelled", self._log_prefix)
+                verbose_proxy_logger.info(
+                    "%s%s refresh loop cancelled",
+                    self._log_prefix,
+                    self.token_label,
+                )
                 break
             except Exception as e:
                 verbose_proxy_logger.error(
-                    f"{self._log_prefix}Error in RDS IAM token refresh loop: {e}. "
-                    f"Retrying in {self.FALLBACK_REFRESH_INTERVAL_SECONDS}s..."
+                    "%sError in %s refresh loop: %s. Retrying in %ss...",
+                    self._log_prefix,
+                    self.token_label,
+                    e,
+                    self.FALLBACK_REFRESH_INTERVAL_SECONDS,
                 )
                 # On error, wait before retrying to avoid tight error loops
                 try:
@@ -550,7 +780,7 @@ class PrismaWrapper:
 
     async def _safe_refresh_token(self) -> None:
         """
-        Refresh the RDS IAM token with proper locking to prevent race conditions.
+        Refresh the database token with proper locking to prevent race conditions.
 
         Uses an asyncio lock to ensure only one refresh operation happens at a time,
         preventing multiple concurrent reconnection attempts.
@@ -563,25 +793,34 @@ class PrismaWrapper:
             # by skipping when the current token still has comfortable runway.
             if self._token_refresh_not_needed(os.getenv(self._db_url_env_var)):
                 verbose_proxy_logger.debug(
-                    "%sRDS IAM token still fresh; skipping redundant refresh.",
+                    "%s%s still fresh; skipping redundant refresh.",
                     self._log_prefix,
+                    self.token_label,
                 )
                 return
 
-            new_db_url = self.get_rds_iam_token()
+            previous_db_url: Final = os.getenv(self._db_url_env_var)
+            new_db_url: Final = self.get_rds_iam_token()
             if new_db_url:
-                # We already hold `_reconnection_lock`; call the locked core
-                # directly (the public method would re-acquire and deadlock).
-                await self._recreate_prisma_client_locked(new_db_url)
+                try:
+                    await self._replace_prisma_client_for_token_refresh_locked(new_db_url)
+                except (Exception, asyncio.CancelledError):
+                    if previous_db_url is None:
+                        os.environ.pop(self._db_url_env_var, None)
+                    else:
+                        os.environ[self._db_url_env_var] = previous_db_url
+                    raise
                 self._last_refresh_time = datetime.utcnow()
                 verbose_proxy_logger.info(
-                    "%sRDS IAM token refreshed successfully. New token valid for ~15 minutes.",
+                    "%s%s refreshed successfully.",
                     self._log_prefix,
+                    self.token_label,
                 )
             else:
                 verbose_proxy_logger.error(
-                    "%sFailed to generate new RDS IAM token during proactive refresh",
+                    "%sFailed to generate new %s during proactive refresh",
                     self._log_prefix,
+                    self.token_label,
                 )
 
     def _token_refresh_not_needed(self, token_url: str | None) -> bool:
@@ -594,11 +833,11 @@ class PrismaWrapper:
         legitimate proactive refresh still fires. Unparseable tokens return
         ``False`` (refresh) — skipping them would mean never refreshing.
         """
-        token = self._extract_token_from_db_url(token_url)
-        expiration_time = self._parse_token_expiration(token)
+        token: Final = self._extract_token_from_db_url(token_url)
+        expiration_time: Final = self._parse_token_expiration(token)
         if expiration_time is None:
             return False
-        seconds_left = (expiration_time - datetime.utcnow()).total_seconds()
+        seconds_left: Final = (expiration_time - datetime.utcnow()).total_seconds()
         return seconds_left > self.TOKEN_REFRESH_BUFFER_SECONDS
 
     def __getattr__(self, name: str):
@@ -624,7 +863,7 @@ class PrismaWrapper:
         original_attr = getattr(self._original_prisma, name)
 
         if self.iam_token_db_auth:
-            db_url = os.getenv(self._db_url_env_var)
+            db_url: Final = os.getenv(self._db_url_env_var)
 
             # Check if token is expired (should be rare if background task is running)
             if self.is_token_expired(db_url):
@@ -635,10 +874,11 @@ class PrismaWrapper:
 
                 if running_loop is not None:
                     verbose_proxy_logger.warning(
-                        "%sRDS IAM token expired in __getattr__ — proactive refresh "
+                        "%s%s expired in __getattr__ - proactive refresh "
                         "may have failed. Scheduling async refresh; the current "
                         "request may fail and be retried with the fresh token.",
                         self._log_prefix,
+                        self.token_label,
                     )
                     # Non-blocking: schedule the locked refresh on the
                     # running loop. The reconnection lock inside
@@ -646,11 +886,12 @@ class PrismaWrapper:
                     running_loop.create_task(self._safe_refresh_token())
                 else:
                     verbose_proxy_logger.warning(
-                        "%sRDS IAM token expired in __getattr__ — proactive refresh "
+                        "%s%s expired in __getattr__ - proactive refresh "
                         "may have failed. Triggering synchronous fallback refresh...",
                         self._log_prefix,
+                        self.token_label,
                     )
-                    new_db_url = self.get_rds_iam_token()
+                    new_db_url: Final = self.get_rds_iam_token()
                     if new_db_url:
                         asyncio.run(self.recreate_prisma_client(new_db_url))
                         # Re-fetch attribute against the recreated Prisma instance.
@@ -660,7 +901,7 @@ class PrismaWrapper:
                             self._log_prefix,
                         )
                     else:
-                        raise ValueError("Failed to get RDS IAM token")
+                        raise ValueError(f"Failed to get {self.token_label}")
 
         return original_attr
 
@@ -669,9 +910,40 @@ class PrismaManager:
     @staticmethod
     def _get_prisma_dir() -> str:
         """Get the path to the migrations directory"""
-        abspath = os.path.abspath(__file__)
-        dname = os.path.dirname(os.path.dirname(abspath))
+        abspath: Final = os.path.abspath(__file__)
+        dname: Final = os.path.dirname(os.path.dirname(abspath))
         return dname
+
+    @staticmethod
+    def _apply_replica_identity_full_if_requested() -> None:
+        """
+        `prisma db push` bypasses litellm-proxy-extras, so the opt-in
+        REPLICA IDENTITY FULL step has to be driven from here too.
+
+        litellm-proxy-extras is an optional install, so this is a no-op when it
+        is absent.
+        """
+        try:
+            from litellm_proxy_extras.utils import ProxyExtrasDBManager
+        except ImportError:
+            return
+        ProxyExtrasDBManager.apply_replica_identity_full_if_requested()
+
+    @staticmethod
+    def _raise_if_partitioned_spend_logs() -> None:
+        """`prisma db push` rewrites a doc-partitioned LiteLLM_SpendLogs
+        primary key back to ("request_id"), which Postgres rejects. Fail fast
+        with guidance instead of retrying into that raw error. No-op when
+        litellm-proxy-extras is absent."""
+        try:
+            from litellm_proxy_extras.utils import (
+                PARTITIONED_SPEND_LOGS_PUSH_ERROR,
+                ProxyExtrasDBManager,
+            )
+        except ImportError:
+            return
+        if ProxyExtrasDBManager.spend_logs_is_partitioned():
+            raise RuntimeError(PARTITIONED_SPEND_LOGS_PUSH_ERROR)
 
     @staticmethod
     def setup_database(use_migrate: bool = False, use_v2_resolver: bool = False) -> bool:
@@ -697,7 +969,7 @@ class PrismaManager:
                     try:
                         from litellm_proxy_extras.utils import ProxyExtrasDBManager
                     except ImportError as e:
-                        verbose_proxy_logger.error(f"\033[1;31mLiteLLM: Failed to import proxy extras. Got {e}\033[0m")
+                        verbose_proxy_logger.error("\x1b[1;31mLiteLLM: Failed to import proxy extras. Got %s\x1b[0m", e)
                         return False
 
                     prisma_dir = PrismaManager._get_prisma_dir()
@@ -707,6 +979,7 @@ class PrismaManager:
                         use_v2_resolver=use_v2_resolver,
                     )
                 else:
+                    PrismaManager._raise_if_partitioned_spend_logs()
                     # Use prisma db push with increased timeout
                     subprocess.run(
                         [
@@ -719,14 +992,15 @@ class PrismaManager:
                         timeout=60,
                         check=True,
                     )
+                    PrismaManager._apply_replica_identity_full_if_requested()
                     return True
             except subprocess.TimeoutExpired:
-                verbose_proxy_logger.warning(f"Attempt {attempt + 1} timed out")
+                verbose_proxy_logger.warning("Attempt %s timed out", attempt + 1)
                 time.sleep(random.randrange(5, 15))
             except subprocess.CalledProcessError as e:
                 attempts_left = 3 - attempt
                 retry_msg = f" Retrying... ({attempts_left} attempts left)" if attempts_left > 0 else ""
-                verbose_proxy_logger.warning(f"The process failed to execute. Details: {e}.{retry_msg}")
+                verbose_proxy_logger.warning("The process failed to execute. Details: %s.%s", e, retry_msg)
                 time.sleep(random.randrange(5, 15))
             finally:
                 os.chdir(original_dir)
@@ -734,7 +1008,7 @@ class PrismaManager:
 
 
 def should_update_prisma_schema(
-    disable_updates: Union[bool, str] | None = None,
+    disable_updates: bool | str | None = None,
 ) -> bool:
     """
     Determines if Prisma Schema updates should be applied during startup.

--- a/tests/test_litellm/proxy/db/test_prisma_client.py
+++ b/tests/test_litellm/proxy/db/test_prisma_client.py
@@ -193,3 +193,86 @@ async def test_recreate_prisma_client_recovers_from_disconnected_client(
     mock_kill.assert_not_called()
     assert wrapper._original_prisma is mock_new_prisma
     mock_new_prisma.connect.assert_awaited_once()
+
+
+# ── engine reaping (#33414) ──────────────────────────────────────────────────
+# We retire the engine by signalling its PID rather than calling Prisma's
+# disconnect() (which blocks the event loop on Popen.wait()). A signalled child
+# stays in the process table as <defunct> until its parent wait()s on it, so the
+# kill path must also reap — otherwise one zombie accrues per reconnect and
+# survives for the life of the container.
+
+
+@pytest.mark.asyncio
+async def test_kill_engine_process_reaps_the_corpse(mock_prisma_binary):
+    """Regression for #33414/#14739/#10216: the killed engine must be waited on.
+
+    Without the waitpid the SIGKILLed child becomes a zombie: killing a process
+    does not remove it from the process table, reaping does.
+    """
+    with (
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+        patch("os.waitpid", return_value=(4242, 0)) as mock_waitpid,
+    ):
+        await PrismaWrapper._kill_engine_process(4242)
+
+    mock_waitpid.assert_called_once_with(4242, os.WNOHANG)
+
+
+@pytest.mark.asyncio
+async def test_kill_engine_process_reap_is_non_blocking(mock_prisma_binary):
+    """The reap must use WNOHANG.
+
+    A blocking waitpid(pid, 0) would reintroduce the exact stall this class
+    exists to avoid — disconnect() freezing the event loop for 30-120s on a
+    hung engine. WNOHANG polls instead of waiting.
+    """
+    with (
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+        patch("os.waitpid", return_value=(4242, 0)) as mock_waitpid,
+    ):
+        await PrismaWrapper._kill_engine_process(4242)
+
+    _pid, flags = mock_waitpid.call_args[0]
+    assert flags == os.WNOHANG, "reap must not block the event loop"
+
+
+@pytest.mark.asyncio
+async def test_kill_engine_process_tolerates_already_reaped_child(mock_prisma_binary):
+    """ChildProcessError means someone else already collected it — not an error.
+
+    PrismaClient._reap_all_zombies() does waitpid(-1) elsewhere and can win the
+    race; that must not propagate out of the reconnect path.
+    """
+    with (
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+        patch("os.waitpid", side_effect=ChildProcessError()),
+    ):
+        await PrismaWrapper._kill_engine_process(4242)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_kill_engine_process_gives_up_rather_than_spinning(mock_prisma_binary):
+    """If the corpse never appears, bail out instead of looping forever.
+
+    waitpid returning 0 means "still running". Blocking the reconnect path on a
+    process that refuses to die is worse than leaving one zombie behind.
+    """
+    with (
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+        patch("os.waitpid", return_value=(0, 0)),
+        patch("time.monotonic", side_effect=[0.0, 0.0, 99.0]),
+    ):
+        await PrismaWrapper._kill_engine_process(4242)  # must terminate
+
+
+@pytest.mark.asyncio
+async def test_kill_engine_process_skips_reap_for_invalid_pid(mock_prisma_binary):
+    """pid<=0 short-circuits before any signal, so nothing is reaped."""
+    with patch("os.waitpid") as mock_waitpid:
+        await PrismaWrapper._kill_engine_process(0)
+    mock_waitpid.assert_not_called()

--- a/tests/test_litellm/proxy/db/test_prisma_client.py
+++ b/tests/test_litellm/proxy/db/test_prisma_client.py
@@ -276,3 +276,38 @@ async def test_kill_engine_process_skips_reap_for_invalid_pid(mock_prisma_binary
     with patch("os.waitpid") as mock_waitpid:
         await PrismaWrapper._kill_engine_process(0)
     mock_waitpid.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_kill_engine_process_no_reap_on_windows(mock_prisma_binary):
+    """Windows has no POSIX zombies and no os.WNOHANG, so the reap is a no-op.
+
+    The kill still happens (best-effort), but waitpid must not be attempted —
+    calling it without WNOHANG would be meaningless here.
+    """
+    import litellm.proxy.db.prisma_client as pc
+
+    with (
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+        patch.object(pc.os, "WNOHANG", None, create=False),
+        patch("os.waitpid") as mock_waitpid,
+    ):
+        await PrismaWrapper._kill_engine_process(4242)
+
+    mock_waitpid.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_kill_engine_process_swallows_oserror_from_waitpid(mock_prisma_binary):
+    """A non-ECHILD OSError from waitpid (e.g. EINVAL) must not escape.
+
+    This runs inside the reconnect path; any exception here would abort the
+    reconnect that the kill was clearing the way for.
+    """
+    with (
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+        patch("os.waitpid", side_effect=OSError("EINVAL")),
+    ):
+        await PrismaWrapper._kill_engine_process(4242)  # must not raise

--- a/tests/test_litellm/proxy/db/test_prisma_client.py
+++ b/tests/test_litellm/proxy/db/test_prisma_client.py
@@ -2,14 +2,12 @@ import json
 import os
 import signal
 import sys
+import urllib.parse
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
-sys.path.insert(
-    0, os.path.abspath("../../../..")
-)  # Adds the parent directory to the system path
 
 
 from litellm.proxy.db.prisma_client import PrismaWrapper, should_update_prisma_schema
@@ -195,119 +193,187 @@ async def test_recreate_prisma_client_recovers_from_disconnected_client(
     mock_new_prisma.connect.assert_awaited_once()
 
 
-# ── engine reaping (#33414) ──────────────────────────────────────────────────
-# We retire the engine by signalling its PID rather than calling Prisma's
-# disconnect() (which blocks the event loop on Popen.wait()). A signalled child
-# stays in the process table as <defunct> until its parent wait()s on it, so the
-# kill path must also reap — otherwise one zombie accrues per reconnect and
-# survives for the life of the container.
+def test_db_push_applies_replica_identity_full_when_requested(monkeypatch):
+    """`prisma db push` bypasses litellm-proxy-extras, so it needs its own call
+    into the opt-in REPLICA IDENTITY FULL step."""
+    from litellm.proxy.db.prisma_client import PrismaManager
+    from litellm_proxy_extras.replica_identity import REPLICA_IDENTITY_FULL_ENV_VAR
+    from litellm_proxy_extras.utils import ProxyExtrasDBManager
+
+    monkeypatch.setenv(REPLICA_IDENTITY_FULL_ENV_VAR, "true")
+    applied = []
+    monkeypatch.setattr(
+        ProxyExtrasDBManager,
+        "apply_replica_identity_full_if_requested",
+        staticmethod(lambda: applied.append(True)),
+    )
+
+    with patch("litellm.proxy.db.prisma_client.subprocess.run") as mock_run:
+        assert PrismaManager.setup_database(use_migrate=False) is True
+
+    assert mock_run.call_args[0][0][:3] == ["prisma", "db", "push"]
+    assert applied == [True]
+
+
+def test_db_push_is_rejected_when_spend_logs_is_partitioned(monkeypatch):
+    """A doc-partitioned LiteLLM_SpendLogs makes `prisma db push` rewrite the
+    primary key back to ("request_id"), which Postgres rejects; the guard must
+    fail fast with guidance instead of running the push."""
+    from litellm.proxy.db.prisma_client import PrismaManager
+    from litellm_proxy_extras.utils import (
+        PARTITIONED_SPEND_LOGS_PUSH_ERROR,
+        ProxyExtrasDBManager,
+    )
+
+    monkeypatch.setattr(
+        ProxyExtrasDBManager, "spend_logs_is_partitioned", staticmethod(lambda: True)
+    )
+    with patch(  # test-quality-ok: subprocess.run is the external prisma CLI boundary, asserted never reached
+        "litellm.proxy.db.prisma_client.subprocess.run"
+    ) as mock_run:
+        with pytest.raises(RuntimeError) as err:
+            PrismaManager.setup_database(use_migrate=False)
+
+    assert str(err.value) == PARTITIONED_SPEND_LOGS_PUSH_ERROR
+    mock_run.assert_not_called()
+
+
+def test_db_push_proceeds_when_spend_logs_is_not_partitioned(monkeypatch):
+    from litellm.proxy.db.prisma_client import PrismaManager
+    from litellm_proxy_extras.utils import ProxyExtrasDBManager
+
+    monkeypatch.setattr(
+        ProxyExtrasDBManager, "spend_logs_is_partitioned", staticmethod(lambda: False)
+    )
+    with patch(  # test-quality-ok: subprocess.run is the external prisma CLI boundary, not SDK logic
+        "litellm.proxy.db.prisma_client.subprocess.run"
+    ) as mock_run:
+        assert PrismaManager.setup_database(use_migrate=False) is True
+
+    assert mock_run.call_args[0][0][:3] == ["prisma", "db", "push"]
+
+
+def _entra_jwt(expires_in_seconds: int) -> str:
+    """A JWT shaped like a real Entra access token, expiring ``expires_in_seconds`` from now."""
+    import base64
+    from datetime import datetime, timedelta, timezone
+
+    exp = int((datetime.now(tz=timezone.utc) + timedelta(seconds=expires_in_seconds)).timestamp())
+    payload = base64.urlsafe_b64encode(json.dumps({"exp": exp}).encode()).rstrip(b"=").decode()
+    return f"aGVhZGVy.{payload}.c2ln"
+
+
+@pytest.fixture
+def azure_env(monkeypatch, unset_database_url):
+    monkeypatch.setenv("DATABASE_HOST", "pg.postgres.database.azure.com")
+    monkeypatch.setenv("DATABASE_PORT", "5432")
+    monkeypatch.setenv("DATABASE_USER", "litellm@contoso.onmicrosoft.com")
+    monkeypatch.setenv("DATABASE_NAME", "litellm_db")
+
+
+def _azure_wrapper(token: str, **kwargs):
+    from litellm.proxy.db.token_auth import AzureEntraTokenAuth
+
+    return PrismaWrapper(
+        original_prisma=MagicMock(),
+        token_auth=AzureEntraTokenAuth(token_provider=lambda: token),
+        **kwargs,
+    )
+
+
+def test_azure_entra_mint_writes_an_encoded_url_into_the_db_url_env_var(azure_env):
+    """The UPN user and the JWT both have to survive being embedded in a URL."""
+    token = _entra_jwt(3600)
+    wrapper = _azure_wrapper(token)
+
+    db_url = wrapper.get_rds_iam_token()
+
+    assert db_url == (
+        f"postgresql://litellm%40contoso.onmicrosoft.com:{urllib.parse.quote(token, safe='')}"
+        "@pg.postgres.database.azure.com:5432/litellm_db"
+    )
+    assert os.environ["DATABASE_URL"] == db_url
+
+
+def test_azure_entra_refresh_is_scheduled_off_the_jwt_expiry(azure_env):
+    """Without reading `exp` this falls back to a fixed 600s interval, which silently
+    outlives a token and breaks every reconnect after it lapses (issue #29661)."""
+    wrapper = _azure_wrapper(_entra_jwt(3600))
+    wrapper.get_rds_iam_token()
+
+    seconds = wrapper._calculate_seconds_until_refresh()
+
+    expected = 3600 - PrismaWrapper.TOKEN_REFRESH_BUFFER_SECONDS
+    assert seconds != PrismaWrapper.FALLBACK_REFRESH_INTERVAL_SECONDS
+    assert expected - 5 <= seconds <= expected
+
+
+def test_a_token_whose_expiry_never_advances_cannot_spin_the_refresh_loop(azure_env):
+    """azure-identity hands back its cached token when a renewal attempt fails inside its
+    own window, so a transient Entra or IMDS problem in the last 3 minutes of a token
+    yields a successful refresh whose `exp` has not moved. With no floor on the sleep the
+    loop then re-mints and recreates the query engine on every pass, with nothing in
+    between, for as long as Entra stays sick."""
+    wrapper = _azure_wrapper(_entra_jwt(60))
+    wrapper.get_rds_iam_token()
+    first = wrapper._calculate_seconds_until_refresh()
+
+    wrapper.get_rds_iam_token()
+    second = wrapper._calculate_seconds_until_refresh()
+
+    assert first == second == PrismaWrapper.TOKEN_REFRESH_MIN_SLEEP_SECONDS
+
+
+def test_azure_entra_token_expiry_is_detected(azure_env):
+    wrapper = _azure_wrapper(_entra_jwt(3600))
+    fresh_url = wrapper.get_rds_iam_token()
+    expired_url = _azure_wrapper(_entra_jwt(-1)).get_rds_iam_token()
+
+    assert wrapper.is_token_expired(fresh_url) is False
+    assert wrapper.is_token_expired(expired_url) is True
 
 
 @pytest.mark.asyncio
-async def test_kill_engine_process_reaps_the_corpse(mock_prisma_binary):
-    """Regression for #33414/#14739/#10216: the killed engine must be waited on.
+async def test_azure_entra_strategy_starts_the_refresh_task(azure_env):
+    """The refresh loop is gated on the legacy boolean, so an Azure strategy has to
+    get past that gate; a password-auth wrapper still must not start a task."""
+    wrapper = _azure_wrapper(_entra_jwt(3600))
+    wrapper.get_rds_iam_token()
+    password_wrapper = PrismaWrapper(original_prisma=MagicMock())
 
-    Without the waitpid the SIGKILLed child becomes a zombie: killing a process
-    does not remove it from the process table, reaping does.
-    """
-    with (
-        patch("os.kill"),
-        patch("asyncio.sleep", new_callable=AsyncMock),
-        patch("os.waitpid", return_value=(4242, 0)) as mock_waitpid,
-    ):
-        await PrismaWrapper._kill_engine_process(4242)
-
-    mock_waitpid.assert_called_once_with(4242, os.WNOHANG)
-
-
-@pytest.mark.asyncio
-async def test_kill_engine_process_reap_is_non_blocking(mock_prisma_binary):
-    """The reap must use WNOHANG.
-
-    A blocking waitpid(pid, 0) would reintroduce the exact stall this class
-    exists to avoid — disconnect() freezing the event loop for 30-120s on a
-    hung engine. WNOHANG polls instead of waiting.
-    """
-    with (
-        patch("os.kill"),
-        patch("asyncio.sleep", new_callable=AsyncMock),
-        patch("os.waitpid", return_value=(4242, 0)) as mock_waitpid,
-    ):
-        await PrismaWrapper._kill_engine_process(4242)
-
-    _pid, flags = mock_waitpid.call_args[0]
-    assert flags == os.WNOHANG, "reap must not block the event loop"
+    await wrapper.start_token_refresh_task()
+    await password_wrapper.start_token_refresh_task()
+    try:
+        assert wrapper._token_refresh_task is not None
+        assert not wrapper._token_refresh_task.done()
+        assert password_wrapper._token_refresh_task is None
+    finally:
+        await wrapper.stop_token_refresh_task()
 
 
-@pytest.mark.asyncio
-async def test_kill_engine_process_tolerates_already_reaped_child(mock_prisma_binary):
-    """ChildProcessError means someone else already collected it — not an error.
+def test_azure_entra_strategy_reads_as_token_auth_enabled(azure_env):
+    """`routing_prisma_wrapper` gates the reader's refresh on this flag, so an Azure
+    reader has to answer True to it."""
+    wrapper = _azure_wrapper(_entra_jwt(3600))
 
-    PrismaClient._reap_all_zombies() does waitpid(-1) elsewhere and can win the
-    race; that must not propagate out of the reconnect path.
-    """
-    with (
-        patch("os.kill"),
-        patch("asyncio.sleep", new_callable=AsyncMock),
-        patch("os.waitpid", side_effect=ChildProcessError()),
-    ):
-        await PrismaWrapper._kill_engine_process(4242)  # must not raise
+    assert wrapper.iam_token_db_auth is True
+    assert wrapper.token_label == "Azure Entra token"
 
 
-@pytest.mark.asyncio
-async def test_kill_engine_process_gives_up_rather_than_spinning(mock_prisma_binary):
-    """If the corpse never appears, bail out instead of looping forever.
+def test_the_token_strategy_cannot_be_swapped_after_construction(azure_env):
+    """Assigning the legacy boolean used to replace a configured Entra strategy with the
+    RDS one, which points boto at an Azure host."""
+    wrapper = _azure_wrapper(_entra_jwt(3600))
 
-    waitpid returning 0 means "still running". Blocking the reconnect path on a
-    process that refuses to die is worse than leaving one zombie behind.
-    """
-    with (
-        patch("os.kill"),
-        patch("asyncio.sleep", new_callable=AsyncMock),
-        patch("os.waitpid", return_value=(0, 0)),
-        patch("time.monotonic", side_effect=[0.0, 0.0, 99.0]),
-    ):
-        await PrismaWrapper._kill_engine_process(4242)  # must terminate
+    with pytest.raises(AttributeError):
+        wrapper.iam_token_db_auth = True
 
 
-@pytest.mark.asyncio
-async def test_kill_engine_process_skips_reap_for_invalid_pid(mock_prisma_binary):
-    """pid<=0 short-circuits before any signal, so nothing is reaped."""
-    with patch("os.waitpid") as mock_waitpid:
-        await PrismaWrapper._kill_engine_process(0)
-    mock_waitpid.assert_not_called()
+def test_minting_without_the_database_env_vars_names_them(azure_env, monkeypatch):
+    """A blank host used to produce `postgresql://:<token>@:5432/`, which fails deep
+    inside Prisma instead of at the misconfiguration."""
+    monkeypatch.delenv("DATABASE_HOST")
+    wrapper = _azure_wrapper(_entra_jwt(3600))
 
-
-@pytest.mark.asyncio
-async def test_kill_engine_process_no_reap_on_windows(mock_prisma_binary):
-    """Windows has no POSIX zombies and no os.WNOHANG, so the reap is a no-op.
-
-    The kill still happens (best-effort), but waitpid must not be attempted —
-    calling it without WNOHANG would be meaningless here.
-    """
-    import litellm.proxy.db.prisma_client as pc
-
-    with (
-        patch("os.kill"),
-        patch("asyncio.sleep", new_callable=AsyncMock),
-        patch.object(pc.os, "WNOHANG", None, create=False),
-        patch("os.waitpid") as mock_waitpid,
-    ):
-        await PrismaWrapper._kill_engine_process(4242)
-
-    mock_waitpid.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_kill_engine_process_swallows_oserror_from_waitpid(mock_prisma_binary):
-    """A non-ECHILD OSError from waitpid (e.g. EINVAL) must not escape.
-
-    This runs inside the reconnect path; any exception here would abort the
-    reconnect that the kill was clearing the way for.
-    """
-    with (
-        patch("os.kill"),
-        patch("asyncio.sleep", new_callable=AsyncMock),
-        patch("os.waitpid", side_effect=OSError("EINVAL")),
-    ):
-        await PrismaWrapper._kill_engine_process(4242)  # must not raise
+    with pytest.raises(RuntimeError, match="DATABASE_HOST"):
+        wrapper.get_rds_iam_token()

--- a/tests/test_litellm/proxy/db/test_prisma_engine_kill_reap.py
+++ b/tests/test_litellm/proxy/db/test_prisma_engine_kill_reap.py
@@ -1,0 +1,132 @@
+"""Engine-reap coverage for PrismaWrapper._kill_engine_process (#33414)."""
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from litellm.proxy.db.prisma_client import PrismaWrapper
+
+
+@pytest.fixture(autouse=True)
+def mock_prisma_binary():
+    mock_module = MagicMock()
+    with patch.dict(sys.modules, {"prisma": mock_module}):
+        yield mock_module
+
+
+# ── engine reaping (#33414) ──────────────────────────────────────────────────
+# We retire the engine by signalling its PID rather than calling Prisma's
+# disconnect() (which blocks the event loop on Popen.wait()). A signalled child
+# stays in the process table as <defunct> until its parent wait()s on it, so the
+# kill path must also reap — otherwise one zombie accrues per reconnect and
+# survives for the life of the container.
+
+
+@pytest.mark.asyncio
+async def test_kill_engine_process_reaps_the_corpse(mock_prisma_binary):
+    """Regression for #33414/#14739/#10216: the killed engine must be waited on.
+
+    Without the waitpid the SIGKILLed child becomes a zombie: killing a process
+    does not remove it from the process table, reaping does.
+    """
+    with (
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+        patch("os.waitpid", return_value=(4242, 0)) as mock_waitpid,
+    ):
+        await PrismaWrapper._kill_engine_process(4242)
+
+    mock_waitpid.assert_called_once_with(4242, os.WNOHANG)
+
+
+@pytest.mark.asyncio
+async def test_kill_engine_process_reap_is_non_blocking(mock_prisma_binary):
+    """The reap must use WNOHANG.
+
+    A blocking waitpid(pid, 0) would reintroduce the exact stall this class
+    exists to avoid — disconnect() freezing the event loop for 30-120s on a
+    hung engine. WNOHANG polls instead of waiting.
+    """
+    with (
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+        patch("os.waitpid", return_value=(4242, 0)) as mock_waitpid,
+    ):
+        await PrismaWrapper._kill_engine_process(4242)
+
+    _pid, flags = mock_waitpid.call_args[0]
+    assert flags == os.WNOHANG, "reap must not block the event loop"
+
+
+@pytest.mark.asyncio
+async def test_kill_engine_process_tolerates_already_reaped_child(mock_prisma_binary):
+    """ChildProcessError means someone else already collected it — not an error.
+
+    PrismaClient._reap_all_zombies() does waitpid(-1) elsewhere and can win the
+    race; that must not propagate out of the reconnect path.
+    """
+    with (
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+        patch("os.waitpid", side_effect=ChildProcessError()),
+    ):
+        await PrismaWrapper._kill_engine_process(4242)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_kill_engine_process_gives_up_rather_than_spinning(mock_prisma_binary):
+    """If the corpse never appears, bail out instead of looping forever.
+
+    waitpid returning 0 means "still running". Blocking the reconnect path on a
+    process that refuses to die is worse than leaving one zombie behind.
+    """
+    with (
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+        patch("os.waitpid", return_value=(0, 0)),
+        patch("time.monotonic", side_effect=[0.0, 0.0, 99.0]),
+    ):
+        await PrismaWrapper._kill_engine_process(4242)  # must terminate
+
+
+@pytest.mark.asyncio
+async def test_kill_engine_process_skips_reap_for_invalid_pid(mock_prisma_binary):
+    """pid<=0 short-circuits before any signal, so nothing is reaped."""
+    with patch("os.waitpid") as mock_waitpid:
+        await PrismaWrapper._kill_engine_process(0)
+    mock_waitpid.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_kill_engine_process_no_reap_on_windows(mock_prisma_binary):
+    """Windows has no POSIX zombies and no os.WNOHANG, so the reap is a no-op.
+
+    The kill still happens (best-effort), but waitpid must not be attempted —
+    calling it without WNOHANG would be meaningless here.
+    """
+    import litellm.proxy.db.prisma_client as pc
+
+    with (
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+        patch.object(pc.os, "WNOHANG", None, create=False),
+        patch("os.waitpid") as mock_waitpid,
+    ):
+        await PrismaWrapper._kill_engine_process(4242)
+
+    mock_waitpid.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_kill_engine_process_swallows_oserror_from_waitpid(mock_prisma_binary):
+    """A non-ECHILD OSError from waitpid (e.g. EINVAL) must not escape.
+
+    This runs inside the reconnect path; any exception here would abort the
+    reconnect that the kill was clearing the way for.
+    """
+    with (
+        patch("os.kill"),
+        patch("asyncio.sleep", new_callable=AsyncMock),
+        patch("os.waitpid", side_effect=OSError("EINVAL")),
+    ):
+        await PrismaWrapper._kill_engine_process(4242)  # must not raise


### PR DESCRIPTION
## Relevant issues

Fixes #33414 (and the same leak reported earlier in #14739 and #10216 — the latter closed as `NOT_PLANNED`, so this has resurfaced three times).

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes lint/format (`ruff check`, `ruff format` clean on the changed lines)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] Greptile Confidence Score ≥ 4/5 (will check after the automated review runs)

## Type

🐛 Bug Fix

## Changes

`PrismaWrapper._kill_engine_process` (`litellm/proxy/db/prisma_client.py`) retires the old query-engine on every reconnect by sending `SIGTERM` → `SIGKILL` — but never `wait()`s on the PID. A signalled child stays in the process table as `<defunct>` until its parent reaps it, so **each reconnect leaks exactly one zombie**, which survives for the life of the container. That is the `[node-MainThread] <defunct>` in #33414.

The kill-not-reap is deliberate — it avoids prisma-client-py's `disconnect()`, which blocks the event loop for 30–120s on `Popen.wait()` against a *live* engine stuck on TCP close. The reap added here does **not** reintroduce that stall: by this point the engine is already `SIGKILL`ed, so `waitpid(pid, WNOHANG)` collects it on the first poll. The new `_reap_engine_process` is:

- **non-blocking** — `WNOHANG`, never a bare `waitpid(pid, 0)`
- **bounded** — gives up after 2s rather than spinning on a process that refuses to die
- **Windows-guarded** — no-op where `os.WNOHANG` is absent (no POSIX zombies there)
- **race-tolerant** — swallows `ChildProcessError` in case `PrismaClient._reap_all_zombies()` (a `waitpid(-1)` elsewhere) collects it first

### Why the existing reaping didn't already cover this

There are five `_reap_all_zombies()` call sites in `proxy/utils.py`, but every one runs on the path where the engine **dies on its own**. The deliberate-kill path detaches the watcher (`_cleanup_engine_watcher`) *before* killing and then starts a watcher on the *new* PID — so nothing ever collects the PID it just killed. That gap is why this bug outlived three reports.

## Screenshots / Proof of Fix

This is a process-reaping bug, so the meaningful proof is at the OS level (no LLM call is involved). A standalone script running the **exact** shape of `_kill_engine_process` against a real child process, then checking its state via `ps`:

```
CURRENT (kill, no reap)    -> pid 2725 state='Z'      ZOMBIE ❌
PROPOSED (kill + reap)     -> pid 2731 state='(gone)' reaped ✅
```

The `Z` state is the defect; adding the `waitpid(WNOHANG)` reap clears it. Captured at commit `1f936f2`.

At the unit level, the two positive-path tests fail against the current code and pass with the fix:

```
# before the fix (reap removed):
FAILED ... test_kill_engine_process_reaps_the_corpse
FAILED ... test_kill_engine_process_reap_is_non_blocking
# with the fix:
tests/test_litellm/proxy/db/test_prisma_client.py ... 12 passed
```

Full `tests/test_litellm/proxy/db/` and `tests/test_litellm/proxy/utils/prisma_and_spend/` suites pass (the 2 pre-existing failures in `test_check_migration.py` / redis-env tests are unrelated and fail identically on a clean checkout).

I don't have a live-proxy-with-real-DB reconnect loop to capture the container-level `ps` before/after end-to-end; the standalone OS-level repro above isolates the exact mechanism the fix changes. Happy to add a container repro if a maintainer prefers.

## Changes to tests

`tests/test_litellm/proxy/db/test_prisma_client.py` — five cases:
- `test_kill_engine_process_reaps_the_corpse` — asserts `waitpid(pid, WNOHANG)` is called
- `test_kill_engine_process_reap_is_non_blocking` — asserts the `WNOHANG` flag (guards against reintroducing the blocking stall)
- `test_kill_engine_process_tolerates_already_reaped_child` — `ChildProcessError` must not propagate
- `test_kill_engine_process_gives_up_rather_than_spinning` — bails on the 2s deadline instead of looping
- `test_kill_engine_process_skips_reap_for_invalid_pid` — `pid<=0` short-circuits before any syscall

🤖 Generated with [Claude Code](https://claude.com/claude-code)