### PR TITLE
test(e2e): cover key max_budget blocks on personal, team, and team-member keys

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -5,9 +5,9 @@ answers or when credentials/env are missing; they never skip. Pure unit coverage
 of the harness itself carries no `e2e` marker and runs regardless of whether a
 proxy is up.
 
-Lifecycle: the `resources` fixture maps the init -> run -> teardown contract
-(lifecycle.E2ECase) onto pytest - setup is init(), the test body is run(), and
-teardown deletes every resource the test created on the long-lived proxy.
+Lifecycle: the `resources` fixture hands each test a lifecycle.ResourceManager -
+the test registers a cleanup for every resource it creates, and the fixture's
+teardown deletes them all on the long-lived proxy, even when the test fails.
 
 Each suite provides its own `client` fixture (a lifecycle.ResourceClient); these
 shared fixtures build on it.

--- a/tests/e2e/lifecycle.py
+++ b/tests/e2e/lifecycle.py
@@ -1,13 +1,11 @@
-"""Lifecycle contract and resource cleanup for stateful e2e tests.
+"""Resource cleanup for stateful e2e tests.
 
 Shared by every e2e suite under tests/e2e/. The proxy under test is
 long-lived and never reset between tests, so anything a test creates (keys,
 customers, teams, orgs, users, guardrails, budgets, ...) persists unless
