### PR TITLE
fix: strip thinking blocks for azure_ai to chat/completions

### DIFF
--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -11,6 +11,7 @@ from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     _audio_or_image_in_message_content,
     convert_content_list_to_str,
+    filter_value_from_dict,
 )
 from litellm.llms.azure.common_utils import BaseAzureLLM
 from litellm.llms.base_llm.chat.transformation import LiteLLMLoggingObj
@@ -26,6 +27,34 @@ from litellm.utils import _add_path_to_api_base, supports_tool_choice
 
 class AzureFoundryErrorStrings(str, enum.Enum):
     SET_EXTRA_PARAMETERS_TO_PASS_THROUGH = "Set extra-parameters to 'pass-through'"
+
+
+_OUTPUT_ONLY_MESSAGE_FIELDS: Tuple[str, ...] = (
+    "thinking_blocks",
+    "reasoning_content",
+    "provider_specific_fields",
+)
+
+
+def _strip_unsupported_message_fields(message: AllMessageValues) -> None:
+    """Remove input-forbidden fields from a chat message before it is sent to
+    an Azure AI Foundry hosted model.
+
+    Azure AI Foundry fronts many OpenAI-compatible backends (Fireworks,
+    Mistral, xAI, ...) whose chat-message schemas set ``additionalProperties:
+    false``. LiteLLM-internal / output-only fields that the Anthropic
+    ``/v1/messages`` adapter attaches when replaying assistant turns from an
+    Anthropic-format client (e.g. Claude Code) are not part of that schema and
+    trigger ``400 Extra inputs are not permitted, field:
+    'messages[n].<field>'``. ``cache_control`` is an Anthropic prompt-caching
+    annotation with the same problem. ``thinking_blocks`` and
+    ``reasoning_content`` are output-only; ``provider_specific_fields`` carries
+    Anthropic thought signatures. None are valid OpenAI input, so drop them.
+    """
+    filter_value_from_dict(cast(dict, message), "cache_control")
+    m = cast(dict, message)
+    for field in _OUTPUT_ONLY_MESSAGE_FIELDS:
+        m.pop(field, None)
 
 
 class AzureAIStudioConfig(OpenAIConfig):
@@ -171,6 +200,7 @@ class AzureAIStudioConfig(OpenAIConfig):
             2. If message contains an image or audio, send as is (user-intended)
         """
         for message in messages:
+            _strip_unsupported_message_fields(message)
             # Do nothing if the message contains an image or audio
             if _audio_or_image_in_message_content(message):
                 continue

--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -29,9 +29,28 @@ class AzureFoundryErrorStrings(str, enum.Enum):
     SET_EXTRA_PARAMETERS_TO_PASS_THROUGH = "Set extra-parameters to 'pass-through'"
 
 
-_OUTPUT_ONLY_MESSAGE_FIELDS: Tuple[str, ...] = (
+# Fields that only ever appear at the top level of a chat message and are
+# removed with a plain ``pop``. ``thinking_blocks`` and ``reasoning_content``
+# are output-only reasoning fields; the Fireworks backend accepts
+# ``reasoning_content`` on input, but the direct ``fireworks_ai`` provider
+# strips ``thinking_blocks`` and Azure AI Foundry fronts multiple backends, so
+# drop both as a defensive default for a generic multi-backend provider.
+_TOP_LEVEL_OUTPUT_ONLY_FIELDS: Tuple[str, ...] = (
     "thinking_blocks",
     "reasoning_content",
+)
+
+# Fields that can nest inside a message (e.g. inside ``tool_calls[].function``
+# or content blocks) and must be removed recursively. ``cache_control`` is an
+# Anthropic prompt-caching annotation; ``provider_specific_fields`` carries
+# Anthropic thought signatures and is attached by the Anthropic
+# ``/v1/messages`` adapter at ``tool_calls[].function.provider_specific_fields``
+# (``adapters/transformation.py``), so a top-level ``pop`` misses it and
+# strict upstreams still reject it with
+# ``Extra inputs are not permitted, field:
+# 'messages[n].tool_calls[m].function.provider_specific_fields'``.
+_RECURSIVELY_STRIPPED_FIELDS: Tuple[str, ...] = (
+    "cache_control",
     "provider_specific_fields",
 )
 
@@ -46,14 +65,15 @@ def _strip_unsupported_message_fields(message: AllMessageValues) -> None:
     ``/v1/messages`` adapter attaches when replaying assistant turns from an
     Anthropic-format client (e.g. Claude Code) are not part of that schema and
     trigger ``400 Extra inputs are not permitted, field:
-    'messages[n].<field>'``. ``cache_control`` is an Anthropic prompt-caching
-    annotation with the same problem. ``thinking_blocks`` and
-    ``reasoning_content`` are output-only; ``provider_specific_fields`` carries
-    Anthropic thought signatures. None are valid OpenAI input, so drop them.
+    'messages[n].<field>'``. Top-level output-only fields are popped; fields
+    that can nest (``cache_control``, and ``provider_specific_fields`` which
+    the adapter attaches inside ``tool_calls[].function``) are stripped
+    recursively so nested tool-call signatures are removed too.
     """
