### PR TITLE
docs: add FunASR transcription proxy cookbook

### DIFF
--- a/cookbook/litellm_proxy_server/funasr_audio_transcriptions.md
+++ b/cookbook/litellm_proxy_server/funasr_audio_transcriptions.md
@@ -1,0 +1,88 @@
+# Self-host FunASR audio transcriptions behind LiteLLM
+
+LiteLLM already routes OpenAI-compatible `/audio/transcriptions` providers through
+`custom_openai`. Use this when you want the LiteLLM proxy to expose a local
+FunASR or SenseVoice speech-to-text server without adding a new LiteLLM provider.
+
+## Start a FunASR-compatible transcription server
+
+Install FunASR and the web server dependencies on the machine that will run ASR:
+
+```bash
+python -m pip install -U "funasr>=1.3.20" vllm fastapi uvicorn python-multipart
+funasr-server --model sensevoice --device cuda --port 8000
+```
+
+The server exposes an OpenAI-compatible endpoint at:
+
+```text
+http://localhost:8000/v1/audio/transcriptions
+```
+
+Use `--device cpu` for a CPU-only smoke test, or put the FunASR server on a GPU
+host and point LiteLLM at that host.
+
+## Configure LiteLLM
+
+Add a `custom_openai` model to the proxy config. Set `api_base` to the OpenAI
+base URL, not the full transcription path.
+
+```yaml
+model_list:
+  - model_name: funasr-sensevoice
+    litellm_params:
+      model: custom_openai/FunAudioLLM/SenseVoiceSmall
+      api_base: http://localhost:8000/v1
+      api_key: dummy-key
+```
+
+Start the proxy with that config:
+
+```bash
+litellm --config ./config.yaml
+```
+
+Then call LiteLLM's OpenAI-compatible transcription endpoint:
+
+```bash
+curl -sS http://localhost:4000/v1/audio/transcriptions \
+  -H "Authorization: Bearer sk-1234" \
+  -F model=funasr-sensevoice \
+  -F file=@sample.wav
+```
+
+LiteLLM forwards the multipart request to:
+
+```text
+http://localhost:8000/v1/audio/transcriptions
+```
+
+and returns the FunASR server response to the client.
+
+## Other FunASR models
+
+`FunAudioLLM/SenseVoiceSmall` is a good default for Mandarin, Cantonese, English,
+Japanese, and Korean. For Fun-ASR-Nano or Fun-ASR-MLT-Nano deployments, use the
+model id your FunASR-compatible server accepts, for example:
+
+```yaml
+model_list:
+  - model_name: fun-asr-nano
+    litellm_params:
+      model: custom_openai/FunAudioLLM/Fun-ASR-Nano-2512
+      api_base: http://localhost:8000/v1
+      api_key: dummy-key
+```
+
+FunASR is the toolkit/runtime. Exact language coverage, timestamps, hotwords,
+speaker labels, rich transcription tags, and diarization behavior depend on the
+selected model and server configuration.
+
+## Troubleshooting
+
+- Use `api_base: http://host:8000/v1`; do not include `/audio/transcriptions`.
+- Use a placeholder `api_key` if your local FunASR server does not require auth.
+- If the upstream server validates model ids, set `model:
+  custom_openai/<exact-model-id>`.
+- Test the FunASR server directly with `curl http://host:8000/v1/audio/transcriptions`
+  before testing through the LiteLLM proxy.

--- a/cookbook/litellm_proxy_server/readme.md
+++ b/cookbook/litellm_proxy_server/readme.md
@@ -99,6 +99,12 @@ print(response.text)
 
 ```
 
+### `/audio/transcriptions` (POST)
+
+Use `custom_openai` to proxy OpenAI-compatible speech-to-text services through
+LiteLLM. For a self-hosted FunASR or SenseVoice server, see the
+[FunASR audio transcription cookbook](./funasr_audio_transcriptions.md).
+
 ### Output [Response Format]
 
 Responses from the server are given in the following format.


### PR DESCRIPTION
## Title
Add FunASR transcription proxy cookbook

## Relevant issues
Refs #29367

## Type
- [x] Documentation

## Changes
- Adds a LiteLLM proxy cookbook for routing OpenAI-compatible `/audio/transcriptions` calls to a self-hosted FunASR/SenseVoice server via the existing `custom_openai` provider.
- Shows the FunASR server command, proxy `model_list` config, and curl smoke test through LiteLLM's `/v1/audio/transcriptions` endpoint.
- Links the new cookbook from the proxy server README's API endpoint section.

## Why
`custom_openai` already supports audio transcriptions in LiteLLM. The missing piece for users in #29367 is a copyable config path for local/on-prem ASR servers such as FunASR, SenseVoiceSmall, and Fun-ASR-Nano without adding a new provider implementation.

## Tests
```text
python3 content assertions for required FunASR/SenseVoice snippets and README link
# content assertions passed

python3 YAML parse assertions for both model_list examples
# yaml blocks parsed

git diff --check HEAD~1..HEAD
# passed
```
