### PR TITLE
test(proxy): make streaming-cancel mocks awaitable for the disconnect slot release

### DIFF
--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -2279,7 +2279,8 @@ async def _reserve_for_stream(counter_cache, key_cache, proxy_logging_obj, token
 def _drive_streaming_cancel(valid_token, iterator_hook):
     streaming_logging_obj = MagicMock()
     streaming_logging_obj.async_post_call_streaming_iterator_hook = iterator_hook
-    return ProxyBaseLLMRequestProcessing.async_streaming_data_generator(
+    streaming_logging_obj._arelease_max_parallel_requests_on_disconnect = AsyncMock()
+    generator = ProxyBaseLLMRequestProcessing.async_streaming_data_generator(
         response=MagicMock(),
         user_api_key_dict=valid_token,
         request_data=_request_body(),
@@ -2287,6 +2288,7 @@ def _drive_streaming_cancel(valid_token, iterator_hook):
         serialize_chunk=lambda chunk: chunk,
         serialize_error=lambda exc: str(exc),
     )
+    return generator, streaming_logging_obj
 
 
 @pytest.mark.asyncio
@@ -2305,7 +2307,7 @@ async def test_streaming_cancel_before_any_chunk_reconciles_to_input_cost(
             yield ""  # make this an async generator
         raise asyncio.CancelledError()
 
-    generator = _drive_streaming_cancel(valid_token, cancel_before_chunk)
+    generator, streaming_logging_obj = _drive_streaming_cancel(valid_token, cancel_before_chunk)
     received = []
     with pytest.raises(asyncio.CancelledError):
         async for chunk in generator:
@@ -2318,6 +2320,7 @@ async def test_streaming_cancel_before_any_chunk_reconciles_to_input_cost(
         key="spend:key:key-cancel-no-chunk"
     ) == pytest.approx(0.5)
     assert reservation["finalized"] is True
+    streaming_logging_obj._arelease_max_parallel_requests_on_disconnect.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -2336,7 +2339,7 @@ async def test_streaming_cancel_after_chunk_keeps_reservation(
         yield "data: chunk\n\n"
         raise asyncio.CancelledError()
 
-    generator = _drive_streaming_cancel(valid_token, cancel_after_chunk)
+    generator, streaming_logging_obj = _drive_streaming_cancel(valid_token, cancel_after_chunk)
     received = []
     with pytest.raises(asyncio.CancelledError):
         async for chunk in generator:
@@ -2348,6 +2351,7 @@ async def test_streaming_cancel_after_chunk_keeps_reservation(
         key="spend:key:key-cancel-after-chunk"
     ) == pytest.approx(2.0)
     assert reservation.get("finalized") is not True
+    streaming_logging_obj._arelease_max_parallel_requests_on_disconnect.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -2382,6 +2386,7 @@ async def test_streaming_cancel_in_slow_path_before_yield_refunds(spend_counter_
 
     streaming_logging_obj = MagicMock()
     streaming_logging_obj.async_post_call_streaming_iterator_hook = one_chunk
+    streaming_logging_obj._arelease_max_parallel_requests_on_disconnect = AsyncMock()
     # On the slow path the per-chunk hook is awaited before the chunk is yielded
     # to the client; cancel there. Nothing has reached the client yet.
     streaming_logging_obj.async_post_call_streaming_hook = AsyncMock(
@@ -2411,6 +2416,7 @@ async def test_streaming_cancel_in_slow_path_before_yield_refunds(spend_counter_
         key="spend:key:key-cancel-slowpath"
     ) == pytest.approx(0.5)
     assert reservation["finalized"] is True
+    streaming_logging_obj._arelease_max_parallel_requests_on_disconnect.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -2427,7 +2433,7 @@ async def test_streaming_disconnect_after_consuming_chunk_keeps_reservation(
         yield "data: a\n\n"
         yield "data: b\n\n"
 
-    generator = _drive_streaming_cancel(valid_token, two_chunks)
+    generator, streaming_logging_obj = _drive_streaming_cancel(valid_token, two_chunks)
 
     # Client consumes one chunk, then disconnects. aclose() raises GeneratorExit
     # at the suspended yield, after the chunk already reached the client.
@@ -2440,6 +2446,7 @@ async def test_streaming_disconnect_after_consuming_chunk_keeps_reservation(
         key="spend:key:key-disconnect-after-chunk"
     ) == pytest.approx(2.0)
     assert reservation.get("finalized") is not True
+    streaming_logging_obj._arelease_max_parallel_requests_on_disconnect.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

Repairs the proxy-infra CI breakage introduced by #33736, which landed while its proxy-infra check was still failing and has been breaking litellm_internal_staging and every PR on top of it since

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR changes only a unit test file, so the observable surface is the proxy-infra check itself; no production code changes, hence no live-proxy repro applies

Before, without this fix: the proxy-infra job fails with the same four tests on staging head ca720c44ba (first link) and again on #33801 whose CI merge ref sat on staging tip 577dd3b707 (second link)

- https://github.com/BerriAI/litellm/actions/runs/29622577395
- https://github.com/BerriAI/litellm/actions/runs/29624783051/job/88026890492

```
FAILED tests/test_litellm/proxy/test_budget_reservation.py::test_streaming_cancel_after_chunk_keeps_reservation - TypeError: object MagicMock can't be used in 'await' expression
FAILED tests/test_litellm/proxy/test_budget_reservation.py::test_streaming_cancel_before_any_chunk_reconciles_to_input_cost - TypeError: object MagicMock can't be used in 'await' expression
FAILED tests/test_litellm/proxy/test_budget_reservation.py::test_streaming_cancel_in_slow_path_before_yield_refunds - TypeError: object MagicMock can't be used in 'await' expression
FAILED tests/test_litellm/proxy/test_budget_reservation.py::test_streaming_disconnect_after_consuming_chunk_keeps_reservation - TypeError: object MagicMock can't be used in 'await' expression
```

After, at a67d612cfb (PR head eab54b2cff): the proxy-infra check on this PR runs the same suite and passes in 8m1s

- https://github.com/BerriAI/litellm/actions/runs/29625659037/job/88029418267

The osv-scan failure on this PR is the same pre-existing repo-wide failure visible on every current PR (mcp 1.26.0 advisories in uv.lock, fixed releases available upstream); it is unrelated to this change and tracked separately

## Type

✅ Test

## Changes

#33736 made the shielded streaming cleanup in common_request_processing.py await proxy_logging_obj._arelease_max_parallel_requests_on_disconnect when a client disconnect is recorded and no disconnect-time success event owns the slot release. The four streaming cancel and disconnect tests in tests/test_litellm/proxy/test_budget_reservation.py drive async_streaming_data_generator with a bare MagicMock as proxy_logging_obj, and awaiting a MagicMock call result raises TypeError, so all four fail on every cancel and disconnect path

The fix gives those mocks an AsyncMock for _arelease_max_parallel_requests_on_disconnect, both in the shared _drive_streaming_cancel helper and in the slow-path test that builds its mock inline. Each of the four tests now also asserts the release is awaited exactly once, pinning the single-owner slot release contract #33736 introduced without test coverage. Verified by mutation: removing the release call from _finalize_streaming_generator_cleanup makes these tests fail again, and restoring it turns the whole file green (51 passed)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
