### PR TITLE
fix(bedrock): preserve cache_control when rewriting to guarded_text (#33281)

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -178,17 +178,37 @@ class AmazonConverseConfig(BaseConfig):
                 new_content = []
                 for item in content:
                     if isinstance(item, dict) and item.get("type") == "text":
-                        new_item = {"type": "guarded_text", "text": item["text"]}  # type: ignore
+                        new_item: dict = {"type": "guarded_text", "text": item["text"]}
+                        # Carry over the OpenAI-style ``cache_control`` marker so
+                        # the per-element cache-point loop in
+                        # ``_bedrock_converse_messages_pt`` still emits a
+                        # ``cachePoint`` block for this (now-guarded) text.
+                        # Without this, turning on guardrailConfig silently
+                        # drops prompt-cache breakpoints on every trailing
+                        # user message that used ``index: -1`` or had a
+                        # block-level ``cache_control`` set directly.
+                        item_cache_control = item.get("cache_control")
+                        if item_cache_control is not None:
+                            new_item["cache_control"] = item_cache_control
                         new_content.append(new_item)
                     else:
                         new_content.append(item)
 
                 messages_copy[user_message_index]["content"] = new_content  # type: ignore
             elif isinstance(content, str):
-                # If content is a string, convert it to guarded_text
-                messages_copy[user_message_index]["content"] = [  # type: ignore
-                    {"type": "guarded_text", "text": content}  # type: ignore
-                ]
+                # If content is a string, convert it to guarded_text. Promote
+                # the message-level ``cache_control`` marker to the resulting
+                # ``guarded_text`` element so the per-element cache-point loop
+                # still emits a ``cachePoint`` block. The previous rewrite
+                # dropped the marker here because the user-message branch of
+                # the prompt factory only honors message-level ``cache_control``
+                # for string content — once content becomes a list, only
+                # element-level markers are read.
+                new_item = {"type": "guarded_text", "text": content}
+                user_message_cache_control = user_message.get("cache_control")
+                if user_message_cache_control is not None:
+                    new_item["cache_control"] = user_message_cache_control
+                messages_copy[user_message_index]["content"] = [new_item]  # type: ignore
 
         return messages_copy
 

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -6,9 +6,7 @@ import sys
 import pytest
 from fastapi.testclient import TestClient
 
-sys.path.insert(
-    0, os.path.abspath("../../../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../../.."))  # Adds the parent directory to the system path
 from unittest.mock import MagicMock, patch
 
 import litellm
@@ -33,16 +31,11 @@ def test_transform_usage():
     openai_usage = config._transform_usage(usage)
     assert (
         openai_usage.prompt_tokens
-        == usage["inputTokens"]
-        + usage["cacheReadInputTokens"]
-        + usage["cacheWriteInputTokens"]
+        == usage["inputTokens"] + usage["cacheReadInputTokens"] + usage["cacheWriteInputTokens"]
     )
     assert openai_usage.completion_tokens == usage["outputTokens"]
     assert openai_usage.total_tokens == usage["totalTokens"]
-    assert (
-        openai_usage.prompt_tokens_details.cached_tokens
-        == usage["cacheReadInputTokens"]
-    )
+    assert openai_usage.prompt_tokens_details.cached_tokens == usage["cacheReadInputTokens"]
     assert openai_usage._cache_creation_input_tokens == usage["cacheWriteInputTokens"]
     assert openai_usage._cache_read_input_tokens == usage["cacheReadInputTokens"]
     # completion_tokens_details should always be populated
@@ -196,14 +189,10 @@ def test_apply_tool_call_transformation_if_needed():
         role="user",
         content=json.dumps(tool_response),
     )
-    transformed_message, _ = config.apply_tool_call_transformation_if_needed(
-        message, tool_calls
-    )
+    transformed_message, _ = config.apply_tool_call_transformation_if_needed(message, tool_calls)
     assert len(transformed_message.tool_calls) == 1
     assert transformed_message.tool_calls[0].function.name == "test_function"
-    assert transformed_message.tool_calls[0].function.arguments == json.dumps(
-        tool_response["parameters"]
-    )
+    assert transformed_message.tool_calls[0].function.arguments == json.dumps(tool_response["parameters"])
 
 
 def test_transform_tool_call_with_cache_control():
@@ -252,12 +241,7 @@ def test_transform_tool_call_with_cache_control():
     print(function_out_msg)
     assert function_out_msg["toolSpec"]["name"] == "get_location"
     assert function_out_msg["toolSpec"]["description"] == "Get the user's location"
-    assert (
-        function_out_msg["toolSpec"]["inputSchema"]["json"]["properties"]["location"][
-            "type"
-        ]
-        == "string"
-    )
+    assert function_out_msg["toolSpec"]["inputSchema"]["json"]["properties"]["location"]["type"] == "string"
 
     transformed_cache_msg = result["toolConfig"]["tools"][1]
     assert "cachePoint" in transformed_cache_msg
@@ -324,9 +308,7 @@ def test_reasoning_effort_none_omits_thinking_for_anthropic_converse(model):
         ("bedrock/converse/us.anthropic.claude-sonnet-4-6", "minimal", "low"),
     ],
 )
-def test_reasoning_effort_sets_output_config_for_adaptive_models_converse(
-    model, effort, expected_effort
-):
+def test_reasoning_effort_sets_output_config_for_adaptive_models_converse(model, effort, expected_effort):
     """Adaptive Claude 4.6 / 4.7 on Bedrock Converse routes the tier via ``output_config.effort``."""
     config = AmazonConverseConfig()
 
@@ -397,9 +379,7 @@ def test_output_config_format_translated_to_native_output_config_converse():
     assert additional.get("output_config") == {"effort": "xhigh"}
     assert "format" not in additional["output_config"]
     assert result["outputConfig"]["textFormat"]["type"] == "json_schema"
-    parsed_schema = json.loads(
-        result["outputConfig"]["textFormat"]["structure"]["jsonSchema"]["schema"]
-    )
+    parsed_schema = json.loads(result["outputConfig"]["textFormat"]["structure"]["jsonSchema"]["schema"])
     assert parsed_schema == {**schema, "additionalProperties": False}
 
 
@@ -435,10 +415,7 @@ def test_output_config_format_dropped_on_unsupported_converse_model_warns(caplog
             )
 
     assert "outputConfig" not in result
-    assert any(
-        "dropping `output_config.format`" in record.getMessage()
-        for record in caplog.records
-    )
+    assert any("dropping `output_config.format`" in record.getMessage() for record in caplog.records)
 
 
 def test_output_config_normalized_marker_does_not_leak_into_optional_params():
@@ -474,9 +451,7 @@ def test_output_config_normalized_marker_does_not_leak_into_optional_params():
         ("bedrock/converse/us.anthropic.claude-opus-4-7", "xhigh"),
     ],
 )
-def test_output_config_effort_normalized_for_bedrock_converse_opus(
-    model, expected_effort
-):
+def test_output_config_effort_normalized_for_bedrock_converse_opus(model, expected_effort):
     """Bedrock Converse accepts ``xhigh`` and forwards the provider-safe effort."""
     config = AmazonConverseConfig()
 
@@ -564,17 +539,13 @@ def test_get_supported_openai_params_bedrock_converse():
     for model in litellm.BEDROCK_CONVERSE_MODELS:
         print(f"Testing model: {model}")
         config = AmazonConverseConfig()
-        supported_params_without_prefix = config.get_supported_openai_params(
-            model=model
-        )
+        supported_params_without_prefix = config.get_supported_openai_params(model=model)
 
-        supported_params_with_prefix = config.get_supported_openai_params(
-            model=f"bedrock/converse/{model}"
-        )
+        supported_params_with_prefix = config.get_supported_openai_params(model=f"bedrock/converse/{model}")
 
-        assert set(supported_params_without_prefix) == set(
-            supported_params_with_prefix
-        ), f"Supported params mismatch for model: {model}. Without prefix: {supported_params_without_prefix}, With prefix: {supported_params_with_prefix}"
+        assert set(supported_params_without_prefix) == set(supported_params_with_prefix), (
+            f"Supported params mismatch for model: {model}. Without prefix: {supported_params_without_prefix}, With prefix: {supported_params_with_prefix}"
+        )
         print(f"✅ Passed for model: {model}")
 
 
@@ -632,9 +603,7 @@ def test_parallel_tool_calls_config_kept_for_sonnet_5():
             messages=None,
         )
 
-        assert data["additionalModelRequestFields"]["tool_choice"] == {
-            "disable_parallel_tool_use": True
-        }
+        assert data["additionalModelRequestFields"]["tool_choice"] == {"disable_parallel_tool_use": True}
     finally:
         litellm.model_cost = old_cost
         if old_env is None:
@@ -981,9 +950,7 @@ def test_transform_response_with_structured_response_calling_tool():
         "output": {
             "message": {
                 "content": [
-                    {
-                        "text": "I'll check the current weather in San Francisco for you."
-                    },
+                    {"text": "I'll check the current weather in San Francisco for you."},
                     {
                         "toolUse": {
                             "input": {
@@ -1512,9 +1479,7 @@ def test_transform_request_with_function_tool():
         }
     ]
 
-    messages = [
-        {"role": "user", "content": "What's the weather like in San Francisco?"}
-    ]
+    messages = [{"role": "user", "content": "What's the weather like in San Francisco?"}]
 
     # Transform request
     request_data = config.transform_request(
@@ -1622,22 +1587,18 @@ async def test_assistant_message_cache_control():
         llm_provider="bedrock_converse",
     )
 
-    async_result = (
-        await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
-            messages=messages,
-            model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
-            llm_provider="bedrock_converse",
-        )
+    async_result = await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
+        messages=messages,
+        model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        llm_provider="bedrock_converse",
     )
 
     assert result == async_result
 
-    async_result = (
-        await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
-            messages=messages,
-            model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
-            llm_provider="bedrock_converse",
-        )
+    async_result = await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
+        messages=messages,
+        model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        llm_provider="bedrock_converse",
     )
 
     assert result == async_result
@@ -1683,12 +1644,10 @@ async def test_assistant_message_list_content_cache_control():
         llm_provider="bedrock_converse",
     )
 
-    async_result = (
-        await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
-            messages=messages,
-            model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
-            llm_provider="bedrock_converse",
-        )
+    async_result = await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
+        messages=messages,
+        model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        llm_provider="bedrock_converse",
     )
 
     assert result == async_result
