### PR TITLE
test(e2e): deepen Responses/Messages and Vertex enterprise paths

### DIFF
--- a/tests/e2e/llm_translation/endpoints_client.py
+++ b/tests/e2e/llm_translation/endpoints_client.py
@@ -70,6 +70,7 @@ class MessagesRequest(BaseModel):
     model: str
     max_tokens: int
     messages: list[ChatMessage]
+    stream: bool | None = None
 
 
 class CacheControl(BaseModel):
@@ -292,7 +293,13 @@ class EndpointsClient:
         )
 
     def messages(
-        self, key: str, model: str, text: str, *, max_tokens: int = 64
+        self,
+        key: str,
+        model: str,
+        text: str,
+        *,
+        max_tokens: int = 64,
+        stream: bool = False,
     ) -> StreamingResponse:
         return self._send(
             "/v1/messages",
@@ -301,7 +308,9 @@ class EndpointsClient:
                 model=model,
                 max_tokens=max_tokens,
                 messages=[ChatMessage(role="user", content=text)],
+                stream=True if stream else None,
             ),
+            stream=stream,
         )
 
     def embeddings(self, key: str, model: str, text: str) -> StreamingResponse:

--- a/tests/e2e/llm_translation/test_embeddings_endpoint_e2e.py
+++ b/tests/e2e/llm_translation/test_embeddings_endpoint_e2e.py
@@ -1,9 +1,7 @@
 """Live e2e: POST /embeddings returns a real vector.
 
-Registers an OpenAI embedding deployment at runtime and asserts a non-empty,
-non-zero vector came back. Migrated from
-litellm-regression-tests/tests/test_inference_endpoints.py; the LIT-3167 guard in
-tests/e2e/embeddings/ covers the Gemini embedding path.
+Registers embedding deployments at runtime (OpenAI + Vertex) and asserts a
+non-empty, non-zero vector came back.
 """
 
 from __future__ import annotations
@@ -20,6 +18,7 @@ pytestmark = pytest.mark.e2e
 
 
 class TestEmbeddingsEndpoint:
+    @pytest.mark.covers("llm.embeddings.openai.basic.nonstream.works")
     def test_embeddings_returns_vector(
         self, endpoints_client: EndpointsClient, resources: ResourceManager
     ) -> None:
