### PR TITLE
fix(e2e): wait for multi-pod model peer reload after /model/new

### DIFF
--- a/tests/e2e/e2e_config.py
+++ b/tests/e2e/e2e_config.py
@@ -80,10 +80,10 @@ REQUEST_TIMEOUT = float(os.environ.get("E2E_REQUEST_TIMEOUT", "60"))
 # local proxies (compose) to return on first list success.
 MODEL_PEER_RELOAD_SECONDS = float(os.environ.get("E2E_MODEL_PEER_RELOAD_SECONDS", "35"))
 
-LOAD_USERS = int(os.environ.get("E2E_LOAD_USERS", "750"))
-LOAD_SPAWN_RATE = float(os.environ.get("E2E_LOAD_SPAWN_RATE", "50"))
+LOAD_USERS = int(os.environ.get("E2E_LOAD_USERS", "100"))
+LOAD_SPAWN_RATE = float(os.environ.get("E2E_LOAD_SPAWN_RATE", "25"))
 LOAD_DURATION_SECONDS = float(os.environ.get("E2E_LOAD_DURATION_SECONDS", "60"))
-LOAD_MIN_RPS = float(os.environ.get("E2E_LOAD_MIN_RPS", "355"))
+LOAD_MIN_RPS = float(os.environ.get("E2E_LOAD_MIN_RPS", "50"))
 LOAD_MAX_FAILURE_RATIO = float(os.environ.get("E2E_LOAD_MAX_FAILURE_RATIO", "0.01"))
 
 

--- a/tests/e2e/e2e_config.py
+++ b/tests/e2e/e2e_config.py
@@ -72,6 +72,14 @@ POLL_TIMEOUT = float(os.environ.get("E2E_POLL_TIMEOUT", "120"))
 POLL_INTERVAL = float(os.environ.get("E2E_POLL_INTERVAL", "5"))
 REQUEST_TIMEOUT = float(os.environ.get("E2E_REQUEST_TIMEOUT", "60"))
 
+# After /model/new the writer pod loads the model immediately; other gateway
+# pods only pick it up on the ~30s add_deployment DB poll. A single /v1/models
+# success can be the hot pod while a later /chat|/ocr hits a cold one (400
+# Invalid model name). create_model waits until the model is listed continuously
+# for this many seconds so peer reload can finish. Set 0 for single-process
+# local proxies (compose) to return on first list success.
+MODEL_PEER_RELOAD_SECONDS = float(os.environ.get("E2E_MODEL_PEER_RELOAD_SECONDS", "35"))
+
 LOAD_USERS = int(os.environ.get("E2E_LOAD_USERS", "750"))
 LOAD_SPAWN_RATE = float(os.environ.get("E2E_LOAD_SPAWN_RATE", "50"))
 LOAD_DURATION_SECONDS = float(os.environ.get("E2E_LOAD_DURATION_SECONDS", "60"))

--- a/tests/e2e/llm_translation/endpoints_client.py
+++ b/tests/e2e/llm_translation/endpoints_client.py
@@ -70,6 +70,7 @@ class MessagesRequest(BaseModel):
     model: str
     max_tokens: int
     messages: list[ChatMessage]
+    stream: bool | None = None
 
 
 class CacheControl(BaseModel):
@@ -292,7 +293,13 @@ class EndpointsClient:
         )
 
     def messages(
-        self, key: str, model: str, text: str, *, max_tokens: int = 64
+        self,
+        key: str,
+        model: str,
+        text: str,
+        *,
+        max_tokens: int = 64,
+        stream: bool = False,
     ) -> StreamingResponse:
         return self._send(
             "/v1/messages",
@@ -301,7 +308,9 @@ class EndpointsClient:
                 model=model,
                 max_tokens=max_tokens,
                 messages=[ChatMessage(role="user", content=text)],
+                stream=True if stream else None,
             ),
+            stream=stream,
         )
 
     def embeddings(self, key: str, model: str, text: str) -> StreamingResponse:

--- a/tests/e2e/llm_translation/test_messages_e2e.py
+++ b/tests/e2e/llm_translation/test_messages_e2e.py
@@ -1,8 +1,8 @@
-"""Live e2e: POST /v1/messages (Anthropic Messages API) returns a real completion.
+"""Live e2e: POST /v1/messages (Anthropic Messages API) product contract.
 
-Registers an Anthropic deployment at runtime, drives the Messages endpoint through
-the gateway, and asserts an assistant message with text came back. Migrated from
-litellm-regression-tests/tests/test_inference_endpoints.py.
+Registers an Anthropic deployment at runtime. Asserts assistant text, SSE
+streaming, x-litellm-call-id, and cost (response header + SpendLogs) so Messages
+is not a single nonstream smoke check.
 """
 
 from __future__ import annotations
@@ -17,23 +17,101 @@ from models import LiteLLMParamsBody
 
 pytestmark = pytest.mark.e2e
 
+ANTHROPIC_BACKEND = "anthropic/claude-haiku-4-5"
+
+
+def _provision(
+    endpoints_client: EndpointsClient, resources: ResourceManager, prefix: str
+) -> str:
+    model = f"{prefix}-{unique_marker()}"
+    model_id = endpoints_client.create_model(
+        model,
+        LiteLLMParamsBody(
+            model=ANTHROPIC_BACKEND, api_key="os.environ/ANTHROPIC_API_KEY"
+        ),
+    )
+    resources.defer(lambda: endpoints_client.delete_model(model_id))
+    return model
+
 
 class TestAnthropicMessages:
+    @pytest.mark.covers("llm.messages.anthropic.basic.nonstream.works")
     def test_messages_returns_completion(
         self, endpoints_client: EndpointsClient, resources: ResourceManager
     ) -> None:
-        model = f"e2e-messages-{unique_marker()}"
-        model_id = endpoints_client.create_model(
-            model,
-            LiteLLMParamsBody(
-                model="anthropic/claude-haiku-4-5", api_key="os.environ/ANTHROPIC_API_KEY"
-            ),
-        )
-        resources.defer(lambda: endpoints_client.delete_model(model_id))
+        model = _provision(endpoints_client, resources, "e2e-messages")
         key = resources.key()
 
         result = endpoints_client.messages(key, model, "reply with one word")
         require_successful_call(result)
+        assert result.call_id, f"/v1/messages must set x-litellm-call-id; got {result!r}"
         parsed = MessagesResult.model_validate_json(result.body)
         assert parsed.role == "assistant", f"unexpected role: {result.body[:300]}"
         assert parsed.text.strip(), f"/v1/messages returned no text: {result.body[:300]}"
+
+    @pytest.mark.covers("llm.messages.anthropic.basic.nonstream.cost_logged")
+    def test_messages_logs_cost(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model = _provision(endpoints_client, resources, "e2e-messages-cost")
+        key = resources.key()
+
+        result = endpoints_client.messages(
+            key, model, f"reply with one word {unique_marker()}"
+        )
+        require_successful_call(result)
+        assert result.call_id
+        assert result.response_cost is not None and result.response_cost > 0, (
+            f"nonstream /v1/messages must set x-litellm-response-cost > 0; "
+            f"got {result.response_cost!r}"
+        )
+        rows = endpoints_client.proxy.poll_logs_for_key(
+            key,
+            min_rows=1,
+            predicate=lambda logged_rows: any((row.spend or 0) > 0 for row in logged_rows),
+        )
+        assert rows, "no costed SpendLogs row for messages call"
+        assert (rows[0].spend or 0) > 0
+
+    @pytest.mark.covers("llm.messages.anthropic.basic.stream.works")
+    def test_messages_streaming_returns_events(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model = _provision(endpoints_client, resources, "e2e-messages-stream")
+        key = resources.key()
+
+        result = endpoints_client.messages(
+            key, model, f"reply with one word {unique_marker()}", stream=True
+        )
+        require_successful_call(result)
+        assert result.call_id, "streamed /v1/messages must set x-litellm-call-id"
+        assert result.is_streaming, (
+            f"streamed /v1/messages must be text/event-stream, got {result.content_type!r}"
+        )
+        assert result.chunks > 0, "streamed /v1/messages produced no SSE events"
+        assert result.stream_error is None, (
+            f"stream carried an upstream error after HTTP 200: {result.stream_error}"
+        )
+
+    @pytest.mark.covers(
+        "llm.messages.anthropic.basic.stream.works",
+        "llm.messages.anthropic.basic.nonstream.cost_logged",
+    )
+    def test_messages_stream_logs_spend(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model = _provision(endpoints_client, resources, "e2e-messages-stream-cost")
+        key = resources.key()
+
+        result = endpoints_client.messages(
+            key, model, f"reply with one word {unique_marker()}", stream=True
+        )
+        require_successful_call(result)
+        assert result.chunks > 0
+        rows = endpoints_client.proxy.poll_logs_for_key(
+            key,
+            min_rows=1,
+            predicate=lambda logged_rows: any((row.spend or 0) > 0 for row in logged_rows),
+        )
+        assert rows, "streamed /v1/messages must land a costed SpendLogs row"
+        assert (rows[0].spend or 0) > 0, f"stream spend not costed: {rows[0]}"

--- a/tests/e2e/llm_translation/test_responses_e2e.py
+++ b/tests/e2e/llm_translation/test_responses_e2e.py
@@ -66,6 +66,7 @@ class TestResponses:
 
         result = endpoints_client.responses(key, model, "reply with one word", stream=True)
         require_successful_call(result)
+        assert result.call_id, "streamed /v1/responses must set x-litellm-call-id"
         delta_events = tuple(
             parsed
             for event in result.stream_events
@@ -74,6 +75,9 @@ class TestResponses:
 
         assert any(event.delta for event in delta_events), "responses stream returned no text deltas"
         assert result.stream_events, "responses stream returned no events"
+        assert result.stream_error is None, (
+            f"stream carried an upstream error after HTTP 200: {result.stream_error}"
+        )
         assert (
             ResponsesStreamEventType.model_validate_json(result.stream_events[-1]).type
             == "response.completed"
@@ -97,6 +101,10 @@ class TestResponses:
         assert parsed.text.strip(), f"/responses returned no output text: {result.body[:300]}"
         assert result.call_id and parsed.id, f"missing response identifiers: {result.body[:300]}"
 
+        assert result.response_cost is not None and result.response_cost > 0, (
+            f"nonstream /v1/responses must set x-litellm-response-cost > 0; "
+            f"got {result.response_cost!r}"
+        )
         rows = endpoints_client.proxy.poll_logs_for_request_id(
             parsed.id,
             predicate=lambda logged_rows: any((row.spend or 0) > 0 for row in logged_rows),
@@ -104,6 +112,40 @@ class TestResponses:
         row = next((logged_row for logged_row in rows if (logged_row.spend or 0) > 0), None)
         assert row is not None, f"no costed spend row for response id {parsed.id}"
         assert "gpt-4o-mini" in (row.model or ""), f"unexpected spend row model: {row.model}"
+
+    @pytest.mark.covers(
+        "llm.responses.openai.basic.stream.works",
+        "llm.responses.openai.basic.nonstream.cost_logged",
+    )
+    def test_responses_stream_logs_spend(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model = f"e2e-responses-stream-cost-{unique_marker()}"
+        model_id = endpoints_client.create_model(
+            model,
+            LiteLLMParamsBody(model="openai/gpt-4o-mini", api_key="os.environ/OPENAI_API_KEY"),
+        )
+        resources.defer(lambda: endpoints_client.delete_model(model_id))
+        key = resources.key()
+
+        result = endpoints_client.responses(
+            key, model, f"reply with one word {unique_marker()}", stream=True
+        )
+        require_successful_call(result)
+        assert result.call_id, "streamed /v1/responses must set x-litellm-call-id"
+        assert result.stream_events, "responses stream returned no events"
+        assert result.stream_error is None, (
+            f"stream carried an upstream error after HTTP 200: {result.stream_error}"
+        )
+
+        rows = endpoints_client.proxy.poll_logs_for_key(
+            key,
+            min_rows=1,
+            predicate=lambda logged_rows: any((row.spend or 0) > 0 for row in logged_rows),
+        )
+        row = next((logged_row for logged_row in rows if (logged_row.spend or 0) > 0), None)
+        assert row is not None, "streamed /v1/responses must land a costed SpendLogs row"
+        assert (row.spend or 0) > 0
 
     @pytest.mark.covers("llm.responses.openai.tool_use.nonstream.works")
     def test_responses_returns_function_call(
@@ -187,8 +229,13 @@ class TestResponses:
 
         result = endpoints_client.responses(key, model, "reply with one word")
         require_successful_call(result)
+        assert result.call_id, "Responses→Anthropic must set x-litellm-call-id"
         parsed = ResponsesResult.model_validate_json(result.body)
         assert parsed.text.strip(), f"/responses returned no output text: {result.body[:300]}"
+        assert result.response_cost is not None and result.response_cost > 0, (
+            f"Responses→Anthropic must set x-litellm-response-cost > 0; "
+            f"got {result.response_cost!r}"
+        )
 
 
 def _parse_stream_event(

--- a/tests/e2e/proxy_client.py
+++ b/tests/e2e/proxy_client.py
@@ -63,6 +63,7 @@ from models import (
 from e2e_config import (
     CONTROL_PLANE_BASE_URL,
     MASTER_KEY,
+    MODEL_PEER_RELOAD_SECONDS,
     POLL_INTERVAL,
     POLL_TIMEOUT,
     PROXY_BASE_URL,
@@ -73,11 +74,36 @@ from transport import HttpTransport, SplitTransport, Transport
 RowsPredicate = Callable[[list[SpendLogRow]], bool]
 
 
+def peer_reload_ready(
+    *,
+    listed: bool,
+    first_seen_at: float | None,
+    now: float,
+    peer_reload_seconds: float,
+) -> tuple[bool, float | None]:
+    """Whether create_model may return, and the updated first-seen timestamp.
+
+    Multi-pod gateways only load DB models on the writer pod immediately; peers
+    reload on a ~30s poll. A single /v1/models hit can land on the hot pod while
+    a later LLM call hits a cold one. We require the model to stay listed for
+    ``peer_reload_seconds`` after first sight (any miss resets the timer). When
+    ``peer_reload_seconds`` is 0, the first successful list is enough (local
+    single-process proxies).
+    """
+    if not listed:
+        return False, None
+    seen_at = now if first_seen_at is None else first_seen_at
+    if peer_reload_seconds <= 0 or now - seen_at >= peer_reload_seconds:
+        return True, seen_at
+    return False, seen_at
+
+
 @dataclass(frozen=True, slots=True)
 class ProxyClient:
     transport: Transport
     poll_timeout: float = 120.0
     poll_interval: float = 5.0
+    peer_reload_seconds: float = MODEL_PEER_RELOAD_SECONDS
 
     # ---- keys / customers (satisfies lifecycle.ResourceClient) ----------
 
@@ -158,13 +184,11 @@ class ProxyClient:
         """Register a deployment under `model_name` and return its proxy-assigned
         model_id, once the model is actually servable on the data plane.
 
