### PR TITLE
feat(sap): capability registry, reasoning/thinking, Gemini normalization, cache_control

### DIFF
--- a/litellm/llms/sap/chat/models.py
+++ b/litellm/llms/sap/chat/models.py
@@ -191,7 +191,8 @@ class LLMModelDetails(BaseModel):
     name: str
     version: str = "latest"
     params: dict | None = None
-
+    timeout: int | None = None
+    max_retries: int | None = Field(default=None, ge=0, le=5)
 
 class PromptTemplatingModuleConfig(BaseModel):
     prompt: Template

--- a/litellm/llms/sap/chat/models.py
+++ b/litellm/llms/sap/chat/models.py
@@ -2,7 +2,7 @@ import warnings
 from enum import Enum
 from typing import Literal, Union
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator, model_serializer, model_validator
 
 
 def validate_different_content(v: str | dict | list) -> str:
@@ -24,9 +24,25 @@ def validate_different_content(v: str | dict | list) -> str:
     raise ValueError("Content must be a string")
 
 
+class CacheControl(BaseModel):
+    type: Literal["ephemeral"]
+
+
 class TextContent(BaseModel):
     type_: Literal["text"] = Field(default="text", alias="type")
     text: str
+    cache_control: CacheControl | None = None
+
+    def model_dump(self, **kwargs) -> dict:  # mutable-ok: pydantic override; wire serialization output
+        kwargs["exclude_none"] = True
+        return super().model_dump(**kwargs)
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler, info) -> dict:  # mutable-ok: pydantic serializer contract requires bare dict return
+        result = handler(self)
+        if result.get("cache_control") is None:
+            result.pop("cache_control", None)
+        return result
 
 
 class ImageURLContent(BaseModel):
@@ -88,9 +104,7 @@ class SAPMessage(BaseModel):
     """
 
     role: Literal["system", "developer"] = "system"
-    content: str
-
-    _content_validator = field_validator("content", mode="before")(validate_different_content)
+    content: list[TextContent] | str  # mutable-ok: pydantic field; list[TextContent] carries cache_control natively
 
 
 class SAPUserMessage(BaseModel):
@@ -184,13 +198,15 @@ class Template(BaseModel):
     template: list[ChatMessage]
     defaults: dict[str, str] | None = None
     response_format: ResponseFormat | ResponseFormatJSONSchema | None = None
-    tools: list[ChatCompletionTool] | None = None
+    tools: list[dict] | None = None  # mutable-ok: already-validated dicts passed to wire; list preserves insertion order, dict preserves extension fields like cache_control
 
 
 class LLMModelDetails(BaseModel):
     name: str
     version: str = "latest"
     params: dict | None = None
+    timeout: int | None = None
+    max_retries: int | None = Field(default=None, ge=0, le=5)
 
 
 class PromptTemplatingModuleConfig(BaseModel):

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -2,6 +2,7 @@
 Translate from OpenAI's `/v1/chat/completions` to SAP Generative AI Hub's Orchestration Service`v2/completion`
 """
 
+import re
 from collections.abc import AsyncIterator, Iterator
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Final, Union
@@ -12,8 +13,6 @@ import litellm
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.utils import ModelResponse
 
-from ...openai.chat.gpt_transformation import OpenAIGPTConfig
-
 if TYPE_CHECKING:
     import tiktoken
 
@@ -23,6 +22,7 @@ if TYPE_CHECKING:
 else:
     LiteLLMLoggingObj = Any
 
+from ...openai.chat.gpt_transformation import OpenAIGPTConfig
 from ..credentials import get_token_creator
 from .handler import (
     AsyncSAPStreamIterator,
@@ -44,17 +44,46 @@ from .models import (
 _SAP_MODEL_PARAMS_EXCLUDED_KEYS: Final[frozenset[str]] = frozenset(
     {
         "tools",
-        "tool_choice",
         "stream_options",
         "fallback_sap_modules",
         "placeholder_values",
         "model_version",
+        "timeout",
+        "max_retries",
     }
+)
+
+# ---------------------------------------------------------------------------
+# SAP capability registry
+# ---------------------------------------------------------------------------
+# Models that accept reasoning_effort / thinking parameters on SAP GenAI Hub.
+_REASONING_MODELS: re.Pattern[str] = re.compile(  # rebind-ok: module-level pattern constant; assignment is a one-time initialisation
+    r"^(?:anthropic--claude-(?:4(?:\.[5-9])?|3-7)|o\d|gpt-5(?:[.\-]|$)|cohere--\S*reasoning\S*)"
 )
 
 
 def validate_dict(data: dict, model) -> dict:
     return model(**data).model_dump(by_alias=True, exclude_unset=True)
+
+
+def _build_model_details(
+    model_name: str,
+    model_version: str,
+    params: dict,  # mutable-ok: model params dict forwarded directly to wire payload
+    timeout: int | None,
+    max_retries: int | None,
+) -> dict:  # mutable-ok: wire serialization helper; dict is the required output shape for JSON encoding
+    """Build the model dict for the orchestration request, adding optional fields only when set."""
+    model_details: dict = {  # mutable-ok: ephemeral wire dict built in one shot before JSON encoding
+        "name": model_name,
+        "params": params,
+        "version": model_version,
+    }
+    if timeout is not None:
+        model_details["timeout"] = timeout
+    if max_retries is not None:
+        model_details["max_retries"] = max_retries
+    return model_details
 
 
 def _messages_to_sap_template(messages: list[dict[str, str]]) -> list:
@@ -207,13 +236,15 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
             "temperature",
             "top_p",
             "tools",
-            "tool_choice",
             "function_call",
             "functions",
             "extra_headers",
             "parallel_tool_calls",
             "response_format",
             "timeout",
+            "max_retries",
+            "model_version",
+            "user",
         ]
         # Remove response_format for providers that don't support it on SAP GenAI Hub
         if (
@@ -223,8 +254,8 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
             or model == "gpt-4"
         ):
             params.remove("response_format")
-        if model.startswith("gemini") or model.startswith("amazon"):
-            params.remove("tool_choice")
+        if self._sap_supports_reasoning(model):
+            params.extend(["reasoning_effort", "thinking"])  # mutable-ok: params list is local to this call; extend is the standard list append
         return params
 
     def validate_environment(
@@ -266,12 +297,14 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
             params.pop("strict")
 
         model_version: Final = params.pop("model_version", "latest")
+        timeout = params.pop("timeout", None)  # rebind-ok: popped from params for conditional inclusion below
+        max_retries = params.pop("max_retries", None)  # rebind-ok: popped from params for conditional inclusion below
 
-        tools_ = params.pop("tools", [])
-        tools_ = [validate_dict(tool, ChatCompletionTool) for tool in tools_]
+        tools_ = params.pop("tools", [])  # mutable-ok: intermediate list; immediately validated on the next line
+        tools_ = [validate_dict(tool, ChatCompletionTool) for tool in tools_]  # mutable-ok: validated tool dicts; folded into wire payload below  # rebind-ok: rebound to validated list
         tools: Final = {"tools": tools_} if tools_ else {}
 
-        response_format = params.pop("response_format", {})
+        response_format = params.pop("response_format", {})  # mutable-ok: ephemeral wire dict consumed immediately  # rebind-ok: popped for type inspection below
         resp_type: Final = response_format.get("type", None)
         if resp_type:
             if resp_type == "json_schema":
@@ -299,11 +332,7 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
                     **tools,
                     **response_format,
                 },
-                "model": {
-                    "name": model_name,
-                    "params": params,
-                    "version": model_version,
-                },
+                "model": _build_model_details(model_name, model_version, params, timeout, max_retries),
             },
             **optional_modules,
         }
