### PR TITLE
fix(gigachat): don't claim stop support the provider lacks

### DIFF
--- a/litellm/llms/gigachat/chat/transformation.py
+++ b/litellm/llms/gigachat/chat/transformation.py
@@ -124,14 +124,16 @@ class GigaChatConfig(BaseConfig):
         return headers
 
     def get_supported_openai_params(self, model: str) -> list[str]:
-        """Return list of supported OpenAI parameters."""
+        """Return list of supported OpenAI parameters.
+
+        No stop: the GigaChat request body has no stop field.
+        """
         return [
             "stream",
             "temperature",
             "top_p",
             "max_tokens",
             "max_completion_tokens",
-            "stop",
             "tools",
             "tool_choice",
             "functions",
@@ -160,9 +162,6 @@ class GigaChatConfig(BaseConfig):
                 optional_params["top_p"] = value
             elif param in ("max_tokens", "max_completion_tokens"):
                 optional_params["max_tokens"] = value
-            elif param == "stop":
-                # GigaChat doesn't support stop sequences
-                pass
             elif param == "tools":
                 # Convert tools to functions format
                 optional_params["functions"] = self._convert_tools_to_functions(value)

--- a/tests/llm_translation/test_gigachat.py
+++ b/tests/llm_translation/test_gigachat.py
@@ -359,6 +359,36 @@ class TestGigaChatSupportedParams:
         assert "response_format" in supported
         assert "stream" in supported
 
+    def test_stop_not_supported(self, config):
+        """GigaChat has no stop sequences, so it must not claim `stop`.
+
+        Claiming it suppresses the UnsupportedParamsError users rely on and the
+        sequences are dropped without any warning.
+        """
+        assert "stop" not in config.get_supported_openai_params("GigaChat")
+
+    def test_stop_raises_instead_of_being_dropped(self, config):
+        """Passing stop should surface an error, not vanish."""
+        import litellm
+        from litellm.utils import get_optional_params
+
+        with pytest.raises(litellm.UnsupportedParamsError):
+            get_optional_params(
+                model="GigaChat", custom_llm_provider="gigachat", stop=["END"]
+            )
+
+    def test_stop_still_droppable(self, config):
+        """With drop_params on, stop is dropped quietly - the documented escape."""
+        from litellm.utils import get_optional_params
+
+        params = get_optional_params(
+            model="GigaChat",
+            custom_llm_provider="gigachat",
+            stop=["END"],
+            drop_params=True,
+        )
+        assert "stop" not in params
+
 
 class TestGigaChatToolChoiceMapping:
     """Tests for tool_choice -> function_call mapping"""


### PR DESCRIPTION
## Relevant issues

None open for this.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 (5/5)

## Screenshots / Proof of Fix

GigaChatConfig.get_supported_openai_params listed `stop`, while
map_openai_params dropped it on the floor:

    elif param == "stop":
        # GigaChat doesn't support stop sequences
        pass

The comment is right. The `Chat` request model in the official SDK
(ai-forever/gigachat, `src/gigachat/models/chat.py`) has model, messages,
temperature, top_p, n, stream, max_tokens, repetition_penalty, update_interval,
profanity_check, function_call, functions, flags, storage, function_ranker,
response_format, additional_fields and reasoning_effort. There is no stop field.

The list is what was wrong. Advertising a param skips the UnsupportedParamsError
in utils.py, so the user's stop sequences vanished without a word.

No network needed to see it, get_optional_params decides this before any
request goes out.

Before, at bd44c9e:

    1. user asks gigachat to stop at 'END'
       params actually sent to the provider: {'stream': False}
       -> 'stop' present? False

    2. same call, but a param gigachat never claims (seed)
       UnsupportedParamsError: gigachat does not support parameters: ['seed'],
       for model=GigaChat. To drop these, set `litellm.drop_params=True`

    3. gigachat's own contract
       get_supported_openai_params() lists 'stop'?  True

Same script after the fix, at 18b9b17:

    1. user asks gigachat to stop at 'END'
       UnsupportedParamsError: gigachat does not support parameters: ['stop'],
       for model=GigaChat

    2. same call, but a param gigachat never claims (seed)
       UnsupportedParamsError: gigachat does not support parameters: ['seed'],
       for model=GigaChat

    3. gigachat's own contract
       get_supported_openai_params() lists 'stop'?  False

stop now behaves like every other param the provider can't serve. Callers who
want the old silent behaviour still get it with drop_params=True, which the
third test covers.

This also corrects a public surface. The proxy serves the list at
GET /utils/supported_openai_params, which calls
litellm.get_supported_openai_params(). On main that endpoint tells a client
gigachat supports stop; on this branch it no longer does.

Tests: tests/llm_translation/test_gigachat.py, 39 passed. The two new
assertions fail on main and pass here; the drop_params one is a guard.

## Type

Bug Fix
