### PR TITLE
chore(release): backport #33853 to stable/1.90.x and cut 1.90.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,9 @@ RUN uv sync --frozen --no-default-groups --no-editable \
     --extra semantic-router \
     --python python3
 
-RUN prisma generate --schema=./schema.prisma
+RUN HOME=/opt/prisma XDG_CACHE_HOME=/opt/prisma/.cache PRISMA_BINARY_CACHE_DIR=/opt/prisma/binaries \
+    npm_config_cache=/root/.npm \
+    prisma generate --schema=./schema.prisma
 
 RUN sed -i 's/\r$//' docker/entrypoint.sh && chmod +x docker/entrypoint.sh && \
     sed -i 's/\r$//' docker/prod_entrypoint.sh && chmod +x docker/prod_entrypoint.sh
@@ -72,7 +74,11 @@ USER root
 RUN apk add --no-cache bash openssl tzdata nodejs python3 libsndfile
 
 WORKDIR /app
-ENV PATH="/app/.venv/bin:${PATH}"
+ENV PATH="/app/.venv/bin:${PATH}" \
+    PRISMA_BINARY_CACHE_DIR=/opt/prisma/binaries \
+    PRISMA_CLI_PATH=/opt/prisma/binaries/node_modules/.bin/prisma \
+    PRISMA_CLI_QUERY_ENGINE_TYPE=binary \
+    PRISMA_OFFLINE_MODE=true
 
 # Copy only what runtime needs. The application is installed inside the venv;
 # the rest of the builder's /app is source and build metadata that must not
@@ -87,16 +93,18 @@ COPY --from=builder /app/litellm/proxy/prisma_migration.py /app/litellm/proxy/pr
 # enterprise.enterprise_hooks from it)
 COPY --from=builder /app/enterprise /app/enterprise
 COPY --from=builder /app/litellm-proxy-extras /app/litellm-proxy-extras
-# Prisma binaries live in $HOME/.cache (default prisma-python location),
-# which is /root/.cache here. Copy only the Prisma subdirs — copying the
-# whole /root/.cache drags in the uv build cache (~660 MB, includes a
-# setuptools wheel that surfaces as a CVE finding even though it's not
-# on the runtime sys.path).
-COPY --from=builder /root/.cache/prisma /root/.cache/prisma
-COPY --from=builder /root/.cache/prisma-python /root/.cache/prisma-python
+# Prisma CLI + engines are baked under /opt/prisma, a fixed path every
+# runtime uid can read and that no cache volume mount shadows. The paths are
+# pinned via PRISMA_BINARY_CACHE_DIR / PRISMA_CLI_PATH and recorded into the
+# generated client at build time, so `prisma migrate deploy` on a fresh
+# database needs no npm and no network access (#33650, #24554).
+COPY --from=builder /opt/prisma /opt/prisma
 
 RUN find /app/.venv -type f -path "*/tornado/test/*" -delete && \
-    find /app/.venv -type d -path "*/tornado/test" -delete
+    find /app/.venv -type d -path "*/tornado/test" -delete && \
+    chmod -R a+rX /opt/prisma && \
+    test -x /opt/prisma/binaries/node_modules/.bin/prisma && \
+    test -f /opt/prisma/binaries/node_modules/prisma/build/index.js
 
 EXPOSE 4000/tcp
 

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -57,7 +57,9 @@ RUN uv sync --frozen --no-default-groups --no-editable \
     --extra semantic-router \
     --python python3
 
-RUN prisma generate --schema=./schema.prisma
+RUN HOME=/opt/prisma XDG_CACHE_HOME=/opt/prisma/.cache PRISMA_BINARY_CACHE_DIR=/opt/prisma/binaries \
+    npm_config_cache=/root/.npm \
+    prisma generate --schema=./schema.prisma
 
 RUN sed -i 's/\r$//' docker/entrypoint.sh && chmod +x docker/entrypoint.sh && \
     sed -i 's/\r$//' docker/prod_entrypoint.sh && chmod +x docker/prod_entrypoint.sh
@@ -70,7 +72,11 @@ USER root
 RUN apk add --no-cache bash openssl tzdata nodejs python3 libsndfile
 
 WORKDIR /app
