### PR TITLE
fix(ui): guard breakdown aggregation against missing inner metrics (#33381)

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EndpointUsage/EndpointUsage.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EndpointUsage/EndpointUsage.tsx
@@ -39,16 +39,16 @@ const EndpointUsage: React.FC<EndpointUsageProps> = ({ userSpendData }) => {
             api_key_breakdown: {},
           };
         }
-        aggregatedEndpoints[endpoint].metrics.spend += metrics.metrics.spend;
-        aggregatedEndpoints[endpoint].metrics.prompt_tokens += metrics.metrics.prompt_tokens;
-        aggregatedEndpoints[endpoint].metrics.completion_tokens += metrics.metrics.completion_tokens;
-        aggregatedEndpoints[endpoint].metrics.total_tokens += metrics.metrics.total_tokens;
-        aggregatedEndpoints[endpoint].metrics.api_requests += metrics.metrics.api_requests;
-        aggregatedEndpoints[endpoint].metrics.successful_requests += metrics.metrics.successful_requests || 0;
-        aggregatedEndpoints[endpoint].metrics.failed_requests += metrics.metrics.failed_requests || 0;
-        aggregatedEndpoints[endpoint].metrics.cache_read_input_tokens += metrics.metrics.cache_read_input_tokens || 0;
+        aggregatedEndpoints[endpoint].metrics.spend += metrics.metrics?.spend ?? 0;
+        aggregatedEndpoints[endpoint].metrics.prompt_tokens += metrics.metrics?.prompt_tokens ?? 0;
+        aggregatedEndpoints[endpoint].metrics.completion_tokens += metrics.metrics?.completion_tokens ?? 0;
+        aggregatedEndpoints[endpoint].metrics.total_tokens += metrics.metrics?.total_tokens ?? 0;
+        aggregatedEndpoints[endpoint].metrics.api_requests += metrics.metrics?.api_requests ?? 0;
+        aggregatedEndpoints[endpoint].metrics.successful_requests += metrics.metrics?.successful_requests ?? 0;
+        aggregatedEndpoints[endpoint].metrics.failed_requests += metrics.metrics?.failed_requests ?? 0;
+        aggregatedEndpoints[endpoint].metrics.cache_read_input_tokens += metrics.metrics?.cache_read_input_tokens ?? 0;
         aggregatedEndpoints[endpoint].metrics.cache_creation_input_tokens +=
-          metrics.metrics.cache_creation_input_tokens || 0;
+          metrics.metrics?.cache_creation_input_tokens ?? 0;
       });
     });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.tsx
@@ -170,15 +170,11 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
             tokens: 0,
           };
         }
-        try {
-          modelSpend[model].spend += metrics.metrics.spend;
-        } catch (e) {
-          console.error(`Error adding spend for ${model}: ${e}, got metrics: ${JSON.stringify(metrics)}`);
-        }
-        modelSpend[model].requests += metrics.metrics.api_requests;
-        modelSpend[model].successful_requests += metrics.metrics.successful_requests;
-        modelSpend[model].failed_requests += metrics.metrics.failed_requests;
-        modelSpend[model].tokens += metrics.metrics.total_tokens;
+        modelSpend[model].spend += metrics.metrics?.spend ?? 0;
+        modelSpend[model].requests += metrics.metrics?.api_requests ?? 0;
+        modelSpend[model].successful_requests += metrics.metrics?.successful_requests ?? 0;
+        modelSpend[model].failed_requests += metrics.metrics?.failed_requests ?? 0;
+        modelSpend[model].tokens += metrics.metrics?.total_tokens ?? 0;
       });
     });
 
@@ -254,21 +250,21 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
               cache_creation_input_tokens: 0,
             },
             metadata: {
-              key_alias: metrics.metadata.key_alias,
-              team_id: metrics.metadata.team_id || null,
+              key_alias: metrics.metadata?.key_alias ?? null,
+              team_id: metrics.metadata?.team_id ?? null,
               tags: tagDictionary[key] || [],
             },
           };
         }