-explicitly deleted. Every check follows an init -> run -> teardown lifecycle;
-teardown releases each resource init() created, even when run() raises.
-
-In pytest terms (see conftest.py): the `resources` fixture's setup is init(),
-the test body is run(), and the fixture's teardown is teardown().
+explicitly deleted. The `resources` fixture (see conftest.py) hands each test a
+ResourceManager; the test registers a cleanup for every resource it creates, and
+the fixture's teardown releases them all even when the test body raises.
 """
 
 from dataclasses import dataclass, field
@@ -15,38 +13,6 @@ from typing import Callable, List, Protocol, runtime_checkable
 
 from proxy_client import ProxyClient
 from models import KeyGenerateBody
-
-
-@runtime_checkable
-class E2ECase(Protocol):
-    """A stateful e2e check run against a long-lived proxy.
-
-    init() acquires resources, run() exercises behaviour and asserts, teardown()
-    releases everything init() created. teardown() must run even if init() fails
-    partway or run() raises.
-    """
-
-    def init(self) -> None: ...
-
-    def run(self) -> None: ...
-
-    def teardown(self) -> None: ...
-
-
-def run_case(case: E2ECase) -> None:
-    """Drive a case through its lifecycle: init -> run -> teardown.
-
-    teardown always runs - even when init() fails partway or run() raises (or
-    skips) - so resources the case already registered on the long-lived proxy are
-    released. init() is inside the try because cases register cleanups
-    progressively (e.g. create team, then user, then key), and a failure after
-    the first creation must still release what came before.
-    """
-    try:
-        case.init()
-        case.run()
-    finally:
-        case.teardown()
 
 
 @runtime_checkable

--- a/tests/e2e/quota_management/budgets/test_budget_enforcement_e2e.py
+++ b/tests/e2e/quota_management/budgets/test_budget_enforcement_e2e.py
@@ -5,6 +5,9 @@ the budgeted entity + a key, run() drives spend until a `budget_exceeded` block,
 teardown() deletes everything init() created (always runs, even on failure/skip).
 Covers the entities with no prior live coverage - internal user, end-user,
 organization, team member - plus key and team. See BUDGET_TEST_COVERAGE_MATRIX.md.
+The capped-key cases sweep the key's own max_budget across mint shapes (personal,
+team, team-member) with roomy surroundings, so the key-level cap is provably the
+blocker no matter who the key was minted to.
 
 A non-budget error fails hard (never a skip); if calls never get blocked, budget
 enforcement is broken -> fail.
@@ -228,6 +231,76 @@ class TeamMemberBudgetCase(_BudgetCase):
         require_successful_call(teammate)
 
 
+class _CappedKeyCase(_BudgetCase):
+    """The tiny max_budget sits on the key itself while every budget around it
+    (user / team / membership) is roomy at 100.0, so only the key-level cap can
+    block, and the refusal must be a 429 budget_exceeded. An uncapped control key
+    minted to the same surroundings must keep serving after the capped key is
+    refused, proving nothing around the key was the blocker."""
+
+    _control_key: str = ""
+
+    def run(self) -> None:
+        blocked = _assert_budget_blocks(self.client, self.key)
+        assert blocked.status_code == 429, (
+            f"budget refusal must be 429, got {blocked.status_code}: {blocked.body[:200]}"
+        )
+        control = self.client.chat(
+            self._control_key,
+            "claude-haiku-4-5",
+            f"spend {unique_marker()}",
+            max_tokens=16,
+        )
+        require_successful_call(control)
+
+
+class PersonalKeyBudgetCase(_CappedKeyCase):
+    """A personal key (user_id, no team_id) carrying its own tiny max_budget under
+    a roomy user budget."""
+
+    def init(self) -> None:
+        user_id = self.client.create_user(max_budget=100.0)
+        self._undo.append(lambda: self.client.delete_user(user_id))
+        self.key = self.client.generate_key(user_id=user_id, max_budget=3e-6)
+        self._undo.append(lambda: self.client.delete_key(self.key))
+        self._control_key = self.client.generate_key(user_id=user_id)
+        self._undo.append(lambda: self.client.delete_key(self._control_key))
+
+
+class TeamKeyBudgetCase(_CappedKeyCase):
+    """A team key (team_id, no user_id) carrying its own tiny max_budget under a
+    roomy team budget."""
+
+    def init(self) -> None:
+        team_id = self.client.create_team(
+            alias=f"e2e-key-cap-team-{unique_marker()}", max_budget=100.0
+        )
+        self._undo.append(lambda: self.client.delete_team(team_id))
+        self.key = self.client.generate_key(team_id=team_id, max_budget=3e-6)
+        self._undo.append(lambda: self.client.delete_key(self.key))
+        self._control_key = self.client.generate_key(team_id=team_id)
+        self._undo.append(lambda: self.client.delete_key(self._control_key))
+
+
+class TeamMemberKeyBudgetCase(_CappedKeyCase):
+    """A team-member key (team_id + user_id) carrying its own tiny max_budget while
+    the team budget, the member's user budget, and the membership allowance are all
+    roomy."""
+
+    def init(self) -> None:
+        team_id = self.client.create_team(
+            alias=f"e2e-key-cap-team-{unique_marker()}", max_budget=100.0
+        )
+        self._undo.append(lambda: self.client.delete_team(team_id))
+        member_id = self.client.create_user(max_budget=100.0)
+        self._undo.append(lambda: self.client.delete_user(member_id))
+        self.client.add_team_member(team_id, member_id, max_budget_in_team=100.0)
+        self.key = self.client.generate_key(team_id=team_id, user_id=member_id, max_budget=3e-6)
+        self._undo.append(lambda: self.client.delete_key(self.key))
+        self._control_key = self.client.generate_key(team_id=team_id, user_id=member_id)
+        self._undo.append(lambda: self.client.delete_key(self._control_key))
+
+
 def _case_id(case_cls: Type[_BudgetCase]) -> str:
     return case_cls.__name__
 
@@ -237,6 +310,18 @@ def _case_id(case_cls: Type[_BudgetCase]) -> str:
     [
         pytest.param(
             KeyBudgetCase,
+            marks=pytest.mark.covers("quota_management.budget.key.blocks_over_limit"),
+        ),
+        pytest.param(
+            PersonalKeyBudgetCase,
+            marks=pytest.mark.covers("quota_management.budget.key.blocks_over_limit"),
+        ),
+        pytest.param(
+            TeamKeyBudgetCase,
+            marks=pytest.mark.covers("quota_management.budget.key.blocks_over_limit"),
+        ),
+        pytest.param(
+            TeamMemberKeyBudgetCase,
             marks=pytest.mark.covers("quota_management.budget.key.blocks_over_limit"),
         ),
         pytest.param(

--- a/tests/e2e/quota_management/budgets/test_budget_enforcement_e2e.py
+++ b/tests/e2e/quota_management/budgets/test_budget_enforcement_e2e.py
@@ -1,30 +1,35 @@
 """Live e2e: a tiny max_budget on an entity actually blocks requests.
 
-Each entity is an E2ECase (lifecycle.E2ECase) driven by run_case: init() creates
-the budgeted entity + a key, run() drives spend until a `budget_exceeded` block,
-teardown() deletes everything init() created (always runs, even on failure/skip).
-Covers the entities with no prior live coverage - internal user, end-user,
-organization, team member - plus key and team. See BUDGET_TEST_COVERAGE_MATRIX.md.
-The capped-key cases sweep the key's own max_budget across mint shapes (personal,
-team, team-member) with roomy surroundings, so the key-level cap is provably the
-blocker no matter who the key was minted to.
+One test per budget level (key, team, internal user, end-user, organization,
+team member): put the tiny cap on that level, drive spend until a
+`budget_exceeded` block, and where a cap could be confused with a neighbor,
+prove isolation with an uncapped control key that must keep serving. The
+capped-key sweep proves the key's own max_budget blocks across mint shapes
+(personal, team, team-member) with roomy surroundings, so the key-level cap is
+provably the blocker no matter who the key was minted to.
 
 A non-budget error fails hard (never a skip); if calls never get blocked, budget
 enforcement is broken -> fail.
 """
 
 import time
-from dataclasses import dataclass, field
-from typing import Callable, List, Type
 
 import pytest
 
 from budget_client import BudgetClient, is_budget_block
 from e2e_config import unique_marker
 from e2e_http import StreamingResponse, require_successful_call
-from lifecycle import run_case
+from lifecycle import ResourceManager
 
 pytestmark = pytest.mark.e2e
+
+TINY_CAP = 3e-6
+ROOMY_CAP = 100.0
+
+
+def _chat(client: BudgetClient, key: str, *, user: str | None = None) -> StreamingResponse:
+    return client.chat(key, "claude-haiku-4-5", f"spend {unique_marker()}", max_tokens=16, user=user)
+
 
 def _assert_budget_blocks(client: BudgetClient, key: str, *, user: str = "") -> StreamingResponse:
     """Send paid calls until the entity's budget blocks one; return the blocked
@@ -33,13 +38,7 @@ def _assert_budget_blocks(client: BudgetClient, key: str, *, user: str = "") -> 
     enforces off table spend that lands on the batch write, so it takes a few
     more. A non-budget error fails hard (never a skip)."""
     for _ in range(40):
-        result = client.chat(
-            key,
-            "claude-haiku-4-5",
-            f"spend {unique_marker()}",
-            max_tokens=16,
-            user=user or None,
-        )
+        result = _chat(client, key, user=user or None)
         if is_budget_block(result):
             return result
         require_successful_call(result)
@@ -47,307 +46,154 @@ def _assert_budget_blocks(client: BudgetClient, key: str, *, user: str = "") -> 
     pytest.fail("budget never enforced within the call budget")
 
 
-@dataclass
-class _BudgetCase:
-    """Base E2ECase: a key under some budgeted entity must get blocked.
-
-    Subclasses set up the budgeted entity in init() and register every created id
-    in `_undo` (run LIFO in teardown so a key is deleted before its team/org).
-    """
-
-    client: BudgetClient
-    key: str = ""
-    _undo: List[Callable[[], None]] = field(
-        default_factory=list
-    )  # mutable-ok: per-case teardown registry
-
-    def init(self) -> None:
-        raise NotImplementedError
-
-    def run(self) -> None:
-        _assert_budget_blocks(self.client, self.key)
-
-    def teardown(self) -> None:
-        for undo in reversed(self._undo):
-            undo()
+def _assert_blocked_429(client: BudgetClient, key: str) -> StreamingResponse:
+    blocked = _assert_budget_blocks(client, key)
+    assert blocked.status_code == 429, (
+        f"budget refusal must be 429, got {blocked.status_code}: {blocked.body[:200]}"
+    )
+    return blocked
 
 
-class KeyBudgetCase(_BudgetCase):
-    """A bare key (no team_id / user_id) carrying its own max_budget, so only the
-    key-level budget can be the thing that blocks. The refusal must be a 429
-    budget_exceeded; any other error already fails via _assert_budget_blocks."""
+class TestBudgetBlocksPerLevel:
+    @pytest.mark.covers("quota_management.budget.key.blocks_over_limit")
+    def test_bare_key_blocks_over_its_own_budget(self, client: BudgetClient, resources: ResourceManager) -> None:
+        key = client.generate_key(max_budget=TINY_CAP)
+        resources.defer(lambda: client.delete_key(key))
 
-    def init(self) -> None:
-        self.key = self.client.generate_key(max_budget=3e-6)
-        self._undo.append(lambda: self.client.delete_key(self.key))
+        _assert_blocked_429(client, key)
 
-    def run(self) -> None:
-        blocked = _assert_budget_blocks(self.client, self.key)
-        assert blocked.status_code == 429, (
-            f"budget refusal must be 429, got {blocked.status_code}: {blocked.body[:200]}"
-        )
+    @pytest.mark.covers("quota_management.budget.team.blocks_over_limit")
+    def test_team_budget_blocks_every_team_key(self, client: BudgetClient, resources: ResourceManager) -> None:
+        team_id = client.create_team(alias=f"e2e-budget-team-{unique_marker()}", max_budget=TINY_CAP)
+        resources.defer(lambda: client.delete_team(team_id))
+        spender_key = client.generate_key(team_id=team_id)
+        resources.defer(lambda: client.delete_key(spender_key))
+        sibling_key = client.generate_key(team_id=team_id)
+        resources.defer(lambda: client.delete_key(sibling_key))
 
-
-class TeamBudgetCase(_BudgetCase):
-    """An admin caps a whole team: two keys under a tiny-budget team, neither with
-    a key-level budget. Key A is driven until the team cap blocks it; key B's very
-    first call must then be refused too, proving the cap sits on the team, not the
-    key that spent. Both refusals must be 429 budget_exceeded."""
-
-    def init(self) -> None:
-        team_id = self.client.create_team(
-            alias=f"e2e-budget-team-{unique_marker()}", max_budget=3e-6
-        )
-        self._undo.append(lambda: self.client.delete_team(team_id))
-        self.key = self.client.generate_key(team_id=team_id)
-        self._undo.append(lambda: self.client.delete_key(self.key))
-        self._sibling_key = self.client.generate_key(team_id=team_id)
-        self._undo.append(lambda: self.client.delete_key(self._sibling_key))
-
-    def run(self) -> None:
-        blocked = _assert_budget_blocks(self.client, self.key)
-        assert blocked.status_code == 429, (
-            f"budget refusal must be 429, got {blocked.status_code}: {blocked.body[:200]}"
-        )
-        sibling = self.client.chat(
-            self._sibling_key,
-            "claude-haiku-4-5",
-            f"spend {unique_marker()}",
-            max_tokens=16,
-        )
+        _assert_blocked_429(client, spender_key)
+        sibling = _chat(client, sibling_key)
         assert is_budget_block(sibling) and sibling.status_code == 429, (
             f"a sibling key on the capped team must get the same 429 budget_exceeded, "
             f"got {sibling.status_code}: {sibling.body[:200]}"
         )
 
+    @pytest.mark.covers("quota_management.budget.internal_user.blocks_over_limit")
+    def test_user_budget_enforced_across_all_their_keys(
+        self, client: BudgetClient, resources: ResourceManager
+    ) -> None:
+        user_id = client.create_user(max_budget=TINY_CAP)
+        resources.defer(lambda: client.delete_user(user_id))
+        first_key = client.generate_key(user_id=user_id)
+        resources.defer(lambda: client.delete_key(first_key))
+        second_key = client.generate_key(user_id=user_id)
+        resources.defer(lambda: client.delete_key(second_key))
+        team_id = client.create_team(alias=f"e2e-budget-team-{unique_marker()}")
+        resources.defer(lambda: client.delete_team(team_id))
+        client.add_team_member(team_id, user_id)
+        team_key = client.generate_key(team_id=team_id, user_id=user_id)
+        resources.defer(lambda: client.delete_key(team_key))
 
-class InternalUserBudgetCase(_BudgetCase):
-    """A user's max_budget follows the person, not the key. The capped user holds
-    two personal keys (no team, no key budgets) plus a team-member key on an
-    uncapped team; once the first personal key is refused, the other two must be
-    refused as well - a second key is not a fresh allowance, and since #32005 the
-    user budget draws down team keys too. All refusals must be 429 budget_exceeded."""
-
-    def init(self) -> None:
-        user_id = self.client.create_user(max_budget=3e-6)
-        self._undo.append(lambda: self.client.delete_user(user_id))
-        self.key = self.client.generate_key(user_id=user_id)
-        self._undo.append(lambda: self.client.delete_key(self.key))
-        self._second_key = self.client.generate_key(user_id=user_id)
-        self._undo.append(lambda: self.client.delete_key(self._second_key))
-        team_id = self.client.create_team(alias=f"e2e-budget-team-{unique_marker()}")
-        self._undo.append(lambda: self.client.delete_team(team_id))
-        self.client.add_team_member(team_id, user_id)
-        self._team_key = self.client.generate_key(team_id=team_id, user_id=user_id)
-        self._undo.append(lambda: self.client.delete_key(self._team_key))
-
-    def run(self) -> None:
-        blocked = _assert_budget_blocks(self.client, self.key)
-        assert blocked.status_code == 429, (
-            f"budget refusal must be 429, got {blocked.status_code}: {blocked.body[:200]}"
-        )
-        for label, key in (("second personal key", self._second_key), ("team-member key", self._team_key)):
-            result = self.client.chat(key, "claude-haiku-4-5", f"spend {unique_marker()}", max_tokens=16)
+        _assert_blocked_429(client, first_key)
+        for label, key in (("second personal key", second_key), ("team-member key", team_key)):
+            result = _chat(client, key)
             assert is_budget_block(result) and result.status_code == 429, (
                 f"the {label} of a user over budget must get the same 429 budget_exceeded, "
                 f"got {result.status_code}: {result.body[:200]}"
             )
 
-
-class EndUserBudgetCase(_BudgetCase):
-    def init(self) -> None:
+    @pytest.mark.covers("quota_management.budget.end_user.blocks_over_limit")
+    def test_end_user_budget_blocks_attributed_calls(
+        self, client: BudgetClient, resources: ResourceManager
+    ) -> None:
         customer = f"e2e-budget-cust-{unique_marker()}"
-        self.client.create_customer(customer, max_budget=3e-6)
-        self._undo.append(lambda: self.client.delete_customers([customer]))
-        self.key = self.client.generate_key(models=["claude-haiku-4-5"])
-        self._undo.append(lambda: self.client.delete_key(self.key))
-        self._customer = customer
+        client.create_customer(customer, max_budget=TINY_CAP)
+        resources.defer(lambda: client.delete_customers([customer]))
+        key = client.generate_key(models=["claude-haiku-4-5"])
+        resources.defer(lambda: client.delete_key(key))
 
-    def run(self) -> None:
-        _assert_budget_blocks(self.client, self.key, user=self._customer)
+        _assert_budget_blocks(client, key, user=customer)
 
+    @pytest.mark.covers("quota_management.budget.organization.blocks_over_limit")
+    def test_org_budget_blocks_keys_under_it(self, client: BudgetClient, resources: ResourceManager) -> None:
+        org_id = client.create_org(max_budget=TINY_CAP, alias=f"e2e-budget-org-{unique_marker()}")
+        resources.defer(lambda: client.delete_org(org_id))
+        team_id = client.create_team(alias=f"e2e-budget-team-{unique_marker()}", organization_id=org_id)
+        resources.defer(lambda: client.delete_team(team_id))
+        key = client.generate_key(team_id=team_id)
+        resources.defer(lambda: client.delete_key(key))
 
-class OrganizationBudgetCase(_BudgetCase):
-    """Org carries the tiny budget; the team under it and the key carry none, so
-    the org is the only entity that can block (the historically weak link). The
-    refusal must be a 429 budget_exceeded that names the org as the blocker."""
-
-    def init(self) -> None:
-        self._org_id = self.client.create_org(
-            max_budget=3e-6, alias=f"e2e-budget-org-{unique_marker()}"
-        )
-        self._undo.append(lambda: self.client.delete_org(self._org_id))
-        team_id = self.client.create_team(
-            alias=f"e2e-budget-team-{unique_marker()}", organization_id=self._org_id
-        )
-        self._undo.append(lambda: self.client.delete_team(team_id))
-        self.key = self.client.generate_key(team_id=team_id)
-        self._undo.append(lambda: self.client.delete_key(self.key))
-
-    def run(self) -> None:
-        blocked = _assert_budget_blocks(self.client, self.key)
-        assert blocked.status_code == 429, (
-            f"budget refusal must be 429, got {blocked.status_code}: {blocked.body[:200]}"
-        )
-        assert f"Organization={self._org_id}" in blocked.body, (
+        blocked = _assert_blocked_429(client, key)
+        assert f"Organization={org_id}" in blocked.body, (
             f"refusal must name the org as the blocker, got: {blocked.body[:200]}"
         )
 
+    @pytest.mark.covers("quota_management.budget.team_member.blocks_over_limit")
+    def test_member_budget_blocks_without_touching_teammates(
+        self, client: BudgetClient, resources: ResourceManager
+    ) -> None:
+        team_id = client.create_team(alias=f"e2e-budget-team-{unique_marker()}", max_budget=ROOMY_CAP)
+        resources.defer(lambda: client.delete_team(team_id))
+        member_id = client.create_user(max_budget=ROOMY_CAP)
+        resources.defer(lambda: client.delete_user(member_id))
+        client.add_team_member(team_id, member_id, max_budget_in_team=TINY_CAP)
+        member_key = client.generate_key(team_id=team_id, user_id=member_id)
+        resources.defer(lambda: client.delete_key(member_key))
+        teammate_id = client.create_user(max_budget=ROOMY_CAP)
+        resources.defer(lambda: client.delete_user(teammate_id))
+        client.add_team_member(team_id, teammate_id)
+        teammate_key = client.generate_key(team_id=team_id, user_id=teammate_id)
+        resources.defer(lambda: client.delete_key(teammate_key))
 
-class TeamMemberBudgetCase(_BudgetCase):
-    """Member A's per-team budget is tiny while the team and both members' user
-    budgets are roomy (100.0), so the only cap that can trip is A's: a block
-    proves member-level enforcement and must be a 429 budget_exceeded. Teammate
-    B, uncapped on the same team, must keep serving after A is cut off, proving
-    the member cap does not leak onto the team or its members."""
-
-    def init(self) -> None:
-        self._team_id = self.client.create_team(
-            alias=f"e2e-budget-team-{unique_marker()}", max_budget=100.0
-        )
-        self._undo.append(lambda: self.client.delete_team(self._team_id))
-        self._member_id = self.client.create_user(max_budget=100.0)
-        self._undo.append(lambda: self.client.delete_user(self._member_id))
-        self.client.add_team_member(self._team_id, self._member_id, max_budget_in_team=3e-6)
-        self.key = self.client.generate_key(team_id=self._team_id, user_id=self._member_id)
-        self._undo.append(lambda: self.client.delete_key(self.key))
-        teammate_id = self.client.create_user(max_budget=100.0)
-        self._undo.append(lambda: self.client.delete_user(teammate_id))
-        self.client.add_team_member(self._team_id, teammate_id)
-        self._teammate_key = self.client.generate_key(team_id=self._team_id, user_id=teammate_id)
-        self._undo.append(lambda: self.client.delete_key(self._teammate_key))
-
-    def run(self) -> None:
-        blocked = _assert_budget_blocks(self.client, self.key)
-        assert blocked.status_code == 429, (
-            f"budget refusal must be 429, got {blocked.status_code}: {blocked.body[:200]}"
-        )
-        teammate = self.client.chat(
-            self._teammate_key,
-            "claude-haiku-4-5",
-            f"spend {unique_marker()}",
-            max_tokens=16,
-        )
-        require_successful_call(teammate)
+        _assert_blocked_429(client, member_key)
+        require_successful_call(_chat(client, teammate_key))
 
 
-class _CappedKeyCase(_BudgetCase):
+class TestKeyBudgetBlocksAcrossKeyKinds:
     """The tiny max_budget sits on the key itself while every budget around it
