### PR TITLE
fix(triton): json-encode nested params and guard max_tokens type in /…

### DIFF
--- a/litellm/llms/triton/completion/transformation.py
+++ b/litellm/llms/triton/completion/transformation.py
@@ -198,7 +198,11 @@ class TritonGenerateConfig(TritonConfig):
         data_for_triton: Dict[str, Any] = {
             "text_input": prompt_factory(model=model, messages=messages),
             "parameters": {
-                "max_tokens": int(optional_params.get("max_tokens", optional_params.get("max_completion_tokens", DEFAULT_MAX_TOKENS_FOR_TRITON))),
+                "max_tokens": int(
+                    optional_params.get(
+                        "max_tokens", optional_params.get("max_completion_tokens", DEFAULT_MAX_TOKENS_FOR_TRITON)
+                    )
+                ),
             },
             "stream": bool(stream),
         }

--- a/litellm/llms/triton/completion/transformation.py
+++ b/litellm/llms/triton/completion/transformation.py
@@ -191,14 +191,25 @@ class TritonGenerateConfig(TritonConfig):
     ) -> dict:
         inference_params = optional_params.copy()
         stream = inference_params.pop("stream", False)
+        # max_tokens is handled explicitly below with an int() cast; pop it so the
+        # loop below does not overwrite that cast with a raw (possibly non-int) value.
+        inference_params.pop("max_tokens", None)
+        inference_params.pop("max_completion_tokens", None)
         data_for_triton: Dict[str, Any] = {
             "text_input": prompt_factory(model=model, messages=messages),
             "parameters": {
-                "max_tokens": int(optional_params.get("max_tokens", DEFAULT_MAX_TOKENS_FOR_TRITON)),
+                "max_tokens": int(optional_params.get("max_tokens", optional_params.get("max_completion_tokens", DEFAULT_MAX_TOKENS_FOR_TRITON))),
             },
             "stream": bool(stream),
         }