-        keySpend[key].metrics.spend += metrics.metrics.spend;
-        keySpend[key].metrics.prompt_tokens += metrics.metrics.prompt_tokens;
-        keySpend[key].metrics.completion_tokens += metrics.metrics.completion_tokens;
-        keySpend[key].metrics.total_tokens += metrics.metrics.total_tokens;
-        keySpend[key].metrics.api_requests += metrics.metrics.api_requests;
-        keySpend[key].metrics.successful_requests += metrics.metrics.successful_requests;
-        keySpend[key].metrics.failed_requests += metrics.metrics.failed_requests;
-        keySpend[key].metrics.cache_read_input_tokens += metrics.metrics.cache_read_input_tokens || 0;
-        keySpend[key].metrics.cache_creation_input_tokens += metrics.metrics.cache_creation_input_tokens || 0;
+        keySpend[key].metrics.spend += metrics.metrics?.spend ?? 0;
+        keySpend[key].metrics.prompt_tokens += metrics.metrics?.prompt_tokens ?? 0;
+        keySpend[key].metrics.completion_tokens += metrics.metrics?.completion_tokens ?? 0;
+        keySpend[key].metrics.total_tokens += metrics.metrics?.total_tokens ?? 0;
+        keySpend[key].metrics.api_requests += metrics.metrics?.api_requests ?? 0;
+        keySpend[key].metrics.successful_requests += metrics.metrics?.successful_requests ?? 0;
+        keySpend[key].metrics.failed_requests += metrics.metrics?.failed_requests ?? 0;
+        keySpend[key].metrics.cache_read_input_tokens += metrics.metrics?.cache_read_input_tokens ?? 0;
+        keySpend[key].metrics.cache_creation_input_tokens += metrics.metrics?.cache_creation_input_tokens ?? 0;
       });
     });
 
@@ -297,15 +293,11 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
             tokens: 0,
           };
         }
-        try {
-          providerSpend[provider].spend += metrics.metrics.spend;
-          providerSpend[provider].requests += metrics.metrics.api_requests;
-          providerSpend[provider].successful_requests += metrics.metrics.successful_requests;
-          providerSpend[provider].failed_requests += metrics.metrics.failed_requests;
-          providerSpend[provider].tokens += metrics.metrics.total_tokens;
-        } catch (e) {
-          console.error(`Error processing provider ${provider}: ${e}`);
-        }
+        providerSpend[provider].spend += metrics.metrics?.spend ?? 0;
+        providerSpend[provider].requests += metrics.metrics?.api_requests ?? 0;
+        providerSpend[provider].successful_requests += metrics.metrics?.successful_requests ?? 0;
+        providerSpend[provider].failed_requests += metrics.metrics?.failed_requests ?? 0;
+        providerSpend[provider].tokens += metrics.metrics?.total_tokens ?? 0;
       });
     });
 
@@ -370,11 +362,11 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
             },
           };
         }
-        entitySpend[entity].metrics.spend += data.metrics.spend;
-        entitySpend[entity].metrics.api_requests += data.metrics.api_requests;
-        entitySpend[entity].metrics.successful_requests += data.metrics.successful_requests;
-        entitySpend[entity].metrics.failed_requests += data.metrics.failed_requests;
-        entitySpend[entity].metrics.total_tokens += data.metrics.total_tokens;
+        entitySpend[entity].metrics.spend += data.metrics?.spend ?? 0;
+        entitySpend[entity].metrics.api_requests += data.metrics?.api_requests ?? 0;
+        entitySpend[entity].metrics.successful_requests += data.metrics?.successful_requests ?? 0;
+        entitySpend[entity].metrics.failed_requests += data.metrics?.failed_requests ?? 0;
+        entitySpend[entity].metrics.total_tokens += data.metrics?.total_tokens ?? 0;
       });
     });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.test.tsx
@@ -1162,4 +1162,127 @@ describe("UsagePage", () => {
       expect(screen.getByText("Endpoint Activity")).toBeInTheDocument();
     });
   });
