### PR TITLE
feat(mcp): notify clients when available lists change

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/list_change_notifications.py
+++ b/litellm/proxy/_experimental/mcp_server/list_change_notifications.py
@@ -1,0 +1,58 @@
+import asyncio
+import weakref
+from collections.abc import Awaitable, Callable
+
+from mcp.server.session import ServerSession
+
+from litellm._logging import verbose_logger
+
+
+class MCPListChangeNotifier:
+    def __init__(self) -> None:
+        self._tool_sessions: weakref.WeakSet[ServerSession] = weakref.WeakSet()
+        self._resource_sessions: weakref.WeakSet[ServerSession] = weakref.WeakSet()
+
+    def remember_tool_list_session(self, session: ServerSession) -> None:
+        self._tool_sessions.add(session)
+
+    def remember_resource_list_session(self, session: ServerSession) -> None:
+        self._resource_sessions.add(session)
+
+    async def notify_lists_changed(self) -> None:
+        await asyncio.gather(
+            self._notify_sessions(
+                tuple(self._tool_sessions),
+                lambda session: session.send_tool_list_changed(),
+                self._tool_sessions,
+                "tool",
+            ),
+            self._notify_sessions(
+                tuple(self._resource_sessions),
+                lambda session: session.send_resource_list_changed(),
+                self._resource_sessions,
+                "resource",
+            ),
+        )
+
+    async def _notify_sessions(
+        self,
+        sessions: tuple[ServerSession, ...],
+        send_notification: Callable[[ServerSession], Awaitable[None]],
+        registered_sessions: weakref.WeakSet[ServerSession],
+        list_name: str,
+    ) -> None:
+        results = await asyncio.gather(
+            *(send_notification(session) for session in sessions),
+            return_exceptions=True,
+        )
+        for session, result in zip(sessions, results):
+            if isinstance(result, BaseException):
+                registered_sessions.discard(session)
+                verbose_logger.warning(
+                    "Failed to send MCP %s list-changed notification: %s",
+                    list_name,
+                    result,
+                )
+
+
+mcp_list_change_notifier = MCPListChangeNotifier()

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -373,6 +373,9 @@ if MCP_AVAILABLE:
         _without_authorization,
         global_mcp_server_manager,
     )
+    from litellm.proxy._experimental.mcp_server.list_change_notifications import (
+        mcp_list_change_notifier,
+    )
     from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
         _request_auth_header,
         _request_extra_headers,
@@ -435,9 +438,14 @@ if MCP_AVAILABLE:
         notification_options: Optional[NotificationOptions] = None,
         experimental_capabilities: Optional[Dict[str, Dict[str, Any]]] = None,
     ) -> InitializationOptions:
+        supplied_notification_options = notification_options or NotificationOptions()
         opts = Server.create_initialization_options(
             self,
-            notification_options=notification_options,
+            notification_options=NotificationOptions(
+                prompts_changed=supplied_notification_options.prompts_changed,
+                resources_changed=True,
+                tools_changed=True,
+            ),
             experimental_capabilities=experimental_capabilities or {},
         )
         updates: Dict[str, Any] = {}
@@ -687,6 +695,7 @@ if MCP_AVAILABLE:
         _session_reset_token = None
         if req_ctx:
             _session_reset_token = active_mcp_session_var.set(req_ctx.session)
+            mcp_list_change_notifier.remember_tool_list_session(req_ctx.session)
         _trace_token = None
 
         try:
@@ -1159,6 +1168,7 @@ if MCP_AVAILABLE:
         _session_reset_token = None
         if req_ctx:
             _session_reset_token = active_mcp_session_var.set(req_ctx.session)
+            mcp_list_change_notifier.remember_resource_list_session(req_ctx.session)
 
         try:
             (
@@ -1202,6 +1212,7 @@ if MCP_AVAILABLE:
         _session_reset_token = None
         if req_ctx:
             _session_reset_token = active_mcp_session_var.set(req_ctx.session)
+            mcp_list_change_notifier.remember_resource_list_session(req_ctx.session)
 
         try:
             (

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -143,6 +143,9 @@ if MCP_AVAILABLE:
     from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
         global_mcp_server_manager,
     )
+    from litellm.proxy._experimental.mcp_server.list_change_notifications import (
+        mcp_list_change_notifier,
+    )
     from litellm.proxy._experimental.mcp_server.ui_session_utils import (
         build_effective_auth_contexts,
     )
@@ -1192,6 +1195,7 @@ if MCP_AVAILABLE:
         )
         await global_mcp_server_manager.invalidate_byom_submitted_servers_cache(approved.submitted_by)
         await global_mcp_server_manager.reload_servers_from_database()
+        await mcp_list_change_notifier.notify_lists_changed()
 
         return _redact_mcp_credentials(approved)
 
@@ -1240,6 +1244,7 @@ if MCP_AVAILABLE:
         # Only evict from the runtime registry if the server was previously active
         if was_active:
             await global_mcp_server_manager.reload_servers_from_database()
