### PR TITLE
fix(proxy): reject invalid vector store page sizes

### DIFF
--- a/litellm/proxy/vector_store_endpoints/management_endpoints.py
+++ b/litellm/proxy/vector_store_endpoints/management_endpoints.py
@@ -572,6 +572,9 @@ async def list_vector_stores(
     - page: int - Page number for pagination (default: 1)
     - page_size: int - Number of items per page (default: 100)
     """
+    if page_size < 1:
+        raise HTTPException(status_code=422, detail="page_size must be at least 1")
+
     await check_feature_access_for_user(user_api_key_dict, "vector_stores")
 
     from litellm.proxy.proxy_server import prisma_client

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
@@ -30,6 +30,7 @@ from litellm.proxy.vector_store_endpoints.management_endpoints import (
     _resolve_embedding_config_from_db,
     _resolve_embedding_config_from_router,
     create_vector_store_in_db,
+    list_vector_stores,
     new_vector_store,
 )
 from litellm.proxy.vector_store_endpoints.utils import (
@@ -39,6 +40,25 @@ from litellm.proxy.vector_store_endpoints.utils import (
 )
 from litellm.types.vector_stores import IndexCreateRequest
 from litellm.types.utils import LlmProviders
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("page_size", [0, -1])
+async def test_list_vector_stores_rejects_non_positive_page_size(page_size):
+    """Invalid pagination must fail before feature access or database work."""
+    user = UserAPIKeyAuth(user_id="test-user", user_role=LitellmUserRoles.PROXY_ADMIN)
+    feature_access = AsyncMock()
+
+    with patch(
+        "litellm.proxy.vector_store_endpoints.management_endpoints.check_feature_access_for_user",
+        new=feature_access,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await list_vector_stores(user_api_key_dict=user, page_size=page_size)
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == "page_size must be at least 1"
+    feature_access.assert_not_awaited()
 
 
 def _serialize_litellm_params(litellm_params):


### PR DESCRIPTION
## Relevant issues

Supersedes closed, unmerged PR #33594. This clean replacement contains only the intended pagination fix and regression test; it removes the unrelated CI files that entered the old branch.

## Linear ticket


## Pre-Submission checklist

- [x] I have added a meaningful regression test
- [x] Local mapped tests pass: 75 passed
- [x] Local lint, format, type-budget, import, schema, and secret-scan gates pass
- [x] Scope is isolated to one specific pagination validation bug and two files
- [ ] Hosted CI passes after this replacement PR is opened
- [ ] Greptile Confidence Score is at least 4/5 before maintainer review

## Screenshots / Proof of Fix

The local loopback proof used a dummy master key and no mocks, provider API, database, production service, credentials, or user data.

```bash
curl -i 'http://127.0.0.1:<port>/vector_store/list?page_size=0' \
  -H 'Authorization: Bearer <redacted-local-dummy-key>'
```

Base `265bf871bcb85ef09466b59d1cd93b02d2a0f79e` returned `500 Internal Server Error` with detail `integer division or modulo by zero`.

Fixed `617e9b4ef4c535328ee0bccf7982a24e3dab674a` returned `422 Unprocessable Entity` with detail `page_size must be at least 1`.

The current base and old proof base have identical affected source/test blobs. Current head `7cc846808ec8bc7c8ab66a6279b9e61f81d965f0` and the proof head have identical fixed source/test blobs and stable patch-id `2a85ff274daee8e8e65538ca1c580a8c19b42956`.

## Type

Bug Fix

Test

## Changes

`list_vector_stores` now rejects all non-positive `page_size` values before feature access, database access, or pagination arithmetic.

Regression coverage locks the client-visible 422 status and message for zero and negative values.