### PR TITLE
fix(proxy): persist budget_duration on /customer/update

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1730,6 +1730,7 @@ class UpdateCustomerRequest(LiteLLMPydanticObjectBase):
     blocked: bool = False  # allow/disallow requests for this end-user
     max_budget: Optional[float] = None
     budget_id: Optional[str] = None  # give either a budget_id or max_budget
+    budget_duration: "str | None" = None
     allowed_model_region: Optional[AllowedModelRegion] = (
         None  # require all user requests to use models in this specific region
     )

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1730,7 +1730,7 @@ class UpdateCustomerRequest(LiteLLMPydanticObjectBase):
     blocked: bool = False  # allow/disallow requests for this end-user
     max_budget: Optional[float] = None
     budget_id: Optional[str] = None  # give either a budget_id or max_budget
-    budget_duration: "str | None" = None
+    budget_duration: str | None = None
     allowed_model_region: Optional[AllowedModelRegion] = (
         None  # require all user requests to use models in this specific region
     )

--- a/litellm/proxy/management_endpoints/customer_endpoints.py
+++ b/litellm/proxy/management_endpoints/customer_endpoints.py
@@ -22,6 +22,7 @@ from litellm._logging import verbose_proxy_logger
 from litellm.litellm_core_utils.duration_parser import duration_in_seconds
 from litellm.proxy._types import *
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
 from litellm.proxy.management_endpoints.common_daily_activity import get_daily_activity
 from litellm.proxy.management_helpers.object_permission_utils import (
     _set_object_permission,
@@ -190,6 +191,16 @@ def new_budget_request(data: NewCustomerRequest) -> Optional[BudgetNewRequest]:
             )
         return budget_request
     return None