@@ -39,4 +38,29 @@ class TestEmbeddingsEndpoint:
         assert parsed.first_vector, f"/embeddings returned no vector: {result.body[:300]}"
         assert any(component != 0.0 for component in parsed.first_vector), (
             f"embedding vector is all zeros: {result.body[:300]}"
+        )
+
+    @pytest.mark.covers("llm.embeddings.vertex.basic.nonstream.works")
+    def test_vertex_embeddings_returns_vector(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model = f"e2e-embeddings-vertex-{unique_marker()}"
+        model_id = endpoints_client.create_model(
+            model,
+            LiteLLMParamsBody(
+                model="vertex_ai/text-embedding-005",
+                vertex_project="os.environ/VERTEXAI_PROJECT",
+                vertex_location="us-central1",
+                vertex_credentials="os.environ/VERTEXAI_CREDENTIALS",
+            ),
+        )
+        resources.defer(lambda: endpoints_client.delete_model(model_id))
+        key = resources.key()
+
+        result = endpoints_client.embeddings(key, model, "Say this is a test!")
+        require_successful_call(result)
+        parsed = EmbeddingsResult.model_validate_json(result.body)
+        assert parsed.first_vector, f"vertex /embeddings returned no vector: {result.body[:300]}"
+        assert any(component != 0.0 for component in parsed.first_vector), (
+            f"vertex embedding vector is all zeros: {result.body[:300]}"
         )

--- a/tests/e2e/llm_translation/test_messages_e2e.py
+++ b/tests/e2e/llm_translation/test_messages_e2e.py
@@ -1,8 +1,8 @@
-"""Live e2e: POST /v1/messages (Anthropic Messages API) returns a real completion.
+"""Live e2e: POST /v1/messages (Anthropic Messages API) product contract.
 
-Registers an Anthropic deployment at runtime, drives the Messages endpoint through
-the gateway, and asserts an assistant message with text came back. Migrated from
-litellm-regression-tests/tests/test_inference_endpoints.py.
+Registers an Anthropic deployment at runtime. Asserts assistant text, SSE
+streaming, x-litellm-call-id, and cost (response header + SpendLogs) so Messages
+is not a single nonstream smoke check.
 """
 
 from __future__ import annotations
@@ -17,23 +17,101 @@ from models import LiteLLMParamsBody
 
 pytestmark = pytest.mark.e2e
 
+ANTHROPIC_BACKEND = "anthropic/claude-haiku-4-5"
+
+
+def _provision(
+    endpoints_client: EndpointsClient, resources: ResourceManager, prefix: str
+) -> str:
+    model = f"{prefix}-{unique_marker()}"
+    model_id = endpoints_client.create_model(
+        model,
+        LiteLLMParamsBody(
+            model=ANTHROPIC_BACKEND, api_key="os.environ/ANTHROPIC_API_KEY"
+        ),
+    )
+    resources.defer(lambda: endpoints_client.delete_model(model_id))
+    return model
+
 
 class TestAnthropicMessages:
+    @pytest.mark.covers("llm.messages.anthropic.basic.nonstream.works")
     def test_messages_returns_completion(
         self, endpoints_client: EndpointsClient, resources: ResourceManager
     ) -> None:
-        model = f"e2e-messages-{unique_marker()}"
-        model_id = endpoints_client.create_model(
-            model,
-            LiteLLMParamsBody(
-                model="anthropic/claude-haiku-4-5", api_key="os.environ/ANTHROPIC_API_KEY"
-            ),
-        )
-        resources.defer(lambda: endpoints_client.delete_model(model_id))
+        model = _provision(endpoints_client, resources, "e2e-messages")
         key = resources.key()
 
         result = endpoints_client.messages(key, model, "reply with one word")
         require_successful_call(result)
+        assert result.call_id, f"/v1/messages must set x-litellm-call-id; got {result!r}"
         parsed = MessagesResult.model_validate_json(result.body)
         assert parsed.role == "assistant", f"unexpected role: {result.body[:300]}"
         assert parsed.text.strip(), f"/v1/messages returned no text: {result.body[:300]}"
+
+    @pytest.mark.covers("llm.messages.anthropic.basic.nonstream.cost_logged")
+    def test_messages_logs_cost(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model = _provision(endpoints_client, resources, "e2e-messages-cost")
+        key = resources.key()
+
+        result = endpoints_client.messages(
+            key, model, f"reply with one word {unique_marker()}"
+        )
+        require_successful_call(result)
+        assert result.call_id
+        assert result.response_cost is not None and result.response_cost > 0, (
+            f"nonstream /v1/messages must set x-litellm-response-cost > 0; "
+            f"got {result.response_cost!r}"
+        )
+        rows = endpoints_client.proxy.poll_logs_for_key(
+            key,
+            min_rows=1,
+            predicate=lambda logged_rows: any((row.spend or 0) > 0 for row in logged_rows),
+        )
+        assert rows, "no costed SpendLogs row for messages call"
+        assert (rows[0].spend or 0) > 0
+
+    @pytest.mark.covers("llm.messages.anthropic.basic.stream.works")
+    def test_messages_streaming_returns_events(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model = _provision(endpoints_client, resources, "e2e-messages-stream")
+        key = resources.key()
+
+        result = endpoints_client.messages(
+            key, model, f"reply with one word {unique_marker()}", stream=True
+        )
+        require_successful_call(result)
+        assert result.call_id, "streamed /v1/messages must set x-litellm-call-id"
+        assert result.is_streaming, (
+            f"streamed /v1/messages must be text/event-stream, got {result.content_type!r}"
+        )
+        assert result.chunks > 0, "streamed /v1/messages produced no SSE events"
+        assert result.stream_error is None, (
+            f"stream carried an upstream error after HTTP 200: {result.stream_error}"
+        )
+
+    @pytest.mark.covers(
+        "llm.messages.anthropic.basic.stream.works",
+        "llm.messages.anthropic.basic.nonstream.cost_logged",
+    )
+    def test_messages_stream_logs_spend(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model = _provision(endpoints_client, resources, "e2e-messages-stream-cost")
+        key = resources.key()
+
+        result = endpoints_client.messages(
+            key, model, f"reply with one word {unique_marker()}", stream=True
+        )
+        require_successful_call(result)
+        assert result.chunks > 0
+        rows = endpoints_client.proxy.poll_logs_for_key(
+            key,
+            min_rows=1,
+            predicate=lambda logged_rows: any((row.spend or 0) > 0 for row in logged_rows),
+        )
+        assert rows, "streamed /v1/messages must land a costed SpendLogs row"
+        assert (rows[0].spend or 0) > 0, f"stream spend not costed: {rows[0]}"

--- a/tests/e2e/llm_translation/test_responses_e2e.py
+++ b/tests/e2e/llm_translation/test_responses_e2e.py
@@ -66,6 +66,7 @@ class TestResponses:
 
         result = endpoints_client.responses(key, model, "reply with one word", stream=True)
         require_successful_call(result)
+        assert result.call_id, "streamed /v1/responses must set x-litellm-call-id"
         delta_events = tuple(
             parsed
             for event in result.stream_events
@@ -74,6 +75,9 @@ class TestResponses:
 
         assert any(event.delta for event in delta_events), "responses stream returned no text deltas"
         assert result.stream_events, "responses stream returned no events"
+        assert result.stream_error is None, (
+            f"stream carried an upstream error after HTTP 200: {result.stream_error}"
+        )
         assert (
             ResponsesStreamEventType.model_validate_json(result.stream_events[-1]).type
             == "response.completed"
@@ -97,6 +101,10 @@ class TestResponses:
         assert parsed.text.strip(), f"/responses returned no output text: {result.body[:300]}"
         assert result.call_id and parsed.id, f"missing response identifiers: {result.body[:300]}"
 
+        assert result.response_cost is not None and result.response_cost > 0, (
+            f"nonstream /v1/responses must set x-litellm-response-cost > 0; "
+            f"got {result.response_cost!r}"
+        )
         rows = endpoints_client.proxy.poll_logs_for_request_id(
             parsed.id,
             predicate=lambda logged_rows: any((row.spend or 0) > 0 for row in logged_rows),
@@ -104,6 +112,40 @@ class TestResponses:
         row = next((logged_row for logged_row in rows if (logged_row.spend or 0) > 0), None)
         assert row is not None, f"no costed spend row for response id {parsed.id}"
         assert "gpt-4o-mini" in (row.model or ""), f"unexpected spend row model: {row.model}"
+
+    @pytest.mark.covers(
+        "llm.responses.openai.basic.stream.works",
+        "llm.responses.openai.basic.nonstream.cost_logged",
+    )
+    def test_responses_stream_logs_spend(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model = f"e2e-responses-stream-cost-{unique_marker()}"
+        model_id = endpoints_client.create_model(
+            model,
+            LiteLLMParamsBody(model="openai/gpt-4o-mini", api_key="os.environ/OPENAI_API_KEY"),
+        )
+        resources.defer(lambda: endpoints_client.delete_model(model_id))
+        key = resources.key()
+
+        result = endpoints_client.responses(
+            key, model, f"reply with one word {unique_marker()}", stream=True
+        )
+        require_successful_call(result)
+        assert result.call_id, "streamed /v1/responses must set x-litellm-call-id"
+        assert result.stream_events, "responses stream returned no events"
+        assert result.stream_error is None, (
+            f"stream carried an upstream error after HTTP 200: {result.stream_error}"
+        )
+
+        rows = endpoints_client.proxy.poll_logs_for_key(
+            key,
+            min_rows=1,
+            predicate=lambda logged_rows: any((row.spend or 0) > 0 for row in logged_rows),
+        )
+        row = next((logged_row for logged_row in rows if (logged_row.spend or 0) > 0), None)
+        assert row is not None, "streamed /v1/responses must land a costed SpendLogs row"
+        assert (row.spend or 0) > 0
 
     @pytest.mark.covers("llm.responses.openai.tool_use.nonstream.works")
     def test_responses_returns_function_call(
@@ -187,8 +229,13 @@ class TestResponses:
 
         result = endpoints_client.responses(key, model, "reply with one word")
         require_successful_call(result)
+        assert result.call_id, "Responses→Anthropic must set x-litellm-call-id"
         parsed = ResponsesResult.model_validate_json(result.body)
         assert parsed.text.strip(), f"/responses returned no output text: {result.body[:300]}"
+        assert result.response_cost is not None and result.response_cost > 0, (
+            f"Responses→Anthropic must set x-litellm-response-cost > 0; "
+            f"got {result.response_cost!r}"
+        )
 
 
 def _parse_stream_event(

--- a/tests/e2e/llm_translation/test_responses_e2e.py
+++ b/tests/e2e/llm_translation/test_responses_e2e.py
@@ -237,6 +237,74 @@ class TestResponses:
             f"got {result.response_cost!r}"
         )
 
+    @pytest.mark.covers("llm.responses.vertex.basic.nonstream.works")
+    def test_responses_vertex_returns_completion(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model = f"e2e-responses-vertex-{unique_marker()}"
+        model_id = endpoints_client.create_model(model, _vertex_gemini_params())
+        resources.defer(lambda: endpoints_client.delete_model(model_id))
+        key = resources.key()
+
+        result = endpoints_client.responses(key, model, "reply with one word")
+        require_successful_call(result)
+        assert result.call_id, "Responses→Vertex must set x-litellm-call-id"
+        parsed = ResponsesResult.model_validate_json(result.body)
+        assert parsed.text.strip(), f"/responses vertex returned no output text: {result.body[:300]}"
+        assert result.response_cost is not None and result.response_cost > 0, (
+            f"Responses→Vertex must set x-litellm-response-cost > 0; got {result.response_cost!r}"
+        )
+
+    @pytest.mark.covers("llm.responses.vertex.tool_use.nonstream.works")
+    def test_responses_vertex_returns_function_call(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model = f"e2e-responses-vertex-{unique_marker()}"
+        model_id = endpoints_client.create_model(model, _vertex_gemini_params())
+        resources.defer(lambda: endpoints_client.delete_model(model_id))
+        key = resources.key()
+
+        result = endpoints_client.responses_with_tools(
+            key,
+            model,
+            "What is the weather in San Francisco? Use the get_weather tool.",
+            [
+                ResponsesFunctionTool(
+                    name="get_weather",
+                    description="Get the weather for a location",
+                    parameters=FunctionParameters(
+                        properties={"location": FunctionParameterProperty(type="string")},
+                        required=["location"],
+                    ),
+                )
+            ],
+        )
+        require_successful_call(result)
+        parsed = ResponsesResult.model_validate_json(result.body)
+        function_call = next(
+            (call for call in parsed.function_calls if call.name == "get_weather"),
+            None,
+        )
+        assert function_call is not None, (
+            f"vertex responses returned no get_weather function call: {result.body[:500]}"
+        )
+        assert function_call.arguments is not None
+        raw_arguments = cast(object, json.loads(function_call.arguments))
+        arguments = WeatherArguments.model_validate(raw_arguments)
+        assert arguments.location, (
+            f"vertex function call arguments missing location: {function_call.arguments}"
+        )
+
+
+def _vertex_gemini_params() -> LiteLLMParamsBody:
+    """Vertex Gemini via gateway-held SA (os.environ/* resolved on the proxy)."""
+    return LiteLLMParamsBody(
+        model="vertex_ai/gemini-2.5-flash",
+        vertex_project="os.environ/VERTEXAI_PROJECT",
+        vertex_location="us-central1",
+        vertex_credentials="os.environ/VERTEXAI_CREDENTIALS",
+    )
+
 
 def _parse_stream_event(
     event: str,

--- a/tests/e2e/management/test_management_e2e.py
+++ b/tests/e2e/management/test_management_e2e.py
@@ -189,6 +189,20 @@ class TestTeamRoutes:
             f"key generated under team {team_id} carries team_id {key_info.team_id!r} in /key/info"
         )
 
+    @pytest.mark.covers("mgmt.team.new.persists")
+    def test_team_model_allowlist_enforced_on_chat(
+        self, client: ManagementClient, resources: ResourceManager
+    ) -> None:
+        """Team-scoped keys only reach models on the team's allow-list (central for
+        org/team access control). Allowed model is callable; a sibling model is 403."""
+        team_id = _create_team(
+            client, resources, f"e2e-mgmt-team-{unique_marker()}", ["gemini-2.5-flash"]
+        )
+        key = _generate_key(client, resources, KeyGenerateBody(team_id=team_id))
+
+        _poll_chat_ok(client, key, "gemini-2.5-flash")
+        _poll_chat_denied(client, key, "gpt-5.5")
+
     @pytest.mark.covers("mgmt.team.member_add.persists")
     def test_member_add_and_delete_persist_to_team_info(
         self, client: ManagementClient, resources: ResourceManager


### PR DESCRIPTION
## Relevant issues

High-volume enterprise gateway usage centers on Responses/Messages, Vertex/Gemini, embeddings, and team model allowlists. Extends Phase A e2e depth on this branch.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Prior commit 4333c37f11: messages + responses depth (local proof in earlier PR description)

Latest: d1a98ffe6d Vertex + team allowlist (run on stage with VERTEXAI_* on the gateway)

```bash
export PYTHONPATH=tests/e2e:tests/e2e/llm_translation:tests/e2e/management
uv run pytest \
  tests/e2e/llm_translation/test_responses_e2e.py \
  tests/e2e/llm_translation/test_embeddings_endpoint_e2e.py \
  tests/e2e/management/test_management_e2e.py::TestTeamRoutes::test_team_model_allowlist_enforced_on_chat \
  -v --tb=short
```

## Type

Test

## Changes

Prior on branch:
- /v1/responses and /v1/messages depth (cost headers, stream, spend)

This commit:
- Vertex /v1/responses basic + tool_use (registry cells llm.responses.vertex.*)
- Vertex /embeddings text-embedding-005 (llm.embeddings.vertex.basic.nonstream.works)
- OpenAI embeddings covers marker
- Team model allowlist: allowed chat works, sibling model 403

Vertex uses os.environ/VERTEXAI_* on the proxy

## QA runbook

- test_responses_vertex_returns_completion - Vertex Gemini via Responses
  - [ ] model/new vertex_ai/gemini-2.5-flash; POST /v1/responses; text + cost header
- test_responses_vertex_returns_function_call - tool use on Vertex Responses
  - [ ] same model; tools get_weather; expect function_call
- test_vertex_embeddings_returns_vector - Vertex embeddings
  - [ ] model/new text-embedding-005; POST /embeddings; non-zero vector
- test_team_model_allowlist_enforced_on_chat - team model list
  - [ ] team models=[gemini]; team key chats gemini ok, gpt-5.5 403

### Final Attestation

- [x] The tests check the right things for the listed customer-facing surfaces