### PR TITLE
fix(router): skip RPM cache reads when no deployment configures rpm

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -10206,7 +10206,7 @@ class Router:
         )
 
         ## get model group RPM ##
-        model_group_cache: dict[str, int] | None = None
+        model_group_cache: dict[str, int] | None = None  # mutable-ok: incremented below
         if _any_deployment_has_rpm:
             dt = get_utc_datetime()
             current_minute = dt.strftime("%H-%M")

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -10199,13 +10199,21 @@ class Router:
         instructions = raw_instructions if isinstance(raw_instructions, str) else None
         has_countable_input = messages is not None or input is not None
 
+        # Safe to check statically since `rpm` is a direct litellm_params setting, unlike
+        # max_input_tokens which get_router_model_info() can also derive from the cost map.
+        _any_deployment_has_rpm = self.routing_strategy != "usage-based-routing-v2" and any(
+            (d.get("litellm_params") or {}).get("rpm") is not None for d in _returned_deployments
+        )
+
         ## get model group RPM ##
-        dt = get_utc_datetime()
-        current_minute = dt.strftime("%H-%M")
-        rpm_key = f"{model}:rpm:{current_minute}"
-        model_group_cache = (
-            self.cache.get_cache(key=rpm_key, local_only=True, parent_otel_span=parent_otel_span) or {}
-        )  # check the in-memory cache used by lowest_latency and usage-based routing. Only check the local cache.
+        model_group_cache: dict[str, int] | None = None
+        if _any_deployment_has_rpm:
+            dt = get_utc_datetime()
+            current_minute = dt.strftime("%H-%M")
+            rpm_key = f"{model}:rpm:{current_minute}"
+            model_group_cache = (
+                self.cache.get_cache(key=rpm_key, local_only=True, parent_otel_span=parent_otel_span) or {}
+            )  # check the in-memory cache used by lowest_latency and usage-based routing. Only check the local cache.
         for idx, deployment in enumerate(_returned_deployments):
             # Cache nested dict access to avoid repeated temporary dict allocations
             _litellm_params = deployment.get("litellm_params", {})
@@ -10246,14 +10254,14 @@ class Router:
             except Exception as e:
                 verbose_router_logger.exception("An error occurs - {}".format(str(e)))
 
-            model_id = _model_info.get("id", "")
             ## RPM CHECK ##
-            ### get local router cache ###
-            current_request_cache_local = (
-                self.cache.get_cache(key=model_id, local_only=True, parent_otel_span=parent_otel_span) or 0
-            )
-            ### get usage based cache ###
-            if isinstance(model_group_cache, dict) and self.routing_strategy != "usage-based-routing-v2":
+            if _any_deployment_has_rpm and isinstance(model_group_cache, dict):
+                model_id = _model_info.get("id", "")
+                ### get local router cache ###
+                current_request_cache_local = (
+                    self.cache.get_cache(key=model_id, local_only=True, parent_otel_span=parent_otel_span) or 0
+                )
+                ### get usage based cache ###
                 model_group_cache[model_id] = model_group_cache.get(model_id, 0)
 
                 current_request = max(current_request_cache_local, model_group_cache[model_id])

--- a/tests/router_unit_tests/test_pre_call_checks_optimization.py
+++ b/tests/router_unit_tests/test_pre_call_checks_optimization.py
@@ -71,13 +71,9 @@ class TestPreCallChecksOptimization:
         # 1. Same number of items
         assert len(deployments) == original_length, "List length changed!"
         # 2. Same deployment objects (not replaced with copies)
-        assert [
-            id(d) for d in deployments
-        ] == original_deployment_ids, "Deployment dicts replaced!"
+        assert [id(d) for d in deployments] == original_deployment_ids, "Deployment dicts replaced!"
         # 3. Same nested objects (not replaced with copies)
-        assert [
-            id(d["litellm_params"]) for d in deployments
-        ] == original_litellm_params_ids, "Nested dicts replaced!"
+        assert [id(d["litellm_params"]) for d in deployments] == original_litellm_params_ids, "Nested dicts replaced!"
         # 4. Same values (catches any mutation)
         assert deployments == snapshot, "Values were mutated!"
 
@@ -120,29 +116,143 @@ class TestPreCallChecksOptimization:
         )
 
         # Verify the filtered result only contains the large deployment
-        assert (
-            len(filtered) == 1
-        ), f"Expected 1 deployment after filtering, got {len(filtered)}"
-        assert (
-            filtered[0]["model_info"]["id"] == "large"
-        ), "Wrong deployment kept after filtering"
+        assert len(filtered) == 1, f"Expected 1 deployment after filtering, got {len(filtered)}"
+        assert filtered[0]["model_info"]["id"] == "large", "Wrong deployment kept after filtering"
 
         # Verify the original list still has both deployments
