### PR TITLE
feat(audio): stream OpenAI TTS through the proxy to cut time-to-first-audio

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -80,9 +80,9 @@ from litellm.types.llms.openai import (
     ResponseAPIUsage,
     ResponseCompletedEvent,
     ResponseFailedEvent,
-    SpeechStreamingResponse,
     ResponseIncompleteEvent,
     ResponsesAPIResponse,
+    SpeechStreamingResponse,
 )
 from litellm.types.mcp import MCPPostCallResponseObject
 from litellm.types.prompts.init_prompts import PromptSpec

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -88,6 +88,7 @@ from litellm.types.llms.openai import (
     ResponseAPIUsage,
     ResponseCompletedEvent,
     ResponseFailedEvent,
+    SpeechStreamingResponse,
     ResponseIncompleteEvent,
     ResponsesAPIResponse,
 )
@@ -1983,6 +1984,7 @@ class Logging(LiteLLMLoggingBaseClass):
             or isinstance(logging_result, TranscriptionResponse)
             or isinstance(logging_result, TextCompletionResponse)
             or isinstance(logging_result, HttpxBinaryResponseContent)  # tts
+            or isinstance(logging_result, SpeechStreamingResponse)  # streaming tts (stream_format="sse")
             or isinstance(logging_result, RerankResponse)
             or isinstance(logging_result, FineTuningJob)
             or isinstance(logging_result, LiteLLMBatch)

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -80,6 +80,7 @@ from litellm.types.llms.openai import (
     ResponseAPIUsage,
     ResponseCompletedEvent,
     ResponseFailedEvent,
+    SpeechStreamingResponse,
     ResponseIncompleteEvent,
     ResponsesAPIResponse,
 )
@@ -1921,6 +1922,7 @@ class Logging(LiteLLMLoggingBaseClass):
             or isinstance(logging_result, TranscriptionResponse)
             or isinstance(logging_result, TextCompletionResponse)
             or isinstance(logging_result, HttpxBinaryResponseContent)  # tts
+            or isinstance(logging_result, SpeechStreamingResponse)  # streaming tts (stream_format="sse")
             or isinstance(logging_result, RerankResponse)
             or isinstance(logging_result, FineTuningJob)
             or isinstance(logging_result, LiteLLMBatch)

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -88,9 +88,9 @@ from litellm.types.llms.openai import (
     ResponseAPIUsage,
     ResponseCompletedEvent,
     ResponseFailedEvent,
-    SpeechStreamingResponse,
     ResponseIncompleteEvent,
     ResponsesAPIResponse,
+    SpeechStreamingResponse,
 )
 from litellm.types.mcp import MCPPostCallResponseObject
 from litellm.types.prompts.init_prompts import PromptSpec

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -1,6 +1,7 @@
+import sys
 import time
 import types
-from collections.abc import AsyncIterator, Callable, Coroutine, Iterable, Iterator
+from collections.abc import AsyncIterator, Callable, Coroutine, Iterable, Iterator, Mapping
 from typing import TYPE_CHECKING, Any, Final, Literal, Optional, cast
 from urllib.parse import urlparse
 
@@ -1491,9 +1492,10 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         max_retries: int,
         timeout: float | httpx.Timeout,
         aspeech: bool | None = None,
+        stream_audio: bool = False,
         client=None,
         shared_session: Optional["ClientSession"] = None,
-    ) -> HttpxBinaryResponseContent:
+    ) -> HttpxBinaryResponseContent | SpeechStreamingResponse:
         if aspeech is not None and aspeech is True:
             return self.async_audio_speech(
                 model=model,
@@ -1506,21 +1508,34 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 project=project,
                 max_retries=max_retries,
                 timeout=timeout,
+                stream_audio=stream_audio,
                 client=client,
                 shared_session=shared_session,
             )
 
-        openai_client: Final = self._get_openai_client(
-            is_async=False,
-            api_key=api_key,
-            api_base=api_base,
-            timeout=timeout,
-            max_retries=max_retries,
-            client=client,
-            shared_session=shared_session,
+        openai_client: Final = cast(
+            OpenAI,
+            self._get_openai_client(
+                is_async=False,
+                api_key=api_key,
+                api_base=api_base,
+                timeout=timeout,
+                max_retries=max_retries,
+                client=client,
+                shared_session=shared_session,
+            ),
         )
 
-        response: Final = cast(OpenAI, openai_client).audio.speech.create(
+        if stream_audio:
+            return self.audio_speech_streaming(
+                model=model,
+                input=input,
+                voice=voice,
+                optional_params=optional_params,
+                openai_client=openai_client,
+            )
+
+        response: Final = openai_client.audio.speech.create(
             model=model,
             voice=voice,
             input=input,
@@ -1540,9 +1555,10 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         project: str | None,
         max_retries: int,
         timeout: float | httpx.Timeout,
+        stream_audio: bool = False,
         client=None,
         shared_session: Optional["ClientSession"] = None,
-    ) -> HttpxBinaryResponseContent:
+    ) -> HttpxBinaryResponseContent | SpeechStreamingResponse:
         openai_client: Final = cast(
             AsyncOpenAI,
             self._get_openai_client(
@@ -1556,6 +1572,15 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             ),
         )
 
+        if stream_audio:
+            return await self.async_audio_speech_streaming(
+                model=model,
+                input=input,
+                voice=voice,
+                optional_params=optional_params,
+                openai_client=openai_client,
+            )
+
         response: Final = await openai_client.audio.speech.create(
             model=model,
             voice=voice,
@@ -1564,6 +1589,65 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         )
 
         return HttpxBinaryResponseContent(response=response.response)
+
+    async def async_audio_speech_streaming(
+        self,
+        model: str,
+        input: str,
+        voice: str,
+        optional_params: Mapping[str, object],
+        openai_client: AsyncOpenAI,
+    ) -> "SpeechStreamingResponse":
+        """Open the TTS request in streaming mode and forward the provider frames as they arrive.
+
+        Uses with_streaming_response so the httpx body is not read until iterated, so
+        time-to-first-audio reflects first-chunk latency rather than full generation. This is
+        how OpenAI's /v1/audio/speech behaves for every request (chunked transfer), so the
+        forwarded frames are raw audio bytes by default, or speech.audio.delta SSE frames when
+        the caller sets stream_format="sse". The content-type is carried in ``headers``.
+        """
+        response_cm: Final = openai_client.audio.speech.with_streaming_response.create(
+            model=model,
+            voice=voice,  # pyright: ignore[reportArgumentType]  # provider voice id may be outside the SDK Literal
+            input=input,
+            **optional_params,
+        )
+        response: Final = await response_cm.__aenter__()
+        headers: Final = response.headers
+
+        async def _stream() -> AsyncIterator[bytes]:
+            try:
+                async for chunk in response.iter_bytes():
+                    yield chunk
+            finally:
+                await response_cm.__aexit__(*sys.exc_info())
+
+        return SpeechStreamingResponse(stream_iterator=_stream(), headers=headers)
+
+    def audio_speech_streaming(
+        self,
+        model: str,
+        input: str,
+        voice: str,
+        optional_params: Mapping[str, object],
+        openai_client: OpenAI,
+    ) -> "SpeechStreamingResponse":
+        response_cm: Final = openai_client.audio.speech.with_streaming_response.create(
+            model=model,
+            voice=voice,  # pyright: ignore[reportArgumentType]  # provider voice id may be outside the SDK Literal
+            input=input,
+            **optional_params,
+        )
+        response: Final = response_cm.__enter__()
+        headers: Final = response.headers
+
+        def _stream() -> Iterator[bytes]:
+            try:
+                yield from response.iter_bytes()
+            finally:
+                response_cm.__exit__(*sys.exc_info())
+
+        return SpeechStreamingResponse(stream_iterator=_stream(), headers=headers)
 
 
 class OpenAIFilesAPI(BaseLLM):

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -1,3 +1,4 @@
+import sys
 import time
 import types
 from collections.abc import AsyncIterator, Callable, Coroutine, Iterable, Iterator, Mapping
@@ -1492,9 +1493,10 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         max_retries: int,
         timeout: float | httpx.Timeout,
         aspeech: bool | None = None,
+        stream_audio: bool = False,
         client=None,
         shared_session: Optional["ClientSession"] = None,
-    ) -> HttpxBinaryResponseContent:
+    ) -> HttpxBinaryResponseContent | SpeechStreamingResponse:
         if aspeech is not None and aspeech is True:
             return self.async_audio_speech(
                 model=model,
@@ -1507,21 +1509,34 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 project=project,
                 max_retries=max_retries,
                 timeout=timeout,
+                stream_audio=stream_audio,
                 client=client,
                 shared_session=shared_session,
             )
 