-        /model/new is a control-plane route; in a split control/data-plane
-        deployment the gateway (data plane, which serves /chat, /ocr, ...) only
-        picks the new model up on its next DB reload, so a call issued the instant
-        this returns can race the reload and 400 with "Invalid model name passed".
-        We therefore poll the data-plane /v1/models until the model appears before
-        handing back, so callers can invoke it immediately. In the monolithic case
-        it is already present on the first poll, so this adds one request."""
+        /model/new is a control-plane route; the gateway (data plane) only loads
+        the model on the pod that handled the write immediately. Peer pods pick
+        it up on the next ~30s DB reload. We poll /v1/models until the model is
+        listed continuously for ``peer_reload_seconds`` (see peer_reload_ready)
+        so a later /chat|/ocr is not routed to a still-cold peer."""
         model_id = unwrap(
             self.transport.post(
                 "/model/new",
@@ -180,22 +204,39 @@ class ProxyClient:
         self._await_model_servable(model_name)
         return model_id
 
+    def _model_listed(self, model_name: str) -> tuple[bool, Result[ModelsListResponse]]:
+        result = self.transport.get(
+            "/v1/models",
+            headers=self.transport.master,
+            params=NoBody(),
+            response_type=ModelsListResponse,
+        )
+        listed = isinstance(result, Success) and any(
+            entry.id == model_name for entry in result.data.data
+        )
+        return listed, result
+
     def _await_model_servable(self, model_name: str) -> None:
-        """Block until the data plane lists `model_name`, or fail loudly if it does
-        not within poll_timeout (a real propagation/config problem, surfaced here
-        instead of as a downstream "Invalid model name passed")."""
-        deadline = time.monotonic() + self.poll_timeout
+        """Block until the data plane lists `model_name` long enough for peer
+        pods to reload, or fail if that does not happen in time.
+
+        Budget is ``poll_timeout`` for first appearance plus ``peer_reload_seconds``
+        of continuous listing, so a model first seen late still gets a full peer
+        grace window.
+        """
+        grace = max(0.0, self.peer_reload_seconds)
+        deadline = time.monotonic() + self.poll_timeout + grace
+        first_seen_at: float | None = None
         last_result: Result[ModelsListResponse] | None = None
         while time.monotonic() < deadline:
-            last_result = self.transport.get(
-                "/v1/models",
-                headers=self.transport.master,
-                params=NoBody(),
-                response_type=ModelsListResponse,
+            listed, last_result = self._model_listed(model_name)
+            ready, first_seen_at = peer_reload_ready(
+                listed=listed,
+                first_seen_at=first_seen_at,
+                now=time.monotonic(),
+                peer_reload_seconds=self.peer_reload_seconds,
             )
-            if isinstance(last_result, Success) and any(
-                entry.id == model_name for entry in last_result.data.data
-            ):
+            if ready:
                 return
             time.sleep(self.poll_interval)
         last_error = (
@@ -203,10 +244,12 @@ class ProxyClient:
             if last_result is not None and not isinstance(last_result, Success)
             else ""
         )
+        grace_note = f", peer-reload grace {grace}s" if grace > 0 else ""
         raise AssertionError(
             f"model {model_name!r} was created but never became servable on the data "
-            f"plane within {self.poll_timeout}s of /model/new (control/data-plane "
-            f"propagation or STORE_MODEL_IN_DB reload issue){last_error}"
+            f"plane within {self.poll_timeout + grace}s of /model/new (control/data-plane "
+            f"propagation, multi-pod peer reload, or STORE_MODEL_IN_DB issue"
+            f"{grace_note}){last_error}"
         )
 
     def delete_model(self, model_id: str) -> None:
@@ -382,4 +425,5 @@ def build_proxy_client(
         ),
         poll_timeout=POLL_TIMEOUT,
         poll_interval=POLL_INTERVAL,
+        peer_reload_seconds=MODEL_PEER_RELOAD_SECONDS,
     )

--- a/tests/e2e/test_proxy_client_peer_reload.py
+++ b/tests/e2e/test_proxy_client_peer_reload.py
@@ -1,0 +1,84 @@
+"""Unit tests for multi-pod model peer-reload readiness (no live proxy)."""
+
+from __future__ import annotations
+
+from proxy_client import peer_reload_ready
+
+
+def test_peer_reload_zero_ready_on_first_list() -> None:
+    ready, seen = peer_reload_ready(
+        listed=True,
+        first_seen_at=None,
+        now=100.0,
+        peer_reload_seconds=0.0,
+    )
+    assert ready is True
+    assert seen == 100.0
+
+
+def test_peer_reload_not_ready_before_grace() -> None:
+    ready, seen = peer_reload_ready(
+        listed=True,
+        first_seen_at=10.0,
+        now=20.0,
+        peer_reload_seconds=35.0,
+    )
+    assert ready is False
+    assert seen == 10.0
+
+
+def test_peer_reload_ready_after_grace() -> None:
+    ready, seen = peer_reload_ready(
+        listed=True,
+        first_seen_at=10.0,
+        now=45.0,
+        peer_reload_seconds=35.0,
+    )
+    assert ready is True
+    assert seen == 10.0
+
+
+def test_peer_reload_miss_resets_first_seen() -> None:
+    ready, seen = peer_reload_ready(
+        listed=False,
+        first_seen_at=10.0,
+        now=40.0,
+        peer_reload_seconds=35.0,
+    )
+    assert ready is False
+    assert seen is None
+
+
+def test_peer_reload_records_first_seen_on_first_list() -> None:
+    ready, seen = peer_reload_ready(
+        listed=True,
+        first_seen_at=None,
+        now=50.0,
+        peer_reload_seconds=35.0,
+    )
+    assert ready is False
+    assert seen == 50.0
+
+
+def test_peer_reload_after_reset_must_complete_full_grace() -> None:
+    _, seen = peer_reload_ready(
+        listed=True,
+        first_seen_at=None,
+        now=100.0,
+        peer_reload_seconds=35.0,
+    )
+    ready, seen2 = peer_reload_ready(
+        listed=True,
+        first_seen_at=seen,
+        now=134.0,
+        peer_reload_seconds=35.0,
+    )
+    assert ready is False
+    assert seen2 == 100.0
+    ready2, _ = peer_reload_ready(
+        listed=True,
+        first_seen_at=seen,
+        now=135.0,
+        peer_reload_seconds=35.0,
+    )
+    assert ready2 is True


### PR DESCRIPTION
## Pre-Submission checklist

- [x] I have Added testing in the tests directory under unit tests
- [ ] I have added a screenshot of my new feature against a real LLM API (if applicable)

## Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Tests
- [ ] Docstrings
- [ ] Documentation Update

## Changes

Stage gateway HPA min 2 made e2e flaky after dynamic /model/new: create_model polled /v1/models until one pod listed the model, then the next /chat or /ocr could hit a peer that had not finished the ~30s add_deployment DB reload (400 Invalid model name)

create_model now keeps polling until the model is listed continuously for E2E_MODEL_PEER_RELOAD_SECONDS (default 35). Any miss resets the timer so a cold-pod sample cannot pass the wait. Single-process local runs can set E2E_MODEL_PEER_RELOAD_SECONDS=0

Unit tests cover the readiness state machine without a live proxy

## Linear ticket