### PR TITLE
test(proxy): make model_info endpoint tests hermetic to kill an order/merge-skew flake

### DIFF
--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -1702,8 +1702,8 @@ class TestModelInfoEndpoint:
     async def test_model_info_accessible_model_success(self):
         """Test model_info returns model data for accessible models"""
         from litellm.proxy.proxy_server import model_info
+        from litellm.types.router import Deployment, LiteLLM_Params, ModelInfo
 
-        # Mock user with access to specific models
         user_api_key_dict = UserAPIKeyAuth(
             user_id="test_user",
             api_key="test_key",
@@ -1713,31 +1713,22 @@ class TestModelInfoEndpoint:
 
         with (
             patch("litellm.proxy.proxy_server.llm_router") as mock_router,
-            patch("litellm.proxy.proxy_server.get_key_models") as mock_get_key_models,
-            patch("litellm.proxy.proxy_server.get_team_models") as mock_get_team_models,
+            patch("litellm.proxy.proxy_server.general_settings", {}),
             patch(
-                "litellm.proxy.proxy_server.get_complete_model_list"
-            ) as mock_get_complete_models,
-            patch("litellm.get_llm_provider") as mock_get_provider,
+                "litellm.proxy.utils.get_available_models_for_user",
+                new=AsyncMock(return_value=["gpt-4", "claude-3", "gpt-3.5-turbo"]),
+            ),
+            patch("litellm.get_llm_provider", return_value=(None, "openai", None, None)),
         ):
-            # Setup mocks
-            mock_router.get_model_names.return_value = [
-                "gpt-4",
-                "claude-3",
-                "gpt-3.5-turbo",
-            ]
-            mock_router.get_model_access_groups.return_value = {}
+            mock_router.get_fully_blocked_model_names.return_value = set()
+            mock_router.get_model_list.return_value = []
             mock_router.get_configured_token_limits.return_value = (None, None)
-            mock_get_key_models.return_value = ["gpt-4", "claude-3"]
-            mock_get_team_models.return_value = ["gpt-3.5-turbo"]
-            mock_get_complete_models.return_value = [
-                "gpt-4",
-                "claude-3",
-                "gpt-3.5-turbo",
-            ]
-            mock_get_provider.return_value = (None, "openai", None, None)
+            mock_router.get_deployment_by_model_group_name.return_value = Deployment(
+                model_name="gpt-4",
+                litellm_params=LiteLLM_Params(model="openai/gpt-4"),
+                model_info=ModelInfo(id="gpt-4"),
+            )
 
-            # Test accessible model
             result = await model_info(
                 model_id="gpt-4", user_api_key_dict=user_api_key_dict
             )
@@ -1764,18 +1755,14 @@ class TestModelInfoEndpoint:
 
         with (
             patch("litellm.proxy.proxy_server.llm_router") as mock_router,
-            patch("litellm.proxy.proxy_server.get_key_models") as mock_get_key_models,
-            patch("litellm.proxy.proxy_server.get_team_models") as mock_get_team_models,
+            patch("litellm.proxy.proxy_server.general_settings", {}),
             patch(
-                "litellm.proxy.proxy_server.get_complete_model_list"
-            ) as mock_get_complete_models,
+                "litellm.proxy.utils.get_available_models_for_user",
+                new=AsyncMock(return_value=["gpt-4"]),
+            ),
         ):
-            # Setup mocks - user only has access to gpt-4
-            mock_router.get_model_names.return_value = ["gpt-4", "claude-3"]
-            mock_router.get_model_access_groups.return_value = {}
-            mock_get_key_models.return_value = ["gpt-4"]
-            mock_get_team_models.return_value = []
-            mock_get_complete_models.return_value = ["gpt-4"]  # Only gpt-4 accessible
+            mock_router.get_fully_blocked_model_names.return_value = set()
+            mock_router.get_model_list.return_value = []
 
             # Test inaccessible model should raise 404
             with pytest.raises(HTTPException) as exc_info:
@@ -1791,8 +1778,8 @@ class TestModelInfoEndpoint:
     async def test_model_info_team_model_access(self):
         """Test model_info works with team model access"""
         from litellm.proxy.proxy_server import model_info