@@ -1741,12 +1700,10 @@ async def test_tool_message_cache_control():
         llm_provider="bedrock_converse",
     )
 
-    async_result = (
-        await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
-            messages=messages,
-            model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
-            llm_provider="bedrock_converse",
-        )
+    async_result = await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
+        messages=messages,
+        model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        llm_provider="bedrock_converse",
     )
 
     assert result == async_result
@@ -1760,10 +1717,7 @@ async def test_tool_message_cache_control():
 
     # First should be tool result
     assert "toolResult" in tool_message_content[0]
-    assert (
-        tool_message_content[0]["toolResult"]["content"][0]["text"]
-        == "Weather data: sunny, 25°C"
-    )
+    assert tool_message_content[0]["toolResult"]["content"][0]["text"] == "Weather data: sunny, 25°C"
 
     # Second should be cachePoint
     assert "cachePoint" in tool_message_content[1]
@@ -1805,12 +1759,10 @@ async def test_tool_message_string_content_cache_control():
         llm_provider="bedrock_converse",
     )
 
-    async_result = (
-        await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
-            messages=messages,
-            model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
-            llm_provider="bedrock_converse",
-        )
+    async_result = await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
+        messages=messages,
+        model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        llm_provider="bedrock_converse",
     )
 
     assert result == async_result
@@ -1821,10 +1773,7 @@ async def test_tool_message_string_content_cache_control():
 
     # First should be tool result
     assert "toolResult" in tool_message_content[0]
-    assert (
-        tool_message_content[0]["toolResult"]["content"][0]["text"]
-        == "Weather: sunny, 25°C"
-    )
+    assert tool_message_content[0]["toolResult"]["content"][0]["text"] == "Weather: sunny, 25°C"
 
     # Second should be cachePoint
     assert "cachePoint" in tool_message_content[1]
@@ -1864,9 +1813,7 @@ async def test_tool_message_search_results_maps_to_bedrock_search_result_block()
                     "source": "Great Source of Information About Apptio",
                     "title": "12adbd74-46bd-4a88-88b2-0048755f6eb5",
                     "content": [
-                        {
-                            "text": "Apptio is a company that makes calls to Bedrock using passthrough APIs via LiteLLM"
-                        }
+                        {"text": "Apptio is a company that makes calls to Bedrock using passthrough APIs via LiteLLM"}
                     ],
                     "citations": {"enabled": True},
                 }
@@ -1879,12 +1826,10 @@ async def test_tool_message_search_results_maps_to_bedrock_search_result_block()
         model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
         llm_provider="bedrock_converse",
     )
-    async_result = (
-        await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
-            messages=messages,
-            model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
-            llm_provider="bedrock_converse",
-        )
+    async_result = await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
+        messages=messages,
+        model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        llm_provider="bedrock_converse",
     )
     assert result == async_result
 
@@ -1893,10 +1838,7 @@ async def test_tool_message_search_results_maps_to_bedrock_search_result_block()
     assert tool_result["status"] == "success"
     assert len(tool_result["content"]) == 1
     assert "searchResult" in tool_result["content"][0]
-    assert (
-        tool_result["content"][0]["searchResult"]["title"]
-        == "12adbd74-46bd-4a88-88b2-0048755f6eb5"
-    )
+    assert tool_result["content"][0]["searchResult"]["title"] == "12adbd74-46bd-4a88-88b2-0048755f6eb5"
 
 
 @pytest.mark.asyncio
@@ -1933,12 +1875,10 @@ async def test_tool_message_empty_search_results_falls_back_to_content():
         model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
         llm_provider="bedrock_converse",
     )
-    async_result = (
-        await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
-            messages=messages,
-            model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
-            llm_provider="bedrock_converse",
-        )
+    async_result = await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
+        messages=messages,
+        model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        llm_provider="bedrock_converse",
     )
     assert result == async_result
 
@@ -2100,12 +2040,10 @@ async def test_assistant_tool_calls_cache_control():
         llm_provider="bedrock_converse",
     )
 
-    async_result = (
-        await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
-            messages=messages,
-            model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
-            llm_provider="bedrock_converse",
-        )
+    async_result = await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
+        messages=messages,
+        model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        llm_provider="bedrock_converse",
     )
 
     assert result == async_result
@@ -2160,12 +2098,10 @@ async def test_multiple_tool_calls_with_mixed_cache_control():
         llm_provider="bedrock_converse",
     )
 
-    async_result = (
-        await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
-            messages=messages,
-            model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
-            llm_provider="bedrock_converse",
-        )
+    async_result = await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
+        messages=messages,
+        model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        llm_provider="bedrock_converse",
     )
 
     assert result == async_result
@@ -2211,12 +2147,10 @@ async def test_no_cache_control_no_cache_point():
         llm_provider="bedrock_converse",
     )
 
-    async_result = (
-        await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
-            messages=messages,
-            model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
-            llm_provider="bedrock_converse",
-        )
+    async_result = await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
+        messages=messages,
+        model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        llm_provider="bedrock_converse",
     )
 
     assert result == async_result
@@ -2386,10 +2320,7 @@ def test_guarded_text_with_mixed_content_types():
 
     # Third should be guardContent
     assert "guardContent" in content[2]
-    assert (
-        content[2]["guardContent"]["text"]["text"]
-        == "This sensitive content should be guarded"
-    )
+    assert content[2]["guardContent"]["text"]["text"] == "This sensitive content should be guarded"
 
 
 @pytest.mark.asyncio
@@ -2484,10 +2415,7 @@ def test_guarded_text_with_tool_calls():
 
     # Second should be guardContent
     assert "guardContent" in content[1]
-    assert (
-        content[1]["guardContent"]["text"]["text"]
-        == "Please be careful with sensitive information"
-    )
+    assert content[1]["guardContent"]["text"]["text"] == "Please be careful with sensitive information"
 
     # Other messages should not have guardContent
     for i in range(1, 3):
@@ -2532,10 +2460,7 @@ def test_guarded_text_guardrail_config_preserved():
     # GuardrailConfig should also be in inferenceConfig
     assert "inferenceConfig" in result
     assert "guardrailConfig" in result["inferenceConfig"]
-    assert (
-        result["inferenceConfig"]["guardrailConfig"]["guardrailIdentifier"]
-        == "gr-abc123"
-    )
+    assert result["inferenceConfig"]["guardrailConfig"]["guardrailIdentifier"] == "gr-abc123"
 
 
 def test_auto_convert_last_user_message_to_guarded_text():
@@ -2554,52 +2479,36 @@ def test_auto_convert_last_user_message_to_guarded_text():
         }
     ]
 
-    optional_params = {
-        "guardrailConfig": {"guardrailIdentifier": "gr-abc123", "guardrailVersion": "1"}
-    }
+    optional_params = {"guardrailConfig": {"guardrailIdentifier": "gr-abc123", "guardrailVersion": "1"}}
 
     # Test the helper method directly
-    converted_messages = config._convert_consecutive_user_messages_to_guarded_text(
-        messages, optional_params
-    )
+    converted_messages = config._convert_consecutive_user_messages_to_guarded_text(messages, optional_params)
 
     # Verify the conversion
     assert len(converted_messages) == 1
     assert converted_messages[0]["role"] == "user"
     assert len(converted_messages[0]["content"]) == 1
     assert converted_messages[0]["content"][0]["type"] == "guarded_text"
-    assert (
-        converted_messages[0]["content"][0]["text"]
-        == "What is the main topic of this legal document?"
-    )
+    assert converted_messages[0]["content"][0]["text"] == "What is the main topic of this legal document?"
 
 
 def test_auto_convert_last_user_message_string_content():
     """Test that last user message with string content is automatically converted to guarded_text when guardrailConfig is present."""
     config = AmazonConverseConfig()
 
-    messages = [
-        {"role": "user", "content": "What is the main topic of this legal document?"}
-    ]
+    messages = [{"role": "user", "content": "What is the main topic of this legal document?"}]
 
-    optional_params = {
-        "guardrailConfig": {"guardrailIdentifier": "gr-abc123", "guardrailVersion": "1"}
-    }
+    optional_params = {"guardrailConfig": {"guardrailIdentifier": "gr-abc123", "guardrailVersion": "1"}}
 
     # Test the helper method directly
-    converted_messages = config._convert_consecutive_user_messages_to_guarded_text(
-        messages, optional_params
-    )
+    converted_messages = config._convert_consecutive_user_messages_to_guarded_text(messages, optional_params)
 
     # Verify the conversion
     assert len(converted_messages) == 1
     assert converted_messages[0]["role"] == "user"
     assert len(converted_messages[0]["content"]) == 1
     assert converted_messages[0]["content"][0]["type"] == "guarded_text"
-    assert (
-        converted_messages[0]["content"][0]["text"]
-        == "What is the main topic of this legal document?"
-    )
+    assert converted_messages[0]["content"][0]["text"] == "What is the main topic of this legal document?"
 
 
 def test_no_conversion_when_no_guardrail_config():
@@ -2621,9 +2530,7 @@ def test_no_conversion_when_no_guardrail_config():
     optional_params = {}
 
     # Test the helper method directly
-    converted_messages = config._convert_consecutive_user_messages_to_guarded_text(
-        messages, optional_params
-    )
+    converted_messages = config._convert_consecutive_user_messages_to_guarded_text(messages, optional_params)
 
     # Verify no conversion happened
     assert converted_messages == messages
@@ -2640,14 +2547,10 @@ def test_no_conversion_when_guarded_text_already_present():
         }
     ]
 
-    optional_params = {
-        "guardrailConfig": {"guardrailIdentifier": "gr-abc123", "guardrailVersion": "1"}
-    }
+    optional_params = {"guardrailConfig": {"guardrailIdentifier": "gr-abc123", "guardrailVersion": "1"}}
 
     # Test the helper method directly
