### PR TITLE
fix(anthropic): strip uniqueItems + other unsupported array/object constraints from output_format schema

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -553,12 +553,8 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 # Sub-schema constraints (e.g. ``contains``) are serialized as JSON so
                 # the advisory note preserves what the constraint actually required,
                 # instead of just noting that it existed.
-                note_value = (
-                    json.dumps(value) if isinstance(value, (dict, list)) else value
-                )
-                constraint_descriptions.append(
-                    constraint_labels[field].format(note_value)
-                )
+                note_value = json.dumps(value) if isinstance(value, (dict, list)) else value
+                constraint_descriptions.append(constraint_labels[field].format(note_value))
 
         result: Dict[str, Any] = {}
 

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -478,10 +478,15 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         """
         Filter out unsupported fields from JSON schema for Anthropic's output_format API.
 
-        Anthropic's output_format doesn't support certain JSON schema properties:
-        - maxItems/minItems: Not supported for array types
-        - minimum/maximum: Not supported for numeric types
-        - minLength/maxLength: Not supported for string types
+        Anthropic's output_format doesn't support certain JSON schema properties.
+        These are cross-element / count constraints that cannot be enforced by the
+        constrained-decoding grammar Anthropic compiles the schema into, so the API
+        rejects them with a 400 ``invalid_request_error`` (e.g. "output_format.schema:
+        For 'array' type, property 'uniqueItems' is not supported"):
+        - maxItems/minItems/uniqueItems/contains/minContains/maxContains: array constraints
+        - minimum/maximum/exclusiveMinimum/exclusiveMaximum: numeric constraints
+        - minLength/maxLength: string constraints
+        - minProperties/maxProperties: object constraints
 
         This mirrors the transformation done by the Anthropic Python SDK.
         See: https://platform.claude.com/docs/en/build-with-claude/structured-outputs#how-sdk-transformation-works
@@ -502,16 +507,22 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         if not isinstance(schema, dict):
             return schema
 
-        # All numeric/string/array constraints not supported by Anthropic
+        # All numeric/string/array/object constraints not supported by Anthropic
         unsupported_fields = {
             "maxItems",
-            "minItems",  # array constraints
+            "minItems",
+            "uniqueItems",
+            "contains",
+            "minContains",
+            "maxContains",  # array constraints
             "minimum",
             "maximum",  # numeric constraints
             "exclusiveMinimum",
             "exclusiveMaximum",  # numeric constraints
             "minLength",
             "maxLength",  # string constraints
+            "minProperties",
+            "maxProperties",  # object constraints
         }
 
         # Build description additions from removed constraints
@@ -519,16 +530,27 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         constraint_labels = {
             "minItems": "minimum number of items: {}",
             "maxItems": "maximum number of items: {}",
+            "uniqueItems": "all array items must be unique",
+            "contains": "array must contain an item matching a schema",
+            "minContains": "minimum number of matching items: {}",
+            "maxContains": "maximum number of matching items: {}",
             "minimum": "minimum value: {}",
             "maximum": "maximum value: {}",
             "exclusiveMinimum": "exclusive minimum value: {}",
             "exclusiveMaximum": "exclusive maximum value: {}",
             "minLength": "minimum length: {}",
             "maxLength": "maximum length: {}",
+            "minProperties": "minimum number of properties: {}",
+            "maxProperties": "maximum number of properties: {}",
         }
         for field in unsupported_fields:
             if field in schema:
-                constraint_descriptions.append(constraint_labels[field].format(schema[field]))
+                value = schema[field]
+                # A falsy boolean constraint (e.g. ``uniqueItems: false``) imposes no
+                # real requirement, so don't add a misleading advisory note for it.
+                if isinstance(value, bool) and not value:
+                    continue
+                constraint_descriptions.append(constraint_labels[field].format(value))
 
         result: Dict[str, Any] = {}
 

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -531,7 +531,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             "minItems": "minimum number of items: {}",
             "maxItems": "maximum number of items: {}",
             "uniqueItems": "all array items must be unique",
-            "contains": "array must contain an item matching a schema",
+            "contains": "array must contain an item matching: {}",
             "minContains": "minimum number of matching items: {}",
             "maxContains": "maximum number of matching items: {}",
             "minimum": "minimum value: {}",
@@ -550,7 +550,15 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 # real requirement, so don't add a misleading advisory note for it.
                 if isinstance(value, bool) and not value:
                     continue
-                constraint_descriptions.append(constraint_labels[field].format(value))
+                # Sub-schema constraints (e.g. ``contains``) are serialized as JSON so
+                # the advisory note preserves what the constraint actually required,
+                # instead of just noting that it existed.
+                note_value = (
+                    json.dumps(value) if isinstance(value, (dict, list)) else value
+                )
+                constraint_descriptions.append(
+                    constraint_labels[field].format(note_value)
+                )
 
         result: Dict[str, Any] = {}
 

--- a/tests/litellm/llms/anthropic/test_anthropic_schema_filter.py
+++ b/tests/litellm/llms/anthropic/test_anthropic_schema_filter.py
@@ -45,21 +45,14 @@ class TestFilterAnthropicOutputSchema:
         assert "minimum value: 0" in result["properties"]["age"]["description"]
         assert "maximum value: 150" in result["properties"]["age"]["description"]
         # Score had no description, should get one from constraints
-        assert (
-            "exclusive minimum value: 0" in result["properties"]["score"]["description"]
-        )
-        assert (
-            "exclusive maximum value: 100"
-            in result["properties"]["score"]["description"]
-        )
+        assert "exclusive minimum value: 0" in result["properties"]["score"]["description"]
+        assert "exclusive maximum value: 100" in result["properties"]["score"]["description"]
 
     def test_removes_string_constraints(self):
         """Test that minLength/maxLength are removed from string schemas."""
         schema = {
             "type": "object",
-            "properties": {
-                "name": {"type": "string", "minLength": 1, "maxLength": 100}
-            },
+            "properties": {"name": {"type": "string", "minLength": 1, "maxLength": 100}},
         }
 
         result = AnthropicConfig.filter_anthropic_output_schema(schema)
@@ -178,10 +171,7 @@ class TestFilterAnthropicOutputSchema:
         assert "uniqueItems" not in result["properties"]["tags"]
         assert result["properties"]["tags"]["items"] == {"type": "string"}
         # Constraint intent preserved in the description
-        assert (
-            "all array items must be unique"
-            in result["properties"]["tags"]["description"]
-        )
+        assert "all array items must be unique" in result["properties"]["tags"]["description"]
 
     def test_removes_contains_constraints(self):
         """Test that contains/minContains/maxContains are removed from arrays."""

--- a/tests/litellm/llms/anthropic/test_anthropic_schema_filter.py
+++ b/tests/litellm/llms/anthropic/test_anthropic_schema_filter.py
@@ -199,7 +199,10 @@ class TestFilterAnthropicOutputSchema:
         assert "minContains" not in result
         assert "maxContains" not in result
         assert result["items"] == {"type": "integer"}
-        assert "array must contain an item matching a schema" in result["description"]
+        # The contains sub-schema is serialized into the advisory note so the model
+        # knows what item the array must contain.
+        assert "array must contain an item matching:" in result["description"]
+        assert '"const": 1' in result["description"]
         assert "minimum number of matching items: 1" in result["description"]
         assert "maximum number of matching items: 3" in result["description"]
 

--- a/tests/litellm/llms/anthropic/test_anthropic_schema_filter.py
+++ b/tests/litellm/llms/anthropic/test_anthropic_schema_filter.py
@@ -154,3 +154,81 @@ class TestFilterAnthropicOutputSchema:
         result = AnthropicConfig.filter_anthropic_output_schema(schema)
 
         assert result == schema  # Should be unchanged
+
+    def test_removes_uniqueitems(self):
+        """Test that uniqueItems is removed from array schemas.
+
+        Reproduces the 400 ``invalid_request_error``:
+        "output_format.schema: For 'array' type, property 'uniqueItems' is not
+        supported".
+        """
+        schema = {
+            "type": "object",
+            "properties": {
+                "tags": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "uniqueItems": True,
+                }
+            },
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert "uniqueItems" not in result["properties"]["tags"]
+        assert result["properties"]["tags"]["items"] == {"type": "string"}
+        # Constraint intent preserved in the description
+        assert (
+            "all array items must be unique"
+            in result["properties"]["tags"]["description"]
+        )
+
+    def test_removes_contains_constraints(self):
+        """Test that contains/minContains/maxContains are removed from arrays."""
+        schema = {
+            "type": "array",
+            "items": {"type": "integer"},
+            "contains": {"type": "integer", "const": 1},
+            "minContains": 1,
+            "maxContains": 3,
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert "contains" not in result
+        assert "minContains" not in result
+        assert "maxContains" not in result
+        assert result["items"] == {"type": "integer"}
+        assert "array must contain an item matching a schema" in result["description"]
+        assert "minimum number of matching items: 1" in result["description"]
+        assert "maximum number of matching items: 3" in result["description"]
+
+    def test_removes_object_property_constraints(self):
+        """Test that minProperties/maxProperties are removed from object schemas."""
+        schema = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "minProperties": 1,
+            "maxProperties": 5,
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert "minProperties" not in result
+        assert "maxProperties" not in result
+        assert "minimum number of properties: 1" in result["description"]
+        assert "maximum number of properties: 5" in result["description"]
+
+    def test_uniqueitems_false_skips_misleading_note(self):
+        """``uniqueItems: false`` is stripped but must not add a 'unique' note."""
+        schema = {
+            "type": "array",
+            "items": {"type": "string"},
+            "uniqueItems": False,
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert "uniqueItems" not in result
+        # A disabled constraint imposes no requirement -> no advisory note
+        assert "unique" not in result.get("description", "")

--- a/tests/test_litellm/llms/anthropic/test_anthropic_output_format_filter.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_output_format_filter.py
@@ -1,0 +1,73 @@
+"""
+Coverage for filter_anthropic_output_schema's array/object constraint stripping.
+
+Mirrors tests/litellm/llms/anthropic/test_anthropic_schema_filter.py, but lives
+under tests/test_litellm/ so the coverage-uploading CI job exercises the newly
+added keyword handling (uniqueItems / contains / minProperties / maxProperties)
+and the ``uniqueItems: false`` branch.
+"""
+
+from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+
+
+class TestOutputFormatArrayObjectConstraints:
+    def test_removes_uniqueitems(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "tags": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "uniqueItems": True,
+                }
+            },
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert "uniqueItems" not in result["properties"]["tags"]
+        assert "all array items must be unique" in result["properties"]["tags"]["description"]
+
+    def test_uniqueitems_false_skips_misleading_note(self):
+        schema = {
+            "type": "array",
+            "items": {"type": "string"},
+            "uniqueItems": False,
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert "uniqueItems" not in result
+        assert "unique" not in result.get("description", "")
+
+    def test_removes_contains_constraints(self):
+        schema = {
+            "type": "array",
+            "items": {"type": "integer"},
+            "contains": {"type": "integer", "const": 1},
+            "minContains": 1,
+            "maxContains": 3,
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert "contains" not in result
+        assert "minContains" not in result
+        assert "maxContains" not in result
+        assert "array must contain an item matching:" in result["description"]
+        assert '"const": 1' in result["description"]
+
+    def test_removes_object_property_constraints(self):
+        schema = {
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "minProperties": 1,
+            "maxProperties": 5,
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert "minProperties" not in result
+        assert "maxProperties" not in result
+        assert "minimum number of properties: 1" in result["description"]
+        assert "maximum number of properties: 5" in result["description"]


### PR DESCRIPTION
## Relevant issues

No existing issue tracks the `uniqueItems` gap specifically. Related prior work on this same filter: #19444 (the filter's own tracking issue), #21045, #22447, #22500, #29203 and #29624 (stripping numeric/count/length constraints for Anthropic and Bedrock structured outputs), and #18625 / #19201 (why `vertex_ai` Claude avoids this path; it is forced onto tool-use, which ignores these keywords)

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Anthropic's structured outputs compile the `output_format` JSON schema into a constrained-decoding grammar and reject keywords the grammar cannot enforce with a 400 `invalid_request_error`, e.g. `output_format.schema: For 'array' type, property 'uniqueItems' is not supported`. `filter_anthropic_output_schema` already strips `minimum/maximum/exclusiveMinimum/exclusiveMaximum/minLength/maxLength/minItems/maxItems` into description notes, but not `uniqueItems`, `contains/minContains/maxContains`, or `minProperties/maxProperties`, so those reached the API and 400'd. `vertex_ai` Claude is unaffected because it is routed through tool-use emulation (`input_schema`), which silently ignores these keywords; that asymmetry is what made this easy to miss

All runs below are fully e2e with zero mocks: a live LiteLLM proxy in front of a real Azure AI Foundry Claude deployment (`azure_ai/claude-sonnet-4-6`), costing real $. The before run is at `fcd236097e` (current `litellm_internal_staging` tip, pre-fix); the after run is at this PR's head `dba83b71ba`. Same five requests both times, each a `response_format: json_schema` call whose schema carries one group of unsupported keywords:

| Schema keyword(s)                    | Before `fcd236097e` | After `dba83b71ba` |
| ------------------------------------ | ------------------- | ------------------ |
| none (control)                       | 200                 | 200                |
| `uniqueItems`                        | 400                 | 200                |
| `contains`+`minContains`+`maxContains` | 400               | 200                |
| `minProperties`+`maxProperties`      | 400                 | 200                |
| `multipleOf` (not in this PR)        | 400                 | 400                |

Example request (the `uniqueItems` case; the other payloads differ only in which keyword they set):

```bash
curl -sS "http://localhost:$PORT/v1/chat/completions" \
  -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' -d '{
    "model": "claude-sonnet-4-6",
    "messages": [{"role": "user", "content": "List three distinct colors."}],
    "response_format": {"type": "json_schema", "json_schema": {"name": "colors", "schema": {
      "type": "object",
      "properties": {"colors": {"type": "array", "items": {"type": "string"}, "uniqueItems": true}},
      "required": ["colors"], "additionalProperties": false}}}
  }'
```

Raw results, before (`fcd236097e`):

```
clean            | HTTP 200 | {"colors":["red","blue","green"]}
uniqueItems      | HTTP 400 | output_format.schema: For 'array' type, property 'uniqueItems' is not supported
contains         | HTTP 400 | output_format.schema: For 'array' type, property 'contains' is not supported
minMaxProperties | HTTP 400 | output_format.schema: For 'object' type, property 'minProperties' is not supported
multipleOf       | HTTP 400 | output_format.schema: For 'integer' type, property 'multipleOf' is not supported
```

Raw results, after (`dba83b71ba`):

```
clean            | HTTP 200 | {"colors":["red","blue","green"]}
uniqueItems      | HTTP 200 | {"colors":["red","green","blue"]}
contains         | HTTP 200 | {"nums":[1,2,3]}
minMaxProperties | HTTP 200 | {"city":"Paris"}
multipleOf       | HTTP 400 | output_format.schema: For 'integer' type, property 'multipleOf' is not supported
```

The `multipleOf` row shows the strip list is still not exhaustive after this PR; it fails identically before and after and is left for a follow-up, since this PR only targets the array/object keywords that were reported failing. These keywords are also confirmed rejected by the Anthropic API directly (not an Azure quirk): the same schemas 400 against `api.anthropic.com` with the `structured-outputs-2025-11-13` beta header

## Type

🐛 Bug Fix

## Changes

`litellm/llms/anthropic/chat/transformation.py`: add `uniqueItems`, `contains`, `minContains`, `maxContains`, `minProperties`, `maxProperties` to `filter_anthropic_output_schema`'s `unsupported_fields` set and `constraint_labels` map, so they are stripped from the `output_format` schema and their intent is moved into the field description, exactly as already done for the numeric/length constraints and as the Anthropic SDK does. A disabled boolean constraint (`uniqueItems: false`) is stripped without adding a misleading advisory note, and sub-schema constraints (`contains`) are JSON-serialized into the note so the requirement is preserved

Tests: `tests/litellm/llms/anthropic/test_anthropic_schema_filter.py` covers `uniqueItems`, `contains/minContains/maxContains`, `minProperties/maxProperties`, and the `uniqueItems: false` edge case; `tests/test_litellm/llms/anthropic/test_anthropic_output_format_filter.py` mirrors them so the coverage-uploading CI job exercises the new branches

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
