### PR TITLE
fix(budget): correct multi-day rollover in standardized reset-time handlers

### DIFF
--- a/litellm/litellm_core_utils/duration_parser.py
+++ b/litellm/litellm_core_utils/duration_parser.py
@@ -236,8 +236,9 @@ def _handle_hour_reset(current_time: datetime, base_midnight: datetime, value: i
 
     # Handle overnight case
     if next_hour >= 24:
+        days_ahead = next_hour // 24
         next_hour = next_hour % 24
-        next_day = base_midnight + timedelta(days=1)
+        next_day = base_midnight + timedelta(days=days_ahead)
         return next_day.replace(hour=next_hour)
 
     return current_time.replace(hour=next_hour, minute=0, second=0, microsecond=0)
@@ -270,8 +271,9 @@ def _handle_minute_reset(current_time: datetime, base_midnight: datetime, value:
 
     # Handle overnight case
     if next_hour >= 24:
+        days_ahead = next_hour // 24
         next_hour = next_hour % 24
-        next_day = base_midnight + timedelta(days=1)
+        next_day = base_midnight + timedelta(days=days_ahead)
         return next_day.replace(hour=next_hour, minute=next_minute, second=0, microsecond=0)
 
     return current_time.replace(hour=next_hour, minute=next_minute, second=0, microsecond=0)
@@ -309,8 +311,9 @@ def _handle_second_reset(current_time: datetime, base_midnight: datetime, value:
 
     # Handle overnight case
     if next_hour >= 24:
+        days_ahead = next_hour // 24
         next_hour = next_hour % 24
-        next_day = base_midnight + timedelta(days=1)
+        next_day = base_midnight + timedelta(days=days_ahead)
         return next_day.replace(hour=next_hour, minute=next_minute, second=next_second, microsecond=0)
 
     return current_time.replace(hour=next_hour, minute=next_minute, second=next_second, microsecond=0)

--- a/tests/test_litellm/litellm_core_utils/test_duration_parser.py
+++ b/tests/test_litellm/litellm_core_utils/test_duration_parser.py
@@ -71,6 +71,31 @@ class TestStandardizedResetTime(unittest.TestCase):
         second_result = get_next_standardized_reset_time("15s", base_time, "UTC")
         self.assertEqual(second_result, second_expected)
 
+    def test_multi_day_rollover_resets(self):
+        """Durations spanning more than 24h must advance the full number of days."""
+        # Base time: 2023-05-15 10:00 UTC
+        base_time = datetime(2023, 5, 15, 10, 0, 0, tzinfo=timezone.utc)
+
+        # 48h aligns to midnight + 48h; first boundary after 10:00 is the 17th.
+        self.assertEqual(
+            get_next_standardized_reset_time("48h", base_time, "UTC"),
+            datetime(2023, 5, 17, 0, 0, 0, tzinfo=timezone.utc),
+        )
+        # 72h -> the 18th (previously advanced only a single day).
+        self.assertEqual(
+            get_next_standardized_reset_time("72h", base_time, "UTC"),
+            datetime(2023, 5, 18, 0, 0, 0, tzinfo=timezone.utc),
+        )
+        # 3000m == 50h and 180000s == 50h -> 10:00 + 50h == the 17th at 12:00.
+        self.assertEqual(
+            get_next_standardized_reset_time("3000m", base_time, "UTC"),
+            datetime(2023, 5, 17, 12, 0, 0, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            get_next_standardized_reset_time("180000s", base_time, "UTC"),
+            datetime(2023, 5, 17, 12, 0, 0, tzinfo=timezone.utc),
+        )
+
     def test_timezone_handling(self):
         """Test timezone handling with different regions"""
         # Base time: 2023-05-15 22:30:00 UTC (late in UTC day)


### PR DESCRIPTION
Closes #17993

### What's broken

`_handle_hour_reset`, `_handle_minute_reset` and `_handle_second_reset` in `duration_parser.py` reduce the overflowing `next_hour` with `% 24` but always advance the date by a single day:

```python
if next_hour >= 24:
    next_hour = next_hour % 24
    next_day = base_midnight + timedelta(days=1)   # drops whole-day overflow
```

For any duration spanning **≥ 48h**, `next_hour // 24` is ≥ 2, so a single `timedelta(days=1)` discards the extra days:

```python
base = 2023-05-15 10:00 UTC
get_next_standardized_reset_time("48h",  base, "UTC")  # -> 2023-05-16 00:00  (expected 2023-05-17 00:00)
get_next_standardized_reset_time("72h",  base, "UTC")  # -> 2023-05-16 00:00  (expected 2023-05-18 00:00)
get_next_standardized_reset_time("3000m", base, "UTC") # -> 2023-05-16 12:00  (expected 2023-05-17 12:00)
```

So a "48h" budget reset lands only ~14h out, and "72h" advances a single day instead of three. Durations in (24h, 48h) happen to work only because `next_hour // 24 == 1` there, masking the bug. `30h` is even listed as a supported example in the docstring, so N > 24 is in-contract.

### Fix

Capture `days_ahead = next_hour // 24` before the modulo and advance by that many days (all three handlers share the identical block):

```diff
-        next_hour = next_hour % 24
-        next_day = base_midnight + timedelta(days=1)
+        days_ahead = next_hour // 24
+        next_hour = next_hour % 24
+        next_day = base_midnight + timedelta(days=days_ahead)
```

### Tests

Adds `test_multi_day_rollover_resets` to `TestStandardizedResetTime` covering `48h`, `72h`, `3000m`, `180000s`. Verified the fix produces the correct instants for these plus the existing `1h`/`2h` controls (unchanged).