-    converted_messages = config._convert_consecutive_user_messages_to_guarded_text(
-        messages, optional_params
-    )
+    converted_messages = config._convert_consecutive_user_messages_to_guarded_text(messages, optional_params)
 
     # Verify no conversion happened
     assert converted_messages == messages
@@ -2673,14 +2576,10 @@ def test_auto_convert_with_mixed_content():
         }
     ]
 
-    optional_params = {
-        "guardrailConfig": {"guardrailIdentifier": "gr-abc123", "guardrailVersion": "1"}
-    }
+    optional_params = {"guardrailConfig": {"guardrailIdentifier": "gr-abc123", "guardrailVersion": "1"}}
 
     # Test the helper method directly
-    converted_messages = config._convert_consecutive_user_messages_to_guarded_text(
-        messages, optional_params
-    )
+    converted_messages = config._convert_consecutive_user_messages_to_guarded_text(messages, optional_params)
 
     # Verify the conversion
     assert len(converted_messages) == 1
@@ -2689,17 +2588,11 @@ def test_auto_convert_with_mixed_content():
 
     # First element should be converted to guarded_text
     assert converted_messages[0]["content"][0]["type"] == "guarded_text"
-    assert (
-        converted_messages[0]["content"][0]["text"]
-        == "What is the main topic of this legal document?"
-    )
+    assert converted_messages[0]["content"][0]["text"] == "What is the main topic of this legal document?"
 
     # Second element should remain unchanged
     assert converted_messages[0]["content"][1]["type"] == "image_url"
-    assert (
-        converted_messages[0]["content"][1]["image_url"]["url"]
-        == "https://example.com/image.jpg"
-    )
+    assert converted_messages[0]["content"][1]["image_url"]["url"] == "https://example.com/image.jpg"
 
 
 def test_auto_convert_in_full_transformation():
@@ -2718,9 +2611,7 @@ def test_auto_convert_in_full_transformation():
         }
     ]
 
-    optional_params = {
-        "guardrailConfig": {"guardrailIdentifier": "gr-abc123", "guardrailVersion": "1"}
-    }
+    optional_params = {"guardrailConfig": {"guardrailIdentifier": "gr-abc123", "guardrailVersion": "1"}}
 
     # Test the full transformation
     result = config._transform_request(
@@ -2740,10 +2631,7 @@ def test_auto_convert_in_full_transformation():
     assert "content" in message
     assert len(message["content"]) == 1
     assert "guardContent" in message["content"][0]
-    assert (
-        message["content"][0]["guardContent"]["text"]["text"]
-        == "What is the main topic of this legal document?"
-    )
+    assert message["content"][0]["guardContent"]["text"]["text"] == "What is the main topic of this legal document?"
 
 
 def test_convert_consecutive_user_messages_to_guarded_text():
@@ -2757,14 +2645,10 @@ def test_convert_consecutive_user_messages_to_guarded_text():
         {"role": "user", "content": [{"type": "text", "text": "Third user message"}]},
     ]
 
-    optional_params = {
-        "guardrailConfig": {"guardrailIdentifier": "gr-abc123", "guardrailVersion": "1"}
-    }
+    optional_params = {"guardrailConfig": {"guardrailIdentifier": "gr-abc123", "guardrailVersion": "1"}}
 
     # Test the helper method directly
-    converted_messages = config._convert_consecutive_user_messages_to_guarded_text(
-        messages, optional_params
-    )
+    converted_messages = config._convert_consecutive_user_messages_to_guarded_text(messages, optional_params)
 
     # Verify the conversion - only the last two user messages should be converted
     assert len(converted_messages) == 4
@@ -2799,14 +2683,10 @@ def test_convert_all_user_messages_when_all_consecutive():
         {"role": "user", "content": [{"type": "text", "text": "Third user message"}]},
     ]
 
-    optional_params = {
-        "guardrailConfig": {"guardrailIdentifier": "gr-abc123", "guardrailVersion": "1"}
-    }
+    optional_params = {"guardrailConfig": {"guardrailIdentifier": "gr-abc123", "guardrailVersion": "1"}}
 
     # Test the helper method directly
-    converted_messages = config._convert_consecutive_user_messages_to_guarded_text(
-        messages, optional_params
-    )
+    converted_messages = config._convert_consecutive_user_messages_to_guarded_text(messages, optional_params)
 
     # Verify all three user messages are converted
     assert len(converted_messages) == 3
@@ -2830,14 +2710,10 @@ def test_convert_consecutive_user_messages_with_string_content():
         {"role": "user", "content": "Second user message"},
     ]
 
-    optional_params = {
-        "guardrailConfig": {"guardrailIdentifier": "gr-abc123", "guardrailVersion": "1"}
-    }
+    optional_params = {"guardrailConfig": {"guardrailIdentifier": "gr-abc123", "guardrailVersion": "1"}}
 
     # Test the helper method directly
-    converted_messages = config._convert_consecutive_user_messages_to_guarded_text(
-        messages, optional_params
-    )
+    converted_messages = config._convert_consecutive_user_messages_to_guarded_text(messages, optional_params)
 
     # Verify the conversion
     assert len(converted_messages) == 3
@@ -2870,14 +2746,10 @@ def test_skip_consecutive_user_messages_with_existing_guarded_text():
         {"role": "user", "content": [{"type": "text", "text": "Should be converted"}]},
     ]
 
-    optional_params = {
-        "guardrailConfig": {"guardrailIdentifier": "gr-abc123", "guardrailVersion": "1"}
-    }
+    optional_params = {"guardrailConfig": {"guardrailIdentifier": "gr-abc123", "guardrailVersion": "1"}}
 
     # Test the helper method directly
-    converted_messages = config._convert_consecutive_user_messages_to_guarded_text(
-        messages, optional_params
-    )
+    converted_messages = config._convert_consecutive_user_messages_to_guarded_text(messages, optional_params)
 
     # Verify the conversion
     assert len(converted_messages) == 2
@@ -3446,24 +3318,22 @@ def test_drop_thinking_param_when_thinking_blocks_missing():
         optional_params = {"thinking": {"type": "enabled", "budget_tokens": 1000}}
 
         # Verify the condition is detected
-        assert last_assistant_with_tool_calls_has_no_thinking_blocks(
-            messages_without_thinking_blocks
-        ), "Should detect missing thinking_blocks"
+        assert last_assistant_with_tool_calls_has_no_thinking_blocks(messages_without_thinking_blocks), (
+            "Should detect missing thinking_blocks"
+        )
 
         # Simulate what _transform_request_helper does
         if (
             optional_params.get("thinking") is not None
             and messages_without_thinking_blocks is not None
-            and last_assistant_with_tool_calls_has_no_thinking_blocks(
-                messages_without_thinking_blocks
-            )
+            and last_assistant_with_tool_calls_has_no_thinking_blocks(messages_without_thinking_blocks)
         ):
             if litellm.modify_params:
                 optional_params.pop("thinking", None)
 
-        assert (
-            "thinking" not in optional_params
-        ), "thinking param should be dropped when modify_params=True and thinking_blocks are missing"
+        assert "thinking" not in optional_params, (
+            "thinking param should be dropped when modify_params=True and thinking_blocks are missing"
+        )
 
         # Test case 2: thinking should NOT be dropped when thinking_blocks are present
         messages_with_thinking_blocks = [
@@ -3478,58 +3348,46 @@ def test_drop_thinking_param_when_thinking_blocks_missing():
                         "function": {"name": "search", "arguments": "{}"},
                     }
                 ],
-                "thinking_blocks": [
-                    {"type": "thinking", "thinking": "Let me search for weather..."}
-                ],
+                "thinking_blocks": [{"type": "thinking", "thinking": "Let me search for weather..."}],
             },
             {"role": "tool", "content": "Weather is sunny", "tool_call_id": "call_123"},
         ]
 
-        optional_params_with_thinking = {
-            "thinking": {"type": "enabled", "budget_tokens": 1000}
-        }
+        optional_params_with_thinking = {"thinking": {"type": "enabled", "budget_tokens": 1000}}
 
         # Verify the condition is NOT detected when thinking_blocks are present
-        assert not last_assistant_with_tool_calls_has_no_thinking_blocks(
-            messages_with_thinking_blocks
-        ), "Should NOT detect missing thinking_blocks when they are present"
+        assert not last_assistant_with_tool_calls_has_no_thinking_blocks(messages_with_thinking_blocks), (
+            "Should NOT detect missing thinking_blocks when they are present"
+        )
 
         # Simulate what _transform_request_helper does
         if (
             optional_params_with_thinking.get("thinking") is not None
             and messages_with_thinking_blocks is not None
-            and last_assistant_with_tool_calls_has_no_thinking_blocks(
-                messages_with_thinking_blocks
-            )
+            and last_assistant_with_tool_calls_has_no_thinking_blocks(messages_with_thinking_blocks)
         ):
             if litellm.modify_params:
                 optional_params_with_thinking.pop("thinking", None)
 
-        assert (
-            "thinking" in optional_params_with_thinking
-        ), "thinking param should NOT be dropped when thinking_blocks are present"
+        assert "thinking" in optional_params_with_thinking, (
+            "thinking param should NOT be dropped when thinking_blocks are present"
+        )
 
         # Test case 3: thinking should NOT be dropped when modify_params=False
         litellm.modify_params = False
 
-        optional_params_no_modify = {
-            "thinking": {"type": "enabled", "budget_tokens": 1000}
-        }
+        optional_params_no_modify = {"thinking": {"type": "enabled", "budget_tokens": 1000}}
 
         # Simulate what _transform_request_helper does
         if (
             optional_params_no_modify.get("thinking") is not None
             and messages_without_thinking_blocks is not None
-            and last_assistant_with_tool_calls_has_no_thinking_blocks(
-                messages_without_thinking_blocks
-            )
+            and last_assistant_with_tool_calls_has_no_thinking_blocks(messages_without_thinking_blocks)
         ):
             if litellm.modify_params:
                 optional_params_no_modify.pop("thinking", None)
 
-        assert (
-            "thinking" in optional_params_no_modify
-        ), "thinking param should NOT be dropped when modify_params=False"
+        assert "thinking" in optional_params_no_modify, "thinking param should NOT be dropped when modify_params=False"
 
     finally:
         # Restore original modify_params setting
