### PR TITLE
fix: add 'xai-oauth' as a valid provider

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -632,7 +632,7 @@ def cost_per_token(
         return tencent_cost_per_token(model=model, usage=usage_block)
     elif custom_llm_provider == "perplexity":
         return perplexity_cost_per_token(model=model, usage=usage_block)
-    elif custom_llm_provider == "xai":
+    elif custom_llm_provider in ["xai", "xai-oauth"]:
         return xai_cost_per_token(model=model, usage=usage_block)
     elif custom_llm_provider == "lemonade":
         return lemonade_cost_per_token(model=model, usage=usage_block)

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -694,7 +694,7 @@ def _get_openai_compatible_provider_info(
             api_base,
             dynamic_api_key,
         ) = litellm.JinaAIEmbeddingConfig()._get_openai_compatible_provider_info(api_base, api_key)
-    elif custom_llm_provider == "xai":
+    elif custom_llm_provider in ["xai", "xai-oauth"]:
         (
             api_base,
             dynamic_api_key,

--- a/litellm/litellm_core_utils/get_supported_openai_params.py
+++ b/litellm/litellm_core_utils/get_supported_openai_params.py
@@ -90,7 +90,7 @@ def get_supported_openai_params(
         return litellm.CerebrasConfig().get_supported_openai_params(model=model)
     elif custom_llm_provider == "baseten":
         return litellm.BasetenConfig().get_supported_openai_params(model=model)
-    elif custom_llm_provider == "xai":
+    elif custom_llm_provider in ["xai", "xai-oauth"]:
         return litellm.XAIChatConfig().get_supported_openai_params(model=model)
     elif custom_llm_provider == "ai21_chat" or custom_llm_provider == "ai21":
         return litellm.AI21ChatConfig().get_supported_openai_params(model=model)

--- a/litellm/llms/__init__.py
+++ b/litellm/llms/__init__.py
@@ -53,7 +53,7 @@ def get_cost_for_web_search_request(
         # Perplexity handles search costs internally in its own cost calculator
         # Return 0.0 to indicate costs are already accounted for
         return 0.0
-    elif custom_llm_provider == "xai":
+    elif custom_llm_provider in ["xai", "xai-oauth"]:
         from .xai.cost_calculator import cost_per_web_search_request
 
         return cost_per_web_search_request(usage=usage, model_info=model_info)

--- a/litellm/llms/xai/oauth.py
+++ b/litellm/llms/xai/oauth.py
@@ -380,4 +380,6 @@ class XAIOAuthAuthenticator:
 
 
 def should_use_xai_oauth(litellm_params: Optional[Dict[str, Any]]) -> bool:
-    return bool((litellm_params or {}).get("use_xai_oauth"))
+    if not litellm_params:
+        return False
+    return bool(litellm_params.get("use_xai_oauth")) or litellm_params.get("custom_llm_provider") == "xai-oauth"

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -990,7 +990,7 @@ def responses_api_bridge_check(
             mode = "responses"
             model_info["mode"] = mode
 
-        if web_search_options is not None and custom_llm_provider == "xai":
+        if web_search_options is not None and custom_llm_provider in ["xai", "xai-oauth"]:
             model_info["mode"] = "responses"
             model = model.replace("responses/", "")
 
@@ -5474,7 +5474,7 @@ def completion(  # type: ignore
         elif custom_llm_provider == "ragflow":
             ## COMPLETION CALL - RAGFlow uses HTTP handler to support custom URL paths
             response = _complete_ragflow(_dispatch_ctx)
-        elif custom_llm_provider == "xai":
+        elif custom_llm_provider in ["xai", "xai-oauth"]:
             ## COMPLETION CALL
             response = _complete_xai(_dispatch_ctx)
         elif custom_llm_provider == "groq":

--- a/litellm/realtime_api/main.py
+++ b/litellm/realtime_api/main.py
@@ -435,7 +435,7 @@ async def _arealtime(
             aws_bedrock_runtime_endpoint=aws_bedrock_runtime_endpoint,
             aws_external_id=aws_external_id,
         )
-    elif _custom_llm_provider == "xai":
+    elif _custom_llm_provider in ["xai", "xai-oauth"]:
         api_base = (
             dynamic_api_base or litellm_params.api_base or get_secret_str("XAI_API_BASE") or "https://api.x.ai/v1"
         )
@@ -548,7 +548,7 @@ async def _realtime_health_check(
             api_base=api_base or "https://api.openai.com/",
             query_params={"model": model},
         )
-    elif custom_llm_provider == "xai":
+    elif custom_llm_provider in ["xai", "xai-oauth"]:
         url = xai_realtime._construct_url(api_base=api_base or "https://api.x.ai/v1", query_params={"model": model})
     elif custom_llm_provider == "vertex_ai":
         vertex_model_params = model_params or {}

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3242,6 +3242,7 @@ class LlmProviders(str, Enum):
     OPENAI_LIKE = "openai_like"  # embedding only
     JINA_AI = "jina_ai"
     XAI = "xai"
+    XAI_OAUTH = "xai-oauth"
     ZAI = "zai"
     CUSTOM_OPENAI = "custom_openai"
     TEXT_COMPLETION_OPENAI = "text-completion-openai"

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3690,7 +3690,7 @@ def pre_process_optional_params(passed_params: dict, non_default_params: dict, c
             and custom_llm_provider != "groq"
             and custom_llm_provider != "nvidia_nim"
             and custom_llm_provider != "cerebras"
-            and custom_llm_provider != "xai"
+            and custom_llm_provider not in ["xai", "xai-oauth"]
             and custom_llm_provider != "ai21_chat"
             and custom_llm_provider != "volcengine"
             and custom_llm_provider != "deepseek"
@@ -4143,7 +4143,7 @@ def get_optional_params(
             model=model,
             drop_params=(drop_params if drop_params is not None and isinstance(drop_params, bool) else False),
         )
-    elif custom_llm_provider == "xai":
+    elif custom_llm_provider in ["xai", "xai-oauth"]:
         optional_params = litellm.XAIChatConfig().map_openai_params(
             model=model,
             non_default_params=non_default_params,
@@ -6000,7 +6000,7 @@ def validate_environment(
                 keys_in_environment = True
             else:
                 missing_keys.append("BASETEN_API_KEY")
-        elif custom_llm_provider == "xai":
+        elif custom_llm_provider in ["xai", "xai-oauth"]:
             if "XAI_API_KEY" in os.environ:
                 keys_in_environment = True
             else:
@@ -7586,6 +7586,7 @@ class ProviderConfigManager:
             LlmProviders.BYTEZ: (lambda: litellm.BytezChatConfig(), False),
             LlmProviders.DATABRICKS: (lambda: litellm.DatabricksConfig(), False),
             LlmProviders.XAI: (lambda: litellm.XAIChatConfig(), False),
+            LlmProviders.XAI_OAUTH: (lambda: litellm.XAIChatConfig(), False),
             LlmProviders.ZAI: (lambda: litellm.ZAIChatConfig(), False),
             LlmProviders.LAMBDA_AI: (lambda: litellm.LambdaAIChatConfig(), False),
             LlmProviders.INCEPTION: (lambda: litellm.InceptionChatConfig(), False),


### PR DESCRIPTION
Resolves #32660

Added `xai-oauth` to the `LlmProviders` Enum and updated routing logic so the router recognizes it as a valid provider identically to `xai`.

Signed-off-by: KartavyaDikshit <kartavyaniraj.dikshit2021@vitstudent.ac.in>