### PR TITLE
fix(proxy): support Azure v1 image generation and editing

### DIFF
--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -1103,6 +1103,9 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 api_version=api_version,
             )
 
+        if api_version in {"v1", "preview"}:
+            return f"{api_base}/openai/v1/images/generations?api-version=preview"
+
         if "/openai/deployments/" in api_base:
             base_url_with_deployment = api_base
         else:
@@ -1112,6 +1115,24 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
         base_url_with_deployment += "?api-version=" + api_version
 
         return base_url_with_deployment
+
+    @staticmethod
+    def _prepare_image_generation_data_for_url(
+        data: dict,
+        model: str | None,
+        api_base: str,
+    ) -> dict:
+        """Return the payload expected by the selected Azure image endpoint.
+
+        The integrated Azure OpenAI v1 image endpoint routes by ``model`` in
+        the JSON body. Keep the caller's deployment name there even when
+        ``base_model`` is configured for capability and pricing metadata.
+        """
+        if "/openai/v1/images/generations" not in api_base or not model:
+            return data
+        updated_data = data.copy()
+        updated_data["model"] = model
+        return updated_data
 
     async def aimage_generation(
         self,
@@ -1137,6 +1158,11 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 azure_client_params=azure_client_params,
                 model=model or data.get("model", ""),
                 base_model=data.get("model", ""),
+            )
+            data = self._prepare_image_generation_data_for_url(
+                data=data,
+                model=model,
+                api_base=img_gen_api_base,
             )
 
             ## LOGGING
@@ -1272,6 +1298,11 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 azure_client_params=azure_client_params,
                 model=model,
                 base_model=base_model,
+            )
+            data = self._prepare_image_generation_data_for_url(
+                data=data,
+                model=model,
+                api_base=img_gen_api_base,
             )
 
             ## LOGGING

--- a/litellm/llms/azure/image_edit/transformation.py
+++ b/litellm/llms/azure/image_edit/transformation.py
@@ -108,18 +108,22 @@ class AzureImageEditConfig(OpenAIImageEditConfig):
         # Create a new dictionary with existing params
         query_params = dict(original_url.params)
 
-        # Add api_version if needed
-        if "api-version" not in query_params and api_version:
-            query_params["api-version"] = api_version
-
-        # Add the path to the base URL using the model as deployment name
-        if "/openai/deployments/" not in api_base:
+        if api_version in {"v1", "preview"}:
             new_url = _add_path_to_api_base(
                 api_base=api_base,
-                ending_path=f"/openai/deployments/{model}/images/edits",
+                ending_path="/openai/v1/images/edits",
             )
+            query_params["api-version"] = "preview"
         else:
-            new_url = api_base
+            if "api-version" not in query_params and api_version:
+                query_params["api-version"] = api_version
+            if "/openai/deployments/" not in api_base:
+                new_url = _add_path_to_api_base(
+                    api_base=api_base,
+                    ending_path=f"/openai/deployments/{model}/images/edits",
+                )
+            else:
+                new_url = api_base
 
         # Use the new query_params dictionary
         final_url = httpx.URL(new_url).copy_with(params=query_params)

--- a/tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py
+++ b/tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py
@@ -2,6 +2,7 @@ import urllib.parse
 from unittest.mock import patch
 
 import litellm
+import pytest
 from litellm.llms.azure.image_edit.transformation import AzureImageEditConfig
 from litellm.types.router import GenericLiteLLMParams
 
@@ -140,6 +141,33 @@ def test_azure_finalize_image_edit_strips_model_after_openai_transform():
     assert data_out.get("prompt") == prompt
     assert data_out.get("n") == 1
     assert len(files) >= 1
+
+
+@pytest.mark.parametrize("api_version", ("v1", "preview"))
+def test_azure_v1_image_edit_uses_integrated_endpoint_and_keeps_model(api_version):
+    config = AzureImageEditConfig()
+    model = "gpt-image-1"
+    litellm_params = GenericLiteLLMParams(
+        api_base="https://example.openai.azure.com",
+        api_version=api_version,
+    )
+    data, _ = config.transform_image_edit_request(
+        model=model,
+        prompt="add a hat",
+        image=b"fake_png_bytes",
+        image_edit_optional_request_params={"n": 1},
+        litellm_params=litellm_params,
+        headers={},
+    )
+
+    resolved = config.get_complete_url(
+        model=model,
+        api_base=litellm_params.api_base,
+        litellm_params=litellm_params.model_dump(exclude_none=True),
+    )
+
+    assert resolved == "https://example.openai.azure.com/openai/v1/images/edits?api-version=preview"
+    assert config.finalize_image_edit_request_data(data, resolved)["model"] == model
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/llms/azure/image_generation/test_azure_v1_image_generation.py
+++ b/tests/test_litellm/llms/azure/image_generation/test_azure_v1_image_generation.py
@@ -1,0 +1,23 @@
+from litellm.llms.azure.azure import AzureChatCompletion
+
+
+def test_azure_image_generation_v1_url_and_model_payload():
+    azure_chat = AzureChatCompletion()
+    url = azure_chat.create_azure_base_url(
+        azure_client_params={
+            "azure_endpoint": "https://my-resource.openai.azure.com",
+            "api_version": "v1",
+        },
+        model="image-deployment",
+        base_model="gpt-image-1",
+    )
+    assert url == "https://my-resource.openai.azure.com/openai/v1/images/generations?api-version=preview"
+
+    data = {"model": "gpt-image-1", "prompt": "x"}
+    prepared = azure_chat._prepare_image_generation_data_for_url(
+        data=data,
+        model="image-deployment",
+        api_base=url,
+    )
+    assert prepared == {"model": "image-deployment", "prompt": "x"}
+    assert data == {"model": "gpt-image-1", "prompt": "x"}

--- a/tests/test_litellm/llms/azure/image_generation/test_azure_v1_image_generation.py
+++ b/tests/test_litellm/llms/azure/image_generation/test_azure_v1_image_generation.py
@@ -1,12 +1,15 @@
+import pytest
+
 from litellm.llms.azure.azure import AzureChatCompletion
 
 
-def test_azure_image_generation_v1_url_and_model_payload():
+@pytest.mark.parametrize("api_version", ("v1", "preview"))
+def test_azure_image_generation_v1_and_preview_url_and_model_payload(api_version):
     azure_chat = AzureChatCompletion()
     url = azure_chat.create_azure_base_url(
         azure_client_params={
             "azure_endpoint": "https://my-resource.openai.azure.com",
-            "api_version": "v1",
+            "api_version": api_version,
         },
         model="image-deployment",
         base_model="gpt-image-1",


### PR DESCRIPTION
## Summary

Support Azure OpenAI v1 image generation and editing while preserving preview behavior

## Reproduction

Configure Azure image generation or image editing with `api_version: v1` or `preview`. Requests resolve to deployment-scoped endpoints instead of the integrated `/openai/v1` image endpoints

## Fix

Use `/openai/v1/images/generations?api-version=preview` for image generation and `/openai/v1/images/edits?api-version=preview` for image editing. Keep the deployment model in the request body or multipart form data for both v1 and preview

## Validation

`uv run --no-sync pytest tests/test_litellm/llms/azure/image_generation/test_azure_v1_image_generation.py tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py -q` -> 15 passed

`uv run --no-sync pytest tests/test_litellm/llms/azure/image_edit/test_azure_image_edit_transformation.py -q` -> 14 passed

Python lint, strict budget, type checks, and format checks passed locally

## Related issue

Fixes #35428
