### PR TITLE
fix(openai): map connection errors to APIConnectionError not 500

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -408,7 +408,9 @@ def _map_openai_exception(
             request=_request,
             litellm_debug_info=extra_information,
         )
-    elif ExceptionCheckers.is_error_str_connection_error(error_str):
+    elif ExceptionCheckers.is_error_str_connection_error(error_str) and getattr(
+        original_exception, "status_code", None
+    ) in (None, 500):
         raise APIConnectionError(
             message=f"APIConnectionError: {exception_provider} - {message}",
             llm_provider=custom_llm_provider,
@@ -768,7 +770,9 @@ def _map_openai_like_exception(
             llm_provider=custom_llm_provider,
             model=model,
         )
-    elif ExceptionCheckers.is_error_str_connection_error(error_str):
+    elif ExceptionCheckers.is_error_str_connection_error(error_str) and getattr(
+        original_exception, "status_code", None
+    ) in (None, 500):
         raise APIConnectionError(
             message=f"{custom_llm_provider.capitalize()}Exception - {error_str}",
             llm_provider=custom_llm_provider,
@@ -1998,7 +2002,9 @@ def _map_azure_exception(
             litellm_debug_info=extra_information,
             response=getattr(original_exception, "response", None),
         )
-    elif ExceptionCheckers.is_error_str_connection_error(error_str):
+    elif ExceptionCheckers.is_error_str_connection_error(error_str) and getattr(
+        original_exception, "status_code", None
+    ) in (None, 500):
         raise APIConnectionError(
             message=f"{exception_provider} APIConnectionError - {message}",
             llm_provider=custom_llm_provider,

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -100,7 +100,6 @@ class ExceptionCheckers:
 
         return False
 
-
     @staticmethod
     def is_error_str_connection_error(error_str: str) -> bool:
         if not isinstance(error_str, str):
@@ -775,7 +774,6 @@ def _map_openai_like_exception(
             llm_provider=custom_llm_provider,
             model=model,
             litellm_debug_info=extra_information,
-            request=httpx.Request(method="POST", url="https://api.openai.com/v1/"),
         )
     elif hasattr(original_exception, "status_code"):
         if original_exception.status_code == 500:

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -100,6 +100,26 @@ class ExceptionCheckers:
 
         return False
 
+
+    @staticmethod
+    def is_error_str_connection_error(error_str: str) -> bool:
+        if not isinstance(error_str, str):
+            return False
+        _error_str_lower = error_str.lower()
+        known_exception_substrings = (
+            "connection error",
+            "connection refused",
+            "connecterror",
+            "connect timeout",
+            "connecttimeout",
+            "name or service not known",
+            "nodename nor servname provided",
+            "temporary failure in name resolution",
+            "network is unreachable",
+            "failed to establish a new connection",
+        )
+        return any(substring in _error_str_lower for substring in known_exception_substrings)
+
     @staticmethod
     def is_azure_content_policy_violation_error(error_str: str) -> bool:
         """
@@ -388,6 +408,14 @@ def _map_openai_exception(
             model=model,
             request=_request,
             litellm_debug_info=extra_information,
+        )
+    elif ExceptionCheckers.is_error_str_connection_error(error_str):
+        raise APIConnectionError(
+            message=f"APIConnectionError: {exception_provider} - {message}",
+            llm_provider=custom_llm_provider,
+            model=model,
+            litellm_debug_info=extra_information,
+            request=httpx.Request(method="POST", url="https://api.openai.com/v1/"),
         )
     elif hasattr(original_exception, "status_code"):
         if original_exception.status_code == 400:
@@ -740,6 +768,14 @@ def _map_openai_like_exception(
             message=f"{custom_llm_provider.capitalize()}Exception - Use 'watsonx_text' route instead. IBM WatsonX does not support `/text/chat` endpoint. - {error_str}",
             llm_provider=custom_llm_provider,
             model=model,
+        )
+    elif ExceptionCheckers.is_error_str_connection_error(error_str):
+        raise APIConnectionError(
+            message=f"{custom_llm_provider.capitalize()}Exception - {error_str}",
+            llm_provider=custom_llm_provider,
+            model=model,
+            litellm_debug_info=extra_information,
+            request=httpx.Request(method="POST", url="https://api.openai.com/v1/"),
         )
     elif hasattr(original_exception, "status_code"):
         if original_exception.status_code == 500:
@@ -1964,7 +2000,7 @@ def _map_azure_exception(
             litellm_debug_info=extra_information,
             response=getattr(original_exception, "response", None),
         )
-    elif "Connection error" in error_str:
+    elif ExceptionCheckers.is_error_str_connection_error(error_str):
         raise APIConnectionError(
             message=f"{exception_provider} APIConnectionError - {message}",
             llm_provider=custom_llm_provider,

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -101,7 +101,7 @@ class ExceptionCheckers:
         return False
 
     @staticmethod
-    def is_error_str_connection_error(error_str: str) -> bool:
+    def is_error_str_connection_error(error_str: object) -> bool:
         if not isinstance(error_str, str):
             return False
         _error_str_lower = error_str.lower()

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -728,6 +728,8 @@ def test_openai_genuine_500_still_maps_to_internal_server_error():
         ("Connection refused", True),
         ("The server had an error processing your request.", False),
         ("invalid_request_error", False),
+        (None, False),
+        (123, False),
     ],
 )
 def test_is_error_str_connection_error(error_str, expected):

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -680,3 +680,55 @@ def test_azure_404_with_invalid_request_error_type_maps_to_not_found():
 
     assert excinfo.value.status_code == 404
     assert "Response with id 'resp_abc' not found." in excinfo.value.message
+
+
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        "Connection error.",
+        "Connection error..",
+        "[Errno 111] Connection refused",
+        "httpx.ConnectError: [Errno 111] Connection refused",
+    ],
+)
+def test_openai_connection_error_wrapped_as_500_maps_to_api_connection_error(error_message):
+    """OpenAI SDK connection failures are often re-wrapped as OpenAIError(status_code=500).
+    They must stay APIConnectionError, not InternalServerError (#33969)."""
+    original_exception = OpenAIError(status_code=500, message=error_message)
+
+    with pytest.raises(litellm.APIConnectionError) as excinfo:
+        exception_type(
+            model="gpt-4o-mini",
+            original_exception=original_exception,
+            custom_llm_provider="openai",
+        )
+
+    assert "InternalServerError" not in type(excinfo.value).__name__
+    assert error_message.split(".")[0] in str(excinfo.value) or "Connection" in str(excinfo.value)
+
+
+def test_openai_genuine_500_still_maps_to_internal_server_error():
+    original_exception = OpenAIError(
+        status_code=500,
+        message="The server had an error processing your request.",
+    )
+
+    with pytest.raises(litellm.InternalServerError):
+        exception_type(
+            model="gpt-4o-mini",
+            original_exception=original_exception,
+            custom_llm_provider="openai",
+        )
+
+
+@pytest.mark.parametrize(
+    "error_str, expected",
+    [
+        ("Connection error.", True),
+        ("Connection refused", True),
+        ("The server had an error processing your request.", False),
+        ("invalid_request_error", False),
+    ],
+)
+def test_is_error_str_connection_error(error_str, expected):
+    assert ExceptionCheckers.is_error_str_connection_error(error_str) is expected

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -732,3 +732,21 @@ def test_openai_genuine_500_still_maps_to_internal_server_error():
 )
 def test_is_error_str_connection_error(error_str, expected):
     assert ExceptionCheckers.is_error_str_connection_error(error_str) is expected
+
+
+@pytest.mark.parametrize("provider", ["predibase", "databricks", "watsonx"])
+def test_openai_like_connection_error_maps_to_api_connection_error(provider):
+    """_map_openai_like_exception must classify connection failures the same way (#33969)."""
+    from litellm.llms.base_llm.chat.transformation import BaseLLMException
+
+    original_exception = BaseLLMException(status_code=500, message="Connection error.")
+
+    with pytest.raises(litellm.APIConnectionError) as excinfo:
+        exception_type(
+            model="dummy-model",
+            original_exception=original_exception,
+            custom_llm_provider=provider,
+        )
+
+    assert "InternalServerError" not in type(excinfo.value).__name__
+    assert "Connection error" in str(excinfo.value)


### PR DESCRIPTION
## Relevant issues

Fixes #33969

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

This is exception classification only; the failure mode is raised inside LiteLLM before an upstream HTTP response exists, so the proof is the mapped exception type for the exact OpenAI SDK error string from #33969

Before (oss daily tip / unfixed mapping): `OpenAIError(status_code=500, message="Connection error.")` becomes `litellm.InternalServerError` with message shaped like `InternalServerError: OpenAIException - Connection error.`

After (`f1383fd`):

```text
$ python - <<'PY'
from litellm.llms.openai.common_utils import OpenAIError
from litellm.litellm_core_utils.exception_mapping_utils import exception_type
import litellm
try:
    exception_type(model="gpt-4o-mini", original_exception=OpenAIError(status_code=500, message="Connection error."), custom_llm_provider="openai")
except Exception as e:
    print(type(e).__name__, e)
PY
APIConnectionError APIConnectionError: OpenAIException - Connection error.
```

Unit coverage on the same commit:

```text
tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py::test_openai_connection_error_wrapped_as_500_maps_to_api_connection_error
tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py::test_openai_genuine_500_still_maps_to_internal_server_error
tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py::test_is_error_str_connection_error
9 passed
```

## Type

Bug Fix
Test

## Changes

mini-swe-agent and similar clients report intermittent `InternalServerError: OpenAIException - Connection error`. The OpenAI Python SDK raises a connection failure with no HTTP status; LiteLLM re-wraps that as `OpenAIError(status_code=500)`, and `_map_openai_exception` then treats any 500 as an upstream InternalServerError

Azure already mapped the `Connection error` string to `APIConnectionError`. OpenAI / OpenAI-compatible paths did not, so transient DNS / TCP / refused-connect failures looked like provider 500s. Clients such as mini-swe-agent then retry under the wrong exception class and logs look like the gateway itself is broken

This PR adds `ExceptionCheckers.is_error_str_connection_error` and uses it in the OpenAI and OpenAI-like mappers (and the existing Azure branch) before the status-code switch. Genuine OpenAI 500 strings such as `The server had an error processing your request.` still map to `InternalServerError`

This does not eliminate real network blips; it stops classifying them as InternalServerError

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
