### PR TITLE
fix(ui): migrate tag deletion to shared DeleteResourceModal

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/index.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/index.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { tagListCall } from "@/components/networking";
+import { tagDeleteCall, tagListCall } from "@/components/networking";
 
 import TagManagement from "./index";
 
@@ -12,10 +13,23 @@ vi.mock("@/components/networking", () => ({
   modelInfoCall: vi.fn(),
 }));
 
+vi.mock("@/components/molecules/notifications_manager", () => ({
+  __esModule: true,
+  default: {
+    success: vi.fn(),
+    fromBackend: vi.fn(),
+  },
+}));
+
 vi.mock("./TagTable", () => ({
   __esModule: true,
-  default: ({ isLoading }: { isLoading?: boolean }) => (
-    <div data-testid="tag-table">{isLoading ? "table-loading" : "table-loaded"}</div>
+  default: ({ isLoading, onDelete }: { isLoading?: boolean; onDelete: (tagName: string) => void }) => (
+    <div data-testid="tag-table">
+      {isLoading ? "table-loading" : "table-loaded"}
+      <button data-testid="mock-delete-trigger" onClick={() => onDelete("test-tag")}>
+        trigger
+      </button>
+    </div>
   ),
 }));
 
@@ -30,6 +44,7 @@ vi.mock("./components/CreateTagModal", () => ({
 }));
 
 const mockTagListCall = vi.mocked(tagListCall);
+const mockTagDeleteCall = vi.mocked(tagDeleteCall);
 
 describe("TagManagement loading state", () => {
   beforeEach(() => {
@@ -55,5 +70,43 @@ describe("TagManagement loading state", () => {
     resolveFetch({});
     expect(await screen.findByText("table-loaded")).toBeInTheDocument();
     expect(mockTagListCall).toHaveBeenCalledWith("sk-test");
+  });
+});
+
+describe("TagManagement delete flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTagListCall.mockResolvedValue({});
+  });
+
+  it("should confirm deletion through the shared DeleteResourceModal and call tagDeleteCall with the tag name", async () => {
+    const user = userEvent.setup();
+    mockTagDeleteCall.mockResolvedValue({});
+    render(<TagManagement accessToken="sk-test" userID="user-1" userRole="Admin" />);
+    await screen.findByText("table-loaded");
+
+    expect(screen.queryByText("Tag Information")).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId("mock-delete-trigger"));
+
+    expect(await screen.findByText("Tag Information")).toBeInTheDocument();
+    expect(screen.getByText("test-tag")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /delete/i }));
+
+    expect(mockTagDeleteCall).toHaveBeenCalledWith("sk-test", "test-tag");
+  });
+
+  it("should not call tagDeleteCall when the deletion is cancelled", async () => {
+    const user = userEvent.setup();
+    render(<TagManagement accessToken="sk-test" userID="user-1" userRole="Admin" />);
+    await screen.findByText("table-loaded");
+
+    await user.click(screen.getByTestId("mock-delete-trigger"));
+    await screen.findByText("Tag Information");
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mockTagDeleteCall).not.toHaveBeenCalled();
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/index.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/tag-management/_components/index.tsx
@@ -7,6 +7,7 @@ import { tagCreateCall, tagListCall, tagDeleteCall } from "@/components/networki
 import { Tag } from "@/components/tag_management/types";
 import TagTable from "./TagTable";
 import NotificationsManager from "@/components/molecules/notifications_manager";
+import DeleteResourceModal from "@/components/common_components/DeleteResourceModal";
 import CreateTagModal from "./components/CreateTagModal";
 
 interface ModelInfo {
@@ -33,6 +34,7 @@ const TagManagement: React.FC<TagProps> = ({ accessToken, userID, userRole }) =>
   const [editTag, setEditTag] = useState<boolean>(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [tagToDelete, setTagToDelete] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
   const [lastRefreshed, setLastRefreshed] = useState("");
   const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);
 
@@ -87,6 +89,7 @@ const TagManagement: React.FC<TagProps> = ({ accessToken, userID, userRole }) =>
 
   const confirmDelete = async () => {
     if (!accessToken || !tagToDelete) return;
+    setIsDeleting(true);
     try {
       await tagDeleteCall(accessToken, tagToDelete);
       NotificationsManager.success("Tag deleted successfully");
@@ -94,9 +97,11 @@ const TagManagement: React.FC<TagProps> = ({ accessToken, userID, userRole }) =>
     } catch (error) {
       console.error("Error deleting tag:", error);
       NotificationsManager.fromBackend("Error deleting tag: " + error);
+    } finally {
+      setIsDeleting(false);
+      setIsDeleteModalOpen(false);
+      setTagToDelete(null);
     }
-    setIsDeleteModalOpen(false);
-    setTagToDelete(null);
   };
 
   useEffect(() => {
@@ -189,40 +194,19 @@ const TagManagement: React.FC<TagProps> = ({ accessToken, userID, userRole }) =>
           />
 
           {/* Delete Confirmation Modal */}
-          {isDeleteModalOpen && (
-            <div className="fixed z-10 inset-0 overflow-y-auto">
-              <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-                <div className="fixed inset-0 transition-opacity" aria-hidden="true">
-                  <div className="absolute inset-0 bg-gray-500 opacity-75"></div>
-                </div>
-                <div className="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-                  <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-                    <div className="sm:flex sm:items-start">
-                      <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
-                        <h3 className="text-lg leading-6 font-medium text-gray-900">Delete Tag</h3>
-                        <div className="mt-2">
-                          <p className="text-sm text-gray-500">Are you sure you want to delete this tag?</p>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-                    <Button onClick={confirmDelete} color="red" className="ml-2">
-                      Delete
-                    </Button>
-                    <Button
-                      onClick={() => {
-                        setIsDeleteModalOpen(false);
-                        setTagToDelete(null);
-                      }}
-                    >
-                      Cancel
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
+          <DeleteResourceModal
+            isOpen={isDeleteModalOpen}
+            title="Delete Tag"
+            message="Are you sure you want to delete this tag? This action cannot be undone."
+            resourceInformationTitle="Tag Information"
+            resourceInformation={[{ label: "Tag Name", value: tagToDelete, code: true }]}
+            onCancel={() => {
+              setIsDeleteModalOpen(false);
+              setTagToDelete(null);
+            }}
+            onOk={confirmDelete}
+            confirmLoading={isDeleting}
+          />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Reproduction and fix are UI-only, so this is best confirmed in the dashboard against a running proxy. Steps at commit 385ffb1da2:

1. Open http://localhost:4000/ui/?page=tag-management
2. Click the overflow (three-dot) menu on any tag row and choose Delete
3. Before this change: the confirmation dialog appears but its Delete and Cancel buttons do nothing, so the tag cannot be deleted
4. After this change: the shared delete dialog opens showing the tag name under "Tag Information", the Delete button removes the tag and shows the success toast, and Cancel closes the dialog without deleting

I am leaving the actual before/after screenshots for the reviewer to capture in a live environment; I did not record them here

## Type

🐛 Bug Fix

## Changes

Deleting a tag stopped working from the tag management page. The delete action moved into a Base UI dropdown menu when the tags table was migrated onto the shared DataTable. That menu is modal by default and holds a pointer-events lock on the page while it opens and closes, which left the old hand-rolled inline confirmation modal underneath that lock and made its Delete and Cancel buttons unclickable

This swaps the inline modal for the shared `DeleteResourceModal`, the same component every other table uses for deletes. It renders through an antd Modal portal that manages its own pointer-events and z-index, so it is not affected by the dropdown's lock. The dialog now also shows the tag name being deleted and gains a deleting loading state so the confirm button reflects progress and cannot be double-clicked

Added a regression test that drives the delete flow through the shared modal and asserts `tagDeleteCall` runs with the tag name, plus a cancel path that asserts no delete fires. The test keys on content only the shared modal renders, so it fails against the old inline modal

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