+
+  // Regression test for https://github.com/BerriAI/litellm/issues/33381
+  // When a day's breakdown contains entries where the inner `metrics`
+  // object is undefined (a data-quality issue at the backend), the
+  // top-keys/top-models/top-model-groups/provider aggregations must
+  // skip those entries instead of throwing
+  // `Cannot read properties of undefined (reading 'spend')`.
+  it("should not crash when breakdown entries are missing inner metrics", async () => {
+    const partialSpendData = {
+      ...mockSpendData,
+      results: [
+        {
+          date: "2025-01-01",
+          metrics: mockSpendData.results[0].metrics,
+          breakdown: {
+            models: {
+              "model-x": {
+                metrics: {
+                  spend: 12.5,
+                  api_requests: 100,
+                  successful_requests: 95,
+                  failed_requests: 5,
+                  total_tokens: 1000,
+                  prompt_tokens: 600,
+                  completion_tokens: 400,
+                  cache_read_input_tokens: 0,
+                  cache_creation_input_tokens: 0,
+                },
+                metadata: {},
+                api_key_breakdown: {},
+              },
+              "model-broken": {
+                // Inner `metrics` deliberately missing — this used to crash
+                // the page with `Cannot read properties of undefined`.
+                metadata: {},
+                api_key_breakdown: {},
+              },
+            },
+            model_groups: {
+              "group-x": {
+                metrics: {
+                  spend: 12.5,
+                  api_requests: 100,
+                  successful_requests: 95,
+                  failed_requests: 5,
+                  total_tokens: 1000,
+                  prompt_tokens: 600,
+                  completion_tokens: 400,
+                  cache_read_input_tokens: 0,
+                  cache_creation_input_tokens: 0,
+                },
+                metadata: {},
+                api_key_breakdown: {},
+              },
+              "group-broken": {
+                metadata: {},
+                api_key_breakdown: {},
+              },
+            },
+            providers: {
+              openai: mockSpendData.results[0].breakdown.providers.openai,
+              broken: { metadata: {} },
+            },
+            api_keys: {
+              "sk-test123": {
+                // Missing inner `metrics`
+                metadata: { key_alias: "Test Key", tags: ["production"] },
+              },
+            },
+            mcp_servers: {},
+            entities: {},
+          },
+        },
+      ],
+      metadata: { ...mockSpendData.metadata, total_pages: 1, page: 1, has_more: false },
+    };
+
+    mockUserDailyActivityAggregatedCall.mockResolvedValueOnce(partialSpendData);
+
+    // Should not throw — the page should render with partial data.
+    expect(() => renderWithProviders(<UsagePage {...defaultProps} />)).not.toThrow();
+
+    // Wait for the request to be made — proves the consumer ran
+    // (without crashing) past the data fetch.
+    await waitFor(() => {
+      expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalled();
+    });
+  });
+
+  // Regression test for https://github.com/BerriAI/litellm/issues/33381
+  // When an api_keys breakdown entry has no `metadata` field at all, the
+  // topKeys aggregation must skip it gracefully instead of throwing
+  // `Cannot read properties of undefined (reading 'key_alias')`.
+  it("should not crash when api_keys entries are missing metadata", async () => {
+    const partialSpendData = {
+      ...mockSpendData,
+      results: [
+        {
+          date: "2025-01-01",
+          metrics: mockSpendData.results[0].metrics,
+          breakdown: {
+            ...mockSpendData.results[0].breakdown,
+            api_keys: {
+              "sk-valid": mockSpendData.results[0].breakdown.api_keys["sk-test123"],
+              "sk-no-meta": {
+                metrics: mockSpendData.results[0].breakdown.api_keys["sk-test123"].metrics,
+                // metadata intentionally missing
+              },
+            },
+          },
+        },
+      ],
+      metadata: { ...mockSpendData.metadata, total_pages: 1, page: 1, has_more: false },
+    };
+
+    mockUserDailyActivityAggregatedCall.mockResolvedValueOnce(partialSpendData);
+
+    expect(() => renderWithProviders(<UsagePage {...defaultProps} />)).not.toThrow();
+
+    await waitFor(() => {
+      expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalled();
+    });
+  });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.tsx
@@ -269,15 +269,15 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
             api_key_breakdown: {},
           };
         }
