### PR TITLE
fix(azure_ai): strip Anthropic-only fields that strict backends reject

### DIFF
--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -169,8 +169,20 @@ class AzureAIStudioConfig(OpenAIConfig):
         - Azure AI Studio doesn't support content as a list. This handles:
             1. Transforms list content to a string.
             2. If message contains an image or audio, send as is (user-intended)
+            3. Strips Anthropic-only fields (thinking_blocks, provider_specific_fields,
+               cache_control) that the Anthropic-messages adapter attaches for
+               Anthropic-format clients. Strict OpenAI-compatible backends behind
+               Azure AI Foundry reject them with "Extra inputs are not permitted".
         """
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            filter_value_from_dict,
+        )
+
         for message in messages:
+            if isinstance(message, dict):
+                for _field in ("thinking_blocks", "provider_specific_fields", "cache_control"):
+                    filter_value_from_dict(cast(dict, message), _field)
+
             # Do nothing if the message contains an image or audio
             if _audio_or_image_in_message_content(message):
                 continue

--- a/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
@@ -262,3 +262,46 @@ def test_drop_tool_level_extra_fields_strips_copilot_mcp_server_name():
         assert "copilot_mcp_server_name" not in tool
     assert result["tools"][0]["type"] == "function"
     assert result["tools"][1]["function"]["name"] == "read_file"
+
+
+def test_transform_messages_strips_anthropic_only_fields():
+    """Azure AI Foundry backends reject non-spec fields the Anthropic-messages adapter attaches
+    (thinking_blocks, provider_specific_fields, cache_control). _transform_messages must strip them,
+    including the nested tool_calls[].function.provider_specific_fields.
+
+    Regression for https://github.com/BerriAI/litellm/issues/33961
+    """
+    config = AzureAIStudioConfig()
+    messages = [
+        {"role": "user", "content": "Read a file."},
+        {
+            "role": "assistant",
+            "content": "I can help.",
+            "thinking_blocks": [
+                {"type": "thinking", "thinking": "let me read it", "signature": "", "cache_control": {}}
+            ],
+            "provider_specific_fields": {"foo": "bar"},
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": "{}",
+                        "provider_specific_fields": {"thought_signature": "abc"},
+                    },
+                }
+            ],
+            "cache_control": {"type": "ephemeral"},
+        },
+    ]
+
+    result = config._transform_messages(messages, model="azure_ai/fw-glm-5.2")
+    assistant = result[1]
+
+    assert "thinking_blocks" not in assistant
+    assert "provider_specific_fields" not in assistant
+    assert "cache_control" not in assistant
+    assert "provider_specific_fields" not in assistant["tool_calls"][0]["function"]
+    assert assistant["content"] == "I can help."
+    assert assistant["tool_calls"][0]["function"]["name"] == "read_file"


### PR DESCRIPTION
## Relevant issues

Fixes #33961

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a pure message-transformation bug (no upstream call needed to trigger it), so the reproduction below drives `AzureAIStudioConfig._transform_messages` with the assistant message an Anthropic-format client echoes back through the Anthropic-messages adapter (a thinking block, a nested tool-call thought signature, and cache_control)

before, base at `1ebf2a78a9`

```
thinking_blocks present:             True
message provider_specific_fields:    True
message cache_control:               True
tool_calls fn provider_specific:     True
```

after, this PR at `b29e9e5ad5`

```
thinking_blocks present:             False
message provider_specific_fields:    False
message cache_control:               False
tool_calls fn provider_specific:     False
tool_calls fn name preserved:        read_file
```

Reproduction script:

```python
from litellm.llms.azure_ai.chat.transformation import AzureAIStudioConfig

messages = [
    {"role": "user", "content": "Read a file."},
    {
        "role": "assistant",
        "content": "I can help.",
        "thinking_blocks": [{"type": "thinking", "thinking": "let me read it", "signature": "", "cache_control": {}}],
        "provider_specific_fields": {"foo": "bar"},
        "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "read_file", "arguments": "{}", "provider_specific_fields": {"thought_signature": "abc"}}}],
        "cache_control": {"type": "ephemeral"},
    },
]
asst = AzureAIStudioConfig()._transform_messages(messages, model="azure_ai/fw-glm-5.2")[1]
print("thinking_blocks" in asst, "provider_specific_fields" in asst, "cache_control" in asst,
      "provider_specific_fields" in asst["tool_calls"][0]["function"])
```

## Type

🐛 Bug Fix

## Changes

Anthropic-format clients such as Claude Code echo prior assistant turns that carry `thinking` blocks. For the `azure_ai` provider there is no native Anthropic-messages config, so the request routes through the Anthropic-messages adapter, which reattaches those onto the outbound OpenAI-format assistant message as a `thinking_blocks` field, a `provider_specific_fields` thought signature nested inside `tool_calls[].function`, and `cache_control` annotations. None of these are OpenAI chat-completions schema fields

`AzureAIStudioConfig._transform_messages` previously only converted list content to a string, so those fields survived serialization and reached the Azure AI Foundry backend. Strict OpenAI-compatible upstreams there (for example Fireworks) set `additionalProperties: false`, so they reject the request with `Extra inputs are not permitted, field: 'messages[n].thinking_blocks'` (and, on tool-use turns, `messages[n].tool_calls[m].function.provider_specific_fields`), breaking multi-turn tool use

`_transform_messages` now strips `thinking_blocks`, `provider_specific_fields`, and `cache_control` from each message with the existing recursive `filter_value_from_dict` helper, so the nested tool-call thought signature is removed too, not just the message-level fields. This mirrors what `fireworks_ai` (`_transform_messages_helper`) and `mistral` already do. Legitimate fields (content, tool-call name and arguments) are preserved. The new test in the mapped `test_azure_ai_transformation.py` asserts all four fields are stripped (it fails on the pre-fix code) and that the tool-call name and content survive