+
+
+def _with_budget_reset_at(budget_table_data: dict) -> dict:
+    budget_duration = budget_table_data.get("budget_duration")
+    if budget_duration is None:
+        return budget_table_data
+    return {
+        **budget_table_data,
+        "budget_reset_at": get_budget_reset_time(budget_duration=budget_duration),
+    }
 
 
 async def _handle_customer_object_permission_update(
@@ -492,6 +503,7 @@ async def update_end_user(
     - blocked: bool = False  # allow/disallow requests for this end-user
     - max_budget: Optional[float] = None
     - budget_id: Optional[str] = None  # give either a budget_id or max_budget
+    - budget_duration: Optional[str] = None  # Budget is reset at the end of specified duration. If not set, budget is never reset. You can set duration as seconds ("30s"), minutes ("30m"), hours ("30h"), days ("30d").
     - allowed_model_region: Optional[AllowedModelRegion] = (
         None  # require all user requests to use models in this specific region
     )
@@ -583,6 +595,8 @@ async def update_end_user(
 
             elif k in LiteLLM_EndUserTable.model_fields.keys():
                 update_end_user_table_data[k] = v
+
+        budget_table_data = _with_budget_reset_at(budget_table_data)
 
         ## Handle object permission updates (MCP servers, vector stores, etc.)
         await _handle_customer_object_permission_update(

--- a/tests/test_litellm/proxy/management_endpoints/test_customer_budget.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_customer_budget.py
@@ -370,3 +370,100 @@ def test_new_budget_request_sets_budget_reset_at_when_duration_provided():
     expected_min = before + timedelta(days=30)
     expected_max = after + timedelta(days=30)
     assert expected_min <= result.budget_reset_at <= expected_max
+
+
+@pytest.mark.asyncio
+@patch("litellm.proxy.proxy_server.prisma_client")
+@patch("litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin")
+async def test_update_customer_persists_budget_duration_on_new_budget(
+    mock_prisma_client, mock_user_api_key_dict, mock_existing_customer
+):
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/33941
+
+    /customer/update on an end-user without an existing budget must persist
+    budget_duration and compute budget_reset_at on the new budget row,
+    instead of silently dropping both.
+    """
+    mock_existing_customer.model_dump.return_value = {
+        "user_id": "test-user",
+        "blocked": False,
+        "litellm_budget_table": None,
+    }
+    mock_prisma_client.db.litellm_endusertable.find_first = AsyncMock(
+        return_value=mock_existing_customer
+    )
+
+    mock_created_budget = MagicMock()
+    mock_created_budget.budget_id = "new-budget-duration"
+    mock_prisma_client.db.litellm_budgettable.create = AsyncMock(
+        return_value=mock_created_budget
+    )
+
+    mock_updated_user = MagicMock()
+    mock_updated_user.model_dump.return_value = {"user_id": "test-user", "blocked": False}
+    mock_prisma_client.db.litellm_endusertable.update = AsyncMock(
+        return_value=mock_updated_user
+    )
+
+    update_request = UpdateCustomerRequest(
+        user_id="test-user",
+        max_budget=50.0,
+        budget_duration="30d",
+    )
+    assert update_request.budget_duration == "30d"
+
+    await update_end_user(update_request, mock_user_api_key_dict)
+
+    mock_prisma_client.db.litellm_budgettable.create.assert_called_once()
+    create_data = mock_prisma_client.db.litellm_budgettable.create.call_args[1]["data"]
+    assert create_data["max_budget"] == 50.0
+    assert create_data["budget_duration"] == "30d"
+    assert create_data["budget_reset_at"] is not None
+    reset_at = create_data["budget_reset_at"].replace(tzinfo=None)
+    assert reset_at > datetime.utcnow()
+
+
+@pytest.mark.asyncio
+@patch("litellm.proxy.proxy_server.prisma_client")
+@patch("litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin")
+async def test_update_customer_persists_budget_duration_on_existing_budget(
+    mock_prisma_client, mock_user_api_key_dict, mock_existing_customer
+):
+    """
+    /customer/update on an end-user with an existing budget must update
+    budget_duration and recompute budget_reset_at on that budget row.
+    """
+    mock_existing_customer.model_dump.return_value = {
+        "user_id": "test-user",
+        "blocked": False,
+        "litellm_budget_table": {
+            "budget_id": "existing-budget-123",
+            "max_budget": 10.0,
+        },
+    }
+    mock_prisma_client.db.litellm_endusertable.find_first = AsyncMock(
+        return_value=mock_existing_customer
+    )
+
+    mock_prisma_client.db.litellm_budgettable.update = AsyncMock(return_value=MagicMock())
+
+    mock_updated_user = MagicMock()
+    mock_updated_user.model_dump.return_value = {"user_id": "test-user", "blocked": False}
+    mock_prisma_client.db.litellm_endusertable.update = AsyncMock(
+        return_value=mock_updated_user
+    )
+
+    update_request = UpdateCustomerRequest(
+        user_id="test-user",
+        budget_duration="7d",
+    )
+
+    await update_end_user(update_request, mock_user_api_key_dict)
+
+    mock_prisma_client.db.litellm_budgettable.update.assert_called_once()
+    update_call = mock_prisma_client.db.litellm_budgettable.update.call_args[1]
+    assert update_call["where"] == {"budget_id": "existing-budget-123"}
+    assert update_call["data"]["budget_duration"] == "7d"
+    assert update_call["data"]["budget_reset_at"] is not None
+    assert not mock_prisma_client.db.litellm_budgettable.create.called

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -3035,6 +3035,7 @@ export interface paths {
          *     - blocked: bool = False  # allow/disallow requests for this end-user
          *     - max_budget: Optional[float] = None
          *     - budget_id: Optional[str] = None  # give either a budget_id or max_budget
+         *     - budget_duration: Optional[str] = None  # Budget is reset at the end of specified duration. If not set, budget is never reset. You can set duration as seconds ("30s"), minutes ("30m"), hours ("30h"), days ("30d").
          *     - allowed_model_region: Optional[AllowedModelRegion] = (
          *         None  # require all user requests to use models in this specific region
          *     )
@@ -3568,6 +3569,7 @@ export interface paths {
          *     - blocked: bool = False  # allow/disallow requests for this end-user
          *     - max_budget: Optional[float] = None
          *     - budget_id: Optional[str] = None  # give either a budget_id or max_budget
+         *     - budget_duration: Optional[str] = None  # Budget is reset at the end of specified duration. If not set, budget is never reset. You can set duration as seconds ("30s"), minutes ("30m"), hours ("30h"), days ("30d").
          *     - allowed_model_region: Optional[AllowedModelRegion] = (
          *         None  # require all user requests to use models in this specific region
          *     )
@@ -31907,6 +31909,8 @@ export interface components {
              * @default false
              */
             blocked: boolean;
+            /** Budget Duration */
+            budget_duration?: string | null;
             /** Budget Id */
             budget_id?: string | null;
             /** Default Model */


### PR DESCRIPTION
## Relevant issues

Fixes #33941

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Ran against a live proxy on localhost:4000 backed by a fresh Postgres, using the exact repro from the issue

```bash
curl -s -X POST "http://localhost:4000/customer/new" \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"user_id": "test-bug-repro@example.com"}'

curl -s -X POST "http://localhost:4000/customer/update" \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"user_id": "test-bug-repro@example.com", "max_budget": 50.0, "budget_duration": "1mo"}'
```

Response before this change had `"budget_duration": null, "budget_reset_at": null`. After this change:

```json
"litellm_budget_table": {
    "budget_id": "9516f98f-62c2-4aee-acc3-cacebd9012df",
    "max_budget": 50.0,
    "budget_duration": "1mo",
    "budget_reset_at": "2026-08-01T00:00:00Z"
}
```

Updating the duration on the same (now existing) budget also works:

```bash
curl -s -X POST "http://localhost:4000/customer/update" \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"user_id": "test-bug-repro@example.com", "budget_duration": "7d"}'
# -> "budget_duration": "7d", "budget_reset_at": "2026-07-20T00:00:00Z"
```

## Type

🐛 Bug Fix

## Changes

The root cause was in request parsing, not the endpoint logic: `UpdateCustomerRequest` never declared `budget_duration`, so pydantic dropped the field before `update_end_user` ran. This PR declares the field, and computes `budget_reset_at` from `budget_duration` before the budget row is created or updated, matching what `/budget/new` does via `get_budget_reset_time`

Regression tests cover both branches: new budget creation persists `budget_duration` and a non-null `budget_reset_at`, and updating an existing budget recomputes `budget_reset_at`

`schema.d.ts` is regenerated because the new request field changes the OpenAPI schema

## QA runbook

1. Start the proxy with a database configured
2. `curl -X POST /customer/new` with a fresh `user_id` (no budget)
3. `curl -X POST /customer/update` with `max_budget` and `budget_duration` as in the repro above
4. `curl /customer/info?end_user_id=...` and confirm `budget_duration` and `budget_reset_at` are set on `litellm_budget_table`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
