### PR TITLE
fix(safe_json_dumps): stringify non-str dict keys instead of silently dropping them

### DIFF
--- a/litellm/litellm_core_utils/safe_json_dumps.py
+++ b/litellm/litellm_core_utils/safe_json_dumps.py
@@ -46,7 +46,7 @@ def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
                     try:
                         str_k = str(k)
                         clean_k = str_k.replace("\x00", "") if "\x00" in str_k else str_k
-                    except Exception:
+                    except Exception:  # noqa: BLE001 - key __str__ must never propagate
                         clean_k = "UnserializableKey"
                 result[clean_k] = _serialize(v, seen, depth + 1)
             seen.remove(id(obj))

--- a/litellm/litellm_core_utils/safe_json_dumps.py
+++ b/litellm/litellm_core_utils/safe_json_dumps.py
@@ -35,9 +35,14 @@ def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
         if isinstance(obj, dict):
             result = {}
             for k, v in obj.items():
-                if isinstance(k, (str)):
+                if isinstance(k, str):
                     clean_k = k.replace("\x00", "") if "\x00" in k else k
-                    result[clean_k] = _serialize(v, seen, depth + 1)
+                else:
+                    # JSON only allows string keys; convert non-str keys (e.g. tuples
+                    # used by the OTel integration as dedup keys) rather than dropping
+                    # them silently, which caused data loss in spend-log payloads.
+                    clean_k = str(k)
+                result[clean_k] = _serialize(v, seen, depth + 1)
             seen.remove(id(obj))
             return result
         elif isinstance(obj, list):

--- a/litellm/litellm_core_utils/safe_json_dumps.py
+++ b/litellm/litellm_core_utils/safe_json_dumps.py
@@ -41,8 +41,13 @@ def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
                     # JSON only allows string keys; convert non-str keys (e.g. tuples
                     # used by the OTel integration as dedup keys) rather than dropping
                     # them silently, which caused data loss in spend-log payloads.
-                    str_k = str(k)
-                    clean_k = str_k.replace("\x00", "") if "\x00" in str_k else str_k
+                    # Mirror the value fallback (lines 68-71): if __str__ raises, use
+                    # a safe placeholder so safe_dumps never propagates an exception.
+                    try:
+                        str_k = str(k)
+                        clean_k = str_k.replace("\x00", "") if "\x00" in str_k else str_k
+                    except Exception:
+                        clean_k = "UnserializableKey"
                 result[clean_k] = _serialize(v, seen, depth + 1)
             seen.remove(id(obj))
             return result

--- a/litellm/litellm_core_utils/safe_json_dumps.py
+++ b/litellm/litellm_core_utils/safe_json_dumps.py
@@ -41,7 +41,8 @@ def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
                     # JSON only allows string keys; convert non-str keys (e.g. tuples
                     # used by the OTel integration as dedup keys) rather than dropping
                     # them silently, which caused data loss in spend-log payloads.
-                    clean_k = str(k)
+                    str_k = str(k)
+                    clean_k = str_k.replace("\x00", "") if "\x00" in str_k else str_k
                 result[clean_k] = _serialize(v, seen, depth + 1)
             seen.remove(id(obj))
             return result

--- a/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
+++ b/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
@@ -277,3 +277,24 @@ def test_integer_dict_keys_are_stringified():
     assert result["1"] == "one"
     assert result["2"] == "two"
     assert result["three"] == 3
+
+
+def test_dict_key_with_raising_str_uses_placeholder():
+    """A hashable key whose __str__ raises must not propagate the exception."""
+
+    class RaisingKey:
+        def __hash__(self):
+            return 7
+
+        def __eq__(self, other):
+            return self is other
+
+        def __str__(self):
+            raise RuntimeError("intentional __str__ failure")
+
+    data = {RaisingKey(): "value", "normal": 1}
+    result = json.loads(safe_dumps(data))
+    assert result.get("UnserializableKey") == "value", (
+        "key whose __str__ raises should fall back to 'UnserializableKey'"
+    )
+    assert result["normal"] == 1

--- a/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
+++ b/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
@@ -128,7 +128,7 @@ def test_non_standard_dict_keys_complex():
         assert result[0]["test"] == "test"
         assert result[1] == "GCCollector"
         assert result[2]["bad_key"] == "bad_value"