-    filter_value_from_dict(cast(dict, message), "cache_control")
     m = cast(dict, message)
-    for field in _OUTPUT_ONLY_MESSAGE_FIELDS:
+    for field in _RECURSIVELY_STRIPPED_FIELDS:
+        filter_value_from_dict(m, field)
+    for field in _TOP_LEVEL_OUTPUT_ONLY_FIELDS:
         m.pop(field, None)
 
 

--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -70,7 +70,7 @@ def _strip_unsupported_message_fields(message: AllMessageValues) -> None:
     the adapter attaches inside ``tool_calls[].function``) are stripped
     recursively so nested tool-call signatures are removed too.
     """
-    m = cast(dict, message)
+    m = cast(dict, message)  # cast-ok: AllMessageValues is a union of TypedDicts; pop/strip need a mutable mapping
     for field in _RECURSIVELY_STRIPPED_FIELDS:
         filter_value_from_dict(m, field)
     for field in _TOP_LEVEL_OUTPUT_ONLY_FIELDS:

--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -74,7 +74,14 @@ def _strip_unsupported_message_fields(message: AllMessageValues) -> None:
     for field in _RECURSIVELY_STRIPPED_FIELDS:
         filter_value_from_dict(m, field)
     for field in _TOP_LEVEL_OUTPUT_ONLY_FIELDS:
-        m.pop(field, None)
+        value = m.pop(field, None)
+        if field == "reasoning_content" and value:
+            verbose_logger.debug(
+                "azure_ai: dropped non-empty 'reasoning_content' from a replayed "
+                "message; some Azure AI Foundry backends accept it on input, but it "
+                "is dropped as a defensive default for a generic multi-backend "
+                "provider."
+            )
 
 
 class AzureAIStudioConfig(OpenAIConfig):

--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -35,7 +35,7 @@ class AzureFoundryErrorStrings(str, enum.Enum):
 # ``reasoning_content`` on input, but the direct ``fireworks_ai`` provider
 # strips ``thinking_blocks`` and Azure AI Foundry fronts multiple backends, so
 # drop both as a defensive default for a generic multi-backend provider.
-_TOP_LEVEL_OUTPUT_ONLY_FIELDS: Tuple[str, ...] = (
+_TOP_LEVEL_OUTPUT_ONLY_FIELDS: tuple[str, ...] = (
     "thinking_blocks",
     "reasoning_content",
 )
@@ -49,7 +49,7 @@ _TOP_LEVEL_OUTPUT_ONLY_FIELDS: Tuple[str, ...] = (
 # strict upstreams still reject it with
 # ``Extra inputs are not permitted, field:
 # 'messages[n].tool_calls[m].function.provider_specific_fields'``.
-_RECURSIVELY_STRIPPED_FIELDS: Tuple[str, ...] = (
+_RECURSIVELY_STRIPPED_FIELDS: tuple[str, ...] = (
     "cache_control",
     "provider_specific_fields",
 )

--- a/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
@@ -309,6 +309,11 @@ def test_transform_request_drops_thinking_blocks_for_fireworks_model():
     The outgoing request payload built by ``transform_request`` must not carry
     it, or the Fireworks backend 400s with
     ``Extra inputs are not permitted, field: 'messages[2].thinking_blocks'``.
+    Also covers the nested ``tool_calls[].function.provider_specific_fields``
+    signature the Anthropic ``/v1/messages`` adapter attaches on tool-use
+    replays, which otherwise 400s with
+    ``Extra inputs are not permitted, field:
+    'messages[n].tool_calls[m].function.provider_specific_fields'``.
     """
     config = AzureAIStudioConfig()
     messages = [
@@ -324,6 +329,17 @@ def test_transform_request_drops_thinking_blocks_for_fireworks_model():
                     "cache_control": {},
                 }
             ],
