### PR TITLE
test(e2e): cover model update persisting to /model/info

### DIFF
--- a/tests/e2e/management/test_management_e2e.py
+++ b/tests/e2e/management/test_management_e2e.py
@@ -9,6 +9,7 @@ so the traffic-facing read-backs poll to a deadline instead of asserting once.
 
 from __future__ import annotations
 
+import math
 import time
 from collections.abc import Callable
 
@@ -22,7 +23,14 @@ from management_client import (
     ROUTE_NOT_ALLOWED_MARKER,
     ManagementClient,
 )
-from models import KeyGenerateBody, OrgNewBody, TeamNewBody, UserNewBody
+from models import (
+    KeyGenerateBody,
+    LiteLLMParamsBody,
+    ModelInfoEntry,
+    OrgNewBody,
+    TeamNewBody,
+    UserNewBody,
+)
 
 pytestmark = pytest.mark.e2e
 
@@ -242,6 +250,59 @@ class TestOrganizationRoutes:
         )
         assert info.models == ["gemini-2.5-flash"], (
             f"/organization/info reports models {info.models}, configured ['gemini-2.5-flash']"
+        )
+
+
+_INITIAL_INPUT_COST = 0.00000111
+_UPDATED_INPUT_COST = 0.00000222
+
+
+def _model_entry(client: ManagementClient, model_name: str) -> ModelInfoEntry | None:
+    return next((entry for entry in client.proxy.model_info() if entry.model_name == model_name), None)
+
+
+class TestModelRoutes:
+    @pytest.mark.covers("mgmt.model.update.persists")
+    def test_update_persists_input_cost_to_model_info(
+        self, client: ManagementClient, resources: ResourceManager
+    ) -> None:
+        model_name = f"e2e-mgmt-model-{unique_marker()}"
+        model_id = client.proxy.create_model(
+            model_name,
+            LiteLLMParamsBody(
+                model="gpt-4o-mini",
+                mock_response="ok",
+                input_cost_per_token=_INITIAL_INPUT_COST,
+            ),
+        )
+        resources.defer(lambda: client.proxy.delete_model(model_id))
+
+        before = _model_entry(client, model_name)
+        assert before is not None, f"{model_name} absent from /model/info right after /model/new"
+        initial = before.litellm_params.input_cost_per_token
+        assert initial is not None and math.isclose(initial, _INITIAL_INPUT_COST, rel_tol=1e-9), (
+            f"/model/info reports input_cost_per_token {initial}, registered {_INITIAL_INPUT_COST}"
+        )
+
+        client.proxy.update_model(
+            model_id,
+            LiteLLMParamsBody(model="gpt-4o-mini", input_cost_per_token=_UPDATED_INPUT_COST),
+        )
+
+        def updated() -> ModelInfoEntry | None:
+            entry = _model_entry(client, model_name)
+            if entry is None:
+                return None
+            cost = entry.litellm_params.input_cost_per_token
+            if cost is not None and math.isclose(cost, _UPDATED_INPUT_COST, rel_tol=1e-9):
+                return entry
+            return None
+
+        _ = _poll(
+            client,
+            updated,
+            f"/model/info never reported input_cost_per_token {_UPDATED_INPUT_COST} for {model_name} "
+            "after /model/update",
         )
 
 

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -547,6 +547,17 @@ class ModelNewResponse(BaseModel):
     model_id: str
 
 
+class ModelUpdateBody(BaseModel):
+    """POST /model/update body: the target deployment (`model_info.id`) plus the
+    `litellm_params` to merge over its stored params. The handler overlays only the
+    non-null fields, so a body carrying `input_cost_per_token` re-prices the
+    deployment while leaving its other params intact."""
+
+    model_config = ConfigDict(protected_namespaces=())
+    litellm_params: LiteLLMParamsBody
+    model_info: ModelInfoBody
+
+
 class ModelListEntry(BaseModel):
     id: str
 

--- a/tests/e2e/proxy_client.py
+++ b/tests/e2e/proxy_client.py
@@ -54,6 +54,7 @@ from models import (
     ModelNewBody,
     ModelNewResponse,
     ModelsListResponse,
+    ModelUpdateBody,
     OcrBody,
     OcrResponse,
     SpendLogRow,
@@ -209,6 +210,23 @@ class ProxyClient:
             f"model {model_name!r} was created but never became servable on the data "
             f"plane within {self.poll_timeout}s of /model/new (control/data-plane "
             f"propagation or STORE_MODEL_IN_DB reload issue){last_error}"
+        )
+
+    def update_model(self, model_id: str, litellm_params: LiteLLMParamsBody) -> None:
+        """Merge `litellm_params` over the deployment `model_id`'s stored params via
+        POST /model/update. The proxy overlays only the non-null fields and clears
+        its model cache, so a later /model/info read reflects the change (eventually,
+        after the reload)."""
+        unwrap(
+            self.transport.post(
+                "/model/update",
+                headers=self.transport.master,
+                json=ModelUpdateBody(
+                    litellm_params=litellm_params,
+                    model_info=ModelInfoBody(id=model_id),
+                ),
+                response_type=NoBody,
+            )
         )
 
     def delete_model(self, model_id: str) -> None:


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4605

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Run against a live proxy backed by real Postgres

```
$ curl -sX POST /model/new  input_cost_per_token=0.00000111  -> model_id ...  ; /model/info shows 1.11e-06
$ curl -sX POST /model/update  input_cost_per_token=0.00000222 (same model_id)  -> HTTP 200
$ curl -s /model/info  -> input_cost_per_token = 2.22e-06
```

The new e2e test `TestModelRoutes::test_update_persists_input_cost_to_model_info` asserts the initial price in /model/info, updates it, and polls until /model/info reflects the new price, and passes against the live proxy

## Type

✅ Test

## Changes

Adds one e2e test in the management suite covering registry cell `mgmt.model.update.persists`. It registers a deployment with a known input_cost_per_token, re-prices it via /model/update, and polls /model/info until the new price persists (rationale: pricing persists). Supporting this, `ProxyClient` gains an `update_model` route (so other suites reuse it) and models.py gains a typed `ModelUpdateBody`. Provider independent

## QA runbook

From `tests/e2e`, with a live proxy and Postgres, run `PYTHONPATH=. pytest management/test_management_e2e.py -k test_update_persists_input_cost_to_model_info`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