-        openai_client: Final = self._get_openai_client(
-            is_async=False,
-            api_key=api_key,
-            api_base=api_base,
-            timeout=timeout,
-            max_retries=max_retries,
-            client=client,
-            shared_session=shared_session,
+        openai_client: Final = cast(
+            OpenAI,
+            self._get_openai_client(
+                is_async=False,
+                api_key=api_key,
+                api_base=api_base,
+                timeout=timeout,
+                max_retries=max_retries,
+                client=client,
+                shared_session=shared_session,
+            ),
         )
 
-        response: Final = cast(OpenAI, openai_client).audio.speech.create(
+        if stream_audio:
+            return self.audio_speech_streaming(
+                model=model,
+                input=input,
+                voice=voice,
+                optional_params=optional_params,
+                openai_client=openai_client,
+            )
+
+        response: Final = openai_client.audio.speech.create(
             model=model,
             voice=voice,
             input=input,
@@ -1541,9 +1556,10 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         project: str | None,
         max_retries: int,
         timeout: float | httpx.Timeout,
+        stream_audio: bool = False,
         client=None,
         shared_session: Optional["ClientSession"] = None,
-    ) -> HttpxBinaryResponseContent:
+    ) -> HttpxBinaryResponseContent | SpeechStreamingResponse:
         openai_client: Final = cast(
             AsyncOpenAI,
             self._get_openai_client(
@@ -1557,6 +1573,15 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             ),
         )
 
+        if stream_audio:
+            return await self.async_audio_speech_streaming(
+                model=model,
+                input=input,
+                voice=voice,
+                optional_params=optional_params,
+                openai_client=openai_client,
+            )
+
         response: Final = await openai_client.audio.speech.create(
             model=model,
             voice=voice,
@@ -1565,6 +1590,65 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         )
 
         return HttpxBinaryResponseContent(response=response.response)
+
+    async def async_audio_speech_streaming(
+        self,
+        model: str,
+        input: str,
+        voice: str,
+        optional_params: Mapping[str, object],
+        openai_client: AsyncOpenAI,
+    ) -> "SpeechStreamingResponse":
+        """Open the TTS request in streaming mode and forward the provider frames as they arrive.
+
+        Uses with_streaming_response so the httpx body is not read until iterated, so
+        time-to-first-audio reflects first-chunk latency rather than full generation. This is
+        how OpenAI's /v1/audio/speech behaves for every request (chunked transfer), so the
+        forwarded frames are raw audio bytes by default, or speech.audio.delta SSE frames when
+        the caller sets stream_format="sse". The content-type is carried in ``headers``.
+        """
+        response_cm: Final = openai_client.audio.speech.with_streaming_response.create(
+            model=model,
+            voice=voice,  # pyright: ignore[reportArgumentType]  # provider voice id may be outside the SDK Literal
+            input=input,
+            **optional_params,
+        )
+        response: Final = await response_cm.__aenter__()
+        headers: Final = response.headers
+
+        async def _stream() -> AsyncIterator[bytes]:
+            try:
+                async for chunk in response.iter_bytes():
+                    yield chunk
+            finally:
+                await response_cm.__aexit__(*sys.exc_info())
+
+        return SpeechStreamingResponse(stream_iterator=_stream(), headers=headers)
+
+    def audio_speech_streaming(
+        self,
+        model: str,
+        input: str,
+        voice: str,
+        optional_params: Mapping[str, object],
+        openai_client: OpenAI,
+    ) -> "SpeechStreamingResponse":
+        response_cm: Final = openai_client.audio.speech.with_streaming_response.create(
+            model=model,
+            voice=voice,  # pyright: ignore[reportArgumentType]  # provider voice id may be outside the SDK Literal
+            input=input,
+            **optional_params,
+        )
+        response: Final = response_cm.__enter__()
+        headers: Final = response.headers
+
+        def _stream() -> Iterator[bytes]:
+            try:
+                yield from response.iter_bytes()
+            finally:
+                response_cm.__exit__(*sys.exc_info())
+
+        return SpeechStreamingResponse(stream_iterator=_stream(), headers=headers)
 
 
 class OpenAIFilesAPI(BaseLLM):

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -262,6 +262,7 @@ from .types.llms.openai import (
     HttpxBinaryResponseContent,
     OpenAIModerationResponse,
     OpenAIWebSearchOptions,
+    SpeechStreamingResponse,
 )
 from .types.utils import (
     AdapterCompletionStreamWrapper,
@@ -7783,7 +7784,7 @@ def transcription(
 
 
 @client
-async def aspeech(*args, **kwargs) -> HttpxBinaryResponseContent:
+async def aspeech(*args, **kwargs) -> HttpxBinaryResponseContent | SpeechStreamingResponse:
     """
     Calls openai tts endpoints.
     """
@@ -7837,12 +7838,18 @@ def speech(
     response_format: str | None = None,
     speed: int | None = None,
     instructions: str | None = None,
+    stream_format: str | None = None,
+    stream_audio: bool = False,
     client=None,
     headers: dict | None = None,
     custom_llm_provider: str | None = None,
     aspeech: bool | None = None,
     **kwargs,
-) -> HttpxBinaryResponseContent | Coroutine[Any, Any, HttpxBinaryResponseContent]:
+) -> (
+    HttpxBinaryResponseContent
+    | SpeechStreamingResponse
+    | Coroutine[Any, Any, HttpxBinaryResponseContent | SpeechStreamingResponse]
+):
     user: Final = kwargs.get("user", None)
     litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
     proxy_server_request: Final = kwargs.get("proxy_server_request", None)
@@ -7861,6 +7868,8 @@ def speech(
         optional_params["speed"] = speed
     if instructions is not None:
         optional_params["instructions"] = instructions
+    if stream_format is not None:
+        optional_params["stream_format"] = stream_format
 
     if timeout is None:
         timeout = litellm.request_timeout
@@ -7901,7 +7910,12 @@ def speech(
         },
         custom_llm_provider=custom_llm_provider,
     )
-    response: HttpxBinaryResponseContent | Coroutine[Any, Any, HttpxBinaryResponseContent] | None = None
+    response: (
+        HttpxBinaryResponseContent
+        | SpeechStreamingResponse
+        | Coroutine[Any, Any, HttpxBinaryResponseContent | SpeechStreamingResponse]
+        | None
+    ) = None  # rebind-ok: assigned per provider branch below
     if custom_llm_provider == "openai" or custom_llm_provider in litellm.openai_compatible_providers:
         if voice is None or not (isinstance(voice, str)):
             raise litellm.BadRequestError(
@@ -7953,6 +7967,7 @@ def speech(
             timeout=timeout,
             client=client,  # pass AsyncOpenAI, OpenAI client
             aspeech=aspeech,
+            stream_audio=stream_audio,
             shared_session=shared_session,
         )
     elif custom_llm_provider == "azure":

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -262,6 +262,7 @@ from .types.llms.openai import (
     HttpxBinaryResponseContent,
     OpenAIModerationResponse,
     OpenAIWebSearchOptions,
+    SpeechStreamingResponse,
 )
 from .types.utils import (
     AdapterCompletionStreamWrapper,
@@ -7852,7 +7853,7 @@ def transcription(
 
 
 @client
-async def aspeech(*args, **kwargs) -> HttpxBinaryResponseContent:
+async def aspeech(*args, **kwargs) -> HttpxBinaryResponseContent | SpeechStreamingResponse:
     """
     Calls openai tts endpoints.
     """
@@ -7906,12 +7907,18 @@ def speech(
     response_format: str | None = None,
     speed: int | None = None,
     instructions: str | None = None,
+    stream_format: str | None = None,
+    stream_audio: bool = False,
     client=None,
     headers: dict | None = None,
     custom_llm_provider: str | None = None,
     aspeech: bool | None = None,
     **kwargs,
-) -> HttpxBinaryResponseContent | Coroutine[object, object, HttpxBinaryResponseContent]:
+) -> (
+    HttpxBinaryResponseContent
+    | SpeechStreamingResponse
+    | Coroutine[object, object, HttpxBinaryResponseContent | SpeechStreamingResponse]
+):
     user: Final = kwargs.get("user", None)
     litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
     proxy_server_request: Final = kwargs.get("proxy_server_request", None)
@@ -7930,6 +7937,8 @@ def speech(
         optional_params["speed"] = speed
     if instructions is not None:
         optional_params["instructions"] = instructions
+    if stream_format is not None:
+        optional_params["stream_format"] = stream_format
 
     if timeout is None:
         timeout = litellm.request_timeout
@@ -7970,7 +7979,12 @@ def speech(
         },
         custom_llm_provider=custom_llm_provider,
     )
-    response: HttpxBinaryResponseContent | Coroutine[object, object, HttpxBinaryResponseContent] | None = None
+    response: (
+        HttpxBinaryResponseContent
+        | SpeechStreamingResponse
+        | Coroutine[object, object, HttpxBinaryResponseContent | SpeechStreamingResponse]
+        | None
+    ) = None  # rebind-ok: assigned per provider branch below
     if custom_llm_provider == "openai" or custom_llm_provider in litellm.openai_compatible_providers:
         if voice is None or not (isinstance(voice, str)):
             raise litellm.BadRequestError(
@@ -8022,6 +8036,7 @@ def speech(
             timeout=timeout,
             client=client,  # pass AsyncOpenAI, OpenAI client
             aspeech=aspeech,
+            stream_audio=stream_audio,
             shared_session=shared_session,
         )
     elif custom_llm_provider == "azure":

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -9911,11 +9911,13 @@ async def audio_speech(
         # arrive so time-to-first-audio reflects first-chunk latency instead of
         # full-generation latency. The media type mirrors what the provider actually
         # returned (text/event-stream for speech.audio.delta frames, or audio/* when the
-        # provider ignored stream_format), so nothing is mislabeled.
+        # provider ignored stream_format). Fall back to application/octet-stream rather
+        # than text/event-stream when the provider omits Content-Type, so raw audio bytes
+        # are never mislabeled as SSE.
         if isinstance(response, SpeechStreamingResponse):
             return StreamingResponse(
                 response.stream_iterator,  # pyright: ignore[reportArgumentType]  # SSE byte iterator
-                media_type=response.headers.get("content-type") or "text/event-stream",
+                media_type=response.headers.get("content-type") or "application/octet-stream",
                 headers=custom_headers,  # pyright: ignore[reportArgumentType]  # header values coerced to str by starlette
             )
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -628,7 +628,10 @@ from litellm.types.llms.anthropic import (
     AnthropicResponseContentBlockText,
     AnthropicResponseUsageBlock,
 )
-from litellm.types.llms.openai import HttpxBinaryResponseContent
+from litellm.types.llms.openai import (
+    HttpxBinaryResponseContent,
+    SpeechStreamingResponse,
+)
 from litellm.types.proxy.control_plane_endpoints import WorkerRegistryEntry
 from litellm.types.proxy.management_endpoints.model_management_endpoints import (
     ModelGroupInfoProxy,
@@ -10326,6 +10329,17 @@ async def audio_speech(
             user_api_key_dict=user_api_key_dict, data=data, call_type="aspeech"
         )
 
+        # OpenAI's /v1/audio/speech always streams the response over chunked transfer, so a
+        # client that reads incrementally (with_streaming_response) sees first-audio well before
+        # generation finishes. Ask the handler to forward the upstream stream instead of buffering
+        # the full clip, so the proxy matches that behavior (and passes through stream_format="sse"
+        # frames when requested). This covers OpenAI and every openai-compatible provider routed
+        # through the OpenAI handler (hosted_vllm, etc); providers with their own handler
+        # (azure/elevenlabs/vertex) ignore the flag and keep returning a buffered response. It is
+        # deliberately not called "stream" so it does not trip _is_streaming_request and skip TTS
+        # cost tracking.
+        data["stream_audio"] = True
+
         ## ROUTE TO CORRECT ENDPOINT ##
         llm_call: Final = await route_request(
             data=data,
@@ -10371,6 +10385,18 @@ async def audio_speech(
         )
         if callback_headers:
             custom_headers.update(callback_headers)
+
+        # Streaming TTS (stream_format="sse"): forward the provider's frames as they
+        # arrive so time-to-first-audio reflects first-chunk latency instead of
+        # full-generation latency. The media type mirrors what the provider actually
+        # returned (text/event-stream for speech.audio.delta frames, or audio/* when the
+        # provider ignored stream_format), so nothing is mislabeled.
+        if isinstance(response, SpeechStreamingResponse):
+            return StreamingResponse(
+                response.stream_iterator,  # pyright: ignore[reportArgumentType]  # SSE byte iterator
+                media_type=response.headers.get("content-type") or "text/event-stream",
+                headers=custom_headers,  # pyright: ignore[reportArgumentType]  # header values coerced to str by starlette
+            )
 
         # Determine media type based on model type
         media_type = "audio/mpeg"  # Default for OpenAI TTS

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -10390,11 +10390,13 @@ async def audio_speech(
         # arrive so time-to-first-audio reflects first-chunk latency instead of
         # full-generation latency. The media type mirrors what the provider actually
         # returned (text/event-stream for speech.audio.delta frames, or audio/* when the
-        # provider ignored stream_format), so nothing is mislabeled.
+        # provider ignored stream_format). Fall back to application/octet-stream rather
+        # than text/event-stream when the provider omits Content-Type, so raw audio bytes
+        # are never mislabeled as SSE.
         if isinstance(response, SpeechStreamingResponse):
             return StreamingResponse(
                 response.stream_iterator,  # pyright: ignore[reportArgumentType]  # SSE byte iterator
-                media_type=response.headers.get("content-type") or "text/event-stream",
+                media_type=response.headers.get("content-type") or "application/octet-stream",
                 headers=custom_headers,  # pyright: ignore[reportArgumentType]  # header values coerced to str by starlette
             )
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -615,7 +615,10 @@ from litellm.types.llms.anthropic import (
     AnthropicResponseContentBlockText,
     AnthropicResponseUsageBlock,
 )
-from litellm.types.llms.openai import HttpxBinaryResponseContent
+from litellm.types.llms.openai import (
+    HttpxBinaryResponseContent,
+    SpeechStreamingResponse,
+)
 from litellm.types.proxy.control_plane_endpoints import WorkerRegistryEntry
 from litellm.types.proxy.management_endpoints.model_management_endpoints import (
     ModelGroupInfoProxy,
@@ -9847,6 +9850,17 @@ async def audio_speech(
             user_api_key_dict=user_api_key_dict, data=data, call_type="aspeech"
         )
 
+        # OpenAI's /v1/audio/speech always streams the response over chunked transfer, so a
+        # client that reads incrementally (with_streaming_response) sees first-audio well before
+        # generation finishes. Ask the handler to forward the upstream stream instead of buffering
+        # the full clip, so the proxy matches that behavior (and passes through stream_format="sse"
+        # frames when requested). This covers OpenAI and every openai-compatible provider routed
+        # through the OpenAI handler (hosted_vllm, etc); providers with their own handler
+        # (azure/elevenlabs/vertex) ignore the flag and keep returning a buffered response. It is
+        # deliberately not called "stream" so it does not trip _is_streaming_request and skip TTS
+        # cost tracking.
+        data["stream_audio"] = True
+
         ## ROUTE TO CORRECT ENDPOINT ##
         llm_call: Final = await route_request(
             data=data,
@@ -9892,6 +9906,18 @@ async def audio_speech(
         )
         if callback_headers:
             custom_headers.update(callback_headers)
+
+        # Streaming TTS (stream_format="sse"): forward the provider's frames as they
+        # arrive so time-to-first-audio reflects first-chunk latency instead of
+        # full-generation latency. The media type mirrors what the provider actually
+        # returned (text/event-stream for speech.audio.delta frames, or audio/* when the
+        # provider ignored stream_format), so nothing is mislabeled.
+        if isinstance(response, SpeechStreamingResponse):
+            return StreamingResponse(
+                response.stream_iterator,  # pyright: ignore[reportArgumentType]  # SSE byte iterator
+                media_type=response.headers.get("content-type") or "text/event-stream",
+                headers=custom_headers,  # pyright: ignore[reportArgumentType]  # header values coerced to str by starlette
+            )
 
         # Determine media type based on model type
         media_type = "audio/mpeg"  # Default for OpenAI TTS

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -1,7 +1,7 @@
-from collections.abc import Iterable, Mapping
+from collections.abc import AsyncIterator, Iterable, Iterator, Mapping
 from enum import Enum
 from os import PathLike
-from typing import IO, Any, Final, Literal, Optional, Union
+from typing import IO, Any, Final, Literal, NamedTuple, Optional, Union
 
 import httpx
 from openai import Omit
@@ -104,6 +104,22 @@ EmbeddingInput = str | list[str]
 
 class HttpxBinaryResponseContent(_HttpxBinaryResponseContent):
     _hidden_params: dict = {}
+
+
+class SpeechStreamingResponse(NamedTuple):
+    """Result of a streaming text-to-speech call (OpenAI ``stream_format="sse"``).
+
+    Holds an iterator over the raw frames as they arrive from the provider, so callers
+    can forward them incrementally instead of buffering the full clip. ``stream_iterator``
+    is async for ``aspeech`` and sync for ``speech``. ``headers`` carries the provider's
+    response headers; callers should label the forwarded stream with its ``content-type``
+    (``text/event-stream`` for ``speech.audio.delta`` frames, or ``audio/*`` when the
+    provider ignored ``stream_format`` and streamed the clip verbatim) rather than assuming
+    SSE, so nothing is mislabeled.
+    """
+
+    stream_iterator: Iterator[bytes] | AsyncIterator[bytes]
+    headers: Mapping[str, str]
 
 
 class NotGiven:

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -4539,3 +4539,67 @@ async def test_restore_correlation_context_works_across_asyncio_task_boundary():
     finally:
         trace_id_var.set("")
         session_id_var.set("")
+
+
+def _make_aspeech_logging_obj(model, text):
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+
+    logging_obj = LiteLLMLoggingObj(
+        model=model,
+        messages=[{"role": "user", "content": text}],
+        stream=False,
+        call_type="aspeech",
+        start_time=time.time(),
+        litellm_call_id="tts-stream-1",
+        function_id="fn",
+    )
+    logging_obj.update_environment_variables(
+        model=model, user="", optional_params={}, litellm_params={"api_base": ""}
+    )
+    logging_obj.model_call_details["input"] = text
+    return logging_obj
+
+
+def test_streaming_tts_response_records_spend():
+    """Regression (streaming TTS budget bypass): a stream_format='sse' response
+    (SpeechStreamingResponse) must be recognized for cost logging so response_cost is
+    recorded, exactly like the non-streaming HttpxBinaryResponseContent path. Otherwise the
+    proxy releases the budget reservation without recording spend and clients exceed budget."""
+    import datetime
+
+    from litellm.types.llms.openai import SpeechStreamingResponse
+
+    model = "streaming-tts-regression"
+    text = "the quick brown fox"
+    litellm.register_model(
+        model_cost={
+            model: {
+                "mode": "audio_speech",
+                "input_cost_per_character": 0.01,
+                "litellm_provider": "openai",
+            }
+        }
+    )
+
+    logging_obj = _make_aspeech_logging_obj(model, text)
+
+    consumed = {"count": 0}
+
+    async def _frames():
+        consumed["count"] += 1
+        yield b'data: {"type":"speech.audio.delta"}\n\n'
+
+    response = SpeechStreamingResponse(
+        stream_iterator=_frames(), headers={"content-type": "text/event-stream"}
+    )
+
+    assert logging_obj._is_recognized_call_type_for_logging(logging_result=response) is True
+
+    now = datetime.datetime.now()
+    logging_obj._success_handler_helper_fn(result=response, start_time=now, end_time=now, cache_hit=False)
+
+    response_cost = logging_obj.model_call_details.get("response_cost")
+    assert response_cost is not None, "streaming TTS must record a response_cost (else budget bypass)"
+    assert response_cost > 0
+    assert response_cost == pytest.approx(0.01 * len(text), rel=0.25)
+    assert consumed["count"] == 0

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -4210,3 +4210,67 @@ def test_pre_call_does_not_pin_request_in_module_state(logging_obj):
     logging_obj.post_call(original_response='{"ok": true}', input=big_input, api_key="sk-test")
 
     assert litellm.error_logs == {}
+
+
+def _make_aspeech_logging_obj(model, text):
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+
+    logging_obj = LiteLLMLoggingObj(
+        model=model,
+        messages=[{"role": "user", "content": text}],
+        stream=False,
+        call_type="aspeech",
+        start_time=time.time(),
+        litellm_call_id="tts-stream-1",
+        function_id="fn",
+    )
+    logging_obj.update_environment_variables(
+        model=model, user="", optional_params={}, litellm_params={"api_base": ""}
+    )
+    logging_obj.model_call_details["input"] = text
+    return logging_obj
+
+
+def test_streaming_tts_response_records_spend():
+    """Regression (streaming TTS budget bypass): a stream_format='sse' response
+    (SpeechStreamingResponse) must be recognized for cost logging so response_cost is
+    recorded, exactly like the non-streaming HttpxBinaryResponseContent path. Otherwise the
+    proxy releases the budget reservation without recording spend and clients exceed budget."""
+    import datetime
+
+    from litellm.types.llms.openai import SpeechStreamingResponse
+
+    model = "streaming-tts-regression"
+    text = "the quick brown fox"
+    litellm.register_model(
+        model_cost={
+            model: {
+                "mode": "audio_speech",
+                "input_cost_per_character": 0.01,
+                "litellm_provider": "openai",
+            }
+        }
+    )
+
+    logging_obj = _make_aspeech_logging_obj(model, text)
+
+    consumed = {"count": 0}
+
+    async def _frames():
+        consumed["count"] += 1
+        yield b'data: {"type":"speech.audio.delta"}\n\n'
+
+    response = SpeechStreamingResponse(
+        stream_iterator=_frames(), headers={"content-type": "text/event-stream"}
+    )
+
+    assert logging_obj._is_recognized_call_type_for_logging(logging_result=response) is True
+
+    now = datetime.datetime.now()
+    logging_obj._success_handler_helper_fn(result=response, start_time=now, end_time=now, cache_hit=False)
+
+    response_cost = logging_obj.model_call_details.get("response_cost")
+    assert response_cost is not None, "streaming TTS must record a response_cost (else budget bypass)"
+    assert response_cost > 0
+    assert response_cost == pytest.approx(0.01 * len(text), rel=0.25)
+    assert consumed["count"] == 0

--- a/tests/test_litellm/llms/openai/speech/test_openai_speech_streaming.py
+++ b/tests/test_litellm/llms/openai/speech/test_openai_speech_streaming.py
@@ -1,0 +1,427 @@
+"""Unit tests for streaming Text-to-Speech (OpenAI ``stream_format="sse"``).
+
+Regression coverage for #33974: streaming TTS must open the provider request in
+streaming mode and forward ``speech.audio.delta`` SSE frames incrementally, instead
+of buffering the full clip (which made proxy TTFT == full generation time).
+"""
+
+from typing import AsyncIterator, Iterator, cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import litellm
+from litellm.llms.openai.openai import OpenAIChatCompletion
+from litellm.types.llms.openai import SpeechStreamingResponse
+
+
+class _MockAsyncResponse:
+    headers = {"content-type": "text/event-stream"}
+
+    async def iter_bytes(self):
+        yield b'event: speech.audio.delta\ndata: {"audio":"AAA"}\n\n'
+        yield b"event: speech.audio.done\ndata: {}\n\n"
+
+
+class _MockAsyncResponseCM:
+    def __init__(self):
+        self.entered = False
+        self.exc_info = None
+
+    async def __aenter__(self):
+        self.entered = True
+        return _MockAsyncResponse()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.exc_info = (exc_type, exc, tb)
+
+
+def _mock_async_client(response_cm, captured):
+    speech = MagicMock()
+
+    def _create(**kwargs):
+        captured.update(kwargs)
+        return response_cm
+
+    speech.with_streaming_response.create = _create
+    client = MagicMock()
+    client.audio.speech = speech
+    return client
+
+
+@pytest.mark.asyncio
+async def test_async_audio_speech_streaming_forwards_sse_frames():
+    """The streaming path opens with_streaming_response and yields the SSE frames verbatim."""
+    captured: dict = {}
+    response_cm = _MockAsyncResponseCM()
+    api = OpenAIChatCompletion()
+
+    result = await api.async_audio_speech_streaming(
+        model="gpt-4o-mini-tts",
+        input="hello",
+        voice="alloy",
+        optional_params={"stream_format": "sse"},
+        openai_client=_mock_async_client(response_cm, captured),  # type: ignore[arg-type]
+    )
+
+    assert isinstance(result, SpeechStreamingResponse)
+    assert response_cm.entered is True
+    # stream_format must reach the SDK create() call
+    assert captured["stream_format"] == "sse"
+    assert captured["model"] == "gpt-4o-mini-tts"
+
+    stream = cast(AsyncIterator[bytes], result.stream_iterator)
+    frames = [chunk async for chunk in stream]
+    assert frames[0].startswith(b"event: speech.audio.delta")
+    assert b"speech.audio.done" in frames[1]
+    assert result.headers["content-type"] == "text/event-stream"
+    # context manager closed after the stream is exhausted
+    assert response_cm.exc_info == (None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_async_audio_speech_streaming_closes_cm_on_error():
+    """An error mid-stream must propagate and still close the streaming context manager."""
+
+    class _RaisingResponse:
+        headers: dict = {}
+
+        async def iter_bytes(self):
+            yield b"a"
+            raise RuntimeError("stream failed")
+
+    class _RaisingCM:
+        def __init__(self):
+            self.exc_info = None
+
+        async def __aenter__(self):
+            return _RaisingResponse()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            self.exc_info = (exc_type, exc, tb)
+
+    cm = _RaisingCM()
+    client = MagicMock()
+    client.audio.speech.with_streaming_response.create = lambda **kw: cm
+    api = OpenAIChatCompletion()
+
+    result = await api.async_audio_speech_streaming(
+        model="gpt-4o-mini-tts",
+        input="hi",
+        voice="alloy",
+        optional_params={"stream_format": "sse"},
+        openai_client=client,  # type: ignore[arg-type]
+    )
+    stream = cast(AsyncIterator[bytes], result.stream_iterator)
+    assert await stream.__anext__() == b"a"
+    with pytest.raises(RuntimeError, match="stream failed"):
+        await stream.__anext__()
+    assert cm.exc_info is not None and cm.exc_info[0] is RuntimeError
+
+
+def test_sync_audio_speech_streaming_forwards_sse_frames():
+    """Sync path mirrors the async one via with_streaming_response."""
+
+    class _SyncResponse:
+        headers = {"content-type": "text/event-stream"}
+
+        def iter_bytes(self) -> Iterator[bytes]:
+            yield b"event: speech.audio.delta\ndata: {}\n\n"
+
+    class _SyncCM:
+        def __enter__(self):
+            return _SyncResponse()
+
+        def __exit__(self, *a):
+            return None
+
+    client = MagicMock()
+    client.audio.speech.with_streaming_response.create = lambda **kw: _SyncCM()
+    api = OpenAIChatCompletion()
+
+    result = api.audio_speech_streaming(
+        model="gpt-4o-mini-tts",
+        input="hi",
+        voice="alloy",
+        optional_params={"stream_format": "sse"},
+        openai_client=client,  # type: ignore[arg-type]
+    )
+    frames = list(cast(Iterator[bytes], result.stream_iterator))
+    assert frames == [b"event: speech.audio.delta\ndata: {}\n\n"]
+
+
+def test_speech_threads_stream_format_into_optional_params():
+    """litellm.speech must forward stream_format to the provider (it was previously dropped)."""
+    captured: dict = {}
+
+    def _spy_audio_speech(**kwargs):
+        captured.update(kwargs)
+        return MagicMock(spec=litellm.llms.openai.openai.HttpxBinaryResponseContent)
+
+    with patch(
+        "litellm.main.openai_chat_completions.audio_speech",
+        side_effect=_spy_audio_speech,
+    ):
+        litellm.speech(
+            model="gpt-4o-mini-tts",
+            input="hi",
+            voice="alloy",
+            stream_format="sse",
+            api_key="sk-test",
+        )
+
+    assert captured["optional_params"].get("stream_format") == "sse"
+
+
+@pytest.mark.asyncio
+async def test_async_audio_speech_streams_plain_audio_without_stream_format():
+    """stream_audio=True must stream even without stream_format="sse" (the common case).
+
+    OpenAI's /v1/audio/speech streams audio bytes over chunked transfer for every request, so
+    the proxy must forward incrementally to match calling OpenAI directly with
+    with_streaming_response. Regression: streaming was previously gated on stream_format="sse",
+    so a plain audio request still buffered the full clip."""
+    captured: dict = {}
+    response_cm = _MockAsyncResponseCM()
+    api = OpenAIChatCompletion()
+
+    result = await api.async_audio_speech(
+        model="gpt-4o-mini-tts",
+        input="hello",
+        voice="alloy",
+        optional_params={},  # no stream_format
+        api_key="sk-test",
+        api_base=None,
+        organization=None,
+        project=None,
+        max_retries=0,
+        timeout=600,
+        stream_audio=True,
+        client=_mock_async_client(response_cm, captured),
+    )
+
+    assert isinstance(result, SpeechStreamingResponse)
+    assert response_cm.entered is True
+    assert "stream_format" not in captured  # plain audio, no sse requested
+
+
+@pytest.mark.asyncio
+async def test_async_audio_speech_buffers_when_stream_audio_false():
+    """stream_audio=False must keep the buffered HttpxBinaryResponseContent contract (SDK back-compat)."""
+    from litellm.types.llms.openai import HttpxBinaryResponseContent
+
+    created: dict = {}
+
+    async def _create(**kwargs):
+        created.update(kwargs)
+        inner = MagicMock()
+        inner.response = MagicMock()
+        return inner
+
+    client = MagicMock()
+    client.audio.speech.create = _create
+    # with_streaming_response must NOT be used on the buffered path
+    client.audio.speech.with_streaming_response.create = MagicMock(
+        side_effect=AssertionError("must not open a streaming request when stream_audio=False")
+    )
+    api = OpenAIChatCompletion()
+
+    result = await api.async_audio_speech(
+        model="gpt-4o-mini-tts",
+        input="hello",
+        voice="alloy",
+        optional_params={},
+        api_key="sk-test",
+        api_base=None,
+        organization=None,
+        project=None,
+        max_retries=0,
+        timeout=600,
+        stream_audio=False,
+        client=client,
+    )
+
+    assert isinstance(result, HttpxBinaryResponseContent)
+    assert created["model"] == "gpt-4o-mini-tts"
+
+
+def test_sync_audio_speech_streams_when_stream_audio_true():
+    """Sync audio_speech(stream_audio=True) must open with_streaming_response and return a
+    SpeechStreamingResponse rather than buffering the clip."""
+
+    class _Resp:
+        headers = {"content-type": "audio/mpeg"}
+
+        def iter_bytes(self) -> Iterator[bytes]:
+            yield b"audio-bytes"
+
+    class _CM:
+        def __enter__(self):
+            return _Resp()
+
+        def __exit__(self, *a):
+            return None
+
+    captured: dict = {}
+    client = MagicMock()
+
+    def _create(**kwargs):
+        captured.update(kwargs)
+        return _CM()
+
+    client.audio.speech.with_streaming_response.create = _create
+    api = OpenAIChatCompletion()
+
+    result = api.audio_speech(
+        model="gpt-4o-mini-tts",
+        input="hi",
+        voice="alloy",
+        optional_params={},
+        api_key="sk-test",
+        api_base=None,
+        organization=None,
+        project=None,
+        max_retries=0,
+        timeout=600,
+        stream_audio=True,
+        client=client,
+    )
+
+    assert isinstance(result, SpeechStreamingResponse)
+    assert list(cast(Iterator[bytes], result.stream_iterator)) == [b"audio-bytes"]
+    assert captured["model"] == "gpt-4o-mini-tts"
+
+
+def test_sync_audio_speech_buffers_when_stream_audio_false():
+    """Sync audio_speech(stream_audio=False) must keep the buffered HttpxBinaryResponseContent
+    contract and must not open a streaming request."""
+    from litellm.types.llms.openai import HttpxBinaryResponseContent
+
+    created: dict = {}
+    client = MagicMock()
+
+    def _create(**kwargs):
+        created.update(kwargs)
+        inner = MagicMock()
+        inner.response = MagicMock()
+        return inner
+
+    client.audio.speech.create = _create
+    client.audio.speech.with_streaming_response.create = MagicMock(
+        side_effect=AssertionError("must not open a streaming request when stream_audio=False")
+    )
+    api = OpenAIChatCompletion()
+
+    result = api.audio_speech(
+        model="gpt-4o-mini-tts",
+        input="hi",
+        voice="alloy",
+        optional_params={},
+        api_key="sk-test",
+        api_base=None,
+        organization=None,
+        project=None,
+        max_retries=0,
+        timeout=600,
+        stream_audio=False,
+        client=client,
+    )
+
+    assert isinstance(result, HttpxBinaryResponseContent)
+    assert created["model"] == "gpt-4o-mini-tts"
+
+
+@pytest.mark.asyncio
+async def test_sync_audio_speech_aspeech_forwards_stream_audio():
+    """audio_speech(aspeech=True) delegates to async_audio_speech and must forward stream_audio,
+    so the async streaming path is reached through the sync entrypoint too."""
+    captured: dict = {}
+    response_cm = _MockAsyncResponseCM()
+    api = OpenAIChatCompletion()
+
+    coro = api.audio_speech(
+        model="gpt-4o-mini-tts",
+        input="hi",
+        voice="alloy",
+        optional_params={},
+        api_key="sk-test",
+        api_base=None,
+        organization=None,
+        project=None,
+        max_retries=0,
+        timeout=600,
+        aspeech=True,
+        stream_audio=True,
+        client=_mock_async_client(response_cm, captured),
+    )
+    result = await cast(AsyncIterator, coro)  # type: ignore[arg-type]
+
+    assert isinstance(result, SpeechStreamingResponse)
+    assert response_cm.entered is True
+
+
+def test_sync_audio_speech_streaming_closes_cm_on_error():
+    """An error mid-stream on the sync path must propagate and still close the context manager
+    with the exception info (the else branch of the finally)."""
+
+    class _RaisingResponse:
+        headers: dict = {}
+
+        def iter_bytes(self) -> Iterator[bytes]:
+            yield b"a"
+            raise RuntimeError("stream failed")
+
+    class _CM:
+        def __init__(self):
+            self.exc_info = None
+
+        def __enter__(self):
+            return _RaisingResponse()
+
+        def __exit__(self, exc_type, exc, tb):
+            self.exc_info = (exc_type, exc, tb)
+            return None
+
+    cm = _CM()
+    client = MagicMock()
+    client.audio.speech.with_streaming_response.create = lambda **kw: cm
+    api = OpenAIChatCompletion()
+
+    result = api.audio_speech_streaming(
+        model="gpt-4o-mini-tts",
+        input="hi",
+        voice="alloy",
+        optional_params={"stream_format": "sse"},
+        openai_client=client,  # type: ignore[arg-type]
+    )
+    stream = cast(Iterator[bytes], result.stream_iterator)
+    assert next(stream) == b"a"
+    with pytest.raises(RuntimeError, match="stream failed"):
+        next(stream)
+    assert cm.exc_info is not None and cm.exc_info[0] is RuntimeError
+
+
+def test_speech_forwards_stream_audio_for_openai_compatible_provider():
+    """stream_audio must reach the OpenAI handler for openai-compatible providers like hosted_vllm,
+    not just custom_llm_provider="openai". Regression: voice-agents point at qwen3-tts served as
+    hosted_vllm and need the same transparent default-path streaming as OpenAI."""
+    captured: dict = {}
+
+    def _spy_audio_speech(**kwargs):
+        captured.update(kwargs)
+        return MagicMock(spec=litellm.llms.openai.openai.HttpxBinaryResponseContent)
+
+    with patch(
+        "litellm.main.openai_chat_completions.audio_speech",
+        side_effect=_spy_audio_speech,
+    ):
+        litellm.speech(
+            model="hosted_vllm/qwen3-tts",
+            input="hi",
+            voice="alloy",
+            stream_audio=True,
+            api_base="http://vllm.local/v1",
+            api_key="sk-test",
+        )
+
+    assert captured.get("stream_audio") is True

--- a/tests/test_litellm/proxy/proxy_server/test_routes_audio.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_audio.py
@@ -256,6 +256,38 @@ def test_audio_speech_streaming_honors_provider_content_type(
     assert response.content == b"ID3\x04mp3-bytes"
 
 
+@pytest.fixture
+def patched_speech_no_content_type(monkeypatch):
+    _patch_speech_streaming(
+        monkeypatch,
+        frames=[b"\x00\x01raw-audio-bytes"],
+        content_type=None,
+    )
+    yield
+
+
+@pytest.mark.parametrize("path", ["/v1/audio/speech", "/audio/speech"])
+def test_audio_speech_streaming_fallback_content_type_is_octet_stream(
+    client, auth_as, patched_speech_no_content_type, path
+):
+    """When a streaming provider omits Content-Type, the proxy must fall back to
+    application/octet-stream, never text/event-stream, so raw audio bytes are not
+    mislabeled as SSE frames (Greptile review of #33976)."""
+    payload = {
+        "model": "gpt-4o-mini-tts",
+        "input": "Hi",
+        "voice": "alloy",
+        "stream_format": "sse",
+    }
+    with auth_as():
+        response = client.post(path, json=payload)
+    assert response.status_code == 200
+    content_type = response.headers.get("content-type", "")
+    assert content_type.startswith("application/octet-stream")
+    assert not content_type.startswith("text/event-stream")
+    assert response.content == b"\x00\x01raw-audio-bytes"
+
+
 def test_audio_speech_requests_upstream_streaming(client, auth_as, monkeypatch):
     """The proxy must ask the handler to stream the upstream (stream_audio=True) even for a plain
     request with no stream_format, so it matches OpenAI's always-chunked /v1/audio/speech and does

--- a/tests/test_litellm/proxy/proxy_server/test_routes_audio.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_audio.py
@@ -99,9 +99,7 @@ def patched_transcription(monkeypatch):
         return data
 
     monkeypatch.setattr(proxy_server, "add_litellm_data_to_request", _add_data)
-    monkeypatch.setattr(
-        proxy_server, "check_file_size_under_limit", lambda **kwargs: True
-    )
+    monkeypatch.setattr(proxy_server, "check_file_size_under_limit", lambda **kwargs: True)
 
     async def _form_data(request):
         from starlette.datastructures import FormData, UploadFile
@@ -160,6 +158,150 @@ def test_audio_speech_error(client, auth_as, patched_speech_error, path):
         response = client.post(path, json=payload)
     assert response.status_code == 500
     assert len(response.content) > 0
+
+
+def _patch_speech_streaming(monkeypatch, frames, content_type):
+    monkeypatch.setattr(proxy_server, "llm_router", MagicMock())
+    monkeypatch.setattr(
+        proxy_server,
+        "proxy_logging_obj",
+        MagicMock(
+            pre_call_hook=AsyncMock(side_effect=lambda **kw: kw["data"]),
+            post_call_failure_hook=AsyncMock(),
+            post_call_response_headers_hook=AsyncMock(return_value={}),
+            update_request_status=AsyncMock(),
+        ),
+    )
+
+    async def _add_data(data, **kwargs):
+        return data
+
+    monkeypatch.setattr(proxy_server, "add_litellm_data_to_request", _add_data)
+
+    from litellm.types.llms.openai import SpeechStreamingResponse
+
+    async def _frames():
+        for frame in frames:
+            yield frame
+
+    headers = {"content-type": content_type} if content_type is not None else {}
+
+    async def _llm_call():
+        return SpeechStreamingResponse(stream_iterator=_frames(), headers=headers)
+
+    async def _fake_route_request(*args, **kwargs):
+        return _llm_call()
+
+    monkeypatch.setattr(proxy_server, "route_request", _fake_route_request)
+
+
+@pytest.fixture
+def patched_speech_sse(monkeypatch):
+    _patch_speech_streaming(
+        monkeypatch,
+        frames=[
+            b'data: {"type":"speech.audio.delta","audio":"AAA"}\n\n',
+            b'data: {"type":"speech.audio.done"}\n\n',
+        ],
+        content_type="text/event-stream; charset=utf-8",
+    )
+    yield
+
+
+@pytest.fixture
+def patched_speech_ignored_stream_format(monkeypatch):
+    _patch_speech_streaming(
+        monkeypatch,
+        frames=[b"ID3\x04mp3-bytes"],
+        content_type="audio/mpeg",
+    )
+    yield
+
+
+@pytest.mark.parametrize("path", ["/v1/audio/speech", "/audio/speech"])
+def test_audio_speech_sse_streaming(client, auth_as, patched_speech_sse, path):
+    """Streaming TTS (stream_format='sse') forwards speech.audio.delta frames verbatim as
+    text/event-stream, instead of re-chunking a buffered audio/mpeg blob (regression #33974)."""
+    payload = {
+        "model": "gpt-4o-mini-tts",
+        "input": "Hi",
+        "voice": "alloy",
+        "stream_format": "sse",
+    }
+    with auth_as():
+        response = client.post(path, json=payload)
+    assert response.status_code == 200
+    assert response.headers.get("content-type", "").startswith("text/event-stream")
+    body = response.content
+    assert b"speech.audio.delta" in body
+    assert b"speech.audio.done" in body
+
+
+@pytest.mark.parametrize("path", ["/v1/audio/speech", "/audio/speech"])
+def test_audio_speech_streaming_honors_provider_content_type(
+    client, auth_as, patched_speech_ignored_stream_format, path
+):
+    """When the provider ignores stream_format and returns audio/mpeg (e.g. tts-1), the proxy
+    must forward that content-type verbatim rather than mislabeling the bytes as SSE."""
+    payload = {
+        "model": "tts-1",
+        "input": "Hi",
+        "voice": "alloy",
+        "stream_format": "sse",
+    }
+    with auth_as():
+        response = client.post(path, json=payload)
+    assert response.status_code == 200
+    assert response.headers.get("content-type", "").startswith("audio/mpeg")
+    assert response.content == b"ID3\x04mp3-bytes"
+
+
+def test_audio_speech_requests_upstream_streaming(client, auth_as, monkeypatch):
+    """The proxy must ask the handler to stream the upstream (stream_audio=True) even for a plain
+    request with no stream_format, so it matches OpenAI's always-chunked /v1/audio/speech and does
+    not buffer the full clip. Named stream_audio (not stream) so TTS cost tracking is not skipped."""
+    monkeypatch.setattr(proxy_server, "llm_router", MagicMock())
+    monkeypatch.setattr(
+        proxy_server,
+        "proxy_logging_obj",
+        MagicMock(
+            pre_call_hook=AsyncMock(side_effect=lambda **kw: kw["data"]),
+            post_call_failure_hook=AsyncMock(),
+            post_call_response_headers_hook=AsyncMock(return_value={}),
+            update_request_status=AsyncMock(),
+        ),
+    )
+
+    async def _add_data(data, **kwargs):
+        return data
+
+    monkeypatch.setattr(proxy_server, "add_litellm_data_to_request", _add_data)
+
+    from litellm.types.llms.openai import SpeechStreamingResponse
+
+    captured: dict = {}
+
+    async def _frames():
+        yield b"audio-bytes"
+
+    async def _llm_call():
+        return SpeechStreamingResponse(stream_iterator=_frames(), headers={"content-type": "audio/mpeg"})
+
+    async def _fake_route_request(*args, **kwargs):
+        captured.update(kwargs.get("data", {}))
+        return _llm_call()
+
+    monkeypatch.setattr(proxy_server, "route_request", _fake_route_request)
+
+    payload = {"model": "gpt-4o-mini-tts", "input": "Hi", "voice": "alloy"}
+    with auth_as():
+        response = client.post("/v1/audio/speech", json=payload)
+
+    assert response.status_code == 200
+    assert captured.get("stream_audio") is True
+    assert "stream" not in captured  # must not be "stream" (would skip cost tracking)
+    assert response.headers.get("content-type", "").startswith("audio/mpeg")
+    assert response.content == b"audio-bytes"
 
 
 @pytest.mark.parametrize("path", ["/v1/audio/transcriptions", "/audio/transcriptions"])


### PR DESCRIPTION
## Relevant issues

Fixes #33974

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured end-to-end against a live proxy hitting the real OpenAI API (gpt-4o-mini-tts). The key metric is time-to-first-byte (TTFB) vs total: streaming means first audio arrives well before generation finishes

Plain request, no stream_format (the common case, matching OpenAI's with_streaming_response examples). Before, at 1ebf2a78a9 the proxy buffered the whole clip; after 7286b36a40 it streams incrementally, matching a direct call to OpenAI

```
# after, via litellm proxy, response_format=pcm
$ curl -sN -X POST http://localhost:4000/v1/audio/speech -H "Authorization: Bearer sk-1234" \
    -d '{"model":"gpt-4o-mini-tts","input":"<~250 char passage>","voice":"coral","response_format":"pcm"}' \
    -D - -o /dev/null -w '[timing] ttfb=%{time_starttransfer}s total=%{time_total}s'
content-type: audio/pcm
[timing] ttfb=0.553630s total=2.922757s

# same request straight to OpenAI (us.api.openai.com), for comparison
content-type: audio/pcm
[timing] ttfb=0.978970s total=4.748323s
```

stream_format="sse" request, gpt-4o-mini-tts; frames arrive incrementally as text/event-stream

```
$ curl -sN ... -d '{... ,"stream_format":"sse"}'   # per-frame arrival, relative to request start
+1.148s  frame#1  delta
+1.157s  frame#2  delta
+1.242s  frame#3  delta
+3.807s  frame#59 done
total frames: 60
content-type: text/event-stream; charset=utf-8
```

A model that ignores stream_format (tts-1) is not mislabeled; the proxy forwards the provider's content-type

```
$ curl -s ... -d '{"model":"tts-1", ... ,"stream_format":"sse"}' -D -
content-type: audio/mpeg
```

## Type

🆕 New Feature

## Changes

The proxy /v1/audio/speech awaited the full clip (HttpxBinaryResponseContent) before sending anything, so time-to-first-audio equaled full-generation time. OpenAI's /v1/audio/speech actually streams over chunked transfer for every request (verified: gpt-4o-mini-tts pcm returns first byte at ~0.55s of a ~2.9s clip), so a client reading incrementally got no benefit through litellm

The OpenAI handler can now open the upstream with with_streaming_response and return a SpeechStreamingResponse whose iterator forwards the provider bytes as they arrive. The proxy asks for this on every speech request and forwards the frames labeled with the provider's actual content-type: audio/* for a normal request, or text/event-stream when the caller sets stream_format="sse" (OpenAI's speech.audio.delta frames). There is no hardcoded model list and no payload difference from calling OpenAI directly; a model that ignores stream_format (e.g. tts-1) just streams a correctly-labeled audio clip. This applies to any openai-compatible provider routed through the OpenAI handler (hosted_vllm, etc); other providers keep returning a buffered response

The streaming toggle is an internal stream_audio flag set by the proxy, deliberately kept distinct from "stream" so it does not trip _is_streaming_request and skip cost tracking. litellm.speech()/aspeech() still return the buffered HttpxBinaryResponseContent by default (stream_audio defaults False), so the SDK contract is unchanged. SpeechStreamingResponse is recognized in the success-logging path so streaming TTS records response_cost from the input characters exactly like the buffered path, closing a budget-bypass gap


### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR