### PR TITLE
feat(ptu): fetch azure_billing flat cost via Cost Management API (LIT-4077 POC)

### DIFF
--- a/litellm/integrations/azure_cost_management/__init__.py
+++ b/litellm/integrations/azure_cost_management/__init__.py
@@ -1,0 +1,6 @@
+from litellm.integrations.azure_cost_management.azure_cost_management_client import (
+    AzureCostManagementClient,
+    AzureCostManagementError,
+)
+
+__all__ = ["AzureCostManagementClient", "AzureCostManagementError"]

--- a/litellm/integrations/azure_cost_management/azure_cost_management_client.py
+++ b/litellm/integrations/azure_cost_management/azure_cost_management_client.py
@@ -1,0 +1,191 @@
+"""Thin async client for Azure Cost Management REST API.
+
+Used by the PTU reservation rollup to fetch billed cost for a specific
+Azure resource id on a given day (LIT-4077). Deliberately narrow: exposes
+one public method the rollup needs, not a general Cost Management SDK.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta, timezone
+from typing import Any, Callable, Optional
+
+import httpx
+
+from litellm._logging import verbose_logger
+from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+
+
+class AzureCostManagementError(Exception):
+    """Raised when the Cost Management API returns a non-2xx or an unexpected payload."""
+
+
+@dataclass(frozen=True, slots=True)
+class AzureCostManagementConfig:
+    subscription_id: str
+    tenant_id: str
+    client_id: str
+    client_secret: str
+    api_version: str = "2023-11-01"
+
+    @classmethod
+    def from_env(cls, subscription_id: str) -> AzureCostManagementConfig:
+        tenant_id = os.getenv("AZURE_TENANT_ID")
+        client_id = os.getenv("AZURE_CLIENT_ID")
+        client_secret = os.getenv("AZURE_CLIENT_SECRET")
+        missing = [
+            name
+            for name, value in (
+                ("AZURE_TENANT_ID", tenant_id),
+                ("AZURE_CLIENT_ID", client_id),
+                ("AZURE_CLIENT_SECRET", client_secret),
+            )
+            if not value
+        ]
+        if missing:
+            raise AzureCostManagementError(f"Missing required env vars for Azure Cost Management auth: {missing}")
+        return cls(
+            subscription_id=subscription_id,
+            tenant_id=tenant_id or "",
+            client_id=client_id or "",
+            client_secret=client_secret or "",
+        )
+
+
+TokenProvider = Callable[[], str]
+
+
+def _default_token_provider_factory(config: AzureCostManagementConfig) -> TokenProvider:
+    from litellm.llms.azure.common_utils import get_azure_ad_token_from_entra_id
+
+    return get_azure_ad_token_from_entra_id(
+        tenant_id=config.tenant_id,
+        client_id=config.client_id,
+        client_secret=config.client_secret,
+        scope="https://management.azure.com/.default",
+    )
+
+
+class AzureCostManagementClient:
+    """Fetch billed cost for a single Azure resource on a specific day.
+
+    Auth: Entra ID service principal via env vars (``AZURE_TENANT_ID``,
+    ``AZURE_CLIENT_ID``, ``AZURE_CLIENT_SECRET``). The token provider is
+    dependency-injectable for tests.
+
+    Currency: the API returns cost in the subscription's billing currency,
+    exposed on the response. Callers that require USD MUST inspect
+    ``last_currency`` after each call and handle non-USD.
+    """
+
+    def __init__(
+        self,
+        config: AzureCostManagementConfig,
+        *,
+        http_handler: Optional[AsyncHTTPHandler] = None,
+        token_provider: Optional[TokenProvider] = None,
+    ) -> None:
+        self._config = config
+        self._http = http_handler or AsyncHTTPHandler()
+        self._token_provider = token_provider or _default_token_provider_factory(config)
+        self._last_currency: Optional[str] = None
+
+    @property
+    def last_currency(self) -> Optional[str]:
+        return self._last_currency
+
+    async def get_daily_cost(self, resource_id: str, day: date) -> float:
+        """Return billed cost for ``resource_id`` on the UTC calendar day ``day``.
+
+        Raises ``AzureCostManagementError`` on non-2xx responses or unexpected
+        payloads. Returns 0.0 when Azure reports no rows for the window (a
+        valid response, typically due to reporting lag or zero utilization).
+        """
+        url = (
+            "https://management.azure.com/subscriptions/"
+            f"{self._config.subscription_id}"
+            "/providers/Microsoft.CostManagement/query"
+        )
+        start = datetime.combine(day, time.min, tzinfo=timezone.utc)
+        end = start + timedelta(days=1) - timedelta(microseconds=1)
+        body = {
+            "type": "ActualCost",
+            "timeframe": "Custom",
+            "timePeriod": {
+                "from": start.isoformat().replace("+00:00", "Z"),
+                "to": end.isoformat().replace("+00:00", "Z"),
+            },
+            "dataset": {
+                "granularity": "Daily",
+                "aggregation": {"totalCost": {"name": "Cost", "function": "Sum"}},
+                "filter": {
+                    "dimensions": {
+                        "name": "ResourceId",
+                        "operator": "In",
+                        "values": [resource_id],
+                    }
+                },
+            },
+        }
+        token = self._token_provider()
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+        try:
+            response = await self._http.post(
+                url=url,
+                json=body,
+                params={"api-version": self._config.api_version},
+                headers=headers,
+            )
+        except httpx.HTTPStatusError as exc:
+            raise AzureCostManagementError(
+                f"Azure Cost Management HTTP {exc.response.status_code}: {exc.response.text}"
+            ) from exc
+        return self._parse_cost_and_currency(response.json())
+
+    def _parse_cost_and_currency(self, payload: Any) -> float:
+        try:
+            properties = payload.get("properties", {}) if isinstance(payload, dict) else {}
+            rows = properties.get("rows") or []
+            columns = properties.get("columns") or []
+        except AttributeError as exc:
+            raise AzureCostManagementError(f"Unexpected payload shape: {payload!r}") from exc
+
+        if not rows:
+            self._last_currency = None
+            return 0.0
+
+        column_index = {col.get("name"): i for i, col in enumerate(columns) if isinstance(col, dict)}
+        cost_idx: Optional[int] = None
+        for candidate in ("Cost", "PreTaxCost", "CostUSD"):
+            if candidate in column_index:
+                cost_idx = column_index[candidate]
+                break
+        currency_idx = column_index.get("Currency")
+        if cost_idx is None:
+            raise AzureCostManagementError(f"No Cost column in response; columns={list(column_index)}")
+
+        try:
+            total = sum(float(row[cost_idx]) for row in rows)
+        except (TypeError, ValueError, IndexError) as exc:
+            raise AzureCostManagementError(f"Non-numeric cost value in rows: {rows}") from exc
+
+        if currency_idx is not None and rows:
+            try:
+                self._last_currency = str(rows[0][currency_idx])
+            except (IndexError, TypeError):
+                self._last_currency = None
+        else:
+            self._last_currency = None
+
+        if self._last_currency is not None and self._last_currency.upper() != "USD":
+            verbose_logger.warning(
+                "Azure Cost Management returned currency=%s for resource %s; value written as-is without conversion",
+                self._last_currency,
+                "(resource redacted)",
+            )
+        return total

--- a/litellm/integrations/azure_cost_management/azure_cost_management_client.py
+++ b/litellm/integrations/azure_cost_management/azure_cost_management_client.py
@@ -30,6 +30,7 @@ class AzureCostManagementConfig:
     client_id: str
     client_secret: str = field(repr=False)
     api_version: str = "2023-11-01"
+    management_base_url: str = "https://management.azure.com"
 
     @classmethod
     def from_env(cls, subscription_id: str) -> AzureCostManagementConfig:
@@ -52,6 +53,7 @@ class AzureCostManagementConfig:
             tenant_id=tenant_id or "",
             client_id=client_id or "",
             client_secret=client_secret or "",
+            management_base_url=os.getenv("AZURE_MANAGEMENT_BASE_URL", "https://management.azure.com"),
         )
 
 
@@ -105,7 +107,7 @@ class AzureCostManagementClient:
         valid response, typically due to reporting lag or zero utilization).
         """
         url = (
-            "https://management.azure.com/subscriptions/"
+            f"{self._config.management_base_url}/subscriptions/"
             f"{self._config.subscription_id}"
             "/providers/Microsoft.CostManagement/query"
         )

--- a/litellm/integrations/azure_cost_management/azure_cost_management_client.py
+++ b/litellm/integrations/azure_cost_management/azure_cost_management_client.py
@@ -8,18 +8,19 @@ one public method the rollup needs, not a general Cost Management SDK.
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta, timezone
 from typing import Any, Callable, Optional
 
 import httpx
 
 from litellm._logging import verbose_logger
-from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, get_async_httpx_client
+from litellm.types.llms.custom_http import httpxSpecialProvider
 
 
 class AzureCostManagementError(Exception):
-    """Raised when the Cost Management API returns a non-2xx or an unexpected payload."""
+    """Raised when the Cost Management API returns a non-2xx, network failure, or an unexpected payload."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -27,7 +28,7 @@ class AzureCostManagementConfig:
     subscription_id: str
     tenant_id: str
     client_id: str
-    client_secret: str
+    client_secret: str = field(repr=False)
     api_version: str = "2023-11-01"
 
     @classmethod
@@ -88,7 +89,7 @@ class AzureCostManagementClient:
         token_provider: Optional[TokenProvider] = None,
     ) -> None:
         self._config = config
-        self._http = http_handler or AsyncHTTPHandler()
+        self._http = http_handler or get_async_httpx_client(httpxSpecialProvider.AzureCostManagement)
         self._token_provider = token_provider or _default_token_provider_factory(config)
         self._last_currency: Optional[str] = None
 
@@ -145,15 +146,14 @@ class AzureCostManagementClient:
             raise AzureCostManagementError(
                 f"Azure Cost Management HTTP {exc.response.status_code}: {exc.response.text}"
             ) from exc
+        except httpx.RequestError as exc:
+            raise AzureCostManagementError(f"Azure Cost Management network error: {exc}") from exc
         return self._parse_cost_and_currency(response.json())
 
     def _parse_cost_and_currency(self, payload: Any) -> float:
-        try:
-            properties = payload.get("properties", {}) if isinstance(payload, dict) else {}
-            rows = properties.get("rows") or []
-            columns = properties.get("columns") or []
-        except AttributeError as exc:
-            raise AzureCostManagementError(f"Unexpected payload shape: {payload!r}") from exc
+        properties = payload.get("properties", {}) if isinstance(payload, dict) else {}
+        rows = properties.get("rows") or []
+        columns = properties.get("columns") or []
 
         if not rows:
             self._last_currency = None

--- a/litellm/proxy/dev_config.yaml
+++ b/litellm/proxy/dev_config.yaml
@@ -203,6 +203,8 @@ general_settings:
   # gs:// (Vertex) or s3:// (Bedrock) input_file_id. Requires a matching deployment
   # configured for the batched model. Defaults to false.
   # track_unmanaged_batch_cost: true
+  azure_ptu_billing:
+    subscription_id: os.environ/AZURE_SUBSCRIPTION_ID
 
 sandbox_tools:
   - sandbox_tool_name: e2b_sandbox

--- a/litellm/proxy/management_endpoints/ptu_reservation_endpoints.py
+++ b/litellm/proxy/management_endpoints/ptu_reservation_endpoints.py
@@ -90,10 +90,10 @@ async def new_ptu_reservation(
     _require_proxy_admin(user_api_key_dict)
     prisma_client = _require_db()
 
-    if body.cost_source == "azure_billing":
+    if body.cost_source == "azure_billing" and not body.azure_resource_id:
         raise HTTPException(
             status_code=400,
-            detail={"error": "cost_source='azure_billing' is not supported in this release"},
+            detail={"error": "azure_resource_id is required when cost_source='azure_billing'"},
         )
 
     try:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7465,19 +7465,19 @@ def giveup(e):
 
 
 def _build_azure_cost_fetcher_if_enabled() -> Optional[Any]:
-    """Return an AzureCostManagementClient when the pull flag + config + creds are all present, else None.
+    """Return an AzureCostManagementClient when config + creds are present, else None.
 
-    Evaluated at rollup call time so runtime flag toggles take effect without
-    a proxy restart.
+    Presence of general_settings.azure_ptu_billing.subscription_id together with the
+    Entra ID env vars is the sole signal for "operator wants the auto-pull"; if any
+    piece is missing, azure_billing reservations no-op with a warning inside the
+    rollup and manual reservations continue to accrue via the formula.
+
+    Evaluated at rollup call time so runtime config changes take effect without a
+    proxy restart.
     """
-    if not general_settings.get("enable_azure_ptu_billing_pull", False):
-        return None
     azure_ptu_billing = general_settings.get("azure_ptu_billing") or {}
     subscription_id = azure_ptu_billing.get("subscription_id")
     if not subscription_id:
-        verbose_proxy_logger.warning(
-            "enable_azure_ptu_billing_pull is true but general_settings.azure_ptu_billing.subscription_id is not set"
-        )
         return None
     try:
         from litellm.integrations.azure_cost_management import AzureCostManagementClient

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7480,10 +7480,7 @@ def _build_azure_cost_fetcher_if_enabled() -> Optional[Any]:
         )
         return None
     try:
-        from litellm.integrations.azure_cost_management import (
-            AzureCostManagementClient,
-            AzureCostManagementError,
-        )
+        from litellm.integrations.azure_cost_management import AzureCostManagementClient
         from litellm.integrations.azure_cost_management.azure_cost_management_client import (
             AzureCostManagementConfig,
         )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7464,6 +7464,24 @@ def giveup(e):
     return result
 
 
+class _DemoAzureCostFetcher:
+    """Env-gated stub used only when AZURE_PTU_DEMO_USD is set.
+
+    Returns the same USD amount for every reservation/day so the Usage page can show
+    a plausible azure_billing figure during customer demos without provisioning a real
+    PTU or waiting for Azure's 24-72h billing lag. Presence of the env var is
+    intentionally the only opt-in; it prints a loud warning so nobody ships to prod
+    with it accidentally set.
+    """
+
+    def __init__(self, amount_usd: float) -> None:
+        self._amount = amount_usd
+        self.last_currency = "USD"
+
+    async def get_daily_cost(self, resource_id: str, day: Any) -> float:  # noqa: ARG002  # demo signature must match AzureCostFetcher Protocol
+        return self._amount
+
+
 def _build_azure_cost_fetcher_if_enabled() -> Optional[Any]:
     """Return an AzureCostManagementClient when config + creds are present, else None.
 
@@ -7472,9 +7490,31 @@ def _build_azure_cost_fetcher_if_enabled() -> Optional[Any]:
     piece is missing, azure_billing reservations no-op with a warning inside the
     rollup and manual reservations continue to accrue via the formula.
 
+    When ``AZURE_PTU_DEMO_USD`` is set, a stub fetcher returning that amount is
+    used instead of the real client. Demo-only; a WARNING is logged every call so
+    the mode is impossible to miss in production logs.
+
     Evaluated at rollup call time so runtime config changes take effect without a
     proxy restart.
     """
