### PR TITLE
fix(ui-dashboard): resolve model filter returning no data on models page

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.test.ts
@@ -109,6 +109,7 @@ describe("useModelsInfo", () => {
       undefined,
       undefined,
       undefined,
+      undefined,
     );
     expect(modelInfoCall).toHaveBeenCalledTimes(1);
   });
@@ -133,6 +134,34 @@ describe("useModelsInfo", () => {
       undefined,
       undefined,
       undefined,
+      undefined,
+    );
+  });
+
+  it("should forward the exact public model name filter to modelInfoCall", async () => {
+    (modelInfoCall as any).mockResolvedValue(mockPaginatedModelInfoResponse);
+
+    const { result } = renderHook(
+      () => useModelsInfo(1, 50, undefined, undefined, undefined, undefined, undefined, "gpt-4"),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(modelInfoCall).toHaveBeenCalledWith(
+      "test-access-token",
+      "test-user-id",
+      "Admin",
+      1,
+      50,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "gpt-4",
     );
   });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
@@ -37,6 +37,7 @@ export const useModelsInfo = (
   teamId?: string,
   sortBy?: string,
   sortOrder?: string,
+  model?: string,
 ) => {
   const { accessToken, userId, userRole } = useAuthorized();
   return useQuery<PaginatedModelInfoResponse>({
@@ -51,10 +52,23 @@ export const useModelsInfo = (
         ...(teamId && { teamId }),
         ...(sortBy && { sortBy }),
         ...(sortOrder && { sortOrder }),
+        ...(model && { model }),
       },
     }),
     queryFn: async () =>
-      await modelInfoCall(accessToken!, userId!, userRole!, page, size, search, modelId, teamId, sortBy, sortOrder),
+      await modelInfoCall(
+        accessToken!,
+        userId!,
+        userRole!,
+        page,
+        size,
+        search,
+        modelId,
+        teamId,
+        sortBy,
+        sortOrder,
+        model,
+      ),
     enabled: Boolean(accessToken && userId && userRole),
   });
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.test.tsx
@@ -38,7 +38,7 @@ const mockUseModelsInfo = vi.fn(() => ({
 })) as any;
 
 vi.mock("../../hooks/models/useModels", () => ({
-  useModelsInfo: (page?: number, size?: number, search?: string) => mockUseModelsInfo(page, size, search),
+  useModelsInfo: (...args: any[]) => mockUseModelsInfo(...args),
 }));
 
 // Mock the useModelCostMap hook