-        data_for_triton["parameters"].update(inference_params)
+        for k, v in inference_params.items():
+            if isinstance(v, (dict, list, tuple)):
+                # Triton's `parameters` field only accepts int/bool/string values.
+                # JSON-encode nested structures (e.g. chat_template_kwargs) so they
+                # survive the round trip; backends can json.loads() them back.
+                data_for_triton["parameters"][k] = json.dumps(v)
+            else:
+                data_for_triton["parameters"][k] = v
         return data_for_triton
 
     def transform_response(

--- a/tests/llm_translation/test_triton.py
+++ b/tests/llm_translation/test_triton.py
@@ -373,6 +373,98 @@ async def test_triton_embeddings():
         pytest.fail(f"Error occurred: {e}")
 
 
+def test_triton_generate_request_serializes_dict_params():
+    """
+    Triton's `parameters` field only accepts int/bool/string values.
+    Nested dict/list params (e.g. chat_template_kwargs) must be JSON-encoded
+    rather than forwarded as raw objects, otherwise Triton rejects the request.
+    """
+    from litellm.llms.triton.completion.transformation import TritonGenerateConfig
+
+    config = TritonGenerateConfig()
+    data_for_triton = config.transform_request(
+        model="triton/qwen3.6-27b",
+        messages=[{"role": "user", "content": "test?"}],
+        optional_params={
+            "max_tokens": 10,
+            "temperature": 0.7,
+            "chat_template_kwargs": {"enable_thinking": False},
+        },
+        litellm_params={},
+        headers={},
+    )
+
+    assert data_for_triton["parameters"]["max_tokens"] == 10
+    assert isinstance(data_for_triton["parameters"]["max_tokens"], int)
+    assert data_for_triton["parameters"]["temperature"] == 0.7
+    assert isinstance(data_for_triton["parameters"]["chat_template_kwargs"], str)
+    assert json.loads(data_for_triton["parameters"]["chat_template_kwargs"]) == {
+        "enable_thinking": False
+    }
+
+
+def test_triton_generate_request_serializes_tuple_params():
+    """Tuples must be JSON-encoded too (Triton only accepts int/bool/string)."""
+    from litellm.llms.triton.completion.transformation import TritonGenerateConfig
+
+    config = TritonGenerateConfig()
+    data_for_triton = config.transform_request(
+        model="triton/qwen3.6-27b",
+        messages=[{"role": "user", "content": "test?"}],
+        optional_params={
+            "max_tokens": 10,
+            "stop_sequences": ("foo", "bar"),
+        },
+        litellm_params={},
+        headers={},
+    )
+
+    assert isinstance(data_for_triton["parameters"]["stop_sequences"], str)
+    assert json.loads(data_for_triton["parameters"]["stop_sequences"]) == ["foo", "bar"]
+
+
+def test_triton_generate_request_max_tokens_always_int():
+    """
+    max_tokens must always be an integer in the Triton payload even if the caller
+    passes it as a string (e.g. from a JSON-decoded HTTP request body).
+    The explicit int() cast must not be silently overwritten by the param loop.
+    """
+    from litellm.llms.triton.completion.transformation import TritonGenerateConfig
+
+    config = TritonGenerateConfig()
+    data_for_triton = config.transform_request(
+        model="triton/llama-3-8b-instruct",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={"max_tokens": 10},
+        litellm_params={},
+        headers={},
+    )
+
+    assert data_for_triton["parameters"]["max_tokens"] == 10
+    assert isinstance(data_for_triton["parameters"]["max_tokens"], int), (
+        "max_tokens must be int; the param loop must not overwrite the int() cast"
+    )
+
+
+def test_triton_generate_request_max_completion_tokens_fallback():
+    """max_completion_tokens should be used when max_tokens is absent."""
+    from litellm.llms.triton.completion.transformation import TritonGenerateConfig
+
+    config = TritonGenerateConfig()
+    data_for_triton = config.transform_request(
+        model="triton/llama-3-8b-instruct",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={"max_completion_tokens": 20},
+        litellm_params={},
+        headers={},
+    )
+
+    assert data_for_triton["parameters"]["max_tokens"] == 20
+    assert isinstance(data_for_triton["parameters"]["max_tokens"], int)
+    # max_completion_tokens must not appear as a separate key in parameters
+    assert "max_completion_tokens" not in data_for_triton["parameters"]
+
+
 def test_triton_generate_raw_request():
     from litellm.utils import return_raw_request
     from litellm.types.utils import CallTypes

--- a/tests/test_litellm/llms/triton/test_triton_transformation.py
+++ b/tests/test_litellm/llms/triton/test_triton_transformation.py
@@ -1,0 +1,88 @@
+"""Unit tests for Triton /generate request transformation.
+
+These live under tests/test_litellm/ (rather than tests/llm_translation/) so CI
+actually runs them and reports coverage for the transformation module.
+"""
+
+import json
+
+from litellm.llms.triton.completion.transformation import TritonGenerateConfig
+
+
+def test_triton_generate_request_serializes_dict_params():
+    """Triton's `parameters` field only accepts int/bool/string values.
+
+    Nested dict params (e.g. chat_template_kwargs) must be JSON-encoded rather
+    than forwarded as raw objects, otherwise Triton rejects the request.
+    """
+    config = TritonGenerateConfig()
+    data_for_triton = config.transform_request(
+        model="triton/qwen3.6-27b",
+        messages=[{"role": "user", "content": "test?"}],
+        optional_params={
+            "max_tokens": 10,
+            "temperature": 0.7,
+            "chat_template_kwargs": {"enable_thinking": False},
+        },
+        litellm_params={},
+        headers={},
+    )
+
+    assert data_for_triton["parameters"]["max_tokens"] == 10
+    assert isinstance(data_for_triton["parameters"]["max_tokens"], int)
+    assert data_for_triton["parameters"]["temperature"] == 0.7
+    assert isinstance(data_for_triton["parameters"]["chat_template_kwargs"], str)
+    assert json.loads(data_for_triton["parameters"]["chat_template_kwargs"]) == {"enable_thinking": False}
+
+
+def test_triton_generate_request_serializes_tuple_params():
+    """Tuples must be JSON-encoded too (Triton only accepts int/bool/string)."""
+    config = TritonGenerateConfig()
+    data_for_triton = config.transform_request(
+        model="triton/qwen3.6-27b",
+        messages=[{"role": "user", "content": "test?"}],
+        optional_params={"max_tokens": 10, "stop_sequences": ("foo", "bar")},
+        litellm_params={},
+        headers={},
+    )
+
+    assert isinstance(data_for_triton["parameters"]["stop_sequences"], str)
+    assert json.loads(data_for_triton["parameters"]["stop_sequences"]) == ["foo", "bar"]
+
+
+def test_triton_generate_request_max_tokens_always_int():
+    """max_tokens must stay an int in the payload.
+
+    The explicit int() cast must not be silently overwritten by the loop that
+    copies the remaining optional_params into `parameters`.
+    """
+    config = TritonGenerateConfig()
+    data_for_triton = config.transform_request(
+        model="triton/llama-3-8b-instruct",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={"max_tokens": 10},
+        litellm_params={},
+        headers={},
+    )
+
+    assert data_for_triton["parameters"]["max_tokens"] == 10
+    assert isinstance(data_for_triton["parameters"]["max_tokens"], int), (
+        "max_tokens must be int; the param loop must not overwrite the int() cast"
+    )
+
+
+def test_triton_generate_request_max_completion_tokens_fallback():
+    """max_completion_tokens is used when max_tokens is absent, and is not
+    forwarded as a separate Triton parameter."""
+    config = TritonGenerateConfig()
+    data_for_triton = config.transform_request(
+        model="triton/llama-3-8b-instruct",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={"max_completion_tokens": 20},
+        litellm_params={},
+        headers={},
+    )
+
+    assert data_for_triton["parameters"]["max_tokens"] == 20
+    assert isinstance(data_for_triton["parameters"]["max_tokens"], int)
+    assert "max_completion_tokens" not in data_for_triton["parameters"]


### PR DESCRIPTION
…generate

Two bugs in TritonGenerateConfig.transform_request:

1. **Nested value crash**: the old `parameters.update(inference_params)` forwarded dict/list/tuple values directly to Triton, which only accepts int/bool/string. Replaced with an explicit loop that JSON-encodes nested structures so they survive the round trip (backends can json.loads() them back).

2. **max_tokens type loss**: `max_tokens` was initialized with an explicit `int()` cast but then overwritten by the same loop with the raw (possibly string) value from `inference_params`. Triton requires an integer; a string value caused a type-rejection error. Fixed by popping `max_tokens` (and `max_completion_tokens`) from `inference_params` before the loop so the cast is never overridden. `max_completion_tokens` is also now honoured as a fallback when `max_tokens` is absent, and is not leaked as a separate key in `parameters`.

Tests added:
- test_triton_generate_request_serializes_dict_params
- test_triton_generate_request_serializes_tuple_params
- test_triton_generate_request_max_tokens_always_int
- test_triton_generate_request_max_completion_tokens_fallback

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
