### PR TITLE
build(rust): raise pyo3 to 0.29 so the native bridge compiles on Python 3.14

### DIFF
--- a/litellm-rust/Cargo.lock
+++ b/litellm-rust/Cargo.lock
@@ -20,12 +20,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "autocfg"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,21 +228,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,17 +242,6 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -310,7 +278,6 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -609,15 +576,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,15 +677,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,29 +752,26 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.23.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977dc837525cfd22919ba6a831413854beb7c99a256c03bf8624ad707e45810e"
+checksum = "b3ef68daa7316a3fac65e5e18b2203f010346de1c1c53456811a2624673ab046"
 dependencies = [
- "futures",
+ "futures-channel",
+ "futures-util",
  "once_cell",
  "pin-project-lite",
  "pyo3",
@@ -834,19 +780,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -854,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -866,13 +811,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -1321,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "thiserror"
@@ -1558,12 +1502,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"

--- a/litellm-rust/Cargo.toml
+++ b/litellm-rust/Cargo.toml
@@ -15,8 +15,8 @@ repository = "https://github.com/BerriAI/litellm"
 litellm-core = { path = "crates/core" }
 litellm-ai-gateway = { path = "crates/ai-gateway", default-features = false }
 axum = "0.7"
-pyo3 = "0.23.5"
-pyo3-async-runtimes = { version = "0.23.0", features = ["tokio-runtime"] }
+pyo3 = "0.29.0"
+pyo3-async-runtimes = { version = "0.29.0", features = ["tokio-runtime"] }
 rand = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls", "http2", "stream"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/litellm-rust/crates/ai-gateway/src/python/config.rs
+++ b/litellm-rust/crates/ai-gateway/src/python/config.rs
@@ -17,7 +17,7 @@ use crate::gil;
 /// Load the router's `model_list` from `config_path` via the Python reader.
 pub fn load_router_from_config(config_path: &str) -> CoreResult<Router> {
     gil::record_acquisition();
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let model_list = py
             .import("litellm.proxy.read_model_list")
             .and_then(|module| module.getattr("read_model_list"))

--- a/litellm-rust/crates/python-bridge/src/gil.rs
+++ b/litellm-rust/crates/python-bridge/src/gil.rs
@@ -2,7 +2,7 @@
 //!
 //! A single chokepoint for releasing the GIL around blocking work. Every
 //! blocking call in the bridge goes through [`release_gil`] instead of calling
-//! `Python::allow_threads` directly, so the release count stays accurate and we
+//! `Python::detach` directly, so the release count stays accurate and we
 //! have one place to extend later (timing histograms, per-call labels, etc.).
 
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -23,7 +23,7 @@ where
     T: Send,
 {
     GIL_RELEASES.fetch_add(1, Ordering::Relaxed);
-    py.allow_threads(f)
+    py.detach(f)
 }
 
 /// Total GIL releases performed by the bridge so far.

--- a/litellm-rust/crates/python-bridge/src/lib.rs
+++ b/litellm-rust/crates/python-bridge/src/lib.rs
@@ -167,7 +167,7 @@ fn aocr(
         .await
         .map_err(core_error_to_pyerr)?;
 
-        Python::with_gil(|py| json_to_py(py, value))
+        Python::attach(|py| json_to_py(py, value))
     })
 }
 


### PR DESCRIPTION
## Relevant issues

Part of #26343 (Python 3.14 support); addresses the pyo3 build failure reported in #33116

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This is a build-compatibility change, so the proof is the native module refusing to compile on Python 3.14 before and building plus running after, with a live Mistral OCR round-trip exercising the migrated GIL calls end to end (no mocks; a bad key returns 401 from the real API)

Before (pyo3 0.23.5, at `04a5ebb94d`) building the native module for Python 3.14 aborts in pyo3-ffi's build script:

```console
$ uvx maturin@1.9.4 build -i python3.14
error: failed to run custom build command for `pyo3-ffi v0.23.5`
  error: the configured Python interpreter version (3.14) is newer than PyO3's maximum supported version (3.13)
```

After (pyo3 0.29.0, at `9011b24c9f`) wheels build for both cp313 and cp314:

```console
$ uvx maturin@1.9.4 build -i python3.13 -i python3.14 --out wheels
📦 Built wheel for CPython 3.13 to wheels/litellm-1.94.0-cp313-cp313-macosx_11_0_arm64.whl
📦 Built wheel for CPython 3.14 to wheels/litellm-1.94.0-cp314-cp314-macosx_11_0_arm64.whl
```

The compiled bridge exercised directly on Python 3.14, calling the live Mistral OCR API with a bad key so a 401 comes back only after the request is marshaled, the GIL is released via `detach`, the tokio runtime runs, and the GIL is reacquired via `attach`:

```console
# python 3.14.6
gil_stats before: {'releases': 0}
sync ocr: RuntimeError [401] OCR request failed with status 401: {"detail":"Unauthorized"}
gil_stats after sync: {'releases': 1}
async aocr: RuntimeError [401] OCR request failed with status 401: {"detail":"Unauthorized"}
RESULT: PASS (sync=401 async=401 releases_delta=1)
```

The same probe on Python 3.13 returns byte-for-byte the same result as the 0.23.5 baseline, so `with_gil` -> `attach` and `allow_threads` -> `detach` are behavior-neutral on GIL-enabled builds

The workspace checks that CI runs pass on both interpreters at `9011b24c9f` with the lockfile locked:

```console
$ cargo fmt --check && cargo clippy --workspace --all-targets --locked -- -D warnings && cargo test --workspace --locked
test result: ok. 35 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
test result: ok. 38 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Type

🐛 Bug Fix
🚄 Infrastructure

## Changes

pyo3 and pyo3-async-runtimes move from 0.23 to 0.29, the first line that supports Python 3.14 (support landed in 0.26) and the current newest release. pyo3 0.23.5 hard-caps the interpreter at 3.13, so any 3.14 install that falls back to the sdist fails in pyo3-ffi's build script before anything links

Three call sites use APIs that were renamed across that range and are migrated in lockstep: `Python::with_gil` becomes `Python::attach` (the async OCR result marshaling and the `python-config` router loader) and `Python::allow_threads` becomes `Python::detach` (the single GIL-release chokepoint). On a GIL-enabled interpreter these are pure renames with identical semantics, so behavior on Python 3.10 through 3.13 is unchanged, and the lockfile churn is confined to the pyo3 crates

No new tests are added: this is a dependency bump with no unit-testable surface, the Python glue is untouched, and parity is proven by the existing workspace suite passing identically on 3.13 and 3.14 plus the end-to-end native probe above

This change only makes the source build succeed on 3.14; publishing cp314 wheels and widening the CI matrix are deliberately separate follow-ups, so a 3.14 install still builds from the sdist and needs a Rust toolchain until those land, which is a visible actionable error rather than a silent failure

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
