### PR TITLE
fix(ui): removing a key from the model JSON editors no longer silently survives

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -168,12 +168,12 @@ def update_db_model(db_model: Deployment, updated_patch: updateDeployment) -> Pr
     if updated_patch.litellm_params_keys_to_delete:
         for key in updated_patch.litellm_params_keys_to_delete:
             if key != "model":
-                merged_deployment_dict["litellm_params"].pop(key, None)  # type: ignore
+                merged_deployment_dict["litellm_params"].pop(key, None)
 
     if updated_patch.model_info_keys_to_delete:
         for key in updated_patch.model_info_keys_to_delete:
             if key not in PROTECTED_MODEL_INFO_KEYS:
-                merged_deployment_dict.get("model_info", {}).pop(key, None)  # type: ignore
+                merged_deployment_dict.get("model_info", {}).pop(key, None)
 
     # convert to prisma compatible format
 

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -66,6 +66,21 @@ from litellm.utils import get_utc_datetime
 
 router = APIRouter()
 
+# model_info fields that are structural or privileged (id, team assignment,
+# audit metadata) and must go through their own dedicated flows -- never via
+# the generic `model_info_keys_to_delete` JSON-editor deletion path.
+PROTECTED_MODEL_INFO_KEYS = {
+    "id",
+    "db_model",
+    "team_id",
+    "team_public_model_name",
+    "blocked",
+    "created_at",
+    "created_by",
+    "updated_at",
+    "updated_by",
+}
+
 
 async def update_team(*args, **kwargs):
     """
@@ -142,6 +157,23 @@ def update_db_model(db_model: Deployment, updated_patch: updateDeployment) -> Pr
             if field in SPECIAL_MODEL_INFO_PARAMS and getattr(updated_patch.model_info, field) is None:
                 merged_deployment_dict["model_info"].pop(field, None)  # type: ignore
                 merged_deployment_dict.get("litellm_params", {}).pop(field, None)  # type: ignore
+
+    # Explicit key deletion for the admin UI's raw JSON editors. A key the user
+    # removes from the JSON textarea is simply absent from the patch, which the
+    # merges above can't distinguish from "field not touched" -- so the stale
+    # value survives. `*_keys_to_delete` lets the caller name removed keys
+    # explicitly. `model` is excluded because litellm_params always requires it,
+    # and `PROTECTED_MODEL_INFO_KEYS` are structural/privileged fields (id,
+    # team assignment, audit metadata) that must go through their own flows.
+    if updated_patch.litellm_params_keys_to_delete:
+        for key in updated_patch.litellm_params_keys_to_delete:
+            if key != "model":
+                merged_deployment_dict["litellm_params"].pop(key, None)  # type: ignore
+
+    if updated_patch.model_info_keys_to_delete:
+        for key in updated_patch.model_info_keys_to_delete:
+            if key not in PROTECTED_MODEL_INFO_KEYS:
+                merged_deployment_dict.get("model_info", {}).pop(key, None)  # type: ignore
 
     # convert to prisma compatible format
 

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -365,6 +365,16 @@ class updateDeployment(BaseModel):
     model_info: Optional[ModelInfo] = None
     blocked: Optional[bool] = None
 
+    # Explicit key removal for the free-form JSON editors on the admin UI.
+    # `litellm_params`/`model_info` are merged (not replaced) against the stored
+    # blob so that sparse partial updates (e.g. rotating just `api_key`) don't
+    # wipe out unrelated fields. That merge means a key dropped from the raw
+    # JSON textarea silently survives, since "absent" and "removed" look the
+    # same to a merge. These let a caller name keys to delete explicitly
+    # instead of relying on absence.
+    litellm_params_keys_to_delete: Optional[List[str]] = None
+    model_info_keys_to_delete: Optional[List[str]] = None
+
     model_config = ConfigDict(protected_namespaces=())
 
 

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -2940,6 +2940,147 @@ class TestUpdateDBModelClearPricing:
         assert info["cache_creation_input_token_cost"] == 0.000003
 
 
+class TestUpdateDBModelKeyDeletion:
+    """Regression test for #34005: removing a key from the raw JSON editors on the admin UI
+    (model json / litellm params) did nothing -- the merge in `update_db_model` treats an
+    absent key as "not touched", so the stale value survived every save.
+    `litellm_params_keys_to_delete` and `model_info_keys_to_delete` let the caller name
+    removed keys explicitly.
+    """
+
+    def test_litellm_params_keys_to_delete_removes_custom_key(self):
+        """Mirrors the issue's own repro: a JSON blob with custom keys (`abc`, `someKey`)
+        where only `someKey` is removed on save."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            update_db_model,
+        )
+        from litellm.types.router import Deployment, LiteLLM_Params, ModelInfo, updateLiteLLMParams
+
+        db_model = Deployment(
+            model_name="openai/gpt-4",
+            litellm_params=LiteLLM_Params(model="openai/gpt-4", tpm=1000, someKey=True, abc=123),
+            model_info=ModelInfo(id="dep-del-0"),
+        )
+
+        result = update_db_model(
+            db_model=db_model,
+            updated_patch=updateDeployment(
+                litellm_params=updateLiteLLMParams(tpm=1000, abc=123),
+                litellm_params_keys_to_delete=["someKey"],
+            ),
+        )
+
+        params = json.loads(result["litellm_params"])
+        assert "someKey" not in params
+        # Untouched keys survive the delete
+        assert params["tpm"] == 1000
+        assert params["abc"] == 123
+
+    def test_model_info_keys_to_delete_removes_custom_key(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            update_db_model,
+        )
+        from litellm.types.router import Deployment, LiteLLM_Params, ModelInfo
+
+        db_model = Deployment(
+            model_name="openai/gpt-4",
+            litellm_params=LiteLLM_Params(model="openai/gpt-4"),
+            model_info=ModelInfo(id="dep-del-1", someExtra="drop-me", keep="stay"),
+        )
+
+        result = update_db_model(
+            db_model=db_model,
+            updated_patch=updateDeployment(
+                model_info=ModelInfo(id="dep-del-1"),
+                model_info_keys_to_delete=["someExtra"],
+            ),
+        )
+
+        info = json.loads(result["model_info"])
+        assert "someExtra" not in info
+        assert info["keep"] == "stay"
+
+    def test_keys_to_delete_cannot_remove_protected_model_info_fields(self):
+        """Security guard: team_id and other structural fields must survive even if a
+        caller lists them in `model_info_keys_to_delete`."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            update_db_model,
+        )
+        from litellm.types.router import Deployment, LiteLLM_Params, ModelInfo
+
+        db_model = Deployment(
+            model_name="openai/gpt-4",
+            litellm_params=LiteLLM_Params(model="openai/gpt-4"),
+            model_info=ModelInfo(id="dep-del-2", team_id="team-keep-me"),
+        )
+
+        result = update_db_model(
+            db_model=db_model,
+            updated_patch=updateDeployment(
+                model_info=ModelInfo(id="dep-del-2"),
+                model_info_keys_to_delete=["team_id", "id"],
+            ),
+        )
+
+        info = json.loads(result["model_info"])
+        assert info.get("team_id") == "team-keep-me"
+        assert info.get("id") == "dep-del-2"
+
+    def test_keys_to_delete_cannot_remove_model_field(self):
+        """`model` is required by litellm_params; deletion must not be able to strip it
+        even if a caller lists it."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            update_db_model,
+        )
+        from litellm.types.router import Deployment, LiteLLM_Params, ModelInfo
+
+        db_model = Deployment(
+            model_name="openai/gpt-4",
+            litellm_params=LiteLLM_Params(model="openai/gpt-4"),
+            model_info=ModelInfo(id="dep-del-3"),
+        )
+
+        result = update_db_model(
+            db_model=db_model,
+            updated_patch=updateDeployment(
+                model_info=ModelInfo(id="dep-del-3"),
+                litellm_params_keys_to_delete=["model"],
+            ),
+        )
+
+        params = json.loads(result["litellm_params"])
+        assert params.get("model") == "openai/gpt-4"
+
+    def test_no_keys_to_delete_is_a_no_op(self):
+        """Existing callers that never set `*_keys_to_delete` (e.g. the credentials-rotation
+        modal, which sends a sparse litellm_params on purpose) must be completely
+        unaffected by this field's presence."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            update_db_model,
+        )
+        from litellm.types.router import Deployment, LiteLLM_Params, ModelInfo, updateLiteLLMParams
+
+        db_model = Deployment(
+            model_name="openai/gpt-4",
+            litellm_params=LiteLLM_Params(model="openai/gpt-4", rpm=5, tpm=1000),
+            model_info=ModelInfo(id="dep-del-4"),
+        )
+
+        # Sparse patch: only rpm, same shape update_model_credentials_modal sends for
+        # api_key (a single field, everything else left untouched).
+        result = update_db_model(
+            db_model=db_model,
+            updated_patch=updateDeployment(
+                litellm_params=updateLiteLLMParams(rpm=50),
+                model_info=ModelInfo(id="dep-del-4"),
+            ),
+        )
+
+        params = json.loads(result["litellm_params"])
+        assert params["rpm"] == 50
+        assert params["tpm"] == 1000  # untouched field preserved by the merge
+
+
 class TestGetModelInfoWithIdBlocked:
     """`ProxyConfig.get_model_info_with_id` must propagate the DB-level `blocked`
     column into the in-memory `model_info` dict so the router filter can read it."""

--- a/ui/litellm-dashboard/src/components/model_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.test.tsx
@@ -581,6 +581,103 @@ describe("ModelInfoView", () => {
     expect(updatePayload.litellm_params.litellm_credential_name).not.toBe("from-json");
   });
 
+  it("reports a key removed from the LiteLLM Params JSON editor as litellm_params_keys_to_delete (regression: #34005)", async () => {
+    // Removing a key from the raw JSON editor used to be silently ignored: the backend
+    // merges litellm_params rather than replacing it, so an absent key looked identical
+    // to an untouched one and the stale value survived every save.
+    const customKeyModelData = {
+      ...defaultModelData,
+      litellm_params: {
+        ...defaultModelData.litellm_params,
+        someKey: true,
+      },
+    };
+    mockUseModelsInfo.mockReturnValue({
+      data: { data: [customKeyModelData] },
+      isLoading: false,
+      error: null,
+    });
+    mockModelInfoV1Call.mockResolvedValue({ data: [customKeyModelData] });
+
+    const user = userEvent.setup();
+    render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /edit settings/i })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /edit settings/i }));
+
+    const litellmParamsInput = screen
+      .getAllByRole("textbox")
+      .find(
+        (input) =>
+          input.tagName === "TEXTAREA" && (input as HTMLTextAreaElement).value.includes('"custom_llm_provider"'),
+      );
+    expect(litellmParamsInput).toBeDefined();
+    if (!litellmParamsInput) {
+      return;
+    }
+    expect((litellmParamsInput as HTMLTextAreaElement).value).toContain("someKey");
+    await user.clear(litellmParamsInput);
+    await user.paste(`{"model":"gpt-4","api_base":"https://api.openai.com/v1","custom_llm_provider":"openai"}`);
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockModelPatchUpdateCall).toHaveBeenCalled();
+    });
+
+    const updatePayload = mockModelPatchUpdateCall.mock.calls[0][1];
+    expect(updatePayload.litellm_params).not.toHaveProperty("someKey");
+    expect(updatePayload.litellm_params_keys_to_delete).toContain("someKey");
+  });
+
+  it("reports a key removed from the Model Info JSON editor as model_info_keys_to_delete (regression: #34005)", async () => {
+    const customKeyModelData = {
+      ...defaultModelData,
+      model_info: {
+        ...defaultModelData.model_info,
+        custom_note: "drop-me",
+      },
+    };
+    mockUseModelsInfo.mockReturnValue({
+      data: { data: [customKeyModelData] },
+      isLoading: false,
+      error: null,
+    });
+    mockModelInfoV1Call.mockResolvedValue({ data: [customKeyModelData] });
+
+    const user = userEvent.setup();
+    render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /edit settings/i })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /edit settings/i }));
+
+    const modelInfoInput = screen
+      .getAllByRole("textbox")
+      .find(
+        (input) => input.tagName === "TEXTAREA" && (input as HTMLTextAreaElement).value.includes('"custom_note"'),
+      );
+    expect(modelInfoInput).toBeDefined();
+    if (!modelInfoInput) {
+      return;
+    }
+    await user.clear(modelInfoInput);
+    await user.paste(JSON.stringify({ ...customKeyModelData.model_info, custom_note: undefined }));
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockModelPatchUpdateCall).toHaveBeenCalled();
+    });
+
+    const updatePayload = mockModelPatchUpdateCall.mock.calls[0][1];
+    expect(updatePayload.model_info).not.toHaveProperty("custom_note");
+    expect(updatePayload.model_info_keys_to_delete).toContain("custom_note");
+  });
+
   it("should not include vector_store_ids in update payload when model has none", async () => {
     // Regression: editing a model without vector stores used to inject
     // vector_store_ids: [] into litellm_params, which then propagated to

--- a/ui/litellm-dashboard/src/components/model_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.test.tsx
@@ -657,9 +657,7 @@ describe("ModelInfoView", () => {
 
     const modelInfoInput = screen
       .getAllByRole("textbox")
-      .find(
-        (input) => input.tagName === "TEXTAREA" && (input as HTMLTextAreaElement).value.includes('"custom_note"'),
-      );
+      .find((input) => input.tagName === "TEXTAREA" && (input as HTMLTextAreaElement).value.includes('"custom_note"'));
     expect(modelInfoInput).toBeDefined();
     if (!modelInfoInput) {
       return;

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -433,10 +433,30 @@ export default function ModelInfoView({
       // Credential rotation has its own dedicated path (UpdateModelCredentialsModal).
       const safeLitellmParams = stripMaskedSecrets(updatedLitellmParams);
 
+      // A key removed from either raw JSON editor is just absent from the
+      // recomputed blob above -- the backend's merge can't tell that apart from
+      // "field not touched", so the stale value would otherwise survive the save
+      // (#34005). Diff against the pre-edit snapshot and name the removed keys
+      // explicitly. Diffed against `updatedLitellmParams` (pre-mask-strip), not
+      // `safeLitellmParams`: an untouched masked secret is still present there
+      // (with its masked value) and must NOT be reported as deleted.
+      const litellmParamsKeysToDelete = Object.keys(modelData?.litellm_params ?? {}).filter(
+        (key) => !(key in updatedLitellmParams),
+      );
+      const modelInfoKeysToDelete = Object.keys(modelData?.model_info ?? {}).filter(
+        (key) => !(key in updatedModelInfo),
+      );
+
       const updateData = {
         model_name: values.model_name,
         litellm_params: safeLitellmParams,
         model_info: updatedModelInfo,
+        ...(litellmParamsKeysToDelete.length > 0 && {
+          litellm_params_keys_to_delete: litellmParamsKeysToDelete,
+        }),
+        ...(modelInfoKeysToDelete.length > 0 && {
+          model_info_keys_to_delete: modelInfoKeysToDelete,
+        }),
       };
 
       await modelPatchUpdateCall(accessToken, updateData, modelId);

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -33423,7 +33423,11 @@ export interface components {
             /** Blocked */
             blocked?: boolean | null;
             litellm_params?: components["schemas"]["updateLiteLLMParams"] | null;
+            /** Litellm Params Keys To Delete */
+            litellm_params_keys_to_delete?: string[] | null;
             model_info?: components["schemas"]["litellm__types__router__ModelInfo"] | null;
+            /** Model Info Keys To Delete */
+            model_info_keys_to_delete?: string[] | null;
             /** Model Name */
             model_name?: string | null;
         };


### PR DESCRIPTION
## What does this PR do?

Fixes #34005.

Editing a model's raw `litellm_params` / `model_info` JSON on the admin UI (Models → edit a model → the JSON textareas) and removing a key had no effect: it kept coming back on save.

## Root cause

`PATCH /model/{model_id}/update` merges the incoming `litellm_params`/`model_info` into the stored blob with `dict.update()` (`update_db_model` in `litellm/proxy/management_endpoints/model_management_endpoints.py`). A key the user deletes from the JSON textarea is simply *absent* from the outgoing payload, which looks identical to "field not touched" from the merge's point of view — so the old value survives every save.

This is intentional behavior for *sparse* patches (e.g. `UpdateModelCredentialsModal` sends only `{"api_key": "..."}` and expects everything else to be left alone), so switching the merge to a full replace would silently wipe out unrelated fields on that flow. The two callers need different semantics for the same request shape, which the API had no way to distinguish.

## Fix

- **Backend** (`litellm/types/router.py`, `litellm/proxy/management_endpoints/model_management_endpoints.py`): `updateDeployment` gains two optional fields, `litellm_params_keys_to_delete` and `model_info_keys_to_delete`. `update_db_model` pops exactly those keys from the merged dict after the existing merge/null-clear logic runs. `model` is excluded (required by `litellm_params`), and a `PROTECTED_MODEL_INFO_KEYS` set guards structural/privileged `model_info` fields (`id`, `team_id`, `team_public_model_name`, `db_model`, `blocked`, audit timestamps) so this path can't be used to strip them.
- **Frontend** (`ui/litellm-dashboard/src/components/model_info_view.tsx`): `handleModelUpdate` already recomputes the *full* desired `litellm_params`/`model_info` blob from the JSON editors before saving (that part was already correct). It now also diffs that recomputed blob against the pre-edit snapshot (`modelData`) and includes any keys the user removed in `*_keys_to_delete`. The diff runs against the pre-mask-strip value so an untouched masked secret (e.g. `azure_ad_token: "az**...**BB"`) is never reported as "deleted" — it's still present in the diffed object, just excluded from the outgoing `litellm_params` blob by the existing `stripMaskedSecrets` guard.

Existing sparse-patch callers (`UpdateModelCredentialsModal`, `EditAutoRouterModal`, `AllModelsTab`'s `blocked` toggle) never set the new fields, so they're unaffected — verified by a dedicated no-op regression test.

## Testing

- `tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py`: new `TestUpdateDBModelKeyDeletion` class (5 tests) covering custom-key deletion for both blobs, the `PROTECTED_MODEL_INFO_KEYS` guard, the `model` guard, and the sparse-patch no-op case. Full file: 81 passed.
- `ui/litellm-dashboard/src/components/model_info_view.test.tsx`: two new regression tests driving the actual JSON textareas through Testing Library and asserting the outgoing payload. Full file: 44 passed.
- `ruff format --check` / `ruff check` clean on the two changed `litellm/**/*.py` files (pre-existing lint items elsewhere in those files are unrelated to this diff). `eslint` on the two changed frontend files: 0 errors (pre-existing warnings only, unrelated to this change).

## Type

🐛 Bug Fix

## Checklist

- [x] Added a test case to make sure the changes work as expected (backend + frontend)
- [x] Ran the relevant tests locally