### PR TITLE
fix(anthropic): respect drop_params when mapping metadata.user_id to user in Responses adapter

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -8,6 +8,7 @@ path used for OpenAI and Azure models.
 import json
 from typing import Any, Dict, List, Optional, Union, cast
 
+import litellm
 from litellm.litellm_core_utils.reasoning_effort_utils import (
     reasoning_effort_from_thinking_budget,
 )
@@ -374,11 +375,8 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
 
         # metadata user_id -> user
         metadata = anthropic_request.get("metadata")
-        if isinstance(metadata, dict) and "user_id" in metadata:
-            import litellm
-
-            if not litellm.drop_params:
-                responses_kwargs["user"] = str(metadata["user_id"])[:64]
+        if isinstance(metadata, dict) and "user_id" in metadata and litellm.drop_params is not True:
+            responses_kwargs["user"] = str(metadata["user_id"])[:64]
 
         return responses_kwargs
 

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -375,7 +375,10 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
         # metadata user_id -> user
         metadata = anthropic_request.get("metadata")
         if isinstance(metadata, dict) and "user_id" in metadata:
-            responses_kwargs["user"] = str(metadata["user_id"])[:64]
+            import litellm
+
+            if not litellm.drop_params:
+                responses_kwargs["user"] = str(metadata["user_id"])[:64]
 
         return responses_kwargs
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -1034,3 +1034,48 @@ class TestTranslateResponse:
         assert "text" in types
         assert "tool_use" in types
         assert result["stop_reason"] == "tool_use"
+
+
+# ---------------------------------------------------------------------------
+# metadata.user_id -> user honors litellm.drop_params (issue #26241)
+# ---------------------------------------------------------------------------
+
+
+class TestUserMappingHonorsDropParams:
+    """metadata.user_id maps to top-level `user` only when drop_params is off."""
+
+    def test_user_mapped_when_drop_params_false(self):
+        import litellm
+
+        original = litellm.drop_params
+        try:
+            litellm.drop_params = False
+            req = _make_request(metadata={"user_id": "u-123"})
+            kwargs = _ADAPTER.translate_request(req)
+            assert kwargs["user"] == "u-123"
+        finally:
+            litellm.drop_params = original
+
+    def test_user_dropped_when_drop_params_true(self):
+        import litellm
+
+        original = litellm.drop_params
+        try:
+            litellm.drop_params = True
+            req = _make_request(metadata={"user_id": "u-123"})
+            kwargs = _ADAPTER.translate_request(req)
+            assert "user" not in kwargs
+        finally:
+            litellm.drop_params = original
+
+    def test_no_user_id_leaves_no_user_key(self):
+        import litellm
+
+        original = litellm.drop_params
+        try:
+            litellm.drop_params = True
+            req = _make_request(metadata={"session": "s-1"})
+            kwargs = _ADAPTER.translate_request(req)
+            assert "user" not in kwargs
+        finally:
+            litellm.drop_params = original


### PR DESCRIPTION
## Relevant issues

Fixes #26241

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

A live-provider curl does not reproduce this one: real OpenAI/Anthropic Responses endpoints accept a top-level `user`, so the 400 only happens against a strict or custom gateway that rejects `user`, and standing one of those up would itself be a mock. The faithful, deterministic proof is the translated Responses payload the adapter produces, captured at commit 6847897c74 (after) and its parent (before).

Before (parent of 6847897c74), with `litellm.drop_params = True` and `metadata={"user_id": "u-123"}`, `LiteLLMAnthropicToResponsesAPIAdapter.translate_request(...)` returns:

```
{'model': 'openai.gpt-5.1-codex', 'input': [...], 'max_output_tokens': 1024, 'user': 'u-123'}
```

`user` is present despite `drop_params`, which is what the strict gateway 400s on. The regression test `test_user_dropped_when_drop_params_true` fails at the parent commit with exactly this output.

After (6847897c74), same inputs:

```
{'model': 'openai.gpt-5.1-codex', 'input': [...], 'max_output_tokens': 1024}
```

`user` is omitted, so the strict gateway stops rejecting the request. With `drop_params` off (the default), `user` is still mapped, so existing behavior is unchanged.

Full adapter suite at 6847897c74:

```
84 passed in 0.88s
```

## Type

🐛 Bug Fix

## Changes

`LiteLLMAnthropicToResponsesAPIAdapter.translate_request()` mapped `metadata.user_id` to a top-level `user` field unconditionally. Some strict or custom `/responses` gateways reject that with `400 Unsupported parameter: user`, and `litellm_settings.drop_params: true` did not help because the mapping never checked the global.

This guards the mapping on `litellm.drop_params`: when `drop_params` is enabled the `user` field is skipped, otherwise it is mapped exactly as before. One guard in `litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py`, no signature or public API change.

Tests added to the existing mapped file `tests/.../responses_adapters/test_responses_adapters_transformation.py`:

- `test_user_mapped_when_drop_params_false` - default behavior preserved, `user` mapped.
- `test_user_dropped_when_drop_params_true` - `user` omitted (the fix); fails before the change.
- `test_no_user_id_leaves_no_user_key` - no `metadata.user_id` still yields no `user` key.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