+        from litellm.types.router import Deployment, LiteLLM_Params, ModelInfo
 
-        # Mock user with team access
         user_api_key_dict = UserAPIKeyAuth(
             user_id="test_user",
             api_key="test_key",
@@ -1803,23 +1790,22 @@ class TestModelInfoEndpoint:
 
         with (
             patch("litellm.proxy.proxy_server.llm_router") as mock_router,
-            patch("litellm.proxy.proxy_server.get_key_models") as mock_get_key_models,
-            patch("litellm.proxy.proxy_server.get_team_models") as mock_get_team_models,
+            patch("litellm.proxy.proxy_server.general_settings", {}),
             patch(
-                "litellm.proxy.proxy_server.get_complete_model_list"
-            ) as mock_get_complete_models,
-            patch("litellm.get_llm_provider") as mock_get_provider,
+                "litellm.proxy.utils.get_available_models_for_user",
+                new=AsyncMock(return_value=["team-model-1"]),
+            ),
+            patch("litellm.get_llm_provider", return_value=(None, "custom", None, None)),
         ):
-            # Setup mocks
-            mock_router.get_model_names.return_value = ["team-model-1"]
-            mock_router.get_model_access_groups.return_value = {}
+            mock_router.get_fully_blocked_model_names.return_value = set()
+            mock_router.get_model_list.return_value = []
             mock_router.get_configured_token_limits.return_value = (None, None)
-            mock_get_key_models.return_value = []
-            mock_get_team_models.return_value = ["team-model-1"]
-            mock_get_complete_models.return_value = ["team-model-1"]
-            mock_get_provider.return_value = (None, "custom", None, None)
+            mock_router.get_deployment_by_model_group_name.return_value = Deployment(
+                model_name="team-model-1",
+                litellm_params=LiteLLM_Params(model="custom/team-model-1"),
+                model_info=ModelInfo(id="team-model-1"),
+            )
 
-            # Test team model access
             result = await model_info(
                 model_id="team-model-1", user_api_key_dict=user_api_key_dict
             )
@@ -2947,7 +2933,7 @@ class TestGetModelInfoWithIdBlocked:
     def test_get_model_info_with_id_propagates_blocked_true(self):
         from litellm.proxy.proxy_server import ProxyConfig
 
-        model = MagicMock()
+        model = MagicMock(spec=["model_id", "model_info", "blocked"])
         model.model_id = "dep-1"
         model.model_info = {}
         model.blocked = True

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -1244,7 +1244,8 @@ def test_ProxyConfig_get_model_info_with_id_returns_router_model_info():
     assert snapshot == {"id": "m-1", "db_model": True, "blocked": False}
 
 
-def test_ProxyConfig_get_model_info_with_id_missing_model_id_raises():
+def test_ProxyConfig_get_model_info_with_id_missing_model_id_raises(monkeypatch):
+    monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", False)
     pc = ProxyConfig()
     # model with no model_id, no model_info — accessing .model_id will fail.
     bad = SimpleNamespace(model_info=None)


### PR DESCRIPTION
## Relevant issues

Fixes the `proxy-endpoints` and `proxy-server` CI flake first observed on #33807 (`TestModelInfoEndpoint` failing with `ValueError: not enough values to unpack (expected 2, got 0)`)

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This is a test-only change (no file under `litellm/` is touched), so there is no runtime/product behavior to curl against a live proxy; the meaningful proof is the deterministic before/after of the flaky tests themselves, captured at specific commits

