### PR TITLE
test(e2e): cover MCP api_key tools/list + tools/call over a virtual key

### DIFF
--- a/tests/e2e/mcp/mcp_client.py
+++ b/tests/e2e/mcp/mcp_client.py
@@ -44,6 +44,7 @@ class McpServerNewResponse(BaseModel):
 
 class McpServerRow(BaseModel):
     server_id: str
+    server_name: str | None = None
     alias: str | None = None
     url: str | None = None
 

--- a/tests/e2e/mcp/test_mcp_api_key_tools_e2e.py
+++ b/tests/e2e/mcp/test_mcp_api_key_tools_e2e.py
@@ -1,0 +1,87 @@
+"""Live e2e: the MCP gateway brokers a config-registered upstream server over a virtual key.
+
+Exercises the api_key auth family end to end: a LiteLLM virtual key (x-litellm-api-key)
+discovers an upstream MCP server's tools (tools/list) and invokes one (tools/call), with
+the gateway injecting the upstream credential itself. The upstream here is the
+config-registered "hugging_face" server; it is only the vehicle. The call runs
+hub_repo_search and asserts a Hub search for GPT-2 under the openai-community namespace
+surfaces openai-community/gpt2, so a broken grant, a dropped upstream credential, or a
+tool that never ran fails rather than passing on a bare 200. The server is owned by
+gateway config, so the test looks it up by name, hard-fails (never skips) when absent,
+and tears down only the virtual key.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from e2e_config import unique_marker
+from e2e_http import unwrap
+from lifecycle import ResourceManager
+from mcp_client import McpClient
+
+pytestmark = pytest.mark.e2e
+
+UPSTREAM_SERVER_NAME = "hugging_face"
+SEARCH_TOOL = "hub_repo_search"
+SEARCH_QUERY = "gpt2"
+SEARCH_AUTHOR = "openai-community"
+CANONICAL_REPO_ID = "openai-community/gpt2"
+
+
+def _find_server(client: McpClient, server_name: str) -> str:
+    """Return the server_id of a config-registered MCP server, or hard-fail.
+
+    Live e2e never skips for a missing upstream: a gateway without the server is a red
+    run so the operator knows the suite cannot prove the product path.
+    """
+    for row in client.registered_servers():
+        if row.server_name == server_name:
+            return row.server_id
+    pytest.fail(
+        f"gateway has no {server_name!r} MCP server registered; add it to the proxy "
+        "config and restart"
+    )
+
+
+class TestMcpApiKeyToolAccess:
+    @pytest.mark.covers("mcp.list_tools.api_key.succeeds", "mcp.call_tool.api_key.succeeds")
+    def test_virtual_key_lists_and_calls_upstream_tool(
+        self,
+        client: McpClient,
+        resources: ResourceManager,
+    ) -> None:
+        server_id = _find_server(client, UPSTREAM_SERVER_NAME)
+
+        key = client.generate_key(
+            user_id=f"e2e-mcp-api-key-{unique_marker()}",
+            mcp_servers=[server_id],
+        )
+        resources.defer(lambda: client.proxy.delete_key(key))
+
+        tools = unwrap(client.list_tools(key))
+        tool_name = tools.tool_name_containing(server_id, SEARCH_TOOL)
+        assert tool_name is not None, (
+            f"granted key never saw {SEARCH_TOOL} on server {UPSTREAM_SERVER_NAME!r}; "
+            f"tools={tools.tool_names_for_server(server_id)}"
+        )
+
+        call = unwrap(
+            client.call_tool(
+                key,
+                server_id=server_id,
+                name=tool_name,
+                arguments={
+                    "query": SEARCH_QUERY,
+                    "author": SEARCH_AUTHOR,
+                    "repo_types": ["model"],
+                    "limit": 10,
+                },
+            )
+        )
+        assert call.is_error is not True, f"{SEARCH_TOOL} errored: {call}"
+        body = call.all_text
+        assert CANONICAL_REPO_ID in body, (
+            f"{SEARCH_TOOL} for {SEARCH_QUERY!r} under {SEARCH_AUTHOR!r} must surface "
+            f"{CANONICAL_REPO_ID!r}; got: {body[:800]!r}"
+        )


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4627

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Captured at commit `86e52148c8` against a live proxy (local, port 12253) with the `hugging_face` MCP server configured (`url https://huggingface.co/mcp`, `auth_type bearer_token`, `auth_value os.environ/HUGGING_FACE_BEARER_TOKEN`). Real upstream, no mocks

```
### 1) hugging_face server is registered from gateway config
$ curl -s localhost:12253/v1/mcp/server -H "Authorization: Bearer sk-1234"
server_name=hugging_face  id=4acf03be2771d47cdf8be684806ca7d2  auth_type=bearer_token  url=https://huggingface.co/mcp

### 2) mint a virtual key scoped to that server
$ curl -s -X POST localhost:12253/key/generate -H "Authorization: Bearer sk-1234" \
    -d '{"models":[],"object_permission":{"mcp_servers":["4acf03be2771d47cdf8be684806ca7d2"]}}'
scoped key: sk-TYyxg09... (mcp_servers=[4acf03be2771d47cdf8be684806ca7d2])

### 3) tools/list over the virtual key (api_key path) shows the upstream's tools
$ curl -s localhost:12253/mcp-rest/tools/list -H "x-litellm-api-key: $KEY"
['hf_fs', 'hf_whoami', 'hub_repo_details', 'hub_repo_search']

### 4) tools/call hub_repo_search returns the canonical repo id
$ curl -s -X POST localhost:12253/mcp-rest/tools/call -H "x-litellm-api-key: $KEY" \
    -d '{"name":"hub_repo_search","server_id":"4acf03be2771d47cdf8be684806ca7d2","arguments":{"query":"gpt2","author":"openai-community","repo_types":["model"],"limit":10}}'
isError= False
first result line: Found 4 repositories across models matching query "gpt2", author "openai-community".
contains openai-community/gpt2: True
```

The test drives exactly this path through the shared transport and asserts step 4 surfaces `openai-community/gpt2`, so a broken grant, a dropped upstream credential, or a tool that never ran fails rather than passing on a bare 200

## Type

✅ Test

## Changes

Adds a live e2e for the MCP gateway's api_key auth family: a LiteLLM virtual key discovers a config-registered upstream MCP server's tools (`tools/list`) and invokes one (`tools/call`), with the gateway injecting the upstream credential. The upstream is incidental (the `hugging_face` server here); what is under test is the gateway tool surface over a virtual key, which maps to the `mcp.list_tools.api_key.succeeds` and `mcp.call_tool.api_key.succeeds` registry cells

The server is owned by gateway config, so the test looks it up by name, hard-fails (never skips) when absent, and tears down only the virtual key. A `server_name` field is added to the suite's `McpServerRow` so the lookup works

## QA runbook

- tests/e2e/mcp/test_mcp_api_key_tools_e2e.py::TestMcpApiKeyToolAccess::test_virtual_key_lists_and_calls_upstream_tool - a virtual key granted a config-registered MCP server discovers its tools and calls one, and the real upstream returns grounded results
  - [ ] Configure an MCP server named `hugging_face` on the gateway (`url https://huggingface.co/mcp`, `auth_type bearer_token`, `auth_value os.environ/HUGGING_FACE_BEARER_TOKEN`), set `HUGGING_FACE_BEARER_TOKEN`, restart
  - [ ] `GET /v1/mcp/server` with the master key and note the `hugging_face` server_id
  - [ ] `POST /key/generate` with `object_permission.mcp_servers=[<that id>]`
  - [ ] `GET /mcp-rest/tools/list` with header `x-litellm-api-key: <key>` and expect `hub_repo_search` among the tools
  - [ ] `POST /mcp-rest/tools/call` with `name=hub_repo_search`, `server_id=<that id>`, args `{query: gpt2, author: openai-community, repo_types: [model], limit: 10}` and expect `openai-community/gpt2` in the response with `isError` false
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey; it keys on the canonical repo id rather than a bare 200, so a broken grant, a dropped upstream credential, or a tool that never ran fails it

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
