### PR TITLE
fix(ui): hide guardrail group headers when only one group has entries

### DIFF
--- a/ui/litellm-dashboard/src/components/team/TeamInfo.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.test.tsx
@@ -1,8 +1,8 @@
 import * as networking from "@/components/networking";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { renderWithProviders } from "../../../tests/test-utils";
+import { renderWithProviders, testQueryClient } from "../../../tests/test-utils";
 import TeamInfoView from "./TeamInfo";
 
 vi.mock("@/components/networking", () => ({
@@ -1022,6 +1022,101 @@ describe("TeamInfoView", () => {
 
       const payload = vi.mocked(networking.teamUpdateCall).mock.calls[0][1] as Record<string, unknown>;
       expect(payload).not.toHaveProperty("model_aliases");
+    });
+  });
+
+  describe("guardrails dropdown grouping", () => {
+    const guardrail = (name: string, defaultOn: boolean) => ({
+      guardrail_name: name,
+      litellm_params: { default_on: defaultOn },
+    });
+
+    const openGuardrailsDropdown = async (user: ReturnType<typeof userEvent.setup>) => {
+      renderWithProviders(<TeamInfoView {...defaultProps} />);
+
+      await waitFor(() => {
+        const teamNameElements = screen.queryAllByText("Test Team");
+        expect(teamNameElements.length).toBeGreaterThan(0);
+      });
+
+      await user.click(screen.getByRole("tab", { name: "Settings" }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /edit settings/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /edit settings/i }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/^Guardrails/)).toBeInTheDocument();
+      });
+
+      const dropdownsBefore = new Set(document.querySelectorAll(".ant-select-dropdown"));
+
+      await user.click(screen.getByLabelText(/^Guardrails/));
+
+      return waitFor(
+        () => {
+          const opened = Array.from(document.querySelectorAll(".ant-select-dropdown")).find(
+            (el) => !dropdownsBefore.has(el),
+          );
+          expect(opened).toBeDefined();
+          return opened as HTMLElement;
+        },
+        { timeout: 5000 },
+      );
+    };
+
+    beforeEach(() => {
+      testQueryClient.clear();
+      vi.mocked(networking.teamInfoCall).mockResolvedValue(createMockTeamData());
+    });
+
+    it("should not render the Global or Other group headers when no global guardrails exist", async () => {
+      const user = userEvent.setup({ delay: null });
+      vi.mocked(networking.getGuardrailsList).mockResolvedValue({
+        guardrails: [guardrail("dwacxzcz", false), guardrail("dwadsa", false)],
+      });
+
+      const dropdown = await openGuardrailsDropdown(user);
+
+      await waitFor(() => {
+        expect(within(dropdown).getByTitle("dwacxzcz")).toBeInTheDocument();
+      });
+      expect(within(dropdown).getByTitle("dwadsa")).toBeInTheDocument();
+      expect(within(dropdown).queryByText("Global")).not.toBeInTheDocument();
+      expect(within(dropdown).queryByText("Other")).not.toBeInTheDocument();
+    });
+
+    it("should not render the Global or Other group headers when every guardrail is global", async () => {
+      const user = userEvent.setup({ delay: null });
+      vi.mocked(networking.getGuardrailsList).mockResolvedValue({
+        guardrails: [guardrail("always-on", true)],
+      });
+
+      const dropdown = await openGuardrailsDropdown(user);
+
+      await waitFor(() => {
+        expect(within(dropdown).getByTitle("always-on")).toBeInTheDocument();
+      });
+      expect(within(dropdown).queryByText("Global")).not.toBeInTheDocument();
+      expect(within(dropdown).queryByText("Other")).not.toBeInTheDocument();
+    });
+
+    it("should render both group headers when global and non-global guardrails exist", async () => {
+      const user = userEvent.setup({ delay: null });
+      vi.mocked(networking.getGuardrailsList).mockResolvedValue({
+        guardrails: [guardrail("always-on", true), guardrail("opt-in", false)],
+      });
+
+      const dropdown = await openGuardrailsDropdown(user);
+
+      await waitFor(() => {
+        expect(within(dropdown).getByText("Global")).toBeInTheDocument();
+      });
+      expect(within(dropdown).getByText("Other")).toBeInTheDocument();
+      expect(within(dropdown).getByTitle("always-on")).toBeInTheDocument();
+      expect(within(dropdown).getByTitle("opt-in")).toBeInTheDocument();
     });
   });
 });

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -14,7 +14,7 @@ import {
   teamMemberUpdateCall,
   teamUpdateCall,
 } from "@/components/networking";
-import { useGuardrails } from "@/app/(dashboard)/hooks/guardrails/useGuardrails";
+import { useGuardrails, GuardrailListItem } from "@/app/(dashboard)/hooks/guardrails/useGuardrails";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
 import { mapEmptyStringToNull } from "@/utils/keyUpdateUtils";
 import { isProxyAdminRole } from "@/utils/roles";
@@ -679,6 +679,16 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
     ? nonGlobalOptIns
     : [...Array.from(globalGuardrailNames).filter((n) => !optedOutGlobals.has(n)), ...nonGlobalOptIns];
 