**BEFORE (the exact merge-skew window, `8536e3b80e` = product refactor #33721 landed, test not yet updated)** — the two tests from #33807's CI, in isolation:

```
$ git checkout 8536e3b80e -- litellm/proxy/utils.py tests/.../test_model_management_endpoints.py
$ pytest -p no:randomly \
    "tests/.../test_model_management_endpoints.py::TestModelInfoEndpoint::test_model_info_accessible_model_success" \
    "tests/.../test_model_management_endpoints.py::TestModelInfoEndpoint::test_model_info_team_model_access"

    configured_input, configured_output = llm_router.get_configured_token_limits(model_id)
E   ValueError: not enough values to unpack (expected 2, got 0)
2 failed
```

**BEFORE (current tip, the two sibling manifestations of the same root cause)** — deterministic under an enterprise license (`premium_user is True`), order-dependent otherwise:

```
$ pytest -p no:randomly \
    "tests/.../test_model_management_endpoints.py::TestGetModelInfoWithIdBlocked::test_get_model_info_with_id_propagates_blocked_true"
E   pydantic_core._pydantic_core.ValidationError: 2 validation errors for ModelInfo
E   updated_by  Input should be a valid string [input_value=<MagicMock name='mock.updated_by'>]
1 failed

$ pytest -n 2 tests/test_litellm/proxy/proxy_server        # 3x, deterministic
FAILED .../test_proxy_config.py::test_ProxyConfig_get_model_info_with_id_missing_model_id_raises
1 failed, 578 passed   (x3)
```

**AFTER (this PR, `44604620a4`)** — the two shards that went red, run the way CI runs them (`-n 2`), repeatedly:

```
# tests/test_litellm/proxy/management_endpoints  (6x deterministic + 4x random order)
1856 passed
# tests/test_litellm/proxy/proxy_server          (4x -n 2)
579 passed
```

The rewritten `TestModelInfoEndpoint` also passes against BOTH the pre-#33721 (`get_model_group_info`) and post-#33721 (`get_configured_token_limits`) endpoint, so a future merge-skew cannot reproduce the original failure

## Type

✅ Test

🐛 Bug Fix

## Changes

Root cause (full RCA linked below). The `model_info` / `get_model_info_with_id` endpoint unit tests drove refactored endpoints with bare, unspec'd `MagicMock()` routers and models. Because the mocks were unspec'd, any attribute or method the refactored endpoints newly read auto-materialized a child `MagicMock`, and whether that child was reached depended on process-global state the endpoints branch on: `premium_user`, and the real `get_available_models_for_user` chain reading `litellm` globals, both of which sibling tests in the same xdist worker mutate. When reached, the child `MagicMock` either unpacked to empty (`a, b = mock.method()` raises `not enough values to unpack (expected 2, got 0)`, since a bare `MagicMock`'s default `__iter__` yields nothing) or leaked into `RouterModelInfo(**model_info)` and failed Pydantic's `str` validation. The tests pass in isolation and fail under xdist / CI merge-skew

The specific #33807 failure was this class surfaced by merge timing: #33721 (2026-07-17 20:04) added a `get_configured_token_limits` unpack to `create_model_info_response`; #33742 (21:17) band-aided the test with `get_configured_token_limits.return_value = (None, None)`; #33807's branch was based at 19:28 (before #33721), so GitHub's PR-merge CI ran #33721's product code against the un-updated bare-mock test, deterministically hitting the unpack. Locally the branch stayed green because its pinned tree still used the old `get_model_group_info` path

The fix is test-only, no product change:
- `TestModelInfoEndpoint`: mock the real seam the refactored endpoint uses (`litellm.proxy.utils.get_available_models_for_user`), return a real `Deployment` from the router's `get_deployment_by_model_group_name`, configure the exact router methods the endpoint calls, pin `general_settings`, and delete the dead `proxy_server.get_key_models` / `get_team_models` / `get_complete_model_list` patches the refactor had stranded (the endpoint imports those fresh from `auth.model_checks`, so the patches were silent no-ops)
- `TestGetModelInfoWithIdBlocked`: `MagicMock(spec=["model_id", "model_info", "blocked"])` so unset enterprise columns read as `None` instead of child mocks
- `test_ProxyConfig_get_model_info_with_id_missing_model_id_raises`: pin `premium_user=False` so the asserted `AttributeError` no longer flips to a `TypeError` with the ambient license global

Same root-cause class still lives (out of scope for this isolated PR, flagged in the RCA for follow-up) in `tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py::test_model_info_v1_*` and `tests/test_litellm/proxy/guardrails/test_guardrail_coverage.py::test_secret_detection_*`, both of which I observed failing under xdist ordering and neither of which this PR touches

RCA: https://app.notion.com/p/3a343b8acdab81e49681cf3defd58a52

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
