### PR TITLE
fix(router): propagate capability flags to shared backend cost map key

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -270,6 +270,8 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
             "realtime",
         ]
     ]
+    supported_endpoints: Optional[List[str]]
+    use_openai_responses_path: Optional[bool]
     tpm: Optional[int]
     rpm: Optional[int]
     provider_specific_entry: Optional[Dict[str, float]]

--- a/tests/test_litellm/test_router_model_cost_isolation.py
+++ b/tests/test_litellm/test_router_model_cost_isolation.py
@@ -803,6 +803,8 @@ def test_shared_backend_model_info_keeps_schema_fields_and_drops_the_rest():
             "litellm_provider": "openai",
             "max_tokens": 128000,
             "supports_vision": True,
+            "supported_endpoints": ["/v1/responses"],
+            "use_openai_responses_path": True,
             "input_cost_per_token": 0.99,
             "output_cost_per_token": 0.99,
             "id": "deploy-a",
@@ -818,7 +820,57 @@ def test_shared_backend_model_info_keeps_schema_fields_and_drops_the_rest():
         "litellm_provider": "openai",
         "max_tokens": 128000,
         "supports_vision": True,
+        "supported_endpoints": ["/v1/responses"],
+        "use_openai_responses_path": True,
     }
+
+
+def test_capability_flags_propagate_from_deployment_model_info_to_shared_key():
+    """Backend-model capability facts (supported_endpoints,
+    use_openai_responses_path) declared in a deployment's model_info must reach
+    the shared backend key: the Bedrock Mantle routing gates read them raw off
+    litellm.model_cost and document proxy model_info as an override path for
+    models missing from the built-in cost map.
+    """
+    from litellm.llms.bedrock_mantle.common_utils import (
+        mantle_base_segment,
+        mantle_supports_responses,
+    )
+
+    bare_model = "somelab.lit4544-unmapped-model"
+    backend_model = f"bedrock_mantle/{bare_model}"
+    deploy_id = "lit4544-mantle-deploy"
+
+    model_keys = {
+        key: copy.deepcopy(litellm.model_cost.get(key))
+        for key in (bare_model, backend_model, deploy_id)
+    }
+    try:
+        Router(
+            model_list=[
+                {
+                    "model_name": "mantle-alias",
+                    "litellm_params": {
+                        "model": backend_model,
+                        "api_key": "fake-key",
+                    },
+                    "model_info": {
+                        "id": deploy_id,
+                        "supported_endpoints": ["/v1/responses"],
+                        "use_openai_responses_path": True,
+                    },
+                },
+            ],
+        )
+
+        shared_entry = litellm.model_cost.get(backend_model) or {}
+        assert shared_entry.get("supported_endpoints") == ["/v1/responses"]
+        assert shared_entry.get("use_openai_responses_path") is True
+        assert "id" not in shared_entry
+        assert mantle_supports_responses(bare_model, litellm.model_cost) is True
+        assert mantle_base_segment(bare_model, litellm.model_cost) == "openai/v1"
+    finally:
+        _restore_model_cost_entries(model_keys)
 
 
 def test_wildcard_zero_cost_request_does_not_poison_named_deployment_pricing():


### PR DESCRIPTION
## Relevant issues

Follow-up to #34041

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Scenario: day-0 capability rollout on AWS Bedrock Mantle. A config deployment declares native Responses support in `model_info` before the model cost map ships that flag. To reproduce faithfully what a proxy running an older map sees, the proxy is pointed at the cost map snapshot from commit c0352c5aa8, the last one where `bedrock_mantle/openai.gpt-oss-120b` has no `supported_endpoints`; everything else hits the real AWS Bedrock Mantle API and costs real $

```yaml
model_list:
  - model_name: gpt-oss-120b
    litellm_params:
      model: bedrock_mantle/openai.gpt-oss-120b
      aws_region_name: us-east-1
    model_info:
      supported_endpoints:
        - /v1/chat/completions
        - /v1/responses

general_settings:
  master_key: sk-mantle-flags-qa
```