+            "tool_calls": [
+                {
+                    "id": "toolu_1",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": '{"path": "foo.txt"}',
+                        "provider_specific_fields": {"thought_signature": "sig"},
+                    },
+                }
+            ],
         },
         {"role": "user", "content": "go ahead"},
     ]
@@ -336,8 +352,56 @@ def test_transform_request_drops_thinking_blocks_for_fireworks_model():
         headers={},
     )
 
+    def _assert_no_unsupported_fields(node):
+        if isinstance(node, dict):
+            assert "thinking_blocks" not in node
+            assert "reasoning_content" not in node
+            assert "provider_specific_fields" not in node
+            assert "cache_control" not in node
+            for value in node.values():
+                _assert_no_unsupported_fields(value)
+        elif isinstance(node, list):
+            for item in node:
+                _assert_no_unsupported_fields(item)
+
     for message in payload["messages"]:
-        assert "thinking_blocks" not in message
-        assert "reasoning_content" not in message
-        assert "provider_specific_fields" not in message
-        assert "cache_control" not in message
+        _assert_no_unsupported_fields(message)
+
+
+def test_transform_messages_strips_nested_tool_call_provider_specific_fields():
+    """Regression: the Anthropic ``/v1/messages`` adapter attaches the thought
+    signature at ``tool_calls[].function.provider_specific_fields``
+    (``adapters/transformation.py``). A top-level ``pop`` of
+    ``provider_specific_fields`` from the message misses the nested copy, so
+    strict upstreams (Fireworks-on-Azure) still 400 with
+    ``Extra inputs are not permitted, field:
+    'messages[1].tool_calls[0].function.provider_specific_fields'``.
+    ``_transform_messages`` must strip it recursively.
+    """
+    config = AzureAIStudioConfig()
+    messages = [
+        {"role": "user", "content": "Run the tool."},
+        {
+            "role": "assistant",
+            "content": "Calling the tool now.",
+            "tool_calls": [
+                {
+                    "id": "toolu_1",
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "arguments": '{"path": "foo.txt"}',
+                        "provider_specific_fields": {"thought_signature": "sig"},
+                    },
+                }
+            ],
+        },
+        {"role": "user", "content": "show me the result"},
+    ]
+
+    out = config._transform_messages(messages, model="glm-5.2")
+
+    tool_call = out[1]["tool_calls"][0]
+    assert "provider_specific_fields" not in tool_call
+    assert "provider_specific_fields" not in tool_call["function"]
+    assert tool_call["function"]["name"] == "read_file"

--- a/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
@@ -262,3 +262,82 @@ def test_drop_tool_level_extra_fields_strips_copilot_mcp_server_name():
         assert "copilot_mcp_server_name" not in tool
     assert result["tools"][0]["type"] == "function"
     assert result["tools"][1]["function"]["name"] == "read_file"
