### PR TITLE
fix: allow transcription token usage without input_token_details

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/usage_object_transformation.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/usage_object_transformation.py
@@ -24,7 +24,7 @@ class TranscriptionUsageObjectTransformation:
         if isinstance(usage_object, TranscriptionUsageDurationObject):
             return None
         elif isinstance(usage_object, TranscriptionUsageTokensObject):
-            prompt_tokens_details: Optional[PromptTokensDetailsWrapper] = None
+            prompt_tokens_details: PromptTokensDetailsWrapper | None = None
             if usage_object.input_token_details is not None:
                 prompt_tokens_details = PromptTokensDetailsWrapper(
                     text_tokens=usage_object.input_token_details.text_tokens,

--- a/litellm/litellm_core_utils/llm_cost_calc/usage_object_transformation.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/usage_object_transformation.py
@@ -24,13 +24,16 @@ class TranscriptionUsageObjectTransformation:
         if isinstance(usage_object, TranscriptionUsageDurationObject):
             return None
         elif isinstance(usage_object, TranscriptionUsageTokensObject):
+            prompt_tokens_details: Optional[PromptTokensDetailsWrapper] = None
+            if usage_object.input_token_details is not None:
+                prompt_tokens_details = PromptTokensDetailsWrapper(
+                    text_tokens=usage_object.input_token_details.text_tokens,
+                    audio_tokens=usage_object.input_token_details.audio_tokens,
+                )
             return Usage(
                 prompt_tokens=usage_object.input_tokens,
                 completion_tokens=usage_object.output_tokens,
                 total_tokens=usage_object.total_tokens,
-                prompt_tokens_details=PromptTokensDetailsWrapper(
-                    text_tokens=usage_object.input_token_details.text_tokens,
-                    audio_tokens=usage_object.input_token_details.audio_tokens,
-                ),
+                prompt_tokens_details=prompt_tokens_details,
             )
         return None

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2368,7 +2368,7 @@ class TranscriptionUsageTokensObject(BaseModel):
     input_tokens: int
     output_tokens: int
     total_tokens: int
-    input_token_details: TranscriptionUsageInputTokenDetailsObject
+    input_token_details: Optional[TranscriptionUsageInputTokenDetailsObject] = None
 
 
 class TranscriptionResponse(OpenAIObject):

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2368,7 +2368,7 @@ class TranscriptionUsageTokensObject(BaseModel):
     input_tokens: int
     output_tokens: int
     total_tokens: int
-    input_token_details: Optional[TranscriptionUsageInputTokenDetailsObject] = None
+    input_token_details: TranscriptionUsageInputTokenDetailsObject | None = None
 
 
 class TranscriptionResponse(OpenAIObject):

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_usage_object_transformation.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_usage_object_transformation.py
@@ -1,0 +1,70 @@
+"""
+Tests for
+``litellm.litellm_core_utils.llm_cost_calc.usage_object_transformation``.
+
+Regression coverage for transcription token-usage objects whose
+``input_token_details`` is ``None``. OpenAI-compatible transcription servers
+(for example llama.cpp with ``response_format=json``) return a ``tokens`` usage
+block without that field, so the transformation must preserve the token totals
+that drive spend accounting instead of dereferencing the missing detail object.
+"""
+
+from litellm.litellm_core_utils.llm_cost_calc.usage_object_transformation import (
+    TranscriptionUsageObjectTransformation,
+)
+from litellm.types.utils import (
+    TranscriptionUsageDurationObject,
+    TranscriptionUsageInputTokenDetailsObject,
+    TranscriptionUsageTokensObject,
+)
+
+
+def test_transform_transcription_usage_object_without_input_token_details():
+    usage_object = TranscriptionUsageTokensObject(
+        type="tokens",
+        input_tokens=5,
+        output_tokens=10,
+        total_tokens=15,
+    )
+
+    result = TranscriptionUsageObjectTransformation.transform_transcription_usage_object(
+        usage_object
+    )
+
+    assert result is not None
+    assert result.prompt_tokens == 5
+    assert result.completion_tokens == 10
+    assert result.total_tokens == 15
+    assert result.prompt_tokens_details is None
+
+
+def test_transform_transcription_usage_object_with_input_token_details():
+    usage_object = TranscriptionUsageTokensObject(
+        type="tokens",
+        input_tokens=5,
+        output_tokens=10,
+        total_tokens=15,
+        input_token_details=TranscriptionUsageInputTokenDetailsObject(
+            audio_tokens=2, text_tokens=3
+        ),
+    )
+
+    result = TranscriptionUsageObjectTransformation.transform_transcription_usage_object(
+        usage_object
+    )
+
+    assert result is not None
+    assert result.total_tokens == 15
+    assert result.prompt_tokens_details is not None
+    assert result.prompt_tokens_details.text_tokens == 3
+    assert result.prompt_tokens_details.audio_tokens == 2
+
+
+def test_transform_transcription_usage_object_duration_returns_none():
+    usage_object = TranscriptionUsageDurationObject(type="duration", seconds=1.5)
+
+    result = TranscriptionUsageObjectTransformation.transform_transcription_usage_object(
+        usage_object
+    )
+
+    assert result is None

--- a/tests/test_litellm/litellm_core_utils/llm_response_utils/test_convert_dict_to_response.py
+++ b/tests/test_litellm/litellm_core_utils/llm_response_utils/test_convert_dict_to_response.py
@@ -1,0 +1,65 @@
+"""
+Tests for non-streaming response conversion in
+``litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response``.
+
+Regression coverage for transcription token-usage objects that omit
+``input_token_details``. OpenAI-compatible transcription servers (for example
+llama.cpp with ``response_format=json``) return a ``tokens`` usage block
+without ``input_token_details``, which previously raised a pydantic
+ValidationError because the field was required.
+"""
+
+import pytest
+
+from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
+    convert_to_model_response_object,
+)
+from litellm.types.utils import (
+    TranscriptionResponse,
+    TranscriptionUsageTokensObject,
+)
+
+
+def test_transcription_token_usage_without_input_token_details():
+    response_object = {
+        "text": "the quick brown fox",
+        "usage": {
+            "type": "tokens",
+            "input_tokens": 5,
+            "output_tokens": 10,
+            "total_tokens": 15,
+        },
+    }
+
+    result = convert_to_model_response_object(
+        response_object=response_object,
+        response_type="audio_transcription",
+    )
+
+    assert isinstance(result, TranscriptionResponse)
+    assert result.text == "the quick brown fox"
+    assert isinstance(result.usage, TranscriptionUsageTokensObject)
+    assert result.usage.input_token_details is None
+
+
+def test_transcription_token_usage_with_input_token_details():
+    response_object = {
+        "text": "hello world",
+        "usage": {
+            "type": "tokens",
+            "input_tokens": 5,
+            "output_tokens": 10,
+            "total_tokens": 15,
+            "input_token_details": {"audio_tokens": 2, "text_tokens": 3},
+        },
+    }
+
+    result = convert_to_model_response_object(
+        response_object=response_object,
+        response_type="audio_transcription",
+    )
+
+    assert isinstance(result.usage, TranscriptionUsageTokensObject)
+    assert result.usage.input_token_details is not None
+    assert result.usage.input_token_details.audio_tokens == 2
+    assert result.usage.input_token_details.text_tokens == 3