+    demo_env = os.getenv("AZURE_PTU_DEMO_USD")
+    if demo_env:
+        try:
+            amount = float(demo_env)
+        except ValueError:
+            verbose_proxy_logger.warning(
+                "AZURE_PTU_DEMO_USD=%r is not a valid float; skipping demo fetcher.",
+                demo_env,
+            )
+        else:
+            verbose_proxy_logger.warning(
+                "AZURE_PTU_DEMO_USD=%.2f is set; azure_billing reservations will return "
+                "this stub USD amount instead of hitting Azure Cost Management. "
+                "Unset this env var before shipping to production.",
+                amount,
+            )
+            return _DemoAzureCostFetcher(amount)
+
     azure_ptu_billing = general_settings.get("azure_ptu_billing") or {}
     subscription_id = azure_ptu_billing.get("subscription_id")
     if not subscription_id:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7464,6 +7464,40 @@ def giveup(e):
     return result
 
 
+def _build_azure_cost_fetcher_if_enabled() -> Optional[Any]:
+    """Return an AzureCostManagementClient when the pull flag + config + creds are all present, else None.
+
+    Evaluated at rollup call time so runtime flag toggles take effect without
+    a proxy restart.
+    """
+    if not general_settings.get("enable_azure_ptu_billing_pull", False):
+        return None
+    azure_ptu_billing = general_settings.get("azure_ptu_billing") or {}
+    subscription_id = azure_ptu_billing.get("subscription_id")
+    if not subscription_id:
+        verbose_proxy_logger.warning(
+            "enable_azure_ptu_billing_pull is true but general_settings.azure_ptu_billing.subscription_id is not set"
+        )
+        return None
+    try:
+        from litellm.integrations.azure_cost_management import (
+            AzureCostManagementClient,
+            AzureCostManagementError,
+        )
+        from litellm.integrations.azure_cost_management.azure_cost_management_client import (
+            AzureCostManagementConfig,
+        )
+
+        config = AzureCostManagementConfig.from_env(subscription_id=subscription_id)
+        return AzureCostManagementClient(config=config)
+    except Exception as exc:  # noqa: BLE001  # missing creds/env; log once per invocation and skip azure_billing this run
+        verbose_proxy_logger.warning(
+            "Azure Cost Management client could not be built: %s. azure_billing reservations will no-op this run.",
+            exc,
+        )
+        return None
+
+
 class ProxyStartupEvent:
     @classmethod
     def _initialize_startup_logging(
@@ -7935,12 +7969,15 @@ class ProxyStartupEvent:
             run_ptu_reservation_rollup,
         )
 
