### PR TITLE
test(e2e): cover key block persisting to /key/info

### DIFF
--- a/tests/e2e/management/management_client.py
+++ b/tests/e2e/management/management_client.py
@@ -14,6 +14,7 @@ from e2e_http import NoBody, ProbeResult, Result, StreamingResponse, Success, Un
 from models import (
     ChatBody,
     ChatMessage,
+    KeyBlockBody,
     KeyDeleteBody,
     KeyGenerateBody,
     KeyListParams,
@@ -85,6 +86,16 @@ class ManagementClient:
                 "/key/delete",
                 headers=self.proxy.transport.master,
                 json=KeyDeleteBody(keys=[key]),
+                response_type=NoBody,
+            )
+        )
+
+    def block_key(self, key: str) -> None:
+        _ = unwrap(
+            self.proxy.transport.post(
+                "/key/block",
+                headers=self.proxy.transport.master,
+                json=KeyBlockBody(key=key),
                 response_type=NoBody,
             )
         )

--- a/tests/e2e/management/test_management_e2e.py
+++ b/tests/e2e/management/test_management_e2e.py
@@ -169,6 +169,19 @@ class TestKeyRoutes:
         _ = _poll(client, rejected, "deleted key was still accepted on chat (never rejected 401) at the deadline")
 
 
+    @pytest.mark.covers("mgmt.key.block.persists")
+    def test_block_persists_to_key_info(self, client: ManagementClient, resources: ResourceManager) -> None:
+        key = _generate_key(client, resources, KeyGenerateBody(models=["gemini-2.5-flash"]))
+        assert not client.proxy.key_info(key).blocked, "/key/info reports the key blocked before /key/block ran"
+
+        client.block_key(key)
+
+        def blocked() -> bool | None:
+            return True if client.proxy.key_info(key).blocked else None
+
+        _ = _poll(client, blocked, "/key/info never reported the key blocked after /key/block before the deadline")
+
+
 class TestTeamRoutes:
     @pytest.mark.covers("mgmt.team.new.persists")
     def test_new_persists_to_team_info_and_binds_keys(

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -94,6 +94,7 @@ class KeyInfo(BaseModel):
     tpm_limit: int | None = None
     rpm_limit: int | None = None
     team_id: str | None = None
+    blocked: bool | None = None
     spend: float | None = None
     max_budget: float | None = None
     budget_reset_at: str | None = None
@@ -579,6 +580,10 @@ class CredentialCreateResponse(BaseModel):
 class KeyUpdateBody(BaseModel):
     key: str
     models: list[str]
+
+
+class KeyBlockBody(BaseModel):
+    key: str
 
 
 class KeyListParams(BaseModel):


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4602

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Run against a live proxy backed by real Postgres

```
$ curl -sX POST /key/generate -d '{"models":["gpt-5.5"]}'   -> key sk-qeujWbzI8...  ; /key/info blocked = None
$ curl -sX POST /key/block -d '{"key":"sk-qeujWbzI8..."}'    -> HTTP 200
$ curl -s /key/info?key=...                                  -> blocked = True
```

The new e2e test `TestKeyRoutes::test_block_persists_to_key_info` asserts the key is not blocked before /key/block and blocked after, and passes against the live proxy

## Type

✅ Test

## Changes

Adds one e2e test in the management suite covering registry cell `mgmt.key.block.persists`. It generates a key, asserts /key/info reports it unblocked (the before state), blocks it via /key/block, then polls /key/info until `blocked` is true. Supporting this, `ManagementClient` gains a `block_key` route, models.py gains a typed `KeyBlockBody`, and `KeyInfo` gains the `blocked` field it reads back. Provider independent

## QA runbook

From `tests/e2e`, with a live proxy and Postgres, run `PYTHONPATH=. pytest management/test_management_e2e.py -k test_block_persists_to_key_info`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
