### PR TITLE
test(e2e): cover key regeneration rotating to a working new key

### DIFF
--- a/tests/e2e/management/management_client.py
+++ b/tests/e2e/management/management_client.py
@@ -16,8 +16,10 @@ from models import (
     ChatMessage,
     KeyDeleteBody,
     KeyGenerateBody,
+    KeyGenerateResponse,
     KeyListParams,
     KeyListResponse,
+    KeyRegenerateBody,
     KeyUpdateBody,
     OrgDeleteBody,
     OrgInfoParams,
@@ -88,6 +90,16 @@ class ManagementClient:
                 response_type=NoBody,
             )
         )
+
+    def regenerate_key(self, key: str) -> str:
+        return unwrap(
+            self.proxy.transport.post(
+                "/key/regenerate",
+                headers=self.proxy.transport.master,
+                json=KeyRegenerateBody(key=key),
+                response_type=KeyGenerateResponse,
+            )
+        ).key
 
     def key_alias_count(self, key_alias: str) -> int:
         return unwrap(

--- a/tests/e2e/management/test_management_e2e.py
+++ b/tests/e2e/management/test_management_e2e.py
@@ -169,6 +169,32 @@ class TestKeyRoutes:
         _ = _poll(client, rejected, "deleted key was still accepted on chat (never rejected 401) at the deadline")
 
 
+class TestKeyRegeneration:
+    @pytest.mark.covers("mgmt.key.regenerate.happy_path")
+    def test_regenerate_rotates_to_a_working_new_key(
+        self, client: ManagementClient, resources: ResourceManager
+    ) -> None:
+        old_key = _generate_key(client, resources, KeyGenerateBody(models=["gpt-5.5"]))
+
+        new_key = client.regenerate_key(old_key)
+        resources.defer(lambda: client.proxy.delete_key(new_key))
+        assert new_key != old_key, "regenerate returned the same key string, so no rotation happened"
+
+        def new_accepted() -> bool | None:
+            outcome = client.chat_status(new_key, "gpt-5.5", f"say hi {unique_marker()}")
+            return True if outcome.status_code != 401 else None
+
+        _ = _poll(client, new_accepted, "regenerated key was never accepted at auth (still 401) at the deadline")
+
+        def old_rejected() -> bool | None:
+            outcome = client.chat_status(old_key, "gpt-5.5", f"say hi {unique_marker()}")
+            return True if outcome.status_code == 401 else None
+
+        _ = _poll(
+            client, old_rejected, "old key was still accepted after regeneration (never rejected 401) at the deadline"
+        )
+
+
 class TestTeamRoutes:
     @pytest.mark.covers("mgmt.team.new.persists")
     def test_new_persists_to_team_info_and_binds_keys(

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -73,6 +73,10 @@ class KeyGenerateResponse(BaseModel):
     key: str
 
 
+class KeyRegenerateBody(BaseModel):
+    key: str
+
+
 class KeyDeleteBody(BaseModel):
     keys: list[str]
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4595

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Run against a live proxy backed by real Postgres

```
$ curl -sX POST /key/generate -d '{"models":["gpt-5.5"]}'      -> old key sk-gSw-WWbfkfp...
$ curl -sX POST /key/regenerate -d '{"key":"sk-gSw-..."}'      -> new key sk-vgm_WDoB5gj...  (differs: yes)
$ curl -sX POST /chat/completions   (old key)                 -> HTTP 401
$ curl -sX POST /chat/completions   (new key)                 -> HTTP 400
```

The new key clears authentication (a 400 from the upstream stub request, not a 401), while the old key is rejected at auth with a 401. The new e2e test `TestKeyRegeneration::test_regenerate_rotates_to_a_working_new_key` encodes exactly this and passes against the live proxy

## Type

✅ Test

## Changes

Adds one e2e test in the management suite covering registry cell `mgmt.key.regenerate.happy_path`. It generates a key, rotates it through `/key/regenerate`, and asserts the rotation contract: the returned key differs, the new key is accepted at auth, and the old key is rejected with a 401. Supporting this, `ManagementClient` gains a `regenerate_key` route and `models.py` gains a typed `KeyRegenerateBody`. The test tears the new key down on completion and judges only auth outcomes, so it is provider independent

## QA runbook

From `tests/e2e`, with a live proxy and Postgres, run `PYTHONPATH=. pytest management/test_management_e2e.py -k test_regenerate_rotates_to_a_working_new_key` with `LITELLM_PROXY_URL` / `LITELLM_MASTER_KEY` set

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