### PR DESCRIPTION
## Relevant issues

Fixes #33764

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Verified through the mapped regression tests, which exercise the exact paths from the issue and the cost path that the same responses reach:

```
$ pytest tests/test_litellm/litellm_core_utils/llm_response_utils/test_convert_dict_to_response.py \
         tests/test_litellm/litellm_core_utils/llm_cost_calc/test_usage_object_transformation.py -q
# on the base branch (no fix):
#   test_transcription_token_usage_without_input_token_details -> pydantic ValidationError
#   test_transform_transcription_usage_object_without_input_token_details -> AttributeError (NoneType.text_tokens)
# with this change: 5 passed
```

## Type

🐛 Bug Fix

## Changes

`TranscriptionUsageTokensObject.input_token_details` was required, but OpenAI-compatible transcription servers such as llama.cpp with `response_format=json` return a `tokens` usage block without it. `convert_to_model_response_object` then raised `pydantic ValidationError` while building the usage object, so the whole transcription request failed.

This makes `input_token_details` optional with a default of `None`.

That alone exposes a second defect on the same responses: `transform_transcription_usage_object` (`litellm_core_utils/llm_cost_calc/usage_object_transformation.py`) dereferenced `input_token_details.text_tokens`/`audio_tokens` unconditionally, so those responses would raise `AttributeError` during cost calculation and could be logged with no cost, skipping spend accounting. This guards the detail breakdown: the returned `Usage` keeps its `prompt_tokens`/`completion_tokens`/`total_tokens` (which drive spend) and only omits `prompt_tokens_details` when the provider did not send the detail. Responses that do include the details are unchanged.

## QA runbook

Send a transcription request against an OpenAI-compatible server that returns token usage without `input_token_details` (for example llama.cpp with `response_format=json`); it now returns a `TranscriptionResponse` and the request is cost-tracked on its token totals instead of raising.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