@@ -332,8 +361,6 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
                 stream_config["chunk_size"] = stream_options["chunk_size"]
             if "delimiters" in stream_options:
                 stream_config["delimiters"] = stream_options["delimiters"]
-
-        optional_params.pop("tool_choice", None)
 
         modules: Final = [
             self._build_prompt_module(
@@ -387,13 +414,16 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
         api_key: str | None = None,
         json_mode: bool | None = None,
     ) -> ModelResponse:
-        logging_obj.post_call(
-            input=messages,
-            api_key=api_key,
-            original_response=raw_response.text,
-            additional_args={"complete_input_dict": request_data},
-        )
-        response = ModelResponse.model_validate(raw_response.json()["final_result"])
+        final_result = raw_response.json()["final_result"]  # rebind-ok: extracted from raw response for normalisation then model_validate
+
+        # SAP's orchestration service returns Gemini thinking as a list of
+        # {"content": str, "signature": str} objects under reasoning_content.
+        # Normalize to litellm's standard fields before model_validate, which
+        # crashes on a list-shaped reasoning_content.
+        if model.startswith("gemini"):
+            self._normalize_gemini_reasoning(final_result)
+
+        response = ModelResponse.model_validate(final_result)  # rebind-ok: constructed from final_result; referenced below for hidden params
 
         # Strip markdown code blocks if JSON response_format was used with Anthropic models
         # SAP GenAI Hub with Anthropic models sometimes wraps JSON in ```json ... ```
@@ -405,6 +435,46 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
                 response = self._strip_markdown_json(response)
 
         return response
+
+    @staticmethod
+    def _sap_supports_reasoning(model: str) -> bool:
+        """Return True if *model* accepts reasoning_effort / thinking on SAP GenAI Hub."""
+        return bool(_REASONING_MODELS.match(model))
+
+    @staticmethod
+    def _normalize_gemini_reasoning(final_result: dict) -> None:  # mutable-ok: final_result mutated in place to prepare for model_validate
+        """Normalize SAP Gemini reasoning_content from list to litellm's standard fields.
+
+        SAP's orchestration service returns Gemini thinking as a list of
+        {"content": str, "signature": str} objects under reasoning_content.
+        litellm uses two parallel fields for this:
+        - thinking_blocks: list of ChatCompletionThinkingBlock dicts, preserving
+          signature tokens that Gemini requires to replay thinking in multi-turn
+          requests and that the Responses API serializes for round-trip preservation.
+        - reasoning_content: plain str derived from the same blocks, exposed to
+          callers and used by streaming accumulators and the Responses API.
+        Both must be populated; populating only the string loses the signatures.
+        """
+        for choice in final_result.get("choices") or []:
+            msg = (choice.get("message") or {}) if isinstance(choice, dict) else {}
+            rc = msg.get("reasoning_content")
+            if not isinstance(rc, list):
+                continue
+            blocks: list[dict] = []  # mutable-ok: local accumulator; assigned once to msg field below
+            texts: list[str] = []  # mutable-ok: local accumulator; joined to string below
+            for item in rc:
+                if not isinstance(item, dict):
+                    continue
+                thought = item.get("content", "")
+                block: dict = {"type": "thinking", "thinking": thought}  # mutable-ok: local block dict; signature optionally appended then collected
+                if item.get("signature") is not None:
+                    block["signature"] = item["signature"]  # mutable-ok: block is a local dict
+                blocks.append(block)
+                texts.append(thought)
+            msg["thinking_blocks"] = (
+                blocks if blocks else None
+            )  # rebind-ok: normalizing SAP Gemini list to ChatCompletionThinkingBlock list
+            msg["reasoning_content"] = "\n\n".join(texts) or None  # rebind-ok: normalizing SAP Gemini list to plain str
 
     def _strip_markdown_json(self, response: ModelResponse) -> ModelResponse:
         """Strip markdown code block wrapper from JSON content if present.

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -4,6 +4,7 @@ Translate from OpenAI's `/v1/chat/completions` to SAP Generative AI Hub's Orches
 
 from collections.abc import AsyncIterator, Iterator
 from functools import cached_property
+import re
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -46,17 +47,90 @@ from .models import (
 _SAP_MODEL_PARAMS_EXCLUDED_KEYS: frozenset[str] = frozenset(
     {
         "tools",
-        "tool_choice",
         "stream_options",
         "fallback_sap_modules",
         "placeholder_values",
         "model_version",
+        "timeout",
+        "max_retries",
     }
 )
 
+# ---------------------------------------------------------------------------
+# SAP capability registry
+# ---------------------------------------------------------------------------
+# Models that accept reasoning_effort / thinking parameters on SAP GenAI Hub.
+_REASONING_MODELS: re.Pattern[str] = re.compile(
+    r"^(?:anthropic--claude-(?:4(?:\.[5-9])?|3-7)|o\d|gpt-5(?:[.\-]|$)|cohere--\S*reasoning\S*)"
+)
 
-def validate_dict(data: dict, model) -> dict:
+# Models that support Anthropic-style cache_control on message content parts.
+_CACHE_CONTROL_MODELS: re.Pattern[str] = re.compile(r"^anthropic--")
+
+
+def validate_dict(data: dict, model) -> dict:  # mutable-ok: pydantic validation boundary; both input and output are untyped wire dicts
     return model(**data).model_dump(by_alias=True, exclude_unset=True)
+
+
+def _validate_tool(
+    tool: dict,  # mutable-ok: untyped tool dict from litellm boundary
+) -> dict:  # mutable-ok: wire serialization helper; dict is the required output shape for JSON encoding
+    """Validate a tool definition against ChatCompletionTool and preserve cache_control.
+
+    cache_control is an Anthropic prompt-caching extension that sits on the tool
+    object itself (not inside `function`).  ChatCompletionTool does not declare it
+    as a field because its model_dump forces exclude_unset=False for FunctionTool
+    defaults -- adding cache_control there would emit `cache_control: null` for every
+    tool that omits it, which the API rejects.  We therefore validate the known schema
+    and re-attach the extension field explicitly.
+    """
+    result = validate_dict(tool, ChatCompletionTool)
+    if "cache_control" in tool and tool["cache_control"] is not None:
+        result["cache_control"] = tool["cache_control"]
+    return result
+
+
+def _fold_message_cache_control(message: dict) -> dict:  # mutable-ok: message dicts are untyped at the litellm boundary
+    """Fold a message-level cache_control onto the content block.
+
+    litellm's cache_control_injection_points hook places cache_control on the
+    message dict itself when content is a plain string.  SAPMessage has no such
+    field, so it would be silently dropped.  Convert to a single-element content
+    list so the marker reaches the wire payload.
+    """
+    cc = message.get("cache_control")
+    if cc is None:
+        return message
+    content = message.get("content")
+    if isinstance(content, str):
+        return {  # mutable-ok: ephemeral wire dict; built once and immediately returned to caller
+            **{k: v for k, v in message.items() if k != "cache_control"},  # mutable-ok: dict comprehension filters one key; returned immediately
+            "content": [  # mutable-ok: list literal builds the wire content block in one shot
+                {"type": "text", "text": content, "cache_control": cc},  # mutable-ok: inner dict literal is the wire content block
+            ],
+        }
+    # content already a list -- marker is redundant; drop it to avoid duplication
+    return {k: v for k, v in message.items() if k != "cache_control"}  # mutable-ok: dict comprehension filters one key; returned immediately
+
+
+def _build_model_details(
+    model_name: str,
+    model_version: str,
+    params: dict,  # mutable-ok: model params dict forwarded directly to wire payload
+    timeout: int | None,
+    max_retries: int | None,
+) -> dict:  # mutable-ok: wire serialization helper; dict is the required output shape for JSON encoding
+    """Build the model dict for the orchestration request, adding optional fields only when set."""
+    model_details: dict = {  # mutable-ok: ephemeral wire dict built in one shot before JSON encoding
+        "name": model_name,
+        "params": params,
+        "version": model_version,
+    }
+    if timeout is not None:
+        model_details["timeout"] = timeout
+    if max_retries is not None:
+        model_details["max_retries"] = max_retries
+    return model_details
 
 
 def _messages_to_sap_template(messages: list[dict[str, str]]) -> list:  # type: ignore[type-arg]
@@ -69,13 +143,13 @@ def _messages_to_sap_template(messages: list[dict[str, str]]) -> list:  # type: 
         elif message["role"] == "tool":
             template.append(validate_dict(message, SAPToolChatMessage))
         else:
-            template.append(validate_dict(message, SAPMessage))
+            template.append(validate_dict(_fold_message_cache_control(message), SAPMessage))
     return template
 
 
 def _tools_response_format_and_stream(optional_params: dict, model_params: dict) -> tuple[dict, dict, dict]:
     tools_ = optional_params.pop("tools", [])
-    tools_ = [validate_dict(tool, ChatCompletionTool) for tool in tools_]
+    tools_ = [_validate_tool(tool) for tool in tools_]
     tools: dict = {"tools": tools_} if tools_ else {}
 
     response_format = model_params.pop("response_format", {})
@@ -209,13 +283,15 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
             "temperature",
             "top_p",
             "tools",
-            "tool_choice",
             "function_call",
             "functions",
             "extra_headers",
             "parallel_tool_calls",
             "response_format",
             "timeout",
+            "max_retries",
+            "model_version",
+            "user",
         ]
         # Remove response_format for providers that don't support it on SAP GenAI Hub
         if (
@@ -225,8 +301,8 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
             or model == "gpt-4"
         ):
             params.remove("response_format")
-        if model.startswith("gemini") or model.startswith("amazon"):
-            params.remove("tool_choice")
+        if self._sap_supports_reasoning(model):
+            params.extend(["reasoning_effort", "thinking"])
         return params
 
     def validate_environment(
@@ -268,9 +344,11 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
             params.pop("strict")
 
         model_version = params.pop("model_version", "latest")
+        timeout = params.pop("timeout", None)
+        max_retries = params.pop("max_retries", None)
 
         tools_ = params.pop("tools", [])
-        tools_ = [validate_dict(tool, ChatCompletionTool) for tool in tools_]
+        tools_ = [_validate_tool(tool) for tool in tools_]
         tools = {"tools": tools_} if tools_ else {}
 
         response_format = params.pop("response_format", {})
@@ -301,11 +379,7 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
                     **tools,
                     **response_format,
                 },
-                "model": {
-                    "name": model_name,
-                    "params": params,
-                    "version": model_version,
-                },
+                "model": _build_model_details(model_name, model_version, params, timeout, max_retries),
             },
             **optional_modules,
         }
@@ -350,7 +424,8 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
             fallback_model = modules_dict.pop("model", None)
             if fallback_model is None:
                 raise ValueError("Each entry in `fallback_sap_modules` must include a 'model' key.")
-            fallback_model = fallback_model.removeprefix("sap/")
+            if fallback_model.startswith("sap/"):
+                fallback_model = fallback_model[4:]
             fallback_template = modules_dict.pop("messages", [])
 
             modules.append(
@@ -407,6 +482,32 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
                 response = self._strip_markdown_json(response)
 
         return response
+
+    @staticmethod
+    def _sap_supports_reasoning(model: str) -> bool:
+        """Return True if *model* accepts reasoning_effort / thinking on SAP GenAI Hub."""
+        return bool(_REASONING_MODELS.match(model))
+
+    @staticmethod
+    def _sap_supports_cache_control(model: str) -> bool:
+        """Return True if *model* supports Anthropic-style cache_control content parts."""
+        return bool(_CACHE_CONTROL_MODELS.match(model))
+
+    @staticmethod
+    def _normalize_gemini_reasoning(final_result: dict) -> None:
+        """Coerce Gemini's list-shaped reasoning_content to a plain string in-place.
+
+        Gemini models on SAP GenAI Hub return reasoning_content as a list of
+        {"thought": str, "signature": str} objects.  ModelResponse expects a
+        plain str, so model_validate crashes without this normalisation step.
+        """
+        for choice in final_result.get("choices") or []:
+            msg = (choice.get("message") or {}) if isinstance(choice, dict) else {}
+            rc = msg.get("reasoning_content")
+            if isinstance(rc, list):
+                msg["reasoning_content"] = (
+                    "\n\n".join(item.get("thought", "") for item in rc if isinstance(item, dict)) or None
+                )
 
     def _strip_markdown_json(self, response: ModelResponse) -> ModelResponse:
         """Strip markdown code block wrapper from JSON content if present.

--- a/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
+++ b/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
@@ -34,9 +34,7 @@ class TestSAPTransformationIntegration:
 
         result = mock_config.transform_request(model, messages, optional_params, {}, {})
 
-        model_params = result["config"]["modules"]["prompt_templating"]["model"][
-            "params"
-        ]
+        model_params = result["config"]["modules"]["prompt_templating"]["model"]["params"]
 
         assert "temperature" in model_params
         assert "frequency_penalty" in model_params
@@ -44,18 +42,16 @@ class TestSAPTransformationIntegration:
         assert "model_version" not in model_params
         assert "tools" not in model_params
 
-        model_version = result["config"]["modules"]["prompt_templating"]["model"][
-            "version"
-        ]
+        model_version = result["config"]["modules"]["prompt_templating"]["model"]["version"]
         assert model_version == "v1.5"
 
         prompt = result["config"]["modules"]["prompt_templating"]["prompt"]
         if "tools" in prompt:
             assert isinstance(prompt["tools"], list)
             for tool in prompt["tools"]:
-                assert (
-                    tool["function"]["parameters"]["type"] == "object"
-                ), "SAP API requires parameters.type == 'object'"
+                assert tool["function"]["parameters"]["type"] == "object", (
+                    "SAP API requires parameters.type == 'object'"
+                )
                 assert "properties" in tool["function"]["parameters"]
 
     def test_transform_request_parameter_handling_robustness(self, mock_config):
@@ -96,33 +92,25 @@ class TestSAPTransformationIntegration:
 
         for i, test_case in enumerate(test_cases):
             filtered_params = {
-                k: v
-                for k, v in test_case["params"].items()
-                if k not in {"tools", "model_version", "deployment_url"}
+                k: v for k, v in test_case["params"].items() if k not in {"tools", "model_version", "deployment_url"}
             }
 
             for expected_param in test_case["expected_in_model"]:
-                assert (
-                    expected_param in filtered_params
-                ), f"Case {i + 1}: {expected_param} should be in model params"
+                assert expected_param in filtered_params, f"Case {i + 1}: {expected_param} should be in model params"
 
             for excluded_param in test_case["expected_excluded"]:
-                assert (
-                    excluded_param not in filtered_params
-                ), f"Case {i + 1}: {excluded_param} should be excluded from model params"
+                assert excluded_param not in filtered_params, (
+                    f"Case {i + 1}: {excluded_param} should be excluded from model params"
+                )
 
-            result = mock_config.transform_request(
-                model, messages, test_case["params"], {}, {}
-            )
+            result = mock_config.transform_request(model, messages, test_case["params"], {}, {})
             if result and "config" in result:
-                model_params = result["config"]["modules"]["prompt_templating"][
-                    "model"
-                ]["params"]
+                model_params = result["config"]["modules"]["prompt_templating"]["model"]["params"]
 
                 for excluded_param in test_case["expected_excluded"]:
-                    assert (
-                        excluded_param not in model_params
-                    ), f"Case {i + 1}: {excluded_param} should not be in actual model params"
+                    assert excluded_param not in model_params, (
+                        f"Case {i + 1}: {excluded_param} should not be in actual model params"
+                    )
 
     def test_config_transform_with_response_format_json_object(self, mock_config):
         expected_dict = {
@@ -145,9 +133,7 @@ class TestSAPTransformationIntegration:
         }
         config = mock_config.transform_request(
             model="gpt-4o",
-            messages=[
-                {"role": "user", "content": "First man on the moon, answer in json"}
-            ],
+            messages=[{"role": "user", "content": "First man on the moon, answer in json"}],
             optional_params={
                 "response_format": {"type": "json_object"},
                 "deployment_url": "shouldn't be in results",
@@ -189,9 +175,7 @@ class TestSAPTransformationIntegration:
 
         config = mock_config.transform_request(
             model="gpt-4o",
-            messages=[
-                {"role": "user", "content": "First man on the moon, answer in json"}
-            ],
+            messages=[{"role": "user", "content": "First man on the moon, answer in json"}],
             optional_params={
                 "response_format": expected_response_format,
                 "deployment_url": "shouldn't be in results",
@@ -199,27 +183,15 @@ class TestSAPTransformationIntegration:
             litellm_params={},
             headers={},
         )
-        assert (
-            config["config"]["modules"]["prompt_templating"]["prompt"][
-                "response_format"
-            ]
-            == expected_response_format
-        )
-        assert (
-            len(config["config"]["modules"]["prompt_templating"]["model"]["params"])
-            == 0
-        )
+        assert config["config"]["modules"]["prompt_templating"]["prompt"]["response_format"] == expected_response_format
+        assert len(config["config"]["modules"]["prompt_templating"]["model"]["params"]) == 0
 
     def test_config_transform_with_stream(self, mock_config):
         expected_dict = {
             "config": {
                 "modules": {
                     "prompt_templating": {
-                        "prompt": {
-                            "template": [
-                                {"role": "user", "content": "Hello, how are you?"}
-                            ]
-                        },
+                        "prompt": {"template": [{"role": "user", "content": "Hello, how are you?"}]},
                         "model": {
                             "name": "anthropic--claude-4-sonnet",
                             "params": {},
@@ -257,9 +229,7 @@ class TestSAPTransformationIntegration:
             headers={},
         )
 
-        assert config["config"]["modules"]["prompt_templating"]["prompt"][
-            "defaults"
-        ] == {"user_query": "default value"}
+        assert config["config"]["modules"]["prompt_templating"]["prompt"]["defaults"] == {"user_query": "default value"}
         assert config["config"]["modules"]["prompt_templating"]["model"]["params"] == {}
 
     def test_sap_placeholder_values(self, mock_config):
@@ -323,14 +293,8 @@ class TestSAPTransformationIntegration:
         assert config["placeholder_values"] == placeholder_values
         modules = config["config"]["modules"]
         assert modules["grounding"]["type"] == "document_grounding_service"
-        assert (
-            modules["grounding"]["config"]["placeholders"]["output"]
-            == "grounding_response"
-        )
-        assert (
-            modules["grounding"]["config"]["filters"][0]["data_repository_type"]
-            == "vector"
-        )
+        assert modules["grounding"]["config"]["placeholders"]["output"] == "grounding_response"
+        assert modules["grounding"]["config"]["filters"][0]["data_repository_type"] == "vector"
         assert modules["prompt_templating"]["model"]["params"] == {}
 
     def test_grounding_search_config_rejects_both_count_fields(self, mock_config):
@@ -442,10 +406,7 @@ class TestSAPTransformationIntegration:
                 headers={},
             )
 
-        assert (
-            "For using SAP Filtering Module you must provide at least one property"
-            in str(exc_info.value)
-        )
+        assert "For using SAP Filtering Module you must provide at least one property" in str(exc_info.value)
 
     def test_sap_masking(self, mock_config):
         masking_config = {
@@ -509,9 +470,7 @@ class TestSAPTransformationIntegration:
                 headers={},
             )
 
-        assert "must set exactly one of: 'providers' or 'masking_providers'" in str(
-            exc_info.value
-        )
+        assert "must set exactly one of: 'providers' or 'masking_providers'" in str(exc_info.value)
 
     def test_masking_providers_deprecated_emits_warning(self, mock_config):
         masking_config = {
@@ -533,8 +492,7 @@ class TestSAPTransformationIntegration:
                 headers={},
             )
         assert any(
-            issubclass(warning.category, DeprecationWarning)
-            and "masking_providers" in str(warning.message)
+            issubclass(warning.category, DeprecationWarning) and "masking_providers" in str(warning.message)
             for warning in w
         ), "Expected DeprecationWarning for 'masking_providers'"
 
@@ -573,10 +531,7 @@ class TestSAPTransformationIntegration:
                 headers={},
             )
 
-        assert (
-            "TranslationModuleConfig requires at least one of 'input' or 'output'"
-            in str(exc_info.value)
-        )
+        assert "TranslationModuleConfig requires at least one of 'input' or 'output'" in str(exc_info.value)
 
     def test_sap_multiple_modules(self, mock_config):
         translation_config = {
@@ -629,13 +584,340 @@ class TestSAPTransformationIntegration:
                 ][0]["content"]
                 == "Hello world!"
             )
-            assert (
-                config["config"]["modules"][0]["prompt_templating"]["prompt"][
-                    "template"
-                ][0]["content"]
-                == "Hello."
+            assert config["config"]["modules"][0]["prompt_templating"]["prompt"]["template"][0]["content"] == "Hello."
+            assert config["config"]["modules"][1]["translation"]["input"]["type"] == "sap_document_translation"
+
+
+class TestGeminiReasoningNormalization:
+    """Unit tests for _normalize_gemini_reasoning.
+
+    Verifies that list-shaped reasoning_content from Gemini is coerced to str
+    before model_validate is called, without touching other shapes.
+    """
+
+    def _make_final_result(self, reasoning_content):
+        """Helper: build a minimal final_result dict with given reasoning_content."""
+        result = {
+            "id": "test-id",
+            "object": "chat.completion",
+            "model": "gemini-2.0-flash",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "Hello",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+        if reasoning_content is not None:
+            result["choices"][0]["message"]["reasoning_content"] = reasoning_content
+        return result
+
+    def test_list_shaped_is_joined_to_string(self):
+        """Gemini list of content dicts is joined into a newline-separated string."""
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        final_result = self._make_final_result(
+            [
+                {"content": "First thought.", "signature": "sig1"},
+                {"content": "Second thought.", "signature": "sig2"},
+            ]
+        )
+        GenAIHubOrchestrationConfig._normalize_gemini_reasoning(final_result)
+        assert final_result["choices"][0]["message"]["reasoning_content"] == "First thought.\n\nSecond thought."
+
+    def test_string_reasoning_content_is_untouched(self):
+        """A reasoning_content that is already a str is left as-is."""
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        final_result = self._make_final_result("already a string")
+        GenAIHubOrchestrationConfig._normalize_gemini_reasoning(final_result)
+        assert final_result["choices"][0]["message"]["reasoning_content"] == "already a string"
+
+    def test_missing_reasoning_content_is_untouched(self):
+        """A message without reasoning_content is left unchanged."""
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        final_result = self._make_final_result(None)
+        # reasoning_content key is absent — _make_final_result(None) does not add it
+        assert "reasoning_content" not in final_result["choices"][0]["message"]
+        GenAIHubOrchestrationConfig._normalize_gemini_reasoning(final_result)
+        assert "reasoning_content" not in final_result["choices"][0]["message"]
+
+    def test_empty_list_becomes_none(self):
+        """An empty list collapses to None so model_validate sees no reasoning."""
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        final_result = self._make_final_result([])
+        GenAIHubOrchestrationConfig._normalize_gemini_reasoning(final_result)
+        assert final_result["choices"][0]["message"]["reasoning_content"] is None
+
+    def test_model_validate_succeeds_after_normalization(self):
+        """model_validate no longer raises after normalisation."""
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+        from litellm.types.utils import ModelResponse
+
+        final_result = self._make_final_result([{"content": "Thinking hard.", "signature": "abc"}])
+        GenAIHubOrchestrationConfig._normalize_gemini_reasoning(final_result)
+        response = ModelResponse.model_validate(final_result)
+        assert response.choices[0].message.reasoning_content == "Thinking hard."
+
+
+class TestReasoningCapability:
+    """Unit tests for reasoning_effort / thinking parameter routing.
+
+    Verifies that capable models expose the params and that they land in
+    model.params, while non-capable models have them silently dropped.
+    """
+
+    def _transform(self, model: str, **kwargs) -> dict:
+        """Run transform_request and return the parsed body."""
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        cfg = GenAIHubOrchestrationConfig()
+        return cfg.transform_request(
+            model=model,
+            messages=[{"role": "user", "content": "Hi"}],
+            optional_params=dict(kwargs),
+            litellm_params={},
+            headers={},
+        )
+
+    def _model_params(self, body: dict) -> dict:
+        return body["config"]["modules"]["prompt_templating"]["model"]["params"]
+
+    # --- get_supported_openai_params ---
+
+    def test_reasoning_params_exposed_for_claude_3_7(self):
+        """reasoning_effort and thinking appear for claude-3-7 models."""
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        cfg = GenAIHubOrchestrationConfig()
+        params = cfg.get_supported_openai_params("anthropic--claude-3-7-sonnet")
+        assert "reasoning_effort" in params
+        assert "thinking" in params
+
+    def test_reasoning_params_exposed_for_claude_4(self):
+        """reasoning_effort and thinking appear for claude-4 models."""
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        cfg = GenAIHubOrchestrationConfig()
+        params = cfg.get_supported_openai_params("anthropic--claude-4-opus")
+        assert "reasoning_effort" in params
+        assert "thinking" in params
+
+    def test_reasoning_params_absent_for_gpt4o(self):
+        """reasoning_effort and thinking are not exposed for gpt-4o."""
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        cfg = GenAIHubOrchestrationConfig()
+        params = cfg.get_supported_openai_params("gpt-4o")
+        assert "reasoning_effort" not in params
+        assert "thinking" not in params
+
+    # --- transform_request model.params ---
+
+    def test_reasoning_effort_lands_in_model_params_for_o3(self):
+        """reasoning_effort is forwarded into model.params for o-series models."""
+        body = self._transform("o3", reasoning_effort="high")
+        assert self._model_params(body).get("reasoning_effort") == "high"
+
+    def test_thinking_lands_in_model_params_for_claude_3_7(self):
+        """thinking dict is forwarded into model.params for claude-3-7."""
+        thinking = {"type": "enabled", "budget_tokens": 8000}
+        body = self._transform("anthropic--claude-3-7-sonnet", thinking=thinking)
+        assert self._model_params(body).get("thinking") == thinking
+
+
+
+
+class TestModelVersionAdvertisement:
+    """model_version is advertised in get_supported_openai_params and lands in
+    model.version (not model.params) in the serialised request body.
+    """
+
+    def _cfg(self):
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        cfg = GenAIHubOrchestrationConfig()
+        return cfg
+
+    def _transform(self, model: str, **kwargs) -> dict:
+        cfg = self._cfg()
+        return cfg.transform_request(
+            model=model,
+            messages=[{"role": "user", "content": "Hi"}],
+            optional_params=dict(kwargs),
+            litellm_params={},
+            headers={},
+        )
+
+    def test_model_version_advertised_for_all_models(self):
+        for model in ("gpt-4o", "anthropic--claude-4-sonnet", "gemini-1.5-pro"):
+            params = self._cfg().get_supported_openai_params(model)
+            assert "model_version" in params, f"model_version missing for {model}"
+
+    def test_model_version_lands_in_model_version_field(self):
+        body = self._transform("gpt-4o", model_version="1.2.3")
+        pt = body["config"]["modules"]["prompt_templating"]
+        assert pt["model"]["version"] == "1.2.3"
+
+    def test_model_version_absent_from_model_params(self):
+        body = self._transform("gpt-4o", model_version="1.2.3")
+        pt = body["config"]["modules"]["prompt_templating"]
+        assert "model_version" not in pt["model"]["params"]
+
+    def test_model_version_defaults_to_latest(self):
+        body = self._transform("gpt-4o")
+        pt = body["config"]["modules"]["prompt_templating"]
+        assert pt["model"]["version"] == "latest"
+
+
+class TestToolChoiceDropped:
+    """SAP orchestration v2 does not support tool_choice.
+
+    It is not advertised in get_supported_openai_params, so callers receive
+    UnsupportedParamsError immediately via the generic litellm layer.
+    tools themselves are still forwarded normally.
+    """
+
+    _TOOL = {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Return weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }
+
+    def _transform(self, model: str, **kwargs) -> dict:
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        cfg = GenAIHubOrchestrationConfig()
+        return cfg.transform_request(
+            model=model,
+            messages=[{"role": "user", "content": "What is the weather?"}],
+            optional_params=dict(kwargs),
+            litellm_params={},
+            headers={},
+        )
+
+    def _prompt(self, body: dict) -> dict:
+        return body["config"]["modules"]["prompt_templating"]["prompt"]
+
+    def test_tool_choice_not_advertised(self):
+        """tool_choice must not appear in get_supported_openai_params for any model."""
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        cfg = GenAIHubOrchestrationConfig()
+        for model in ("gpt-4o", "anthropic--claude-4-sonnet", "gemini-1.5-pro", "amazon--titan"):
+            assert "tool_choice" not in cfg.get_supported_openai_params(model), (
+                f"tool_choice must not be advertised for {model}"
             )
-            assert (
-                config["config"]["modules"][1]["translation"]["input"]["type"]
-                == "sap_document_translation"
-            )
+
+    def test_tools_still_advertised(self):
+        """tools must still be advertised — only tool_choice is unsupported."""
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        cfg = GenAIHubOrchestrationConfig()
+        for model in ("gpt-4o", "anthropic--claude-4-sonnet"):
+            assert "tools" in cfg.get_supported_openai_params(model)
+
+    def test_tools_still_forwarded(self):
+        """Dropping tool_choice must not also suppress the tools list."""
+        body = self._transform("gpt-4o", tools=[self._TOOL])
+        assert "tools" in self._prompt(body)
+        assert self._prompt(body)["tools"][0]["function"]["name"] == "get_weather"
+
+
+class TestTimeoutAndMaxRetries:
+    """timeout and max_retries land in model-level sibling fields,
+    not inside model.params.
+    """
+
+    def _transform(self, model: str, **kwargs) -> dict:
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        cfg = GenAIHubOrchestrationConfig()
+        return cfg.transform_request(
+            model=model,
+            messages=[{"role": "user", "content": "Hi"}],
+            optional_params=dict(kwargs),
+            litellm_params={},
+            headers={},
+        )
+
+    def _model(self, body: dict) -> dict:
+        return body["config"]["modules"]["prompt_templating"]["model"]
+
+    def test_timeout_and_max_retries_advertised(self):
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        cfg = GenAIHubOrchestrationConfig()
+        for model in ("gpt-4o", "anthropic--claude-4-sonnet"):
+            params = cfg.get_supported_openai_params(model)
+            assert "timeout" in params, f"timeout missing for {model}"
+            assert "max_retries" in params, f"max_retries missing for {model}"
+
+    def test_timeout_lands_at_model_level(self):
+        body = self._transform("gpt-4o", timeout=120)
+        model = self._model(body)
+        assert model.get("timeout") == 120
+        assert "timeout" not in model.get("params", {})
+
+    def test_max_retries_lands_at_model_level(self):
+        body = self._transform("gpt-4o", max_retries=3)
+        model = self._model(body)
+        assert model.get("max_retries") == 3
+        assert "max_retries" not in model.get("params", {})
+
+    def test_timeout_and_max_retries_together(self):
+        body = self._transform("gpt-4o", timeout=60, max_retries=2)
+        model = self._model(body)
+        assert model.get("timeout") == 60
+        assert model.get("max_retries") == 2
+        assert "timeout" not in model.get("params", {})
+        assert "max_retries" not in model.get("params", {})
+
+    def test_absent_when_not_passed(self):
+        """Neither key appears in the serialised body when not supplied."""
+        body = self._transform("gpt-4o", temperature=0.7)
+        model = self._model(body)
+        assert "timeout" not in model
+        assert "max_retries" not in model
+
+
+class TestUserForwarding:
+    """user param is advertised and lands in model.params (correct per SDK v2)."""
+
+    def _cfg(self):
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        return GenAIHubOrchestrationConfig()
+
+    def _transform(self, **kwargs) -> dict:
+        cfg = self._cfg()
+        return cfg.transform_request(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "Hi"}],
+            optional_params=dict(kwargs),
+            litellm_params={},
+            headers={},
+        )
+
+    def test_user_advertised(self):
+        params = self._cfg().get_supported_openai_params("gpt-4o")
+        assert "user" in params
+
+    def test_user_lands_in_model_params(self):
+        body = self._transform(user="uid-abc123")
+        pt = body["config"]["modules"]["prompt_templating"]
+        assert pt["model"]["params"].get("user") == "uid-abc123"

--- a/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
+++ b/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
@@ -639,3 +639,514 @@ class TestSAPTransformationIntegration:
                 config["config"]["modules"][1]["translation"]["input"]["type"]
                 == "sap_document_translation"
             )
+
+class TestGeminiReasoningNormalization:
+    """Unit tests for _normalize_gemini_reasoning.
+
+    Verifies that list-shaped reasoning_content from Gemini is coerced to str
+    before model_validate is called, without touching other shapes.
+    """
+
+    def _make_final_result(self, reasoning_content):
+        """Helper: build a minimal final_result dict with given reasoning_content."""
+        result = {
+            "id": "test-id",
+            "object": "chat.completion",
+            "model": "gemini-2.0-flash",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "Hello",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+        if reasoning_content is not None:
+            result["choices"][0]["message"]["reasoning_content"] = reasoning_content
+        return result
+
+    def test_list_shaped_is_joined_to_string(self):
+        """Gemini list of thought dicts is joined into a newline-separated string."""
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        final_result = self._make_final_result(
+            [
+                {"thought": "First thought.", "signature": "sig1"},
+                {"thought": "Second thought.", "signature": "sig2"},
+            ]
+        )
+        GenAIHubOrchestrationConfig._normalize_gemini_reasoning(final_result)
+        assert (
+            final_result["choices"][0]["message"]["reasoning_content"]
+            == "First thought.\n\nSecond thought."
+        )
+
+    def test_string_reasoning_content_is_untouched(self):
+        """A reasoning_content that is already a str is left as-is."""
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        final_result = self._make_final_result("already a string")
+        GenAIHubOrchestrationConfig._normalize_gemini_reasoning(final_result)
+        assert final_result["choices"][0]["message"]["reasoning_content"] == "already a string"
+
+    def test_missing_reasoning_content_is_untouched(self):
+        """A message without reasoning_content is left unchanged."""
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        final_result = self._make_final_result(None)
+        # reasoning_content key is absent — _make_final_result(None) does not add it
+        assert "reasoning_content" not in final_result["choices"][0]["message"]
+        GenAIHubOrchestrationConfig._normalize_gemini_reasoning(final_result)
+        assert "reasoning_content" not in final_result["choices"][0]["message"]
+
+    def test_empty_list_becomes_none(self):
+        """An empty list collapses to None so model_validate sees no reasoning."""
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        final_result = self._make_final_result([])
+        GenAIHubOrchestrationConfig._normalize_gemini_reasoning(final_result)
+        assert final_result["choices"][0]["message"]["reasoning_content"] is None
+
+    def test_model_validate_succeeds_after_normalization(self):
+        """model_validate no longer raises after normalisation."""
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+        from litellm.types.utils import ModelResponse
+
+        final_result = self._make_final_result(
+            [{"thought": "Thinking hard.", "signature": "abc"}]
+        )
+        GenAIHubOrchestrationConfig._normalize_gemini_reasoning(final_result)
+        response = ModelResponse.model_validate(final_result)
+        assert response.choices[0].message.reasoning_content == "Thinking hard."
+
+
+class TestReasoningCapability:
+    """Unit tests for reasoning_effort / thinking parameter routing.
+
+    Verifies that capable models expose the params and that they land in
+    model.params, while non-capable models have them silently dropped.
+    """
+
+    def _transform(self, model: str, **kwargs) -> dict:
+        """Run transform_request and return the parsed body."""
+        from unittest.mock import MagicMock
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        cfg = GenAIHubOrchestrationConfig()
+        logging_obj = MagicMock()
+        return cfg.transform_request(
+            model=model,
+            messages=[{"role": "user", "content": "Hi"}],
+            optional_params=dict(kwargs),
+            litellm_params={},
+            headers={},
+        )
+
+    def _model_params(self, body: dict) -> dict:
+        return body["config"]["modules"]["prompt_templating"]["model"]["params"]
+
+    # --- get_supported_openai_params ---
+
+    def test_reasoning_params_exposed_for_claude_3_7(self):
+        """reasoning_effort and thinking appear for claude-3-7 models."""
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        cfg = GenAIHubOrchestrationConfig()
+        params = cfg.get_supported_openai_params("anthropic--claude-3-7-sonnet")
+        assert "reasoning_effort" in params
+        assert "thinking" in params
+
+    def test_reasoning_params_exposed_for_claude_4(self):
+        """reasoning_effort and thinking appear for claude-4 models."""
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        cfg = GenAIHubOrchestrationConfig()
+        params = cfg.get_supported_openai_params("anthropic--claude-4-opus")
+        assert "reasoning_effort" in params
+        assert "thinking" in params
+
+    def test_reasoning_params_absent_for_gpt4o(self):
+        """reasoning_effort and thinking are not exposed for gpt-4o."""
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        cfg = GenAIHubOrchestrationConfig()
+        params = cfg.get_supported_openai_params("gpt-4o")
+        assert "reasoning_effort" not in params
+        assert "thinking" not in params
+
+    # --- transform_request model.params ---
+
+    def test_reasoning_effort_lands_in_model_params_for_o3(self):
+        """reasoning_effort is forwarded into model.params for o-series models."""
+        body = self._transform("o3", reasoning_effort="high")
+        assert self._model_params(body).get("reasoning_effort") == "high"
+
+    def test_thinking_lands_in_model_params_for_claude_3_7(self):
+        """thinking dict is forwarded into model.params for claude-3-7."""
+        thinking = {"type": "enabled", "budget_tokens": 8000}
+        body = self._transform("anthropic--claude-3-7-sonnet", thinking=thinking)
+        assert self._model_params(body).get("thinking") == thinking
+
+
+class TestCacheControl:
+    """Unit tests for cache_control preservation on message content parts."""
+
+    def _transform(self, model: str, messages: list) -> dict:
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+        cfg = GenAIHubOrchestrationConfig()
+        return cfg.transform_request(
+            model=model,
+            messages=messages,
+            optional_params={},
+            litellm_params={},
+            headers={},
+        )
+
+    def _template(self, body: dict) -> list:
+        return body["config"]["modules"]["prompt_templating"]["prompt"]["template"]
+
+    def test_cache_control_preserved_on_text_content(self):
+        """cache_control on a TextContent part survives validation and appears in payload."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Hello",
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            }
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        template = self._template(body)
+        content = template[0]["content"]
+        assert isinstance(content, list)
+        assert content[0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_plain_text_content_unaffected(self):
+        """Text content without cache_control still serialises cleanly."""
+        messages = [{"role": "user", "content": "Hello"}]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        template = self._template(body)
+        assert template[0]["content"] == "Hello"
+
+    def test_cache_control_preserved_on_multiple_parts(self):
+        """cache_control is preserved on each part independently."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Part A", "cache_control": {"type": "ephemeral"}},
+                    {"type": "text", "text": "Part B"},
+                ],
+            }
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        content = self._template(body)[0]["content"]
+        assert content[0].get("cache_control") == {"type": "ephemeral"}
+        assert "cache_control" not in content[1]
+
+    def test_cache_control_preserved_on_system_message(self):
+        """cache_control on a system message content part reaches the payload."""
+        messages = [
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "You are a helpful assistant.",
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            },
+            {"role": "user", "content": "Hello"},
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        template = self._template(body)
+        system_content = template[0]["content"]
+        assert isinstance(system_content, list)
+        assert system_content[0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_system_message_without_cache_control_stays_string(self):
+        """A plain system message is still serialised as a string, not a list."""
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello"},
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        template = self._template(body)
+        assert isinstance(template[0]["content"], str)
+
+    def test_cache_control_preserved_on_tool_definition(self):
+        """cache_control on a tool definition reaches the payload."""
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            "cache_control": {"type": "ephemeral"},
+        }
+        messages = [{"role": "user", "content": "Hi"}]
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+        cfg = GenAIHubOrchestrationConfig()
+        body = cfg.transform_request(
+            model="anthropic--claude-3-5-sonnet",
+            messages=messages,
+            optional_params={"tools": [tool]},
+            litellm_params={},
+            headers={},
+        )
+        tools = body["config"]["modules"]["prompt_templating"]["prompt"]["tools"]
+        assert tools[0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_tool_without_cache_control_omits_field(self):
+        """A tool without cache_control does not emit cache_control: null."""
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        messages = [{"role": "user", "content": "Hi"}]
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+        cfg = GenAIHubOrchestrationConfig()
+        body = cfg.transform_request(
+            model="anthropic--claude-3-5-sonnet",
+            messages=messages,
+            optional_params={"tools": [tool]},
+            litellm_params={},
+            headers={},
+        )
+        tools = body["config"]["modules"]["prompt_templating"]["prompt"]["tools"]
+        assert "cache_control" not in tools[0]
+
+    def test_message_level_cache_control_folded_onto_string_content(self):
+        """cache_control on the message dict (string content) is folded into a content block.
+
+        litellm's cache_control_injection_points hook produces this shape for
+        plain-string content.  The marker must not be silently dropped.
+        """
+        messages = [
+            {
+                "role": "system",
+                "content": "You are a helpful assistant.",
+                "cache_control": {"type": "ephemeral"},
+            },
+            {"role": "user", "content": "Hello"},
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        template = self._template(body)
+        system_content = template[0]["content"]
+        assert isinstance(system_content, list), "string content should have been promoted to a list"
+        assert system_content[0]["text"] == "You are a helpful assistant."
+        assert system_content[0].get("cache_control") == {"type": "ephemeral"}
+
+    def test_null_cache_control_on_content_block_is_omitted(self):
+        """cache_control: null on a content block must not appear in the payload.
+
+        Sending null reaches AI Core and causes a 400 ('None is not of type object').
+        """
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Hello", "cache_control": None},
+                ],
+            }
+        ]
+        body = self._transform("anthropic--claude-3-5-sonnet", messages)
+        content = self._template(body)[0]["content"]
+        assert isinstance(content, list)
+        assert "cache_control" not in content[0]
+
+
+class TestModelVersionAdvertisement:
+    """model_version is advertised in get_supported_openai_params and lands in
+    model.version (not model.params) in the serialised request body.
+    """
+
+    def _cfg(self):
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+        cfg = GenAIHubOrchestrationConfig()
+        return cfg
+
+    def _transform(self, model: str, **kwargs) -> dict:
+        cfg = self._cfg()
+        return cfg.transform_request(
+            model=model,
+            messages=[{"role": "user", "content": "Hi"}],
+            optional_params=dict(kwargs),
+            litellm_params={},
+            headers={},
+        )
+
+    def test_model_version_advertised_for_all_models(self):
+        for model in ("gpt-4o", "anthropic--claude-4-sonnet", "gemini-1.5-pro"):
+            params = self._cfg().get_supported_openai_params(model)
+            assert "model_version" in params, f"model_version missing for {model}"
+
+    def test_model_version_lands_in_model_version_field(self):
+        body = self._transform("gpt-4o", model_version="1.2.3")
+        pt = body["config"]["modules"]["prompt_templating"]
+        assert pt["model"]["version"] == "1.2.3"
+
+    def test_model_version_absent_from_model_params(self):
+        body = self._transform("gpt-4o", model_version="1.2.3")
+        pt = body["config"]["modules"]["prompt_templating"]
+        assert "model_version" not in pt["model"]["params"]
+
+    def test_model_version_defaults_to_latest(self):
+        body = self._transform("gpt-4o")
+        pt = body["config"]["modules"]["prompt_templating"]
+        assert pt["model"]["version"] == "latest"
+
+
+class TestToolChoiceDropped:
+    """SAP orchestration v2 rejects tool_choice in the request body (HTTP 400).
+
+    It is not advertised in get_supported_openai_params so callers receive
+    UnsupportedParamsError immediately.  The defensive pop in _build_prompt_module
+    ensures it never reaches the wire even if injected via fallback_sap_modules.
+    tools themselves are still forwarded normally.
+    """
+
+    _TOOL = {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Return weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }
+
+    def _transform(self, model: str, **kwargs) -> dict:
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+        cfg = GenAIHubOrchestrationConfig()
+        return cfg.transform_request(
+            model=model,
+            messages=[{"role": "user", "content": "What is the weather?"}],
+            optional_params=dict(kwargs),
+            litellm_params={},
+            headers={},
+        )
+
+    def _prompt(self, body: dict) -> dict:
+        return body["config"]["modules"]["prompt_templating"]["prompt"]
+
+    def test_tool_choice_not_advertised(self):
+        """tool_choice must not appear in get_supported_openai_params for any model."""
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+        cfg = GenAIHubOrchestrationConfig()
+        for model in ("gpt-4o", "anthropic--claude-4-sonnet", "gemini-1.5-pro", "amazon--titan"):
+            assert "tool_choice" not in cfg.get_supported_openai_params(model), (
+                f"tool_choice must not be advertised for {model}"
+            )
+
+    def test_tools_still_advertised(self):
+        """tools must still be advertised — only tool_choice is unsupported."""
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+        cfg = GenAIHubOrchestrationConfig()
+        for model in ("gpt-4o", "anthropic--claude-4-sonnet"):
+            assert "tools" in cfg.get_supported_openai_params(model)
+
+    def test_tools_still_forwarded(self):
+        """Dropping tool_choice must not also suppress the tools list."""
+        body = self._transform("gpt-4o", tools=[self._TOOL])
+        assert "tools" in self._prompt(body)
+        assert self._prompt(body)["tools"][0]["function"]["name"] == "get_weather"
+
+
+class TestTimeoutAndMaxRetries:
+    """timeout and max_retries land in model-level sibling fields,
+    not inside model.params.
+    """
+
+    def _transform(self, model: str, **kwargs) -> dict:
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+        cfg = GenAIHubOrchestrationConfig()
+        return cfg.transform_request(
+            model=model,
+            messages=[{"role": "user", "content": "Hi"}],
+            optional_params=dict(kwargs),
+            litellm_params={},
+            headers={},
+        )
+
+    def _model(self, body: dict) -> dict:
+        return body["config"]["modules"]["prompt_templating"]["model"]
+
+    def test_timeout_and_max_retries_advertised(self):
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+        cfg = GenAIHubOrchestrationConfig()
+        for model in ("gpt-4o", "anthropic--claude-4-sonnet"):
+            params = cfg.get_supported_openai_params(model)
+            assert "timeout" in params, f"timeout missing for {model}"
+            assert "max_retries" in params, f"max_retries missing for {model}"
+
+    def test_timeout_lands_at_model_level(self):
+        body = self._transform("gpt-4o", timeout=120)
+        model = self._model(body)
+        assert model.get("timeout") == 120
+        assert "timeout" not in model.get("params", {})
+
+    def test_max_retries_lands_at_model_level(self):
+        body = self._transform("gpt-4o", max_retries=3)
+        model = self._model(body)
+        assert model.get("max_retries") == 3
+        assert "max_retries" not in model.get("params", {})
+
+    def test_timeout_and_max_retries_together(self):
+        body = self._transform("gpt-4o", timeout=60, max_retries=2)
+        model = self._model(body)
+        assert model.get("timeout") == 60
+        assert model.get("max_retries") == 2
+        assert "timeout" not in model.get("params", {})
+        assert "max_retries" not in model.get("params", {})
+
+    def test_absent_when_not_passed(self):
+        """Neither key appears in the serialised body when not supplied."""
+        body = self._transform("gpt-4o", temperature=0.7)
+        model = self._model(body)
+        assert "timeout" not in model
+        assert "max_retries" not in model
+
+
+class TestUserForwarding:
+    """user param is advertised and lands in model.params (correct per SDK v2)."""
+
+    def _cfg(self):
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+        return GenAIHubOrchestrationConfig()
+
+    def _transform(self, **kwargs) -> dict:
+        cfg = self._cfg()
+        return cfg.transform_request(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "Hi"}],
+            optional_params=dict(kwargs),
+            litellm_params={},
+            headers={},
+        )
+
+    def test_user_advertised(self):
+        params = self._cfg().get_supported_openai_params("gpt-4o")
+        assert "user" in params
+
+    def test_user_lands_in_model_params(self):
+        body = self._transform(user="uid-abc123")
+        pt = body["config"]["modules"]["prompt_templating"]
+        assert pt["model"]["params"].get("user") == "uid-abc123"


