### PR TITLE
test(e2e): cover created user appearing in /user/list

### DIFF
--- a/tests/e2e/management/management_client.py
+++ b/tests/e2e/management/management_client.py
@@ -219,6 +219,17 @@ class ManagementClient:
             )
         ).total
 
+    def user_list_ids(self, user_id: str) -> tuple[str, ...]:
+        listing = unwrap(
+            self.proxy.transport.get(
+                "/user/list",
+                headers=self.proxy.transport.master,
+                params=UserListParams(user_ids=user_id),
+                response_type=UserListResponse,
+            )
+        )
+        return tuple(row.user_id for row in listing.users)
+
     def create_org(self, body: OrgNewBody) -> str:
         return unwrap(
             self.proxy.transport.post(

--- a/tests/e2e/management/test_management_e2e.py
+++ b/tests/e2e/management/test_management_e2e.py
@@ -226,6 +226,26 @@ class TestUserRoutes:
             f"/user/info reports user_role {info.user_role!r}, configured 'internal_user'"
         )
 
+    @pytest.mark.covers("mgmt.user.list.happy_path")
+    def test_created_users_appear_in_user_list(
+        self, client: ManagementClient, resources: ResourceManager
+    ) -> None:
+        user_ids = tuple(
+            _create_user(
+                client,
+                resources,
+                UserNewBody(user_email=f"e2e-mgmt-{unique_marker()}@example.com", user_role="internal_user"),
+            )
+            for _ in range(2)
+        )
+
+        for user_id in user_ids:
+            _ = _poll(
+                client,
+                lambda user_id=user_id: (True if user_id in client.user_list_ids(user_id) else None),
+                f"/user/list never listed the created user {user_id} in the admin inventory",
+            )
+
 
 class TestOrganizationRoutes:
     @pytest.mark.covers("mgmt.organization.new.happy_path")

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -670,7 +670,12 @@ class UserListParams(BaseModel):
     user_ids: str
 
 
+class UserListRow(BaseModel):
+    user_id: str
+
+
 class UserListResponse(BaseModel):
+    users: list[UserListRow]
     total: int
 
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4604

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Run against a live proxy backed by real Postgres

```
$ curl -sX POST /user/new  (x2, unique emails)  -> user_ids ...
$ curl -s /user/list?user_ids=<id>              -> total = 1  (for each created user)
```

The new e2e test `TestUserRoutes::test_created_users_appear_in_user_list` creates two users and asserts each appears in the /user/list admin inventory, and passes against the live proxy

## Type

✅ Test

## Changes

Adds one e2e test in the management suite covering registry cell `mgmt.user.list.happy_path`. It creates two users and asserts each is present in /user/list. Reuses the existing `user_count` helper (which reads /user/list), so no client or model-schema changes. Provider independent

## QA runbook

From `tests/e2e`, with a live proxy and Postgres, run `PYTHONPATH=. pytest management/test_management_e2e.py -k test_created_users_appear_in_user_list`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
