### PR TITLE
test(e2e): cover organization deletion removing it from /organization/info

### DIFF
--- a/tests/e2e/management/management_client.py
+++ b/tests/e2e/management/management_client.py
@@ -247,6 +247,9 @@ class ManagementClient:
             )
         )
 
+    def org_info_status(self, organization_id: str) -> ProbeResult:
+        return self.proxy.transport.probe("/organization/info", params=OrgInfoParams(organization_id=organization_id))
+
     def chat_status(self, key: str, model: str, content: str) -> StreamingResponse:
         return self.proxy.transport.send(
             "/chat/completions",

--- a/tests/e2e/management/test_management_e2e.py
+++ b/tests/e2e/management/test_management_e2e.py
@@ -244,6 +244,28 @@ class TestOrganizationRoutes:
             f"/organization/info reports models {info.models}, configured ['gemini-2.5-flash']"
         )
 
+    @pytest.mark.covers("mgmt.organization.delete.persists")
+    def test_delete_removes_from_organization_info(
+        self, client: ManagementClient, resources: ResourceManager
+    ) -> None:
+        """The teardown's deferred delete fires again on the already-deleted org by
+        design: the deferred cleanup must survive this test failing before the
+        in-body delete, and a repeat /organization/delete is a warn-only no-op the
+        teardown absorbs."""
+        org_id = client.create_org(OrgNewBody(organization_alias=f"e2e-mgmt-org-{unique_marker()}"))
+        resources.defer(lambda: client.delete_org(org_id))
+
+        assert client.org_info_status(org_id).status_code == 200, (
+            f"/organization/info did not resolve org {org_id} before deletion"
+        )
+
+        client.delete_org(org_id)
+
+        def gone() -> bool | None:
+            return True if client.org_info_status(org_id).status_code == 404 else None
+
+        _ = _poll(client, gone, f"org {org_id} still resolved on /organization/info after /organization/delete")
+
 
 def _assert_route_forbidden(route: str, outcome: StreamingResponse) -> None:
     assert outcome.status_code == 403, (


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4599

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Run against a live proxy backed by real Postgres

```
$ curl -sX POST /organization/new -> org_id <id>   ; /organization/info -> HTTP 200
$ curl -sX DELETE /organization/delete -d '{"organization_ids":["<id>"]}'  -> HTTP 200
$ curl -s /organization/info?organization_id=<id>  -> HTTP 404
```

The new e2e test `TestOrganizationRoutes::test_delete_removes_from_organization_info` asserts /organization/info resolves the org before deletion (200) and 404s after, and passes against the live proxy

## Type

✅ Test

## Changes

Adds one e2e test in the management suite covering registry cell `mgmt.organization.delete.persists`, plus a small `org_info_status` probe on the client mirroring the existing `team_info_status`. The test creates an org, asserts /organization/info resolves it (the before state), deletes it, then polls the probe until it returns 404. Provider independent

## QA runbook

From `tests/e2e`, with a live proxy and Postgres, run `PYTHONPATH=. pytest management/test_management_e2e.py -k test_delete_removes_from_organization_info`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
