### PR TITLE
fix(proxy): forward container pagination params

### DIFF
--- a/litellm/proxy/container_endpoints/endpoints.py
+++ b/litellm/proxy/container_endpoints/endpoints.py
@@ -21,6 +21,9 @@ from litellm.proxy.container_endpoints.ownership import (
     get_container_forwarding_params,
     record_container_owner,
 )
+from litellm.proxy.container_endpoints.request_utils import (
+    get_container_list_query_params,
+)
 
 router = APIRouter()
 
@@ -206,9 +209,7 @@ async def list_containers(
         version,
     )
 
-    # Read query parameters
-    query_params = dict(request.query_params)
-    data: Dict[str, Any] = {"query_params": query_params}
+    data: Dict[str, Any] = get_container_list_query_params(request)
 
     # Extract custom_llm_provider using priority chain
     custom_llm_provider = (

--- a/litellm/proxy/container_endpoints/handler_factory.py
+++ b/litellm/proxy/container_endpoints/handler_factory.py
@@ -23,6 +23,9 @@ from litellm.proxy.container_endpoints.ownership import (
     assert_user_can_access_container,
     get_container_forwarding_params,
 )
+from litellm.proxy.container_endpoints.request_utils import (
+    get_container_list_query_params,
+)
 
 
 def _load_endpoints_config() -> Dict:
@@ -373,11 +376,9 @@ async def _process_request(
         version,
     )
 
-    query_params = dict(request.query_params)
-    data: Dict[str, Any] = {
-        "query_params": query_params,
-        **path_params,
-    }
+    data: Dict[str, Any] = dict(path_params)
+    if route_type == "alist_container_files":
+        data.update(get_container_list_query_params(request))
 
     custom_llm_provider = (
         get_custom_llm_provider_from_request_headers(request=request)

--- a/litellm/proxy/container_endpoints/request_utils.py
+++ b/litellm/proxy/container_endpoints/request_utils.py
@@ -1,0 +1,39 @@
+"""Request parsing helpers for LiteLLM container proxy endpoints."""
+
+from typing import Any, Dict
+
+from fastapi import HTTPException, Request
+
+
+def get_container_list_query_params(request: Request) -> Dict[str, Any]:
+    """Return validated OpenAI-compatible container list query parameters.
+
+    The container SDK functions accept ``after``, ``limit`` and ``order`` as
+    top-level keyword arguments. Proxy handlers must not pass them inside a
+    nested ``query_params`` object, because the SDK silently ignores that
+    object.
+    """
+
+    data: Dict[str, Any] = {}
+
+    after = request.query_params.get("after")
+    if after is not None:
+        data["after"] = after
+
+    limit_value = request.query_params.get("limit")
+    if limit_value is not None:
+        try:
+            limit = int(limit_value)
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(status_code=422, detail="limit must be an integer") from exc
+        if not 1 <= limit <= 100:
+            raise HTTPException(status_code=422, detail="limit must be between 1 and 100")
+        data["limit"] = limit
+
+    order = request.query_params.get("order")
+    if order is not None:
+        if order not in {"asc", "desc"}:
+            raise HTTPException(status_code=422, detail="order must be 'asc' or 'desc'")
+        data["order"] = order
+
+    return data

--- a/tests/test_litellm/containers/test_container_pagination.py
+++ b/tests/test_litellm/containers/test_container_pagination.py
@@ -1,0 +1,31 @@
+import pytest
+from fastapi import HTTPException, Request
+
+from litellm.proxy.container_endpoints.request_utils import (
+    get_container_list_query_params,
+)
+
+
+def _request(query: str) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "query_string": query.encode(),
+        }
+    )
+
+
+def test_get_container_list_query_params_returns_provider_kwargs():
+    assert get_container_list_query_params(_request("after=cursor&limit=20&order=desc")) == {
+        "after": "cursor",
+        "limit": 20,
+        "order": "desc",
+    }
+
+
+@pytest.mark.parametrize("query", ["limit=0", "limit=101", "limit=invalid", "order=middle"])
+def test_get_container_list_query_params_rejects_invalid_values(query: str):
+    with pytest.raises(HTTPException) as exc_info:
+        get_container_list_query_params(_request(query))
+
+    assert exc_info.value.status_code == 422


### PR DESCRIPTION
## Summary

Container list pagination parameters were nested under `query_params` and ignored by the provider

## Reproduction

Call `GET /v1/containers?after=cursor&limit=20&order=desc`. The provider does not receive `after`, `limit`, and `order` as top-level list arguments

## Fix

Validate and forward the list parameters as top-level arguments for the container list endpoint and dynamic container file-list route

## Validation

`uv run pytest tests/test_litellm/containers/test_container_pagination.py tests/test_litellm/containers/test_container_handler_url.py tests/test_litellm/containers/test_container_api.py -q` -> 22 passed

`make pre-commit` passed

## Related issue

Fixes #35429