-        modelSpend[model].metrics.spend += metrics.metrics.spend;
-        modelSpend[model].metrics.prompt_tokens += metrics.metrics.prompt_tokens;
-        modelSpend[model].metrics.completion_tokens += metrics.metrics.completion_tokens;
-        modelSpend[model].metrics.total_tokens += metrics.metrics.total_tokens;
-        modelSpend[model].metrics.api_requests += metrics.metrics.api_requests;
-        modelSpend[model].metrics.successful_requests += metrics.metrics.successful_requests || 0;
-        modelSpend[model].metrics.failed_requests += metrics.metrics.failed_requests || 0;
-        modelSpend[model].metrics.cache_read_input_tokens += metrics.metrics.cache_read_input_tokens || 0;
-        modelSpend[model].metrics.cache_creation_input_tokens += metrics.metrics.cache_creation_input_tokens || 0;
+        modelSpend[model].metrics.spend += metrics.metrics?.spend ?? 0;
+        modelSpend[model].metrics.prompt_tokens += metrics.metrics?.prompt_tokens ?? 0;
+        modelSpend[model].metrics.completion_tokens += metrics.metrics?.completion_tokens ?? 0;
+        modelSpend[model].metrics.total_tokens += metrics.metrics?.total_tokens ?? 0;
+        modelSpend[model].metrics.api_requests += metrics.metrics?.api_requests ?? 0;
+        modelSpend[model].metrics.successful_requests += metrics.metrics?.successful_requests ?? 0;
+        modelSpend[model].metrics.failed_requests += metrics.metrics?.failed_requests ?? 0;
+        modelSpend[model].metrics.cache_read_input_tokens += metrics.metrics?.cache_read_input_tokens ?? 0;
+        modelSpend[model].metrics.cache_creation_input_tokens += metrics.metrics?.cache_creation_input_tokens ?? 0;
       });
     });
 
@@ -315,16 +315,16 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
             api_key_breakdown: {},
           };
         }
-        modelGroupSpend[modelGroup].metrics.spend += metrics.metrics.spend;
-        modelGroupSpend[modelGroup].metrics.prompt_tokens += metrics.metrics.prompt_tokens;
-        modelGroupSpend[modelGroup].metrics.completion_tokens += metrics.metrics.completion_tokens;
-        modelGroupSpend[modelGroup].metrics.total_tokens += metrics.metrics.total_tokens;
-        modelGroupSpend[modelGroup].metrics.api_requests += metrics.metrics.api_requests;
-        modelGroupSpend[modelGroup].metrics.successful_requests += metrics.metrics.successful_requests || 0;
-        modelGroupSpend[modelGroup].metrics.failed_requests += metrics.metrics.failed_requests || 0;
-        modelGroupSpend[modelGroup].metrics.cache_read_input_tokens += metrics.metrics.cache_read_input_tokens || 0;
+        modelGroupSpend[modelGroup].metrics.spend += metrics.metrics?.spend ?? 0;
+        modelGroupSpend[modelGroup].metrics.prompt_tokens += metrics.metrics?.prompt_tokens ?? 0;
+        modelGroupSpend[modelGroup].metrics.completion_tokens += metrics.metrics?.completion_tokens ?? 0;
+        modelGroupSpend[modelGroup].metrics.total_tokens += metrics.metrics?.total_tokens ?? 0;
+        modelGroupSpend[modelGroup].metrics.api_requests += metrics.metrics?.api_requests ?? 0;
+        modelGroupSpend[modelGroup].metrics.successful_requests += metrics.metrics?.successful_requests ?? 0;
+        modelGroupSpend[modelGroup].metrics.failed_requests += metrics.metrics?.failed_requests ?? 0;
+        modelGroupSpend[modelGroup].metrics.cache_read_input_tokens += metrics.metrics?.cache_read_input_tokens ?? 0;
         modelGroupSpend[modelGroup].metrics.cache_creation_input_tokens +=
-          metrics.metrics.cache_creation_input_tokens || 0;
+          metrics.metrics?.cache_creation_input_tokens ?? 0;
       });
     });
 
