### PR TITLE
fix(proxy): decode model-embedded code interpreter file ids

### DIFF
--- a/litellm/litellm_core_utils/file_id_utils.py
+++ b/litellm/litellm_core_utils/file_id_utils.py
@@ -1,0 +1,58 @@
+"""Lightweight helpers for LiteLLM model-embedded file and batch IDs."""
+
+import base64
+import re
+from typing import Optional
+
+
+def decode_model_from_file_id(encoded_id: str) -> Optional[str]:
+    """Extract the model name from a model-embedded file or batch ID."""
+    try:
+        if not isinstance(encoded_id, str):
+            return None
+
+        if encoded_id.startswith("file-"):
+            b64_part = encoded_id[5:]
+        elif encoded_id.startswith("batch_"):
+            b64_part = encoded_id[6:]
+        else:
+            b64_part = encoded_id
+
+        padded = b64_part + "=" * (-len(b64_part) % 4)
+        decoded = base64.urlsafe_b64decode(padded).decode()
+        if decoded.startswith("litellm:") and ";model," in decoded:
+            match = re.search(r";model,([^;]+)", decoded)
+            if match:
+                return match.group(1).strip()
+    except Exception:
+        pass
+    return None
+
+
+def get_original_file_id(encoded_id: str) -> str:
+    """Extract the provider ID from a model-embedded file or batch ID."""
+    try:
+        if not isinstance(encoded_id, str):
+            return encoded_id
+
+        if encoded_id.startswith("file-"):
+            b64_part = encoded_id[5:]
+        elif encoded_id.startswith("batch_"):
+            b64_part = encoded_id[6:]
+        else:
+            b64_part = encoded_id
+
+        padded = b64_part + "=" * (-len(b64_part) % 4)
+        decoded = base64.urlsafe_b64decode(padded).decode()
+        if decoded.startswith("litellm:") and ";model," in decoded:
+            match = re.search(r"litellm:([^;]+);model,", decoded)
+            if match:
+                return match.group(1)
+    except Exception:
+        pass
+    return encoded_id
+
+
+def is_model_embedded_id(file_id: str) -> bool:
+    """Return whether a file or batch ID contains LiteLLM model metadata."""
+    return decode_model_from_file_id(file_id) is not None

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -649,7 +649,8 @@ def update_responses_tools_with_model_file_ids(
     Updates responses API tools with provider-specific file IDs.
 
     Pass 1 (always): decode unified vector_store_ids in file_search tools.
-    Pass 2 (needs mapping): map code_interpreter container file_ids to provider IDs.
+    Pass 2 (always): map managed code_interpreter file IDs when a mapping is
+    available, otherwise decode IDs produced by the x-litellm-model upload path.
 
     Args:
         tools: The responses API tools parameter
@@ -660,13 +661,15 @@ def update_responses_tools_with_model_file_ids(
     if not tools or not isinstance(tools, list):
         return tools
 
+    from litellm.proxy.openai_files_endpoints.common_utils import (
+        get_original_file_id,
+        is_model_embedded_id,
+    )
+
     # Pass 1: decode unified vector_store_ids (no mapping needed)
     tools = _decode_vector_store_ids_in_tools(tools) or tools
 
-    # Pass 2: map code_interpreter file IDs (requires mapping)
-    if not model_file_id_mapping or not model_id:
-        return tools
-
+    # Pass 2: map or decode code_interpreter file IDs.
     updated_tools = []
     for tool in tools:
         if not isinstance(tool, dict):
@@ -684,13 +687,14 @@ def update_responses_tools_with_model_file_ids(
                     updated_file_ids = []
                     for file_id in container_file_ids:
                         if isinstance(file_id, str):
-                            # Check if we have a mapping for this file ID
-                            if file_id in model_file_id_mapping:
-                                # Map to provider-specific file ID
-                                provider_file_id = model_file_id_mapping.get(file_id, {}).get(model_id) or file_id
-                                updated_file_ids.append(provider_file_id)
-                            else:
-                                updated_file_ids.append(file_id)
+                            provider_file_id = (
+                                model_file_id_mapping.get(file_id, {}).get(model_id)
+                                if model_file_id_mapping and model_id
+                                else None
+                            )
+                            if not provider_file_id and is_model_embedded_id(file_id):
+                                provider_file_id = get_original_file_id(file_id)
+                            updated_file_ids.append(provider_file_id or file_id)
                         else:
                             updated_file_ids.append(file_id)
 

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -23,6 +23,10 @@ from typing import (
 
 import litellm
 from litellm import verbose_logger
+from litellm.litellm_core_utils.file_id_utils import (
+    get_original_file_id,
+    is_model_embedded_id,
+)
 from litellm.router_utils.batch_utils import InMemoryFile
 from litellm.types.llms.openai import (
     AllMessageValues,
@@ -660,11 +664,6 @@ def update_responses_tools_with_model_file_ids(
     """
     if not tools or not isinstance(tools, list):
         return tools
-
-    from litellm.proxy.openai_files_endpoints.common_utils import (
-        get_original_file_id,
-        is_model_embedded_id,
-    )
 
     # Pass 1: decode unified vector_store_ids (no mapping needed)
     tools = _decode_vector_store_ids_in_tools(tools) or tools

--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -5,6 +5,11 @@ from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import TYPE_CHECKING, List, Literal, Optional, Union
 
+from litellm.litellm_core_utils.file_id_utils import (
+    decode_model_from_file_id,
+    get_original_file_id,
+    is_model_embedded_id,  # noqa: F401  # preserve the proxy-module import path
+)
 from litellm.repositories.table_repositories import (
     ManagedFileRepository,
     ManagedObjectRepository,
@@ -147,72 +152,6 @@ def encode_batch_response_ids(response, model: str) -> None:
                 attr,
                 encode_file_id_with_model(file_id=getattr(response, attr), model=model),
             )
-
-
-def decode_model_from_file_id(encoded_id: str) -> Optional[str]:
-    """
-    Extract model name from an encoded file/batch ID.
-    Handles IDs that start with "file-" or "batch_" prefix.
-    """
-    try:
-        if not isinstance(encoded_id, str):
-            return None
-
-        # Remove prefix if present (file-, batch_, etc.)
-        if encoded_id.startswith("file-"):
-            b64_part = encoded_id[5:]  # Remove "file-"
-        elif encoded_id.startswith("batch_"):
-            b64_part = encoded_id[6:]  # Remove "batch_"
-        else:
-            b64_part = encoded_id
-
-        padded = b64_part + "=" * (-len(b64_part) % 4)
-        decoded = base64.urlsafe_b64decode(padded).decode()
-        if decoded.startswith("litellm:") and ";model," in decoded:
-            match = re.search(r";model,([^;]+)", decoded)
-            if match:
-                return match.group(1).strip()
-
-        return None
-    except Exception:
-        return None
-
-
-def get_original_file_id(encoded_id: str) -> str:
-    """
-    Extract the original provider file/batch ID from an encoded ID.
-    Handles IDs that start with "file-" or "batch_" prefix.
-    """
-    try:
-        if not isinstance(encoded_id, str):
-            return encoded_id
-
-        # Remove prefix if present (file-, batch_, etc.)
-        if encoded_id.startswith("file-"):
-            b64_part = encoded_id[5:]  # Remove "file-"
-        elif encoded_id.startswith("batch_"):
-            b64_part = encoded_id[6:]  # Remove "batch_"
-        else:
-            b64_part = encoded_id
-
-        padded = b64_part + "=" * (-len(b64_part) % 4)
-        decoded = base64.urlsafe_b64decode(padded).decode()
-
-        if decoded.startswith("litellm:") and ";model," in decoded:
-            match = re.search(r"litellm:([^;]+);model,", decoded)
-            if match:
-                return match.group(1)
-
-        return encoded_id
-    except Exception:
-        return encoded_id
-
-
-def is_model_embedded_id(file_id: str) -> bool:
-    """
-    Check if a file/batch ID has model routing information embedded.
-    """
-    return decode_model_from_file_id(file_id) is not None
 
 
 # ============================================================================

--- a/tests/test_litellm/llms/test_file_search_responses.py
+++ b/tests/test_litellm/llms/test_file_search_responses.py
@@ -3,7 +3,7 @@ Unit tests for file_search / vector_store support in the Responses API.
 
 Coverage:
   A1-A7  _decode_vector_store_ids_in_tools()
-  B1-B3  update_responses_tools_with_model_file_ids()
+  B1-B5  update_responses_tools_with_model_file_ids()
   C1,D1  supports_native_file_search()
   E1-E4  file_search guard in responses/main.py
   F1-F6  ManagedFiles hook access control
@@ -161,6 +161,51 @@ class TestUpdateResponsesToolsWithModelFileIds:
         assert result is not None
         assert result[0]["vector_store_ids"] == ["vs_decoded"]
         assert result[1]["container"]["file_ids"] == ["provider_file_xyz"]
+
+    def test_B4_code_interpreter_model_embedded_id_decodes_without_mapping(self):
+        """x-litellm-model file IDs decode even without managed-file state."""
+        from litellm.proxy.openai_files_endpoints.common_utils import (
+            encode_file_id_with_model,
+        )
+
+        provider_file_id = "file-provider-native"
+        encoded_file_id = encode_file_id_with_model(
+            file_id=provider_file_id,
+            model="gpt-5.1",
+        )
+        tools = [_code_interpreter_tool([encoded_file_id])]
+
+        result = update_responses_tools_with_model_file_ids(
+            tools=tools,
+            model_id=None,
+            model_file_id_mapping=None,
+        )
+
+        assert result is not None
+        assert result[0]["container"]["file_ids"] == [provider_file_id]
+
+    def test_B5_code_interpreter_mapping_precedes_model_embedded_decode(self):
+        """A deployment-specific mapping remains authoritative."""
+        from litellm.proxy.openai_files_endpoints.common_utils import (
+            encode_file_id_with_model,
+        )
+
+        model_id = "model-abc"
+        encoded_file_id = encode_file_id_with_model(
+            file_id="file-provider-native",
+            model="gpt-5.1",
+        )
+        tools = [_code_interpreter_tool([encoded_file_id])]
+        mapping = {encoded_file_id: {model_id: "file-deployment-specific"}}
+
+        result = update_responses_tools_with_model_file_ids(
+            tools=tools,
+            model_id=model_id,
+            model_file_id_mapping=mapping,
+        )
+
+        assert result is not None
+        assert result[0]["container"]["file_ids"] == ["file-deployment-specific"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Decode model-embedded File IDs in Responses `code_interpreter.container.file_ids` without importing `litellm.proxy` from Core

## Reproduction

1. Upload a file through `/v1/files` with model-based routing
2. Pass the returned wrapped ID to Responses Code Interpreter
3. The provider rejects the wrapped ID because it exceeds the 64-character limit

## Cause

`update_responses_tools_with_model_file_ids()` returned early when managed-file mapping data was unavailable, so the wrapped ID was forwarded unchanged

## Fix

- Move the lightweight File ID decoding helpers to `litellm_core_utils`
- Reuse them from Core and proxy while preserving the proxy-module import path
- Preserve deployment-specific mapping as the first choice and decode model-embedded IDs as fallback

## Validation

- Focused regression tests B1-B5: 5 passed
- Ruff, strict budget, py_compile, and git diff check: passed

Fixes #25757