### PR TITLE
fix(mcp): add Google Sheets, Drive, Calendar, and Docs to the OpenAPI registry

### DIFF
--- a/litellm/proxy/openapi_registry.json
+++ b/litellm/proxy/openapi_registry.json
@@ -93,6 +93,89 @@
       ]
     },
     {
+      "name": "google_sheets",
+      "title": "Google Sheets",
+      "description": "Read, write, and format data in Google Sheets spreadsheets",
+      "icon_url": "https://cdn.simpleicons.org/googlesheets",
+      "spec_url": "https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/googleapis.com/sheets/v4/openapi.yaml",
+      "oauth": {
+        "authorization_url": "https://accounts.google.com/o/oauth2/v2/auth",
+        "token_url": "https://oauth2.googleapis.com/token",
+        "pkce": true,
+        "docs_url": "https://developers.google.com/sheets/api/guides/authorizing"
+      },
+      "key_tools": [
+        { "name": "create_spreadsheet", "description": "Create a new spreadsheet" },
+        { "name": "get_spreadsheet", "description": "Get spreadsheet metadata and sheet properties" },
+        { "name": "get_values", "description": "Read cell values from a range" },
+        { "name": "update_values", "description": "Write cell values to a range" },
+        { "name": "append_values", "description": "Append rows of values to a range" },
+        { "name": "clear_values", "description": "Clear cell values in a range" },
+        { "name": "batch_update", "description": "Apply batched formatting and structural updates" }
+      ]
+    },
+    {
+      "name": "google_drive",
+      "title": "Google Drive",
+      "description": "List, read, upload, and manage files in Google Drive",
+      "icon_url": "https://cdn.simpleicons.org/googledrive",
+      "spec_url": "https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/googleapis.com/drive/v3/openapi.yaml",
+      "oauth": {
+        "authorization_url": "https://accounts.google.com/o/oauth2/v2/auth",
+        "token_url": "https://oauth2.googleapis.com/token",
+        "pkce": true,
+        "docs_url": "https://developers.google.com/drive/api/guides/api-specific-auth"
+      },
+      "key_tools": [
+        { "name": "list_files", "description": "List and search files" },
+        { "name": "get_file", "description": "Get file metadata" },
+        { "name": "create_file", "description": "Create a file or folder" },
+        { "name": "update_file", "description": "Update file metadata or content" },
+        { "name": "copy_file", "description": "Copy a file" },
+        { "name": "delete_file", "description": "Delete a file" },
+        { "name": "list_permissions", "description": "List sharing permissions on a file" }
+      ]
+    },
+    {
+      "name": "google_calendar",
+      "title": "Google Calendar",
+      "description": "Read and manage Google Calendar events and calendars",
+      "icon_url": "https://cdn.simpleicons.org/googlecalendar",
+      "spec_url": "https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/googleapis.com/calendar/v3/openapi.yaml",
+      "oauth": {
+        "authorization_url": "https://accounts.google.com/o/oauth2/v2/auth",
+        "token_url": "https://oauth2.googleapis.com/token",
+        "pkce": true,
+        "docs_url": "https://developers.google.com/workspace/calendar/api/guides/auth"
+      },
+      "key_tools": [
+        { "name": "list_events", "description": "List events on a calendar" },
+        { "name": "get_event", "description": "Get a single event" },
+        { "name": "insert_event", "description": "Create an event" },
+        { "name": "update_event", "description": "Update an event" },
+        { "name": "delete_event", "description": "Delete an event" },
+        { "name": "query_freebusy", "description": "Query free/busy availability" }
+      ]
+    },
+    {
+      "name": "google_docs",
+      "title": "Google Docs",
+      "description": "Create, read, and edit Google Docs documents",
+      "icon_url": "https://cdn.simpleicons.org/googledocs",
+      "spec_url": "https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/googleapis.com/docs/v1/openapi.yaml",
+      "oauth": {
+        "authorization_url": "https://accounts.google.com/o/oauth2/v2/auth",
+        "token_url": "https://oauth2.googleapis.com/token",
+        "pkce": true,
+        "docs_url": "https://developers.google.com/docs/api/how-tos/authorizing"
+      },
+      "key_tools": [
+        { "name": "create_document", "description": "Create a new document" },
+        { "name": "get_document", "description": "Get a document's full content" },
+        { "name": "batch_update_document", "description": "Apply batched edits to a document" }
+      ]
+    },
+    {
       "name": "stripe",
       "title": "Stripe",
       "description": "Payments, customers, subscriptions, and billing",

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -5399,7 +5399,8 @@ def test_bundled_openapi_registry_parses_and_entries_are_well_formed():
     assert apis, "registry must not be empty"
     names = [entry["name"] for entry in apis]
     assert len(names) == len(set(names)), "duplicate registry entry names"
-    assert "google_sheets" in names, "LIT-4629: Google Sheets must be in the catalog"
+    for google_entry in ("google_sheets", "google_drive", "google_calendar", "google_docs"):
+        assert google_entry in names, f"LIT-4629: {google_entry} must be in the catalog"
 
     for entry in apis:
         for required in ("name", "title", "description", "icon_url", "spec_url"):

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -5376,3 +5376,40 @@ async def test_edit_mcp_server_snapshot_failure_skips_purge_but_edit_succeeds():
 
     assert result.server_id == server_id
     mock_purge.assert_not_awaited()
+
+
+def test_bundled_openapi_registry_parses_and_entries_are_well_formed():
+    """The OpenAPI quick-picker registry ships as a bundled JSON file; a malformed file or entry
+    silently degrades the picker to empty (the endpoint swallows load errors), so pin the file's
+    shape here: it must parse, and every entry needs the fields the create-form prefill reads.
+    OAuth-capable entries must carry both endpoint URLs; a catalog entry with a blank
+    authorization_url would recreate the exact 400 ("authorization url is not set") the catalog
+    exists to prevent for spec-only servers, which never run OAuth endpoint discovery."""
+    import json
+    import os
+
+    registry_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "..", "..", "..", "..", "litellm", "proxy", "openapi_registry.json",
+    )
+    with open(registry_path) as f:
+        registry = json.load(f)
+
+    apis = registry["apis"]
+    assert apis, "registry must not be empty"
+    names = [entry["name"] for entry in apis]
+    assert len(names) == len(set(names)), "duplicate registry entry names"
+    assert "google_sheets" in names, "LIT-4629: Google Sheets must be in the catalog"
+
+    for entry in apis:
+        for required in ("name", "title", "description", "icon_url", "spec_url"):
+            assert entry.get(required), f"{entry.get('name')}: missing {required}"
+        assert entry["spec_url"].startswith("https://"), f"{entry['name']}: non-https spec_url"
+        oauth = entry.get("oauth")
+        if oauth is not None:
+            for required in ("authorization_url", "token_url"):
+                assert oauth.get(required, "").startswith("https://"), (
+                    f"{entry['name']}: oauth.{required} must be a non-empty https URL"
+                )
+        for tool in entry.get("key_tools", []):
+            assert tool.get("name") and tool.get("description"), f"{entry['name']}: malformed key_tool"


