### PR TITLE
fix(cloudflare): flatten OpenAI content-part message arrays to a string

### DIFF
--- a/litellm/llms/cloudflare/chat/transformation.py
+++ b/litellm/llms/cloudflare/chat/transformation.py
@@ -1,8 +1,11 @@
-from typing import List, Optional, Union
+from typing import Any, Coroutine, List, Literal, Optional, Union, overload
 
 import httpx
 
 from litellm._logging import verbose_logger
+from litellm.litellm_core_utils.prompt_templates.common_utils import (
+    handle_messages_with_content_list_to_str_conversion,
+)
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
 from litellm.secret_managers.main import (
@@ -85,6 +88,32 @@ class CloudflareChatConfig(OpenAIGPTConfig):
             api_key=api_key,
             api_base=api_base,
         )
+
+    @overload
+    def _transform_messages(
+        self, messages: List[AllMessageValues], model: str, is_async: Literal[True]
+    ) -> Coroutine[Any, Any, List[AllMessageValues]]: ...
+
+    @overload
+    def _transform_messages(
+        self,
+        messages: List[AllMessageValues],
+        model: str,
+        is_async: Literal[False] = False,
+    ) -> List[AllMessageValues]: ...
+
+    def _transform_messages(
+        self, messages: List[AllMessageValues], model: str, is_async: bool = False
+    ) -> Union[List[AllMessageValues], Coroutine[Any, Any, List[AllMessageValues]]]:
+        """
+        Cloudflare Workers AI requires message content to be a string, so OpenAI
+        content-part arrays have to be flattened before the request is sent
+        """
+        messages = handle_messages_with_content_list_to_str_conversion(messages)
+        if is_async:
+            return super()._transform_messages(messages=messages, model=model, is_async=True)
+        else:
+            return super()._transform_messages(messages=messages, model=model, is_async=False)
 
     def get_error_class(
         self, error_message: str, status_code: int, headers: Union[dict, httpx.Headers]

--- a/litellm/llms/cloudflare/chat/transformation.py
+++ b/litellm/llms/cloudflare/chat/transformation.py
@@ -91,20 +91,20 @@ class CloudflareChatConfig(OpenAIGPTConfig):
 
     @overload
     def _transform_messages(
-        self, messages: List[AllMessageValues], model: str, is_async: Literal[True]
-    ) -> Coroutine[Any, Any, List[AllMessageValues]]: ...
+        self, messages: list[AllMessageValues], model: str, is_async: Literal[True]
+    ) -> Coroutine[Any, Any, list[AllMessageValues]]: ...
 
     @overload
     def _transform_messages(
         self,
-        messages: List[AllMessageValues],
+        messages: list[AllMessageValues],
         model: str,
         is_async: Literal[False] = False,
-    ) -> List[AllMessageValues]: ...
+    ) -> list[AllMessageValues]: ...
 
     def _transform_messages(
-        self, messages: List[AllMessageValues], model: str, is_async: bool = False
-    ) -> Union[List[AllMessageValues], Coroutine[Any, Any, List[AllMessageValues]]]:
+        self, messages: list[AllMessageValues], model: str, is_async: bool = False
+    ) -> Union[list[AllMessageValues], Coroutine[Any, Any, list[AllMessageValues]]]:
         """
         Cloudflare Workers AI requires message content to be a string, so OpenAI
         content-part arrays have to be flattened before the request is sent

--- a/litellm/llms/cloudflare/chat/transformation.py
+++ b/litellm/llms/cloudflare/chat/transformation.py
@@ -89,30 +89,31 @@ class CloudflareChatConfig(OpenAIGPTConfig):
             api_base=api_base,
         )
 
+    # fmt: off
+    # The signature mirrors OpenAIGPTConfig._transform_messages, which is overloaded
+    # on is_async; the annotations below are the base's own.
     @overload
-    def _transform_messages(
-        self, messages: list[AllMessageValues], model: str, is_async: Literal[True]
-    ) -> Coroutine[Any, Any, list[AllMessageValues]]: ...
+    def _transform_messages(  # mutable-ok: base signature
+        self, messages: list[AllMessageValues], model: str, is_async: Literal[True]  # mutable-ok: base signature
+    ) -> Coroutine[Any, Any, list[AllMessageValues]]: ...  # mutable-ok: base signature
 
     @overload
-    def _transform_messages(
-        self,
-        messages: list[AllMessageValues],
-        model: str,
-        is_async: Literal[False] = False,
-    ) -> list[AllMessageValues]: ...
+    def _transform_messages(  # mutable-ok: base signature
+        self, messages: list[AllMessageValues], model: str, is_async: Literal[False] = False  # mutable-ok: base signature
+    ) -> list[AllMessageValues]: ...  # mutable-ok: base signature
 
-    def _transform_messages(
-        self, messages: list[AllMessageValues], model: str, is_async: bool = False
-    ) -> list[AllMessageValues] | Coroutine[Any, Any, list[AllMessageValues]]:
+    def _transform_messages(  # mutable-ok: base signature
+        self, messages: list[AllMessageValues], model: str, is_async: bool = False  # mutable-ok: base signature
+    ) -> list[AllMessageValues] | Coroutine[Any, Any, list[AllMessageValues]]:  # mutable-ok: base signature
+        # fmt: on
         """
         Cloudflare Workers AI requires message content to be a string, so OpenAI
         content-part arrays have to be flattened before the request is sent
         """
-        messages = handle_messages_with_content_list_to_str_conversion(messages)
+        flattened: Final = handle_messages_with_content_list_to_str_conversion(messages)
         if is_async:
-            return super()._transform_messages(messages=messages, model=model, is_async=True)
-        return super()._transform_messages(messages=messages, model=model, is_async=False)
+            return super()._transform_messages(messages=flattened, model=model, is_async=True)
+        return super()._transform_messages(messages=flattened, model=model, is_async=False)
 
     def get_error_class(self, error_message: str, status_code: int, headers: dict | httpx.Headers) -> BaseLLMException:
         return CloudflareError(

--- a/litellm/llms/cloudflare/chat/transformation.py
+++ b/litellm/llms/cloudflare/chat/transformation.py
@@ -1,4 +1,5 @@
-from typing import Any, Coroutine, Final, Literal, overload
+from collections.abc import Coroutine
+from typing import Any, Final, Literal, overload
 
 import httpx
 
@@ -99,7 +100,7 @@ class CloudflareChatConfig(OpenAIGPTConfig):
 
     @overload
     def _transform_messages(  # mutable-ok: base signature
-        self, messages: list[AllMessageValues], model: str, is_async: Literal[False] = False  # mutable-ok: base signature
+        self, messages: list[AllMessageValues], model: str, is_async: Literal[False] = False  # mutable-ok: base sig
     ) -> list[AllMessageValues]: ...  # mutable-ok: base signature
 
     def _transform_messages(  # mutable-ok: base signature

--- a/litellm/llms/cloudflare/chat/transformation.py
+++ b/litellm/llms/cloudflare/chat/transformation.py
@@ -1,5 +1,5 @@
 from collections.abc import Coroutine
-from typing import Any, Final, Literal, overload
+from typing import Any, Final, Literal, overload  # noqa: TID251  # Any only appears in the base overload's Coroutine[Any, Any, ...]
 
 import httpx
 

--- a/litellm/llms/cloudflare/chat/transformation.py
+++ b/litellm/llms/cloudflare/chat/transformation.py
@@ -1,5 +1,10 @@
 from collections.abc import Coroutine
-from typing import Any, Final, Literal, overload  # noqa: TID251  # Any only appears in the base overload's Coroutine[Any, Any, ...]
+from typing import (  # noqa: TID251  # Any only appears in the base overload's Coroutine[Any, Any, ...]
+    Any,
+    Final,
+    Literal,
+    overload,
+)
 
 import httpx
 

--- a/litellm/llms/cloudflare/chat/transformation.py
+++ b/litellm/llms/cloudflare/chat/transformation.py
@@ -1,8 +1,11 @@
-from typing import Final
+from typing import Any, Coroutine, Final, Literal, overload
 
 import httpx
 
 from litellm._logging import verbose_logger
+from litellm.litellm_core_utils.prompt_templates.common_utils import (
+    handle_messages_with_content_list_to_str_conversion,
+)
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
 from litellm.secret_managers.main import (
@@ -85,6 +88,31 @@ class CloudflareChatConfig(OpenAIGPTConfig):
             api_key=api_key,
             api_base=api_base,
         )
+
+    @overload
+    def _transform_messages(
+        self, messages: list[AllMessageValues], model: str, is_async: Literal[True]
+    ) -> Coroutine[Any, Any, list[AllMessageValues]]: ...
+
+    @overload
+    def _transform_messages(
+        self,
+        messages: list[AllMessageValues],
+        model: str,
+        is_async: Literal[False] = False,
+    ) -> list[AllMessageValues]: ...
+
+    def _transform_messages(
+        self, messages: list[AllMessageValues], model: str, is_async: bool = False
+    ) -> list[AllMessageValues] | Coroutine[Any, Any, list[AllMessageValues]]:
+        """
+        Cloudflare Workers AI requires message content to be a string, so OpenAI
+        content-part arrays have to be flattened before the request is sent
+        """
+        messages = handle_messages_with_content_list_to_str_conversion(messages)
+        if is_async:
+            return super()._transform_messages(messages=messages, model=model, is_async=True)
+        return super()._transform_messages(messages=messages, model=model, is_async=False)
 
     def get_error_class(self, error_message: str, status_code: int, headers: dict | httpx.Headers) -> BaseLLMException:
         return CloudflareError(

--- a/litellm/llms/cloudflare/chat/transformation.py
+++ b/litellm/llms/cloudflare/chat/transformation.py
@@ -1,10 +1,5 @@
 from collections.abc import Coroutine
-from typing import (  # noqa: TID251  # Any only appears in the base overload's Coroutine[Any, Any, ...]
-    Any,
-    Final,
-    Literal,
-    overload,
-)
+from typing import Final, Literal, overload
 
 import httpx
 
@@ -101,7 +96,7 @@ class CloudflareChatConfig(OpenAIGPTConfig):
     @overload
     def _transform_messages(  # mutable-ok: base signature
         self, messages: list[AllMessageValues], model: str, is_async: Literal[True]  # mutable-ok: base signature
-    ) -> Coroutine[Any, Any, list[AllMessageValues]]: ...  # mutable-ok: base signature
+    ) -> Coroutine[object, object, list[AllMessageValues]]: ...  # mutable-ok: base signature
 
     @overload
     def _transform_messages(  # mutable-ok: base signature
@@ -110,7 +105,7 @@ class CloudflareChatConfig(OpenAIGPTConfig):
 
     def _transform_messages(  # mutable-ok: base signature
         self, messages: list[AllMessageValues], model: str, is_async: bool = False  # mutable-ok: base signature
-    ) -> list[AllMessageValues] | Coroutine[Any, Any, list[AllMessageValues]]:  # mutable-ok: base signature
+    ) -> list[AllMessageValues] | Coroutine[object, object, list[AllMessageValues]]:  # mutable-ok: base signature
         # fmt: on
         """
         Cloudflare Workers AI requires message content to be a string, so OpenAI

--- a/tests/test_litellm/llms/cloudflare/test_cloudflare_transformation.py
+++ b/tests/test_litellm/llms/cloudflare/test_cloudflare_transformation.py
@@ -162,6 +162,47 @@ def test_transform_request_passes_tools_through_in_openai_format():
     assert body["tool_choice"] == "auto"
 
 
+def test_transform_request_flattens_content_part_arrays_to_string():
+    config = CloudflareChatConfig()
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Hello"},
+                {"type": "text", "text": "More text"},
+            ],
+        }
+    ]
+
+    body = config.transform_request(
+        model="@cf/meta/llama-2-7b-chat-int8",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+
+    assert body["messages"][0]["content"] == "HelloMore text"
+
+
+def test_transform_request_leaves_string_content_untouched():
+    config = CloudflareChatConfig()
+    messages = [
+        {"role": "system", "content": "you are terse"},
+        {"role": "user", "content": "weather in nyc?"},
+    ]
+
+    body = config.transform_request(
+        model="@cf/meta/llama-2-7b-chat-int8",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+
+    assert [m["content"] for m in body["messages"]] == ["you are terse", "weather in nyc?"]
+
+
 def test_validate_environment_requires_api_key():
     config = CloudflareChatConfig()
 

--- a/tests/test_litellm/llms/cloudflare/test_cloudflare_transformation.py
+++ b/tests/test_litellm/llms/cloudflare/test_cloudflare_transformation.py
@@ -190,3 +190,44 @@ def test_validate_environment_sets_bearer_and_content_type():
 
     assert headers["Authorization"] == "Bearer cf-key"
     assert headers["Content-Type"] == "application/json"
+
+
+def test_transform_request_flattens_content_part_arrays_to_string():
+    config = CloudflareChatConfig()
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Hello"},
+                {"type": "text", "text": "More text"},
+            ],
+        }
+    ]
+
+    body = config.transform_request(
+        model="@cf/meta/llama-2-7b-chat-int8",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+
+    assert body["messages"][0]["content"] == "HelloMore text"
+
+
+def test_transform_request_leaves_string_content_untouched():
+    config = CloudflareChatConfig()
+    messages = [
+        {"role": "system", "content": "you are terse"},
+        {"role": "user", "content": "weather in nyc?"},
+    ]
+
+    body = config.transform_request(
+        model="@cf/meta/llama-2-7b-chat-int8",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+
+    assert [m["content"] for m in body["messages"]] == ["you are terse", "weather in nyc?"]


### PR DESCRIPTION
## Relevant issues

Fixes #33984

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

I do not have Cloudflare Workers AI credentials, so I cannot show a live proxy round trip against the real API. What I can show is the request body litellm builds, which is the payload Cloudflare rejects in the issue

Before, on the current daily OSS branch:

```
$ python -c "
import copy
from litellm.llms.cloudflare.chat.transformation import CloudflareChatConfig
msgs=[{'role':'user','content':[{'type':'text','text':'Hello'},{'type':'text','text':'More text'}]}]
body=CloudflareChatConfig().transform_request(model='@cf/meta/llama-3.2-1b-instruct',
    messages=copy.deepcopy(msgs), optional_params={}, litellm_params={}, headers={})
print(repr(body['messages'][0]['content']))"
[{'type': 'text', 'text': 'Hello'}, {'type': 'text', 'text': 'More text'}]
```

That is the `array` that Cloudflare answers with `Type mismatch of '/messages/0/content' 'array' not in 'string'`

After this change, same command:

```
'HelloMore text'
```

A reviewer with Workers AI credentials can confirm end to end with

```
curl -sS http://localhost:4000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"cloudflare/@cf/meta/llama-3.2-1b-instruct","messages":[{"role":"user","content":[{"type":"text","text":"Hello"},{"type":"text","text":"More text"}]}]}'
```

which fails with the Cloudflare type mismatch before this change and returns a normal completion after

## Type

🐛 Bug Fix

## Changes

`CloudflareChatConfig` extends `OpenAIGPTConfig` and inherited its `_transform_messages`, which keeps OpenAI content-part arrays as a list. Cloudflare Workers AI wants `message.content` to be a string, so any client sending the modern content-part format got the request rejected outright while the same conversation sent as plain strings worked

This overrides `_transform_messages` to run `handle_messages_with_content_list_to_str_conversion` before delegating to the parent, so the flattening happens on both the sync and async paths and everything else the parent does is preserved. That helper is the same one DeepSeek, Mistral, Moonshot, Heroku, SambaNova, Docker Model Runner and openai_like already use for providers with this constraint, so this keeps Cloudflare consistent with its siblings rather than adding a bespoke transform

Two regression tests cover it: one asserts a content-part array is flattened to a string, and one asserts plain string content is passed through untouched so the flattening cannot regress the common case. The first fails on the current branch and passes with the fix

## QA runbook

Point a `cloudflare/` model at a Workers AI account and send a chat completion whose `content` is a content-part array, for example from an OpenAI-compatible client that uses the modern format. It should now complete instead of returning `AiError: Bad input`. Sending the same request with plain string content should behave exactly as before

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
