### PR TITLE
test(e2e): cover created team appearing in /team/list

### DIFF
--- a/tests/e2e/management/management_client.py
+++ b/tests/e2e/management/management_client.py
@@ -28,6 +28,7 @@ from models import (
     TeamDeleteBody,
     TeamInfoParams,
     TeamInfoResponse,
+    TeamListResponse,
     TeamMemberAddBody,
     TeamMemberDeleteBody,
     TeamMemberEntry,
@@ -128,6 +129,19 @@ class ManagementClient:
                 response_type=TeamInfoResponse,
             )
         ).team_info
+
+    def team_list_ids(self) -> tuple[str, ...]:
+        return tuple(
+            entry.team_id
+            for entry in unwrap(
+                self.proxy.transport.get(
+                    "/team/list",
+                    headers=self.proxy.transport.master,
+                    params=NoBody(),
+                    response_type=TeamListResponse,
+                )
+            ).root
+        )
 
     def team_info_status(self, team_id: str) -> ProbeResult:
         return self.proxy.transport.probe("/team/info", params=TeamInfoParams(team_id=team_id))

--- a/tests/e2e/management/test_management_e2e.py
+++ b/tests/e2e/management/test_management_e2e.py
@@ -189,6 +189,19 @@ class TestTeamRoutes:
             f"key generated under team {team_id} carries team_id {key_info.team_id!r} in /key/info"
         )
 
+    @pytest.mark.covers("mgmt.team.list.happy_path")
+    def test_created_team_appears_in_team_list(
+        self, client: ManagementClient, resources: ResourceManager
+    ) -> None:
+        alias = f"e2e-mgmt-team-{unique_marker()}"
+        team_id = _create_team(client, resources, alias, ["gemini-2.5-flash"])
+
+        _ = _poll(
+            client,
+            lambda: team_id if team_id in client.team_list_ids() else None,
+            f"/team/list never included the created team {team_id}",
+        )
+
     @pytest.mark.covers("mgmt.team.member_add.persists")
     def test_member_add_and_delete_persist_to_team_info(
         self, client: ManagementClient, resources: ResourceManager

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -634,6 +634,15 @@ class TeamDeleteBody(BaseModel):
     team_ids: list[str]
 
 
+class TeamListEntry(BaseModel):
+    team_id: str
+
+
+class TeamListResponse(RootModel[list[TeamListEntry]]):
+    """GET /team/list answers with a bare array of team objects (not an object
+    wrapping them). Only team_id is read; pydantic ignores the rest."""
+
+
 UserRole = Literal["proxy_admin", "proxy_admin_viewer", "internal_user", "internal_user_viewer"]
 
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4603

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Run against a live proxy backed by real Postgres

```
$ curl -sX POST /team/new -d '{"team_alias":"tl-..."}'   -> team_id dc7f495d-...
$ curl -s /team/list                                     -> contains dc7f495d-... : True
```

The new e2e test `TestTeamRoutes::test_created_team_appears_in_team_list` polls /team/list until the created team id appears, and passes against the live proxy

## Type

✅ Test

## Changes

Adds one e2e test in the management suite covering registry cell `mgmt.team.list.happy_path`. It creates a team and asserts its id shows up in /team/list. Supporting this, `ManagementClient` gains a `team_list_ids` route and models.py gains a `TeamListResponse` (the endpoint returns a bare array). Provider independent

## QA runbook

From `tests/e2e`, with a live proxy and Postgres, run `PYTHONPATH=. pytest management/test_management_e2e.py -k test_created_team_appears_in_team_list`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