### PR DESCRIPTION
## Relevant issues

Spec-only (OpenAPI) MCP servers never run OAuth endpoint discovery, so a server created without the catalog prefill has an empty `authorization_url` and the OAuth flow dies at `/authorize` with 400 "MCP server authorization url is not set". Google Sheets was the reported case; Gmail was the only Google entry in the quick-picker registry, so creating a Sheets server from a custom spec URL left the OAuth fields blank

## Linear ticket

Part of LIT-4629

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Registry served live by a proxy running this branch, after the change (before it, `gmail` is the only Google entry; verify with `git show origin/litellm_internal_staging:litellm/proxy/openapi_registry.json`):

```
$ curl -s http://127.0.0.1:4630/v1/mcp/openapi-registry -H "Authorization: Bearer sk-..." | python3 -c "
import json,sys
for a in json.load(sys.stdin)['apis']:
    if a['name'].startswith('google'):
        print(a['name'], '|', a['oauth']['authorization_url'], '|', a['oauth']['token_url'], '| pkce:', a['oauth']['pkce'])"
google_sheets   | https://accounts.google.com/o/oauth2/v2/auth | https://oauth2.googleapis.com/token | pkce: True
google_drive    | https://accounts.google.com/o/oauth2/v2/auth | https://oauth2.googleapis.com/token | pkce: True
google_calendar | https://accounts.google.com/o/oauth2/v2/auth | https://oauth2.googleapis.com/token | pkce: True
google_docs     | https://accounts.google.com/o/oauth2/v2/auth | https://oauth2.googleapis.com/token | pkce: True
```

End to end control with the prefilled values (the exact flow that 400s without them): a Google Sheets server created via `POST /v1/mcp/server/oauth/session` with this entry's `spec_url`, `authorization_url`, and `token_url`, then the authorize endpoint the UI drives:

```
$ curl -s -o /dev/null -w 'HTTP %{http_code}\nLocation: %{redirect_url}\n' -G \
    "http://127.0.0.1:4630/v1/mcp/server/oauth/<server_id>/authorize" \
    -H "Authorization: Bearer sk-..." \
    --data-urlencode "redirect_uri=http://127.0.0.1:4630/ui/mcp/oauth/callback" \
    --data-urlencode "state=prb-verify" \
    --data-urlencode "code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM" \
    --data-urlencode "code_challenge_method=S256" \
    --data-urlencode "response_type=code"
HTTP 307
Location: https://accounts.google.com/o/oauth2/v2/auth?client_id=...&state=...&response_type=code&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fspreadsheets&code_challenge=...&code_challenge_method=S256
```

## Type

🐛 Bug Fix

## Changes

Adds `google_sheets`, `google_drive`, `google_calendar`, and `google_docs` entries to `litellm/proxy/openapi_registry.json`, mirroring the existing `gmail` entry with Google's current OAuth endpoints and PKCE. All four `spec_url`s and `icon_url`s were verified reachable, and the curated `key_tools` names were written against the real operationIds in each spec so the create form's fuzzy tool suggestions match

Adds `test_bundled_openapi_registry_parses_and_entries_are_well_formed`, the registry file's first test. The registry endpoint swallows load errors and returns an empty picker, so a malformed entry previously degraded silently; the test pins that the file parses and that every entry carries the fields the create form prefill reads, with non-empty https OAuth URLs

The entries deliberately do not carry Google's `access_type=offline` and `prompt=consent` authorize parameters (needed for refresh tokens); the registry schema has no field for authorize parameters today, the existing `gmail` entry has the same gap, and that is tracked separately on the Linear ticket. Nothing changes for existing servers or any other code path; this PR only adds catalog data and its missing test

## QA runbook

1. Start the proxy and open the Admin UI, MCP Servers page, Add New MCP Server
2. Choose the OpenAPI server type; the Popular APIs picker should now show Google Sheets, Google Drive, Google Calendar, and Google Docs tiles
3. Click Google Sheets; the spec URL, auth type (OAuth 2.0, interactive), Authorization URL, and Token URL fields prefill with the values shown above
4. Enter a GCP OAuth client id and secret plus a scope such as `https://www.googleapis.com/auth/spreadsheets`, then start the OAuth flow; the browser should land on the Google consent screen (HTTP 307 to `accounts.google.com/o/oauth2/v2/auth`) instead of the previous 400 "MCP server authorization url is not set"

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