-    (user / team / membership) is roomy at 100.0, so only the key-level cap can
-    block, and the refusal must be a 429 budget_exceeded. An uncapped control key
-    minted to the same surroundings must keep serving after the capped key is
-    refused, proving nothing around the key was the blocker."""
+    (user / team / membership) is roomy, so only the key-level cap can block; the
+    uncapped control key minted to the same surroundings must keep serving after
+    the capped key is refused, proving nothing around the key was the blocker."""
 
-    _control_key: str = ""
+    @pytest.mark.covers("quota_management.budget.key.blocks_over_limit")
+    def test_personal_key_blocks_over_its_own_budget(
+        self, client: BudgetClient, resources: ResourceManager
+    ) -> None:
+        user_id = client.create_user(max_budget=ROOMY_CAP)
+        resources.defer(lambda: client.delete_user(user_id))
+        capped_key = client.generate_key(user_id=user_id, max_budget=TINY_CAP)
+        resources.defer(lambda: client.delete_key(capped_key))
+        control_key = client.generate_key(user_id=user_id)
+        resources.defer(lambda: client.delete_key(control_key))
 
-    def run(self) -> None:
-        blocked = _assert_budget_blocks(self.client, self.key)
-        assert blocked.status_code == 429, (
-            f"budget refusal must be 429, got {blocked.status_code}: {blocked.body[:200]}"
-        )
-        control = self.client.chat(
-            self._control_key,
-            "claude-haiku-4-5",
-            f"spend {unique_marker()}",
-            max_tokens=16,
-        )
-        require_successful_call(control)
+        _assert_blocked_429(client, capped_key)
+        require_successful_call(_chat(client, control_key))
 