@@ -3550,31 +3408,17 @@ def test_supports_native_structured_outputs():
         config = AmazonConverseConfig()
 
         # Supported models (have supports_native_structured_output=true in cost JSON)
-        assert config._supports_native_structured_outputs(
-            "anthropic.claude-sonnet-4-5-20250929-v1:0"
-        )
-        assert config._supports_native_structured_outputs(
-            "anthropic.claude-haiku-4-5-20251001-v1:0"
-        )
-        assert config._supports_native_structured_outputs(
-            "anthropic.claude-opus-4-6-v1"
-        )
+        assert config._supports_native_structured_outputs("anthropic.claude-sonnet-4-5-20250929-v1:0")
+        assert config._supports_native_structured_outputs("anthropic.claude-haiku-4-5-20251001-v1:0")
+        assert config._supports_native_structured_outputs("anthropic.claude-opus-4-6-v1")
         # Regional prefix is stripped by get_bedrock_base_model
-        assert config._supports_native_structured_outputs(
-            "eu.anthropic.claude-opus-4-5-20251101-v1:0"
-        )
+        assert config._supports_native_structured_outputs("eu.anthropic.claude-opus-4-5-20251101-v1:0")
         # Claude 4.6 Sonnet
         assert config._supports_native_structured_outputs("anthropic.claude-sonnet-4-6")
-        assert config._supports_native_structured_outputs(
-            "us.anthropic.claude-sonnet-4-6"
-        )
+        assert config._supports_native_structured_outputs("us.anthropic.claude-sonnet-4-6")
         # Non-Anthropic models
-        assert config._supports_native_structured_outputs(
-            "qwen.qwen3-235b-a22b-2507-v1:0"
-        )
-        assert config._supports_native_structured_outputs(
-            "mistral.mistral-large-3-675b-instruct"
-        )
+        assert config._supports_native_structured_outputs("qwen.qwen3-235b-a22b-2507-v1:0")
+        assert config._supports_native_structured_outputs("mistral.mistral-large-3-675b-instruct")
         assert config._supports_native_structured_outputs("minimax.minimax-m2")
         assert config._supports_native_structured_outputs("moonshot.kimi-k2-thinking")
         assert config._supports_native_structured_outputs("nvidia.nemotron-nano-3-30b")
@@ -3582,23 +3426,15 @@ def test_supports_native_structured_outputs():
         assert config._supports_native_structured_outputs("deepseek.v3-v1:0")
 
         # Unsupported models -- should fall back to tool-call approach
-        assert not config._supports_native_structured_outputs(
-            "anthropic.claude-sonnet-4-20250514-v1:0"
-        )
-        assert not config._supports_native_structured_outputs(
-            "meta.llama3-3-70b-instruct-v1:0"
-        )
+        assert not config._supports_native_structured_outputs("anthropic.claude-sonnet-4-20250514-v1:0")
+        assert not config._supports_native_structured_outputs("meta.llama3-3-70b-instruct-v1:0")
         assert not config._supports_native_structured_outputs("amazon.nova-pro-v1:0")
         # Excluded: broken constrained decoding on Bedrock
         assert not config._supports_native_structured_outputs("openai.gpt-oss-120b-1:0")
-        assert not config._supports_native_structured_outputs(
-            "mistral.magistral-small-2509"
-        )
+        assert not config._supports_native_structured_outputs("mistral.magistral-small-2509")
         # Excluded: ignores schema or broken on Bedrock
         assert not config._supports_native_structured_outputs("google.gemma-3-27b-it")
-        assert not config._supports_native_structured_outputs(
-            "nvidia.nemotron-nano-12b-v2"
-        )
+        assert not config._supports_native_structured_outputs("nvidia.nemotron-nano-12b-v2")
     finally:
         litellm.model_cost = old_cost
         if old_env is None:
@@ -3684,19 +3520,14 @@ def test_translate_response_format_native_output_config():
         assert "fake_stream" not in result
 
         # Verify the schema content (additionalProperties: false is added by normalization)
-        schema_str = result["outputConfig"]["textFormat"]["structure"]["jsonSchema"][
-            "schema"
-        ]
+        schema_str = result["outputConfig"]["textFormat"]["structure"]["jsonSchema"]["schema"]
         parsed_schema = json.loads(schema_str)
         expected_schema = {
             **response_format["json_schema"]["schema"],
             "additionalProperties": False,
         }
         assert parsed_schema == expected_schema
-        assert (
-            result["outputConfig"]["textFormat"]["structure"]["jsonSchema"]["name"]
-            == "WeatherResult"
-        )
+        assert result["outputConfig"]["textFormat"]["structure"]["jsonSchema"]["name"] == "WeatherResult"
     finally:
         litellm.model_cost = old_cost
         if old_env is None:
@@ -3774,9 +3605,7 @@ def test_native_structured_output_no_fake_stream():
         assert "fake_stream" not in result
 
         # Verify the schema content
-        schema_str = result["outputConfig"]["textFormat"]["structure"]["jsonSchema"][
-            "schema"
-        ]
+        schema_str = result["outputConfig"]["textFormat"]["structure"]["jsonSchema"]["schema"]
         assert json.loads(schema_str) == {
             "type": "object",
             "properties": {"answer": {"type": "string"}},
@@ -3829,10 +3658,7 @@ def test_transform_request_with_output_config():
 
     assert "outputConfig" in result
     assert result["outputConfig"]["textFormat"]["type"] == "json_schema"
-    assert (
-        result["outputConfig"]["textFormat"]["structure"]["jsonSchema"]["name"]
-        == "TestSchema"
-    )
+    assert result["outputConfig"]["textFormat"]["structure"]["jsonSchema"]["name"] == "TestSchema"
 
 
 def test_transform_request_strips_anthropic_output_config():
@@ -3953,10 +3779,7 @@ def test_transform_response_native_structured_output():
     )
 
     # Content should be the JSON text directly
-    assert (
-        result.choices[0].message.content
-        == '{"temp": 62, "description": "Mild and foggy"}'
-    )
+    assert result.choices[0].message.content == '{"temp": 62, "description": "Mild and foggy"}'
     # Should NOT have tool_calls
     assert result.choices[0].message.tool_calls is None
     assert result.choices[0].finish_reason == "stop"
@@ -4069,10 +3892,7 @@ def test_add_additional_properties_definitions():
     # definitions object
     assert result["definitions"]["Item"]["additionalProperties"] is False
     # Nested object inside definitions
-    assert (
-        result["definitions"]["Item"]["properties"]["details"]["additionalProperties"]
-        is False
-    )
+    assert result["definitions"]["Item"]["properties"]["details"]["additionalProperties"] is False
 
 
 def test_json_object_no_schema_skips_tool_injection():
@@ -4129,9 +3949,7 @@ def test_output_config_applies_additional_properties():
     output_config = AmazonConverseConfig._create_output_config_for_response_format(
         json_schema=schema, name="test_schema"
     )
-    parsed = json.loads(
-        output_config["textFormat"]["structure"]["jsonSchema"]["schema"]
-    )
+    parsed = json.loads(output_config["textFormat"]["structure"]["jsonSchema"]["schema"])
     assert parsed["additionalProperties"] is False
     assert parsed["properties"]["nested"]["additionalProperties"] is False
 
@@ -4180,12 +3998,7 @@ def test_parallel_tool_calls_newer_model_adds_disable_flag():
 
     assert "additionalModelRequestFields" in request_data
     assert "tool_choice" in request_data["additionalModelRequestFields"]
-    assert (
-        request_data["additionalModelRequestFields"]["tool_choice"][
-            "disable_parallel_tool_use"
-        ]
-        is True
-    )
+    assert request_data["additionalModelRequestFields"]["tool_choice"]["disable_parallel_tool_use"] is True
     assert "parallel_tool_calls" not in request_data["additionalModelRequestFields"]
 
 
@@ -4217,12 +4030,7 @@ def test_parallel_tool_calls_flag_decoupled_from_ttl_pricing(monkeypatch):
         headers={},
     )
 
-    assert (
-        request_data["additionalModelRequestFields"]["tool_choice"][
-            "disable_parallel_tool_use"
-        ]
-        is True
-    )
+    assert request_data["additionalModelRequestFields"]["tool_choice"]["disable_parallel_tool_use"] is True
 
 
 def test_parallel_tool_calls_older_model_drops_disable_flag():
@@ -4254,9 +4062,7 @@ def test_parallel_tool_calls_older_model_drops_disable_flag():
 class TestBedrockMinThinkingBudgetTokens:
     """Test that thinking.budget_tokens is clamped to the Bedrock minimum (1024)."""
 
-    def _map_params(
-        self, thinking_value, model="anthropic.claude-sonnet-4-5-20250929-v1:0"
-    ):
+    def _map_params(self, thinking_value, model="anthropic.claude-sonnet-4-5-20250929-v1:0"):
         """Helper to call map_openai_params with the given thinking value."""
         config = AmazonConverseConfig()
         non_default_params = {"thinking": thinking_value}
@@ -4483,9 +4289,7 @@ def test_streaming_filters_json_tool_call_with_real_tools():
 
     # Chunk 2: json_tool_call delta — should become text, not tool_use
     json_delta = ContentBlockDeltaEvent(toolUse={"input": '{"temp": 62}'})
-    text_2, tool_use_2, _, _, _ = decoder._handle_converse_delta_event(
-        json_delta, index=0
-    )
+    text_2, tool_use_2, _, _, _ = decoder._handle_converse_delta_event(json_delta, index=0)
     assert text_2 == '{"temp": 62}'
     assert tool_use_2 is None
 
@@ -4509,9 +4313,7 @@ def test_streaming_filters_json_tool_call_with_real_tools():
 
     # Chunk 5: real tool delta
     real_delta = ContentBlockDeltaEvent(toolUse={"input": '{"location": "SF"}'})
-    text_5, tool_use_5, _, _, _ = decoder._handle_converse_delta_event(
-        real_delta, index=1
-    )
+    text_5, tool_use_5, _, _, _ = decoder._handle_converse_delta_event(real_delta, index=1)
     assert text_5 == ""
     assert tool_use_5 is not None
     assert tool_use_5["function"]["arguments"] == '{"location": "SF"}'
