### PR TITLE
test(e2e): add Azure AI Foundry and Anthropic /v1/messages coverage for the Rust bridge

### DIFF
--- a/tests/e2e/llm_translation/test_messages_azure_foundry_e2e.py
+++ b/tests/e2e/llm_translation/test_messages_azure_foundry_e2e.py
@@ -146,6 +146,7 @@ class TestAzureFoundryMessages:
         require_successful_call(result)
         assert result.is_streaming, f"response was not streamed: {result.headers}"
         assert not result.stream_error, f"stream errored: {result.stream_error}"
+        assert result.stream_events, "stream produced no SSE events"
         assert any("tool_use" in event for event in result.stream_events), (
             "stream carried no tool_use block"
         )

--- a/tests/e2e/llm_translation/test_messages_azure_foundry_e2e.py
+++ b/tests/e2e/llm_translation/test_messages_azure_foundry_e2e.py
@@ -1,0 +1,154 @@
+"""Live e2e: POST /v1/messages routed to Azure AI Foundry Anthropic deployments.
+
+Registers `azure_ai/<claude>` deployments at runtime and drives the Messages
+endpoint through the gateway across the behaviors an Anthropic client relies on:
+a basic completion, a streamed completion, and tool use (non-streaming and
+streaming). Auth is the Azure API key (`x-api-key`); the deployment reads
+`AZURE_AI_API_BASE` / `AZURE_AI_API_KEY` from the proxy env, so no secret is
+sent in the request.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from e2e_config import unique_marker
+from e2e_http import StreamingResponse, require_successful_call, unwrap
+from endpoints_client import EndpointsClient
+from lifecycle import ResourceManager
+from models import (
+    AnthropicCustomTool,
+    AnthropicMessagesBody,
+    ChatMessage,
+    JsonSchemaProperty,
+    LiteLLMParamsBody,
+    ToolInputSchema,
+)
+
+pytestmark = pytest.mark.e2e
+
+AZURE_FOUNDRY_MODEL = "azure_ai/claude-haiku-4-5"
+
+WEATHER_TOOL = AnthropicCustomTool(
+    name="get_weather",
+    description="Get the current weather for a city.",
+    input_schema=ToolInputSchema(
+        properties={"city": JsonSchemaProperty(type="string")},
+        required=["city"],
+    ),
+)
+
+
+def _assert_streamed_ok(result: StreamingResponse) -> None:
+    require_successful_call(result)
+    assert result.is_streaming, f"response was not streamed: {result.headers}"
+    assert not result.stream_error, f"stream errored: {result.stream_error}"
+    assert result.stream_events, "stream produced no SSE events"
+    assert any("content_block_delta" in event for event in result.stream_events), (
+        "stream carried no content deltas"
+    )
+    assert any("message_stop" in event for event in result.stream_events), (
+        "stream never reached message_stop"
+    )
+
+
+class TestAzureFoundryMessages:
+    def _register(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> tuple[str, str]:
+        model = f"e2e-azure-foundry-messages-{unique_marker()}"
+        model_id = endpoints_client.create_model(
+            model,
+            LiteLLMParamsBody(
+                model=AZURE_FOUNDRY_MODEL,
+                api_base="os.environ/AZURE_AI_API_BASE",
+                api_key="os.environ/AZURE_AI_API_KEY",
+            ),
+        )
+        resources.defer(lambda: endpoints_client.delete_model(model_id))
+        return model, resources.key(models=[model])
+
+    @pytest.mark.covers("llm.messages.azure_foundry.basic.nonstream.works")
+    def test_basic_nonstream(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model, key = self._register(endpoints_client, resources)
+        response = unwrap(
+            endpoints_client.proxy.messages(
+                key,
+                AnthropicMessagesBody(
+                    model=model,
+                    max_tokens=64,
+                    messages=[ChatMessage(role="user", content="Reply with one word.")],
+                ),
+            )
+        )
+        assert response.content, f"no content blocks in response: {response}"
+        text = "".join(block.text or "" for block in response.content if block.type == "text")
+        assert text.strip(), f"/v1/messages returned no text: {response}"
+
+    @pytest.mark.covers("llm.messages.azure_foundry.basic.stream.works")
+    def test_basic_stream(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model, key = self._register(endpoints_client, resources)
+        result = endpoints_client.proxy.messages_stream(
+            key,
+            AnthropicMessagesBody(
+                model=model,
+                max_tokens=64,
+                stream=True,
+                messages=[ChatMessage(role="user", content="Count from one to three.")],
+            ),
+        )
+        _assert_streamed_ok(result)
+
+    @pytest.mark.covers("llm.messages.azure_foundry.tool_use.nonstream.works")
+    def test_tool_use_nonstream(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model, key = self._register(endpoints_client, resources)
+        response = unwrap(
+            endpoints_client.proxy.messages(
+                key,
+                AnthropicMessagesBody(
+                    model=model,
+                    max_tokens=256,
+                    tools=[WEATHER_TOOL],
+                    messages=[
+                        ChatMessage(role="user", content="What is the weather in Paris? Use the tool.")
+                    ],
+                ),
+            )
+        )
+        assert response.content, f"no content blocks in response: {response}"
+        assert any(block.type == "tool_use" for block in response.content), (
+            f"model did not call the tool: {response}"
+        )
+
+    @pytest.mark.covers("llm.messages.azure_foundry.tool_use.stream.works")
+    def test_tool_use_stream(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model, key = self._register(endpoints_client, resources)
+        result = endpoints_client.proxy.messages_stream(
+            key,
+            AnthropicMessagesBody(
+                model=model,
+                max_tokens=256,
+                stream=True,
+                tools=[WEATHER_TOOL],
+                messages=[
+                    ChatMessage(role="user", content="What is the weather in Paris? Use the tool.")
+                ],
+            ),
+        )
+        require_successful_call(result)
+        assert result.is_streaming, f"response was not streamed: {result.headers}"
+        assert not result.stream_error, f"stream errored: {result.stream_error}"
+        assert any("tool_use" in event for event in result.stream_events), (
+            "stream carried no tool_use block"
+        )
+        assert any("message_stop" in event for event in result.stream_events), (
+            "stream never reached message_stop"
+        )

--- a/tests/e2e/llm_translation/test_messages_e2e.py
+++ b/tests/e2e/llm_translation/test_messages_e2e.py
@@ -11,12 +11,28 @@ from __future__ import annotations
 import pytest
 
 from e2e_config import unique_marker
-from e2e_http import require_successful_call
+from e2e_http import require_successful_call, unwrap
 from endpoints_client import EndpointsClient, MessagesResult
 from lifecycle import ResourceManager
-from models import AnthropicMessagesBody, ChatMessage, LiteLLMParamsBody
+from models import (
+    AnthropicCustomTool,
+    AnthropicMessagesBody,
+    ChatMessage,
+    JsonSchemaProperty,
+    LiteLLMParamsBody,
+    ToolInputSchema,
+)
 
 pytestmark = pytest.mark.e2e
+
+WEATHER_TOOL = AnthropicCustomTool(
+    name="get_weather",
+    description="Get the current weather for a city.",
+    input_schema=ToolInputSchema(
+        properties={"city": JsonSchemaProperty(type="string")},
+        required=["city"],
+    ),
+)
 
 
 class TestAnthropicMessages:
@@ -69,4 +85,28 @@ class TestAnthropicMessages:
         )
         assert any("message_stop" in event for event in result.stream_events), (
             "stream never reached message_stop"
+        )
+
+    @pytest.mark.covers("llm.messages.anthropic.tool_use.nonstream.works")
+    def test_messages_tool_use(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model, key = self._register(endpoints_client, resources)
+
+        response = unwrap(
+            endpoints_client.proxy.messages(
+                key,
+                AnthropicMessagesBody(
+                    model=model,
+                    max_tokens=256,
+                    tools=[WEATHER_TOOL],
+                    messages=[
+                        ChatMessage(role="user", content="What is the weather in Paris? Use the tool.")
+                    ],
+                ),
+            )
+        )
+        assert response.content, f"no content blocks in response: {response}"
+        assert any(block.type == "tool_use" for block in response.content), (
+            f"model did not call the tool: {response}"
         )

--- a/tests/e2e/llm_translation/test_messages_e2e.py
+++ b/tests/e2e/llm_translation/test_messages_e2e.py
@@ -1,7 +1,8 @@
 """Live e2e: POST /v1/messages (Anthropic Messages API) returns a real completion.
 
 Registers an Anthropic deployment at runtime, drives the Messages endpoint through
