### PR TITLE
build(deps): allow redisvl, pypdf, and openapi-core on Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ extra_proxy = [
     "google-cloud-iam>=2.19.1,<3.0",
     # Not in PyPI proxy extra.
     "resend>=2.23.0,<3.0",
-    "redisvl>=0.4.1,<1.0; python_version < '3.14'",
+    "redisvl>=0.4.1,<1.0",
     "a2a-sdk>=1.1.0,<2.0",
 ]
 utils = [
@@ -136,7 +136,7 @@ proxy-runtime = [
     "mangum>=0.17.0,<1.0",
     "azure-ai-contentsafety>=1.0.0,<2.0",
     "azure-storage-file-datalake>=12.20.0,<13.0",
-    "pypdf>=6.12.0,<7.0; python_version < '3.14'",
+    "pypdf>=6.12.0,<7.0",
     "llm-sandbox>=0.3.39,<1.0",
     "detect-secrets>=1.5.0,<2.0",
 ]
@@ -181,7 +181,7 @@ dev = [
     "pytest-rerunfailures==15.1",
     "pytest-cov==5.0.0",
     "parameterized==0.9.0",
-    "openapi-core==0.22.0; python_version < '3.14'",
+    "openapi-core==0.22.0",
     "pytest-timeout==2.4.0",
     "vcrpy==8.2.1",
     "pytest-recording==0.13.4",

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-13T21:03:01.672393Z"
+exclude-newer = "2026-07-15T00:56:28.454719Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -1047,7 +1047,7 @@ name = "coloredlogs"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "humanfriendly", marker = "python_full_version < '3.14'" },
+    { name = "humanfriendly" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
 wheels = [
@@ -2966,7 +2966,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
@@ -3293,10 +3293,10 @@ name = "jsonschema-path"
 version = "0.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pathable", marker = "python_full_version < '3.14'" },
-    { name = "pyyaml", marker = "python_full_version < '3.14'" },
-    { name = "referencing", marker = "python_full_version < '3.14'" },
-    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6e/45/41ebc679c2a4fced6a722f624c18d658dee42612b83ea24c1caf7c0eb3a8/jsonschema_path-0.3.4.tar.gz", hash = "sha256:8365356039f16cc65fddffafda5f58766e34bebab7d6d105616ab52bc4297001", size = 11159, upload-time = "2025-01-24T14:33:16.547Z" }
 wheels = [
@@ -3779,7 +3779,7 @@ extra-proxy = [
     { name = "google-cloud-iam" },
     { name = "google-cloud-kms" },
     { name = "prisma" },
-    { name = "redisvl", marker = "python_full_version < '3.14'" },
+    { name = "redisvl" },
     { name = "resend" },
 ]
 google = [
@@ -3841,7 +3841,7 @@ proxy-runtime = [
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-sdk" },
     { name = "prometheus-client" },
-    { name = "pypdf", marker = "python_full_version < '3.14'" },
+    { name = "pypdf" },
     { name = "sentry-sdk" },
 ]
 semantic-router = [
@@ -3897,7 +3897,7 @@ dev = [
     { name = "fastapi-offline" },
     { name = "flake8" },
     { name = "langfuse" },
-    { name = "openapi-core", marker = "python_full_version < '3.14'" },
+    { name = "openapi-core" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-instrumentation-fastapi" },
@@ -4008,13 +4008,13 @@ requires-dist = [
     { name = "pydantic-settings", marker = "extra == 'proxy'", specifier = ">=2.14.1,<3.0" },
     { name = "pyjwt", marker = "extra == 'proxy'", specifier = ">=2.13.0,<3.0" },
     { name = "pynacl", marker = "extra == 'proxy'", specifier = ">=1.6.2,<2.0" },
-    { name = "pypdf", marker = "python_full_version < '3.14' and extra == 'proxy-runtime'", specifier = ">=6.12.0,<7.0" },
+    { name = "pypdf", marker = "extra == 'proxy-runtime'", specifier = ">=6.12.0,<7.0" },
     { name = "pyroscope-io", marker = "sys_platform != 'win32' and extra == 'proxy'", specifier = ">=0.8.16,<1.0" },
     { name = "python-dotenv", specifier = ">=1.0.0,<2.0" },
     { name = "python-multipart", marker = "extra == 'proxy'", specifier = ">=0.0.27,<1.0" },
     { name = "pyyaml", marker = "extra == 'cli'", specifier = ">=6.0.3,<7.0" },
     { name = "pyyaml", marker = "extra == 'proxy'", specifier = ">=6.0.3,<7.0" },
-    { name = "redisvl", marker = "python_full_version < '3.14' and extra == 'extra-proxy'", specifier = ">=0.4.1,<1.0" },
+    { name = "redisvl", marker = "extra == 'extra-proxy'", specifier = ">=0.4.1,<1.0" },
     { name = "requests", marker = "extra == 'cli'", specifier = ">=2.32.0,<3.0" },
     { name = "resend", marker = "extra == 'extra-proxy'", specifier = ">=2.23.0,<3.0" },
     { name = "restrictedpython", marker = "extra == 'proxy'", specifier = ">=8.1,<9.0" },
@@ -4072,7 +4072,7 @@ dev = [
     { name = "fastapi-offline", specifier = "==1.7.6" },
     { name = "flake8", specifier = "==7.3.0" },
     { name = "langfuse", specifier = "==2.59.7" },
-    { name = "openapi-core", marker = "python_full_version < '3.14'", specifier = "==0.22.0" },
+    { name = "openapi-core", specifier = "==0.22.0" },
     { name = "opentelemetry-api", specifier = "==1.28.0" },
     { name = "opentelemetry-exporter-otlp", specifier = "==1.28.0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = "==0.49b0" },
@@ -4481,7 +4481,7 @@ version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/15/76f86faa0902836cc133939732f7611ace68cf54148487a99c539c272dc8/ml_dtypes-0.4.1.tar.gz", hash = "sha256:fad5f2de464fd09127e49b7fd1252b9006fb43d2edc1ff112d390c324af5ca7a", size = 692594, upload-time = "2024-09-13T19:07:11.624Z" }
 wheels = [
@@ -4980,14 +4980,14 @@ name = "openapi-core"
 version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "isodate", marker = "python_full_version < '3.14'" },
-    { name = "jsonschema", marker = "python_full_version < '3.14'" },
-    { name = "jsonschema-path", marker = "python_full_version < '3.14'" },
-    { name = "more-itertools", marker = "python_full_version < '3.14'" },
-    { name = "openapi-schema-validator", marker = "python_full_version < '3.14'" },
-    { name = "openapi-spec-validator", marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
-    { name = "werkzeug", marker = "python_full_version < '3.14'" },
+    { name = "isodate" },
+    { name = "jsonschema" },
+    { name = "jsonschema-path" },
+    { name = "more-itertools" },
+    { name = "openapi-schema-validator" },
+    { name = "openapi-spec-validator" },
+    { name = "typing-extensions" },
+    { name = "werkzeug" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/65/ee75f25b9459a02df6f713f8ffde5dacb57b8b4e45145cde4cab28b5abba/openapi_core-0.22.0.tar.gz", hash = "sha256:b30490dfa74e3aac2276105525590135212352f5dd7e5acf8f62f6a89ed6f2d0", size = 109242, upload-time = "2025-12-22T19:19:49.608Z" }
 wheels = [
@@ -4999,9 +4999,9 @@ name = "openapi-schema-validator"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonschema", marker = "python_full_version < '3.14'" },
-    { name = "jsonschema-specifications", marker = "python_full_version < '3.14'" },
-    { name = "rfc3339-validator", marker = "python_full_version < '3.14'" },
+    { name = "jsonschema" },
+    { name = "jsonschema-specifications" },
+    { name = "rfc3339-validator" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/f3/5507ad3325169347cd8ced61c232ff3df70e2b250c49f0fe140edb4973c6/openapi_schema_validator-0.6.3.tar.gz", hash = "sha256:f37bace4fc2a5d96692f4f8b31dc0f8d7400fd04f3a937798eaf880d425de6ee", size = 11550, upload-time = "2025-01-10T18:08:22.268Z" }
 wheels = [
@@ -5013,10 +5013,10 @@ name = "openapi-spec-validator"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonschema", marker = "python_full_version < '3.14'" },
-    { name = "jsonschema-path", marker = "python_full_version < '3.14'" },
-    { name = "lazy-object-proxy", marker = "python_full_version < '3.14'" },
-    { name = "openapi-schema-validator", marker = "python_full_version < '3.14'" },
+    { name = "jsonschema" },
+    { name = "jsonschema-path" },
+    { name = "lazy-object-proxy" },
+    { name = "openapi-schema-validator" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/af/fe2d7618d6eae6fb3a82766a44ed87cd8d6d82b4564ed1c7cfb0f6378e91/openapi_spec_validator-0.7.2.tar.gz", hash = "sha256:cc029309b5c5dbc7859df0372d55e9d1ff43e96d678b9ba087f7c56fc586f734", size = 36855, upload-time = "2025-06-07T14:48:56.299Z" }
 wheels = [
@@ -7163,16 +7163,16 @@ name = "redisvl"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "coloredlogs", marker = "python_full_version < '3.14'" },
-    { name = "ml-dtypes", marker = "python_full_version < '3.14'" },
+    { name = "coloredlogs" },
+    { name = "ml-dtypes" },
     { name = "numpy", version = "1.26.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "pydantic", marker = "python_full_version < '3.14'" },
-    { name = "python-ulid", marker = "python_full_version < '3.14'" },
-    { name = "pyyaml", marker = "python_full_version < '3.14'" },
-    { name = "redis", marker = "python_full_version < '3.14'" },
-    { name = "tabulate", marker = "python_full_version < '3.14'" },
-    { name = "tenacity", marker = "python_full_version < '3.14'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "pydantic" },
+    { name = "python-ulid" },
+    { name = "pyyaml" },
+    { name = "redis" },
+    { name = "tabulate" },
+    { name = "tenacity" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/33/ab14865a0b2a31b1d003c29e7e8ea3a7a2f2c8ecb24e58e58d606e1f031b/redisvl-0.4.1.tar.gz", hash = "sha256:fd6a36426ba94792c0efca20915c31232d4ee3cc58eb23794a62c142696401e6", size = 77688, upload-time = "2025-02-21T22:51:41.389Z" }
 wheels = [
@@ -7406,7 +7406,7 @@ name = "rfc3339-validator"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six", marker = "python_full_version < '3.14'" },
+    { name = "six" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
 wheels = [


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

litellm already installs on Python 3.14; this change is about the optional dependencies that were still fenced off from it. The proof has two halves: nothing moves for the existing 3.10 through 3.13 range, and the three packages genuinely install and work on a real 3.14 interpreter. Because this is a packaging change, the realistic proof is a source install plus importing and exercising the features, not an LLM call; a plain `pip install litellm` on 3.14 additionally waits on the cp314 wheels that ship separately

Commits the proof was captured at: markers present at `966ff65fec`, markers removed at `4b85239c70`, native 3.14 re-verified on this branch tip `3d972c8f55` (after merging #33798 so the Rust bridge builds on 3.14)

**1. No regression on Python 3.10 through 3.13.** Regenerating the lock with the markers gone changed no package version on any Python branch. A name+version map of every locked package is identical before and after, and the lock diff contains no version, hash, or artifact-url change at all:

```
$ diff <(vmap uv.lock@966ff65fec) <(vmap uv.lock@4b85239c70)   # 420 packages each side
        (no output -> every package resolves to the same version)

$ git diff 966ff65fec..4b85239c70 -- uv.lock | grep -E '^[+-](version = |.*sha256|.*files.pythonhosted)'
        (no output -> only marker text and uv's rolling exclude-newer timestamp changed)
```

The same three feature suites run green before and after on 3.13.13, so the un-gated deps behave identically where they were already installed:

```
# 966ff65fec (markers present)
$ uv run --python 3.13 pytest \
    tests/test_litellm/caching/test_redis_semantic_cache.py \
    tests/test_litellm/interactions/test_openapi_compliance.py \
    tests/test_litellm/test_rag_openai_ingestion.py -q
56 passed in 12.08s

# 4b85239c70 (markers removed)
$ uv run --python 3.13 pytest <same three files> -q
56 passed in 7.63s
```

**2. The three packages install and work on native Python 3.14.** With #33798 merged in, a full extras sync builds and resolves on 3.14.6 with no forward-compatibility shim:

```
# 3d972c8f55, on python 3.14.6
$ uv sync --all-extras --python 3.14
Resolved 420 packages ... (exit 0)

$ uv run --python 3.14 pytest tests/test_litellm/interactions/test_openapi_compliance.py -q
13 passed in 1.25s
# this suite does `from openapi_core import OpenAPI` at module top, so collection
# itself fails if openapi-core is still gated out

$ uv run --python 3.14 python -c "import pypdf; \
    from litellm.rag.ingestion.file_parsers.pdf_parser import extract_text_from_pdf; \
    t=extract_text_from_pdf(open('tests/llm_translation/fixtures/dummy.pdf','rb').read()); \
    assert t and len(t)>0; print('pypdf', pypdf.__version__, '| chars', len(t), '|', repr(t.strip()))"
pypdf 6.13.3 | chars 13 | 'Test PDF File'
# real bytes through litellm's own parser, which returns nothing if pypdf is absent

$ uv run --python 3.14 python -c "import redisvl; \
    from redisvl.extensions.llmcache import SemanticCache; \
    from redisvl.utils.vectorize import CustomTextVectorizer; \
    import litellm.caching.redis_semantic_cache; print('redisvl', redisvl.__version__)"
redisvl 0.4.1

$ uv run --python 3.14 python -c "import redisvl, pypdf, openapi_core; \
    print(redisvl.__version__, pypdf.__version__, openapi_core.__version__)"
0.4.1 6.13.3 0.22.0
```

One honesty note on redisvl: its existing unit suite mocks the client through `sys.modules`, so it passes with or without the package installed; the real-import line above is what demonstrates the package is present on 3.14. A full semantic-cache round-trip additionally needs a live Redis with the RediSearch module, which is orthogonal to whether the dependency is installable

## Type

🚄 Infrastructure

## Changes

Three optional dependencies were still excluded on Python 3.14 by `python_version < '3.14'` environment markers, so the features that depend on them stayed unavailable there even after litellm itself became installable on 3.14. This removes that marker from redisvl (the Redis semantic cache, `litellm/caching/redis_semantic_cache.py`), pypdf (RAG PDF ingestion, `litellm/rag/ingestion/file_parsers/pdf_parser.py`), and openapi-core (the dev dependency behind the OpenAPI compliance tests). All three declare support for 3.14 within their pinned bands, and the regenerated lock confirms they resolve on 3.14 with no change anywhere else

semantic-router and aurelio-sdk keep their markers on purpose: every published semantic-router release still caps python_requires below 3.14, so the semantic guardrail cannot run there until upstream ships a compatible release

The lock regeneration is marker-only. redisvl stays at 0.4.1, pypdf at 6.13.3, and openapi-core at 0.22.0, each now also covering 3.14; no other package moved on any Python version. The single non-marker line in the lock diff is uv's rolling exclude-newer timestamp, which has no effect on resolution. `make pre-commit` and `uv lock --check` both pass locally

This is the Python-side half of enabling 3.14; it merges in #33798, which raised the Rust bridge's pyo3 to 0.29, so a source install now builds the native module on 3.14 as well. No new test file is added deliberately: the change is a dependency-marker removal held to the smallest reviewable diff, and it is covered by the existing feature suites run before and after on 3.13 and natively on 3.14 above, rather than a 3.14-only test that current CI has no lane to run yet

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