@@ -4544,9 +4346,7 @@ def test_streaming_without_json_mode_passes_all_tools():
 
     # json_tool_call delta — should be a tool_use, not text
     json_delta = ContentBlockDeltaEvent(toolUse={"input": '{"data": 1}'})
-    text, tool_use_delta, _, _, _ = decoder._handle_converse_delta_event(
-        json_delta, index=0
-    )
+    text, tool_use_delta, _, _, _ = decoder._handle_converse_delta_event(json_delta, index=0)
     assert text == ""
     assert tool_use_delta is not None
     assert tool_use_delta["function"]["arguments"] == '{"data": 1}'
@@ -5030,11 +4830,7 @@ def test_transform_response_citation_null_source_title_become_empty_strings():
                 "content": [
                     {
                         "citationsContent": {
-                            "content": [
-                                {
-                                    "text": "Apptio is a company that makes calls to Bedrock"
-                                }
-                            ],
+                            "content": [{"text": "Apptio is a company that makes calls to Bedrock"}],
                             "citations": [
                                 {
                                     "location": {
@@ -5169,15 +4965,11 @@ def test_transform_response_citations_offset_tracks_text_only_blocks():
     message = result.choices[0].message
     expected_start = len(leading_text)
     assert message.content == leading_text + cited_text
-    assert (
-        message.content[expected_start : expected_start + len(cited_text)] == cited_text
-    )
+    assert message.content[expected_start : expected_start + len(cited_text)] == cited_text
     assert message.annotations is not None
     assert len(message.annotations) == 1
     assert message.annotations[0]["url_citation"]["start_index"] == expected_start
-    assert message.annotations[0]["url_citation"]["end_index"] == expected_start + len(
-        cited_text
-    )
+    assert message.annotations[0]["url_citation"]["end_index"] == expected_start + len(cited_text)
 
 
 def test_transform_response_stitches_citations_for_whitespace_punctuation_text():
@@ -5287,9 +5079,7 @@ def test_bedrock_tool_message_openai_file_pdf_becomes_document():
         },
     ]
 
-    translated_msg = _bedrock_converse_messages_pt(
-        messages=messages, model="", llm_provider=""
-    )
+    translated_msg = _bedrock_converse_messages_pt(messages=messages, model="", llm_provider="")
 
     tool_result = translated_msg[-1]["content"][-1]["toolResult"]
     assert tool_result["toolUseId"] == "tooluse_pdf_1"
@@ -5331,9 +5121,7 @@ def test_bedrock_tool_message_image_url_pdf_data_uri_becomes_document():
         },
     ]
 
-    translated_msg = _bedrock_converse_messages_pt(
-        messages=messages, model="", llm_provider=""
-    )
+    translated_msg = _bedrock_converse_messages_pt(messages=messages, model="", llm_provider="")
 
     tool_result = translated_msg[-1]["content"][-1]["toolResult"]
     assert tool_result["toolUseId"] == "tooluse_pdf_img_1"
@@ -5390,9 +5178,7 @@ def test_bedrock_tool_message_file_id_http_url_becomes_document():
         "process_image_sync",
         return_value=fake_document_block,
     ) as mock_proc:
-        translated_msg = _bedrock_converse_messages_pt(
-            messages=messages, model="", llm_provider=""
-        )
+        translated_msg = _bedrock_converse_messages_pt(messages=messages, model="", llm_provider="")
 
     mock_proc.assert_called_once()
     assert mock_proc.call_args.kwargs["image_url"] == pdf_url
@@ -5463,9 +5249,7 @@ def test_bedrock_tool_message_image_url_png_still_becomes_image():
         },
     ]
 
-    translated_msg = _bedrock_converse_messages_pt(
-        messages=messages, model="", llm_provider=""
-    )
+    translated_msg = _bedrock_converse_messages_pt(messages=messages, model="", llm_provider="")
 
     tool_result = translated_msg[-1]["content"][-1]["toolResult"]
     assert len(tool_result["content"]) == 1
@@ -5657,12 +5441,10 @@ async def test_grounding_source_and_query_rendered_as_text():
         model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
         llm_provider="bedrock_converse",
     )
-    async_result = (
-        await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
-            messages=messages,
-            model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
-            llm_provider="bedrock_converse",
-        )
+    async_result = await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
+        messages=messages,
+        model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        llm_provider="bedrock_converse",
     )
 
     assert result == async_result
@@ -5707,10 +5489,7 @@ def _agentic_messages_with_ttl(ttl_target: str):
 
 def _collect_cache_points(result):
     return [
-        block["cachePoint"]
-        for message in result
-        for block in message.get("content") or []
-        if "cachePoint" in block
+        block["cachePoint"] for message in result for block in message.get("content") or [] if "cachePoint" in block
     ]
 
 
@@ -5736,12 +5515,10 @@ async def test_message_level_cache_control_honors_ttl_for_supported_model(
         model="global.anthropic.claude-opus-4-7",
         llm_provider="bedrock_converse",
     )
-    async_result = (
-        await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
-            messages=messages,
-            model="global.anthropic.claude-opus-4-7",
-            llm_provider="bedrock_converse",
-        )
+    async_result = await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
+        messages=messages,
+        model="global.anthropic.claude-opus-4-7",
+        llm_provider="bedrock_converse",
     )
     assert result == async_result
 
@@ -5837,3 +5614,300 @@ def test_adaptive_thinking_dropped_when_max_tokens_too_small_converse():
     )
 
     assert "thinking" not in optional_params
