### PR TITLE
feat(pricing): add zai/glm-5.2 to model cost map

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -39380,6 +39380,21 @@
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
+    "zai/glm-5.2": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
     "zai/glm-5": {
         "cache_creation_input_token_cost": 0,
         "cache_read_input_token_cost": 2e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -39471,6 +39471,21 @@
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
+    "zai/glm-5.2": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
     "zai/glm-5": {
         "cache_creation_input_token_cost": 0,
         "cache_read_input_token_cost": 2e-07,


### PR DESCRIPTION
## Relevant issues

Fixes #33937

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

The native z.ai cost map was missing `zai/glm-5.2`, while GLM-5.2 was already present through other provider routes such as Cloudflare and Fireworks AI. This adds the native z.ai entry using z.ai’s published pricing and model metadata.

Pricing source: https://docs.z.ai/guides/overview/pricing

Model source: https://docs.z.ai/guides/llm/glm-5.2

Verified the new entry exists in both cost maps and keeps the existing native z.ai convention of representing the 128K output limit as `128000`:

```bash
python -c "import json; paths=('model_prices_and_context_window.json','litellm/model_prices_and_context_window_backup.json'); keys=('litellm_provider','input_cost_per_token','output_cost_per_token','cache_read_input_token_cost','max_input_tokens','max_output_tokens','supports_prompt_caching','supports_reasoning','mode'); [print(p, json.dumps({k: json.load(open(p, encoding='utf-8'))['zai/glm-5.2'][k] for k in keys}, sort_keys=True)) for p in paths]"
```

Output:

```text
model_prices_and_context_window.json {"cache_read_input_token_cost": 2.6e-07, "input_cost_per_token": 1.4e-06, "litellm_provider": "zai", "max_input_tokens": 1048576, "max_output_tokens": 128000, "mode": "chat", "output_cost_per_token": 4.4e-06, "supports_prompt_caching": true, "supports_reasoning": true}
litellm/model_prices_and_context_window_backup.json {"cache_read_input_token_cost": 2.6e-07, "input_cost_per_token": 1.4e-06, "litellm_provider": "zai", "max_input_tokens": 1048576, "max_output_tokens": 128000, "mode": "chat", "output_cost_per_token": 4.4e-06, "supports_prompt_caching": true, "supports_reasoning": true}
```

Also verified both JSON files parse successfully:

```bash
python -m json.tool model_prices_and_context_window.json
python -m json.tool litellm/model_prices_and_context_window_backup.json
```

## Type

🆕 New Feature

## Changes

Adds `zai/glm-5.2` to `model_prices_and_context_window.json` and mirrors the same entry into `litellm/model_prices_and_context_window_backup.json`.

The new entry includes GLM-5.2 pricing, 1M input context, 128K output limit, prompt caching support, reasoning support, function calling support, and tool choice support for the native z.ai provider.

This fills the native z.ai provider gap while leaving the existing Cloudflare and Fireworks AI GLM-5.2 entries unchanged.


### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
