### PR TITLE
fix(proxy): prevent transform request from blocking event loop

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -11002,7 +11002,11 @@ async def transform_request(request: TransformRequestBody):
     except ValueError as e:
         raise HTTPException(status_code=400, detail={"error": str(e)})
 
-    return return_raw_request(endpoint=request.call_type, kwargs=request.request_body)
+    return await asyncio.to_thread(
+        return_raw_request,
+        endpoint=request.call_type,
+        kwargs=request.request_body,
+    )
 
 
 async def _check_if_model_is_user_added(

--- a/tests/test_litellm/proxy/proxy_server/test_routes_utils.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_utils.py
@@ -8,6 +8,8 @@ Pins (PR2):
 
 from __future__ import annotations
 
+import asyncio
+import threading
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -158,3 +160,36 @@ def test_transform_request_unsafe_body(client, auth_as, monkeypatch):
         response = client.post("/utils/transform_request", json=payload)
     assert response.status_code == 400
     assert "unsafe" in response.text or "error" in response.text
+
+
+@pytest.mark.asyncio
+async def test_transform_request_does_not_block_event_loop(monkeypatch):
+    monkeypatch.setattr(proxy_server, "llm_router", None)
+    monkeypatch.setattr(proxy_server, "is_request_body_safe", lambda **kwargs: True)
+
+    event_loop_progressed = threading.Event()
+
+    def blocking_return_raw_request(endpoint, kwargs):
+        if not event_loop_progressed.wait(timeout=1):
+            raise AssertionError("event loop was blocked")
+        return {
+            "raw_request_api_base": "https://example.com/v1/chat/completions",
+            "raw_request_body": kwargs,
+            "raw_request_headers": {},
+        }
+
+    monkeypatch.setattr(
+        "litellm.utils.return_raw_request", blocking_return_raw_request
+    )
+
+    async def heartbeat():
+        event_loop_progressed.set()
+
+    heartbeat_task = asyncio.create_task(heartbeat())
+    await proxy_server.transform_request(
+        proxy_server.TransformRequestBody(
+            call_type="completion",
+            request_body={"model": "openai/test-model"},
+        )
+    )
+    await heartbeat_task


### PR DESCRIPTION
## TLDR

Problem this solves:

- Transform requests can block unrelated proxy requests
- Liveliness checks wait for slow provider I/O

How it solves it:

- Runs synchronous request transformation in a worker thread
- Adds a regression test for event loop responsiveness

## User Flow

Before: a proxy operator sees liveliness checks stall behind a slow transform request

1. They send `POST http://localhost:4000/utils/transform_request` for an OpenAI model
2. The configured provider takes about one second to reject the request
3. They send `GET http://localhost:4000/health/liveliness` while transformation is waiting
4. The health request returns `200` only after the transform request finishes

After: the same health check stays responsive while transformation waits

1. They send `POST http://localhost:4000/utils/transform_request` for the same OpenAI model
2. The configured provider takes about one second to reject the request
3. They send `GET http://localhost:4000/health/liveliness` while transformation is waiting
4. The health request returns `200` immediately while transformation continues

## Relevant issues

Fixes #33952

## Affected release

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Shared setup: a live proxy uses `allow_client_side_credentials: true` and a local OpenAI-compatible HTTP endpoint that waits one second before returning `401`. The transform request is started first, then the liveliness request is sent 50 ms later

### Before (252c71c0b2)

1. Send `POST http://localhost:41991/utils/transform_request` with `model: openai/test-model`, the delayed endpoint as `api_base`, `timeout: 2`, and `num_retries: 0`
2. Send `GET http://localhost:41991/health/liveliness` after 50 ms
3. Observe `transform_http=200 total=1.987718s`
4. Observe `health_http=200 total=1.930412s`
5. Observe one provider request to `POST /v1/chat/completions`

### After (0a8cadec98)

1. Send the same transform request to `http://localhost:41992/utils/transform_request`
2. Send `GET http://localhost:41992/health/liveliness` after 50 ms
3. Observe `health_http=200 total=0.032746s`
4. Observe `transform_http=200 total=1.329601s`
5. Observe one provider request to `POST /v1/chat/completions`

## Type

Bug Fix

## Caveats (if any)

### Low

- Slow transformations occupy a worker thread until completion

## QA runbook

- `tests/test_litellm/proxy/proxy_server/test_routes_utils.py::test_transform_request_does_not_block_event_loop` - a synchronous transformation cannot block another coroutine
  - [ ] Start the proxy with `allow_client_side_credentials: true`
  - [ ] Start an OpenAI-compatible endpoint that waits one second before returning `401`
  - [ ] POST `/utils/transform_request` with that endpoint as `api_base`
  - [ ] GET `/health/liveliness` while the transform request is waiting
  - [ ] Expect the health request to return before the transform request
  - [ ] Expect the transformed request body to remain unchanged
  - [ ] Sanity check: the delayed endpoint receives exactly one provider request

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
