### PR TITLE
fix(hosted_vllm): preserve reasoning history from Anthropic thinking blocks

### DIFF
--- a/litellm/llms/hosted_vllm/chat/transformation.py
+++ b/litellm/llms/hosted_vllm/chat/transformation.py
@@ -28,6 +28,8 @@ from litellm.types.llms.openai import (
     AllMessageValues,
     ChatCompletionAssistantToolCall,
     ChatCompletionFileObject,
+    ChatCompletionRedactedThinkingBlock,
+    ChatCompletionThinkingBlock,
     ChatCompletionToolCallFunctionChunk,
     ChatCompletionVideoObject,
     ChatCompletionVideoUrlObject,
@@ -144,6 +146,21 @@ class HostedVLLMChatConfig(OpenAIGPTConfig):
                 return True
         return False
 
+    @staticmethod
+    def _convert_thinking_blocks_to_reasoning_content(
+        thinking_blocks: list[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]],
+    ) -> str | None:
+        """
+        vLLM's OpenAI-compatible server expects prior reasoning to be passed back
+        via `reasoning_content` on assistant messages, not Anthropic-style
+        `thinking_blocks`. Redacted thinking blocks carry no plain text and are
+        skipped.
+        """
+        thinking_texts = [block.get("thinking", "") for block in thinking_blocks if block.get("type") == "thinking"]
+        if not thinking_texts:
+            return None
+        return "\n".join(thinking_texts)
+
     def _convert_file_to_video_url(self, content_item: ChatCompletionFileObject) -> ChatCompletionVideoObject:
         file = content_item.get("file", {})
         file_id = file.get("file_id")
@@ -174,12 +191,17 @@ class HostedVLLMChatConfig(OpenAIGPTConfig):
         """
         Support translating:
         - video files from file_id or file_data to video_url
-        - thinking_blocks on assistant messages are removed, and content lists
-          are converted to strings for vLLM compatibility
+        - thinking_blocks on assistant messages are converted to `reasoning_content`
+          (vLLM's reasoning-parser convention) unless `reasoning_content` is already
+          set, and content lists are converted to strings for vLLM compatibility
         """
         for message in messages:
             if message["role"] == "assistant":
-                message.pop("thinking_blocks", None)
+                thinking_blocks = message.pop("thinking_blocks", None)
+                if thinking_blocks and not message.get("reasoning_content"):
+                    reasoning_content = self._convert_thinking_blocks_to_reasoning_content(thinking_blocks)
+                    if reasoning_content is not None:
+                        message["reasoning_content"] = reasoning_content
                 existing_content = message.get("content")
                 if isinstance(existing_content, list):
                     text_parts = []

