### PR TITLE
test(e2e): cover key budget_duration resets on personal, team, and team-member keys

### DIFF
--- a/tests/e2e/quota_management/budgets/test_budget_reset_e2e.py
+++ b/tests/e2e/quota_management/budgets/test_budget_reset_e2e.py
@@ -47,7 +47,7 @@ def _poll_until_serves_again(client: BudgetClient, key: str) -> None:
     pytest.fail(f"budget never reset within {RESET_DEADLINE_SECONDS}s")
 
 
-class TestBudgetResetDiagonal:
+class TestBudgetResetPerLevel:
     @pytest.mark.covers("quota_management.budget.key.resets_after_window")
     def test_bare_key_budget_resets_after_window(self, client: BudgetClient, resources: ResourceManager) -> None:
         key = client.generate_key(max_budget=TINY_CAP, budget_duration=WINDOW)

--- a/tests/e2e/quota_management/budgets/test_budget_reset_e2e.py
+++ b/tests/e2e/quota_management/budgets/test_budget_reset_e2e.py
@@ -12,6 +12,7 @@ from lifecycle import ResourceManager
 pytestmark = pytest.mark.e2e
 
 TINY_CAP = 3e-6
+ROOMY_CAP = 100.0
 WINDOW = "30s"
 RESET_DEADLINE_SECONDS = 150
 
@@ -111,6 +112,45 @@ class TestBudgetResetDiagonal:
         resources.defer(lambda: client.delete_team(team_id))
         client.add_team_member(team_id, user_id, max_budget_in_team=100.0)
         key = client.generate_key(team_id=team_id, user_id=user_id)
+        resources.defer(lambda: client.delete_key(key))
+
+        _drive_to_block(client, key)
+        _poll_until_serves_again(client, key)
+
+
+class TestKeyBudgetResetAcrossKeyKinds:
+    """The tiny max_budget and its 30s window sit on the key itself while the user,
+    team, and membership around it are roomy (100.0), so the key's own budget is
+    the only thing that can block and the only thing that has to reset."""
+
+    @pytest.mark.covers("quota_management.budget.key.resets_after_window")
+    def test_personal_key_resets_after_window(self, client: BudgetClient, resources: ResourceManager) -> None:
+        user_id = client.create_user(max_budget=ROOMY_CAP)
+        resources.defer(lambda: client.delete_user(user_id))
+        key = client.generate_key(user_id=user_id, max_budget=TINY_CAP, budget_duration=WINDOW)
+        resources.defer(lambda: client.delete_key(key))
+
+        _drive_to_block(client, key)
+        _poll_until_serves_again(client, key)
+
+    @pytest.mark.covers("quota_management.budget.key.resets_after_window")
+    def test_team_key_resets_after_window(self, client: BudgetClient, resources: ResourceManager) -> None:
+        team_id = client.create_team(alias=f"e2e-key-reset-team-{unique_marker()}", max_budget=ROOMY_CAP)
+        resources.defer(lambda: client.delete_team(team_id))
+        key = client.generate_key(team_id=team_id, max_budget=TINY_CAP, budget_duration=WINDOW)
+        resources.defer(lambda: client.delete_key(key))
+
+        _drive_to_block(client, key)
+        _poll_until_serves_again(client, key)
+
+    @pytest.mark.covers("quota_management.budget.key.resets_after_window")
+    def test_team_member_key_resets_after_window(self, client: BudgetClient, resources: ResourceManager) -> None:
+        team_id = client.create_team(alias=f"e2e-key-reset-team-{unique_marker()}", max_budget=ROOMY_CAP)
+        resources.defer(lambda: client.delete_team(team_id))
+        member_id = client.create_user(max_budget=ROOMY_CAP)
+        resources.defer(lambda: client.delete_user(member_id))
+        client.add_team_member(team_id, member_id, max_budget_in_team=ROOMY_CAP)
+        key = client.generate_key(team_id=team_id, user_id=member_id, max_budget=TINY_CAP, budget_duration=WINDOW)
         resources.defer(lambda: client.delete_key(key))
 
         _drive_to_block(client, key)


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

All runs are against a live proxy on localhost:4000 running staging commit 366ec6f487 with a throwaway Postgres and Redis, the fast budget rescheduler (`proxy_budget_rescheduler_min_time: 5` / `max_time: 10`), and real provider calls (`claude-haiku-4-5` is backed by `groq/llama-3.3-70b-versatile` locally since that is the only live provider key on this machine). The test content that ran is byte-identical to this PR's commit 4e5fcdba3e