@@ -363,16 +363,16 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
             api_key_breakdown: {},
           };
         }
-        providerSpendMap[provider].metrics.spend += metrics.metrics.spend;
-        providerSpendMap[provider].metrics.prompt_tokens += metrics.metrics.prompt_tokens;
-        providerSpendMap[provider].metrics.completion_tokens += metrics.metrics.completion_tokens;
-        providerSpendMap[provider].metrics.total_tokens += metrics.metrics.total_tokens;
-        providerSpendMap[provider].metrics.api_requests += metrics.metrics.api_requests;
-        providerSpendMap[provider].metrics.successful_requests += metrics.metrics.successful_requests || 0;
-        providerSpendMap[provider].metrics.failed_requests += metrics.metrics.failed_requests || 0;
-        providerSpendMap[provider].metrics.cache_read_input_tokens += metrics.metrics.cache_read_input_tokens || 0;
+        providerSpendMap[provider].metrics.spend += metrics.metrics?.spend ?? 0;
+        providerSpendMap[provider].metrics.prompt_tokens += metrics.metrics?.prompt_tokens ?? 0;
+        providerSpendMap[provider].metrics.completion_tokens += metrics.metrics?.completion_tokens ?? 0;
+        providerSpendMap[provider].metrics.total_tokens += metrics.metrics?.total_tokens ?? 0;
+        providerSpendMap[provider].metrics.api_requests += metrics.metrics?.api_requests ?? 0;
+        providerSpendMap[provider].metrics.successful_requests += metrics.metrics?.successful_requests ?? 0;
+        providerSpendMap[provider].metrics.failed_requests += metrics.metrics?.failed_requests ?? 0;
+        providerSpendMap[provider].metrics.cache_read_input_tokens += metrics.metrics?.cache_read_input_tokens ?? 0;
         providerSpendMap[provider].metrics.cache_creation_input_tokens +=
-          metrics.metrics.cache_creation_input_tokens || 0;
+          metrics.metrics?.cache_creation_input_tokens ?? 0;
       });
     });
 
@@ -405,21 +405,21 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
               cache_creation_input_tokens: 0,
             },
             metadata: {
-              key_alias: metrics.metadata.key_alias,
+              key_alias: metrics.metadata?.key_alias ?? null,
               team_id: null,
-              tags: metrics.metadata.tags || [],
+              tags: metrics.metadata?.tags ?? [],
             },
           };
         }
-        keySpend[key].metrics.spend += metrics.metrics.spend;
-        keySpend[key].metrics.prompt_tokens += metrics.metrics.prompt_tokens;
-        keySpend[key].metrics.completion_tokens += metrics.metrics.completion_tokens;
-        keySpend[key].metrics.total_tokens += metrics.metrics.total_tokens;
-        keySpend[key].metrics.api_requests += metrics.metrics.api_requests;
-        keySpend[key].metrics.successful_requests += metrics.metrics.successful_requests;
-        keySpend[key].metrics.failed_requests += metrics.metrics.failed_requests;
-        keySpend[key].metrics.cache_read_input_tokens += metrics.metrics.cache_read_input_tokens || 0;
-        keySpend[key].metrics.cache_creation_input_tokens += metrics.metrics.cache_creation_input_tokens || 0;
+        keySpend[key].metrics.spend += metrics.metrics?.spend ?? 0;
+        keySpend[key].metrics.prompt_tokens += metrics.metrics?.prompt_tokens ?? 0;
+        keySpend[key].metrics.completion_tokens += metrics.metrics?.completion_tokens ?? 0;
+        keySpend[key].metrics.total_tokens += metrics.metrics?.total_tokens ?? 0;
+        keySpend[key].metrics.api_requests += metrics.metrics?.api_requests ?? 0;
+        keySpend[key].metrics.successful_requests += metrics.metrics?.successful_requests ?? 0;
+        keySpend[key].metrics.failed_requests += metrics.metrics?.failed_requests ?? 0;
+        keySpend[key].metrics.cache_read_input_tokens += metrics.metrics?.cache_read_input_tokens ?? 0;
+        keySpend[key].metrics.cache_creation_input_tokens += metrics.metrics?.cache_creation_input_tokens ?? 0;
       });
     });
 
