### PR TITLE
test: reorder test_utils tail to keep the daily merge conflict-free

### DIFF
--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4714,34 +4714,6 @@ class TestValidateEnvironmentTencent:
         assert "TENCENT_API_KEY" in result["missing_keys"]
 
 
-@pytest.mark.parametrize(
-    "model",
-    [
-        "vertex_ai/gemini-2.5-flash-image",
-        "vertex_ai/gemini-3-pro-image",
-        "vertex_ai/gemini-3-pro-image-preview",
-        "vertex_ai/gemini-3.1-flash-image",
-        "vertex_ai/gemini-3.1-flash-image-preview",
-        "gemini/gemini-2.5-flash-image",
-        "gemini/gemini-3-pro-image",
-        "gemini/gemini-3-pro-image-preview",
-        "gemini/gemini-3.1-flash-image",
-        "gemini/gemini-3.1-flash-image-preview",
-    ],
-)
-def test_gemini_image_models_do_not_support_reasoning(
-    model: str, local_model_cost_map: None
-) -> None:
-    assert model in litellm.model_cost, (
-        f"{model} is missing from the local model cost map. "
-        "Add its entry to litellm/model_prices_and_context_window_backup.json."
-    )
-    assert litellm.supports_reasoning(model) is False, (
-        f"{model} incorrectly classified as reasoning-capable. "
-        "Add 'supports_reasoning: false' to its model_cost entry."
-    )
-
-
 class TestVertexEmbeddingEncodingFormat:
     """vertex_ai/gemini embeddings must accept encoding_format="float" — it's
     the OpenAI SDK default and float lists are exactly what the vertex API
@@ -4790,3 +4762,31 @@ class TestVertexEmbeddingEncodingFormat:
             custom_llm_provider="vertex_ai",
         )
         assert optional_params.get("outputDimensionality") == 256
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "vertex_ai/gemini-2.5-flash-image",
+        "vertex_ai/gemini-3-pro-image",
+        "vertex_ai/gemini-3-pro-image-preview",
+        "vertex_ai/gemini-3.1-flash-image",
+        "vertex_ai/gemini-3.1-flash-image-preview",
+        "gemini/gemini-2.5-flash-image",
+        "gemini/gemini-3-pro-image",
+        "gemini/gemini-3-pro-image-preview",
+        "gemini/gemini-3.1-flash-image",
+        "gemini/gemini-3.1-flash-image-preview",
+    ],
+)
+def test_gemini_image_models_do_not_support_reasoning(
+    model: str, local_model_cost_map: None
+) -> None:
+    assert model in litellm.model_cost, (
+        f"{model} is missing from the local model cost map. "
+        "Add its entry to litellm/model_prices_and_context_window_backup.json."
+    )
+    assert litellm.supports_reasoning(model) is False, (
+        f"{model} incorrectly classified as reasoning-capable. "
+        "Add 'supports_reasoning: false' to its model_cost entry."
+    )


### PR DESCRIPTION
## Relevant issues

Unblocks #33784 (the daily OSS branch merge into `litellm_internal_staging`), which is currently CONFLICTING on this single file

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This change has no runtime or proxy surface; it only reorders two blocks in a unit-test file so the daily merge stays clean, so the meaningful proof is that the branch merge #33784 performs goes from conflicting to clean with both branches' tests preserved

Before, merging the current daily OSS tip into `litellm_internal_staging`:

```
$ git merge --no-commit --no-ff origin/litellm_oss_daily_2026_07_16
CONFLICT (content): Merge conflict in tests/test_litellm/test_utils.py
Automatic merge failed; fix conflicts and then commit the result.
# conflicted files: tests/test_litellm/test_utils.py
```

After, merging this branch into `litellm_internal_staging`:

```
$ git merge --no-commit --no-ff origin/litellm_/resolve-merge-conflicts-e10f1c
Auto-merging tests/test_litellm/test_utils.py
Automatic merge went well; stopped before committing as requested
# conflicted files: (none)
```

The merged file keeps everything from both sides: staging's per-model prompt-cache tests and their top-of-file imports (`get_prompt_cache_min_tokens`, `is_prompt_caching_valid_prompt`), and this branch's `TestVertexEmbeddingEncodingFormat`. No test body changes on either side

## Type

✅ Test

## Changes

On the daily OSS branch, `tests/test_litellm/test_utils.py` appended `TestVertexEmbeddingEncodingFormat` (from #33617) at the very end of the file. On `litellm_internal_staging`, the per-model prompt-cache tests were independently appended at the same end-of-file position. Git cannot order two unrelated insertions that share one anchor, so the branch merge collides there even though nothing actually overlaps

This moves `TestVertexEmbeddingEncodingFormat` to sit just above `test_gemini_image_models_do_not_support_reasoning`, a test both branches already share unchanged. That leaves the gemini test as the file's tail, so staging's additions and this branch's additions land at different anchors and git merges both cleanly. It is a pure reorder with no test-logic change, and it deliberately pulls no `litellm_internal_staging` content into the OSS branch, so the public daily branch is not synced with internal staging

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