+            await mcp_list_change_notifier.notify_lists_changed()
         return _redact_mcp_credentials(rejected)
 
     @router.get(
@@ -1423,13 +1428,17 @@ if MCP_AVAILABLE:
         # failure here (e.g. an unrelated malformed row in the table) must not
         # surface as a 500 and orphan the created server, which would push the
         # caller to retry and create duplicates.
+        registry_changed = False
         try:
             await global_mcp_server_manager.add_server(new_mcp_server)
+            registry_changed = True
             await global_mcp_server_manager.reload_servers_from_database()
         except Exception as e:
             verbose_proxy_logger.exception(
                 f"MCP server {new_mcp_server.server_id} created but in-memory registry refresh failed: {str(e)}"
             )
+        if registry_changed:
+            await mcp_list_change_notifier.notify_lists_changed()
 
         return _redact_mcp_credentials(new_mcp_server)
 
@@ -1808,6 +1817,7 @@ if MCP_AVAILABLE:
 
         # Ensure registry is up to date by reloading from database
         await global_mcp_server_manager.reload_servers_from_database()
+        await mcp_list_change_notifier.notify_lists_changed()
 
         # TODO: Enterprise: Finish audit log trail
         if litellm.store_audit_logs:
@@ -2377,6 +2387,7 @@ if MCP_AVAILABLE:
 
         # Ensure registry is up to date by reloading from database
         await global_mcp_server_manager.reload_servers_from_database()
+        await mcp_list_change_notifier.notify_lists_changed()
 
         # If a field that determines which upstream OAuth token gets minted changed (url/audience, OAuth
         # mode/grant, authorization-server endpoints, or the OAuth client + scopes), every stored per-user

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_list_change_notifications.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_list_change_notifications.py
@@ -1,0 +1,30 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from mcp.server.session import ServerSession
+
+from litellm.proxy._experimental.mcp_server.list_change_notifications import (
+    MCPListChangeNotifier,
+)
+
+
+@pytest.mark.asyncio
+async def test_notify_lists_changed_fans_out_and_discards_failed_sessions():
+    notifier = MCPListChangeNotifier()
+    tool_session = MagicMock(spec=ServerSession)
+    tool_session.send_tool_list_changed = AsyncMock()
+    failed_tool_session = MagicMock(spec=ServerSession)
+    failed_tool_session.send_tool_list_changed = AsyncMock(side_effect=RuntimeError("closed"))
+    resource_session = MagicMock(spec=ServerSession)
+    resource_session.send_resource_list_changed = AsyncMock()
+
+    notifier.remember_tool_list_session(tool_session)
+    notifier.remember_tool_list_session(failed_tool_session)
+    notifier.remember_resource_list_session(resource_session)
+
+    await notifier.notify_lists_changed()
+    await notifier.notify_lists_changed()
+
+    assert tool_session.send_tool_list_changed.await_count == 2
+    failed_tool_session.send_tool_list_changed.assert_awaited_once()
+    assert resource_session.send_resource_list_changed.await_count == 2

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -4975,6 +4975,23 @@ class TestGatewayCreateInitializationOptions:
             _mcp_gateway_initialize_instructions.reset(instructions_token)
             _mcp_gateway_server_name.reset(server_name_token)
 
+    def test_advertises_dynamic_tool_and_resource_lists(self):
+        try:
+            from mcp.server.lowlevel.server import NotificationOptions
+
+            from litellm.proxy._experimental.mcp_server.server import server
+        except ImportError:
+            pytest.skip("MCP server not available")
+
+        opts = server.create_initialization_options(notification_options=NotificationOptions(prompts_changed=True))
+
+        assert opts.capabilities.tools is not None
+        assert opts.capabilities.tools.listChanged is True
+        assert opts.capabilities.resources is not None
+        assert opts.capabilities.resources.listChanged is True
+        assert opts.capabilities.prompts is not None
+        assert opts.capabilities.prompts.listChanged is True
+
     @pytest.mark.asyncio
     async def test_scoped_request_uses_configured_server_alias(self):
         try:

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -2663,11 +2663,16 @@ class TestAddMCPServerAtomicity:
                 "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
                 mock_manager,
             ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.mcp_list_change_notifier.notify_lists_changed",
+                new_callable=AsyncMock,
+            ) as notify_lists_changed,
         ):
             result = await add_mcp_server(payload=payload, user_api_key_dict=admin)
 
         create_mock.assert_awaited_once()
         mock_manager.reload_servers_from_database.assert_awaited_once()
+        notify_lists_changed.assert_awaited_once()
         assert result.server_id == "created-1"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks. Local `make lint` and focused unit tests pass; remote CI is pending
- [x] My PR scope is as isolated as possible and solves one specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Commit `c67ceb1`

Using the MCP SDK in-memory transport with the actual LiteLLM MCP server and `ClientSession`, the client initialized, called `tools/list` and `resources/list`, and received both server notifications after the list-change notifier ran.

```text
tools=0
resources=0
notifications=ResourceListChangedNotification, ToolListChangedNotification
```

## Type

New Feature

## Changes

LiteLLM now advertises `tools.listChanged` and `resources.listChanged` while preserving the configured prompt notification capability.

Stateful sessions are retained with weak references after they list tools or resources. Registry create, update, delete, approve, and active-to-rejected transitions fan out the corresponding standard MCP notifications. Failed sessions are removed without interrupting notifications to healthy clients.

The new tests cover capability negotiation, notification fanout and failure isolation, and notification delivery when a committed create survives a later registry reload failure.

### Final Attestation

- [ ] The tests check the right things, including edge cases, and regressions in the respective real-world use cases are not possible after this PR