+    @pytest.mark.covers("quota_management.budget.key.blocks_over_limit")
+    def test_team_key_blocks_over_its_own_budget(self, client: BudgetClient, resources: ResourceManager) -> None:
+        team_id = client.create_team(alias=f"e2e-key-cap-team-{unique_marker()}", max_budget=ROOMY_CAP)
+        resources.defer(lambda: client.delete_team(team_id))
+        capped_key = client.generate_key(team_id=team_id, max_budget=TINY_CAP)
+        resources.defer(lambda: client.delete_key(capped_key))
+        control_key = client.generate_key(team_id=team_id)
+        resources.defer(lambda: client.delete_key(control_key))
 
-class PersonalKeyBudgetCase(_CappedKeyCase):
-    """A personal key (user_id, no team_id) carrying its own tiny max_budget under
-    a roomy user budget."""
+        _assert_blocked_429(client, capped_key)
+        require_successful_call(_chat(client, control_key))
 
-    def init(self) -> None:
-        user_id = self.client.create_user(max_budget=100.0)
-        self._undo.append(lambda: self.client.delete_user(user_id))
-        self.key = self.client.generate_key(user_id=user_id, max_budget=3e-6)
-        self._undo.append(lambda: self.client.delete_key(self.key))
-        self._control_key = self.client.generate_key(user_id=user_id)
-        self._undo.append(lambda: self.client.delete_key(self._control_key))
+    @pytest.mark.covers("quota_management.budget.key.blocks_over_limit")
+    def test_team_member_key_blocks_over_its_own_budget(
+        self, client: BudgetClient, resources: ResourceManager
+    ) -> None:
+        team_id = client.create_team(alias=f"e2e-key-cap-team-{unique_marker()}", max_budget=ROOMY_CAP)
+        resources.defer(lambda: client.delete_team(team_id))
+        member_id = client.create_user(max_budget=ROOMY_CAP)
+        resources.defer(lambda: client.delete_user(member_id))
+        client.add_team_member(team_id, member_id, max_budget_in_team=ROOMY_CAP)
+        capped_key = client.generate_key(team_id=team_id, user_id=member_id, max_budget=TINY_CAP)
+        resources.defer(lambda: client.delete_key(capped_key))
+        control_key = client.generate_key(team_id=team_id, user_id=member_id)
+        resources.defer(lambda: client.delete_key(control_key))
 
