### PR TITLE
fix(proxy): preserve vector store client errors

### DIFF
--- a/litellm/proxy/vector_store_endpoints/management_endpoints.py
+++ b/litellm/proxy/vector_store_endpoints/management_endpoints.py
@@ -541,6 +541,8 @@ async def new_vector_store(
             "message": f"Vector store {vector_store.get('vector_store_id')} created successfully",
             "vector_store": response_vs,
         }
+    except HTTPException:
+        raise
     except Exception as e:
         verbose_proxy_logger.exception(f"Error creating vector store: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
@@ -2069,6 +2069,58 @@ async def test_new_vector_store_auto_resolves_embedding_config():
     )
 
 
+@pytest.mark.asyncio
+async def test_new_vector_store_preserves_missing_field_http_400():
+    user_api_key = MagicMock(spec=UserAPIKeyAuth)
+    user_api_key.team_id = None
+    user_api_key.user_id = None
+
+    with patch(
+        "litellm.proxy.vector_store_endpoints.management_endpoints.check_feature_access_for_user",
+        new=AsyncMock(),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await new_vector_store(
+                vector_store={"custom_llm_provider": "openai"},
+                user_api_key_dict=user_api_key,
+            )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "vector_store_id and custom_llm_provider are required"
+
+
+@pytest.mark.asyncio
+async def test_new_vector_store_preserves_duplicate_store_http_400():
+    user_api_key = MagicMock(spec=UserAPIKeyAuth)
+    user_api_key.team_id = None
+    user_api_key.user_id = None
+    duplicate_error = HTTPException(
+        status_code=400, detail="Vector store with ID vs-existing already exists"
+    )
+
+    with (
+        patch(
+            "litellm.proxy.vector_store_endpoints.management_endpoints.check_feature_access_for_user",
+            new=AsyncMock(),
+        ),
+        patch(
+            "litellm.proxy.vector_store_endpoints.management_endpoints.create_vector_store_in_db",
+            new=AsyncMock(side_effect=duplicate_error),
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await new_vector_store(
+                vector_store={
+                    "vector_store_id": "vs-existing",
+                    "custom_llm_provider": "openai",
+                },
+                user_api_key_dict=user_api_key,
+            )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == duplicate_error.detail
+
+
 def test_resolve_embedding_config_from_router():
     """Test that _resolve_embedding_config_from_router correctly extracts credentials from config-defined models."""
     from litellm.types.router import Deployment, LiteLLM_Params


### PR DESCRIPTION
## Relevant issues

Supersedes closed, unmerged PR #33595. This clean replacement contains only the intended endpoint fix and regression tests; it removes the unrelated CI files that entered the old branch.

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful regression tests
- [x] Local mapped tests pass: 75 passed
- [x] Local lint, format, type-budget, import, schema, and secret-scan gates pass
- [x] Scope is isolated to one specific create error-propagation bug and two files
- [ ] Hosted CI passes after this replacement PR is opened
- [ ] Greptile Confidence Score is at least 4/5 before maintainer review

## Screenshots / Proof of Fix

The local loopback proof used a dummy master key and no mocks, provider API, database, production service, credentials, or user data.

```bash
curl -i -X POST http://127.0.0.1:<port>/vector_store/new \
  -H 'Authorization: Bearer <redacted-local-dummy-key>' \
  -H 'Content-Type: application/json' \
  --data-binary '{"custom_llm_provider":"openai"}'
```

Base `265bf871bcb85ef09466b59d1cd93b02d2a0f79e` returned `500 Internal Server Error` with detail `400: vector_store_id and custom_llm_provider are required`.

Fixed `b1a56cce1bfb5d5af508dfa07a0b119452a495ee` returned `400 Bad Request` with detail `vector_store_id and custom_llm_provider are required`.

The current base and old proof base have identical affected source/test blobs. Current head `3d30440c288d996a0554b3e02b5fa7baed50a622` and the proof head have identical fixed source/test blobs and stable patch-id `9467f36837d3953238e98debaf388ec2742be40f`.

## Type

Bug Fix

Test

## Changes

`new_vector_store` now re-raises FastAPI `HTTPException` values before its generic error wrapper, preserving intended client-error statuses and details while unexpected failures continue to return 500.

Regression tests cover both missing required fields and duplicate vector-store IDs.