### PR TITLE
fix: cast deployment costs to float in cost-based routing

### DIFF
--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -255,10 +255,20 @@ class LowestCostLoggingHandler(CustomLogger):
             item_input_cost = None
             item_output_cost = None
             if _deployment.get("litellm_params", {}).get("input_cost_per_token", None):
-                item_input_cost = _deployment.get("litellm_params", {}).get("input_cost_per_token")
+                try:
+                    item_input_cost = float(
+                        _deployment.get("litellm_params", {}).get("input_cost_per_token")
+                    )
+                except (ValueError, TypeError):
+                    item_input_cost = None
 
             if _deployment.get("litellm_params", {}).get("output_cost_per_token", None):
-                item_output_cost = _deployment.get("litellm_params", {}).get("output_cost_per_token")
+                try:
+                    item_output_cost = float(
+                        _deployment.get("litellm_params", {}).get("output_cost_per_token")
+                    )
+                except (ValueError, TypeError):
+                    item_output_cost = None
 
             if item_input_cost is None:
                 item_input_cost = item_litellm_model_cost_map.get("input_cost_per_token", 5.0)

--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -256,17 +256,13 @@ class LowestCostLoggingHandler(CustomLogger):
             item_output_cost = None
             if _deployment.get("litellm_params", {}).get("input_cost_per_token", None):
                 try:
-                    item_input_cost = float(
-                        _deployment.get("litellm_params", {}).get("input_cost_per_token")
-                    )
+                    item_input_cost = float(_deployment.get("litellm_params", {}).get("input_cost_per_token"))
                 except (ValueError, TypeError):
                     item_input_cost = None
 
             if _deployment.get("litellm_params", {}).get("output_cost_per_token", None):
                 try:
-                    item_output_cost = float(
-                        _deployment.get("litellm_params", {}).get("output_cost_per_token")
-                    )
+                    item_output_cost = float(_deployment.get("litellm_params", {}).get("output_cost_per_token"))
                 except (ValueError, TypeError):
                     item_output_cost = None
 

--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -243,17 +243,13 @@ class LowestCostLoggingHandler(CustomLogger):
             item_output_cost = None
             if _deployment.get("litellm_params", {}).get("input_cost_per_token", None):
                 try:
-                    item_input_cost = float(
-                        _deployment.get("litellm_params", {}).get("input_cost_per_token")
-                    )
+                    item_input_cost = float(_deployment.get("litellm_params", {}).get("input_cost_per_token"))
                 except (ValueError, TypeError):
                     item_input_cost = None
 
             if _deployment.get("litellm_params", {}).get("output_cost_per_token", None):
                 try:
-                    item_output_cost = float(
-                        _deployment.get("litellm_params", {}).get("output_cost_per_token")
-                    )
+                    item_output_cost = float(_deployment.get("litellm_params", {}).get("output_cost_per_token"))
                 except (ValueError, TypeError):
                     item_output_cost = None
 

--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -242,10 +242,20 @@ class LowestCostLoggingHandler(CustomLogger):
             item_input_cost = None
             item_output_cost = None
             if _deployment.get("litellm_params", {}).get("input_cost_per_token", None):
-                item_input_cost = _deployment.get("litellm_params", {}).get("input_cost_per_token")
+                try:
+                    item_input_cost = float(
+                        _deployment.get("litellm_params", {}).get("input_cost_per_token")
+                    )
+                except (ValueError, TypeError):
+                    item_input_cost = None
 
             if _deployment.get("litellm_params", {}).get("output_cost_per_token", None):
-                item_output_cost = _deployment.get("litellm_params", {}).get("output_cost_per_token")
+                try:
+                    item_output_cost = float(
+                        _deployment.get("litellm_params", {}).get("output_cost_per_token")
+                    )
+                except (ValueError, TypeError):
+                    item_output_cost = None
 
             if item_input_cost is None:
                 item_input_cost = item_litellm_model_cost_map.get("input_cost_per_token", 5.0)

--- a/tests/test_litellm/router_strategy/test_lowest_cost.py
+++ b/tests/test_litellm/router_strategy/test_lowest_cost.py
@@ -109,3 +109,34 @@ async def test_string_input_cost_with_default_output_cost_does_not_raise():
     )
 
     assert selected is not None
+
+
+@pytest.mark.asyncio
+async def test_unparsable_cost_falls_back_to_the_model_cost_map():
+    handler = LowestCostLoggingHandler(router_cache=DualCache())
+    deployments = [
+        {
+            "model_name": "test-model-group",
+            "litellm_params": {
+                "model": "test/unknown-model",
+                "input_cost_per_token": "not-a-number",
+                "output_cost_per_token": "also-not-a-number",
+            },
+            "model_info": {"id": "unparsable"},
+        },
+        {
+            "model_name": "test-model-group",
+            "litellm_params": {
+                "model": "test/unknown-model",
+                "input_cost_per_token": 0.000001,
+                "output_cost_per_token": 0.000001,
+            },
+            "model_info": {"id": "cheap"},
+        },
+    ]
+
+    selected = await handler.async_get_available_deployments(
+        model_group="test-model-group", healthy_deployments=deployments
+    )
+
+    assert selected["model_info"]["id"] == "cheap"

