### PR TITLE
fix(ui): stop credential edit from persisting the masked api key

### DIFF
--- a/ui/litellm-dashboard/e2e_tests/tests/modelsPage/credentials.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/modelsPage/credentials.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from "@playwright/test";
+import { ADMIN_STORAGE_PATH } from "../../constants";
+import { Role, users } from "../../fixtures/users";
+
+test.describe("Edit LLM credential", () => {
+  test.use({ storageState: ADMIN_STORAGE_PATH });
+
+  const masterKey = users[Role.ProxyAdmin].password;
+  const SEED_API_KEY = "sk-e2e-credential-ABCDEFGHIJKLMNOP";
+  const SEED_API_BASE = "https://api.openai.com/v1";
+  const NEW_API_BASE = "https://proxy.e2e.example.com/v1";
+
+  let credentialName: string;
+
+  test.beforeEach(async ({ page }) => {
+    credentialName = `e2e-cred-${Date.now()}`;
+    const res = await page.request.post("/credentials", {
+      headers: { Authorization: `Bearer ${masterKey}` },
+      data: {
+        credential_name: credentialName,
+        credential_values: { api_key: SEED_API_KEY, api_base: SEED_API_BASE },
+        credential_info: { custom_llm_provider: "openai" },
+      },
+    });
+    expect(res.ok(), `POST /credentials for ${credentialName}`).toBe(true);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.request.delete(`/credentials/${credentialName}`, {
+      headers: { Authorization: `Bearer ${masterKey}` },
+    });
+  });
+
+  test("changing only the api base does not overwrite the stored api key with its masked value", async ({ page }) => {
+    await page.goto("/ui");
+    await page.getByText("Models + Endpoints").click();
+    await page.getByRole("tab", { name: "LLM Credentials" }).click();
+
+    const row = page.locator("tr", { hasText: credentialName });
+    await expect(row).toBeVisible({ timeout: 15_000 });
+    await row.getByRole("button").first().click();
+
+    const modal = page.locator(".ant-modal-content").filter({ hasText: "Edit Credential" });
+    await expect(modal).toBeVisible({ timeout: 10_000 });
+
+    const apiKeyField = modal.locator("#api_key");
+    const apiBaseField = modal.locator("#api_base");
+    await expect(apiKeyField).toBeVisible({ timeout: 15_000 });
+
+    await expect(apiKeyField, "form pre-fills the api key with the backend's masked value").toHaveValue(/\*{2,}/);
+    await expect(apiKeyField).not.toHaveValue(SEED_API_KEY);
+
+    await apiBaseField.fill(NEW_API_BASE);
+
+    const patchPromise = page.waitForRequest(
+      (req) => req.method() === "PATCH" && req.url().includes(`/credentials/${credentialName}`),
+    );
+    await modal.getByRole("button", { name: "Update Credential" }).click();
+    const patchReq = await patchPromise;
+    const patchBody = JSON.parse(patchReq.postData() ?? "{}");
+
+    expect(patchBody.credential_values.api_base, "UI sends the edited api base").toBe(NEW_API_BASE);
+    expect("api_key" in patchBody.credential_values, "UI must not send the masked api key back on update").toBe(false);
+
+    await expect(page.getByText("Credential updated successfully")).toBeVisible({ timeout: 10_000 });
+
+    const infoRes = await page.request.get(`/credentials/by_name/${credentialName}`, {
+      headers: { Authorization: `Bearer ${masterKey}` },
+    });
+    expect(infoRes.ok()).toBe(true);
+    const cred = await infoRes.json();
+    expect(cred.credential_values.api_base, "edited api base persisted to the backend").toBe(NEW_API_BASE);
+    expect(cred.credential_values.api_key, "a stored api key is still present (returned masked)").toMatch(/\*{2,}/);
+  });
+});

--- a/ui/litellm-dashboard/src/components/model_add/credentials.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/credentials.tsx
@@ -27,6 +27,7 @@ import EditCredentialsModal from "./EditCredentialModal";
 import { useCredentials } from "@/app/(dashboard)/hooks/credentials/useCredentials";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { isProxyAdminRole } from "@/utils/roles";