+
+
+# --- Regression: Bedrock Converse guardrail rewrite must not drop cache_control ---
+#
+# https://github.com/BerriAI/litellm/issues/33281
+#
+# When ``guardrailConfig`` is set on a Bedrock Converse request, the transformation
+# in ``_convert_consecutive_user_messages_to_guarded_text`` rewrites trailing
+# user-message text elements as ``{"type": "guarded_text", ...}``. The previous
+# rewrite constructed a new dict that copied only ``type`` and ``text``, so any
+# ``cache_control`` set on the original element (or on the message itself, for
+# string content) was silently dropped. Because the prompt-factory
+# ``_get_cache_point_block`` loop reads ``cache_control`` from each content
+# element, dropping the marker meant no ``cachePoint`` block was ever emitted
+# after the trailing ``guardContent`` block — every ordinary chat turn lost
+# its conversation-prefix breakpoint whenever guardrails were enabled.
+#
+# The fix carries the ``cache_control`` marker over to the new ``guarded_text``
+# dict so the per-element cache-point loop still fires. The tests below pin
+# both rewrite paths (list content with element-level marker, string content
+# with message-level marker) and the end-to-end ``_transform_request`` output.
+
+
+def test_guarded_text_rewrite_preserves_element_level_cache_control():
+    """When a text element is rewritten to ``guarded_text``, any
+    ``cache_control`` marker on the original element must survive the rewrite.
+
+    Regression test for BerriAI/litellm#33281."""
+    config = AmazonConverseConfig()
+
+    messages = [
+        {"role": "user", "content": "first question"},
+        {"role": "assistant", "content": "first answer"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "earlier context"},
+                {
+                    "type": "text",
+                    "text": "second question",
+                    "cache_control": {"type": "ephemeral"},
+                },
+            ],
+        },
+    ]
+
+    optional_params = {"guardrailConfig": {"guardrailIdentifier": "gr-x", "guardrailVersion": "1"}}
+
+    converted = config._convert_consecutive_user_messages_to_guarded_text(messages, optional_params)
+
+    trailing = converted[-1]
+    assert trailing["role"] == "user"
+    new_content = trailing["content"]
+
+    # Both elements were text -> both should now be guarded_text.
+    assert all(item["type"] == "guarded_text" for item in new_content)
+    assert new_content[0]["text"] == "earlier context"
+    assert new_content[1]["text"] == "second question"
+
+    # The element that originally had cache_control must still carry it,
+    # otherwise the per-element cache-point loop in the prompt factory
+    # silently drops the cachePoint block for the trailing user message.
+    # The first element never had a marker, so it stays clean.
+    assert "cache_control" not in new_content[0]
+    assert "cache_control" in new_content[1]
+    assert new_content[1]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_guarded_text_rewrite_preserves_message_level_cache_control_for_string_content():
+    """When string content is rewritten to ``[{"type": "guarded_text", ...}]``,
+    a message-level ``cache_control`` must be promoted to the new element so
+    the per-element cache-point loop can still see it.
+
+    The user-message branch of the prompt factory only honors message-level
+    ``cache_control`` when content is a string — once content becomes a list,
+    only element-level markers are read — so dropping the marker here would
+    silently remove the cachePoint on every trailing string-content user
+    message.
+
+    Regression test for BerriAI/litellm#33281."""
+    config = AmazonConverseConfig()
+
+    messages = [
+        {"role": "user", "content": "first question"},
+        {"role": "assistant", "content": "first answer"},
+        {
+            "role": "user",
+            "content": "second question",
+            "cache_control": {"type": "ephemeral"},
+        },
+    ]
+
+    optional_params = {"guardrailConfig": {"guardrailIdentifier": "gr-x", "guardrailVersion": "1"}}
+
+    converted = config._convert_consecutive_user_messages_to_guarded_text(messages, optional_params)
+
+    trailing = converted[-1]
+    assert trailing["role"] == "user"
+    # After rewrite, content is a list of guarded_text elements.
+    new_content = trailing["content"]
+    assert isinstance(new_content, list)
+    assert len(new_content) == 1
+    assert new_content[0]["type"] == "guarded_text"
+    assert new_content[0]["text"] == "second question"
+    # The marker must have been promoted to the new element so the
+    # cache-point loop can still see it on the list-content path.
+    assert new_content[0].get("cache_control") == {"type": "ephemeral"}
+
+
+def test_guarded_text_rewrite_without_cache_control_is_unchanged():
+    """Sanity check: when neither the message nor any text element carries a
+    cache_control marker, the rewrite produces a plain ``guarded_text`` dict
+    with no spurious key.
+
+    Regression test for BerriAI/litellm#33281."""
+    config = AmazonConverseConfig()
+
+    messages = [
+        {"role": "user", "content": "second question"},
+    ]
+
+    optional_params = {"guardrailConfig": {"guardrailIdentifier": "gr-x", "guardrailVersion": "1"}}
+
+    converted = config._convert_consecutive_user_messages_to_guarded_text(messages, optional_params)
+
+    trailing = converted[-1]
+    new_content = trailing["content"]
+    assert new_content == [{"type": "guarded_text", "text": "second question"}]
+
+
+def test_transform_request_emits_cachePoint_after_guardContent_when_guardrail_enabled():
+    """End-to-end check: when ``cache_control_injection_points`` requests a
+    marker on the trailing user message (``index: -1``) AND
+    ``guardrailConfig`` is set, the transformed Converse request must still
+    contain a ``cachePoint`` block immediately after the rewritten
+    ``guardContent`` block.
+
+    Without the fix the cachePoint is silently dropped — the ``guarded_text``
+    rewrite strips the cache_control marker that the
+    ``AnthropicCacheControlHook`` placed on the trailing message's content,
+    so the per-element cache-point loop in the prompt factory never sees it
+    and no ``cachePoint`` block is emitted for the last user message.
+
+    Regression test for BerriAI/litellm#33281."""
+    config = AmazonConverseConfig()
+
+    # Simulate the state after the AnthropicCacheControlHook has applied the
+    # ``index: -1`` injection point to the trailing string-content user
+    # message — see ``_safe_insert_cache_control_in_message`` in
+    # ``litellm/integrations/anthropic_cache_control_hook.py``. For string
+    # content, that hook attaches the marker at message level; for list
+    # content, on the last element.
+    messages = [
+        {"role": "user", "content": "first question"},
+        {"role": "assistant", "content": "first answer"},
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "second question",
+                    "cache_control": {"type": "ephemeral"},
+                },
+            ],
+        },
+    ]
+
+    optional_params = {
+        "guardrailConfig": {
+            "guardrailIdentifier": "gr-x",
+            "guardrailVersion": "1",
+            "trace": "disabled",
+        }
+    }
+
+    result = config._transform_request(
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+    )
+
+    # The trailing user message should be rewritten to guarded_text AND still
+    # emit a cachePoint block immediately after its guardContent wrapper.
+    bedrock_messages = result["messages"]
+    trailing_bedrock = bedrock_messages[-1]
+    assert trailing_bedrock["role"] == "user"
+
+    content_blocks = trailing_bedrock["content"]
+    # guardContent block followed by cachePoint block.
+    assert any("guardContent" in block for block in content_blocks)
+    assert any("cachePoint" in block for block in content_blocks)
+
+    # And the cachePoint must come AFTER the guardContent, not before —
+    # a cachePoint is the breakpoint for everything preceding it, so it
+    # has to follow the guardContent block it covers.
+    guard_idx = next(i for i, block in enumerate(content_blocks) if "guardContent" in block)
+    cache_idx = next(i for i, block in enumerate(content_blocks) if "cachePoint" in block)
+    assert cache_idx > guard_idx, (
+        f"cachePoint must follow the guardContent block it covers; got content={content_blocks!r}"
+    )
+    # Default ttl-less cachePoint.
+    assert content_blocks[cache_idx]["cachePoint"] == {"type": "default"}
+
+
+def test_transform_request_emits_cachePoint_when_guardrail_enabled_for_string_content():
+    """End-to-end variant for the string-content rewrite path: a message-level
+    ``cache_control`` set by the AnthropicCacheControlHook on a string-content
+    trailing user message must still produce a cachePoint block after the
+    guardContent block when guardrailConfig is enabled.
+
+    Regression test for BerriAI/litellm#33281."""
+    config = AmazonConverseConfig()
+
+    messages = [
+        {"role": "user", "content": "first question"},
+        {"role": "assistant", "content": "first answer"},
+        {
+            "role": "user",
+            "content": "second question",
+            "cache_control": {"type": "ephemeral"},
+        },
+    ]
+
+    optional_params = {
+        "guardrailConfig": {
+            "guardrailIdentifier": "gr-x",
+            "guardrailVersion": "1",
+            "trace": "disabled",
+        }
+    }
+
+    result = config._transform_request(
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+    )
+
+    trailing_bedrock = result["messages"][-1]
+    content_blocks = trailing_bedrock["content"]
+
+    assert any("guardContent" in block for block in content_blocks)
+    assert any("cachePoint" in block for block in content_blocks)
+
+    guard_idx = next(i for i, block in enumerate(content_blocks) if "guardContent" in block)
+    cache_idx = next(i for i, block in enumerate(content_blocks) if "cachePoint" in block)
+    assert cache_idx > guard_idx, (
+        f"cachePoint must follow the guardContent block it covers; got content={content_blocks!r}"
+    )
+    assert content_blocks[cache_idx]["cachePoint"] == {"type": "default"}
+
+
+def test_transform_request_emits_no_cachePoint_without_guardrail_baseline():
+    """Sanity baseline: without a guardrail, a cacheControl marker on the
+    trailing user message still produces a cachePoint — confirming the
+    comparison case used in the issue reproducer.
+
+    This is the *control* arm of the regression test for
+    BerriAI/litellm#33281: it shows that cachePoint emission was already
+    working in the no-guardrail path, which is exactly what makes the
+    guardrail-path regression a regression."""
+    config = AmazonConverseConfig()
+
+    messages = [
+        {"role": "user", "content": "first question"},
+        {"role": "assistant", "content": "first answer"},
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "second question",
+                    "cache_control": {"type": "ephemeral"},
+                },
+            ],
+        },
+    ]
+
+    # No guardrailConfig here.
+    optional_params: dict = {}
+
+    result = config._transform_request(
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+    )
+
+    trailing_bedrock = result["messages"][-1]
+    content_blocks = trailing_bedrock["content"]
+
+    # Plain text + cachePoint — no guardContent wrapper.
+    assert any("text" in block for block in content_blocks)
+    assert any("cachePoint" in block for block in content_blocks)
+    assert not any("guardContent" in block for block in content_blocks)
+    assert content_blocks[-1] == {"cachePoint": {"type": "default"}}

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EndpointUsage/EndpointUsage.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EndpointUsage/EndpointUsage.tsx
@@ -39,16 +39,16 @@ const EndpointUsage: React.FC<EndpointUsageProps> = ({ userSpendData }) => {
             api_key_breakdown: {},
           };
         }
-        aggregatedEndpoints[endpoint].metrics.spend += metrics.metrics.spend;
-        aggregatedEndpoints[endpoint].metrics.prompt_tokens += metrics.metrics.prompt_tokens;
-        aggregatedEndpoints[endpoint].metrics.completion_tokens += metrics.metrics.completion_tokens;
-        aggregatedEndpoints[endpoint].metrics.total_tokens += metrics.metrics.total_tokens;
-        aggregatedEndpoints[endpoint].metrics.api_requests += metrics.metrics.api_requests;
-        aggregatedEndpoints[endpoint].metrics.successful_requests += metrics.metrics.successful_requests || 0;
-        aggregatedEndpoints[endpoint].metrics.failed_requests += metrics.metrics.failed_requests || 0;
-        aggregatedEndpoints[endpoint].metrics.cache_read_input_tokens += metrics.metrics.cache_read_input_tokens || 0;
+        aggregatedEndpoints[endpoint].metrics.spend += metrics.metrics?.spend ?? 0;
+        aggregatedEndpoints[endpoint].metrics.prompt_tokens += metrics.metrics?.prompt_tokens ?? 0;
+        aggregatedEndpoints[endpoint].metrics.completion_tokens += metrics.metrics?.completion_tokens ?? 0;
+        aggregatedEndpoints[endpoint].metrics.total_tokens += metrics.metrics?.total_tokens ?? 0;
+        aggregatedEndpoints[endpoint].metrics.api_requests += metrics.metrics?.api_requests ?? 0;
+        aggregatedEndpoints[endpoint].metrics.successful_requests += metrics.metrics?.successful_requests ?? 0;
+        aggregatedEndpoints[endpoint].metrics.failed_requests += metrics.metrics?.failed_requests ?? 0;
+        aggregatedEndpoints[endpoint].metrics.cache_read_input_tokens += metrics.metrics?.cache_read_input_tokens ?? 0;
         aggregatedEndpoints[endpoint].metrics.cache_creation_input_tokens +=
-          metrics.metrics.cache_creation_input_tokens || 0;
+          metrics.metrics?.cache_creation_input_tokens ?? 0;
       });
     });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.tsx
@@ -170,15 +170,11 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
             tokens: 0,
           };
         }
-        try {
-          modelSpend[model].spend += metrics.metrics.spend;
-        } catch (e) {
-          console.error(`Error adding spend for ${model}: ${e}, got metrics: ${JSON.stringify(metrics)}`);
-        }
-        modelSpend[model].requests += metrics.metrics.api_requests;
-        modelSpend[model].successful_requests += metrics.metrics.successful_requests;
-        modelSpend[model].failed_requests += metrics.metrics.failed_requests;
-        modelSpend[model].tokens += metrics.metrics.total_tokens;
+        modelSpend[model].spend += metrics.metrics?.spend ?? 0;
+        modelSpend[model].requests += metrics.metrics?.api_requests ?? 0;
+        modelSpend[model].successful_requests += metrics.metrics?.successful_requests ?? 0;
+        modelSpend[model].failed_requests += metrics.metrics?.failed_requests ?? 0;
+        modelSpend[model].tokens += metrics.metrics?.total_tokens ?? 0;
       });
     });
 
@@ -254,21 +250,21 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
               cache_creation_input_tokens: 0,
             },
             metadata: {
-              key_alias: metrics.metadata.key_alias,
-              team_id: metrics.metadata.team_id || null,
+              key_alias: metrics.metadata?.key_alias ?? null,
+              team_id: metrics.metadata?.team_id ?? null,
               tags: tagDictionary[key] || [],
             },
           };
         }