-the gateway, and asserts an assistant message with text came back. Migrated from
+the gateway, and asserts an assistant message with text came back, both
+non-streaming and streamed. Migrated from
 litellm-regression-tests/tests/test_inference_endpoints.py.
 """
 
@@ -13,15 +14,15 @@ from e2e_config import unique_marker
 from e2e_http import require_successful_call
 from endpoints_client import EndpointsClient, MessagesResult
 from lifecycle import ResourceManager
-from models import LiteLLMParamsBody
+from models import AnthropicMessagesBody, ChatMessage, LiteLLMParamsBody
 
 pytestmark = pytest.mark.e2e
 
 
 class TestAnthropicMessages:
-    def test_messages_returns_completion(
+    def _register(
         self, endpoints_client: EndpointsClient, resources: ResourceManager
-    ) -> None:
+    ) -> tuple[str, str]:
         model = f"e2e-messages-{unique_marker()}"
         model_id = endpoints_client.create_model(
             model,
@@ -30,10 +31,42 @@ class TestAnthropicMessages:
             ),
         )
         resources.defer(lambda: endpoints_client.delete_model(model_id))
-        key = resources.key()
+        return model, resources.key()
+
+    @pytest.mark.covers("llm.messages.anthropic.basic.nonstream.works")
+    def test_messages_returns_completion(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model, key = self._register(endpoints_client, resources)
 
         result = endpoints_client.messages(key, model, "reply with one word")
         require_successful_call(result)
         parsed = MessagesResult.model_validate_json(result.body)
         assert parsed.role == "assistant", f"unexpected role: {result.body[:300]}"
         assert parsed.text.strip(), f"/v1/messages returned no text: {result.body[:300]}"
+
+    @pytest.mark.covers("llm.messages.anthropic.basic.stream.works")
+    def test_messages_streams_completion(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model, key = self._register(endpoints_client, resources)
+
+        result = endpoints_client.proxy.messages_stream(
+            key,
+            AnthropicMessagesBody(
+                model=model,
+                max_tokens=64,
+                stream=True,
+                messages=[ChatMessage(role="user", content="Count from one to three.")],
+            ),
+        )
+        require_successful_call(result)
+        assert result.is_streaming, f"response was not streamed: {result.headers}"
+        assert not result.stream_error, f"stream errored: {result.stream_error}"
+        assert result.stream_events, "stream produced no SSE events"
+        assert any("content_block_delta" in event for event in result.stream_events), (
+            "stream carried no content deltas"
+        )
+        assert any("message_stop" in event for event in result.stream_events), (
+            "stream never reached message_stop"
+        )

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -244,6 +244,7 @@ class CountTokensBody(BaseModel):
 
 class AnthropicContentBlock(BaseModel):
     type: str | None = None
+    text: str | None = None
 
 
 class AnthropicMessagesResponse(BaseModel):


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4609

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live end-to-end proof against the real Azure AI Foundry Anthropic API is pending the Azure credential provisioning in the companion litellm-ops change (which adds `AZURE_AI_API_KEY` / `AZURE_AI_API_BASE` to the `berrie-litellm-stage` provider-keys secret); once those land in the stage cluster the `litellm-e2e` Job exercises these tests against the live proxy. This is deliberate sequencing rather than a skipped step

Structural validation at commit `90955fad06`:

- `make lint-e2e-basedpyright` reports 0 errors, 0 warnings across `tests/e2e`
- pytest collects all 7 behaviors under python 3.12
- every `@pytest.mark.covers` id resolves to an existing registry row, so there are no orphan markers

## Type

✅ Test

## Changes

Adds e2e coverage under `tests/e2e/llm_translation` for the Anthropic Messages surface the Rust bridge serves, at API-key auth scope

`test_messages_azure_foundry_e2e.py` registers `azure_ai/claude-*` deployments at runtime and drives `/v1/messages` across four behaviors: basic non-streaming, basic streaming, tool use non-streaming, and tool use streaming (registry route `azure_foundry`). Auth is the Azure API key; the deployment resolves `AZURE_AI_API_BASE` / `AZURE_AI_API_KEY` from the proxy env, so no secret is sent in the request

`test_messages_e2e.py` gains streamed and tool-use Anthropic cases alongside the existing basic completion, and all three declare their registry cells

`models.py` models the `text` field on `AnthropicContentBlock` so the non-streaming assertions check the returned text rather than only the block type

OCR is already covered by `test_ocr_rust_e2e.py` across four providers, so it is untouched here. The Rust OpenAI responses-websocket surface is deferred to a follow-up: the harness has no responses-over-websocket suite today and the endpoint mapping needs confirmation before a faithful test

## QA runbook

- `tests/e2e/llm_translation/test_messages_azure_foundry_e2e.py::TestAzureFoundryMessages::test_basic_nonstream` - an azure_ai Anthropic deployment answers /v1/messages with real text
  - [ ] POST /model/new (master key) with litellm_params model=azure_ai/claude-haiku-4-5, api_base=os.environ/AZURE_AI_API_BASE, api_key=os.environ/AZURE_AI_API_KEY (requires those two env vars on the proxy)
  - [ ] POST /v1/messages with that model, max_tokens 64, one user message
  - [ ] Expect 200 with a content block of type text carrying non-empty text
  - [ ] Sanity check: the test asserts real returned text, not just a 200
- `tests/e2e/llm_translation/test_messages_azure_foundry_e2e.py::TestAzureFoundryMessages::test_basic_stream` - the same deployment streams /v1/messages
  - [ ] POST /v1/messages with stream=true against that deployment
  - [ ] Expect text/event-stream with content_block_delta events and a terminal message_stop
  - [ ] Sanity check: the test asserts streamed deltas and the terminal event, not just a 200
- `tests/e2e/llm_translation/test_messages_azure_foundry_e2e.py::TestAzureFoundryMessages::test_tool_use_nonstream` - the deployment calls a tool
  - [ ] POST /v1/messages with a get_weather tool and a prompt that needs it
  - [ ] Expect a content block of type tool_use
  - [ ] Sanity check: the test asserts a tool_use block, not just a 200
- `tests/e2e/llm_translation/test_messages_azure_foundry_e2e.py::TestAzureFoundryMessages::test_tool_use_stream` - the deployment streams a tool call
  - [ ] POST /v1/messages with the tool and stream=true
  - [ ] Expect SSE events including a tool_use block and message_stop
  - [ ] Sanity check: the test asserts a streamed tool_use block and the terminal event
- `tests/e2e/llm_translation/test_messages_e2e.py::TestAnthropicMessages::test_messages_streams_completion` - an anthropic deployment streams /v1/messages
  - [ ] POST /model/new with anthropic/claude-haiku-4-5, api_key=os.environ/ANTHROPIC_API_KEY
  - [ ] POST /v1/messages with stream=true
  - [ ] Expect SSE content_block_delta events and message_stop
  - [ ] Sanity check: the test asserts streamed deltas and the terminal event
- `tests/e2e/llm_translation/test_messages_e2e.py::TestAnthropicMessages::test_messages_tool_use` - an anthropic deployment calls a tool
  - [ ] POST /model/new with anthropic/claude-haiku-4-5, api_key=os.environ/ANTHROPIC_API_KEY
  - [ ] POST /v1/messages with a get_weather tool and a prompt that needs it
  - [ ] Expect a content block of type tool_use
  - [ ] Sanity check: the test asserts a tool_use block, not just a 200

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
