### PR TITLE
chore(release): backport #33929 to rc/1.94.0

### DIFF
--- a/litellm/llms/fireworks_ai/chat/transformation.py
+++ b/litellm/llms/fireworks_ai/chat/transformation.py
@@ -133,6 +133,32 @@ class FireworksAIConfig(FireworksAIMixin, OpenAIGPTConfig):
     def get_config(cls):
         return super().get_config()
 
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        messages: List[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> dict:
+        api_key = self._get_api_key(api_key)
+        if api_key is None:
+            raise ValueError("FIREWORKS_API_KEY is not set")
+
+        validated_headers = OpenAIGPTConfig.validate_environment(
+            self,
+            headers=headers,
+            model=model,
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params=litellm_params,
+            api_key=api_key,
+            api_base=api_base,
+        )
+        return self._add_session_affinity_header(validated_headers, litellm_params)
+
     def get_supported_openai_params(self, model: str):
         # Base parameters supported by all models
         supported_params = [

--- a/litellm/llms/fireworks_ai/common_utils.py
+++ b/litellm/llms/fireworks_ai/common_utils.py
@@ -64,9 +64,16 @@ class FireworksAIMixin:
         if api_key is None:
             raise ValueError("FIREWORKS_API_KEY is not set")
 
-        validated_headers = {"Authorization": "Bearer {}".format(api_key), **headers}
-        if not any(key.lower() == "x-session-affinity" for key in validated_headers):
-            session_id = get_fireworks_session_id(litellm_params)
-            if session_id:
-                validated_headers["x-session-affinity"] = session_id
-        return validated_headers
+        auth_headers = {"Authorization": "Bearer {}".format(api_key), **headers}
+        content_type_header = (
+            {} if any(key.lower() == "content-type" for key in auth_headers) else {"Content-Type": "application/json"}
+        )
+        return self._add_session_affinity_header({**auth_headers, **content_type_header}, litellm_params)
+
+    def _add_session_affinity_header(self, headers: dict, litellm_params: dict) -> dict:
+        if any(key.lower() == "x-session-affinity" for key in headers):
+            return headers
+        session_id = get_fireworks_session_id(litellm_params)
+        if not session_id:
+            return headers
+        return {**headers, "x-session-affinity": session_id}

--- a/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
@@ -123,6 +123,90 @@ def test_validate_environment_preserves_explicit_session_affinity_header():
     assert headers["x-session-affinity"] == "explicit-session"
 
 
+def test_validate_environment_sets_json_content_type():
+    config = FireworksAIConfig()
+
+    headers = config.validate_environment(
+        headers={},
+        model="accounts/fireworks/models/test-model",
+        messages=[],
+        optional_params={},
+        litellm_params={},
+        api_key="test-key",
+    )
+
+    assert headers["Content-Type"] == "application/json"
+
+
+def test_validate_environment_preserves_explicit_content_type():
+    config = FireworksAIConfig()
+
+    headers = config.validate_environment(
+        headers={"content-type": "multipart/form-data"},
+        model="accounts/fireworks/models/test-model",
+        messages=[],
+        optional_params={},
+        litellm_params={},
+        api_key="test-key",
+    )
+
+    assert headers["content-type"] == "multipart/form-data"
+    assert "Content-Type" not in headers
+
+
+def test_validate_environment_sets_json_content_type_with_session_affinity():
+    config = FireworksAIConfig()
+
+    headers = config.validate_environment(
+        headers={},
+        model="accounts/fireworks/models/test-model",
+        messages=[],
+        optional_params={},
+        litellm_params={"litellm_session_id": "session-123"},
+        api_key="test-key",
+    )
+
+    assert headers["Content-Type"] == "application/json"
+    assert headers["Authorization"] == "Bearer test-key"
+    assert headers["x-session-affinity"] == "session-123"
+
+
+def test_validate_environment_resolves_api_key_from_env_and_sets_content_type(monkeypatch):
+    monkeypatch.setenv("FIREWORKS_API_KEY", "fw-env-key")
+    config = FireworksAIConfig()
+
+    headers = config.validate_environment(
+        headers={},
+        model="accounts/fireworks/models/test-model",
+        messages=[],
+        optional_params={},
+        litellm_params={},
+    )
+
+    assert headers["Authorization"] == "Bearer fw-env-key"
+    assert headers["Content-Type"] == "application/json"
+
+
+def test_validate_environment_raises_without_api_key(monkeypatch):
+    for env_var in (
+        "FIREWORKS_API_KEY",
+        "FIREWORKS_AI_API_KEY",
+        "FIREWORKSAI_API_KEY",
+        "FIREWORKS_AI_TOKEN",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+    config = FireworksAIConfig()
+
+    with pytest.raises(ValueError, match="FIREWORKS_API_KEY is not set"):
+        config.validate_environment(
+            headers={},
+            model="accounts/fireworks/models/test-model",
+            messages=[],
+            optional_params={},
+            litellm_params={},
+        )
+
+
 def test_get_fireworks_session_id_prefers_litellm_session_id_over_trace_id():
     assert (
         get_fireworks_session_id(


### PR DESCRIPTION
## Relevant issues

Backports [#33929](https://github.com/BerriAI/litellm/pull/33929) onto the `rc/1.94.0` line. That PR fixes a regression introduced by [#33717](https://github.com/BerriAI/litellm/pull/33717), which is already on this line as commit `b3d05bd10b`. #33717 changed `FireworksAIConfig` to `class FireworksAIConfig(FireworksAIMixin, OpenAIGPTConfig)` so chat requests would pick up the new `x-session-affinity` header. Putting the mixin first in the MRO also meant the mixin's `validate_environment` won over the OpenAI base one, and only the base set a default `Content-Type: application/json`. Since litellm posts the body pre-serialized via `data=json.dumps(...)`, httpx never re-adds the header, so Fireworks saw `application/octet-stream` and rejected every chat and text completion call with `415 Unsupported Media Type`

The fix gives `FireworksAIConfig` its own `validate_environment` that delegates header construction to `OpenAIGPTConfig` and then layers only the Fireworks `x-session-affinity` header on top, so the content type default cannot drift away from the base again

No version bump. The line's `pyproject.toml` already holds `1.94.0` and that version is unreleased on every surface checked (DockerHub 404, GHCR 404, no `release/v1.94.0` branch, no `v1.94.0` tag), so this pick rides the pending version

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Up front, so nobody is misled: this machine has no Fireworks credential, so the proof below does not call `api.fireworks.ai`. Instead the same request path runs end to end through a real proxy against a local endpoint that enforces the exact rule Fireworks enforces, rejecting any body whose content type is not `application/json` with a 415. That reproduces the reported symptom and the mechanism; it does not re-verify Fireworks' own behavior. A reviewer with a Fireworks key can substitute the real base URL and see the same before and after

Before, on the line tip `5d4c4d0fce` (pre-pick), port 4001:

```bash
curl -s -w '\nHTTP_STATUS=%{http_code}\n' -X POST http://127.0.0.1:4001/v1/chat/completions \
  -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
  -d '{"model":"fw-test","messages":[{"role":"user","content":"ping"}]}'
```

```
{"error":{"message":"litellm.BadRequestError: Fireworks_aiException - {\"error\": {\"message\": \"Unsupported Media Type\", \"type\": \"invalid_request_error\"}} ...","code":"415"}}
HTTP_STATUS=415

headers the proxy actually sent upstream:
content_type      : application/octet-stream
has_authorization : True
```

After, on this branch at `d75a0716d8`, port 4002, same request:

```
{"id":"chatcmpl-fake-1","object":"chat.completion","model":"fw-test","choices":[{"finish_reason":"stop","index":0,"message":{"content":"pong","role":"assistant"}}],"usage":{"completion_tokens":1,"prompt_tokens":1,"total_tokens":2}}
HTTP_STATUS=200

headers the proxy actually sent upstream:
content_type      : application/json
has_authorization : True
```

The `x-session-affinity` feature that #33717 added is what the regression rode in on, so it is worth showing it still works after the pick. Same branch at `d75a0716d8`, adding a session id:

```bash
curl -s -X POST http://127.0.0.1:4002/v1/chat/completions \
  -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
  -d '{"model":"fw-test","messages":[{"role":"user","content":"ping"}],"litellm_session_id":"sess-regression-check"}'
```

```
HTTP_STATUS=200
content_type      : application/json
x_session_affinity: sess-regression-check
has_authorization : True
```

Header behavior across every `FireworksAIMixin` subclass on this line, captured by calling `validate_environment` directly before and after the pick. The only difference the pick makes is the added `Content-Type`; a caller-supplied content type still wins, `x-session-affinity` is unchanged, and the missing-key error is unchanged:

| case | before | after |
| --- | --- | --- |
| chat, empty headers | `Authorization` | `Authorization`, `Content-Type: application/json` |
| completion, empty headers | `Authorization` | `Authorization`, `Content-Type: application/json` |
| chat, caller sent `Content-Type: text/plain` | `text/plain` | `text/plain` (unchanged) |
| chat, caller sent lowercase `content-type` | `text/plain` | `text/plain` (unchanged, no duplicate added) |
| chat, session id present | `x-session-affinity: sess-abc` | same, plus `Content-Type` |
| chat, caller sent `x-session-affinity` | caller value wins | same, plus `Content-Type` |
| any, no api key | `ValueError: FIREWORKS_API_KEY is not set` | unchanged |

`FireworksAIRerankConfig` overrides `validate_environment` with its own narrower signature and already hardcoded `Content-Type: application/json`, so rerank never had the bug and the pick does not touch it

## Type

🐛 Bug Fix
🧹 Refactoring

## Changes

One cherry-pick, applied with `-x` and verbatim; `git patch-id --stable` matches the staging commit exactly, so there are no adaptation notes

- #33929 fix(fireworks_ai): restore Content-Type application/json header (fixes 415), from `3fcd19d7ad`

Verification on this line, judged as a delta against a baseline captured on the tip before picking:

- Targeted tests `tests/test_litellm/llms/fireworks_ai/`: 73 passed pre-pick, 78 passed post-pick, zero failures on either side. The 5 new tests are the ones #33929 added, and they pass here, which is what shows the fix actually lands on this line rather than just applying cleanly
- Full mirrored suite `tests/test_litellm`, judged as a delta between the pre-pick tip and the post-pick tree: 81 failures pre-pick vs 74 post-pick, noisy in both directions and none in Fireworks. Every failure that showed up only post-pick passed when re-run in isolation on both trees, so the pick introduces zero repeatable new failures. The movement is pre-existing `pytest-xdist` ordering flake plus live-API tests (Google interactions) that fail identically with and without the pick
- Symbol closure: every identifier the picked diff references resolves on this line. `OpenAIGPTConfig.validate_environment` exists with the exact signature the pick calls and does set the JSON content type, which is the part that makes the delegation deliver the fix instead of quietly doing nothing
- Dependency scan of the line's lock with grype, before and after: 1 finding both times, 0 High, 0 Critical, nothing new introduced. The one carried finding is a Medium in `diskcache 5.6.3` with no fixed version published, so there is nothing in range to move to
- The pick is `git patch-id --stable` identical to #33929, so its runtime behavior on this line matches the already-merged staging change exactly. A deep adversarial verification pass confirmed end to end that the fix reaches the wire through `litellm.completion` and that the delegated `OpenAIGPTConfig` base is what supplies the JSON content type the fix depends on

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