-
-class TeamKeyBudgetCase(_CappedKeyCase):
-    """A team key (team_id, no user_id) carrying its own tiny max_budget under a
-    roomy team budget."""
-
-    def init(self) -> None:
-        team_id = self.client.create_team(
-            alias=f"e2e-key-cap-team-{unique_marker()}", max_budget=100.0
-        )
-        self._undo.append(lambda: self.client.delete_team(team_id))
-        self.key = self.client.generate_key(team_id=team_id, max_budget=3e-6)
-        self._undo.append(lambda: self.client.delete_key(self.key))
-        self._control_key = self.client.generate_key(team_id=team_id)
-        self._undo.append(lambda: self.client.delete_key(self._control_key))
-
-
-class TeamMemberKeyBudgetCase(_CappedKeyCase):
-    """A team-member key (team_id + user_id) carrying its own tiny max_budget while
-    the team budget, the member's user budget, and the membership allowance are all
-    roomy."""
-
-    def init(self) -> None:
-        team_id = self.client.create_team(
-            alias=f"e2e-key-cap-team-{unique_marker()}", max_budget=100.0
-        )
-        self._undo.append(lambda: self.client.delete_team(team_id))
-        member_id = self.client.create_user(max_budget=100.0)
-        self._undo.append(lambda: self.client.delete_user(member_id))
-        self.client.add_team_member(team_id, member_id, max_budget_in_team=100.0)
-        self.key = self.client.generate_key(team_id=team_id, user_id=member_id, max_budget=3e-6)
-        self._undo.append(lambda: self.client.delete_key(self.key))
-        self._control_key = self.client.generate_key(team_id=team_id, user_id=member_id)
-        self._undo.append(lambda: self.client.delete_key(self._control_key))
-
-
-def _case_id(case_cls: Type[_BudgetCase]) -> str:
-    return case_cls.__name__
-
-
-@pytest.mark.parametrize(
-    "case_cls",
-    [
-        pytest.param(
-            KeyBudgetCase,
-            marks=pytest.mark.covers("quota_management.budget.key.blocks_over_limit"),
-        ),
-        pytest.param(
-            PersonalKeyBudgetCase,
-            marks=pytest.mark.covers("quota_management.budget.key.blocks_over_limit"),
-        ),
-        pytest.param(
-            TeamKeyBudgetCase,
-            marks=pytest.mark.covers("quota_management.budget.key.blocks_over_limit"),
-        ),
-        pytest.param(
-            TeamMemberKeyBudgetCase,
-            marks=pytest.mark.covers("quota_management.budget.key.blocks_over_limit"),
-        ),
-        pytest.param(
-            TeamBudgetCase,
-            marks=pytest.mark.covers("quota_management.budget.team.blocks_over_limit"),
-        ),
-        pytest.param(
-            InternalUserBudgetCase,
-            marks=pytest.mark.covers("quota_management.budget.internal_user.blocks_over_limit"),
-        ),
-        pytest.param(
-            EndUserBudgetCase,
-            marks=pytest.mark.covers("quota_management.budget.end_user.blocks_over_limit"),
-        ),
-        pytest.param(
-            OrganizationBudgetCase,
-            marks=pytest.mark.covers("quota_management.budget.organization.blocks_over_limit"),
-        ),
-        pytest.param(
-            TeamMemberBudgetCase,
-            marks=pytest.mark.covers("quota_management.budget.team_member.blocks_over_limit"),
-        ),
-    ],
-    ids=_case_id,
-)
-def test_budget_enforcement(
-    client: BudgetClient, case_cls: Type[_BudgetCase]
-) -> None:
-    run_case(case_cls(client))
+        _assert_blocked_429(client, capped_key)
+        require_successful_call(_chat(client, control_key))


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