+import { stripMaskedSecrets } from "@/utils/maskedSecretUtils";
 interface CredentialsPanelProps {
   uploadProps: UploadProps;
 }
@@ -52,9 +53,11 @@ const CredentialsPanel: React.FC<CredentialsPanelProps> = ({ uploadProps }) => {
       return;
     }
 
-    const filter_credential_values = Object.entries(values)
-      .filter(([key]) => !restrictedFields.includes(key))
-      .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {});
+    const filter_credential_values = stripMaskedSecrets(
+      Object.entries(values)
+        .filter(([key]) => !restrictedFields.includes(key))
+        .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {}),
+    );
     // Transform form values into credential structure
     const newCredential = {
       credential_name: values.credential_name,

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -22,6 +22,7 @@ import VectorStoreSelector from "./vector_store_management/VectorStoreSelector";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { copyToClipboard as utilCopyToClipboard } from "../utils/dataUtils";
+import { isMaskedSecret, stripMaskedSecrets } from "../utils/maskedSecretUtils";
 import { formItemValidateJSON, truncateString } from "../utils/textUtils";
 import AutoRouterConnectionTest from "./add_model/auto_router_connection_test";
 import { AutoRouterTestTarget, buildAutoRouterTestTargets } from "./add_model/build_auto_router_test_targets";
@@ -57,18 +58,6 @@ interface ModelInfoViewProps {
   onModelUpdate?: (updatedModel: any) => void;
   modelAccessGroups: string[] | null;
 }
-
-// The /model/info response redacts secrets by masking them (e.g. "sk-1****2345"),
-// not by removing them. The edit form must never echo a masked value back on save:
-// the backend would encrypt the asterisks and overwrite the real secret. A run of
-// 2+ mask chars only appears in masker output (real config — incl. wildcard model
-// names like "openai/*" — carries at most a single "*"), so this reliably detects a
-// redacted value without a provider-metadata lookup. API-key rotation goes through
-// UpdateModelCredentialsModal instead, which sends only the new key.
-const isMaskedSecret = (value: unknown): boolean => typeof value === "string" && /\*{2,}/.test(value);
-
-const stripMaskedSecrets = (params: Record<string, unknown>): Record<string, unknown> =>
-  Object.fromEntries(Object.entries(params).filter(([, value]) => !isMaskedSecret(value)));
 
 const normalizeTierModels = (value: unknown): string[] => {
   if (Array.isArray(value)) return value;

--- a/ui/litellm-dashboard/src/utils/maskedSecretUtils.ts
+++ b/ui/litellm-dashboard/src/utils/maskedSecretUtils.ts
@@ -1,0 +1,10 @@
+// The proxy redacts secrets in API responses by masking them (e.g. "sk-1****2345"),
+// not by removing them. Edit forms must never echo a masked value back on save: the
+// backend would encrypt the asterisks and overwrite the real secret. A run of 2+ mask
+// chars only appears in masker output (real config -- incl. wildcard model names like
+// "openai/*" -- carries at most a single "*"), so this reliably detects a redacted
+// value without a provider-metadata lookup.
+export const isMaskedSecret = (value: unknown): boolean => typeof value === "string" && /\*{2,}/.test(value);
+
+export const stripMaskedSecrets = (params: Record<string, unknown>): Record<string, unknown> =>
+  Object.fromEntries(Object.entries(params).filter(([, value]) => !isMaskedSecret(value)));


### PR DESCRIPTION
## Description

## Relevant issues

## Linear ticket

Resolves LIT-3553

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a UI fix, so the proof is the end-user flow against a live proxy hitting the real OpenAI API. Steps assume the proxy on localhost:4000, master key sk-1234, and a real key in $OPENAI_API_KEY

Runtime verification video (this PR branch, live Admin UI against the real OpenAI API): the credential is edited changing only the API Base, the intercepted PATCH omits `api_key`, and the chat request still returns 200 after the edit

![PR #33797 fix verification](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvMDYzMDMwZTgtMWE3NS00ZWY1LWJiMTYtMmJhZGJkYjY5ODU0IiwiaWF0IjoxNzg0MzM3MzI0LCJleHAiOjE3ODQ5NDIxMjQsImZpbGVuYW1lIjoicHIzMzc5N19maXhfdmVyaWZ5LndlYnAifQ.E0JrTP9IGKdrq4vtxU-1miX10GFpiSBkDafHsRJnlRw)

Setup (real key, real completion, so the credential is actually exercised)

1. Create a credential holding the real key

   ```bash
   curl -s -X POST http://localhost:4000/credentials -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "{
     \"credential_name\": \"lit3553-openai\",
     \"credential_values\": {\"api_key\": \"$OPENAI_API_KEY\", \"api_base\": \"https://api.openai.com/v1\"},
     \"credential_info\": {\"custom_llm_provider\": \"openai\"}
   }"
   ```

2. Add a model that uses that credential

   ```bash
   curl -s -X POST http://localhost:4000/model/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{
     "model_name": "lit3553-probe",
     "litellm_params": {"model": "openai/gpt-4o-mini", "litellm_credential_name": "lit3553-openai"}
   }'
   ```

3. Confirm a real completion works (expect 200 with a normal answer)

   ```bash
   curl -s -X POST http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
     -d '{"model":"lit3553-probe","messages":[{"role":"user","content":"ping"}]}'
   ```

Edit only the base in the UI

4. Open http://localhost:4000/ui/?page=models and select the "LLM Credentials" tab
5. Click the pencil on `lit3553-openai`; note the API Key field shows a masked value like `sk****`
6. Change only the API Base (for example to `https://api.openai.com/v1/`) and click Update Credential

Confirm the key survived

7. Re-run the step 3 completion and expect 200 again, because the real api_key was preserved

Before this fix (captured on litellm_internal_staging, without the patch), step 7 returned 401 with an invalid api key of the form `sk****`, since the masked value from step 5 was sent back and stored over the real key. After this fix step 7 returns 200

The same repro is automated as a Playwright e2e in the dashboard suite (`e2e_tests/tests/modelsPage/credentials.spec.ts`); it seeds a credential, edits only the api base in the LLM Credentials tab, intercepts the outgoing PATCH, and asserts it no longer carries the masked api_key while the new base persists. Run it against the harness with

```
cd ui/litellm-dashboard
./e2e_tests/run_e2e.sh e2e_tests/tests/modelsPage/credentials.spec.ts
```

Verified red before / green after locally against a live proxy and Postgres. With the fix in place the spec passes (`1 passed`). With the `stripMaskedSecrets(...)` wrap dropped from `credentials.tsx handleUpdateCredential` it fails at the intercepted PATCH:

```
Error: UI must not send the masked api key back on update
  63 | expect("api_key" in patchBody.credential_values, ...).toBe(false);
Expected: false
Received: true
1 failed
```

## Type

🐛 Bug Fix

## Changes

The Edit Credential modal pre-fills its fields from the credential the backend returns, and the backend masks secret values (`api_key` becomes `sk****IA`). On save the update handler bundled every field, including that masked placeholder, into `credential_values` and sent it to `PATCH /credentials/{name}`, which encrypted and stored the asterisks over the real secret. Changing any single field therefore destroyed the api_key

`handleUpdateCredential` now runs `credential_values` through `stripMaskedSecrets` before the PATCH, so a value that is still masked is dropped rather than written back. This mirrors the guard the model edit form already applies at save time. The `isMaskedSecret` and `stripMaskedSecrets` helpers move out of `model_info_view.tsx` into `src/utils/maskedSecretUtils.ts` so both call sites share one implementation instead of duplicating the mask-detection regex

This is the client half of the issue. The endpoint still trusts whatever a client sends, so a follow-up server-side guard in `update_db_credential` (drop an incoming value that equals the mask of the stored secret) is worth adding as a backstop for non-UI callers

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


Link to Devin session: https://app.devin.ai/sessions/7a78c7d5bcc449e3964e7c663de90f35