```
$ python -m pytest "tests/e2e/quota_management/budgets/test_budget_reset_e2e.py::TestKeyBudgetResetAcrossKeyKinds" -v
tests/e2e/quota_management/budgets/test_budget_reset_e2e.py::TestKeyBudgetResetAcrossKeyKinds::test_personal_key_resets_after_window PASSED [ 33%]
tests/e2e/quota_management/budgets/test_budget_reset_e2e.py::TestKeyBudgetResetAcrossKeyKinds::test_team_key_resets_after_window PASSED [ 66%]
tests/e2e/quota_management/budgets/test_budget_reset_e2e.py::TestKeyBudgetResetAcrossKeyKinds::test_team_member_key_resets_after_window PASSED [100%]
============================== 3 passed in 43.00s ==============================
```

Five consecutive runs of the new class with cooldowns between them: 3 passed in 43.00s, 94.48s, 93.54s, 93.66s, 88.54s; zero failures (the spread is the expected wall-clock alignment of the 30s window). A full-file pass, all 8 tests including the existing reset diagonal, also came back green:

```
$ python -m pytest tests/e2e/quota_management/budgets/test_budget_reset_e2e.py -v
...
======================== 8 passed in 233.31s (0:03:53) =========================
```

`basedpyright tests/e2e` reports 0 errors and `python -m coverage_registry.collector --strict` passes

## Type

✅ Test

## Changes

Covers the "Key `max_budget` resets" row of the budgets coverage matrix for the three unexercised key kinds. The existing `test_bare_key_budget_resets_after_window` proves a bare key's `budget_duration` window zeroes its spend and unblocks it; the new `TestKeyBudgetResetAcrossKeyKinds` proves the same key-level reset still happens when the key is minted to a person (`user_id`), a team (`team_id`), or a team membership (both)

Each test puts the tiny cap (3e-6) and the 30s window on the key itself while the user, team, and membership budgets around it are roomy (100.0) with no `budget_duration` of their own, so the key's budget is the only thing that can block and the only thing that has to reset. The block phase stays bounded under one window so the block is observed before the reset job can fire, and every refusal during the reset wait must remain a budget block; a 5xx or a never-resetting key fails loudly

A follow-up commit also renames the pre-existing `TestBudgetResetDiagonal` to `TestBudgetResetPerLevel`; "diagonal" was planning-doc jargon that means nothing in the code, while the class actually holds one reset test per budget level. Pure rename, single definition, no other references; the file still collects 8 tests

All three tests intentionally mark the existing registry cell `quota_management.budget.key.resets_after_window` (shared with the bare-key test, same pattern as the team-member-key variant sharing `internal_user.resets_after_window`): the matrix tracks the per-key-kind split while the registry keeps one row per budget level x behavior, so the denominator does not grow. The before/after `budget_reset_at` and spend-zeroed state asserts are deliberately not duplicated here; they live once in `test_budget_reset_advances_e2e.py`

## QA runbook

- [x] `TestKeyBudgetResetAcrossKeyKinds::test_personal_key_resets_after_window` creates a user with `max_budget` 100, mints that user a personal key with `max_budget` 3e-6 and `budget_duration` 30s, drives `/chat/completions` until a call is refused as a budget block, then polls past the window until the same key serves 200 again, failing on any non-budget error during the wait; teardown deletes the key, then the user
- [x] `TestKeyBudgetResetAcrossKeyKinds::test_team_key_resets_after_window` creates a team with `max_budget` 100, mints a team key with `max_budget` 3e-6 and `budget_duration` 30s, drives it to a budget block, polls until it serves again; teardown deletes the key, then the team
- [x] `TestKeyBudgetResetAcrossKeyKinds::test_team_member_key_resets_after_window` creates a team and a user each with `max_budget` 100, adds the user to the team with `max_budget_in_team` 100, mints a team-member key (`team_id` + `user_id`) with `max_budget` 3e-6 and `budget_duration` 30s, drives it to a budget block, polls until it serves again; teardown deletes the key, the user, then the team
- [x] `python -m coverage_registry.collector --strict` passes with the three tests sharing `quota_management.budget.key.resets_after_window`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