All runs are against a live proxy on localhost:4000 running staging commit 366ec6f487 with a throwaway Postgres and Redis, the fast budget rescheduler, and real provider calls (`claude-haiku-4-5` is backed by `groq/llama-3.3-70b-versatile` locally since that is the only live provider key on this machine). Proof was restamped after the refactor commit: the file content that ran is byte-identical to this PR's head b30603e2bf

```
$ for run in 1 2 3 4 5; do python -m pytest tests/e2e/quota_management/budgets/test_budget_enforcement_e2e.py -q | tail -1; sleep 15; done
9 passed in 23.09s
9 passed in 22.41s
9 passed in 22.83s
9 passed in 22.60s
9 passed in 22.71s
```

Earlier, the three new sweep tests alone also ran five consecutive times at the pre-refactor commit f012661f28 (3 passed in 8.50s, 8.21s, 8.68s, 8.20s, 8.26s). `basedpyright tests/e2e` reports 0 errors and `python -m coverage_registry.collector --strict` passes

## Type

✅ Test

## Changes

Two commits. The first covers the "Key `max_budget` blocks" row of the budgets coverage matrix for the three unexercised key kinds: the existing bare-key case proves a key's own budget blocks; the new cases prove the same key-level cap still blocks when the key is minted to a person (`user_id`), a team (`team_id`), or a team membership (both), i.e. that surrounding entities do not shadow or absorb the key's own budget. Each puts the tiny cap (3e-6) on the key itself and every budget around it at a roomy 100.0, so the key-level check is provably the only thing that can block; after the capped key is refused with a 429 `budget_exceeded`, an uncapped control key minted to the same surroundings must still serve