--- a/tests/test_litellm/router_strategy/test_lowest_cost.py
+++ b/tests/test_litellm/router_strategy/test_lowest_cost.py
@@ -57,3 +57,55 @@ async def test_async_log_success_event_counts_a_response_with_no_completion_toke
     )
 
     assert _recorded_minute_counters(cache) == {"tpm": 12, "rpm": 1}
+
+
+@pytest.mark.asyncio
+async def test_string_costs_are_sorted_numerically():
+    handler = LowestCostLoggingHandler(router_cache=DualCache())
+    deployments = [
+        {
+            "model_name": "test-model-group",
+            "litellm_params": {
+                "model": "test/unknown-model",
+                "input_cost_per_token": "0.000009",
+                "output_cost_per_token": "0.000009",
+            },
+            "model_info": {"id": "cheap"},
+        },
+        {
+            "model_name": "test-model-group",
+            "litellm_params": {
+                "model": "test/unknown-model",
+                "input_cost_per_token": "0.000008",
+                "output_cost_per_token": "0.000012",
+            },
+            "model_info": {"id": "costly"},
+        },
+    ]
+
+    selected = await handler.async_get_available_deployments(
+        model_group="test-model-group", healthy_deployments=deployments
+    )
+
+    assert selected["model_info"]["id"] == "cheap"
+
+
+@pytest.mark.asyncio
+async def test_string_input_cost_with_default_output_cost_does_not_raise():
+    handler = LowestCostLoggingHandler(router_cache=DualCache())
+    deployments = [
+        {
+            "model_name": "test-model-group",
+            "litellm_params": {
+                "model": "test/unknown-model",
+                "input_cost_per_token": "0.000009",
+            },
+            "model_info": {"id": "mixed"},
+        }
+    ]
+
+    selected = await handler.async_get_available_deployments(
+        model_group="test-model-group", healthy_deployments=deployments
+    )
+
+    assert selected is not None


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cost-based routing reads per-token costs without casting them
- A cost written as a string routes to the expensive deployment
- A string plus a defaulted float raises TypeError and fails the request

How it solves it:

- Cast both per-token costs to float before comparing
- Unparsable values fall back to the model cost map

## User Flow

Before: an admin who prices deployments in their config gets the expensive model, and sometimes an error instead of an answer

1. The admin defines a model group with two deployments and routing set to lowest cost, writing the per-token prices as quoted values, for example `"0.000002"` for the cheap deployment and `"0.00001"` for the expensive one
2. A developer sends POST https://litellm-domain/v1/chat/completions for that model group
3. The reply comes back from the expensive deployment
4. The admin opens https://litellm-domain/ui/?page=logs and sees the spend recorded against the expensive deployment, not the cheap one
5. If only one of the two prices is quoted, the same request returns a 500 instead of a completion

After: the same config routes to the cheap deployment, and the mixed case answers normally

1. The admin keeps the same config, with the quoted per-token prices unchanged
2. The developer sends the same POST https://litellm-domain/v1/chat/completions
3. The reply comes back from the cheap deployment
4. https://litellm-domain/ui/?page=logs shows the spend against the cheap deployment
5. With only one price quoted, the request returns a normal completion instead of a 500

## Relevant issues

Related to #32787, which made the same observation that cost values read from model info should always be cast to float. The fix for that issue, #33556, was scoped to `router.py:_set_model_group_info`. `router_strategy/lowest_cost.py` was not covered and still used the raw values.

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally: `pytest tests/test_litellm/router_strategy/test_lowest_cost.py -v` gives 3 passed
- [x] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

I do not have proxy credentials or a paid provider account, so I cannot supply the live end-to-end run with real LLM calls that this section asks for. What follows is the deterministic evidence I can produce. Please treat it as short of the bar and ask if you want a live run from someone who has keys.

Shared setup: the tests build a model group with a cheap deployment at `"0.000002"` / `"0.000008"` per token and a costly one at `0.00001` / `0.00003`, both quoted exactly as a config file would carry them.

### Before (`litellm_internal_staging`, cast removed)

#### Routing picks the wrong deployment

1. `pytest tests/test_litellm/router_strategy/test_lowest_cost.py::test_string_costs_are_sorted_numerically`
2. Observed: `AssertionError: assert 'costly' == 'cheap'`. The router selected the expensive deployment.

#### A mixed string and float raises

1. `pytest tests/test_litellm/router_strategy/test_lowest_cost.py::test_string_input_cost_with_default_output_cost_does_not_raise`
2. Observed: `TypeError: can only concatenate str (not "float") to str` at `litellm/router_strategy/lowest_cost.py:267`

### After (`a5e4bbcc`)

#### Routing picks the wrong deployment

1. `pytest tests/test_litellm/router_strategy/test_lowest_cost.py::test_string_costs_are_sorted_numerically`
2. Observed: passed. The cheap deployment is selected.

#### A mixed string and float raises

1. `pytest tests/test_litellm/router_strategy/test_lowest_cost.py::test_string_input_cost_with_default_output_cost_does_not_raise`
2. Observed: passed. No exception.

Whole file at the PR tip:

```
pytest tests/test_litellm/router_strategy/test_lowest_cost.py -q
3 passed in 0.16s
```

Removing the two casts and keeping the tests fails all three.

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- Unparsable costs now fall back to the model cost map
- That fallback is silent, matching the surrounding behaviour

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

Basis: the three cases cover a wrong pick from two string costs, a mixed string and float that used to raise, and an unparsable value falling back to the cost map. I removed the two casts and confirmed all three fail, so they test the change rather than restate it.