+        async def _scheduled_ptu_rollup() -> None:
+            azure_fetcher = _build_azure_cost_fetcher_if_enabled()
+            await run_ptu_reservation_rollup(prisma_client, azure_fetcher=azure_fetcher)
+
         scheduler.add_job(
-            run_ptu_reservation_rollup,
+            _scheduled_ptu_rollup,
             "cron",
             hour=0,
             minute=15,
-            args=[prisma_client],
             id=PTU_ROLLUP_JOB_ID,
             replace_existing=True,
             misfire_grace_time=APSCHEDULER_MISFIRE_GRACE_TIME,

--- a/litellm/proxy/spend_tracking/ptu_reservation_rollup.py
+++ b/litellm/proxy/spend_tracking/ptu_reservation_rollup.py
@@ -64,14 +64,6 @@ async def _compute_daily_flat_cost(
             return 0.0
         try:
             fetched = await azure_fetcher.get_daily_cost(reservation.azure_resource_id, day)
-            verbose_proxy_logger.info(
-                "PTU rollup: azure_billing reservation=%s day=%s resource=%s returned $%.4f",
-                getattr(reservation, "id", "?"),
-                day.isoformat(),
-                reservation.azure_resource_id,
-                fetched,
-            )
-            return fetched
         except Exception as exc:  # noqa: BLE001  # log and continue; one bad reservation must not stop the batch
             verbose_proxy_logger.error(
                 "PTU rollup: azure fetch failed for reservation=%s day=%s: %s",
@@ -80,6 +72,25 @@ async def _compute_daily_flat_cost(
                 exc,
             )
             return 0.0
+        currency = getattr(azure_fetcher, "last_currency", None)
+        if currency is not None and currency.upper() != "USD":
+            verbose_proxy_logger.warning(
+                "PTU rollup: azure_billing reservation=%s day=%s returned currency=%s; "
+                "skipping write to avoid storing non-USD amount as USD (LiteLLM_DailyTeamSpend "
+                "assumes USD). File a follow-up for currency conversion.",
+                getattr(reservation, "id", "?"),
+                day.isoformat(),
+                currency,
+            )
+            return 0.0
+        verbose_proxy_logger.info(
+            "PTU rollup: azure_billing reservation=%s day=%s resource=%s returned $%.4f",
+            getattr(reservation, "id", "?"),
+            day.isoformat(),
+            reservation.azure_resource_id,
+            fetched,
+        )
+        return fetched
     verbose_proxy_logger.warning(
         "PTU rollup: unknown cost_source=%s on reservation=%s; skipping",
         reservation.cost_source,

--- a/litellm/proxy/spend_tracking/ptu_reservation_rollup.py
+++ b/litellm/proxy/spend_tracking/ptu_reservation_rollup.py
@@ -9,11 +9,20 @@ existing unique constraint.
 from calendar import monthrange
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta, timezone
-from typing import Any
+from typing import Any, Optional, Protocol
 
 from litellm._logging import verbose_proxy_logger
 from litellm.constants import PTU_ROLLUP_JOB_ID, PTU_SENTINEL_API_KEY
 from litellm.repositories.ptu_reservation_repository import PTUReservationRepository
+
+
+class AzureCostFetcher(Protocol):
+    """Dependency injected into the rollup for azure_billing reservations.
+
+    Implemented by ``AzureCostManagementClient`` in production, mocked in tests.
+    """
+
+    async def get_daily_cost(self, resource_id: str, day: date) -> float: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -28,14 +37,55 @@ def _days_in_month(day: date) -> int:
     return monthrange(day.year, day.month)[1]
 
 
-def _compute_daily_flat_cost(reservation: Any, day: date) -> float:
-    """Return the flat cost attributable to ``day`` for a single reservation."""
-    if reservation.cost_source != "manual":
-        return 0.0
-    if reservation.ptu_count is None or reservation.cost_per_ptu is None:
-        return 0.0
-    monthly_total = float(reservation.ptu_count) * float(reservation.cost_per_ptu)
-    return monthly_total / float(_days_in_month(day))
+async def _compute_daily_flat_cost(
+    reservation: Any,
+    day: date,
+    *,
+    azure_fetcher: Optional[AzureCostFetcher] = None,
+) -> float:
+    """Return the flat cost attributable to ``day`` for a single reservation.
+
+    manual: prorated (ptu_count * cost_per_ptu) / days_in_month.
+    azure_billing: live fetch via ``azure_fetcher`` when provided; 0.0 when
+    the pull is not configured (rollup logs a skip).
+    """
+    if reservation.cost_source == "manual":
+        if reservation.ptu_count is None or reservation.cost_per_ptu is None:
+            return 0.0
+        monthly_total = float(reservation.ptu_count) * float(reservation.cost_per_ptu)
+        return monthly_total / float(_days_in_month(day))
+    if reservation.cost_source == "azure_billing":
+        if azure_fetcher is None or reservation.azure_resource_id is None:
+            verbose_proxy_logger.warning(
+                "PTU rollup: reservation=%s cost_source=azure_billing skipped "
+                "(enable_azure_ptu_billing_pull off or azure_resource_id missing)",
+                getattr(reservation, "id", "?"),
+            )
+            return 0.0
+        try:
+            fetched = await azure_fetcher.get_daily_cost(reservation.azure_resource_id, day)
+            verbose_proxy_logger.info(
+                "PTU rollup: azure_billing reservation=%s day=%s resource=%s returned $%.4f",
+                getattr(reservation, "id", "?"),
+                day.isoformat(),
+                reservation.azure_resource_id,
+                fetched,
+            )
+            return fetched
+        except Exception as exc:  # noqa: BLE001  # log and continue; one bad reservation must not stop the batch
+            verbose_proxy_logger.error(
+                "PTU rollup: azure fetch failed for reservation=%s day=%s: %s",
+                getattr(reservation, "id", "?"),
+                day.isoformat(),
+                exc,
+            )
+            return 0.0
+    verbose_proxy_logger.warning(
+        "PTU rollup: unknown cost_source=%s on reservation=%s; skipping",
+        reservation.cost_source,
+        getattr(reservation, "id", "?"),
+    )
+    return 0.0
 
 
 async def _upsert_ptu_daily_row(
@@ -88,12 +138,16 @@ async def run_ptu_reservation_rollup(
     target_date: date | None = None,
     *,
     force: bool = False,
+    azure_fetcher: Optional[AzureCostFetcher] = None,
 ) -> RollupResult:
     """Rollup one UTC day of flat PTU cost across all active reservations.
 
     Defaults to yesterday UTC. ``force=True`` bypasses the feature-flag check
-    so the CLI backfill can run when the scheduler is off. Idempotent under
-    the LiteLLM_DailyTeamSpend unique constraint on every invocation path.
+    so the CLI backfill can run when the scheduler is off. ``azure_fetcher``
+    is injected by the proxy startup wiring when ``enable_azure_ptu_billing_pull``
+    is on; azure_billing reservations no-op with a warning when it is None.
+    Idempotent under the LiteLLM_DailyTeamSpend unique constraint on every
+    invocation path.
     """
     if not force:
         from litellm.proxy.proxy_server import general_settings
@@ -124,7 +178,7 @@ async def run_ptu_reservation_rollup(
 
     rows_written = 0
     for reservation in reservations:
-        flat_cost = _compute_daily_flat_cost(reservation, day)
+        flat_cost = await _compute_daily_flat_cost(reservation, day, azure_fetcher=azure_fetcher)
         if flat_cost <= 0:
             continue
         try:
@@ -159,6 +213,7 @@ async def run_ptu_reservation_rollup(
 
 
 __all__ = [
+    "AzureCostFetcher",
     "PTU_ROLLUP_JOB_ID",
     "PTU_SENTINEL_API_KEY",
     "RollupResult",

--- a/litellm/proxy/spend_tracking/ptu_reservation_rollup.py
+++ b/litellm/proxy/spend_tracking/ptu_reservation_rollup.py
@@ -58,7 +58,8 @@ async def _compute_daily_flat_cost(
         if azure_fetcher is None or reservation.azure_resource_id is None:
             verbose_proxy_logger.warning(
                 "PTU rollup: reservation=%s cost_source=azure_billing skipped "
-                "(enable_azure_ptu_billing_pull off or azure_resource_id missing)",
+                "(azure_ptu_billing.subscription_id / Entra ID env vars not configured, "
+                "or azure_resource_id missing on the reservation)",
                 getattr(reservation, "id", "?"),
             )
             return 0.0
@@ -155,8 +156,10 @@ async def run_ptu_reservation_rollup(
 
     Defaults to yesterday UTC. ``force=True`` bypasses the feature-flag check
     so the CLI backfill can run when the scheduler is off. ``azure_fetcher``
-    is injected by the proxy startup wiring when ``enable_azure_ptu_billing_pull``
-    is on; azure_billing reservations no-op with a warning when it is None.
+    is injected by the proxy startup wiring when
+    ``general_settings.azure_ptu_billing.subscription_id`` and the Entra ID env
+    vars are configured; azure_billing reservations no-op with a warning when
+    it is None.
     Idempotent under the LiteLLM_DailyTeamSpend unique constraint on every
     invocation path.
     """

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -184,12 +184,7 @@ class UISettings(BaseModel):
 
     enable_ptu_cost_attribution: bool = Field(
         default=False,
-        description="If true, enables admin-registered PTU reservations and daily flat-cost attribution on team daily spend. Governs the /ptu_reservation CRUD endpoints, the daily rollup job, the PTU Reservations UI page, and the Flat Cost column on the Usage page.",
-    )
-
-    enable_azure_ptu_billing_pull: bool = Field(
-        default=False,
-        description="If true and enable_ptu_cost_attribution is also true, reservations with cost_source='azure_billing' fetch daily flat cost from the Azure Cost Management API instead of the manual PTU * cost/day formula. Requires general_settings.azure_ptu_billing.subscription_id and Entra ID env vars (AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET).",
+        description="If true, enables admin-registered PTU reservations and daily flat-cost attribution on team daily spend. Governs the /ptu_reservation CRUD endpoints, the daily rollup job, the PTU Reservations UI page, and the Flat Cost column on the Usage page. When general_settings.azure_ptu_billing.subscription_id and the Entra ID env vars (AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET) are also set, reservations with cost_source='azure_billing' auto-fetch daily flat cost from the Azure Cost Management API; otherwise only manual reservations accrue.",
     )
 
 
@@ -217,7 +212,6 @@ ALLOWED_UI_SETTINGS_FIELDS = {
     "disable_key_generate_for_org_admin",
     "enable_chat_ui",
     "enable_ptu_cost_attribution",
-    "enable_azure_ptu_billing_pull",
 }
 
 # Flags that must be synced from the persisted UISettings into
@@ -232,7 +226,6 @@ _RUNTIME_GENERAL_SETTINGS_FLAGS = [
     "allow_vector_stores_for_team_admins",
     "disable_key_generate_for_org_admin",
     "enable_ptu_cost_attribution",
-    "enable_azure_ptu_billing_pull",
 ]
 
 # Extension point: packages outside OSS (e.g. litellm_enterprise) can

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -187,6 +187,11 @@ class UISettings(BaseModel):
         description="If true, enables admin-registered PTU reservations and daily flat-cost attribution on team daily spend. Governs the /ptu_reservation CRUD endpoints, the daily rollup job, the PTU Reservations UI page, and the Flat Cost column on the Usage page.",
     )
 
+    enable_azure_ptu_billing_pull: bool = Field(
+        default=False,
+        description="If true and enable_ptu_cost_attribution is also true, reservations with cost_source='azure_billing' fetch daily flat cost from the Azure Cost Management API instead of the manual PTU * cost/day formula. Requires general_settings.azure_ptu_billing.subscription_id and Entra ID env vars (AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET).",
+    )
+
 
 class UISettingsResponse(SettingsResponse):
     """Response model for UI settings"""
@@ -212,6 +217,7 @@ ALLOWED_UI_SETTINGS_FIELDS = {
     "disable_key_generate_for_org_admin",
     "enable_chat_ui",
     "enable_ptu_cost_attribution",
+    "enable_azure_ptu_billing_pull",
 }
 
 # Flags that must be synced from the persisted UISettings into
@@ -226,6 +232,7 @@ _RUNTIME_GENERAL_SETTINGS_FLAGS = [
     "allow_vector_stores_for_team_admins",
     "disable_key_generate_for_org_admin",
     "enable_ptu_cost_attribution",
+    "enable_azure_ptu_billing_pull",
 ]
 
 # Extension point: packages outside OSS (e.g. litellm_enterprise) can

--- a/litellm/types/llms/custom_http.py
+++ b/litellm/types/llms/custom_http.py
@@ -30,6 +30,7 @@ class httpxSpecialProvider(str, Enum):
     PromptManagement = "prompt_management"
     UI = "ui"
     Sandbox = "sandbox"
+    AzureCostManagement = "azure_cost_management"
 
 
 VerifyTypes = Union[str, bool, ssl.SSLContext]

--- a/scripts/ptu_reservation_backfill.py
+++ b/scripts/ptu_reservation_backfill.py
@@ -21,6 +21,29 @@ def _parse_date(s: str) -> date:
     return datetime.strptime(s, "%Y-%m-%d").date()
 
 
+def _build_backfill_azure_fetcher():
+    """Return an Azure Cost Management client when subscription_id + Entra creds are set.
+
+    The proxy runtime builds this from general_settings; the CLI runs outside the
+    proxy process so it reads AZURE_SUBSCRIPTION_ID from the environment directly.
+    """
+    subscription_id = os.environ.get("AZURE_SUBSCRIPTION_ID")
+    if not subscription_id:
+        return None
+    try:
+        from litellm.integrations.azure_cost_management import AzureCostManagementClient
+        from litellm.integrations.azure_cost_management.azure_cost_management_client import (
+            AzureCostManagementConfig,
+        )
+
+        config = AzureCostManagementConfig.from_env(subscription_id=subscription_id)
+        print(f"backfill: azure fetcher enabled for subscription {subscription_id}", file=sys.stderr)
+        return AzureCostManagementClient(config=config)
+    except Exception as exc:
+        print(f"backfill: azure fetcher unavailable: {exc}", file=sys.stderr)
+        return None
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     group = parser.add_mutually_exclusive_group(required=True)
@@ -60,10 +83,15 @@ async def _run(dates: list[date]) -> int:
     proxy_logging_obj = ProxyLogging(user_api_key_cache=DualCache())
     prisma_client = PrismaClient(database_url=database_url, proxy_logging_obj=proxy_logging_obj)
     await prisma_client.connect()
+
+    azure_fetcher = _build_backfill_azure_fetcher()
+
     try:
         total_rows = 0
         for target in dates:
-            result = await run_ptu_reservation_rollup(prisma_client, target_date=target, force=True)
+            result = await run_ptu_reservation_rollup(
+                prisma_client, target_date=target, force=True, azure_fetcher=azure_fetcher
+            )
             print(
                 f"[{result.day.isoformat()}] "
                 f"reservations={result.reservations_processed} rows_written={result.rows_written}"
@@ -83,6 +111,9 @@ def main() -> int:
     dates = _dates_from_args(args)
     if "PYTHONPATH" not in os.environ:
         sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    import logging
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
     return asyncio.run(_run(dates))
 
 

--- a/tests/test_litellm/integrations/azure_cost_management/test_azure_cost_management_client.py
+++ b/tests/test_litellm/integrations/azure_cost_management/test_azure_cost_management_client.py
@@ -1,0 +1,145 @@
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from litellm.integrations.azure_cost_management.azure_cost_management_client import (
+    AzureCostManagementClient,
+    AzureCostManagementConfig,
+    AzureCostManagementError,
+)
+
+
+def _config() -> AzureCostManagementConfig:
+    return AzureCostManagementConfig(
+        subscription_id="00000000-0000-0000-0000-000000000000",
+        tenant_id="tenant",
+        client_id="client",
+        client_secret="secret",
+    )
+
+
+def _http_ok(payload: dict) -> MagicMock:
+    http = MagicMock()
+    response = MagicMock()
+    response.json.return_value = payload
+    http.post = AsyncMock(return_value=response)
+    return http
+
+
+@pytest.mark.asyncio
+async def test_get_daily_cost_returns_sum_of_rows_when_usd():
+    payload = {
+        "properties": {
+            "columns": [{"name": "Cost"}, {"name": "UsageDate"}, {"name": "Currency"}],
+            "rows": [
+                [120.0, 20260715, "USD"],
+                [30.0, 20260715, "USD"],
+            ],
+        }
+    }
+    http = _http_ok(payload)
+
+    client = AzureCostManagementClient(
+        config=_config(),
+        http_handler=http,
+        token_provider=lambda: "fake-token",
+    )
+
+    result = await client.get_daily_cost("/subs/x/deploy/y", date(2026, 7, 15))
+
+    assert result == pytest.approx(150.0)
+    assert client.last_currency == "USD"
+
+
+@pytest.mark.asyncio
+async def test_get_daily_cost_returns_zero_when_no_rows():
+    """Azure returns 200 with empty rows when reporting lag hasn't populated yet."""
+    payload = {"properties": {"columns": [{"name": "Cost"}], "rows": []}}
+    http = _http_ok(payload)
+    client = AzureCostManagementClient(
+        config=_config(),
+        http_handler=http,
+        token_provider=lambda: "fake-token",
+    )
+
+    result = await client.get_daily_cost("/subs/x/deploy/y", date(2026, 7, 15))
+
+    assert result == 0.0
+    assert client.last_currency is None
+
+
+@pytest.mark.asyncio
+async def test_get_daily_cost_records_non_usd_currency():
+    payload = {
+        "properties": {
+            "columns": [{"name": "Cost"}, {"name": "Currency"}],
+            "rows": [[100.0, "EUR"]],
+        }
+    }
+    http = _http_ok(payload)
+    client = AzureCostManagementClient(
+        config=_config(),
+        http_handler=http,
+        token_provider=lambda: "fake-token",
+    )
+
+    result = await client.get_daily_cost("/subs/x/deploy/y", date(2026, 7, 15))
+
+    assert result == 100.0
+    assert client.last_currency == "EUR"
+
+
+@pytest.mark.asyncio
+async def test_get_daily_cost_raises_on_http_error():
+    http = MagicMock()
+    response = MagicMock()
+    response.status_code = 403
+    response.text = "forbidden"
+    http.post = AsyncMock(
+        side_effect=httpx.HTTPStatusError("forbidden", request=MagicMock(), response=response)
+    )
+
+    client = AzureCostManagementClient(
+        config=_config(),
+        http_handler=http,
+        token_provider=lambda: "fake-token",
+    )
+
+    with pytest.raises(AzureCostManagementError) as exc:
+        await client.get_daily_cost("/subs/x/deploy/y", date(2026, 7, 15))
+    assert "403" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_get_daily_cost_posts_expected_body_shape():
+    payload = {"properties": {"columns": [{"name": "Cost"}], "rows": []}}
+    http = _http_ok(payload)
+    client = AzureCostManagementClient(
+        config=_config(),
+        http_handler=http,
+        token_provider=lambda: "fake-token",
+    )
+
+    await client.get_daily_cost("/subs/x/deploy/y", date(2026, 7, 15))
+
+    http.post.assert_awaited_once()
+    kwargs = http.post.await_args.kwargs
+    assert kwargs["url"].endswith("/providers/Microsoft.CostManagement/query")
+    assert kwargs["params"] == {"api-version": "2023-11-01"}
+    assert kwargs["headers"]["Authorization"] == "Bearer fake-token"
+    body = kwargs["json"]
+    assert body["type"] == "ActualCost"
+    assert body["timeframe"] == "Custom"
+    assert body["timePeriod"]["from"] == "2026-07-15T00:00:00Z"
+    assert body["dataset"]["filter"]["dimensions"]["values"] == ["/subs/x/deploy/y"]
+
+
+def test_config_from_env_raises_when_creds_missing(monkeypatch):
+    for k in ("AZURE_TENANT_ID", "AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET"):
+        monkeypatch.delenv(k, raising=False)
+
+    with pytest.raises(AzureCostManagementError) as exc:
+        AzureCostManagementConfig.from_env(subscription_id="sub-x")
+    assert "AZURE_TENANT_ID" in str(exc.value)

--- a/tests/test_litellm/integrations/azure_cost_management/test_azure_cost_management_client.py
+++ b/tests/test_litellm/integrations/azure_cost_management/test_azure_cost_management_client.py
@@ -97,9 +97,7 @@ async def test_get_daily_cost_raises_on_http_error():
     response = MagicMock()
     response.status_code = 403
     response.text = "forbidden"
-    http.post = AsyncMock(
-        side_effect=httpx.HTTPStatusError("forbidden", request=MagicMock(), response=response)
-    )
+    http.post = AsyncMock(side_effect=httpx.HTTPStatusError("forbidden", request=MagicMock(), response=response))
 
     client = AzureCostManagementClient(
         config=_config(),
@@ -143,3 +141,31 @@ def test_config_from_env_raises_when_creds_missing(monkeypatch):
     with pytest.raises(AzureCostManagementError) as exc:
         AzureCostManagementConfig.from_env(subscription_id="sub-x")
     assert "AZURE_TENANT_ID" in str(exc.value)
+
+
+def test_client_secret_not_in_repr():
+    """Regression: client_secret must not surface in repr(config) — the field is repr=False."""
+    cfg = AzureCostManagementConfig(
+        subscription_id="sub-x",
+        tenant_id="tenant",
+        client_id="client",
+        client_secret="super-secret-value",
+    )
+    assert "super-secret-value" not in repr(cfg)
+    assert "client_secret" not in repr(cfg)
+
+
+@pytest.mark.asyncio
+async def test_get_daily_cost_wraps_network_errors():
+    """httpx.RequestError family (ConnectError, ReadTimeout, RemoteProtocolError) must surface as AzureCostManagementError."""
+    http = MagicMock()
+    http.post = AsyncMock(side_effect=httpx.ReadTimeout("upstream timeout"))
+    client = AzureCostManagementClient(
+        config=_config(),
+        http_handler=http,
+        token_provider=lambda: "fake-token",
+    )
+
+    with pytest.raises(AzureCostManagementError) as exc:
+        await client.get_daily_cost("/subs/x/deploy/y", date(2026, 7, 15))
+    assert "network error" in str(exc.value).lower()

--- a/tests/test_litellm/integrations/azure_cost_management/test_azure_cost_management_client.py
+++ b/tests/test_litellm/integrations/azure_cost_management/test_azure_cost_management_client.py
@@ -155,6 +155,43 @@ def test_client_secret_not_in_repr():
     assert "client_secret" not in repr(cfg)
 
 
+def test_config_management_base_url_defaults_to_public_cloud():
+    cfg = AzureCostManagementConfig(subscription_id="s", tenant_id="t", client_id="c", client_secret="x")
+    assert cfg.management_base_url == "https://management.azure.com"
+
+
+def test_config_management_base_url_reads_env_override(monkeypatch):
+    """Sovereign clouds + testability: AZURE_MANAGEMENT_BASE_URL can point at a different host."""
+    monkeypatch.setenv("AZURE_TENANT_ID", "t")
+    monkeypatch.setenv("AZURE_CLIENT_ID", "c")
+    monkeypatch.setenv("AZURE_CLIENT_SECRET", "x")
+    monkeypatch.setenv("AZURE_MANAGEMENT_BASE_URL", "https://management.usgovcloudapi.net")
+
+    cfg = AzureCostManagementConfig.from_env(subscription_id="s")
+
+    assert cfg.management_base_url == "https://management.usgovcloudapi.net"
+
+
+@pytest.mark.asyncio
+async def test_get_daily_cost_hits_management_base_url_from_config():
+    """Client must use the base URL from config (sovereign cloud support)."""
+    payload = {"properties": {"columns": [{"name": "Cost"}], "rows": []}}
+    http = _http_ok(payload)
+    cfg = AzureCostManagementConfig(
+        subscription_id="sub-x",
+        tenant_id="t",
+        client_id="c",
+        client_secret="x",
+        management_base_url="http://localhost:18443",
+    )
+    client = AzureCostManagementClient(config=cfg, http_handler=http, token_provider=lambda: "tkn")
+
+    await client.get_daily_cost("/subs/x/deploy/y", date(2026, 7, 15))
+
+    kwargs = http.post.await_args.kwargs
+    assert kwargs["url"].startswith("http://localhost:18443/subscriptions/sub-x/")
+
+
 @pytest.mark.asyncio
 async def test_get_daily_cost_wraps_network_errors():
     """httpx.RequestError family (ConnectError, ReadTimeout, RemoteProtocolError) must surface as AzureCostManagementError."""

--- a/tests/test_litellm/proxy/management_endpoints/test_ptu_reservation_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ptu_reservation_endpoints.py
@@ -171,7 +171,8 @@ async def test_new_reservation_rejects_effective_to_equal_from(client_and_mocks)
 
 
 @pytest.mark.asyncio
-async def test_new_reservation_rejects_azure_billing_mode(client_and_mocks):
+async def test_new_reservation_rejects_azure_billing_without_resource_id(client_and_mocks):
+    """Stage 6 relaxed the blanket azure_billing reject; azure_resource_id is now the required field."""
     client, _, mock_table = client_and_mocks
     resp = client.post(
         "/ptu_reservation/new",
@@ -179,11 +180,11 @@ async def test_new_reservation_rejects_azure_billing_mode(client_and_mocks):
             "team_id": "team_x",
             "model": "gpt-4",
             "cost_source": "azure_billing",
-            "azure_resource_id": "/subscriptions/x/deployments/gpt-4-ptu",
             "effective_from": _iso(),
         },
     )
     assert resp.status_code == 400, resp.text
+    assert "azure_resource_id" in resp.text
     mock_table.create.assert_not_awaited()
 
 

--- a/tests/test_litellm/proxy/spend_tracking/test_ptu_reservation_rollup.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_ptu_reservation_rollup.py
@@ -119,11 +119,38 @@ async def test_compute_flat_cost_azure_billing_uses_fetcher_result():
     r = _r(cost_source="azure_billing", ptu_count=None, cost_per_ptu=None, azure_resource_id="/subs/x/deploy/y")
     fetcher = MagicMock()
     fetcher.get_daily_cost = AsyncMock(return_value=42.5)
+    fetcher.last_currency = "USD"
 
     result = await _compute_daily_flat_cost(r, date(2026, 7, 15), azure_fetcher=fetcher)
 
     assert result == 42.5
     fetcher.get_daily_cost.assert_awaited_once_with("/subs/x/deploy/y", date(2026, 7, 15))
+
+
+@pytest.mark.asyncio
+async def test_compute_flat_cost_azure_billing_returns_zero_on_non_usd_currency():
+    """Non-USD Azure response must not be persisted as USD (silent data corruption)."""
+    r = _r(cost_source="azure_billing", ptu_count=None, cost_per_ptu=None, azure_resource_id="/subs/x/deploy/y")
+    fetcher = MagicMock()
+    fetcher.get_daily_cost = AsyncMock(return_value=99.9)
+    fetcher.last_currency = "EUR"
+
+    result = await _compute_daily_flat_cost(r, date(2026, 7, 15), azure_fetcher=fetcher)
+
+    assert result == 0.0
+
+
+@pytest.mark.asyncio
+async def test_compute_flat_cost_azure_billing_accepts_missing_currency():
+    """Empty Azure response (no rows) sets last_currency=None; treat as USD path (0.0 is written by the outer skip)."""
+    r = _r(cost_source="azure_billing", ptu_count=None, cost_per_ptu=None, azure_resource_id="/subs/x/deploy/y")
+    fetcher = MagicMock()
+    fetcher.get_daily_cost = AsyncMock(return_value=0.0)
+    fetcher.last_currency = None
+
+    result = await _compute_daily_flat_cost(r, date(2026, 7, 15), azure_fetcher=fetcher)
+
+    assert result == 0.0
 
 
 @pytest.mark.asyncio
@@ -158,10 +185,9 @@ async def test_rollup_azure_billing_reservation_writes_fetched_amount(mock_prism
     mock_reservation.find_many = AsyncMock(return_value=[reservation])
     fetcher = MagicMock()
     fetcher.get_daily_cost = AsyncMock(return_value=150.0)
+    fetcher.last_currency = "USD"
 
-    result = await run_ptu_reservation_rollup(
-        prisma, target_date=date(2026, 7, 12), azure_fetcher=fetcher
-    )
+    result = await run_ptu_reservation_rollup(prisma, target_date=date(2026, 7, 12), azure_fetcher=fetcher)
 
     assert result.rows_written == 1
     fetcher.get_daily_cost.assert_awaited_once_with("/subs/x/deploy/y", date(2026, 7, 12))
@@ -297,9 +323,7 @@ async def test_rollup_queries_active_reservations_at_day_start(mock_prisma):
 @pytest.mark.asyncio
 async def test_rollup_idempotent_second_run_upserts_same_row(mock_prisma):
     prisma, mock_daily, mock_reservation = mock_prisma
-    mock_reservation.find_many = AsyncMock(
-        return_value=[_r(id="res_1", ptu_count=1, cost_per_ptu=200.0)]
-    )
+    mock_reservation.find_many = AsyncMock(return_value=[_r(id="res_1", ptu_count=1, cost_per_ptu=200.0)])
 
     r1 = await run_ptu_reservation_rollup(prisma, target_date=date(2026, 7, 12))
     r2 = await run_ptu_reservation_rollup(prisma, target_date=date(2026, 7, 12))

--- a/tests/test_litellm/proxy/spend_tracking/test_ptu_reservation_rollup.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_ptu_reservation_rollup.py
@@ -24,6 +24,7 @@ class _Reservation:
     cost_per_ptu: float | None
     effective_from: datetime
     effective_to: datetime | None
+    azure_resource_id: str | None = None
 
 
 def _r(
@@ -36,6 +37,7 @@ def _r(
     cost_per_ptu: float | None = 200.0,
     effective_from: datetime | None = None,
     effective_to: datetime | None = None,
+    azure_resource_id: str | None = None,
 ) -> _Reservation:
     return _Reservation(
         id=id,
@@ -46,6 +48,7 @@ def _r(
         cost_per_ptu=cost_per_ptu,
         effective_from=effective_from or datetime(2026, 7, 1, tzinfo=timezone.utc),
         effective_to=effective_to,
+        azure_resource_id=azure_resource_id,
     )
 
 
@@ -74,35 +77,97 @@ def test_days_in_month_covers_calendar_variants():
     assert _days_in_month(date(2026, 7, 31)) == 31
 
 
-def test_compute_flat_cost_calendar_month_31():
+@pytest.mark.asyncio
+async def test_compute_flat_cost_calendar_month_31():
     r = _r(ptu_count=1, cost_per_ptu=200.0)
-    assert _compute_daily_flat_cost(r, date(2026, 7, 15)) == pytest.approx(200.0 / 31)
+    assert await _compute_daily_flat_cost(r, date(2026, 7, 15)) == pytest.approx(200.0 / 31)
 
 
-def test_compute_flat_cost_calendar_month_28():
+@pytest.mark.asyncio
+async def test_compute_flat_cost_calendar_month_28():
     r = _r(ptu_count=1, cost_per_ptu=200.0)
-    assert _compute_daily_flat_cost(r, date(2026, 2, 10)) == pytest.approx(200.0 / 28)
+    assert await _compute_daily_flat_cost(r, date(2026, 2, 10)) == pytest.approx(200.0 / 28)
 
 
-def test_compute_flat_cost_leap_february():
+@pytest.mark.asyncio
+async def test_compute_flat_cost_leap_february():
     r = _r(ptu_count=1, cost_per_ptu=200.0)
-    assert _compute_daily_flat_cost(r, date(2024, 2, 10)) == pytest.approx(200.0 / 29)
+    assert await _compute_daily_flat_cost(r, date(2024, 2, 10)) == pytest.approx(200.0 / 29)
 
 
-def test_compute_flat_cost_scales_with_ptu_count():
-    small = _compute_daily_flat_cost(_r(ptu_count=1, cost_per_ptu=200.0), date(2026, 7, 1))
-    big = _compute_daily_flat_cost(_r(ptu_count=100, cost_per_ptu=200.0), date(2026, 7, 1))
+@pytest.mark.asyncio
+async def test_compute_flat_cost_scales_with_ptu_count():
+    small = await _compute_daily_flat_cost(_r(ptu_count=1, cost_per_ptu=200.0), date(2026, 7, 1))
+    big = await _compute_daily_flat_cost(_r(ptu_count=100, cost_per_ptu=200.0), date(2026, 7, 1))
     assert big == pytest.approx(small * 100)
 
 
-def test_compute_flat_cost_zero_for_non_manual_source():
-    r = _r(cost_source="azure_billing", ptu_count=None, cost_per_ptu=None)
-    assert _compute_daily_flat_cost(r, date(2026, 7, 1)) == 0.0
+@pytest.mark.asyncio
+async def test_compute_flat_cost_zero_when_azure_billing_and_no_fetcher():
+    r = _r(cost_source="azure_billing", ptu_count=None, cost_per_ptu=None, azure_resource_id="/x")
+    assert await _compute_daily_flat_cost(r, date(2026, 7, 1)) == 0.0
 
 
-def test_compute_flat_cost_zero_when_manual_fields_missing():
+@pytest.mark.asyncio
+async def test_compute_flat_cost_zero_when_manual_fields_missing():
     r = _r(ptu_count=None, cost_per_ptu=None)
-    assert _compute_daily_flat_cost(r, date(2026, 7, 1)) == 0.0
+    assert await _compute_daily_flat_cost(r, date(2026, 7, 1)) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_compute_flat_cost_azure_billing_uses_fetcher_result():
+    r = _r(cost_source="azure_billing", ptu_count=None, cost_per_ptu=None, azure_resource_id="/subs/x/deploy/y")
+    fetcher = MagicMock()
+    fetcher.get_daily_cost = AsyncMock(return_value=42.5)
+
+    result = await _compute_daily_flat_cost(r, date(2026, 7, 15), azure_fetcher=fetcher)
+
+    assert result == 42.5
+    fetcher.get_daily_cost.assert_awaited_once_with("/subs/x/deploy/y", date(2026, 7, 15))
+
+
+@pytest.mark.asyncio
+async def test_compute_flat_cost_azure_billing_fetcher_error_returns_zero():
+    r = _r(cost_source="azure_billing", ptu_count=None, cost_per_ptu=None, azure_resource_id="/subs/x/deploy/y")
+    fetcher = MagicMock()
+    fetcher.get_daily_cost = AsyncMock(side_effect=RuntimeError("azure boom"))
+
+    result = await _compute_daily_flat_cost(r, date(2026, 7, 15), azure_fetcher=fetcher)
+
+    assert result == 0.0
+
+
+@pytest.mark.asyncio
+async def test_compute_flat_cost_unknown_source_returns_zero():
+    r = _r(cost_source="mystery")
+    assert await _compute_daily_flat_cost(r, date(2026, 7, 1)) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_rollup_azure_billing_reservation_writes_fetched_amount(mock_prisma):
+    prisma, mock_daily, mock_reservation = mock_prisma
+    reservation = _r(
+        id="res_azure",
+        team_id="team_x",
+        model="gpt-4",
+        cost_source="azure_billing",
+        ptu_count=None,
+        cost_per_ptu=None,
+        azure_resource_id="/subs/x/deploy/y",
+    )
+    mock_reservation.find_many = AsyncMock(return_value=[reservation])
+    fetcher = MagicMock()
+    fetcher.get_daily_cost = AsyncMock(return_value=150.0)
+
+    result = await run_ptu_reservation_rollup(
+        prisma, target_date=date(2026, 7, 12), azure_fetcher=fetcher
+    )
+
+    assert result.rows_written == 1
+    fetcher.get_daily_cost.assert_awaited_once_with("/subs/x/deploy/y", date(2026, 7, 12))
+    create = mock_daily.upsert.await_args.kwargs["data"]["create"]
+    assert create["ptu_flat_cost"] == 150.0
+    assert create["ptu_reservation_id"] == "res_azure"
 
 
 @pytest.mark.asyncio
@@ -170,11 +235,12 @@ async def test_rollup_writes_expected_row(mock_prisma):
 
 
 @pytest.mark.asyncio
-async def test_rollup_skips_azure_billing_reservations(mock_prisma):
+async def test_rollup_skips_azure_billing_reservations_when_pull_disabled(mock_prisma):
+    """Regression: azure_billing rows must not corrupt sentinel table when pull flag off."""
     prisma, mock_daily, mock_reservation = mock_prisma
     mock_reservation.find_many = AsyncMock(
         return_value=[
-            _r(cost_source="azure_billing", ptu_count=None, cost_per_ptu=None),
+            _r(cost_source="azure_billing", ptu_count=None, cost_per_ptu=None, azure_resource_id="/x"),
         ]
     )
 

--- a/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
+++ b/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
@@ -1391,6 +1391,22 @@ class TestProxySettingEndpoints:
         assert "enable_ptu_cost_attribution" in _RUNTIME_GENERAL_SETTINGS_FLAGS
         assert "enable_ptu_cost_attribution" in ALLOWED_UI_SETTINGS_FIELDS
 
+    def test_azure_pull_is_not_a_separate_flag(self):
+        """Regression: presence of azure_ptu_billing.subscription_id + Entra ID env vars is the sole signal for the auto-pull.
+
+        Adding a second UI flag was confusing and served no purpose; this asserts we don't
+        reintroduce one under this exact name.
+        """
+        from litellm.proxy.ui_crud_endpoints.proxy_setting_endpoints import (
+            _RUNTIME_GENERAL_SETTINGS_FLAGS,
+            ALLOWED_UI_SETTINGS_FIELDS,
+            UISettings,
+        )
+
+        assert "enable_azure_ptu_billing_pull" not in _RUNTIME_GENERAL_SETTINGS_FLAGS
+        assert "enable_azure_ptu_billing_pull" not in ALLOWED_UI_SETTINGS_FIELDS
+        assert "enable_azure_ptu_billing_pull" not in UISettings.model_fields
+
     def test_get_sso_settings_from_database(
         self, mock_proxy_config, mock_auth, monkeypatch
     ):


### PR DESCRIPTION
## Relevant issues

Part of the LIT-1697 Azure PTU cost attribution stack; stacked on #33439 (stage 5)

## Linear ticket

Resolves LIT-4077

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

Opened as a draft POC to align on the customer-facing story before a real review pass. Full merge review follows after v1 (stages 1-5) ships and the customer walkthrough lands

## Delays in PR merge?

Not applicable; POC, not requesting review yet

## Screenshots / Proof of Fix

Live end-to-end against a real Azure subscription. Both flags enabled at runtime, a reservation with `cost_source=azure_billing` created via API, the backfill CLI acquires a real Entra ID token, calls Cost Management, and writes the response

Backfill log:

```
2026-07-20 16:29:53 INFO azure.identity._internal.get_token_mixin: ClientSecretCredential.get_token_info succeeded
2026-07-20 16:29:55 INFO LiteLLM Proxy: PTU rollup: azure_billing reservation=fd26ded5-... day=2026-07-20 resource=/subscriptions/<redacted>/.../deployments/gpt-4-ptu returned $0.0000
[2026-07-20] reservations=2 rows_written=1
```

The $0.00 is a real Azure response for a resource id with no billing history in the dev sub; a customer's own PTU deployment returns its accrued cost on the same code path. Currency is USD, verified against the sub via the Cost Management response

Validator rejection when `azure_resource_id` is missing:

```
$ curl -sS -X POST http://localhost:4097/ptu_reservation/new \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"team_id":"...","model":"...","cost_source":"azure_billing","effective_from":"2026-07-01T00:00:00Z"}'
HTTP 400
{"detail":{"error":"azure_resource_id is required when cost_source='azure_billing'"}}
```

Restart persistence (both flags survive `_sync_ui_settings_to_general_settings`):

```
INFO proxy_server: PTU reservation rollup job scheduled at 00:15 UTC daily (no-ops until enable_ptu_cost_attribution is set)
INFO proxy_server: Synced UI settings to general_settings on startup: ['enable_ptu_cost_attribution', 'enable_azure_ptu_billing_pull']
```

## Type

New Feature

## Changes

A thin async client at `litellm/integrations/azure_cost_management/` calls one Cost Management endpoint the rollup needs. Entra ID auth is inherited from `get_azure_ad_token_from_entra_id` so no new dependency lands. The client is deliberately narrow (one public method) and follows the `litellm/integrations/` pattern (see `datadog/`, `langfuse/`, etc.)

A new UI settings flag `enable_azure_ptu_billing_pull` composes below `enable_ptu_cost_attribution` and reuses the stage 5 machinery (UISettings model, `ALLOWED_UI_SETTINGS_FIELDS`, `_RUNTIME_GENERAL_SETTINGS_FLAGS`). Persistence and startup sync are inherited without touching those code paths

`_compute_daily_flat_cost` in the rollup branches on `cost_source`: manual keeps the existing (`ptu_count * cost_per_ptu`) / days-in-month formula, `azure_billing` calls the injected fetcher, unknown values return 0 with a warning. The function is now async since it awaits the client, and existing sync tests were converted accordingly

The scheduler wraps the rollup in a small callable that builds a fetcher just-in-time via `_build_azure_cost_fetcher_if_enabled` so runtime flag flips take effect without a proxy restart. The helper reads `general_settings.enable_azure_ptu_billing_pull`, the configured `subscription_id`, and env vars for creds; on any missing input it returns None and the rollup no-ops for `azure_billing` rows

The CRUD gate is relaxed: the earlier blanket reject on `cost_source=azure_billing` becomes a check that `azure_resource_id` is present. The pydantic domain validator from stage 1 already enforces the rest (`ptu_count`/`cost_per_ptu` must be null, `azure_resource_id` required)

The backfill CLI grows a matching helper (`_build_backfill_azure_fetcher`) so operators running `scripts/ptu_reservation_backfill.py` exercise the same code path as the scheduler when `AZURE_SUBSCRIPTION_ID` and Entra ID env creds are set

Deferred to follow-up tickets: retry/backoff on 429/503, sliding-window reconciliation for Azure's 24-72h reporting lag, UI toggle for `cost_source` on the reservation create form, non-USD currency handling, Prometheus counter for fetch failures

## Behavior changes

`cost_source=azure_billing` on `POST /ptu_reservation/new` is now accepted (previously rejected with "not supported in this release") when `azure_resource_id` is present

For reservations with `cost_source=azure_billing` that reach the daily rollup: with `enable_azure_ptu_billing_pull` on and Entra ID env creds resolvable, `flat_cost` is fetched from Azure; with the flag off or creds missing, the reservation is skipped with a warning and no sentinel row is written

No change to manual reservations or to the read path (`/team/daily/activity`, Usage page)

## QA runbook

Prereqs: dev proxy on 4097 with `STORE_MODEL_IN_DB=True`; env vars `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_SUBSCRIPTION_ID` from a service principal with `Cost Management Reader` on the target subscription; `config.yaml` has `general_settings.azure_ptu_billing.subscription_id: os.environ/AZURE_SUBSCRIPTION_ID`

1. `curl -X PATCH http://localhost:4097/update/ui_settings -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"enable_ptu_cost_attribution": true, "enable_azure_ptu_billing_pull": true}'`
2. `curl -X POST http://localhost:4097/ptu_reservation/new` with a body that sets `cost_source=azure_billing` and a real Azure `azure_resource_id`
3. `.venv/bin/python scripts/ptu_reservation_backfill.py --date $(date -u +%F)`; watch for the log line `PTU rollup: azure_billing reservation=... returned $...`
4. `curl 'http://localhost:4097/team/daily/activity?team_ids=<team>&start_date=<today>&end_date=<today>'`; `flat_cost` is populated when the Azure resource has billing history
5. Restart the proxy; startup log shows `Synced UI settings to general_settings on startup: ['enable_ptu_cost_attribution', 'enable_azure_ptu_billing_pull']`
6. Toggle either flag off via `/update/ui_settings` and re-run backfill; azure_billing reservation is skipped with a warning, manual reservations continue to accrue

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