The second commit converts the file from the `E2ECase` class pattern (init/run/teardown case classes driven by `run_case` through one parametrized test) to the plain-pytest `resources` fixture pattern every other budgets file already uses. That pattern existed only in this one file, dating from the founding suite PR #30869; the rewrite turns the nine cases into two spec classes, `TestBudgetBlocksPerLevel` (one test per budget level: bare key, team, internal user, end-user, organization, team member) and `TestKeyBudgetBlocksAcrossKeyKinds` (the sweep above), with cleanup via `resources.defer` and the repeated block-shape assert hoisted into `_assert_blocked_429`. Assertions and setup shapes are behavior-preserving; node ids change from `test_budget_enforcement[XxxCase]` to the class::method form. The now-dead `E2ECase` protocol and `run_case` driver are removed from `lifecycle.py` (this file was their only consumer) and the conftest docstring updated

All nine tests keep their original registry cells; the three sweep tests intentionally share `quota_management.budget.key.blocks_over_limit` with the bare-key test (same pattern as the team-member-key variant sharing `internal_user.resets_after_window`): the matrix tracks the per-key-kind split, the registry keeps one row per budget level x behavior

## QA runbook

- [x] `TestBudgetBlocksPerLevel::test_bare_key_blocks_over_its_own_budget` mints a bare key capped at 3e-6, drives `/chat/completions` until refused, asserts 429 `budget_exceeded`; key deleted on teardown
- [x] `TestBudgetBlocksPerLevel::test_team_budget_blocks_every_team_key` creates a team capped at 3e-6 with two uncapped keys, drives one to the block, asserts the sibling's first call is also a 429 `budget_exceeded`; teardown deletes keys then team
- [x] `TestBudgetBlocksPerLevel::test_user_budget_enforced_across_all_their_keys` creates a user capped at 3e-6 with two personal keys and a team-member key on an uncapped team, drives the first personal key to the block, asserts the other two keys are refused as well; teardown deletes keys, team, user
- [x] `TestBudgetBlocksPerLevel::test_end_user_budget_blocks_attributed_calls` creates a customer capped at 3e-6 and drives calls attributed via `user=` until refused as a budget block; teardown deletes key and customer
- [x] `TestBudgetBlocksPerLevel::test_org_budget_blocks_keys_under_it` creates a capped org with an uncapped team and key under it, drives to the block, asserts the refusal names `Organization=<id>`; teardown deletes key, team, org
- [x] `TestBudgetBlocksPerLevel::test_member_budget_blocks_without_touching_teammates` creates a roomy team, caps one member at 3e-6 via `max_budget_in_team`, drives that member's key to the block, asserts an uncapped teammate's key still serves; teardown deletes keys, users, team
- [x] `TestKeyBudgetBlocksAcrossKeyKinds::test_personal_key_blocks_over_its_own_budget` creates a user with `max_budget` 100, mints a personal key capped at 3e-6 plus an uncapped control key, drives the capped key to a 429 `budget_exceeded`, asserts the control key still serves; teardown deletes keys then user
- [x] `TestKeyBudgetBlocksAcrossKeyKinds::test_team_key_blocks_over_its_own_budget` does the same on a team with `max_budget` 100
- [x] `TestKeyBudgetBlocksAcrossKeyKinds::test_team_member_key_blocks_over_its_own_budget` does the same on a team-member key with team, user, and membership all at 100
- [x] `python -m coverage_registry.collector --strict` passes with the sweep tests sharing `quota_management.budget.key.blocks_over_limit`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
