### PR TITLE
fix(langfuse_otel): surface proxy model_group as observation model

### DIFF
--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -242,6 +242,14 @@ class LangfuseOtelLogger(OpenTelemetry):
 
         LangfuseOtelLogger._set_observation_output(span=span, response_obj=response_obj)
 
+        model_group = (kwargs.get("standard_logging_object") or {}).get("model_group")
+        if isinstance(model_group, str) and model_group:
+            safe_set_attribute(
+                span,
+                "langfuse.observation.model.name",
+                model_group,
+            )
+
     @staticmethod
     def _get_langfuse_otel_host() -> Optional[str]:
         """

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -1,5 +1,6 @@
 import json
 import os
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -352,6 +353,57 @@ class TestLangfuseOtelIntegration:
             assert (
                 actual == expected
             ), "Mismatch in observation output OTEL attribute for tool calls."
+
+    def test_streaming_response_model_uses_proxy_alias(self):
+        """Regression for https://github.com/BerriAI/litellm/issues/25628.
+
+        The langfuse_otel callback must surface `litellm_params.metadata.model_group`
+        (proxy alias) as the observation model, not `response_obj.model` (the upstream
+        provider model). Bug manifested on streaming requests where the proxy had
+        not restamped `response_obj.model` before the callback fired."""
+        from datetime import datetime, timedelta
+
+        from litellm.litellm_core_utils.litellm_logging import (
+            get_standard_logging_object_payload,
+        )
+        from litellm.types.utils import ModelResponse
+
+        proxy_alias = "groq-gpt-oss-120b"
+        upstream_model = "openai/gpt-oss-120b"
+
+        response_obj = ModelResponse(model=upstream_model)
+        start_time = datetime(2025, 1, 1, 0, 0, 0)
+        end_time = start_time + timedelta(seconds=1)
+
+        proxy_shaped_kwargs: dict[str, Any] = {
+            "litellm_params": {"metadata": {"model_group": proxy_alias}},
+        }
+
+        logging_obj = MagicMock()
+        standard_logging_object = get_standard_logging_object_payload(
+            kwargs=proxy_shaped_kwargs,
+            init_response_obj=response_obj,
+            start_time=start_time,
+            end_time=end_time,
+            logging_obj=logging_obj,
+            status="success",
+        )
+        assert standard_logging_object is not None
+        assert standard_logging_object["model_group"] == proxy_alias
+
+        callback_kwargs = {**proxy_shaped_kwargs, "standard_logging_object": standard_logging_object}
+
+        mock_span = MagicMock()
+        LangfuseOtelLogger.set_langfuse_otel_attributes(
+            mock_span, callback_kwargs, response_obj
+        )
+
+        attrs = {
+            call.args[0]: call.args[1]
+            for call in mock_span.set_attribute.call_args_list
+        }
+
+        assert attrs.get("langfuse.observation.model.name") == proxy_alias
 
     def test_construct_dynamic_otel_headers_with_langfuse_keys(self):
         """Test that construct_dynamic_otel_headers creates proper auth headers when langfuse keys are provided."""


### PR DESCRIPTION
## Relevant issues

Fixes #25628

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy on :4000, `langfuse_otel` callback, alias `groq-llama-3.3-70b` fronting `groq/llama-3.3-70b-versatile`

```bash
curl -sN http://localhost:4000/chat/completions \
  -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' \
  -d '{"model":"groq-llama-3.3-70b","messages":[{"role":"user","content":"say hi in one word"}],"stream":true,"metadata":{"session_id":"<id>"}}'
```

Both legs return HTTP 200 with an alias-stamped response body; the regression is in the exported trace's `observations[type=GENERATION].model`

Parent `5d4c4d0fce` — trace [dee296089c7d5114eb08f40477831730](https://cloud.langfuse.com/project/cmrowk9im0a2yad0dm4ajgp0p/traces/dee296089c7d5114eb08f40477831730): `llama-3.3-70b-versatile`

Fix `bc2c111e1f` — trace [1cdd0caae4bb2a74e06d40d1db93b13a](https://cloud.langfuse.com/project/cmrowk9im0a2yad0dm4ajgp0p/traces/1cdd0caae4bb2a74e06d40d1db93b13a): `groq-llama-3.3-70b`

## Type

🐛 Bug Fix

## Changes

`langfuse_otel` delegated observation naming to the shared arize helper, which reads `response_obj.model`. On the streaming path the proxy has not restamped that field yet when the callback fires, so the exported trace shows the raw upstream model instead of the `model_list` alias

`_set_langfuse_specific_attributes` now also stamps `langfuse.observation.model.name` from `standard_logging_object.model_group`, which Langfuse then surfaces as the observation's model

Regression test drives the real `get_standard_logging_object_payload` from the proxy's boundary shape so drift on that lift also fails the test

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR