### PR TITLE
feat(bedrock): add bedrock_mantle google.gemma-4-e4b

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -44568,6 +44568,25 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "bedrock_mantle/google.gemma-4-e4b": {
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "bedrock_mantle",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "use_openai_responses_path": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": false,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "bedrock_mantle/xai.grok-4.3": {
         "use_openai_responses_path": true,
         "input_cost_per_token": 1.25e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -44689,6 +44689,25 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "bedrock_mantle/google.gemma-4-e4b": {
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "bedrock_mantle",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "use_openai_responses_path": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": false,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "bedrock_mantle/xai.grok-4.3": {
         "use_openai_responses_path": true,
         "input_cost_per_token": 1.25e-06,

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -177,7 +177,7 @@ class TestBedrockMantleConfig:
 
     @pytest.mark.parametrize(
         "model_id",
-        ["google.gemma-4-31b", "google.gemma-4-26b-a4b", "google.gemma-4-e2b"],
+        ["google.gemma-4-31b", "google.gemma-4-26b-a4b", "google.gemma-4-e2b", "google.gemma-4-e4b"],
     )
     def test_chat_base_for_gemma_4_uses_openai_v1(
         self, monkeypatch, local_cost_map, model_id
@@ -644,6 +644,7 @@ class TestBedrockMantlePricing:
         ("google.gemma-4-31b", 1.4e-07, 4e-07, 256000),
         ("google.gemma-4-26b-a4b", 1.3e-07, 4e-07, 256000),
         ("google.gemma-4-e2b", 4e-08, 8e-08, 128000),
+        ("google.gemma-4-e4b", 0.0, 0.0, 128000),
     ],
 )
 def test_gemma_4_bedrock_mantle_model_metadata(
@@ -675,6 +676,7 @@ def test_gemma_4_bedrock_mantle_model_metadata(
         "google.gemma-4-31b",
         "google.gemma-4-26b-a4b",
         "google.gemma-4-e2b",
+        "google.gemma-4-e4b",
     ],
 )
 def test_gemma_4_models_register_under_bedrock_mantle(local_cost_map, model_id):


### PR DESCRIPTION
## Summary

Adds support for the `bedrock_mantle/google.gemma-4-e4b` model.

## Changes

- Added `bedrock_mantle/google.gemma-4-e4b` to:
  - `model_prices_and_context_window.json`
  - `litellm/model_prices_and_context_window_backup.json`
- Added the model to the existing Bedrock Mantle transformation tests.

## Notes

- Pricing is set to `0.0` because there is currently no official published provider pricing for this provider/model combination.
- Token limits and capabilities mirror the documented characteristics of the Gemma 4 E4B model and follow the existing Bedrock Mantle implementation pattern.

## Testing

- Updated the existing Bedrock Mantle parameterized tests to include the new model.
Resolves #33916