### PR TITLE
feat: add Kimi K3 pricing for moonshot and openrouter prefixes

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -28327,6 +28327,22 @@
         "supports_video_input": true,
         "supports_vision": true
     },
+    "moonshot/kimi-k3": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "moonshot",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://platform.kimi.ai/docs/pricing/chat-k3",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "moonshot/kimi-latest": {
         "cache_read_input_token_cost": 1.5e-07,
         "deprecation_date": "2026-01-28",
@@ -31270,6 +31286,22 @@
         "supports_function_calling": true,
         "supports_tool_choice": true,
         "supports_video_input": true,
+        "supports_vision": true
+    },
+    "openrouter/moonshotai/kimi-k3": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://openrouter.ai/moonshotai/kimi-k3",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "openrouter/openai/gpt-3.5-turbo": {

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -28341,6 +28341,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
+        "supports_video_input": true,
         "supports_vision": true
     },
     "moonshot/kimi-latest": {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -28402,6 +28402,22 @@
         "supports_video_input": true,
         "supports_vision": true
     },
+    "moonshot/kimi-k3": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "moonshot",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://platform.kimi.ai/docs/pricing/chat-k3",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "moonshot/kimi-latest": {
         "cache_read_input_token_cost": 1.5e-07,
         "deprecation_date": "2026-01-28",
@@ -31345,6 +31361,22 @@
         "supports_function_calling": true,
         "supports_tool_choice": true,
         "supports_video_input": true,
+        "supports_vision": true
+    },
+    "openrouter/moonshotai/kimi-k3": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://openrouter.ai/moonshotai/kimi-k3",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
         "supports_vision": true
     },
     "openrouter/openai/gpt-3.5-turbo": {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -28416,6 +28416,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
+        "supports_video_input": true,
         "supports_vision": true
     },
     "moonshot/kimi-latest": {

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -3544,7 +3544,7 @@ def test_completion_cost_prices_anthropic_shaped_cache_read_tokens():
     "model_name",
     ["moonshot/kimi-k3", "openrouter/moonshotai/kimi-k3"],
 )
-def test_kimi_k3_pricing(model_name):
+def test_kimi_k3_pricing(monkeypatch, model_name):
     """
     Kimi K3 (Moonshot's 1M-context flagship, launched 2026-07-16) had no pricing
     entry for either the native moonshot/ prefix or the openrouter/ prefix, so
@@ -3553,8 +3553,8 @@ def test_kimi_k3_pricing(model_name):
     cache miss, $0.30/M cache hit, $15.00/M output, 1,048,576 context) and the
     OpenRouter models API, which quote identical numbers.
     """
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
 
     model_info = litellm.model_cost.get(model_name)
     assert model_info is not None, f"Missing model pricing entry: {model_name}"

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -3538,3 +3538,36 @@ def test_completion_cost_prices_anthropic_shaped_cache_read_tokens():
     )
 
     assert cost == pytest.approx(3 * 5e-6 + 4014 * 5e-7 + 5 * 3e-5, rel=1e-9)
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    ["moonshot/kimi-k3", "openrouter/moonshotai/kimi-k3"],
+)
+def test_kimi_k3_pricing(model_name):
+    """
+    Kimi K3 (Moonshot's 1M-context flagship, launched 2026-07-16) had no pricing
+    entry for either the native moonshot/ prefix or the openrouter/ prefix, so
+    cost tracking billed it at zero. Prices verified against Moonshot's official
+    pricing page (https://platform.kimi.ai/docs/pricing/chat-k3: $3.00/M input
+    cache miss, $0.30/M cache hit, $15.00/M output, 1,048,576 context) and the
+    OpenRouter models API, which quote identical numbers.
+    """
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    model_info = litellm.model_cost.get(model_name)
+    assert model_info is not None, f"Missing model pricing entry: {model_name}"
+    assert model_info["input_cost_per_token"] == 3e-06
+    assert model_info["output_cost_per_token"] == 1.5e-05
+    assert model_info["cache_read_input_token_cost"] == 3e-07
+    assert model_info["max_input_tokens"] == 1048576
+    assert model_info["supports_reasoning"] is True
+
+    prompt_cost, completion_cost_value = cost_per_token(
+        model=model_name,
+        prompt_tokens=1000,
+        completion_tokens=100,
+    )
+    assert prompt_cost == pytest.approx(1000 * 3e-06)
+    assert completion_cost_value == pytest.approx(100 * 1.5e-05)


### PR DESCRIPTION
## Relevant issues

No open issue for this. Moonshot launched Kimi K3 (their 1M-context flagship) on July 16 and it is already live on both the native Moonshot API and OpenRouter, but litellm has no pricing entry for either prefix, so spend tracking bills it at $0

## Linear ticket

External contributor; no Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests (`test_kimi_k3_pricing` in `tests/test_litellm/test_cost_calculator.py`, parametrized over both prefixes; verified it fails without the new entries and passes with them)
- [x] My PR passes all CI/CD checks (locally: `make lint` fully green, `make test-unit-root` 1927 passed, `make pre-commit` clean; whole-suite `make test-unit` cannot collect on the daily base itself due to a pre-existing duplicate test basename, unrelated to this diff)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem (missing pricing for one newly launched model, native prefix plus its openrouter sibling, matching how existing kimi entries carry both)
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile scored 5/5 on the re-review after its two P2 findings were addressed in 9689677cbc)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy from this branch with the local cost map and a minimal config listing both prefixes:

```yaml
model_list:
  - model_name: kimi-k3
    litellm_params:
      model: moonshot/kimi-k3
      api_key: sk-dummy
  - model_name: kimi-k3-openrouter
    litellm_params:
      model: openrouter/moonshotai/kimi-k3
      api_key: sk-or-v1-dummy
general_settings:
  master_key: sk-1234
```

**Before** (base `1ebf2a78a9`, no entries): pricing comes back zero and a 100k-in / 10k-out call is billed nothing

```
$ curl -s http://localhost:4001/v1/model/info -H "Authorization: Bearer sk-1234" | jq '.data[] | {model_name, input_cost_per_token: .model_info.input_cost_per_token, output_cost_per_token: .model_info.output_cost_per_token}'
{ "model_name": "kimi-k3", "input_cost_per_token": 0, "output_cost_per_token": 0 }
{ "model_name": "kimi-k3-openrouter", "input_cost_per_token": 0, "output_cost_per_token": 0 }

$ curl -s -X POST http://localhost:4001/spend/calculate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"completion_response": {"model": "moonshot/kimi-k3", "usage": {"prompt_tokens": 100000, "completion_tokens": 10000, "total_tokens": 110000}, "choices": [{"message": {"role": "assistant", "content": "x"}}]}}'
{"cost":0.0}
```

**After** (this PR, `591d9bd54e`): both prefixes return the real prices and the correct math, 100000 x $3/M + 10000 x $15/M = $0.45

```
$ curl -s http://localhost:4001/v1/model/info -H "Authorization: Bearer sk-1234" | jq '.data[] | {model_name, litellm_model: .litellm_params.model, input_cost_per_token: .model_info.input_cost_per_token, output_cost_per_token: .model_info.output_cost_per_token, cache_read_input_token_cost: .model_info.cache_read_input_token_cost, max_input_tokens: .model_info.max_input_tokens}'
{
  "model_name": "kimi-k3",
  "litellm_model": "moonshot/kimi-k3",
  "input_cost_per_token": 0.000003,
  "output_cost_per_token": 0.000015,
  "cache_read_input_token_cost": 3E-7,
  "max_input_tokens": 1048576
}
{
  "model_name": "kimi-k3-openrouter",
  "litellm_model": "openrouter/moonshotai/kimi-k3",
  "input_cost_per_token": 0.000003,
  "output_cost_per_token": 0.000015,
  "cache_read_input_token_cost": 3E-7,
  "max_input_tokens": 1048576
}

$ curl -s -X POST http://localhost:4001/spend/calculate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"completion_response": {"model": "moonshot/kimi-k3", "usage": {"prompt_tokens": 100000, "completion_tokens": 10000, "total_tokens": 110000}, "choices": [{"message": {"role": "assistant", "content": "x"}}]}}'
{"cost":0.44999999999999996}

$ same call with "openrouter/moonshotai/kimi-k3"
{"cost":0.44999999999999996}
```

Prices cross-checked against two sources that quote identical numbers. Moonshot's official pricing page (https://platform.kimi.ai/docs/pricing/chat-k3): input $3.00/M cache miss, $0.30/M cache hit, output $15.00/M, context 1,048,576. And OpenRouter's public models API:

```
$ curl -s https://openrouter.ai/api/v1/models | jq '.data[] | select(.id=="moonshotai/kimi-k3") | {id, context_length, pricing}'
{
  "id": "moonshotai/kimi-k3",
  "context_length": 1048576,
  "pricing": { "prompt": "0.000003", "completion": "0.000015", "input_cache_read": "0.0000003" }
}
```

One honest caveat: I don't have Moonshot or OpenRouter credits on this machine, so no paid completion was run; the entries only feed the pricing and cost-tracking surfaces and those are what the before/after exercises end to end on a live proxy

## Type

🆕 New Feature

## Changes

Adds `moonshot/kimi-k3` and `openrouter/moonshotai/kimi-k3` to `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json`, inserted alphabetically next to the existing kimi entries. Both carry $3/M input, $15/M output, $0.30/M cache read, 1,048,576 context, and capability flags following the existing `moonshot/kimi-k2.6` and `openrouter/moonshotai/kimi-k2.5` conventions (function calling, tool choice, response schema, reasoning, vision; OpenRouter reports text+image input for K3, and its parameter list includes `reasoning_effort` and `structured_outputs`). The `source` field on each entry points at the page its numbers came from

The parametrized regression test asserts the pricing fields and the computed cost for both prefixes, so removal or silent price drift on these entries fails CI

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

---

quick note from a college freshman doing his best for the greater good: sorry ahead of time if something in here is obviously wrong. I traced the numbers from Moonshot's own pricing page and OpenRouter's API myself and built the change with Claude Code helping me through it, so if I slipped somewhere I'd really like to know and learn from it :)