-ENV PATH="/app/.venv/bin:${PATH}"
+ENV PATH="/app/.venv/bin:${PATH}" \
+    PRISMA_BINARY_CACHE_DIR=/opt/prisma/binaries \
+    PRISMA_CLI_PATH=/opt/prisma/binaries/node_modules/.bin/prisma \
+    PRISMA_CLI_QUERY_ENGINE_TYPE=binary \
+    PRISMA_OFFLINE_MODE=true
 
 # Copy only what runtime needs. The application is installed inside the venv;
 # the rest of the builder's /app is source and build metadata that must not
@@ -85,16 +91,20 @@ COPY --from=builder /app/litellm/proxy/prisma_migration.py /app/litellm/proxy/pr
 # enterprise.enterprise_hooks from it)
 COPY --from=builder /app/enterprise /app/enterprise
 COPY --from=builder /app/litellm-proxy-extras /app/litellm-proxy-extras
-# Prisma binaries live in $HOME/.cache (default prisma-python location),
-# which is /root/.cache here. Copy them from the builder so they survive
-# deployments that volume-mount /app/.cache (e.g. readOnlyRootFilesystem
-# + emptyDir) — otherwise the mount would shadow the baked-in query engine.
-# Only the Prisma subdirs: the whole /root/.cache drags in the uv build cache.
-COPY --from=builder /root/.cache/prisma /root/.cache/prisma
-COPY --from=builder /root/.cache/prisma-python /root/.cache/prisma-python
+# Prisma CLI + engines are baked under /opt/prisma, a fixed path every
+# runtime uid can read and that no cache volume mount shadows (unlike
+# /app/.cache or $HOME/.cache in readOnlyRootFilesystem + emptyDir setups).
+# The paths are pinned via PRISMA_BINARY_CACHE_DIR / PRISMA_CLI_PATH and
+# recorded into the generated client at build time, so `prisma migrate
+# deploy` on a fresh database needs no npm and no network access
+# (#33650, #24554).
+COPY --from=builder /opt/prisma /opt/prisma
 
 RUN find /app/.venv -type f -path "*/tornado/test/*" -delete && \
-    find /app/.venv -type d -path "*/tornado/test" -delete
+    find /app/.venv -type d -path "*/tornado/test" -delete && \
+    chmod -R a+rX /opt/prisma && \
+    test -x /opt/prisma/binaries/node_modules/.bin/prisma && \
+    test -f /opt/prisma/binaries/node_modules/prisma/build/index.js
 
 EXPOSE 4000/tcp
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm"
-version = "1.90.5"
+version = "1.90.6"
 description = "Library to easily interface with LLM API providers"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"
