### PR TITLE
fix(router): cancel orphaned selector sync tasks

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -80,6 +80,7 @@ from litellm.litellm_core_utils.sensitive_data_masker import (
     mask_sensitive_structure,
 )
 from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+from litellm.router_strategy.base_routing_strategy import BaseRoutingStrategy
 from litellm.router_strategy.budget_limiter import RouterBudgetLimiting
 from litellm.router_strategy.least_busy import LeastBusyLoggingHandler
 from litellm.router_strategy.lowest_cost import LowestCostLoggingHandler
@@ -902,6 +903,9 @@ class Router:
         selector_ids = {id(s) for s in selectors if s is not None}
         if not selector_ids:
             return
+        for selector in selectors:
+            if isinstance(selector, BaseRoutingStrategy):
+                selector.cancel_sync_task()
         if isinstance(litellm.callbacks, list):
             litellm.callbacks = [c for c in litellm.callbacks if id(c) not in selector_ids]
         if isinstance(litellm.input_callback, list):

--- a/litellm/router_strategy/base_routing_strategy.py
+++ b/litellm/router_strategy/base_routing_strategy.py
@@ -42,11 +42,15 @@ class BaseRoutingStrategy(ABC):
     async def cleanup(self):
         """Cleanup method to be called when shutting down"""
         if self._sync_task is not None:
-            self._sync_task.cancel()
+            self.cancel_sync_task()
             try:
                 await self._sync_task
             except asyncio.CancelledError:
                 pass
+
+    def cancel_sync_task(self) -> None:
+        if self._sync_task is not None:
+            self._sync_task.cancel()
 
     async def _increment_value_list_in_current_window(
         self, increment_list: List[Tuple[str, int]], ttl: int

--- a/tests/test_litellm/router_strategy/test_base_routing_strategy.py
+++ b/tests/test_litellm/router_strategy/test_base_routing_strategy.py
@@ -56,6 +56,22 @@ async def base_strategy(mock_dual_cache):
 
 
 @pytest.mark.asyncio
+async def test_cleanup_cancels_sync_task(mock_dual_cache):
+    strategy = BaseRoutingStrategy(
+        dual_cache=mock_dual_cache,
+        should_batch_redis_writes=True,
+        default_sync_interval=1,
+    )
+    sync_task = strategy._sync_task
+    assert sync_task is not None
+    assert not sync_task.done()
+
+    await strategy.cleanup()
+
+    assert sync_task.cancelled()
+
+
+@pytest.mark.asyncio
 async def test_increment_value_in_current_window(base_strategy, mock_dual_cache):
     # Test incrementing value in current window
     key = "test_key"

--- a/tests/test_litellm/router_strategy/test_router_routing_groups.py
+++ b/tests/test_litellm/router_strategy/test_router_routing_groups.py
@@ -5,6 +5,7 @@ the implicit `"default"` group driven by the router's top-level
 `routing_strategy` / `routing_strategy_args`.
 """
 
+import asyncio
 import os
 import sys
 from unittest.mock import patch
@@ -502,6 +503,30 @@ def test_unregister_router_selectors_removes_by_identity(monkeypatch):
     router._unregister_router_selectors([selector])
     assert all(c is not selector for c in litellm.callbacks)
     assert all(c is not selector for c in litellm.input_callback)
+
+
+@pytest.mark.asyncio
+async def test_update_settings_cancels_replaced_routing_group_sync_task(monkeypatch):
+    monkeypatch.setattr(litellm, "callbacks", [])
+    monkeypatch.setattr(litellm, "input_callback", [])
+    router = _build_router(
+        routing_groups=[
+            {
+                "group_name": "usage",
+                "models": ["filtered-model"],
+                "routing_strategy": "usage-based-routing-v2",
+            }
+        ]
+    )
+    selector = router._group_selectors["usage"]["usage-based-routing-v2"]
+    sync_task = selector._sync_task
+    assert sync_task is not None
+    assert not sync_task.done()
+
+    router.update_settings(routing_groups=[])
+    await asyncio.sleep(0)
+
+    assert sync_task.cancelled()
 
 
 def test_init_routing_groups_with_none_clears_state():


### PR DESCRIPTION
## Relevant issues

Fixes #31857

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in PR merge, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

This leak occurs during Router selector replacement and does not require an LLM request. The following reproduction exercises the real `Router.update_settings()` lifecycle without mocks

Run the script from the repository root at each commit:

```bash
.venv/bin/python - <<'PY'
import asyncio

import litellm
from litellm import Router

models = [
    {
        "model_name": "test-model",
        "litellm_params": {
            "model": "openai/gpt-4o-mini",
            "api_key": "sk-test",
            "api_base": "https://example.invalid",
        },
        "model_info": {"id": "deployment-1"},
    }
]
groups = [
    {
        "group_name": "usage",
        "models": ["test-model"],
        "routing_strategy": "usage-based-routing-v2",
    }
]


def active_sync_task_count():
    return sum(
        "periodic_sync_in_memory_spend_with_redis" in task.get_coro().__qualname__
        for task in asyncio.all_tasks()
        if not task.done()
    )


async def main():
    litellm.callbacks = []
    litellm.input_callback = []
    router = Router(
        model_list=models,
        routing_strategy="simple-shuffle",
        routing_groups=groups,
    )
    await asyncio.sleep(0)
    print(f"initial_live_sync_tasks={active_sync_task_count()}")

    for _ in range(5):
        router.update_settings(routing_groups=[])
        router.update_settings(routing_groups=groups)
        await asyncio.sleep(0)

    print(f"live_sync_tasks_after_5_reloads={active_sync_task_count()}")


asyncio.run(main())
PY
```

Before, commit `bd44c9e305`:

```text
initial_live_sync_tasks=1
live_sync_tasks_after_5_reloads=6
```

Each routing group reload leaves the previous selector's Redis synchronization task running

After, commit `1bbe6cb396`:

```text
initial_live_sync_tasks=1
live_sync_tasks_after_5_reloads=1
```

The previous selector task is cancelled during unregister, so only the current selector's task remains active

Local verification on `1bbe6cb396`:

```text
.venv/bin/pytest -q tests/test_litellm/router_strategy/test_base_routing_strategy.py tests/test_litellm/router_strategy/test_router_routing_groups.py
42 passed in 0.89s

make pre-commit
All checks passed
```

## Type

Bug Fix

## Changes

Router strategy selectors were removed from the global callback lists during routing strategy or routing group updates, but persistent synchronization tasks owned by `BaseRoutingStrategy` were not cancelled. The bound coroutine retained the old selector and continued running after every configuration reload

`BaseRoutingStrategy` now exposes synchronous task cancellation for lifecycle transitions. `Router._unregister_router_selectors()` invokes it before removing selectors from the callback lists

The regression test replaces a real `usage-based-routing-v2` routing group and verifies that the previous selector's synchronization task reaches the cancelled state

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
