### PR TITLE
fix(azure): support prompt cache retention for chat completions

### DIFF
--- a/litellm/llms/azure/chat/gpt_transformation.py
+++ b/litellm/llms/azure/chat/gpt_transformation.py
@@ -106,6 +106,7 @@ class AzureOpenAIConfig(BaseConfig):
             "audio",
             "web_search_options",
             "prompt_cache_key",
+            "prompt_cache_retention",
             "store",
         ]
 

--- a/tests/test_litellm/llms/azure/chat/test_azure_chat_gpt_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_chat_gpt_transformation.py
@@ -1,9 +1,7 @@
 import os
 import sys
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
-)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../..")))
 
 from litellm.llms.azure.chat.gpt_transformation import AzureOpenAIConfig
 
@@ -41,6 +39,25 @@ class TestAzureOpenAIConfig:
         supported_params = config.get_supported_openai_params("gpt-4.1")
         assert "prompt_cache_key" in supported_params
 
+    def test_prompt_cache_retention_supported(self):
+        config = AzureOpenAIConfig()
+
+        supported_params = config.get_supported_openai_params("gpt-4.1")
+
+        assert "prompt_cache_retention" in supported_params
+
+    def test_prompt_cache_retention_is_mapped(self):
+        config = AzureOpenAIConfig()
+
+        optional_params = config.map_openai_params(
+            non_default_params={"prompt_cache_retention": "24h"},
+            optional_params={},
+            model="gpt-4.1",
+            drop_params=False,
+        )
+
+        assert optional_params == {"prompt_cache_retention": "24h"}
+
 
 def test_map_openai_params_with_preview_api_version():
     config = AzureOpenAIConfig()
@@ -51,6 +68,4 @@ def test_map_openai_params_with_preview_api_version():
     model = "azure/gpt-4-1"
     drop_params = False
     api_version = "preview"
-    assert config.map_openai_params(
-        non_default_params, optional_params, model, drop_params, api_version
-    )
+    assert config.map_openai_params(non_default_params, optional_params, model, drop_params, api_version)


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live Azure proof is pending because my local environment has no Azure OpenAI credentials. This draft does not claim end-to-end provider proof.

## Type

🐛 Bug Fix

## Changes

- Azure Chat Completions did not advertise `prompt_cache_retention` as supported, so LiteLLM filtered the parameter before constructing the provider request.
- Add `prompt_cache_retention` to Azure Chat's supported OpenAI parameters so the existing mapping path forwards it unchanged to Azure.
- Add focused regression coverage for supported-parameter discovery and passthrough with the documented `24h` value.

The change intentionally leaves deployment, model, region, API-version, and retention-value validation to Azure.

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
