### PR TITLE
build(deps): bump mcp lock to 1.28.1 to clear image-scan findings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ proxy = [
     "boto3>=1.43.1,<2.0",
     "azure-identity>=1.25.2,<2.0",
     "azure-storage-blob>=12.28.0,<13.0",
-    "mcp>=1.26.0,<2.0",
+    "mcp>=1.28.1,<2.0",
     "litellm-proxy-extras==0.4.78",
     "litellm-enterprise==0.1.51",
     "RestrictedPython>=8.1,<9.0",

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-13T21:03:01.672393Z"
+exclude-newer = "2026-07-15T01:30:52.847089Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -4431,7 +4431,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4449,9 +4449,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-15T01:55:15.469432Z"
+exclude-newer = "2026-07-15T02:04:45.513604Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3990,7 +3990,7 @@ requires-dist = [
     { name = "litellm-proxy-extras", marker = "extra == 'proxy'", editable = "litellm-proxy-extras" },
     { name = "llm-sandbox", marker = "extra == 'proxy-runtime'", specifier = ">=0.3.39,<1.0" },
     { name = "mangum", marker = "extra == 'proxy-runtime'", specifier = ">=0.17.0,<1.0" },
-    { name = "mcp", marker = "extra == 'proxy'", specifier = ">=1.26.0,<2.0" },
+    { name = "mcp", marker = "extra == 'proxy'", specifier = ">=1.28.1,<2.0" },
     { name = "mlflow", marker = "extra == 'mlflow'", specifier = ">=3.11.1,<4.0" },
     { name = "numpy", marker = "extra == 'stt-nvidia-riva'", specifier = ">=1.26.0" },
     { name = "numpydoc", marker = "extra == 'utils'", specifier = ">=1.8.0,<2.0" },


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before: the image-scan check currently fails on every PR because the shipped image carries mcp 1.26.0, e.g. [this run](https://github.com/BerriAI/litellm/actions/runs/29624783030/job/88026890262) on #33801

```
NAME  INSTALLED  FIXED IN  TYPE    VULNERABILITY        SEVERITY  EPSS         RISK
mcp   1.26.0     1.27.2    python  GHSA-jpw9-pfvf-9f58  High      0.3% (16th)  0.2
mcp   1.26.0     1.27.2    python  GHSA-hvrp-rf83-w775  High      0.2% (13th)  0.2
mcp   1.26.0     1.28.1    python  GHSA-vj7q-gjh5-988w  High      0.2% (7th)   0.1
[0038] ERROR discovered vulnerabilities at or above the severity threshold
```

After, at 52834fc12a (this PR's lock), building the same image and scanning it with the same grype version and flags the workflow pins (v0.114.0, `--only-fixed --fail-on high`):

```
$ docker build -f docker/Dockerfile.non_root -t litellm-image-scan:head .
$ grype litellm-image-scan:head --only-fixed --fail-on high --output table
No vulnerabilities found
```

The local build and scan ran on arm64; the image-scan check on this PR is the matching amd64 run. The follow-up commit a920ad507a only raises the pyproject floor and re-records it in the lock; the resolved package set, and therefore the image content, is identical to the scanned 52834fc12a

## Type

🚄 Infrastructure

## Changes

`uv lock --upgrade-package mcp`, taking mcp from 1.26.0 to 1.28.1 (the current latest), plus raising the `pyproject.toml` floor from `mcp>=1.26.0,<2.0` to `mcp>=1.28.1,<2.0`. The floor raise is what makes the bump durable: with the old floor, any future unrelated `uv lock --upgrade-package X` whose dependency tree conflicts with mcp 1.28.x could legally resolve mcp back down to 1.26.0, and the regression would only surface as a red image-scan check after the fact. With the floor raised the resolver refuses outright, and installs that consume `litellm[proxy]` from PyPI without our lock get the same guarantee. The Docker images install with `uv sync --frozen`, so the shipped image picks the version up from the lock. The `exclude-newer` timestamp churn in the diff is uv refreshing its relative "3 days" snapshot setting, the same churn present in every recent lock update

Between 1.26.0 and 1.28.1 the upstream changes are additive (OAuth resource validation on the client, streamable HTTP stream buffering, stdio robustness fixes) plus two DeprecationWarnings introduced in 1.28.0 for the websocket transport and the experimental tasks API; litellm imports neither deprecated surface, verified by grepping every `mcp` import in `litellm/` and `enterprise/`

No new tests: this bump is scanner-driven rather than feature-driven, the enforcement that the image stays clean is the image-scan workflow itself, and a static version-floor test would duplicate that gate while going stale on the next advisory. For verification, the mcp-related unit suites (about 2600 tests across the `tests/test_litellm` mcp directories) were run on 1.28.1, and the five files under `tests/test_litellm/proxy/_experimental/mcp_server` were additionally run A/B on 1.26.0 and 1.28.1 in the same environment: results are identical on both versions (337 passing, and the same 68 tests failing locally on both for environment reasons that reproduce at the staging tip without this change), so the bump changes no test outcome

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
