### PR TITLE
fix(auth): set budget_reset_at when JWT upsert seeds a budget_duration

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -66,6 +66,7 @@ from litellm.proxy.auth.budget_throttle import (
 )
 from litellm.proxy.spend_tracking.budget_reservation import get_budget_window_start
 from litellm.proxy.common_utils.cache_pydantic_utils import CacheCodec
+from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
 from litellm.proxy.common_utils.http_parsing_utils import (
     _safe_get_request_headers,
     _safe_get_request_query_params,
@@ -1677,6 +1678,13 @@ async def get_user_object(
                     new_user_params["user_email"] = user_email
                 if litellm.default_internal_user_params is not None:
                     new_user_params.update(litellm.default_internal_user_params)
+                if (
+                    new_user_params.get("budget_duration") is not None
+                    and new_user_params.get("budget_reset_at") is None
+                ):
+                    new_user_params["budget_reset_at"] = get_budget_reset_time(
+                        budget_duration=new_user_params["budget_duration"]
+                    )
 
                 response = await UserRepository(prisma_client).table.create(
                     data=new_user_params,

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -8,7 +8,7 @@ sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import httpx
 import pytest
@@ -742,6 +742,51 @@ async def test_default_internal_user_params_with_get_user_object(monkeypatch):
     assert creation_args["models"] == ["gpt-4", "claude-3-opus"]
     assert creation_args["max_budget"] == 200.0
     assert creation_args["user_role"] == "internal_user"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("has_budget_duration", [True, False])
+async def test_get_user_object_upsert_sets_budget_reset_at(monkeypatch, has_budget_duration):
+    """The JWT first-login upsert must compute budget_reset_at when
+    default_internal_user_params carries a budget_duration; otherwise the row
+    lands with budget_reset_at=NULL and shows a null reset time until the next
+    reset sweep heals it. Without a budget_duration, no reset time is written."""
+    default_params = {"max_budget": 300.0}
+    if has_budget_duration:
+        default_params["budget_duration"] = "24h"
+    monkeypatch.setattr(litellm, "default_internal_user_params", default_params)
+
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db = AsyncMock()
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(return_value=None)
+    mock_prisma_client.db.litellm_usertable.create = AsyncMock(return_value=MagicMock(organization_memberships=[]))
+
+    mock_cache = MagicMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=None)
+    mock_cache.async_set_cache = AsyncMock()
+
+    user_id = f"jwt_upsert_reset_at_{has_budget_duration}"
+    try:
+        await get_user_object(
+            user_id=user_id,
+            prisma_client=mock_prisma_client,
+            user_api_key_cache=mock_cache,
+            user_id_upsert=True,
+            proxy_logging_obj=None,
+        )
+    except Exception as e:
+        print(e)
+
+    mock_prisma_client.db.litellm_usertable.create.assert_called_once()
+    creation_args = mock_prisma_client.db.litellm_usertable.create.call_args[1]["data"]
+
+    if has_budget_duration:
+        reset_at = creation_args.get("budget_reset_at")
+        assert isinstance(reset_at, datetime), f"expected a computed budget_reset_at, got {creation_args!r}"
+        assert reset_at > datetime.now(timezone.utc)
+    else:
+        assert "budget_reset_at" not in creation_args
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

Complements #33623

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy on localhost:4000 with JWT auth against a local JWKS, `litellm_jwtauth: {user_id_jwt_field: sub, user_id_upsert: true}` and `litellm_settings.default_internal_user_params: {budget_duration: 24h, max_budget: 300}`. Each run sends a real chat completion through Groq (`groq/openai/gpt-oss-20b`) with a freshly signed RS256 JWT whose `sub` is a user that does not exist yet, so the request itself triggers the first-login upsert, then reads the created row back with the master key

Before (commit f21704c672, current staging): the upsert seeds the budget fields but leaves the reset timestamp NULL

```
$ curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $JWT" \
    -d '{"model":"gpt-oss-20b","messages":[{"role":"user","content":"Reply with exactly: pong"}]}'
{"content": "pong", "model": "gpt-oss-20b"}

$ curl -s "http://localhost:4000/user/info?user_id=jwt-proof-before" -H 'Authorization: Bearer sk-1234'
{
  "user_id": "jwt-proof-before",
  "max_budget": 300.0,
  "budget_duration": "24h",
  "budget_reset_at": null,
  "spend": 0.0
}
```

After (commit 1fcd05a4a6, this PR): same flow with a new `sub`, and the row is born with a computed reset time

```
$ curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $JWT" \
    -d '{"model":"gpt-oss-20b","messages":[{"role":"user","content":"Reply with exactly: pong"}]}'
{"content": "pong"}

$ curl -s "http://localhost:4000/user/info?user_id=jwt-proof-after" -H 'Authorization: Bearer sk-1234'
{
  "user_id": "jwt-proof-after",
  "max_budget": 300.0,
  "budget_duration": "24h",
  "budget_reset_at": "2026-07-22T00:00:00Z",
  "spend": 0.0
}
```

## Type

🐛 Bug Fix

## Changes

The JWT first-login upsert in `get_user_object` (`litellm/proxy/auth/auth_checks.py`) creates the user row by merging `general_settings.default_internal_user_params` straight into `table.create`, so a configured `budget_duration` landed with `budget_reset_at = NULL`. Every other write path already computes it at creation time: `/user/new` and UI SSO via `generate_key_helper_fn`, `/key/generate`, `/key/update`, and `/team/new`. This upsert was the one writer that forgot

PR #33623 fixes the reader side, teaching the reset sweep to treat NULL `budget_reset_at` with a non-NULL `budget_duration` as due, which heals such rows within one sweep cycle. This PR closes the writer side: until that sweep runs, the row shows `budget_reset_at: null` in `/user/info` and the UI (which is what confused the original reporter), and its first budget window starts at whenever the sweep happens to fire instead of one full duration after creation. With both PRs, rows are created correct and any legacy NULL row still self-heals

The fix computes `budget_reset_at` via the same `get_budget_reset_time` helper the other paths use, only when the merged params carry a `budget_duration` and no explicit `budget_reset_at`

Regression test: `test_get_user_object_upsert_sets_budget_reset_at` in `tests/test_litellm/proxy/auth/test_auth_checks.py`, parametrized both ways; with a `budget_duration` in `default_internal_user_params` the created row must carry a future `budget_reset_at`, and without one no reset timestamp may be written. Verified it fails on the pre-fix code and passes with the fix; full file 184 passed

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
