### PR TITLE
test(e2e): lower default Locust load for single-replica stage

### DIFF
--- a/tests/e2e/e2e_config.py
+++ b/tests/e2e/e2e_config.py
@@ -72,10 +72,10 @@ POLL_TIMEOUT = float(os.environ.get("E2E_POLL_TIMEOUT", "120"))
 POLL_INTERVAL = float(os.environ.get("E2E_POLL_INTERVAL", "5"))
 REQUEST_TIMEOUT = float(os.environ.get("E2E_REQUEST_TIMEOUT", "60"))
 
-LOAD_USERS = int(os.environ.get("E2E_LOAD_USERS", "750"))
-LOAD_SPAWN_RATE = float(os.environ.get("E2E_LOAD_SPAWN_RATE", "50"))
+LOAD_USERS = int(os.environ.get("E2E_LOAD_USERS", "100"))
+LOAD_SPAWN_RATE = float(os.environ.get("E2E_LOAD_SPAWN_RATE", "25"))
 LOAD_DURATION_SECONDS = float(os.environ.get("E2E_LOAD_DURATION_SECONDS", "60"))
-LOAD_MIN_RPS = float(os.environ.get("E2E_LOAD_MIN_RPS", "355"))
+LOAD_MIN_RPS = float(os.environ.get("E2E_LOAD_MIN_RPS", "50"))
 LOAD_MAX_FAILURE_RATIO = float(os.environ.get("E2E_LOAD_MAX_FAILURE_RATIO", "0.01"))
 
 


### PR DESCRIPTION
## Pre-Submission checklist

- [x] I have Added testing in the tests directory under unit tests
- [ ] I have added a screenshot of my new feature against a real LLM API (if applicable)

## Type

- [ ] New Feature
- [x] Bug Fix
- [x] Tests
- [ ] Docstrings
- [ ] Documentation Update

## Changes

Lower default Locust knobs in tests/e2e/e2e_config.py for the stage single-replica gateway

| knob | was | now |
|------|-----|-----|
| E2E_LOAD_USERS default | 750 | 100 |
| E2E_LOAD_SPAWN_RATE default | 50 | 25 |
| E2E_LOAD_MIN_RPS default | 355 | 50 |

The env var names already existed (E2E_LOAD_USERS / SPAWN_RATE / MIN_RPS); only the defaults change. Stage can still override via Job env. Build litellm-e2e with this ref to pick up the lighter profile without relying on ops extraEnv

## Linear ticket