```bash
LITELLM_MODEL_COST_MAP_URL=https://raw.githubusercontent.com/BerriAI/litellm/c0352c5aa8cf44e089a8c630bb3b09a7040926b0/model_prices_and_context_window.json \
AWS_PROFILE=litellm-dev AWS_REGION=us-east-1 \
litellm --config mantle_flags_qa_config.yaml --port 4926 --host 127.0.0.1 --detailed_debug 2>&1 | tee litellm.log
```

Before (captured at fa59cfa6da): the whitelist strips the flag from the shared backend key and a live `/v1/responses` request is silently downgraded to ChatCompletions emulation

```bash
curl -s 'http://127.0.0.1:4926/public/litellm_model_cost_map' | python3 -c 'import json,sys
e = json.load(sys.stdin).get("bedrock_mantle/openai.gpt-oss-120b") or {}
print(json.dumps({"supported_endpoints": e.get("supported_endpoints"), "mode": e.get("mode")}))'
```

```json
{"supported_endpoints": null, "mode": "chat"}
```

```bash
curl -s 'http://127.0.0.1:4926/v1/responses' -H 'Authorization: Bearer sk-mantle-flags-qa' -H 'Content-Type: application/json' \
  -d '{"model": "gpt-oss-120b", "input": "Reply with exactly: responses route check", "max_output_tokens": 200}'
# {'status': 'completed', 'text': ['responses route check']}

grep -o "https://bedrock-mantle[^ ']*" litellm.log | sort | uniq -c
#    1 https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions
```

After (captured at 1e6a34850d): same config and commands. The flag reaches the shared key, per-deployment metadata stays off it, and the paid request routes to the native Responses endpoint

```json
{"supported_endpoints": ["/v1/chat/completions", "/v1/responses"], "mode": "chat", "id": null, "db_model": null}
```

```bash
curl -s -D - 'http://127.0.0.1:4926/v1/responses' -H 'Authorization: Bearer sk-mantle-flags-qa' -H 'Content-Type: application/json' \
  -d '{"model": "gpt-oss-120b", "input": "Reply with exactly: native responses ok", "max_output_tokens": 200}'
```

```text
HTTP/1.1 200 OK
x-litellm-model-id: d04789b55a7ef697e4aecddafaca934c3a84367eb93501adcd3a69452c074691
x-litellm-response-cost: 6.209999999999999e-05
{'status': 'completed', 'model': 'gpt-oss-120b', 'text': ['native responses ok']}
```

```bash
grep -o "https://bedrock-mantle[^ ']*" litellm.log | sort | uniq -c
#    1 https://bedrock-mantle.us-east-1.api.aws/v1/responses
```

## Type

🐛 Bug Fix

## Changes

PR #34041 replaced the pricing-only denylist for shared backend cost map keys with a whitelist derived from `ModelInfoBase`. `supported_endpoints` and `use_openai_responses_path` are cost map schema fields; the Bedrock Mantle routing gates `mantle_supports_responses` and `mantle_base_segment` read them raw off `litellm.model_cost` and document proxy `model_info` as an override path. Both fields were missing from the `ModelInfoBase` TypedDict, so the whitelist silently dropped them and that override stopped propagating. They are backend model capability facts like `mode` and `supports_*`, identical across deployments sharing a backend, not per-deployment metadata, so they belong on the shared key

This PR declares both fields on `ModelInfoBase`, which adds them back to `SHARED_BACKEND_MODEL_INFO_FIELDS`. Regression tests cover the whitelist helper keeping them and the router registration path landing them on the shared `bedrock_mantle/...` key where the routing gates read them, while per-deployment metadata (`id`, `db_model`, `access_via_team_ids`) stays stripped; both router tests fail at the base commit and pass with the fix

One pre-existing quirk surfaced during QA, out of scope here: `register_model` resolves an unknown prefixed key through `get_model_info`, so when a bare built-in entry exists for the same model id (e.g. `qwen.qwen3-coder-next` under `bedrock_converse`) the registration merges onto that bare key and the `bedrock_mantle/...` key is never created, leaving the gates blind to the override. The override therefore takes effect for models whose prefixed entry exists or that are absent from the map entirely. That behavior predates #34041

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