-        keySpend[key].metrics.spend += metrics.metrics.spend;
-        keySpend[key].metrics.prompt_tokens += metrics.metrics.prompt_tokens;
-        keySpend[key].metrics.completion_tokens += metrics.metrics.completion_tokens;
-        keySpend[key].metrics.total_tokens += metrics.metrics.total_tokens;
-        keySpend[key].metrics.api_requests += metrics.metrics.api_requests;
-        keySpend[key].metrics.successful_requests += metrics.metrics.successful_requests;
-        keySpend[key].metrics.failed_requests += metrics.metrics.failed_requests;
-        keySpend[key].metrics.cache_read_input_tokens += metrics.metrics.cache_read_input_tokens || 0;
-        keySpend[key].metrics.cache_creation_input_tokens += metrics.metrics.cache_creation_input_tokens || 0;
+        keySpend[key].metrics.spend += metrics.metrics?.spend ?? 0;
+        keySpend[key].metrics.prompt_tokens += metrics.metrics?.prompt_tokens ?? 0;
+        keySpend[key].metrics.completion_tokens += metrics.metrics?.completion_tokens ?? 0;
+        keySpend[key].metrics.total_tokens += metrics.metrics?.total_tokens ?? 0;
+        keySpend[key].metrics.api_requests += metrics.metrics?.api_requests ?? 0;
+        keySpend[key].metrics.successful_requests += metrics.metrics?.successful_requests ?? 0;
+        keySpend[key].metrics.failed_requests += metrics.metrics?.failed_requests ?? 0;
+        keySpend[key].metrics.cache_read_input_tokens += metrics.metrics?.cache_read_input_tokens ?? 0;
+        keySpend[key].metrics.cache_creation_input_tokens += metrics.metrics?.cache_creation_input_tokens ?? 0;
       });
     });
 
@@ -297,15 +293,11 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
             tokens: 0,
           };
         }
-        try {
-          providerSpend[provider].spend += metrics.metrics.spend;
-          providerSpend[provider].requests += metrics.metrics.api_requests;
-          providerSpend[provider].successful_requests += metrics.metrics.successful_requests;
-          providerSpend[provider].failed_requests += metrics.metrics.failed_requests;
-          providerSpend[provider].tokens += metrics.metrics.total_tokens;
-        } catch (e) {
-          console.error(`Error processing provider ${provider}: ${e}`);
-        }
+        providerSpend[provider].spend += metrics.metrics?.spend ?? 0;
+        providerSpend[provider].requests += metrics.metrics?.api_requests ?? 0;
+        providerSpend[provider].successful_requests += metrics.metrics?.successful_requests ?? 0;
+        providerSpend[provider].failed_requests += metrics.metrics?.failed_requests ?? 0;
+        providerSpend[provider].tokens += metrics.metrics?.total_tokens ?? 0;
       });
     });
 
@@ -370,11 +362,11 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
             },
           };
         }
-        entitySpend[entity].metrics.spend += data.metrics.spend;
-        entitySpend[entity].metrics.api_requests += data.metrics.api_requests;
-        entitySpend[entity].metrics.successful_requests += data.metrics.successful_requests;
-        entitySpend[entity].metrics.failed_requests += data.metrics.failed_requests;
-        entitySpend[entity].metrics.total_tokens += data.metrics.total_tokens;
+        entitySpend[entity].metrics.spend += data.metrics?.spend ?? 0;
+        entitySpend[entity].metrics.api_requests += data.metrics?.api_requests ?? 0;
+        entitySpend[entity].metrics.successful_requests += data.metrics?.successful_requests ?? 0;
+        entitySpend[entity].metrics.failed_requests += data.metrics?.failed_requests ?? 0;
+        entitySpend[entity].metrics.total_tokens += data.metrics?.total_tokens ?? 0;
       });
     });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.test.tsx
@@ -1162,4 +1162,127 @@ describe("UsagePage", () => {
       expect(screen.getByText("Endpoint Activity")).toBeInTheDocument();
     });
   });
+
+  // Regression test for https://github.com/BerriAI/litellm/issues/33381
+  // When a day's breakdown contains entries where the inner `metrics`
+  // object is undefined (a data-quality issue at the backend), the
+  // top-keys/top-models/top-model-groups/provider aggregations must
+  // skip those entries instead of throwing
+  // `Cannot read properties of undefined (reading 'spend')`.
+  it("should not crash when breakdown entries are missing inner metrics", async () => {
+    const partialSpendData = {
+      ...mockSpendData,
+      results: [
+        {
+          date: "2025-01-01",
+          metrics: mockSpendData.results[0].metrics,
+          breakdown: {
+            models: {
+              "model-x": {
+                metrics: {
+                  spend: 12.5,
+                  api_requests: 100,
+                  successful_requests: 95,
+                  failed_requests: 5,
+                  total_tokens: 1000,
+                  prompt_tokens: 600,
+                  completion_tokens: 400,
+                  cache_read_input_tokens: 0,
+                  cache_creation_input_tokens: 0,
+                },
+                metadata: {},
+                api_key_breakdown: {},
+              },
+              "model-broken": {
+                // Inner `metrics` deliberately missing — this used to crash
+                // the page with `Cannot read properties of undefined`.
+                metadata: {},
+                api_key_breakdown: {},
+              },
+            },
+            model_groups: {
+              "group-x": {
+                metrics: {
+                  spend: 12.5,
+                  api_requests: 100,
+                  successful_requests: 95,
+                  failed_requests: 5,
+                  total_tokens: 1000,
+                  prompt_tokens: 600,
+                  completion_tokens: 400,
+                  cache_read_input_tokens: 0,
+                  cache_creation_input_tokens: 0,
+                },
+                metadata: {},
+                api_key_breakdown: {},
+              },
+              "group-broken": {
+                metadata: {},
+                api_key_breakdown: {},
+              },
+            },
+            providers: {
+              openai: mockSpendData.results[0].breakdown.providers.openai,
+              broken: { metadata: {} },
+            },
+            api_keys: {
+              "sk-test123": {
+                // Missing inner `metrics`
+                metadata: { key_alias: "Test Key", tags: ["production"] },
+              },
+            },
+            mcp_servers: {},
+            entities: {},
+          },
+        },
+      ],
+      metadata: { ...mockSpendData.metadata, total_pages: 1, page: 1, has_more: false },
+    };
+
+    mockUserDailyActivityAggregatedCall.mockResolvedValueOnce(partialSpendData);
+
+    // Should not throw — the page should render with partial data.
+    expect(() => renderWithProviders(<UsagePage {...defaultProps} />)).not.toThrow();
+
+    // Wait for the request to be made — proves the consumer ran
+    // (without crashing) past the data fetch.
+    await waitFor(() => {
+      expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalled();
+    });
+  });
+
+  // Regression test for https://github.com/BerriAI/litellm/issues/33381
+  // When an api_keys breakdown entry has no `metadata` field at all, the
+  // topKeys aggregation must skip it gracefully instead of throwing
+  // `Cannot read properties of undefined (reading 'key_alias')`.
+  it("should not crash when api_keys entries are missing metadata", async () => {
+    const partialSpendData = {
+      ...mockSpendData,
+      results: [
+        {
+          date: "2025-01-01",
+          metrics: mockSpendData.results[0].metrics,
+          breakdown: {
+            ...mockSpendData.results[0].breakdown,
+            api_keys: {
+              "sk-valid": mockSpendData.results[0].breakdown.api_keys["sk-test123"],
+              "sk-no-meta": {
+                metrics: mockSpendData.results[0].breakdown.api_keys["sk-test123"].metrics,
+                // metadata intentionally missing
+              },
+            },
+          },
+        },
+      ],
+      metadata: { ...mockSpendData.metadata, total_pages: 1, page: 1, has_more: false },
+    };
+
+    mockUserDailyActivityAggregatedCall.mockResolvedValueOnce(partialSpendData);
+
+    expect(() => renderWithProviders(<UsagePage {...defaultProps} />)).not.toThrow();
+
+    await waitFor(() => {
+      expect(mockUserDailyActivityAggregatedCall).toHaveBeenCalled();
+    });
+  });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/UsagePageView.tsx
@@ -269,15 +269,15 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
             api_key_breakdown: {},
           };
         }
-        modelSpend[model].metrics.spend += metrics.metrics.spend;
-        modelSpend[model].metrics.prompt_tokens += metrics.metrics.prompt_tokens;
-        modelSpend[model].metrics.completion_tokens += metrics.metrics.completion_tokens;
-        modelSpend[model].metrics.total_tokens += metrics.metrics.total_tokens;
-        modelSpend[model].metrics.api_requests += metrics.metrics.api_requests;
-        modelSpend[model].metrics.successful_requests += metrics.metrics.successful_requests || 0;
-        modelSpend[model].metrics.failed_requests += metrics.metrics.failed_requests || 0;
-        modelSpend[model].metrics.cache_read_input_tokens += metrics.metrics.cache_read_input_tokens || 0;
-        modelSpend[model].metrics.cache_creation_input_tokens += metrics.metrics.cache_creation_input_tokens || 0;
+        modelSpend[model].metrics.spend += metrics.metrics?.spend ?? 0;
+        modelSpend[model].metrics.prompt_tokens += metrics.metrics?.prompt_tokens ?? 0;
+        modelSpend[model].metrics.completion_tokens += metrics.metrics?.completion_tokens ?? 0;
+        modelSpend[model].metrics.total_tokens += metrics.metrics?.total_tokens ?? 0;
+        modelSpend[model].metrics.api_requests += metrics.metrics?.api_requests ?? 0;
+        modelSpend[model].metrics.successful_requests += metrics.metrics?.successful_requests ?? 0;
+        modelSpend[model].metrics.failed_requests += metrics.metrics?.failed_requests ?? 0;
+        modelSpend[model].metrics.cache_read_input_tokens += metrics.metrics?.cache_read_input_tokens ?? 0;
+        modelSpend[model].metrics.cache_creation_input_tokens += metrics.metrics?.cache_creation_input_tokens ?? 0;
       });
     });
 
@@ -315,16 +315,16 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
             api_key_breakdown: {},
           };
         }
