### PR TITLE
test(cache): run disk cache tests in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,7 @@ dev = [
     "pytest-timeout==2.4.0",
     "vcrpy==8.2.1",
     "pytest-recording==0.13.4",
+    "diskcache>=5.6.3,<6.0",
 ]
 e2e-dev = [
     "playwright==1.61.0",
@@ -234,6 +235,7 @@ ci = [
     "langgraph>=1.2.4,<1.3.0",
     "langgraph-prebuilt>=1.1.0,<1.3.0",
     "claude-agent-sdk==0.1.44",
+    "diskcache>=5.6.3,<6.0",
 ]
 healthcheck = [
     "httpx==0.28.1",

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-15T21:54:47.972166Z"
+exclude-newer = "2026-07-17T19:37:15.999873Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -4090,6 +4090,7 @@ ci = [
     { name = "blockbuster" },
     { name = "claude-agent-sdk" },
     { name = "detect-secrets" },
+    { name = "diskcache" },
     { name = "google-generativeai" },
     { name = "jsonlines" },
     { name = "langchain" },
@@ -4114,6 +4115,7 @@ dev = [
     { name = "basedpyright" },
     { name = "botocore-stubs" },
     { name = "diff-cover" },
+    { name = "diskcache" },
     { name = "fakeredis" },
     { name = "fastapi-offline" },
     { name = "flake8" },
@@ -4266,6 +4268,7 @@ ci = [
     { name = "blockbuster", specifier = "==1.5.26" },
     { name = "claude-agent-sdk", specifier = "==0.1.44" },
     { name = "detect-secrets", specifier = "==1.5.0" },
+    { name = "diskcache", specifier = ">=5.6.3,<6.0" },
     { name = "google-generativeai", specifier = "==0.8.6" },
     { name = "jsonlines", specifier = "==4.0.0" },
     { name = "langchain", specifier = "==1.3.9" },
@@ -4290,6 +4293,7 @@ dev = [
     { name = "basedpyright", specifier = "==1.39.7" },
     { name = "botocore-stubs", specifier = "==1.43.14" },
     { name = "diff-cover", specifier = "==9.7.2" },
+    { name = "diskcache", specifier = ">=5.6.3,<6.0" },
     { name = "fakeredis", specifier = "==2.34.1" },
     { name = "fastapi-offline", specifier = "==1.7.6" },
     { name = "flake8", specifier = "==7.3.0" },


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

`diskcache` was only in the optional `caching` extra, so `tests/test_litellm/caching/test_disk_cache.py` hit its `pytest.importorskip("diskcache")` and skipped in every unit-test shard, which is why `DiskCache` coverage reports at 0% on the `responses-caching-types` shard. With diskcache in the `ci` group the shard collects and runs the file instead of skipping it

```
$ uv run --frozen --group ci pytest -q tests/test_litellm/caching/test_disk_cache.py
7 passed
```

## Type

✅ Test

## Changes

`diskcache` moves into the `dev` and `ci` dependency groups so the disk cache tests run locally and on the `responses-caching-types` CI shard. The unit-test shards install `--group ci`, so the `ci` entry is what makes the tests execute in CI; the `dev` entry keeps them running under the default local dev environment. The optional `caching` runtime extra is unchanged

## Behavior changes

No runtime behavior change. This only affects which dependency groups install `diskcache`, so the existing disk cache tests stop being skipped

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/34020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->