--- a/tests/test_litellm/llms/hosted_vllm/chat/test_hosted_vllm_chat_transformation.py
+++ b/tests/test_litellm/llms/hosted_vllm/chat/test_hosted_vllm_chat_transformation.py
@@ -186,8 +186,9 @@ def test_hosted_vllm_supports_thinking():
 
 def test_hosted_vllm_thinking_blocks_prepended_to_assistant_content():
     """
-    Test that thinking_blocks on assistant messages are removed and content
-    stays a string for vLLM compatibility.
+    Test that thinking_blocks on assistant messages are converted to
+    `reasoning_content` (vLLM's reasoning-parser field) and content stays a
+    string for vLLM compatibility.
     """
     config = HostedVLLMChatConfig()
     messages = [
@@ -223,12 +224,13 @@ def test_hosted_vllm_thinking_blocks_prepended_to_assistant_content():
     assert isinstance(assistant_msg["content"], str)
     assert assistant_msg["content"] == "Here is my answer."
     assert "thinking_blocks" not in assistant_msg
+    assert assistant_msg["reasoning_content"] == "Let me reason about this..."
 
 
 def test_hosted_vllm_thinking_blocks_with_list_content():
     """
-    Test thinking_blocks are removed and assistant content list is converted
-    to a string.
+    Test thinking_blocks are converted to `reasoning_content` and assistant
+    content list is converted to a string.
     """
     config = HostedVLLMChatConfig()
     messages = [
@@ -260,6 +262,70 @@ def test_hosted_vllm_thinking_blocks_with_list_content():
     assert isinstance(assistant_msg["content"], str)
     assert assistant_msg["content"] == "Response text"
     assert "thinking_blocks" not in assistant_msg
+    assert assistant_msg["reasoning_content"] == "Step 1 reasoning\nStep 2 reasoning"
+
+
+def test_hosted_vllm_redacted_thinking_blocks_have_no_reasoning_content():
+    """
+    Redacted thinking blocks carry no plain text, so no `reasoning_content`
+    should be synthesized from them.
+    """
+    config = HostedVLLMChatConfig()
+    messages = [
+        {
+            "role": "assistant",
+            "content": "Here is my answer.",
+            "thinking_blocks": [
+                {
+                    "type": "redacted_thinking",
+                    "data": "opaque-encrypted-data",
+                }
+            ],
+        },
+    ]
+    transformed = config.transform_request(
+        model="hosted_vllm/llama-3.1-70b-instruct",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+    assistant_msg = transformed["messages"][0]
+    assert "thinking_blocks" not in assistant_msg
+    assert "reasoning_content" not in assistant_msg
+
+
+def test_hosted_vllm_existing_reasoning_content_is_not_overwritten():
+    """
+    If the caller already sent `reasoning_content` directly (e.g. an
+    OpenAI-compatible client round-tripping vLLM's own reasoning output),
+    thinking_blocks must not clobber it.
+    """
+    config = HostedVLLMChatConfig()
+    messages = [
+        {
+            "role": "assistant",
+            "content": "Here is my answer.",
+            "reasoning_content": "Original reasoning from vLLM.",
+            "thinking_blocks": [
+                {
+                    "type": "thinking",
+                    "thinking": "Some other reasoning",
+                    "signature": "sig1",
+                },
+            ],
+        },
+    ]
+    transformed = config.transform_request(
+        model="hosted_vllm/llama-3.1-70b-instruct",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+    assistant_msg = transformed["messages"][0]
+    assert "thinking_blocks" not in assistant_msg
+    assert assistant_msg["reasoning_content"] == "Original reasoning from vLLM."
 
 
 def test_hosted_vllm_assistant_structured_content_is_preserved():


### PR DESCRIPTION
When a client sends Anthropic-format requests (e.g. Claude Code via /v1/messages) that get translated to hosted_vllm's OpenAI-compatible chat/completions format, assistant thinking_blocks were unconditionally dropped in _transform_messages instead of being converted to reasoning_content, vLLM's reasoning-parser field for prior reasoning history. OpenAI-compatible clients that already send reasoning_content directly were unaffected, since that field was never touched, but Anthropic-format clients lost their reasoning history on every follow-up turn.

Convert thinking_blocks into reasoning_content (skipping redacted_thinking, which carries no plain text) unless reasoning_content is already set on the message.

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

To prove this end-to-end without a mock in the transformation path, I ran the real proxy against a tiny HTTP server standing in for a self-hosted vLLM backend that records the exact request LiteLLM forwards upstream and returns a canned completion. The fix only changes that outgoing request body, so the stand-in captures precisely what a real vLLM would receive. Config used:

```yaml
model_list:
  - model_name: hosted-vllm-reasoning
    litellm_params:
      model: hosted_vllm/reasoner
      api_base: http://127.0.0.1:8090/v1
      api_key: fake-key

general_settings:
  master_key: sk-1234
```

The same Claude-Code-style `/v1/messages` request was sent in both runs, carrying a prior assistant turn with a `thinking` block:

```bash
curl -s http://localhost:4000/v1/messages \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -H "anthropic-version: 2023-06-01" \
  -d '{
    "model": "hosted-vllm-reasoning",
    "max_tokens": 512,
    "messages": [
      {"role": "user", "content": "What is 2+2?"},
      {"role": "assistant", "content": [
        {"type": "thinking", "thinking": "2+2 is basic addition. 2+2=4.", "signature": "sig-abc"},
        {"type": "text", "text": "2+2 equals 4."}
      ]},
      {"role": "user", "content": "Now multiply that result by 10."}
    ]
  }'
```

Before, on the parent commit, the assistant turn reaches vLLM with the reasoning history stripped; there is no `reasoning_content` and no `thinking_blocks`:

```json
[
  {
    "role": "user",
    "content": "What is 2+2?"
  },
  {
    "role": "assistant",
    "content": "2+2 equals 4."
  },
  {
    "role": "user",
    "content": "Now multiply that result by 10."
  }
]
```

After, on afbaaa711a (this branch), the same assistant turn reaches vLLM with the reasoning preserved as `reasoning_content`:

```json
[
  {
    "role": "user",
    "content": "What is 2+2?"
  },
  {
    "role": "assistant",
    "content": "2+2 equals 4.",
    "reasoning_content": "2+2 is basic addition. 2+2=4."
  },
  {
    "role": "user",
    "content": "Now multiply that result by 10."
  }
]
```

## Type

🐛 Bug Fix

## Changes

`HostedVLLMChatConfig._transform_messages` in `litellm/llms/hosted_vllm/chat/transformation.py` now converts assistant `thinking_blocks` into `reasoning_content` before forwarding to vLLM's OpenAI-compatible chat/completions endpoint, instead of just discarding them. A new `_convert_thinking_blocks_to_reasoning_content` static method joins the plain-text `thinking` field from each block, skipping `redacted_thinking` blocks since they carry no plain text and leaving an existing `reasoning_content` on the message untouched so callers that already send it directly (e.g. OpenAI-compatible clients round-tripping vLLM's own reasoning output) are unaffected.