@@ -272,7 +272,7 @@ source-exclude = [
 profile = "black"
 
 [tool.commitizen]
-version = "1.90.5"
+version = "1.90.6"
 version_files = [
     "pyproject.toml:^version",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-13T22:37:30.905404Z"
+exclude-newer = "2026-07-16T01:46:19.064603Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -7344,15 +7344,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.1.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-16T01:46:19.064603Z"
+exclude-newer = "2026-07-16T01:47:07.411427Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -6220,11 +6220,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.27"
+version = "0.0.30"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/82/c8cd43a6e0719bf5a3b034f6726dd701f75829c08944c83d4b95d02ed0e8/python_multipart-0.0.30.tar.gz", hash = "sha256:0edfe0475c1f46ddd3ff7785a626f6118af32bdcf359bb21260367313bb32118", size = 46316, upload-time = "2026-05-31T19:24:55.198Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fd/0318007beb234790993d3ec5afd051d1dbceb733e81e3afe2b981ece3f37/python_multipart-0.0.30-py3-none-any.whl", hash = "sha256:830964def8c90607ac5daa00514e3987815865713ade8d20febc9177ac0c3c5b", size = 29730, upload-time = "2026-05-31T19:24:53.814Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-16T01:47:07.411427Z"
+exclude-newer = "2026-07-16T01:47:08.761988Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3882,7 +3882,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3900,9 +3900,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-16T01:47:08.761988Z"
+exclude-newer = "2026-07-16T01:47:10.60724Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -5881,16 +5881,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-16T01:47:10.60724Z"
+exclude-newer = "2026-07-16T01:47:11.528984Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -6006,14 +6006,14 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.13.1"
+version = "6.13.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/d9/9d12fa0d9660d03320725ff686c961b645a4218940a82296e1272d9e1ff0/pypdf-6.13.1.tar.gz", hash = "sha256:4841d8a4c1589e5833915dc0c7ddfacff80a2e0bcbeb5d1e681fecaa1674b03a", size = 6477811, upload-time = "2026-06-08T11:01:49.344Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/18/9947cc201af9ccf76720fd3347bf4f70eb882ce3fcf4cb05f7443e4cf871/pypdf-6.13.3.tar.gz", hash = "sha256:f3cb822769725f1bac658c406cfc9460399043f3750c2d3e4650e0a85eacabd7", size = 6484063, upload-time = "2026-06-17T15:22:00.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/dd/8f03e0a5788a5d1feb4550617c3e6db5e9099eaee248a3e482ddaeacbbb0/pypdf-6.13.1-py3-none-any.whl", hash = "sha256:e555e4ce3f561ef069307622f1374136ba964ca6ca24f24158701decaf83ed9b", size = 346259, upload-time = "2026-06-08T11:01:47.741Z" },
+    { url = "https://files.pythonhosted.org/packages/94/56/2967e621598987905fb8cdfadd8f8de6b5c68c9351f0523c4df8409f28f1/pypdf-6.13.3-py3-none-any.whl", hash = "sha256:c6e3f86afb625791510b02ad5480e94b63970bb957df75d44657c282ecc52224", size = 347288, upload-time = "2026-06-17T15:21:59.512Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-16T01:47:11.528984Z"
+exclude-newer = "2026-07-16T01:52:47.260675Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3245,7 +3245,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.90.5"
+version = "1.90.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Relevant issues

Backports the Docker prisma bake onto `stable/1.90.x` and cuts 1.90.6. The runtime image previously shipped the prisma CLI and engines under `/root/.cache`, the default HOME-derived prisma-python cache location, so any deployment whose runtime HOME is not `/root` (kubernetes `runAsUser`, `docker --user`, HOME overrides) missed that cache on a fresh database, fell back to a nodeenv Node download that crashes on Wolfi, and started the proxy with zero tables while every DB-backed endpoint returned 500. The bake now lives at `/opt/prisma`, a path no HOME resolution or cache volume mount can shadow. Relates to #33650 and #24554, both already fixed on the development line by #33853

This PR also carries routine dependency maintenance on the line's lock file, and the version bump to 1.90.6

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

The picked commit carries no new tests because it changes only Dockerfiles; its correctness is proven by the live container run below, which is the meaningful test for this class of change. The unit-test box reflects a zero-regression delta against this line's pre-change baseline, measured as described below rather than as an absolute pass

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

### The prisma bake, proven against a live container

Both images were built locally from a clean `git archive` of this branch, so the build context matches what CI would send. The pick's own build-time assertions are `&&`-chained into a `RUN`, so a drifted layout fails the build rather than silently degrading at container start; both builds passed them.

The claim is that a fresh-database migration now works for any runtime uid with no network. That was exercised directly: a brand new Postgres with zero tables, on a Docker network created with `--internal`, with the container running as uid 12345 and `HOME` pointed at a path that does not exist.

Confirming the network really has no egress, from inside that network:

```
$ docker run --rm --network bp190x-net --entrypoint python3 litellm-bp190x:post-database -c "...socket.create_connection(('registry.npmjs.org', 443))"
no internet, as intended: gaierror
```

Then the migration itself:

```
$ docker run --rm --network bp190x-net --user 12345 -e HOME=/nonexistent \
    -e DATABASE_URL="postgresql://postgres:***@bp190x-pg:5432/litellm" \
    --entrypoint sh litellm-bp190x:post-database \
    -c 'cd /app/litellm-proxy-extras/litellm_proxy_extras && "$PRISMA_CLI_PATH" migrate deploy --schema ./schema.prisma'
...
All migrations have been successfully applied.
```

Verified against the database rather than trusting the exit message:

```
$ docker exec bp190x-pg psql -U postgres -d litellm -tAc \
    "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';"
66
$ docker exec bp190x-pg psql -U postgres -d litellm -tAc \
    "SELECT count(*) FROM _prisma_migrations WHERE finished_at IS NOT NULL;"
127
```

The baked CLI also resolves and runs under the same conditions, which is the specific thing that used to fall through to an npm download:

```
$ docker run --rm --network none --user 12345 --entrypoint sh litellm-bp190x:post-default \
    -c 'test -x "$PRISMA_CLI_PATH" && echo "CLI executable: yes"; HOME=/nonexistent "$PRISMA_CLI_PATH" --version'
CLI executable: yes
prisma                : 5.4.2
```

Both runtime images expose the pinned paths (`PRISMA_CLI_PATH=/opt/prisma/binaries/node_modules/.bin/prisma`, `PRISMA_BINARY_CACHE_DIR=/opt/prisma/binaries`, `PRISMA_CLI_QUERY_ENGINE_TYPE=binary`, `PRISMA_OFFLINE_MODE=true`), and the database image ships the proxy-extras schema with 128 migration entries at the source path the migration job targets.

### The dependency bumps, measured as a delta

Each bumped package resolves to its target in a synced environment: starlette 1.3.1, python-multipart 0.0.30, mcp 1.28.1, pydantic-settings 2.14.2, pypdf 6.13.3.

The mirrored suite on this line is order-dependent under parallel execution, so a single run's failure set is not a reliable signal. The suite was therefore run once before the bumps and twice after, with byte-identical commands:

```
before bumps: 69 failed, 24080 passed, 94 skipped, 2 errors
after  (1):   66 failed, 24083 passed, 94 skipped, 2 errors
after  (2):   65 failed, 24083 passed, 95 skipped, 2 errors
```

Comparing a single post-bump run against the baseline suggests 6 new failures in run 1 and 1 in run 2, but the two post-bump sets disagree with each other despite identical inputs, and every one of those tests passes when run on its own. Intersecting the two post-bump runs and subtracting the baseline, which is the set of failures that actually reproduce and are genuinely new, gives **zero**

### Known noise on this line

The pre-change baseline already fails 71 distinct tests, so absolute red on this branch is not meaningful and only the delta above is. Collecting the whole `tests/test_litellm` tree in one run also needs `--import-mode=importlib`, because `tests/test_litellm/models/test_models.py` and `tests/test_litellm/proxy/client/test_models.py` share a basename with no `__init__.py`. Both conditions predate this PR and also exist on the development line

One new behavior worth flagging for reviewers: starlette 1.3.x deprecates using `httpx` with `starlette.testclient` and emits `StarletteDeprecationWarning` recommending `httpx2`. It is a warning only, it does not affect the shipped proxy, and no test fails on it, but it will start appearing in test output on this line

## Type

🐛 Bug Fix
🚄 Infrastructure

## Changes

In merge order:

- #33853 fix(docker): bake prisma CLI and engines at a fixed path so fresh-DB migrations work for any uid offline
- chore(deps): bump starlette to 1.3.1
- chore(deps): bump python-multipart to 0.0.30
- chore(deps): bump mcp to 1.28.1
- chore(deps): bump pydantic-settings to 2.14.2
- chore(deps): bump pypdf to 6.13.3
- bump: version 1.90.5 to 1.90.6, and the matching `uv.lock` refresh

The cherry-pick is byte-identical to its source on the development line: `git patch-id --stable` returns `730c2276e12028cb46121514058d047d0f27acc3` for both, and `git range-diff` shows no difference beyond the added `(cherry picked from commit ...)` footer. No adaptation was needed, and the pick changes no Python source, so the whole branch diff is `Dockerfile`, `docker/Dockerfile.database`, `pyproject.toml` and `uv.lock`

Every dependency move is lock-only, each one confirmed to move exactly one package in `uv.lock` by parsing both lock files rather than reading the diff. The lock was regenerated with uv 0.11.7, the version this line's Dockerfile pins, so the lock format revision is unchanged. No `pyproject.toml` dependency floor changed, so the wheel's install contract is untouched and only the image's resolved versions move

#33592 was requested but is already present on this line; it shipped in 1.90.5 as f0b7d8df53

#33721 and #33864 were requested and are deliberately excluded. Together they regress `GET /v1/models`: a deployment whose `model_info` carries a non-numeric token limit is registered into the model cost map by the router, which reaches an unguarded `int()` in the cost-map branch of `create_model_info_response` and turns the whole listing into a 500, where this line currently returns 200 and omits that deployment's limits. #33864 hardened the router index path but not the cost-map path. The fix belongs on the development line first and can then be backported alongside both PRs, so `stable/1.90.x` keeps parity with `stable/1.91.x` and `stable/1.92.x`, which excluded the same pair