@@ -1022,12 +1022,12 @@ const getModelActivityData = (userSpendData: { results: DailyData[]; metadata: a
         };
       }
 
-      modelData[model].total_requests += metrics.metrics.api_requests;
-      modelData[model].total_tokens += metrics.metrics.total_tokens;
+      modelData[model].total_requests += metrics.metrics?.api_requests ?? 0;
+      modelData[model].total_tokens += metrics.metrics?.total_tokens ?? 0;
       modelData[model].daily_data.push({
         date: day.date,
-        api_requests: metrics.metrics.api_requests,
-        total_tokens: metrics.metrics.total_tokens,
+        api_requests: metrics.metrics?.api_requests ?? 0,
+        total_tokens: metrics.metrics?.total_tokens ?? 0,
       });
     });
   });


### PR DESCRIPTION
## Summary

The Cost/Global Usage page crashed with
`Cannot read properties of undefined (reading 'spend')` on
deployments whose `/user/daily/activity` response included
breakdown entries where the inner `metrics` object was absent.

This was data-state dependent — a malformed breakdown entry on
any page caused `topModels` / `topModelGroups` / `providerSpend`
/ `topKeys` to throw during the synchronous page-1 render, even
though the page-aware `usePaginatedDailyActivity` hook was
already sequentially fetching all 36 pages. The page rendered
its chrome then died before the subsequent pages arrived.

## Reproduction

1. Use a deployment where the daily-activity breakdown for the
   selected range spans more than one page (`total_pages > 1`,
   `has_more: true`).
2. Ensure that any single page in the response includes a
   breakdown entry (model / model_group / provider / api_key)
   whose inner `metrics` field is missing.
3. Open Admin UI → Usage → Cost / Global Usage.
4. The page renders briefly, then crashes.

## Fix

Guard every per-field read with `metrics.metrics?.X ?? 0` so a
malformed entry contributes zero to the accumulator instead of
taking the page down. The accumulator's own metrics object is
always initialised to our zero defaults, so the accumulator
side stays safe.

The same fix is applied to the related aggregation paths in:

- `UsagePageView.tsx` — `topModels`, `topModelGroups`,
  `providerSpend`, `topKeys`, and the standalone
  `getModelActivityData` helper.
- `EntityUsage/EntityUsage.tsx` — `keySpend`, `providerSpend`,
  `getTopModels`, `getProviderSpend`.
- `EndpointUsage/EndpointUsage.tsx` — `endpointData`.

`EntityUsage` previously had a `try/catch` around the `spend`
update inside `getTopModels` and `getProviderSpend` — those
catch blocks were swallowing the throw and only logging to
console, while the unguarded reads for the other fields on the
same entry still crashed. Both try/catch blocks were removed
in favour of the consistent null-guard pattern.

## Regression tests

`UsagePageView.test.tsx`:

- `should not crash when breakdown entries are missing inner metrics` —
  feeds a response with deliberate missing `metrics` on
  `models["model-broken"]`, `model_groups["group-broken"]`,
  `providers.broken`, and `api_keys["sk-test123"]`, plus a
  sibling valid entry (`model-x`, `group-x`), and asserts the
  page renders without throwing and the request is fired.
- `should not crash when api_keys entries are missing metadata` —
  feeds a response with an api_key entry whose `metadata` field
  is entirely missing, and asserts the page renders without
  throwing.

## Verification

- `npx vitest run src/app/(dashboard)/usage` → **124 passed (124)**
  across 10 test files.
- `npx tsc --noEmit` → no new errors introduced by this PR (the
  pre-existing errors in `roles.test.ts`, `top_key_view.test.tsx`,
  `returnUrlUtils.test.ts` are unrelated and predate this change).
- `npx eslint` on changed files → **0 errors**, 68 pre-existing
  warnings (none new from this change).
- `npx prettier --check` on changed files → all formatted.

Fixes #33381