-        modelGroupSpend[modelGroup].metrics.spend += metrics.metrics.spend;
-        modelGroupSpend[modelGroup].metrics.prompt_tokens += metrics.metrics.prompt_tokens;
-        modelGroupSpend[modelGroup].metrics.completion_tokens += metrics.metrics.completion_tokens;
-        modelGroupSpend[modelGroup].metrics.total_tokens += metrics.metrics.total_tokens;
-        modelGroupSpend[modelGroup].metrics.api_requests += metrics.metrics.api_requests;
-        modelGroupSpend[modelGroup].metrics.successful_requests += metrics.metrics.successful_requests || 0;
-        modelGroupSpend[modelGroup].metrics.failed_requests += metrics.metrics.failed_requests || 0;
-        modelGroupSpend[modelGroup].metrics.cache_read_input_tokens += metrics.metrics.cache_read_input_tokens || 0;
+        modelGroupSpend[modelGroup].metrics.spend += metrics.metrics?.spend ?? 0;
+        modelGroupSpend[modelGroup].metrics.prompt_tokens += metrics.metrics?.prompt_tokens ?? 0;
+        modelGroupSpend[modelGroup].metrics.completion_tokens += metrics.metrics?.completion_tokens ?? 0;
+        modelGroupSpend[modelGroup].metrics.total_tokens += metrics.metrics?.total_tokens ?? 0;
+        modelGroupSpend[modelGroup].metrics.api_requests += metrics.metrics?.api_requests ?? 0;
+        modelGroupSpend[modelGroup].metrics.successful_requests += metrics.metrics?.successful_requests ?? 0;
+        modelGroupSpend[modelGroup].metrics.failed_requests += metrics.metrics?.failed_requests ?? 0;
+        modelGroupSpend[modelGroup].metrics.cache_read_input_tokens += metrics.metrics?.cache_read_input_tokens ?? 0;
         modelGroupSpend[modelGroup].metrics.cache_creation_input_tokens +=
-          metrics.metrics.cache_creation_input_tokens || 0;
+          metrics.metrics?.cache_creation_input_tokens ?? 0;
       });
     });
 
@@ -363,16 +363,16 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
             api_key_breakdown: {},
           };
         }
-        providerSpendMap[provider].metrics.spend += metrics.metrics.spend;
-        providerSpendMap[provider].metrics.prompt_tokens += metrics.metrics.prompt_tokens;
-        providerSpendMap[provider].metrics.completion_tokens += metrics.metrics.completion_tokens;
-        providerSpendMap[provider].metrics.total_tokens += metrics.metrics.total_tokens;
-        providerSpendMap[provider].metrics.api_requests += metrics.metrics.api_requests;
-        providerSpendMap[provider].metrics.successful_requests += metrics.metrics.successful_requests || 0;
-        providerSpendMap[provider].metrics.failed_requests += metrics.metrics.failed_requests || 0;
-        providerSpendMap[provider].metrics.cache_read_input_tokens += metrics.metrics.cache_read_input_tokens || 0;
+        providerSpendMap[provider].metrics.spend += metrics.metrics?.spend ?? 0;
+        providerSpendMap[provider].metrics.prompt_tokens += metrics.metrics?.prompt_tokens ?? 0;
+        providerSpendMap[provider].metrics.completion_tokens += metrics.metrics?.completion_tokens ?? 0;
+        providerSpendMap[provider].metrics.total_tokens += metrics.metrics?.total_tokens ?? 0;
+        providerSpendMap[provider].metrics.api_requests += metrics.metrics?.api_requests ?? 0;
+        providerSpendMap[provider].metrics.successful_requests += metrics.metrics?.successful_requests ?? 0;
+        providerSpendMap[provider].metrics.failed_requests += metrics.metrics?.failed_requests ?? 0;
+        providerSpendMap[provider].metrics.cache_read_input_tokens += metrics.metrics?.cache_read_input_tokens ?? 0;
         providerSpendMap[provider].metrics.cache_creation_input_tokens +=
-          metrics.metrics.cache_creation_input_tokens || 0;
+          metrics.metrics?.cache_creation_input_tokens ?? 0;
       });
     });
 
@@ -405,21 +405,21 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
               cache_creation_input_tokens: 0,
             },
             metadata: {
-              key_alias: metrics.metadata.key_alias,
+              key_alias: metrics.metadata?.key_alias ?? null,
               team_id: null,
-              tags: metrics.metadata.tags || [],
+              tags: metrics.metadata?.tags ?? [],
             },
           };
         }
-        keySpend[key].metrics.spend += metrics.metrics.spend;
-        keySpend[key].metrics.prompt_tokens += metrics.metrics.prompt_tokens;
-        keySpend[key].metrics.completion_tokens += metrics.metrics.completion_tokens;
-        keySpend[key].metrics.total_tokens += metrics.metrics.total_tokens;
-        keySpend[key].metrics.api_requests += metrics.metrics.api_requests;
-        keySpend[key].metrics.successful_requests += metrics.metrics.successful_requests;
-        keySpend[key].metrics.failed_requests += metrics.metrics.failed_requests;
-        keySpend[key].metrics.cache_read_input_tokens += metrics.metrics.cache_read_input_tokens || 0;
-        keySpend[key].metrics.cache_creation_input_tokens += metrics.metrics.cache_creation_input_tokens || 0;
+        keySpend[key].metrics.spend += metrics.metrics?.spend ?? 0;
+        keySpend[key].metrics.prompt_tokens += metrics.metrics?.prompt_tokens ?? 0;
+        keySpend[key].metrics.completion_tokens += metrics.metrics?.completion_tokens ?? 0;
+        keySpend[key].metrics.total_tokens += metrics.metrics?.total_tokens ?? 0;
+        keySpend[key].metrics.api_requests += metrics.metrics?.api_requests ?? 0;
+        keySpend[key].metrics.successful_requests += metrics.metrics?.successful_requests ?? 0;
+        keySpend[key].metrics.failed_requests += metrics.metrics?.failed_requests ?? 0;
+        keySpend[key].metrics.cache_read_input_tokens += metrics.metrics?.cache_read_input_tokens ?? 0;
+        keySpend[key].metrics.cache_creation_input_tokens += metrics.metrics?.cache_creation_input_tokens ?? 0;
       });
     });
 
@@ -1022,12 +1022,12 @@ const getModelActivityData = (userSpendData: { results: DailyData[]; metadata: a
         };
       }
 
-      modelData[model].total_requests += metrics.metrics.api_requests;
-      modelData[model].total_tokens += metrics.metrics.total_tokens;
+      modelData[model].total_requests += metrics.metrics?.api_requests ?? 0;
+      modelData[model].total_tokens += metrics.metrics?.total_tokens ?? 0;
       modelData[model].daily_data.push({
         date: day.date,
-        api_requests: metrics.metrics.api_requests,
-        total_tokens: metrics.metrics.total_tokens,
+        api_requests: metrics.metrics?.api_requests ?? 0,
+        total_tokens: metrics.metrics?.total_tokens ?? 0,
       });
     });
   });


### PR DESCRIPTION
## Summary

When `guardrailConfig` is set on a Bedrock Converse request,
`AmazonConverseConfig._convert_consecutive_user_messages_to_guarded_text`
rewrites trailing user-message text elements to
`{"type": "guarded_text", ...}`. The previous rewrite constructed a new
dict that copied only `type` and `text`, so any `cache_control` marker
on the original element (or on the message itself, for string content)
was silently dropped.

Because the prompt-factory `_get_cache_point_block` loop reads
`cache_control` from each content element, dropping the marker meant no
`cachePoint` block was ever emitted after the trailing `guardContent`
block — every ordinary chat turn lost its conversation-prefix
breakpoint whenever guardrails were enabled. Requests ending in a tool
result were unaffected (tool messages are not rewritten), so cache
behaviour differed between plain turns and tool-loop turns of the same
conversation.

## Reproduction (matches the issue's reproducer)

1. `pip install litellm`
2. Configure a Bedrock Converse request with both `cache_control_injection_points=[{location: message, index: -1}]` and `guardrailConfig`.
3. Run any multi-turn conversation ending with a user message.
4. Observe: with `guardrailConfig` absent, the trailing user message has a
   `cachePoint` block after its `guardContent` wrapper; with
   `guardrailConfig` present, the `cachePoint` block is silently dropped.

## Fix

Two rewrite paths needed the marker preserved:

- **list content** (e.g. `[{"type": "text", "cache_control": ...}]`):
  copy the per-element `cache_control` onto the new `guarded_text`
  dict so the per-element cache-point loop in
  `_bedrock_converse_messages_pt` still fires.
- **string content** with a message-level `cache_control` (placed
  there by `AnthropicCacheControlHook._safe_insert_cache_control_in_message`
  for `index: -1` injection points on string-content messages):
  promote the message-level marker onto the new `guarded_text`
  element. The user-message branch of the prompt factory only honors
  message-level `cache_control` for string content — once content
  becomes a list, only element-level markers are read.

Non-text elements (e.g. images) carrying `cache_control` are already
passed through untouched by the existing `else` branch, so the fix is
localised to the two text rewrites.

## Regression tests

`tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py`:

- `test_guarded_text_rewrite_preserves_element_level_cache_control` —
  list content: `cache_control` on the original element survives the
  rewrite.
- `test_guarded_text_rewrite_preserves_message_level_cache_control_for_string_content` —
  string content: message-level `cache_control` is promoted onto the
  new `guarded_text` element.
- `test_guarded_text_rewrite_without_cache_control_is_unchanged` —
  sanity: a marker-free input produces no spurious key.
- `test_transform_request_emits_cachePoint_after_guardContent_when_guardrail_enabled` —
  end-to-end through `_transform_request` for the list-content path;
  asserts `cachePoint` is emitted AFTER `guardContent` (a cachePoint
  covers everything preceding it).
- `test_transform_request_emits_cachePoint_when_guardrail_enabled_for_string_content` —
  end-to-end variant for the string-content path.
- `test_transform_request_emits_no_cachePoint_without_guardrail_baseline` —
  control arm of the issue reproducer: the same trailing message still
  emits a `cachePoint` when guardrailConfig is absent.

All 6 new tests fail against the pre-fix code (verified via
`git stash`) and pass with the fix applied.

## Verification

- `pytest tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py` →
  **166 passed** (+6 new), 2 pre-existing failures unrelated
  (`botocore` missing in this environment).
- `ruff check litellm/llms/bedrock/chat/converse_transformation.py` →
  clean.
- `ruff format --check` on the changed files → clean.

Fixes #33281