-        assert result[3] == {}
+        assert result[3] == {"GCCollector": "value"}  # non-str key is now stringified, not dropped
         assert result[4]["bad_key"] == "GCCollector"
         assert result[5][0] == "GCCollector"
         assert result[5][1] == "GCCollector"
@@ -230,3 +230,50 @@ def test_pydantic_base_model():
     assert len(result["healthy_endpoints"]) == 2
     assert result["healthy_endpoints"][0]["name"] == "test"
     assert result["healthy_endpoints"][1] == {"value": 1, "label": "one"}
+
+
+def test_tuple_dict_keys_are_stringified_not_dropped():
+    """
+    Regression for #32250.
+
+    The OTel integration stores dedup markers in
+    metadata["_otel_internal"]["spans_logged"] using tuple keys:
+
+        spans_logged[("OpenTelemetry", id(self), *scope)] = True
+
+    Previously safe_dumps silently dropped all non-str dict keys, turning
+    spans_logged into {} in the serialized spend-log payload and causing
+    unbounded growth of the in-memory spend_log_transactions queue.
+
+    Non-str keys must now be converted via str() rather than discarded.
+    """
+    spans_logged = {
+        ("OpenTelemetry", 12345, "success"): True,
+        ("OpenTelemetry", 12346, "failure"): False,
+    }
+    metadata = {
+        "_otel_internal": {
+            "spans_logged": spans_logged,
+        }
+    }
+
+    result = json.loads(safe_dumps({"metadata": metadata}))
+    serialized_spans = result["metadata"]["_otel_internal"]["spans_logged"]
+
+    # Keys must be preserved as their string representation, not silently dropped.
+    assert serialized_spans != {}, "tuple keys must not be silently dropped"
+    assert len(serialized_spans) == 2
+
+    # Values must be preserved correctly.
+    values = list(serialized_spans.values())
+    assert True in values
+    assert False in values
+
+
+def test_integer_dict_keys_are_stringified():
+    """Integer keys are valid JSON only as strings; safe_dumps must stringify them."""
+    data = {1: "one", 2: "two", "three": 3}
+    result = json.loads(safe_dumps(data))
+    assert result["1"] == "one"
+    assert result["2"] == "two"
+    assert result["three"] == 3


### PR DESCRIPTION
## Summary

Fixes #32250.

`safe_dumps._serialize` only retained dict keys where `isinstance(k, str)` was true. Any other key type (tuples, ints, custom objects) was **silently discarded** — data loss with no error.

**Root cause in context:** The OpenTelemetry integration (`litellm/integrations/opentelemetry.py:1101`) stores per-request dedup markers under **tuple keys**:

\`\`\`python
dedupe_key = (self.__class__.__name__, id(self), *scope)
spans_logged[dedupe_key] = True
\`\`\`

When the spend-log payload was serialised via \`safe_dumps\`, every entry in \`spans_logged\` was silently dropped, producing \`"spans_logged": {}\`. This broke the spend-log write path and caused unbounded growth of the in-memory \`spend_log_transactions\` queue (OOM risk).

## Fix

Added an \`else\` branch that converts non-str keys via \`str(k)\` rather than dropping them. String keys go through the existing NUL-byte stripping path unchanged — no change to hot-path behaviour.

\`\`\`python
# before — silently drops tuple/int/custom-object keys
if isinstance(k, str):
    clean_k = k.replace("\x00", "") if "\x00" in k else k
    result[clean_k] = _serialize(v, seen, depth + 1)

# after — stringifies instead of drops
if isinstance(k, str):
    clean_k = k.replace("\x00", "") if "\x00" in k else k
else:
    clean_k = str(k)
result[clean_k] = _serialize(v, seen, depth + 1)
\`\`\`

## Tests

- **`test_tuple_dict_keys_are_stringified_not_dropped`** — reproduces the exact OTel `spans_logged` scenario from the issue; asserts keys are preserved, not dropped
- **`test_integer_dict_keys_are_stringified`** — covers integer key case
- **`test_non_standard_dict_keys_complex`** — updated assertion: `{GCCollector(): "value"}` now serialises to `{"GCCollector": "value"}` instead of `{}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)