### PR TITLE
fix(bedrock_mantle): gate unsupported service_tier on drop_params for the Responses API

### DIFF
--- a/litellm/llms/bedrock_mantle/responses/transformation.py
+++ b/litellm/llms/bedrock_mantle/responses/transformation.py
@@ -17,6 +17,7 @@ BaseAWSLLM._sign_request after the request body is finalized.
 
 from typing import Any, Dict, List, Optional
 
+import litellm
 from litellm._logging import verbose_logger
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 from litellm.llms.bedrock_mantle.common_utils import (
@@ -41,6 +42,8 @@ _BASE_SUFFIXES_TO_STRIP = (
 
 # Per Bedrock Mantle Responses API validation errors.
 _BEDROCK_MANTLE_SUPPORTED_RESPONSE_TOOL_TYPES = frozenset({"function", "mcp", "custom", "namespace", "tool_search"})
+
+_BEDROCK_MANTLE_SUPPORTED_SERVICE_TIERS = frozenset({"auto", "default"})
 
 
 class BedrockMantleResponsesAPIConfig(BedrockMantleAuthMixin, OpenAIResponsesAPIConfig):
@@ -116,15 +119,40 @@ class BedrockMantleResponsesAPIConfig(BedrockMantleAuthMixin, OpenAIResponsesAPI
 
         return kept
 
+    @staticmethod
+    def _handle_unsupported_service_tier(params: dict, drop_params: bool) -> dict:
+        service_tier = params.get("service_tier")
+        if service_tier is None or service_tier in _BEDROCK_MANTLE_SUPPORTED_SERVICE_TIERS:
+            return params
+        if not drop_params:
+            raise litellm.utils.UnsupportedParamsError(
+                status_code=400,
+                message=(
+                    f"bedrock_mantle does not support service_tier={service_tier!r}; the Bedrock Mantle "
+                    "Responses API only accepts 'auto' or 'default'. Set `drop_params: true` (litellm_settings "
+                    "or this deployment's litellm_params) to have LiteLLM drop it, or remove service_tier from "
+                    "the client (Codex CLI sends it when a speed tier is set in ~/.codex/config.toml)."
+                ),
+            )
+        verbose_logger.warning(
+            "Bedrock Mantle Responses API: dropping unsupported service_tier %r (supported: %s).",
+            service_tier,
+            sorted(_BEDROCK_MANTLE_SUPPORTED_SERVICE_TIERS),
+        )
+        return {key: value for key, value in params.items() if key != "service_tier"}
+
     def map_openai_params(
         self,
         response_api_optional_params: ResponsesAPIOptionalRequestParams,
         model: str,
         drop_params: bool,
     ) -> Dict:
-        params = super().map_openai_params(
-            response_api_optional_params=response_api_optional_params,
-            model=model,
+        params = self._handle_unsupported_service_tier(
+            super().map_openai_params(
+                response_api_optional_params=response_api_optional_params,
+                model=model,
+                drop_params=drop_params,
+            ),
             drop_params=drop_params,
         )
 

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -1070,11 +1070,13 @@ def responses(
             )
 
         # Get optional parameters for the responses API
+        request_drop_params = kwargs.get("drop_params")
         responses_api_request_params: Dict = ResponsesAPIRequestUtils.get_optional_params_responses_api(
             model=model,
             responses_api_provider_config=responses_api_provider_config,
             response_api_optional_params=response_api_optional_params,
             allowed_openai_params=allowed_openai_params,
+            drop_params=request_drop_params if isinstance(request_drop_params, bool) else None,
         )
 
         litellm_logging_obj.update_from_kwargs(
@@ -1896,11 +1898,13 @@ def compact_responses(
         )
 
         # Get optional parameters for the responses API
+        request_drop_params = kwargs.get("drop_params")
         responses_api_request_params: Dict = ResponsesAPIRequestUtils.get_optional_params_responses_api(
             model=model,
             responses_api_provider_config=responses_api_provider_config,
             response_api_optional_params=response_api_optional_params,
             allowed_openai_params=None,
+            drop_params=request_drop_params if isinstance(request_drop_params, bool) else None,
         )
 
         # Pre Call logging

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -65,6 +65,7 @@ class ResponsesAPIRequestUtils:
         responses_api_provider_config: BaseResponsesAPIConfig,
         response_api_optional_params: ResponsesAPIOptionalRequestParams,
         allowed_openai_params: Optional[List[str]] = None,
+        drop_params: bool | None = None,
     ) -> Dict:
         """
         Get optional parameters for the responses API.
@@ -83,12 +84,14 @@ class ResponsesAPIRequestUtils:
         # Get supported parameters for the model
         supported_params = responses_api_provider_config.get_supported_openai_params(model)
 
+        should_drop_params = litellm.drop_params or drop_params is True
+
         non_default_params = cast(Dict, response_api_optional_params)
         # Check for unsupported parameters
         ResponsesAPIRequestUtils._check_valid_arg(
             supported_params=supported_params + (allowed_openai_params or []),
             non_default_params=non_default_params,
-            drop_params=litellm.drop_params,
+            drop_params=should_drop_params,
             custom_llm_provider=responses_api_provider_config.custom_llm_provider,
             model=model,
         )
@@ -97,7 +100,7 @@ class ResponsesAPIRequestUtils:
         mapped_params = responses_api_provider_config.map_openai_params(
             response_api_optional_params=response_api_optional_params,
             model=model,
-            drop_params=litellm.drop_params,
+            drop_params=should_drop_params,
         )
 
         # add any allowed_openai_params to the mapped_params

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
@@ -373,6 +373,127 @@ class TestBedrockMantleResponsesTools:
         assert "web_search" in str(mock_warning.call_args)
 
 
+def _codex_exec_tool():
+    return {
+        "type": "custom",
+        "name": "exec",
+        "description": "Run JavaScript code to orchestrate/compose tool calls",
+        "format": {
+            "type": "grammar",
+            "syntax": "lark",
+            "definition": "start: SOURCE\nSOURCE: /[\\s\\S]+/",
+        },
+    }
+
+
+def _codex_wait_tool():
+    return {
+        "type": "function",
+        "name": "wait",
+        "strict": False,
+        "parameters": {
+            "type": "object",
+            "properties": {"cell_id": {"type": "string"}},
+            "required": ["cell_id"],
+            "additionalProperties": False,
+        },
+    }
+
+
+class TestBedrockMantleServiceTier:
+    @pytest.mark.parametrize("tier", ["priority", "flex"])
+    def test_unsupported_service_tier_dropped_when_drop_params_true(self, tier):
+        cfg = BedrockMantleResponsesAPIConfig()
+        params = cfg.map_openai_params(
+            response_api_optional_params={"service_tier": tier},
+            model="openai.gpt-5.5",
+            drop_params=True,
+        )
+        assert "service_tier" not in params
+
+    @pytest.mark.parametrize("tier", ["priority", "flex"])
+    def test_unsupported_service_tier_raises_when_drop_params_false(self, tier):
+        cfg = BedrockMantleResponsesAPIConfig()
+        with pytest.raises(litellm.UnsupportedParamsError) as excinfo:
+            cfg.map_openai_params(
+                response_api_optional_params={"service_tier": tier},
+                model="openai.gpt-5.5",
+                drop_params=False,
+            )
+        assert tier in str(excinfo.value)
+        assert "drop_params" in str(excinfo.value)
+
+    @pytest.mark.parametrize("drop_params", [True, False])
+    @pytest.mark.parametrize("tier", ["auto", "default"])
+    def test_supported_service_tier_kept(self, tier, drop_params):
+        cfg = BedrockMantleResponsesAPIConfig()
+        params = cfg.map_openai_params(
+            response_api_optional_params={"service_tier": tier},
+            model="openai.gpt-5.5",
+            drop_params=drop_params,
+        )
+        assert params["service_tier"] == tier
+
+    def test_absent_service_tier_untouched(self):
+        cfg = BedrockMantleResponsesAPIConfig()
+        params = cfg.map_openai_params(
+            response_api_optional_params={"stream": True},
+            model="openai.gpt-5.5",
+            drop_params=False,
+        )
+        assert "service_tier" not in params
+        assert params["stream"] is True
+
+    def test_drop_logged_at_warning_level(self):
+        from unittest.mock import patch
+
+        cfg = BedrockMantleResponsesAPIConfig()
+        with patch(
+            "litellm.llms.bedrock_mantle.responses.transformation.verbose_logger.warning"
+        ) as mock_warning:
+            cfg.map_openai_params(
+                response_api_optional_params={"service_tier": "priority"},
+                model="openai.gpt-5.5",
+                drop_params=True,
+            )
+        assert mock_warning.call_count == 1
+        assert "priority" in str(mock_warning.call_args)
+
+
+class TestBedrockMantleCodexRequestEndToEnd:
+    def test_codex_priority_tier_request_becomes_mantle_acceptable(self):
+        cfg = BedrockMantleResponsesAPIConfig()
+        params = cfg.map_openai_params(
+            response_api_optional_params={
+                "service_tier": "priority",
+                "stream": True,
+                "store": False,
+                "tool_choice": "auto",
+                "parallel_tool_calls": False,
+                "tools": [_codex_exec_tool(), _codex_wait_tool()],
+            },
+            model="openai.gpt-5.5",
+            drop_params=True,
+        )
+        body = cfg.transform_responses_api_request(
+            model="openai.gpt-5.5",
+            input=[
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hi"}],
+                }
+            ],
+            response_api_optional_request_params=params,
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+        assert "service_tier" not in body
+        assert [tool["name"] for tool in body["tools"]] == ["exec", "wait"]
+        assert body["stream"] is True
+        assert body["tool_choice"] == "auto"
+
+
 class TestBedrockMantleResponsesRegistry:
     def test_registry_returns_config_for_gpt_5_5(self, local_cost_map):
         # gpt-5.x advertises /v1/responses in supported_endpoints (capability)

--- a/tests/test_litellm/responses/test_responses_api_request_body.py
+++ b/tests/test_litellm/responses/test_responses_api_request_body.py
@@ -196,3 +196,66 @@ async def test_aresponses_azure_shell_tool_400_maps_to_bad_request_error():
     assert excinfo.value.status_code == 400
     assert "shell" in str(excinfo.value).lower()
     assert "not supported" in str(excinfo.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_aresponses_request_level_drop_params_drops_bedrock_mantle_service_tier(
+    monkeypatch,
+):
+    """
+    Request-level drop_params=True (as the proxy injects for agentic CLIs) must
+    reach the provider config so bedrock_mantle strips the unsupported
+    service_tier before the request hits the wire.
+    """
+    monkeypatch.setattr(litellm, "drop_params", False)
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        new_callable=AsyncMock,
+    ) as mock_post:
+        mock_post.return_value = MockResponse(
+            _minimal_responses_api_payload("resp_mantle_tier_test", "openai.gpt-5.5"),
+            200,
+        )
+
+        await litellm.aresponses(
+            model="bedrock_mantle/openai.gpt-5.5",
+            api_key="fake-bearer-token",
+            aws_region_name="us-east-1",
+            input="hi",
+            service_tier="priority",
+            drop_params=True,
+        )
+
+        mock_post.assert_called_once()
+        post_kwargs = mock_post.call_args.kwargs
+        request_body = post_kwargs["json"] if "json" in post_kwargs else json.loads(post_kwargs["data"])
+        assert "service_tier" not in request_body
+
+
+@pytest.mark.asyncio
+async def test_aresponses_bedrock_mantle_service_tier_raises_without_drop_params(
+    monkeypatch,
+):
+    """
+    Without drop_params, an unsupported service_tier must fail fast with an
+    error that names drop_params instead of sending a request Mantle rejects.
+    """
+    monkeypatch.setattr(litellm, "drop_params", False)
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        new_callable=AsyncMock,
+    ) as mock_post:
+        with pytest.raises(litellm.BadRequestError) as excinfo:
+            await litellm.aresponses(
+                model="bedrock_mantle/openai.gpt-5.5",
+                api_key="fake-bearer-token",
+                aws_region_name="us-east-1",
+                input="hi",
+                service_tier="priority",
+            )
+
+        mock_post.assert_not_called()
+        assert "drop_params" in str(excinfo.value)
+        assert "priority" in str(excinfo.value)

--- a/tests/test_litellm/responses/test_responses_utils.py
+++ b/tests/test_litellm/responses/test_responses_utils.py
@@ -69,6 +69,44 @@ class TestResponsesAPIRequestUtils:
         assert "unsupported_param" in str(excinfo.value)
         assert model in str(excinfo.value)
 
+    def test_get_optional_params_responses_api_request_level_drop_params(self, monkeypatch):
+        """Request-level drop_params must reach both _check_valid_arg and map_openai_params"""
+        monkeypatch.setattr(litellm, "drop_params", False)
+        config = MagicMock(spec=OpenAIResponsesAPIConfig)
+        config.get_supported_openai_params.return_value = ["temperature"]
+        config.custom_llm_provider = "openai"
+        config.map_openai_params.return_value = {"temperature": 0.7}
+
+        result = ResponsesAPIRequestUtils.get_optional_params_responses_api(
+            model="gpt-4o",
+            responses_api_provider_config=config,
+            response_api_optional_params=ResponsesAPIOptionalRequestParams(
+                {"temperature": 0.7, "service_tier": "priority"}
+            ),
+            drop_params=True,
+        )
+
+        assert config.map_openai_params.call_args.kwargs["drop_params"] is True
+        assert result == {"temperature": 0.7}
+
+    @pytest.mark.parametrize("request_drop_params", [None, False])
+    def test_get_optional_params_responses_api_still_raises_without_drop(
+        self, monkeypatch, request_drop_params
+    ):
+        """Absent or False request-level drop_params must not suppress the unsupported-param error"""
+        monkeypatch.setattr(litellm, "drop_params", False)
+        config = OpenAIResponsesAPIConfig()
+
+        with pytest.raises(litellm.UnsupportedParamsError):
+            ResponsesAPIRequestUtils.get_optional_params_responses_api(
+                model="gpt-4o",
+                responses_api_provider_config=config,
+                response_api_optional_params=ResponsesAPIOptionalRequestParams(
+                    {"temperature": 0.7, "unsupported_param": "value"}
+                ),
+                drop_params=request_drop_params,
+            )
+
     def test_get_requested_response_api_optional_param(self):
         """Test filtering parameters to only include those in ResponsesAPIOptionalRequestParams"""
         # Setup


### PR DESCRIPTION
## Relevant issues

Pairs with #33228 (hoists Codex's `additional_tools` input items, the first of the two Mantle rejections) and #34068 (auto-enables `drop_params` for Codex user agents so this fix needs no extra config)

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All runs hit the real Bedrock Mantle endpoint in us-east-1 (bearer auth, real spend) with this config; the second deployment carries `drop_params: true`

```yaml
model_list:
  - model_name: gpt-5.5
    litellm_params:
      model: bedrock_mantle/openai.gpt-5.5
      api_base: https://bedrock-mantle.us-east-1.api.aws/v1
      aws_region_name: us-east-1
  - model_name: gpt-5.5-drop
    litellm_params:
      model: bedrock_mantle/openai.gpt-5.5
      api_base: https://bedrock-mantle.us-east-1.api.aws/v1
      aws_region_name: us-east-1
      drop_params: true

general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
```

**Before**, at commit 9ad8698aab (the direct parent of this branch), the tier Codex sends when a speed tier is selected reaches Mantle and dies with the raw provider error, and setting `drop_params: true` on the deployment does not help because the Responses path only ever consulted the global `litellm.drop_params`:

```bash
curl -s http://localhost:24815/v1/responses -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.5","stream":false,"store":false,"service_tier":"priority","input":"Reply with exactly: ok"}'
```

```json
{"error":{"message":"litellm.APIConnectionError: Bedrock_mantleException - {\"error\":{\"code\":\"validation_error\",\"message\":\"'priority' is not supported for 'service_tier' on this model\",...}}","code":"500"}}
```

The identical curl with `"model": "gpt-5.5-drop"` (deployment-level `drop_params: true`) returns the same Mantle 400

**After**, at commit 354f3971a9, the deployment without `drop_params` fails fast with an actionable error instead of a provider 500:

```json
{"error":{"message":"litellm.UnsupportedParamsError: bedrock_mantle does not support service_tier='priority'; the Bedrock Mantle Responses API only accepts 'auto' or 'default'. Set `drop_params: true` (litellm_settings or this deployment's litellm_params) to have LiteLLM drop it, or remove service_tier from the client (Codex CLI sends it when a speed tier is set in ~/.codex/config.toml)...","code":"400"}}
```

and the `gpt-5.5-drop` deployment now drops the tier and completes (Mantle reports the default tier):

```json
{"status": "completed", "model": "gpt-5.5-drop", "service_tier": "default"}
output_text: ['ok']
```

Real Codex CLI 0.144.5 end to end at the same commit, with `service_tier = "priority"` set in `~/.codex/config.toml`:

```
$ npx -y @openai/codex@0.144.5 exec --skip-git-repo-check -s read-only \
    -c model_provider=litellm \
    -c 'model_providers.litellm.name="litellm"' \
    -c 'model_providers.litellm.base_url="http://localhost:23917/v1"' \
    -c 'model_providers.litellm.wire_api="responses"' \
    -c 'model_providers.litellm.env_key="LITELLM_KEY"' \
    -m gpt-5.5-drop "Reply with exactly: tier drop works"
codex
tier drop works
tokens used
11,210
```

The same Codex run against the deployment without `drop_params` surfaces the actionable message to the end user:

```
UnsupportedParamsError: bedrock_mantle does not support service_tier='priority'; the Bedrock Mantle Responses API only accepts 'auto' or 'default'. Set `drop_params: true` ...
```

## Type

🐛 Bug Fix

## Changes

Codex CLI 0.144 and later sends `service_tier: "priority"` whenever a speed tier is selected in `~/.codex/config.toml`. Bedrock Mantle's Responses API rejects it (`'priority' is not supported for 'service_tier' on this model`; direct probes show only omitted, `auto`, and `default` are accepted), so those Codex requests through a LiteLLM proxy backed by `bedrock_mantle/` fail with an opaque provider error. The `additional_tools` half of the original Codex breakage is handled by #33228; this PR is scoped to the tier

`BedrockMantleResponsesAPIConfig.map_openai_params` now handles an unsupported `service_tier` according to `drop_params`: with it enabled the tier is dropped and logged at warning level, without it the request fails fast with a `litellm.UnsupportedParamsError` that names `drop_params` and where the tier comes from. Supported values and requests without a tier are untouched

Making that gate reachable required fixing a plumbing gap: `get_optional_params_responses_api` only ever passed the global `litellm.drop_params` into `map_openai_params`, so request-level and deployment-level `drop_params` (including the proxy's agentic-CLI auto-injection, extended to Codex in #34068) never reached Responses transformations. It now accepts an optional `drop_params` argument, ORed with the global, and both call sites in `litellm/responses/main.py` forward the caller's value

Unit tests cover the tier gate (priority and flex dropped with `drop_params`, raising with an actionable message without it, auto and default kept either way, absent tier untouched, warning logged on drop), the plumbing (request-level `drop_params` reaching both the validity check and `map_openai_params`, and absent or False values still raising), and two wire-level tests through `litellm.aresponses()` asserting the outgoing Mantle body has no `service_tier` with `drop_params=True` and that the request fails fast without it

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
