### PR TITLE
fix(router): treat malformed configured token limits as absent on /v1/models

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -8535,7 +8535,8 @@ class Router:
         Return (max_input_tokens, max_output_tokens) explicitly configured in a concrete
         deployment's model_info for model_name, via O(1) index lookup.
 
-        Returns (None, None) for wildcard-expanded or unknown names. Unlike
+        Returns (None, None) for wildcard-expanded or unknown names, and treats a
+        malformed configured value as absent rather than failing the listing. Unlike
         get_model_group_info, this never triggers pattern matching or deep copies, so it
         is safe to call per listed model on the /v1/models hot path.
         """
@@ -8543,12 +8544,18 @@ class Router:
         if deployment is None:
             return (None, None)
 
+        def _as_int(value: object) -> "int | None":
+            if value is None or isinstance(value, bool):
+                return None
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return None
+
         model_info = deployment.model_info
-        max_input = model_info.get("max_input_tokens")
-        max_output = model_info.get("max_output_tokens")
         return (
-            int(max_input) if max_input is not None else None,
-            int(max_output) if max_output is not None else None,
+            _as_int(model_info.get("max_input_tokens")),
+            _as_int(model_info.get("max_output_tokens")),
         )
 
     def get_deployment_credentials_with_provider(

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -556,6 +556,31 @@ def test_create_model_info_response_deployment_limits_override_cost_map():
     assert response["max_output_tokens"] == 16384
 
 
+def test_create_model_info_response_survives_malformed_configured_limits():
+    from litellm import Router
+
+    router = Router(
+        model_list=[
+            {
+                "model_name": "bad-limit-model",
+                "litellm_params": {"model": "openai/some-unmapped-model"},
+                "model_info": {"max_input_tokens": "128,000"},
+            }
+        ]
+    )
+
+    response = create_model_info_response(
+        model_id="bad-limit-model",
+        provider="openai",
+        llm_router=router,
+        get_model_info=_raise_unmapped,
+    )
+
+    assert response["id"] == "bad-limit-model"
+    assert "max_input_tokens" not in response
+    assert "max_output_tokens" not in response
+
+
 def test_create_model_info_response_emits_integer_token_counts():
     response = create_model_info_response(
         model_id="some-model",

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -5775,3 +5775,34 @@ def test_get_configured_token_limits_skips_wildcard_pattern_matching():
         assert router.get_configured_token_limits(
             "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0"
         ) == (None, None)
+
+
+def test_get_configured_token_limits_treats_malformed_values_as_absent():
+    malformed = ["", "unlimited", "128,000", [128000], {"max": 128000}, True]
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": f"bad-limit-{i}",
+                "litellm_params": {"model": "openai/some-unmapped-model"},
+                "model_info": {"max_input_tokens": bad, "max_output_tokens": bad},
+            }
+            for i, bad in enumerate(malformed)
+        ]
+    )
+
+    for i in range(len(malformed)):
+        assert router.get_configured_token_limits(f"bad-limit-{i}") == (None, None)
+
+
+def test_get_configured_token_limits_coerces_numeric_strings():
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "quoted-limits-model",
+                "litellm_params": {"model": "openai/some-unmapped-model"},
+                "model_info": {"max_input_tokens": "32000", "max_output_tokens": "8000"},
+            }
+        ]
+    )
+
+    assert router.get_configured_token_limits("quoted-limits-model") == (32000, 8000)


### PR DESCRIPTION
## Relevant issues

Hardening follow-up to #33721. That change sources /v1/models token limits from the cost map with a per-deployment configured-limit override, but the override path ran a bare int() on the admin-configured model_info values. A single deployment configured with a non-numeric limit (for example "128,000", an empty string, "unlimited", or a YAML list) made the conversion raise inside the per-model listing loop, so the entire GET /v1/models response returned 500, taking well-formed sibling models down with it. Before #33721 the same configuration degraded to a response without limits, so this restores that contract while keeping the O(1) lookup and the configured-limit override

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy with this model_list entry in the config:

```yaml
  - model_name: bad-limit-model
    litellm_params:
      model: openai/gpt-4o
      api_key: sk-fake
    model_info:
      max_input_tokens: "128,000"
```

Before, at `d495da4ce4` (staging tip without this fix):

```
$ curl -s -o /dev/null -w 'HTTP %{http_code}\n' http://localhost:4001/v1/models -H 'Authorization: Bearer sk-1234'
HTTP 500
$ curl -s http://localhost:4001/v1/models -H 'Authorization: Bearer sk-1234'
{"error":{"message":"Internal server error","type":"internal_server_error"}}
```

After, same request with the fix applied (captured at the PR commit):

```
$ curl -s -o /dev/null -w 'HTTP %{http_code}\n' http://localhost:4001/v1/models -H 'Authorization: Bearer sk-1234'
HTTP 200
# per-model limits from the same response:
gpt-4o          in: 128000  out: 16384   (cost map)
custom-good     in: 32000   out: 8000    (configured model_info, override intact)
bad-limit-model in: None    out: None    (malformed value treated as absent)
```

Both new regression tests fail on the pre-fix code with the exact defect (`ValueError: invalid literal for int() with base 10: '128,000'` at litellm/router.py) and pass with it

## Type

🐛 Bug Fix

## Changes

Router.get_configured_token_limits now runs each configured limit through a safe int coercion: None, bools, and values that raise TypeError/ValueError on int() are treated as absent instead of propagating out of the /v1/models listing loop. Numeric strings (a YAML-quoted "32000") still coerce, and well-formed integer configs are unchanged. The docstring now states the malformed-value contract

Tests: test_get_configured_token_limits_treats_malformed_values_as_absent pins (None, None) for the malformed shapes at the Router level, test_get_configured_token_limits_coerces_numeric_strings pins the tolerant path, and test_create_model_info_response_survives_malformed_configured_limits exercises the full /v1/models enrichment with a real Router and asserts the base response comes back instead of an exception

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
