### PR TITLE
test(e2e): cover tag creation persisting for spend categorization

### DIFF
--- a/tests/e2e/management/management_client.py
+++ b/tests/e2e/management/management_client.py
@@ -24,6 +24,10 @@ from models import (
     OrgInfoResponse,
     OrgNewBody,
     OrgNewResponse,
+    TagDeleteBody,
+    TagListEntry,
+    TagListResponse,
+    TagNewBody,
     TeamData,
     TeamDeleteBody,
     TeamInfoParams,
@@ -245,6 +249,36 @@ class ManagementClient:
                 params=OrgInfoParams(organization_id=organization_id),
                 response_type=OrgInfoResponse,
             )
+        )
+
+    def create_tag(self, body: TagNewBody) -> None:
+        _ = unwrap(
+            self.proxy.transport.post(
+                "/tag/new",
+                headers=self.proxy.transport.master,
+                json=body,
+                response_type=NoBody,
+            )
+        )
+
+    def delete_tag(self, name: str) -> None:
+        _ = self.proxy.transport.post(
+            "/tag/delete",
+            headers=self.proxy.transport.master,
+            json=TagDeleteBody(name=name),
+            response_type=NoBody,
+        )
+
+    def tag_list(self) -> tuple[TagListEntry, ...]:
+        return tuple(
+            unwrap(
+                self.proxy.transport.get(
+                    "/tag/list",
+                    headers=self.proxy.transport.master,
+                    params=NoBody(),
+                    response_type=TagListResponse,
+                )
+            ).root
         )
 
     def chat_status(self, key: str, model: str, content: str) -> StreamingResponse:

--- a/tests/e2e/management/test_management_e2e.py
+++ b/tests/e2e/management/test_management_e2e.py
@@ -22,7 +22,7 @@ from management_client import (
     ROUTE_NOT_ALLOWED_MARKER,
     ManagementClient,
 )
-from models import KeyGenerateBody, OrgNewBody, TeamNewBody, UserNewBody
+from models import KeyGenerateBody, OrgNewBody, TagListEntry, TagNewBody, TeamNewBody, UserNewBody
 
 pytestmark = pytest.mark.e2e
 
@@ -242,6 +242,28 @@ class TestOrganizationRoutes:
         )
         assert info.models == ["gemini-2.5-flash"], (
             f"/organization/info reports models {info.models}, configured ['gemini-2.5-flash']"
+        )
+
+
+class TestTagRoutes:
+    @pytest.mark.covers("mgmt.tag.new.happy_path")
+    def test_new_persists_to_tag_list(self, client: ManagementClient, resources: ResourceManager) -> None:
+        name = f"e2e-mgmt-tag-{unique_marker()}"
+        description = "Tag for spend categorization"
+
+        assert all(entry.name != name for entry in client.tag_list()), (
+            f"tag {name!r} was already listed by /tag/list before /tag/new created it"
+        )
+
+        client.create_tag(TagNewBody(name=name, description=description))
+        resources.defer(lambda: client.delete_tag(name))
+
+        def listed() -> TagListEntry | None:
+            return next((entry for entry in client.tag_list() if entry.name == name), None)
+
+        entry = _poll(client, listed, f"/tag/list never listed {name!r} after /tag/new")
+        assert entry.description == description, (
+            f"/tag/list reports description {entry.description!r} for {name!r}, configured {description!r}"
         )
 
 

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -695,3 +695,26 @@ class OrgInfoResponse(BaseModel):
 
 class OrgDeleteBody(BaseModel):
     organization_ids: list[str]
+
+
+# ---------- tags (management) ----------
+
+
+class TagNewBody(BaseModel):
+    name: str
+    description: str | None = None
+
+
+class TagDeleteBody(BaseModel):
+    name: str
+
+
+class TagListEntry(BaseModel):
+    name: str
+    description: str | None = None
+
+
+class TagListResponse(RootModel[list[TagListEntry]]):
+    """GET /tag/list answers with a bare array of tag configs (the stored tags plus
+    any dynamically-seen spend tags), not an object wrapping them. Read the rows off
+    .root."""


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4606

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Run against a live proxy backed by real Postgres

```
$ curl -s /tag/list                                              -> tag-... absent before
$ curl -sX POST /tag/new -d '{"name":"tag-...","description":...}' -> HTTP 200
$ curl -s /tag/list                                              -> contains tag-... : True
```

The new e2e test `TestTagRoutes::test_new_persists_to_tag_list` asserts the tag is absent before creation, creates it, polls /tag/list until it appears, and checks the description round-trips, passing against the live proxy

## Type

✅ Test

## Changes

Adds one e2e test in the management suite covering registry cell `mgmt.tag.new.happy_path`. It creates a tag via /tag/new and asserts it appears in /tag/list with the configured description. Supporting this, `ManagementClient` gains `create_tag` / `tag_list` / `delete_tag` routes and models.py gains the tag request/response models. Provider independent

## QA runbook

From `tests/e2e`, with a live proxy and Postgres, run `PYTHONPATH=. pytest management/test_management_e2e.py -k test_new_persists_to_tag_list`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