+  const allGuardrails: GuardrailListItem[] = guardrailsData?.guardrails ?? [];
+  const globalGuardrails = allGuardrails.filter((g) => g.litellm_params?.default_on);
+  const otherGuardrails = allGuardrails.filter((g) => !g.litellm_params?.default_on);
+
+  const renderGuardrailOption = (g: GuardrailListItem, disabled: boolean) => (
+    <Select.Option key={g.guardrail_name} value={g.guardrail_name} label={g.guardrail_name} disabled={disabled}>
+      {g.guardrail_name}
+    </Select.Option>
+  );
+
   const preventTagMouseDown = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
@@ -1264,36 +1274,28 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                         optionLabelProp="label"
                         tagRender={renderGuardrailTag}
                       >
-                        <Select.OptGroup
-                          label={
-                            <>
-                              <GlobalOutlined style={{ marginInlineEnd: 4 }} />
-                              Global
-                            </>
-                          }
-                        >
-                          {(guardrailsData?.guardrails ?? [])
-                            .filter((g) => g.litellm_params?.default_on)
-                            .map((g) => (
-                              <Select.Option
-                                key={g.guardrail_name}
-                                value={g.guardrail_name}
-                                label={g.guardrail_name}
-                                disabled={killSwitchOn}
-                              >
-                                {g.guardrail_name}
-                              </Select.Option>
-                            ))}
-                        </Select.OptGroup>
-                        <Select.OptGroup label="Other">
-                          {(guardrailsData?.guardrails ?? [])
-                            .filter((g) => !g.litellm_params?.default_on)
-                            .map((g) => (
-                              <Select.Option key={g.guardrail_name} value={g.guardrail_name} label={g.guardrail_name}>
-                                {g.guardrail_name}
-                              </Select.Option>
-                            ))}
-                        </Select.OptGroup>
+                        {globalGuardrails.length > 0 && otherGuardrails.length > 0 ? (
+                          <>
+                            <Select.OptGroup
+                              label={
+                                <>
+                                  <GlobalOutlined style={{ marginInlineEnd: 4 }} />
+                                  Global
+                                </>
+                              }
+                            >
+                              {globalGuardrails.map((g) => renderGuardrailOption(g, Boolean(killSwitchOn)))}
+                            </Select.OptGroup>
+                            <Select.OptGroup label="Other">
+                              {otherGuardrails.map((g) => renderGuardrailOption(g, false))}
+                            </Select.OptGroup>
+                          </>
+                        ) : (
+                          [
+                            ...globalGuardrails.map((g) => renderGuardrailOption(g, Boolean(killSwitchOn))),
+                            ...otherGuardrails.map((g) => renderGuardrailOption(g, false)),
+                          ]
+                        )}
                       </Select>
                     </Form.Item>
 

--- a/ui/litellm-dashboard/tests/test-utils.tsx
+++ b/ui/litellm-dashboard/tests/test-utils.tsx
@@ -3,7 +3,7 @@ import { render, RenderOptions } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 // Create a client for testing
-const queryClient = new QueryClient({
+export const testQueryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: false,
@@ -20,7 +20,7 @@ const queryClient = new QueryClient({
 });
 
 const Providers: React.FC<PropsWithChildren> = ({ children }) => {
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  return <QueryClientProvider client={testQueryClient}>{children}</QueryClientProvider>;
 };
 
 export const renderWithProviders = (ui: React.ReactElement, options?: RenderOptions) =>


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before/after screenshots to be added on this PR

Steps to reproduce, on a proxy with guardrails configured but none marked `default_on`:

1. Start the proxy: `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`
2. Start the dashboard dev server: `npm run dev` in `ui/litellm-dashboard`
3. Confirm no global guardrails exist: `curl -s -H "Authorization: Bearer sk-1234" http://localhost:4000/guardrails/list | jq '[.guardrails[] | select(.litellm_params.default_on == true)]'` should return `[]`
4. Go to http://localhost:3000/?page=teams, click into any team, open the Settings tab and click Edit Settings
5. Open the Guardrails dropdown. Before this change it showed an empty "Global" heading above an "Other" heading; after it shows a plain list of the guardrails with no headings
6. To see the grouped case still works, mark one guardrail `default_on: true` in the config, restart the proxy, and reopen the dropdown; both "Global" and "Other" headings should be back with the guardrails split between them

## Type

🐛 Bug Fix

## Changes

The team settings Guardrails dropdown rendered the "Global" and "Other" `OptGroup` headings unconditionally, so a proxy with no global guardrails got a "Global" heading with nothing under it and an "Other" heading grouping every guardrail. Grouping now only happens when both buckets actually have entries; otherwise the options render as a flat list, since a lone "Global" or lone "Other" heading conveys nothing either

The dropdown option markup moved into a small `renderGuardrailOption` helper so the grouped and flat branches build identical options

`tests/test-utils.tsx` now exports its `QueryClient` as `testQueryClient`. It is a single module-level client with `staleTime: Infinity`, so a query whose mocked response differs per test silently reuses the first test's data for the rest of the file; the new tests clear it in their `beforeEach`. Existing behavior is unchanged for every other test file

Three regression tests cover the dropdown: no globals and all-globals both assert neither heading renders while the options still do, and the mixed case asserts both headings render. The first two fail against the pre-fix component and pass after; the third passes either way and guards against over-correcting into never grouping
