### PR TITLE
fix(a2a): don't claim sampling params the protocol has no field for

### DIFF
--- a/litellm/llms/a2a/chat/transformation.py
+++ b/litellm/llms/a2a/chat/transformation.py
@@ -91,12 +91,16 @@ class A2AConfig(BaseConfig):
         return api_base, api_key, headers
 
     def get_supported_openai_params(self, model: str) -> list[str]:
-        """Return list of supported OpenAI parameters"""
+        """Return list of supported OpenAI parameters.
+
+        A2A has no sampling controls. SendMessageConfiguration carries
+        acceptedOutputModes, taskPushNotificationConfig, historyLength and
+        returnImmediately, nothing else, because the remote agent owns its own
+        model config. Only stream is real here: it picks message/stream over
+        message/send.
+        """
         return [
             "stream",
-            "temperature",
-            "max_tokens",
-            "top_p",
         ]
 
     def map_openai_params(

--- a/tests/llm_translation/test_a2a.py
+++ b/tests/llm_translation/test_a2a.py
@@ -130,3 +130,38 @@ def test_a2a_completion_sync_streaming():
         pytest.skip(f"A2A agent not reachable at {api_base}: {e}")
     except Exception as e:
         pytest.fail(f"Error occurred: {e}")
+
+
+def test_a2a_only_claims_stream():
+    """A2A has no sampling params, so it must not advertise any.
+
+    Claiming one suppresses the UnsupportedParamsError and the value is
+    dropped without telling the caller.
+    """
+    from litellm.llms.a2a.chat.transformation import A2AConfig
+
+    supported = A2AConfig().get_supported_openai_params("test-agent")
+    assert "stream" in supported
+    for param in ("temperature", "max_tokens", "top_p"):
+        assert param not in supported
+
+
+@pytest.mark.parametrize("param,value", [("temperature", 0.5), ("max_tokens", 100), ("top_p", 0.9)])
+def test_a2a_sampling_params_raise(param, value):
+    """Sampling params should surface an error rather than vanish."""
+    from litellm.utils import get_optional_params
+
+    with pytest.raises(litellm.UnsupportedParamsError):
+        get_optional_params(
+            model="test-agent", custom_llm_provider="a2a", **{param: value}
+        )
+
+
+def test_a2a_stream_still_maps():
+    """stream is the one real param, it must survive."""
+    from litellm.utils import get_optional_params
+
+    params = get_optional_params(
+        model="test-agent", custom_llm_provider="a2a", stream=True
+    )
+    assert params["stream"] is True


### PR DESCRIPTION
## Relevant issues

None open for this.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 (4/5)

## Screenshots / Proof of Fix

A2AConfig.get_supported_openai_params advertised four params:

    return [
        "stream",
        "temperature",
        "max_tokens",
        "top_p",
    ]

map_openai_params reads exactly one of them:

    for param, value in non_default_params.items():
        if param == "stream" and value is True:
            optional_params["stream"] = value

and transform_request puts only the message on the wire:

    request_data = {
        "jsonrpc": "2.0",
        "id": request_id,
        "method": method,
        "params": {"message": a2a_message},
    }

grep across litellm/llms/a2a/ finds temperature, max_tokens and top_p only in
that one list, nowhere else. They are accepted and discarded.

This is not a missing implementation, there is nowhere to put them. Per the A2A
spec, SendMessageConfiguration carries acceptedOutputModes,
taskPushNotificationConfig, historyLength and returnImmediately. The spec has no
sampling fields at all, which follows from the protocol's premise that the
remote agent is opaque and owns its own model config.

Effect before this change, at bd44c9e:

    >>> get_optional_params(model="test-agent", custom_llm_provider="a2a", temperature=0.5)
    {}

No error, and the temperature is gone. Any param a2a does not list, say seed,
correctly raises UnsupportedParamsError pointing at drop_params. Listing these
three bypassed that.

After:

    >>> get_optional_params(model="test-agent", custom_llm_provider="a2a", temperature=0.5)
    UnsupportedParamsError: a2a does not support parameters: ['temperature'],
    for model=test-agent. To drop these, set `litellm.drop_params=True`

    >>> get_optional_params(model="test-agent", custom_llm_provider="a2a", stream=True)
    {'stream': True}

This also corrects a public surface. The proxy serves the list at
`GET /utils/supported_openai_params`, which calls
`litellm.get_supported_openai_params()`. On main that endpoint tells a client
a2a supports temperature, max_tokens and top_p; on this branch it no longer does.

Tests: tests/llm_translation/test_a2a.py, 5 passed 4 skipped (the skips are the
pre-existing tests that need a live agent). The four new assertions fail on the
base branch and pass here. test_a2a_stream_still_maps is a guard, it passes
either way.

## Type

Bug Fix
