### PR TITLE
fix(router): stop custom model_info leaking onto shared backend cost map key

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -200,6 +200,7 @@ from litellm.types.utils import (
     CustomPricingLiteLLMParams,
     GenericBudgetConfigType,
     LiteLLMBatch,
+    shared_backend_model_info,
 )
 from litellm.types.utils import ModelInfo
 from litellm.types.utils import ModelInfo as ModelMapInfo
@@ -7495,12 +7496,13 @@ class Router:
             if deployment.litellm_params.custom_llm_provider is not None:
                 _model_name = deployment.litellm_params.custom_llm_provider + "/" + _model_name
 
-            # For the shared backend key, strip custom pricing fields so that
-            # one deployment's pricing overrides don't pollute another
-            # deployment sharing the same backend model name.
-            # Each deployment's full pricing is already stored under its
-            # unique model_id above.
-            _shared_model_info = CustomPricingLiteLLMParams.strip_custom_pricing_fields(_model_info)
+            # For the shared backend key, keep only cost-map schema fields
+            # (minus custom pricing) so that one deployment's pricing overrides
+            # or custom metadata (id, access_via_team_ids, arbitrary keys)
+            # don't pollute another deployment sharing the same backend model
+            # name. Each deployment's full model_info is already stored under
+            # its unique model_id above.
+            _shared_model_info = shared_backend_model_info(_model_info)
             _existing_shared_mode = (cast(Optional[dict], litellm.model_cost.get(_model_name, {})) or {}).get("mode")
             _deployment_mode = _shared_model_info.get("mode")
             # Keep the built-in bridge mode stable for shared backend keys.
@@ -8219,12 +8221,13 @@ class Router:
         if deployment.litellm_params.custom_llm_provider is not None:
             _model_name = deployment.litellm_params.custom_llm_provider + "/" + _model_name
 
-        # For the shared backend key, strip custom pricing fields so that
-        # one deployment's pricing overrides don't pollute another
-        # deployment sharing the same backend model name.
-        # Each deployment's full pricing is already stored under its
-        # unique model_id above (when present).
-        _shared_model_info = CustomPricingLiteLLMParams.strip_custom_pricing_fields(_model_info_dict)
+        # For the shared backend key, keep only cost-map schema fields
+        # (minus custom pricing) so that one deployment's pricing overrides
+        # or custom metadata (id, access_via_team_ids, arbitrary keys)
+        # don't pollute another deployment sharing the same backend model
+        # name. Each deployment's full model_info is already stored under
+        # its unique model_id above (when present).
+        _shared_model_info = shared_backend_model_info(_model_info_dict)
         _backend_alias_cost = {_model_name: _shared_model_info}
         if "responses/" in _model_name:
             _stripped_model_name = _model_name.replace("responses/", "")

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
+    FrozenSet,
     List,
     Literal,
     Mapping,
@@ -3110,6 +3111,21 @@ class CustomPricingLiteLLMParams(BaseModel):
         backend model. Full pricing stays under the deployment's unique model id.
         """
         return {k: v for k, v in model_info.items() if k not in cls.model_fields}
+
+
+SHARED_BACKEND_MODEL_INFO_FIELDS: FrozenSet[str] = frozenset(
+    ModelInfoBase.__required_keys__ | ModelInfoBase.__optional_keys__
+) - frozenset(CustomPricingLiteLLMParams.model_fields)
+
+
+def shared_backend_model_info(model_info: Dict[str, Any]) -> Dict[str, Any]:
+    """Return only the fields safe to register under a shared ``{provider}/{model}``
+    key in ``litellm.model_cost``: cost-map schema fields (``ModelInfoBase``) minus
+    per-deployment pricing overrides. Per-deployment metadata (``id``,
+    ``access_via_team_ids``, arbitrary custom keys) never belongs on the shared key;
+    it stays under the deployment's unique model id.
+    """
+    return {k: v for k, v in model_info.items() if k in SHARED_BACKEND_MODEL_INFO_FIELDS}
 
 
 # Server-controlled fields that bound or drive an interceptor's agentic loop

--- a/tests/test_litellm/test_router_model_cost_isolation.py
+++ b/tests/test_litellm/test_router_model_cost_isolation.py
@@ -683,6 +683,144 @@ def test_custom_pricing_isolated_from_sibling_via_proxy_model_info_path():
         _restore_model_cost_entries(model_keys)
 
 
+def test_custom_model_info_metadata_not_leaked_to_shared_backend_key():
+    """LIT-4544: two deployments share the same backend model but carry
+    different custom model_info (arbitrary keys, access_via_team_ids, ids).
+    None of that per-deployment metadata may land on the shared backend key in
+    litellm.model_cost (served raw by /public/litellm_model_cost_map);
+    before the fix it was merged last-write-wins so values flipped randomly.
+    """
+    backend_model = "openai/gpt-4o-mini"
+    shared_keys = ("gpt-4o-mini", backend_model)
+    leak_fields = ("id", "additionalProp1", "access_via_team_ids", "db_model")
+
+    model_keys = {
+        key: copy.deepcopy(litellm.model_cost.get(key))
+        for key in (*shared_keys, "lit4544-deploy-a", "lit4544-deploy-b")
+    }
+    try:
+        Router(
+            model_list=[
+                {
+                    "model_name": "alias-unrestricted",
+                    "litellm_params": {
+                        "model": backend_model,
+                        "api_key": "fake-key-a",
+                    },
+                    "model_info": {
+                        "id": "lit4544-deploy-a",
+                        "additionalProp1": {"restricted": False, "model_location": "EU"},
+                    },
+                },
+                {
+                    "model_name": "alias-restricted",
+                    "litellm_params": {
+                        "model": backend_model,
+                        "api_key": "fake-key-b",
+                    },
+                    "model_info": {
+                        "id": "lit4544-deploy-b",
+                        "additionalProp1": {"restricted": True, "model_location": "US"},
+                        "access_via_team_ids": ["team-b-only"],
+                    },
+                },
+            ],
+        )
+
+        for shared_key in shared_keys:
+            shared_entry = litellm.model_cost.get(shared_key) or {}
+            leaked = [field for field in leak_fields if field in shared_entry]
+            assert not leaked, (
+                f"per-deployment metadata {leaked} leaked onto shared key "
+                f"{shared_key}: {shared_entry}"
+            )
+
+        entry_a = litellm.model_cost["lit4544-deploy-a"]
+        assert entry_a["additionalProp1"] == {"restricted": False, "model_location": "EU"}
+        entry_b = litellm.model_cost["lit4544-deploy-b"]
+        assert entry_b["additionalProp1"] == {"restricted": True, "model_location": "US"}
+        assert entry_b["access_via_team_ids"] == ["team-b-only"]
+    finally:
+        _restore_model_cost_entries(model_keys)
+
+
+def test_add_deployment_does_not_leak_custom_metadata_to_shared_backend_key():
+    """LIT-4544 dynamic path: deployments added at runtime (e.g. loaded from
+    the DB every scheduler cycle) must not re-pollute the shared backend key
+    with per-deployment metadata either.
+    """
+    backend_model = "openai/gpt-4o-mini"
+    shared_keys = ("gpt-4o-mini", backend_model)
+    deploy_id = "lit4544-add-deployment"
+
+    model_keys = {
+        key: copy.deepcopy(litellm.model_cost.get(key))
+        for key in (*shared_keys, deploy_id)
+    }
+    try:
+        router = Router(model_list=[])
+        router.add_deployment(
+            deployment=Deployment(
+                model_name="alias-dynamic",
+                litellm_params=LiteLLM_Params(
+                    model=backend_model,
+                    api_key="fake-key-dynamic",
+                ),
+                model_info=ModelInfo(
+                    id=deploy_id,
+                    additionalProp1={"restricted": True},
+                    access_via_team_ids=["team-dynamic"],
+                ),
+            )
+        )
+
+        for shared_key in shared_keys:
+            shared_entry = litellm.model_cost.get(shared_key) or {}
+            leaked = [
+                field
+                for field in ("id", "additionalProp1", "access_via_team_ids", "db_model")
+                if field in shared_entry
+            ]
+            assert not leaked, (
+                f"per-deployment metadata {leaked} leaked onto shared key "
+                f"{shared_key}: {shared_entry}"
+            )
+
+        assert litellm.model_cost[deploy_id]["access_via_team_ids"] == ["team-dynamic"]
+    finally:
+        _restore_model_cost_entries(model_keys)
+
+
+def test_shared_backend_model_info_keeps_schema_fields_and_drops_the_rest():
+    """Unit test of the whitelist helper: cost-map schema fields survive,
+    custom pricing overrides and per-deployment metadata do not.
+    """
+    from litellm.types.utils import shared_backend_model_info
+
+    filtered = shared_backend_model_info(
+        {
+            "mode": "chat",
+            "litellm_provider": "openai",
+            "max_tokens": 128000,
+            "supports_vision": True,
+            "input_cost_per_token": 0.99,
+            "output_cost_per_token": 0.99,
+            "id": "deploy-a",
+            "db_model": False,
+            "access_via_team_ids": ["team-a"],
+            "additionalProp1": {"restricted": True},
+            "base_model": "gpt-4o-mini",
+        }
+    )
+
+    assert filtered == {
+        "mode": "chat",
+        "litellm_provider": "openai",
+        "max_tokens": 128000,
+        "supports_vision": True,
+    }
+
+
 def test_wildcard_zero_cost_request_does_not_poison_named_deployment_pricing():
     """LIT-3991 end to end: a proxy has a named text-embedding-3-small
     deployment relying on built-in pricing plus an ``openai/*`` wildcard with


### PR DESCRIPTION
## Relevant issues

Relates to #20999

## Linear ticket

Resolves LIT-4544

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Repro config (from the Linear ticket): two deployments sharing `openai/gpt-4o-mini` with different Model IDs and different custom `model_info`, running against the real OpenAI API

```yaml
model_list:
  - model_name: alias-unrestricted
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      id: deploy-a
      additionalProp1:
        restricted: false
        model_location: EU

  - model_name: alias-restricted
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      id: deploy-b
      additionalProp1:
        restricted: true
        model_location: US
      access_via_team_ids:
        - team-b-only

general_settings:
  master_key: sk-lit4544-qa
  store_model_in_db: false
```

```bash
litellm --config lit4544_qa_config.yaml --port 4787 --host 127.0.0.1
```

Before (captured at base commit 6f62022e84): the shared `gpt-4o-mini` cost map entry carries the last deployment's private metadata

```bash
curl -s 'http://127.0.0.1:4787/public/litellm_model_cost_map' | python3 -c 'import json,sys
e=json.load(sys.stdin)["gpt-4o-mini"]
print(json.dumps({"additionalProp1": e.get("additionalProp1"), "access_via_team_ids": e.get("access_via_team_ids"), "id": e.get("id")}, indent=2))'
```

```json
{
  "additionalProp1": {
    "restricted": true,
    "model_location": "US"
  },
  "access_via_team_ids": [
    "team-b-only"
  ],
  "id": "deploy-b"
}
```

After (captured at 3f712e3fde): same curl, shared key is clean and built-in pricing is intact

```json
{
  "additionalProp1": null,
  "access_via_team_ids": null,
  "id": null,
  "input_cost_per_token": 1.5e-07,
  "mode": "chat"
}
```

`/model/info` still reports each deployment's own metadata correctly (at 3f712e3fde)

```bash
curl -s 'http://127.0.0.1:4787/model/info' -H 'Authorization: Bearer sk-lit4544-qa' | python3 -c 'import json,sys
for m in json.load(sys.stdin)["data"]:
 mi=m["model_info"]
 print({"model_name": m["model_name"], "id": mi["id"], "additionalProp1": mi.get("additionalProp1"), "access_via_team_ids": mi.get("access_via_team_ids")})'
```

```text
{'model_name': 'alias-unrestricted', 'id': 'deploy-a', 'additionalProp1': {'restricted': False, 'model_location': 'EU'}, 'access_via_team_ids': []}
{'model_name': 'alias-restricted', 'id': 'deploy-b', 'additionalProp1': {'restricted': True, 'model_location': 'US'}, 'access_via_team_ids': []}
```

Real paid completions through both aliases still route to the right deployment and cost-track at the built-in gpt-4o-mini rate (at 3f712e3fde)

```bash
for alias in alias-unrestricted alias-restricted; do
  curl -s -D - 'http://127.0.0.1:4787/chat/completions' -H 'Authorization: Bearer sk-lit4544-qa' -H 'Content-Type: application/json' \
    -d "{\"model\": \"$alias\", \"messages\": [{\"role\": \"user\", \"content\": \"Reply with exactly: $alias ok\"}]}" -o /tmp/resp_$alias.json | grep -i "x-litellm-response-cost:\|x-litellm-model-id"
  python3 -c "import json; r=json.load(open('/tmp/resp_$alias.json')); print(r['choices'][0]['message']['content'])"
done
```

```text
x-litellm-model-id: deploy-a
x-litellm-response-cost: 4.6499999999999995e-06
alias-unrestricted ok
x-litellm-model-id: deploy-b
x-litellm-response-cost: 4.6499999999999995e-06
alias-restricted ok
```

The shared key was re-checked after this real traffic and stays clean

## Type

🐛 Bug Fix

## Changes

`Router._create_deployment` and `Router.add_deployment` register each deployment's `model_info` under the shared `{provider}/{model}` key in `litellm.model_cost`, stripping only pricing fields via `CustomPricingLiteLLMParams.strip_custom_pricing_fields`. Everything else survived, so per-deployment metadata (`id`, `access_via_team_ids`, `db_model`, arbitrary custom keys like `additionalProp1`) was merged onto the shared backend entry last-write-wins. With several deployments sharing one backend model the winner depends on registration order per worker process, so `/public/litellm_model_cost_map` and any raw `litellm.model_cost` reader showed one deployment's private metadata under the backend model name and the values flipped between requests

This PR replaces the pricing-only denylist at both registration sites with `shared_backend_model_info`, a whitelist that keeps only cost-map schema fields (`ModelInfoBase` keys minus the custom pricing fields). Schema fields such as `mode`, `max_tokens` and `supports_*` still propagate for models missing from the built-in map, the existing mode preservation logic is untouched, and each deployment's full `model_info` continues to be registered under its unique model id, so custom pricing and cost tracking are unaffected

Regression tests cover the config load path, the dynamic `add_deployment` path (the one background config reloads hit), and the whitelist helper itself; the two router-level tests fail on the base commit with the exact leak from the ticket and pass with the fix

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches router model registration and public cost-map output; behavior change is intentional and scoped, with targeted regression tests, but affects any consumer of shared backend keys in `litellm.model_cost`.
> 
> **Overview**
> Fixes **LIT-4544**: when several deployments share the same backend model (`{provider}/{model}`), per-deployment `model_info` (e.g. `id`, `access_via_team_ids`, custom keys like `additionalProp1`) was merged onto the shared `litellm.model_cost` entry with last-write-wins behavior. That polluted **`/public/litellm_model_cost_map`** and other readers of the shared key.
> 
> Registration in **`Router._create_deployment`** and **`Router.add_deployment`** now uses **`shared_backend_model_info`**, which **whitelists** only `ModelInfoBase` cost-map fields (minus custom pricing overrides) instead of **`strip_custom_pricing_fields`**, which only removed pricing keys and let metadata through. Full per-deployment `model_info` remains on each deployment’s unique model id; existing mode-preservation on the shared key is unchanged.
> 
> Regression tests cover config load, runtime **`add_deployment`**, and the helper itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f712e3fde106b5da383f5a649a3fe04289f03e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->