+
+
+def test_transform_messages_strips_anthropic_replay_fields():
+    """Regression: Anthropic /v1/messages adapter attaches ``thinking_blocks``
+    (and ``provider_specific_fields`` / ``cache_control``) to the OpenAI-format
+    assistant messages it builds when replaying Claude Code turns. Azure AI
+    Foundry hosted model backends with strict chat-message schemas (e.g.
+    Fireworks GLM) reject them with
+    ``Extra inputs are not permitted, field: 'messages[n].thinking_blocks'``.
+    ``_transform_messages`` must drop them before the request is sent.
+    """
+    config = AzureAIStudioConfig()
+    messages = [
+        {"role": "user", "content": "Read a file."},
+        {
+            "role": "assistant",
+            "content": "I can help.",
+            "thinking_blocks": [
+                {
+                    "type": "thinking",
+                    "thinking": "The user wants me to read a file.",
+                    "signature": "",
+                    "cache_control": {},
+                }
+            ],
+            "reasoning_content": "internal reasoning",
+            "provider_specific_fields": {"thought_signature": "sig"},
+            "cache_control": {"type": "ephemeral"},
+        },
+        {"role": "user", "content": "go ahead"},
+    ]
+
+    out = config._transform_messages(messages, model="glm-5.2")
+
+    assert "thinking_blocks" not in out[1]
+    assert "reasoning_content" not in out[1]
+    assert "provider_specific_fields" not in out[1]
+    assert "cache_control" not in out[1]
+    assert out[1]["content"] == "I can help."
+
+
+def test_transform_request_drops_thinking_blocks_for_fireworks_model():
+    """End-to-end of the reported scenario: a Fireworks model deployed on Azure
+    AI Foundry receives a replayed assistant turn carrying ``thinking_blocks``.
+    The outgoing request payload built by ``transform_request`` must not carry
+    it, or the Fireworks backend 400s with
+    ``Extra inputs are not permitted, field: 'messages[2].thinking_blocks'``.
+    """
+    config = AzureAIStudioConfig()
+    messages = [
+        {"role": "user", "content": "Read a file."},
+        {
+            "role": "assistant",
+            "content": "I can help.",
+            "thinking_blocks": [
+                {
+                    "type": "thinking",
+                    "thinking": "The user wants me to read a file.",
+                    "signature": "",
+                    "cache_control": {},
+                }
+            ],
+        },
+        {"role": "user", "content": "go ahead"},
+    ]
+
+    payload = config.transform_request(
+        model="glm-5.2",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+
+    for message in payload["messages"]:
+        assert "thinking_blocks" not in message
+        assert "reasoning_content" not in message
+        assert "provider_specific_fields" not in message
+        assert "cache_control" not in message

--- a/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
+++ b/tests/test_litellm/llms/azure_ai/chat/test_azure_ai_transformation.py
@@ -352,20 +352,29 @@ def test_transform_request_drops_thinking_blocks_for_fireworks_model():
         headers={},
     )
 
-    def _assert_no_unsupported_fields(node):
+    # Match the production invariant exactly: ``_strip_unsupported_message_fields``
+    # pops ``thinking_blocks`` / ``reasoning_content`` at the message top level only,
+    # and strips ``provider_specific_fields`` / ``cache_control`` recursively (they
+    # nest inside ``tool_calls[].function`` / content blocks). Asserting the
+    # top-level-only fields are absent from every nested node would document a
+    # stronger invariant than the code enforces and give a false sense of security.
+    top_level_only_fields = ("thinking_blocks", "reasoning_content")
+    recursively_stripped_fields = ("provider_specific_fields", "cache_control")
+
+    def _assert_no_recursively_stripped_fields(node):
         if isinstance(node, dict):
-            assert "thinking_blocks" not in node
-            assert "reasoning_content" not in node
-            assert "provider_specific_fields" not in node
-            assert "cache_control" not in node
+            for field in recursively_stripped_fields:
+                assert field not in node
             for value in node.values():
-                _assert_no_unsupported_fields(value)
+                _assert_no_recursively_stripped_fields(value)
         elif isinstance(node, list):
             for item in node:
-                _assert_no_unsupported_fields(item)
+                _assert_no_recursively_stripped_fields(item)
 
     for message in payload["messages"]:
-        _assert_no_unsupported_fields(message)
+        for field in top_level_only_fields:
+            assert field not in message
+        _assert_no_recursively_stripped_fields(message)
 
 
 def test_transform_messages_strips_nested_tool_call_provider_specific_fields():