@@ -658,5 +658,115 @@ describe("AllModelsTab", () => {
     await waitFor(() => {
       expect(mockSetSelectedModelId).toHaveBeenCalledWith("clickable-model-id");
     });
+  });
+
+  it("should filter by public model name via the server query instead of the current page (regression #32573)", async () => {
+    mockUseTeams.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    mockUseModelCostMap.mockReturnValue(
+      createModelCostMapMock({
+        "gpt-4-page1": { litellm_provider: "openai" },
+        "gpt-4-page2": { litellm_provider: "openai" },
+      }),
+    );
+
+    const rowFor = (modelName: string) => ({
+      model_name: modelName,
+      litellm_model_name: modelName,
+      provider: "openai",
+      model_info: {
+        id: `id-${modelName}`,
+        db_model: true,
+        direct_access: true,
+        access_via_team_ids: [],
+        access_groups: [],
+      },
+    });
+
+    mockUseModelsInfo.mockImplementation((...args: any[]) => {
+      const model = args[7];
+      const rows = model === "gpt-4-page2" ? [rowFor("gpt-4-page2")] : [rowFor("gpt-4-page1")];
+      return {
+        data: createPaginatedModelData(rows, rows.length, 1, 1, 50),
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      };
+    });
+
+    renderWithProviders(<AllModelsTab {...defaultProps} selectedModelGroup="gpt-4-page2" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("gpt-4-page2")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("gpt-4-page1")).not.toBeInTheDocument();
+    expect(mockUseModelsInfo).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "gpt-4-page2",
+    );
+  });
+
+  it("should not send a model filter for the 'all' and 'wildcard' buckets", async () => {
+    mockUseTeams.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    mockUseModelCostMap.mockReturnValue(createModelCostMapMock({ "openai/*": { litellm_provider: "openai" } }));
+
+    mockUseModelsInfo.mockReturnValue({
+      data: createPaginatedModelData(
+        [
+          {
+            model_name: "openai/*",
+            litellm_model_name: "openai/*",
+            provider: "openai",
+            model_info: {
+              id: "id-wildcard",
+              db_model: true,
+              direct_access: true,
+              access_via_team_ids: [],
+              access_groups: [],
+            },
+          },
+        ],
+        1,
+        1,
+        1,
+        50,
+      ),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    renderWithProviders(<AllModelsTab {...defaultProps} selectedModelGroup="wildcard" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("openai/*")).toBeInTheDocument();
+    });
+    expect(mockUseModelsInfo).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.tsx
@@ -96,11 +96,25 @@ const AllModelsTab = ({
     return sort.desc ? "desc" : "asc";
   }, [sorting]);
 
+  const modelNameFilter =
+    selectedModelGroup && selectedModelGroup !== "all" && selectedModelGroup !== "wildcard"
+      ? selectedModelGroup
+      : undefined;
+
   const {
     data: rawModelData,
     isLoading: isLoadingModelsInfo,
     refetch: refetchModels,
-  } = useModelsInfo(currentPage, pageSize, debouncedSearch || undefined, undefined, teamIdForQuery, sortBy, sortOrder);
+  } = useModelsInfo(
+    currentPage,
+    pageSize,
+    debouncedSearch || undefined,
+    undefined,
+    teamIdForQuery,
+    sortBy,
+    sortOrder,
+    modelNameFilter,
+  );
   const isLoading = isLoadingModelsInfo || isLoadingModelCostMap;
 
   const getProviderFromModel = (model: string) => {
@@ -145,11 +159,7 @@ const AllModelsTab = ({
 
     // Server-side search is now handled by the API, so we only filter by other criteria
     return modelData.data.filter((model: any) => {
-      const modelNameMatch =
-        selectedModelGroup === "all" ||
-        model.model_name === selectedModelGroup ||
-        !selectedModelGroup ||
-        (selectedModelGroup === "wildcard" && model.model_name?.includes("*"));
+      const modelNameMatch = selectedModelGroup !== "wildcard" || Boolean(model.model_name?.includes("*"));
 
       const accessGroupMatch =
         selectedModelAccessGroupFilter === "all" ||

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -1603,6 +1603,7 @@ export const modelInfoCall = async (
   teamId?: string,
   sortBy?: string,
   sortOrder?: string,
+  model?: string,
 ) => {
   /**
    * Get all models on proxy
@@ -1615,6 +1616,9 @@ export const modelInfoCall = async (
     params.append("size", size.toString());
     if (search && search.trim()) {
       params.append("search", search.trim());
+    }
+    if (model && model.trim()) {
+      params.append("model", model.trim());
     }
     if (modelId && modelId.trim()) {
       params.append("modelId", modelId.trim());


### PR DESCRIPTION
## Relevant issues

Fixes #32573

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Captured against a live DB-backed proxy (Postgres) using the dev config's model list. The symptom only appears once the model list paginates, so these runs use `size=5` to force pagination (40 models across 8 pages); `gpt-4o-mini` sits on a later page, not page 1.

Before, the request the pre-fix UI issued (commit c2141b1113): no `model` param, so it fetched a page and filtered it client-side

```
curl -s 'http://localhost:4000/v2/model/info?include_team_models=true&page=1&size=5' \
  -H 'Authorization: Bearer sk-1234'
```
Page 1 returns five models, none of them `gpt-4o-mini`:
```
total_count: 40, total_pages: 8, current_page: 1
model_names: [anthropic-haiku-4-5, anthropic-sonnet-4-5, anthropic-opus-4-5, anthropic-sonnet-4-6, anthropic-opus-4-6]
```
Selecting `gpt-4o-mini` filtered those five visible rows down to zero, so the table rendered empty; that is #32573

After, the request the fixed UI issues (commit c7137e632e): the selected model goes to the server

```
curl -s 'http://localhost:4000/v2/model/info?include_team_models=true&page=1&size=5&model=gpt-4o-mini' \
  -H 'Authorization: Bearer sk-1234'
```
The endpoint applies its existing exact `model_name` filter and returns the model regardless of page:
```
total_count: 1, total_pages: 1, current_page: 1
model_names: [gpt-4o-mini]
```

UI screenshots to follow: on the dev server open Models + Endpoints -> All Models, DevTools Network filtered to `model/info`, select a model, and the request now carries `&model=<name>`; the same action on the bundled `/ui` build sends no such param

## Type

🐛 Bug Fix

## Changes

The All Models tab filtered by the selected model on the client, over only the rows of the current page returned by `/v2/model/info`. Because that endpoint is paginated (default size 50), any selected model that lived on a different page was filtered out to nothing and the table showed no data

`/v2/model/info` already supports an exact `model_name` filter through its `model` query parameter, so this threads the selected public model name from `AllModelsTab` through `useModelsInfo` and `modelInfoCall` into the request, and drops the broken current-page client filter. The "all" and "wildcard" buckets deliberately send no `model` param; wildcard entries are still matched client-side by their `*`

Added a regression test that renders the tab with a model present only on a later page and asserts it still shows, plus tests that the filter is forwarded to `modelInfoCall` and that the "all" and "wildcard" buckets send no filter

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