### PR DESCRIPTION
## Relevant issues

<!-- N/A -->

## Linear ticket

<!-- N/A -->

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix
🆕 New Feature
✅ Test

## Changes

**Gemini reasoning crash fix.** Gemini models on SAP GenAI Hub return `reasoning_content` as a list of `{"thought", "signature"}` objects, but `ModelResponse` expects a plain string — causing a `ValidationError` on every Gemini response that included reasoning. The raw payload is now normalised in-place before validation, joining the thought strings into a single newline-separated value.

**Capability registry.** Added two compiled regexes (`_REASONING_MODELS`, `_CACHE_CONTROL_MODELS`) that encode which SAP GenAI Hub model names support extended features. All capability checks in this PR and future ones go through these two predicates rather than scattered `startswith` guards.

**`reasoning_effort` and `thinking` support.** Capable models (Anthropic Claude 3.7/4.x, OpenAI o-series, GPT-5, Cohere reasoning variants) now advertise `reasoning_effort` and `thinking` in their supported params, so LiteLLM routes them through to `model.params` in the SAP orchestration payload. A defensive guard in `_build_prompt_module` silently drops these params for models that don't support them.

**`cache_control` preservation.** `TextContent` was a plain `BaseModel` with no extra-field policy, so Pydantic silently dropped `cache_control` (and any other unknown field) during message serialisation. Adding `model_config = ConfigDict(extra="allow")` fixes the silent data loss in one line.

**Live blackbox tests.** A new test file (skipped when `AICORE_SERVICE_KEY` is absent) verifies all of the above end-to-end against a real SAP AI Core tenant: `reasoning_effort` on o3, `thinking` on Claude 4, and `cache_control` on Anthropic content parts.

## Screenshots / Proof of Fix

All unit tests pass without credentials:

```
tests/test_litellm/llms/sap/
115 passed, 3 warnings
```

Live tests pass against a real SAP AI Core tenant (5/5):

```
tests/litellm/llms/sap/chat/test_sap_chat_calls.py
TestReasoningEffort::test_o3_reasoning_effort_high         PASSED
TestReasoningEffort::test_o3_reasoning_effort_low          PASSED
TestThinking::test_claude_thinking_enabled                 PASSED
TestCacheControlLive::test_cache_control_ephemeral_accepted       PASSED
TestCacheControlLive::test_mixed_parts_cache_control_accepted     PASSED
5 passed in 20s
```

`make pre-commit` passes all gates (ruff, ruff-strict-budget, basedpyright, type-discipline, circular-imports).

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