@@ -405,3 +414,36 @@ def test_transform_messages_strips_nested_tool_call_provider_specific_fields():
     assert "provider_specific_fields" not in tool_call
     assert "provider_specific_fields" not in tool_call["function"]
     assert tool_call["function"]["name"] == "read_file"
+
+
+def test_strip_unsupported_message_fields_top_level_only_fields_not_stipped_below_top_level():
+    """Document the production invariant Greptile flagged: ``thinking_blocks``
+    and ``reasoning_content`` are popped at the message top level only. They do
+    not appear nested in practice, and the production code does not recurse into
+    content blocks to remove them. A future change that nests them would need a
+    matching production change; pinning the current contract here keeps the test
+    suite and the code in sync rather than asserting a stronger invariant than
+    the code enforces.
+    """
+    from litellm.llms.azure_ai.chat.transformation import (
+        _strip_unsupported_message_fields,
+    )
+
+    # A message that carries a top-level-only field nested inside a content
+    # block; the helper must remove the top-level copy but leave the nested one
+    # (the contract is top-level-only for these fields).
+    message = {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "hi", "thinking_blocks": [{"type": "thinking"}]},
+        ],
+        "thinking_blocks": [{"type": "thinking", "thinking": "top"}],
+        "reasoning_content": "top-level reasoning",
+    }
+
+    _strip_unsupported_message_fields(message)  # type: ignore[arg-type]
+
+    assert "thinking_blocks" not in message
+    assert "reasoning_content" not in message
+    # The nested copy inside the content block is NOT touched (top-level-only):
+    assert "thinking_blocks" in message["content"][0]


### PR DESCRIPTION
## Relevant issues

Fixes #33961.

The same `thinking_blocks` symptom was reported for a different provider path in #32188 (the `openai`/`azure` provider under the `LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES` opt-out flag); this PR fixes the `azure_ai` counterpart and does not resolve 32188.

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Reproduced live against a running LiteLLM proxy (`litellm --config ... --port 4000`) with a real `model_list` entry routing to a Fireworks model deployed on Azure AI Foundry, using the actual `POST /v1/messages` endpoint:

```yaml
model_list:
  - model_name: fw-glm
    litellm_params:
      model: azure_ai/FW-GLM-5.2
      api_base: https://my-resource.services.ai.azure.com
      api_key: os.environ/AZURE_API_KEY
```

**Before the fix**:

```
# thinking-block replay (the reported scenario):
$ curl -s -X POST "http://localhost:4000/v1/messages" \
  -H "Authorization: Bearer $PROXY_KEY" -H "Content-Type: application/json" \
  -d '{"model":"fw-glm","max_tokens":200,"thinking":{"type":"enabled","budget_tokens":1024},
      "messages":[
        {"role":"user","content":"Read a file."},
        {"role":"assistant","content":[
          {"type":"thinking","thinking":"The user wants me to read a file. Let me read it.","signature":""},
          {"type":"text","text":"I can help."}]},
        {"role":"user","content":"go ahead"}]}'

{"error":{"message":"litellm.BadRequestError: Azure_aiException - {\"error\":{\"object\":\"error\",\"type\":\"invalid_request_error\",\"code\":\"invalid_request_error\",\"message\":\"Extra inputs are not permitted, field: 'messages[1].thinking_blocks', value: [{'type': 'thinking', 'thinking': 'The user wants me to read a file. Let me read it.', 'signature': '', 'cache_control': {}}]\"}}. Received Model Group=fw-glm\n...","type":null,"param":null,"code":"400"}}
```

A second, distinct 400 on a multi-turn tool-use + thinking replay (the next failure Claude Code hits), same proxy, same pre-fix code:

```
$ curl -s -X POST "http://localhost:4000/v1/messages" \
  -H "Authorization: Bearer $PROXY_KEY" -H "Content-Type: application/json" \
  -d '{"model":"fw-glm","max_tokens":200,"thinking":{"type":"enabled","budget_tokens":1024},
      "tools":[{"name":"read_file","description":"Read a file","input_schema":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}}],
      "messages":[
        {"role":"user","content":"Run the tool to read foo.txt"},
        {"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"read_file","input":{"path":"foo.txt"}}]},
        {"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"file contents: hello world"}]},
        {"role":"assistant","content":[
          {"type":"thinking","thinking":"The file was read successfully.","signature":""},
          {"type":"text","text":"The file foo.txt was read successfully."}]},
        {"role":"user","content":"Now run it again for bar.txt"}]}'

{"error":{"message":"litellm.BadRequestError: Azure_aiException - {\"error\":{...,\"message\":\"Extra inputs are not permitted, field: 'messages[3].thinking_blocks', value: [{'type': 'thinking', 'thinking': 'The file was read successfully.', 'signature': '', 'cache_control': {}}]\"}}. ...","type":null,"param":null,"code":"400"}}
```

**After the fix**: replayed the identical two requests plus a full 3-turn conversation that echoes the model's own real `thinking` output back across two tool calls (exactly what Claude Code does on each subsequent turn). All returned HTTP 200 with real GLM-5.2 content:

```
=== thinking-block replay === -> HTTP 200
{"id":"chatcmpl-...","type":"message","role":"assistant","model":"fw-glm", ...
 "content":[{"type":"text","text":"1.  **Analyze the Request:** ..."}],"stop_reason":"max_tokens"}

=== multi-turn tool-use + thinking replay === -> HTTP 200
{"id":"chatcmpl-...","type":"message","role":"assistant","model":"fw-glm", ...
 "content":[{"type":"thinking","thinking":"The user wants me to read bar.txt. ..."}, {"type":"text","text":"..."}],"stop_reason":"end_turn"}

=== 3-turn conversation, echoing the model's own thinking + tool_use output each turn === -> HTTP 200 on every turn
(turn 1: tool_use for foo.txt -> tool_result -> model replies with thinking+text;
 turn 2: that exact thinking+text replayed as history, user asks to read bar.txt again ->
 model correctly issues a new tool_use for bar.txt and, after the tool_result, replies
 with thinking+text again -> 200 throughout)
```

**Also verified with the actual reported client (Claude Code CLI, not just curl)**, pointed at the same proxy via `ANTHROPIC_BASE_URL=http://localhost:4000` / `ANTHROPIC_AUTH_TOKEN=$PROXY_KEY` (`--setting-sources project` used to bypass a local `~/.claude/settings.json` env override on the test machine), with `--model fw-glm` routed to `azure_ai/FW-GLM-5.2`, in a scratch directory containing `foo.txt` / `bar.txt`:

```
$ claude -p "Read foo.txt and tell me exactly what it says." --model fw-glm --dangerously-skip-permissions --setting-sources project
```

- **Before the fix**: this single, real Claude Code turn itself 400s, because Claude Code's own internal tool-use loop (call `Read` -> get tool result -> compose final answer) replays its own first-hop `thinking` block on the second internal API call:
  ```
  API Error: 400 litellm.BadRequestError: Azure_aiException - {"error":{"object":"error","type":"invalid_request_error","code":"invalid_request_error","message":"Extra inputs are not permitted, field: 'messages[2].thinking_blocks', value: [{'type': 'thinking', 'thinking': 'The user wants me to read foo.txt and tell them exactly what it says. Let me find and read the file. ...', 'signature': '', 'cache_control': {}}]"}}. Received Model Group=fw-glm
  ```
  (This is a stronger repro than the hand-built curl payloads above: it shows the bug hits on the very first user-facing turn whenever the model does any tool call, not only across manual multi-turn history.)
- **After the fix**: the identical command returns a clean answer (`foo.txt contains exactly: "hello world from foo.txt"`). A follow-up turn in the same session (`claude -p -c "Now also read bar.txt and tell me what it says." ...`, `-c` continues the conversation so the prior turn's `thinking`/tool-use history is replayed) also succeeds cleanly. The proxy access log for this session shows 8x `"POST /v1/messages?beta=true HTTP/1.1" 200 OK` and zero 400s / `Extra inputs` errors.

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
