### PR TITLE
perf(core): fast-path SafeAttributeModel.__delattr__ for declared fields

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -94,7 +94,17 @@ class SafeAttributeModel:
     """
 
     def __delattr__(self, name):
+        # Dropping an unset optional field stored in __dict__ goes straight to
+        # object.__delattr__, skipping pydantic's __delattr__ whose per-call
+        # class getattr lookup and _check_frozen dominate response construction.
         try:
+            if (
+                name in type(self).__pydantic_fields__
+                and name in self.__dict__
+                and not type(self).model_config.get("frozen")
+            ):
+                object.__delattr__(self, name)
+                return
             super().__delattr__(name)
         except AttributeError:
             # noop if attribute does not exist

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -526,3 +526,103 @@ def test_delta_serialization_contract():
     keys = list(extra_dump.keys())
     assert extra_dump["custom_field"] == "v"
     assert keys.index("custom_field") < keys.index("content")
+
+
+def test_safe_attribute_model_delattr():
+    """
+    SafeAttributeModel.__delattr__ must remove a field from the instance so it
+    is omitted from model_dump (OpenAI spec), whether the field is a declared
+    model field or an extra, and deleting a missing attribute must be a no-op.
+    """
+    from litellm.types.utils import Message
+
+    # Unset optional declared fields are dropped during __init__ -> absent from dump
+    msg = Message(content="hi", role="assistant")
+    assert not hasattr(msg, "audio")
+    assert not hasattr(msg, "reasoning_content")
+    assert "audio" not in msg.model_dump()
+    assert "reasoning_content" not in msg.model_dump()
+
+    # Explicitly deleting a present declared field removes it from the dump
+    msg2 = Message(content="hi", role="assistant", reasoning_content="because")
+    assert msg2.reasoning_content == "because"
+    del msg2.reasoning_content
+    assert not hasattr(msg2, "reasoning_content")
+    assert "reasoning_content" not in msg2.model_dump()
+
+    # Extra fields (extra='allow') are still deletable via the fallback path
+    msg3 = Message(content="hi", role="assistant", custom_field=123)
+    assert msg3.custom_field == 123
+    del msg3.custom_field
+    assert not hasattr(msg3, "custom_field")
+    assert "custom_field" not in msg3.model_dump()
+
+    # Deleting a non-existent attribute is a silent no-op
+    msg4 = Message(content="hi", role="assistant")
+    del msg4.does_not_exist
+
+
+def test_delattr_fast_path_matches_pydantic_exactly():
+    """
+    The fast path must be observationally identical to pydantic's own
+    __delattr__ for a declared field, including model_fields_set membership and
+    the exclude_unset dump, both of which the fast path never touches. Deleting
+    the same field through the fast path and through pydantic's __delattr__
+    (reached by skipping SafeAttributeModel in the MRO) must leave identical
+    state, so if a future pydantic release makes __delattr__ mutate
+    __pydantic_fields_set__ the two diverge and this fails rather than silently
+    shifting the serialization contract.
+    """
+    from litellm.types.utils import Message, SafeAttributeModel
+
+    def observe(m: Message) -> tuple:
+        return (
+            hasattr(m, "reasoning_content"),
+            "reasoning_content" in m.model_fields_set,
+            "reasoning_content" in m.model_dump(),
+            "reasoning_content" in m.model_dump(exclude_unset=True),
+        )
+
+    fast = Message(content="hi", role="assistant", reasoning_content="x")
+    del fast.reasoning_content
+
+    control = Message(content="hi", role="assistant", reasoning_content="x")
+    super(SafeAttributeModel, control).__delattr__("reasoning_content")
+
+    assert observe(fast) == observe(control)
+    # A deleted field is gone from __dict__ (so absent from both dumps) yet
+    # stays in model_fields_set, since neither delete path clears fields_set.
+    assert observe(fast) == (False, True, False, False)
+
+
+def test_delattr_fast_path_missing_attribute_is_noop():
+    """
+    The declared-field fast path must stay a silent no-op when the object delete
+    fails: the field passes the __dict__ membership guard but is already gone by
+    the time object.__delattr__ runs. This models a concurrent removal of the same
+    field on a shared response object. Previously the fast-path delete ran outside
+    the AttributeError handler, so the error leaked onto the Message/Delta/Choices/
+    Usage construction hot path instead of being swallowed like the slow path.
+
+    _VanishingDict reports every key as present (passing the guard) while storing
+    nothing, so the real object.__delattr__ still raises AttributeError.
+    """
+    from litellm.types.utils import SafeAttributeModel
+
+    class _VanishingDict(dict):
+        def __contains__(self, key: object) -> bool:
+            return True
+
+    class _RacyModel(SafeAttributeModel):
+        __pydantic_fields__ = {"x": object()}
+        model_config: dict = {}
+
+        def __init__(self) -> None:
+            self.__dict__ = _VanishingDict()
+
+    racy = _RacyModel()
+    assert "x" in racy.__dict__
+    assert "x" not in dict.keys(racy.__dict__)
+
+    del racy.x
+    del racy.x


### PR DESCRIPTION
## Relevant issues

Continues #29762 by @jgowdy-godaddy, rebased onto current `litellm_internal_staging`

## Linear ticket

Reviewed under PERF-11

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Behavior is identical to the previous path; the change removes per-delete pydantic overhead on the response-construction path, so the proof is a live call showing the correct dropped-field shape plus a construction microbenchmark

Live non-streaming call against a real OpenAI model (proxy running this change, combined-verify commit `5174668f`):

```
curl -s http://localhost:4071/v1/chat/completions \
  -H "Authorization: Bearer sk-..." -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.6","messages":[{"role":"user","content":"Say exactly: message ok"}]}'
```

The returned message carries keys `[annotations, content, provider_specific_fields, role]` with content `message ok`, and no `audio` key, confirming the unset optional field is still dropped from the dump (OpenAI spec) after the fast path

Construction microbenchmark on this machine (pydantic 2.13.4, min of 7 rounds x 100k calls, interleaved base vs branch):

| construction | base | this branch |
| --- | --- | --- |
| `Message(content, role)` | 3.95 us/call | 1.73 us/call (-56%) |

A differential dump over Message, Choices, Usage and ModelResponse (construction, explicit declared-field delete, extra-field delete, missing-attribute no-op) is identical between base and this branch aside from the random `id`/`created` fields. The full `test_streaming_handler.py` suite (99 tests) passes

## Type

🚄 Infrastructure

## Changes

Response models (Message, Choices, Usage) delete unset optional fields in `__init__` so `model_dump` matches the OpenAI spec. Each delete routed through pydantic's `BaseModel.__delattr__`, whose per-call `ModelMetaclass.__getattr__` lookup and `_check_frozen` dominate construction

When the target is a declared field already present in `__dict__` on a non-frozen model, this deletes it with `object.__delattr__` directly. That is exactly what pydantic 2.13 does for that case (verified against the installed `BaseModel.__delattr__` source: for `item in self.__pydantic_fields__` it calls `object.__delattr__(self, item)` and nothing else, no `__pydantic_fields_set__`, validator or `__pydantic_extra__` work), minus the metaclass getattr and the frozen check. It falls back to the previous `super().__delattr__` path for extras, private attributes, cached properties and missing names, so behavior is unchanged

The whole method is a single `try`/`except AttributeError`, so the fast path shares the existing silent-no-op handler. A declared field can still pass the `__dict__` membership guard and then be gone by the time `object.__delattr__` runs, if the same field is concurrently removed on a shared response object; keeping the delete inside the handler preserves the pre-existing no-op contract on that race rather than leaking the error onto the construction hot path. The `try` is zero-cost on the success path in CPython 3.11+, so the fast path stays fast

Rebased onto current `litellm_internal_staging`, resolving the conflict with #33992's `Delta` rework. The two changes sit in different regions of `types/utils.py`; the only real overlap was both suites appending new tests to `test_types_utils.py`, so all three test functions are kept. `Message`, `Choices`, `Usage`, and `Delta` still delete declared fields in `__init__` on the new base, so the fast path still applies

`test_delattr_fast_path_missing_attribute_is_noop` locks in the no-op contract: it drives the guard-passes-then-delete-fails race deterministically with a `__dict__` that reports the field present while storing nothing, so `object.__delattr__` raises. It fails on the pre-fix method and passes with the fix

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only change on a narrow delete path with explicit parity and edge-case tests; serialization contract is unchanged when tests pass.
> 
> **Overview**
> **Speeds up chat response object construction** by adding a fast path in `SafeAttributeModel.__delattr__` when dropping unset optional fields during `Message` / `Delta` / `Choices` / `Usage` `__init__`.
> 
> For a **declared, non-frozen** field that is already in `__dict__`, deletion now uses `object.__delattr__` instead of Pydantic’s `__delattr__`, avoiding per-delete metaclass lookups and frozen checks. Extras, private attributes, and other cases still use `super().__delattr__`. The fast-path delete stays inside the existing `try`/`except AttributeError` so a guard-pass-then-missing-field race stays a silent no-op instead of surfacing on the hot path.
> 
> **Tests** lock in dump/`model_fields_set` parity with Pydantic’s delete path and the no-op behavior when `object.__delattr__` fails after the `__dict__` guard passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d2c22622ccdc29f5ea913f2d515a24cc8731100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

