### PR TITLE
fix(proxy): treat malformed cost-map token limits as absent on /v1/models

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -57,6 +57,35 @@ def safe_divide(
     return numerator / denominator
 
 
+def coerce_token_limit(value: object) -> int | None:
+    """
+    Coerce a max_input_tokens / max_output_tokens value to an int, treating a
+    malformed value as absent.
+
+    A deployment's model_info is registered into litellm.model_cost verbatim, so a
+    config value like "128,000" or "" reaches the /v1/models listing uncoerced from
+    both the router index and the cost map. Returning None omits that one limit
+    instead of failing the whole listing.
+
+    Args:
+        value: The raw configured or cost-map value
+
+    Returns:
+        The value as an int, or None if it is missing or not a usable number.
+        Bools are rejected because True/False is never a meaningful token limit.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, (str, float)):
+        try:
+            return int(value)
+        except (TypeError, ValueError, OverflowError):
+            return None
+    return None
+
+
 _FINISH_REASON_MAP: dict[str, OpenAIChatCompletionFinishReason] = {
     # Anthropic
     "stop_sequence": "stop",

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -104,6 +104,7 @@ from litellm.integrations.custom_logger import CustomLogger
 from litellm.integrations.prometheus import PrometheusLogger
 from litellm.integrations.SlackAlerting.slack_alerting import SlackAlerting
 from litellm.integrations.SlackAlerting.utils import _add_langfuse_trace_id_to_alert
+from litellm.litellm_core_utils.core_helpers import coerce_token_limit
 from litellm.litellm_core_utils.litellm_logging import Logging
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.litellm_core_utils.safe_json_loads import safe_json_loads
@@ -6128,12 +6129,8 @@ def create_model_info_response(
     max_input_tokens: int | None = None
     max_output_tokens: int | None = None
     if model_cost_info is not None:
-        cost_map_input = model_cost_info.get("max_input_tokens")
-        if cost_map_input is not None:
-            max_input_tokens = int(cost_map_input)
-        cost_map_output = model_cost_info.get("max_output_tokens")
-        if cost_map_output is not None:
-            max_output_tokens = int(cost_map_output)
+        max_input_tokens = coerce_token_limit(model_cost_info.get("max_input_tokens"))
+        max_output_tokens = coerce_token_limit(model_cost_info.get("max_output_tokens"))
 
     if llm_router is not None:
         configured_input, configured_output = llm_router.get_configured_token_limits(model_id)

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -68,6 +68,7 @@ from litellm.litellm_core_utils.request_timeout_resolver import (
 )
 from litellm.litellm_core_utils.core_helpers import (
     _get_parent_otel_span_from_kwargs,
+    coerce_token_limit,
     get_metadata_variable_name_from_kwargs,
 )
 from litellm.litellm_core_utils.coroutine_checker import coroutine_checker
@@ -8544,18 +8545,10 @@ class Router:
         if deployment is None:
             return (None, None)
 
-        def _as_int(value: object) -> "int | None":
-            if value is None or isinstance(value, bool):
-                return None
-            try:
-                return int(value)
-            except (TypeError, ValueError):
-                return None
-
         model_info = deployment.model_info
         return (
-            _as_int(model_info.get("max_input_tokens")),
-            _as_int(model_info.get("max_output_tokens")),
+            coerce_token_limit(model_info.get("max_input_tokens")),
+            coerce_token_limit(model_info.get("max_output_tokens")),
         )
 
     def get_deployment_credentials_with_provider(

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -478,11 +478,12 @@ class TestPostCallFailureHookLiftsRecoveredPartialSpend:
 
 from typing import cast
 
+import litellm
 from litellm.proxy.utils import create_model_info_response
 from litellm.types.utils import ModelInfo
 
 
-def _fake_model_info(**fields: int) -> ModelInfo:
+def _fake_model_info(**fields: object) -> ModelInfo:
     return cast(ModelInfo, dict(fields))
 
 
@@ -579,6 +580,67 @@ def test_create_model_info_response_survives_malformed_configured_limits():
     assert response["id"] == "bad-limit-model"
     assert "max_input_tokens" not in response
     assert "max_output_tokens" not in response
+
+
+@pytest.mark.parametrize("bad_value", ["128,000", "", "unlimited", [128000], {"max": 128000}, True])
+def test_create_model_info_response_survives_malformed_cost_map_limits(bad_value):
+    response = create_model_info_response(
+        model_id="some-model",
+        provider="openai",
+        llm_router=None,
+        get_model_info=lambda _model: _fake_model_info(
+            max_input_tokens=bad_value, max_output_tokens=bad_value
+        ),
+    )
+
+    assert response["id"] == "some-model"
+    assert "max_input_tokens" not in response
+    assert "max_output_tokens" not in response
+
+
+def test_create_model_info_response_keeps_valid_cost_map_limit_beside_malformed_one():
+    response = create_model_info_response(
+        model_id="some-model",
+        provider="openai",
+        llm_router=None,
+        get_model_info=lambda _model: _fake_model_info(
+            max_input_tokens="128,000", max_output_tokens=16384
+        ),
+    )
+
+    assert "max_input_tokens" not in response
+    assert response["max_output_tokens"] == 16384
+
+
+def test_create_model_info_response_survives_malformed_limits_registered_by_router():
+    """A deployment's model_info is registered into litellm.model_cost verbatim, so a
+    malformed configured limit reaches the listing through the real cost-map lookup and
+    not just the router index. Guarding only the index path still 500s the whole listing."""
+    from litellm import Router
+
+    saved_model_cost = dict(litellm.model_cost)
+    try:
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "openai/some-unmapped-model",
+                    "litellm_params": {"model": "openai/some-unmapped-model"},
+                    "model_info": {"max_input_tokens": "128,000"},
+                }
+            ]
+        )
+
+        response = create_model_info_response(
+            model_id="openai/some-unmapped-model",
+            provider="openai",
+            llm_router=router,
+        )
+    finally:
+        litellm.model_cost.clear()
+        litellm.model_cost.update(saved_model_cost)
+
+    assert response["id"] == "openai/some-unmapped-model"
+    assert "max_input_tokens" not in response
 
 
 def test_create_model_info_response_emits_integer_token_counts():


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Config used for both runs; the first deployment carries a non-numeric limit, the second is a healthy control that shows whether the whole listing survives

```yaml
model_list:
  - model_name: openai/regression-probe-33891
    litellm_params:
      model: openai/regression-probe-33891
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      max_input_tokens: "128,000"

  - model_name: openai/gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-1234
```

Before, at 595e72472a (this branch's parent, tip of litellm_internal_staging at the time)

```
$ curl -s -w "\nHTTP_STATUS: %{http_code}\n" http://localhost:4006/v1/models -H "Authorization: Bearer sk-1234"
{"error":{"message":"Internal server error","type":"internal_server_error"}}
HTTP_STATUS: 500
```

The proxy log shows the cast that failed, inside the per-model listing loop

```
  File "litellm/proxy/utils.py", line 6133, in create_model_info_response
ValueError: invalid literal for int() with base 10: '128,000'
INFO:     127.0.0.1:60986 - "GET /v1/models HTTP/1.1" 500 Internal Server Error
```

After, at ab02127b50

```
$ curl -s -w "\nHTTP_STATUS: %{http_code}\n" http://localhost:4006/v1/models -H "Authorization: Bearer sk-1234"
HTTP_STATUS: 200

{"id": "openai/regression-probe-33891", "object": "model", "created": 1677610602, "owned_by": "openai"}
{"id": "openai/gpt-4o-mini", "object": "model", "created": 1677610602, "owned_by": "openai", "max_input_tokens": 128000, "max_output_tokens": 16384}
total listed: 37
```

The deployment with the malformed value is listed with its limits omitted, the healthy control keeps both of its limits, and the other 35 deployments come back instead of being lost to the 500

Same proxy still serves real traffic, hitting the live OpenAI API

```
$ curl -s http://localhost:4006/v1/chat/completions -H "Authorization: Bearer sk-1234" \
    -H "Content-Type: application/json" \
    -d '{"model":"openai/gpt-4o-mini","messages":[{"role":"user","content":"Reply with exactly: models listing is healthy"}],"max_tokens":20}'
{"id":"chatcmpl-E3B44CYMc7OrjsrqMrgoE9bgMnkVm","created":1784426224,"model":"openai/gpt-4o-mini","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"models listing is healthy","role":"assistant"}}],"usage":{"completion_tokens":4,"prompt_tokens":15,"total_tokens":19}}
HTTP_STATUS: 200
```

## Type

🐛 Bug Fix

## Changes

`create_model_info_response` read `max_input_tokens` and `max_output_tokens` out of the cost map and cast both with a bare `int()`. The surrounding try/except covers only the `get_model_info` lookup, not the casts, so a deployment whose `model_info` carries a non-numeric limit raised inside the per-model loop and failed the entire `GET /v1/models` and `/models` response with a 500. Every healthy deployment went down with it. Before the cost-map switch the same config returned 200 and simply omitted that deployment's limits

The value gets there because a deployment's `model_info` is registered into `litellm.model_cost` verbatim, so it reaches the cost map and not only the router index. `Router.get_configured_token_limits` already coerced this safely for the deployment path, so guarding one path and not the other still left the pair regressing

Both call sites now share `coerce_token_limit` in `litellm_core_utils/core_helpers.py`. It returns `None` for anything that is not a usable number, so the listing omits that one limit and keeps serving, and it rejects bools since `True`/`False` is never a meaningful token limit. Coercion of well-formed values is unchanged, including numeric strings like `"32000"`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