-        assert (
-            len(deployments) == 2
-        ), f"Original list was modified! Expected 2, got {len(deployments)}"
-        assert (
-            deployments[0] is original_small_deployment
-        ), "First deployment object replaced!"
-        assert (
-            deployments[1] is original_large_deployment
-        ), "Second deployment object replaced!"
-        assert (
-            deployments[0].get("model_info", {}).get("id") == "small"
-        ), "First deployment ID changed!"
-        assert (
-            deployments[1].get("model_info", {}).get("id") == "large"
-        ), "Second deployment ID changed!"
+        assert len(deployments) == 2, f"Original list was modified! Expected 2, got {len(deployments)}"
+        assert deployments[0] is original_small_deployment, "First deployment object replaced!"
+        assert deployments[1] is original_large_deployment, "Second deployment object replaced!"
+        assert deployments[0].get("model_info", {}).get("id") == "small", "First deployment ID changed!"
+        assert deployments[1].get("model_info", {}).get("id") == "large", "Second deployment ID changed!"
+
+
+class TestPreCallChecksSkipsRpmCacheReadWhenUnused:
+    """
+    _pre_call_checks() must not read the RPM cache at all when no deployment in
+    the model group configures `rpm` - that cache read (local + usage-based lookup
+    per deployment) runs on every request and is pure overhead when nothing
+    actually gates on it.
+    """
+
+    def test_no_rpm_cache_read_when_no_deployment_has_rpm(self):
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "test",
+                    "litellm_params": {"model": "gpt-5-mini", "api_key": "sk-test"},
+                    "model_info": {"id": "no-rpm-1"},
+                },
+                {
+                    "model_name": "test",
+                    "litellm_params": {"model": "gpt-5.5", "api_key": "sk-test"},
+                    "model_info": {"id": "no-rpm-2"},
+                },
+            ],
+            set_verbose=False,
+            enable_pre_call_checks=True,
+        )
+
+        get_cache_calls = []
+        original_get_cache = router.cache.get_cache
+
+        def _tracking_get_cache(*args, **kwargs):
+            get_cache_calls.append(kwargs.get("key", args[0] if args else None))
+            return original_get_cache(*args, **kwargs)
+
+        router.cache.get_cache = _tracking_get_cache
+
+        deployments = router.get_model_list(model_name="test")
+        assert deployments is not None
+
+        router._pre_call_checks(
+            model="test",
+            healthy_deployments=deployments,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert get_cache_calls == [], f"Expected zero cache reads, got {get_cache_calls}"
+
+    def test_rpm_cache_still_read_and_enforced_when_a_deployment_has_rpm(self):
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "test",
+                    "litellm_params": {"model": "gpt-5-mini", "api_key": "sk-test", "rpm": 1},
+                    "model_info": {"id": "low-rpm"},
+                },
+                {
+                    "model_name": "test",
+                    "litellm_params": {"model": "gpt-5.5", "api_key": "sk-test"},
+                    "model_info": {"id": "no-rpm"},
+                },
+            ],
+            set_verbose=False,
+            enable_pre_call_checks=True,
+        )
+
+        get_cache_calls = []
+        original_get_cache = router.cache.get_cache
+
+        def _tracking_get_cache(*args, **kwargs):
+            key = kwargs.get("key", args[0] if args else None)
+            get_cache_calls.append(key)
+            return original_get_cache(*args, **kwargs)
+
+        router.cache.get_cache = _tracking_get_cache
+
+        deployments = router.get_model_list(model_name="test")
+        assert deployments is not None
+
+        # Simulate the low-rpm deployment already at its limit.
+        router.cache.set_cache(key="low-rpm", value=1, local_only=True)
+
+        filtered = router._pre_call_checks(
+            model="test",
+            healthy_deployments=deployments,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert get_cache_calls, "Expected the RPM cache to be read when a deployment configures rpm"
+        assert [d["model_info"]["id"] for d in filtered] == ["no-rpm"], (
+            "Deployment at its rpm limit should have been filtered out"
+        )
+
+    def test_no_rpm_cache_read_for_usage_based_routing_v2(self):
+        """usage-based-routing-v2 manages its own RPM enforcement; _pre_call_checks
+        must not also read the cache even if a deployment configures `rpm`."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "test",
+                    "litellm_params": {"model": "gpt-5-mini", "api_key": "sk-test", "rpm": 1},
+                    "model_info": {"id": "low-rpm"},
+                },
+            ],
+            set_verbose=False,
+            enable_pre_call_checks=True,
+            routing_strategy="usage-based-routing-v2",
+        )
+
+        get_cache_calls = []
+        original_get_cache = router.cache.get_cache
+
+        def _tracking_get_cache(*args, **kwargs):
+            get_cache_calls.append(kwargs.get("key", args[0] if args else None))
+            return original_get_cache(*args, **kwargs)
+
+        router.cache.get_cache = _tracking_get_cache
+
+        deployments = router.get_model_list(model_name="test")
+        assert deployments is not None
+
+        router._pre_call_checks(
+            model="test",
+            healthy_deployments=deployments,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert get_cache_calls == [], f"Expected zero cache reads under usage-based-routing-v2, got {get_cache_calls}"
 
 
 if __name__ == "__main__":

--- a/tests/router_unit_tests/test_pre_call_checks_optimization.py
+++ b/tests/router_unit_tests/test_pre_call_checks_optimization.py
@@ -255,5 +255,73 @@ class TestPreCallChecksSkipsRpmCacheReadWhenUnused:
         assert get_cache_calls == [], f"Expected zero cache reads under usage-based-routing-v2, got {get_cache_calls}"
 
 
+class TestPreCallChecksExceptionHandling:
+    """
+    _pre_call_checks() wraps the context-window check (get_router_model_info +
+    token counting) in a try/except so a single deployment's failure doesn't
+    take down pre-call filtering for the whole model group.
+    """
+
+    def test_token_counting_failure_returns_original_deployments(self, monkeypatch):
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "test",
+                    "litellm_params": {"model": "gpt-5-mini", "api_key": "sk-test"},
+                    "model_info": {"id": "dep-1", "max_input_tokens": 100},
+                },
+            ],
+            set_verbose=False,
+            enable_pre_call_checks=True,
+        )
+
+        def _raise_token_counting(*args, **kwargs):
+            raise ValueError("boom")
+
+        monkeypatch.setattr(router, "_count_pre_call_check_tokens", _raise_token_counting)
+
+        deployments = router.get_model_list(model_name="test")
+        assert deployments is not None
+
+        result = router._pre_call_checks(
+            model="test",
+            healthy_deployments=deployments,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert result == deployments, "Should return the original deployments unchanged on token counting failure"
+
+    def test_model_info_lookup_failure_is_swallowed(self, monkeypatch):
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "test",
+                    "litellm_params": {"model": "gpt-5-mini", "api_key": "sk-test"},
+                    "model_info": {"id": "dep-1"},
+                },
+            ],
+            set_verbose=False,
+            enable_pre_call_checks=True,
+        )
+
+        def _raise_model_info(*args, **kwargs):
+            raise ValueError("boom")
+
+        monkeypatch.setattr(router, "get_router_model_info", _raise_model_info)
+
+        deployments = router.get_model_list(model_name="test")
+        assert deployments is not None
+
+        result = router._pre_call_checks(
+            model="test",
+            healthy_deployments=deployments,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert [d["model_info"]["id"] for d in result] == ["dep-1"], (
+            "Deployment should still be returned even if get_router_model_info() raises"
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

`Router._pre_call_checks()` runs on every request and read the RPM cache unconditionally, even when no deployment in the model group configures `rpm`. Reproduced directly against `litellm.Router`, tracking every call to `router.cache.get_cache()` during a `_pre_call_checks()` call for a two-deployment model group where neither deployment sets `rpm`:

Before the fix, commit `366ec6f487` (parent of this branch):

```
cache reads before fix (no rpm configured): ['test:rpm:23-18', 'no-rpm-1', 'no-rpm-2']
```

Three cache reads per request (the model-group RPM key, plus one per deployment) despite `rpm` never being checked against anything, since no deployment configures it.

After the fix, commit `c75573bb7a` (this branch HEAD), identical setup:

```
cache reads with fix applied (no rpm configured): []
```

Zero cache reads. Deployments with `rpm` configured are unaffected - verified via `test_rpm_cache_still_read_and_enforced_when_a_deployment_has_rpm`, which confirms the cache is still read and a deployment at its rpm limit is still filtered out.

## Type

🐛 Bug Fix

## Changes

`Router._pre_call_checks()` reads the RPM cache (both the model-group-level key and a per-deployment key inside the loop) on every request that passes through it, regardless of whether any deployment in the group actually configures `rpm`. For model groups with no RPM limits - the common case - this is pure overhead on the hot path.

Adds a static check, `_any_deployment_has_rpm`, based on whether any deployment's `litellm_params.rpm` is set (mirroring the existing `usage-based-routing-v2` exclusion, since that strategy manages its own RPM enforcement separately). Both cache reads are now skipped entirely when the check is false. This is safe to check statically, unlike `max_input_tokens`, which `get_router_model_info()` can also resolve dynamically via litellm's cost map rather than a static `model_info` override - `rpm` has no equivalent dynamic source.

This PR originally shipped alongside a fix for a related but separate bug (context-window checks being silently skipped for Responses API calls), tracked as #32510 against issue #33686. #33686 has since been fixed and merged upstream via #33706, so this PR carries only the RPM-cache-skip optimization, isolated per the repo's scope guidance. #32510 can be closed as superseded once this one is in.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
