### PR TITLE
feat(mcp): enforce delegated-user ceiling for agent-OBO tool calls

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -703,12 +703,12 @@ class MCPRequestHandler:
             case "key_hash":
                 return await MCPRequestHandler._reload_admitted_key(identity.subject)
             case "user_id":
-                return await MCPRequestHandler._reload_admitted_user(identity.subject)
+                return await MCPRequestHandler.reload_admitted_user(identity.subject)
             case _:
                 assert_never(identity.subject_type)
 
     @staticmethod
-    async def _reload_admitted_user(user_id: str) -> UserAPIKeyAuth:
+    async def reload_admitted_user(user_id: str) -> UserAPIKeyAuth:
         """Reload the live user an interactively-minted envelope references and admit them as
         themselves.
 
@@ -770,6 +770,32 @@ class MCPRequestHandler:
             object_permission=object_permission,
             object_permission_id=user_object.object_permission_id,
         )
+
+    @staticmethod
+    async def resolve_delegated_user_contexts(user_id: str) -> list[UserAPIKeyAuth]:
+        """The auth contexts spanning a delegated user's TOTAL MCP reach: their own object-permission
+        context, plus one per team they belong to (a key on that team inherits the team's grants).
+
+        ``get_allowed_mcp_servers`` / ``get_allowed_tools_for_server`` computed over the UNION of these
+        contexts give the user's full cross-team reach, which a single ``UserAPIKeyAuth`` (one team)
+        cannot express; this is what lets a delegated user whose MCP access is granted through team or
+        group membership be counted rather than under-counted. The own context reuses the fail-closed
+        ``reload_admitted_user`` resolver; a listed team with no MCP grants simply contributes nothing
+        to the union, and an unresolvable user still fails closed there.
+        """
+        from litellm.proxy.auth.auth_checks import get_user_object
+        from litellm.proxy.proxy_server import prisma_client, user_api_key_cache
+
+        own_context = await MCPRequestHandler.reload_admitted_user(user_id)
+        user_object = await get_user_object(
+            user_id=user_id,
+            prisma_client=prisma_client,
+            user_api_key_cache=user_api_key_cache,
+            user_id_upsert=False,
+        )
+        team_ids = list(user_object.teams) if user_object is not None and user_object.teams else []
+        team_contexts = [UserAPIKeyAuth(user_id=user_id, team_id=team_id) for team_id in team_ids]
+        return [own_context, *team_contexts]
 
     @staticmethod
     async def _reload_admitted_key(key_hash: str) -> UserAPIKeyAuth:

--- a/litellm/proxy/_experimental/mcp_server/idp_consent.py
+++ b/litellm/proxy/_experimental/mcp_server/idp_consent.py
@@ -1,0 +1,203 @@
+"""Pure logic for the delegated-OBO consent-capture flow (Path B, item 2.2).
+
+A server-terminal ``authorization_code + offline_access`` flow against the user's IdP: unlike the
+per-user MCP-server OAuth flow (which relays the code back to a browser client that finishes the
+exchange), here the gateway is the OAuth client end to end. It generates its own PKCE, seals the user
+and the target IdP into the state, and on callback exchanges the code for the user's tokens itself,
+then stores the refresh_token as the user's IdP grant for the mint arm to use.
+
+This module is the pure core (PKCE, state sealing, authorize-URL building, code exchange); the HTTP
+POST, the crypto, and the persistence are injected so it is testable without a live IdP or DB. The
+endpoints that wire it onto the request path live with the other ``/v1/mcp`` management routes.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+from collections.abc import Awaitable, Callable
+from urllib.parse import urlencode, urlsplit, urlunsplit
+
+from pydantic import BaseModel, ConfigDict
+
+from litellm.proxy._experimental.mcp_server.auth.token_endpoint_auth import (
+    TokenEndpointAuthConfigError,
+    build_token_endpoint_client_auth,
+)
+from litellm.proxy._experimental.mcp_server.outbound_credentials.idp_oauth_config import (
+    IdpOAuthProvider,
+)
+
+# POSTs an OAuth form to a token endpoint and returns the parsed JSON body, or None on any failure.
+TokenEndpointPost = Callable[[str, "dict[str, str]", "dict[str, str]"], Awaitable["dict[str, object] | None"]]
+
+_PKCE_VERIFIER_BYTES = 64
+_CODE_CHALLENGE_METHOD = "S256"
+
+
+_STATE_MAX_AGE_SECONDS = 600.0
+
+
+class CaptureState(BaseModel):
+    """The sealed state carried through the IdP round-trip: who is consenting, for which IdP, and the
+    PKCE verifier to replay at the token exchange. Sealed (encrypted) so the client cannot tamper with
+    the bound user or forge a verifier, and stamped with ``issued_at`` so a captured state cannot be
+    replayed indefinitely."""
+
+    model_config = ConfigDict(frozen=True)
+
+    user_id: str
+    token_url: str
+    code_verifier: str
+    issued_at: float
+
+
+def state_is_fresh(state: CaptureState, *, now: float, max_age_seconds: float = _STATE_MAX_AGE_SECONDS) -> bool:
+    """Whether the sealed state is within its lifetime, bounding replay of a captured state."""
+    return 0 <= (now - state.issued_at) <= max_age_seconds
+
+
+class CapturedGrant(BaseModel):
+    """The user's IdP grant captured from the authorization_code exchange."""
+
+    model_config = ConfigDict(frozen=True)
+
+    access_token: str
+    refresh_token: str | None
+    expires_in: int | None
+    scopes: tuple[str, ...]
+
+
+def generate_pkce() -> tuple[str, str]:
+    """Return a fresh ``(code_verifier, code_challenge)`` pair (RFC 7636 S256)."""
+    verifier = secrets.token_urlsafe(_PKCE_VERIFIER_BYTES)
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).decode().rstrip("=")
+    return verifier, challenge
+
+
+def seal_capture_state(state: CaptureState, encrypt: Callable[[str], str]) -> str:
+    return encrypt(state.model_dump_json())
+
+
+def unseal_capture_state(blob: str, decrypt: Callable[[str], str | None]) -> CaptureState | None:
+    decrypted = decrypt(blob)
+    if decrypted is None:
+        return None
+    try:
+        return CaptureState.model_validate_json(decrypted)
+    except ValueError:
+        return None
+
+
+def build_authorize_url(
+    provider: IdpOAuthProvider,
+    *,
+    redirect_uri: str,
+    state: str,
+    code_challenge: str,
+) -> str:
+    """Build the IdP authorize URL for the consent redirect, merging the OAuth params onto any query
+    the configured ``authorize_url`` already carries."""
+    params = {
+        "response_type": "code",
+        "client_id": provider.client_id,
+        "redirect_uri": redirect_uri,
+        "state": state,
+        "scope": " ".join(provider.scopes),
+        "code_challenge": code_challenge,
+        "code_challenge_method": _CODE_CHALLENGE_METHOD,
+    }
+    parts = urlsplit(provider.authorize_url)
+    merged_query = "&".join(q for q in (parts.query, urlencode(params)) if q)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, merged_query, parts.fragment))
+
+
+def _parse_expires_in(raw: object) -> int | None:
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, (int, float)):
+        return int(raw)
+    if isinstance(raw, str):
+        try:
+            return int(float(raw))
+        except ValueError:
+            return None
+    return None
+
+
+def _parse_scopes(raw: object, fallback: tuple[str, ...]) -> tuple[str, ...]:
+    if isinstance(raw, str) and raw:
+        return tuple(raw.split())
+    return fallback
+
+
+async def default_token_post(url: str, form: dict[str, str], headers: dict[str, str]) -> dict[str, object] | None:
+    """The real httpx POST to an IdP token endpoint for the consent exchange (Oauth2Check provider).
+
+    Returns the parsed JSON body, or None on any failure so the exchange fails closed. Mirrors the
+    per-provider token-endpoint POST helpers; extracting one shared helper across them is a follow-up.
+    """
+    from litellm._logging import verbose_logger  # noqa: PLC0415  # lazy import; avoids cycle
+    from litellm.llms.custom_httpx.http_handler import (  # noqa: PLC0415  # lazy import; avoids cycle
+        get_async_httpx_client,  # pyright: ignore[reportUnknownVariableType]  # httpx handler untyped
+    )
+    from litellm.types.llms.custom_http import httpxSpecialProvider  # noqa: PLC0415  # lazy import
+
+    request_headers = {"Accept": "application/json", **headers}
+    try:
+        client = get_async_httpx_client(llm_provider=httpxSpecialProvider.Oauth2Check)
+        response = await client.post(url, headers=request_headers, data=form)  # pyright: ignore[reportUnknownMemberType]  # AsyncHTTPHandler.post untyped
+        if response is None:
+            return None
+        response.raise_for_status()
+        body: dict[str, object] = response.json()  # pyright: ignore[reportAny]  # untyped JSON body, validated below
+    except Exception as exc:  # noqa: BLE001  # any IdP/transport error is a capture miss, not a 500
+        verbose_logger.warning("MCP IdP consent code exchange failed: %s", exc)
+        return None
+    else:
+        return body
+
+
+async def exchange_code_for_grant(
+    provider: IdpOAuthProvider,
+    *,
+    code: str,
+    redirect_uri: str,
+    code_verifier: str,
+    post: TokenEndpointPost,
+) -> CapturedGrant | None:
+    """Exchange the authorization code for the user's IdP grant (server-side), or None on failure.
+
+    Fails closed (None) rather than raising: a missing access_token, a bad client-auth config, or any
+    transport error is a capture miss the caller surfaces as an error, never a partial grant.
+    """
+    try:
+        client_auth = build_token_endpoint_client_auth(
+            auth_method=None,
+            client_id=provider.client_id,
+            client_secret=provider.client_secret.get_secret_value(),
+        )
+    except TokenEndpointAuthConfigError:
+        return None
+    form = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "code_verifier": code_verifier,
+        **client_auth.body,
+    }
+    body = await post(provider.token_url, form, client_auth.headers)
+    if body is None:
+        return None
+    access_token = body.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        return None
+    refresh_token = body.get("refresh_token")
+    return CapturedGrant(
+        access_token=access_token,
+        refresh_token=refresh_token if isinstance(refresh_token, str) and refresh_token else None,
+        expires_in=_parse_expires_in(body.get("expires_in")),
+        scopes=_parse_scopes(body.get("scope"), provider.scopes),
+    )

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -204,6 +204,33 @@ def _blank_to_none(value: str | None) -> str | None:
     return value.strip() or None
 
 
+def _delegated_reach_denial(
+    server_id: str,
+    tool_name: str,
+    per_context_servers: list[list[str]],
+    per_context_tools: list[list[str] | None],
+) -> Literal["server", "tool"] | None:
+    """Why a delegated call is denied by the user's ceiling, or ``None`` if the user permits it.
+
+    ``per_context_servers`` / ``per_context_tools`` are the allowed servers and per-server allowed
+    tools resolved for each of the delegated user's auth contexts (own + one per team). Reach is the
+    UNION across contexts (the user's total cross-team access): the server must be reachable in some
+    context. Only a context that actually reaches the server contributes its tool grant, since a
+    context that cannot reach the server returns "no restriction" (``None``) for it and would
+    otherwise be misread as allow-all; among the reaching contexts, ``None`` means allow-all and
+    otherwise the tool must appear in the union of their restricted lists.
+    """
+    reaching_context_tools = [
+        tools for servers, tools in zip(per_context_servers, per_context_tools) if server_id in servers
+    ]
+    if not reaching_context_tools:
+        return "server"
+    if any(tools is None for tools in reaching_context_tools):
+        return None
+    allowed_tools = frozenset(tool for tools in reaching_context_tools if tools for tool in tools)
+    return None if tool_name in allowed_tools else "tool"
+
+
 def _uses_issuer_anchor(manual_issuer: str | None, is_discovery_auth_type: bool) -> bool:
     """Whether the endpoints are authoritatively anchored to an admin-pinned issuer (RFC 8414 §3.3).
 
@@ -4001,6 +4028,55 @@ class MCPServerManager:
                 },
             )
 
+    async def check_tool_permission_for_delegated_user(
+        self,
+        tool_name: str,
+        server: MCPServer,
+        user_api_key_auth: UserAPIKeyAuth | None,
+    ) -> None:
+        """For an agent-delegated (on-behalf-of) call, enforce the DELEGATED USER's ceiling as well.
+
+        The preceding key/team check already enforced the agent key's ceiling, so requiring the
+        delegated user to ALSO permit the server and tool makes the effective permission the
+        intersection of the two principals: a delegated run can reach only what both the agent and the
+        triggering user may reach. A non-delegated call early-returns, so its behavior is unchanged.
+
+        The delegated user's reach is resolved across ALL of their auth contexts (own object-permission
+        plus one per team they belong to; ``resolve_delegated_user_contexts``) and UNIONED, so a user
+        whose MCP access is granted directly, through toolsets/access groups, or through team/group
+        membership is counted rather than under-counted. The same ``get_allowed_mcp_servers`` /
+        ``get_allowed_tools_for_server`` primitives the key path uses run per context, so no permission
+        logic is duplicated. Fail-closed: an unresolvable user raises; server-reachability is checked
+        explicitly because the tool predicate allow-alls a server the user has no restriction on.
+        """
+        if user_api_key_auth is None or user_api_key_auth.delegated_user_id is None:
+            return
+        from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
+            MCPRequestHandler,
+        )
+
+        contexts = await MCPRequestHandler.resolve_delegated_user_contexts(user_api_key_auth.delegated_user_id)
+        per_context_servers = [await MCPRequestHandler.get_allowed_mcp_servers(context) for context in contexts]
+        per_context_tools = [
+            await MCPRequestHandler.get_allowed_tools_for_server(server_id=server.server_id, user_api_key_auth=context)
+            for context in contexts
+        ]
+        denial = _delegated_reach_denial(server.server_id, tool_name, per_context_servers, per_context_tools)
+        if denial == "server":
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": f"Delegated user is not allowed to reach server '{server.name}'. A delegated run is limited to the intersection of the agent's and the user's access."
+                },
+            )
+        if denial == "tool":
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": f"Delegated user is not allowed to call tool '{tool_name}' on server '{server.name}'. A delegated run is limited to the intersection of the agent's and the user's access."
+                },
+            )
+
     async def _call_openapi_tool_handler(
         self,
         server: MCPServer,
@@ -4085,8 +4161,16 @@ class MCPServerManager:
                 },
             )
 
-        ## check tool-level permissions from object_permission
+        ## check tool-level permissions from object_permission (the agent key/team ceiling)
         await self.check_tool_permission_for_key_team(
+            tool_name=name,
+            server=server,
+            user_api_key_auth=user_api_key_auth,
+        )
+
+        ## for a delegated (on-behalf-of) call, also enforce the delegated user's ceiling, so the
+        ## effective permission is the intersection of the agent and the user
+        await self.check_tool_permission_for_delegated_user(
             tool_name=name,
             server=server,
             user_api_key_auth=user_api_key_auth,

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/idp_oauth_config.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/idp_oauth_config.py
@@ -1,0 +1,91 @@
+"""The IdP OAuth provider config for delegated-OBO consent capture (Path B, item 2.2).
+
+The mint arm (item 3) exchanges a user's stored IdP grant; this is where that grant comes from: a
+first-time consent flow runs an ``authorization_code + offline_access`` grant against the user's IdP
+(e.g. Okta) so the gateway captures and stores the user's refresh token. The token_exchange server
+config carries the IdP's token endpoint and the gateway's client credentials, but not the authorize
+endpoint or the offline_access scope the capture needs, so those live here.
+
+One provider serves every ``token_exchange`` upstream fronted by the same IdP, so a provider is keyed
+by its token endpoint - the same anchor the mint arm's grant store uses (``idp_grant_key``) - and the
+consent flow stores the captured grant under that key, ready for the mint arm to read.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, SecretStr, TypeAdapter
+
+from litellm.proxy._experimental.mcp_server.outbound_credentials.idp_subject_source import (
+    idp_grant_key,
+)
+
+
+class IdpOAuthProvider(BaseModel):
+    """One IdP's OAuth config for the consent-capture ``authorization_code`` flow.
+
+    ``token_url`` is the IdP's token endpoint; it is also the anchor the captured grant is keyed by
+    (via ``idp_grant_key``), so it must match the ``token_exchange_endpoint`` of the servers this IdP
+    fronts. ``scopes`` must include an offline-access scope for the IdP to return a refresh_token; the
+    default covers the OIDC + Okta case.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    token_url: str
+    authorize_url: str
+    client_id: str
+    client_secret: SecretStr
+    scopes: tuple[str, ...] = ("openid", "offline_access")
+
+    @property
+    def grant_key(self) -> str:
+        """The (user, idp) storage key's idp component the captured grant is stored under."""
+        return idp_grant_key(self.token_url)
+
+
+class IdpOAuthProviderRegistry:
+    """Immutable lookup of the configured IdP providers, keyed by their grant key.
+
+    Built once from config at startup. A provider is resolved by the ``idp`` the consent flow targets
+    (the token endpoint), so the captured grant lands under the exact key the mint arm reads.
+    """
+
+    def __init__(self, providers: tuple[IdpOAuthProvider, ...]) -> None:
+        self._by_key: dict[str, IdpOAuthProvider] = {p.grant_key: p for p in providers}
+
+    def get(self, grant_key: str) -> IdpOAuthProvider | None:
+        return self._by_key.get(grant_key)
+
+    def get_by_token_url(self, token_url: str) -> IdpOAuthProvider | None:
+        return self._by_key.get(idp_grant_key(token_url))
+
+    def __len__(self) -> int:
+        return len(self._by_key)
+
+
+def load_idp_oauth_providers(raw_providers: object) -> IdpOAuthProviderRegistry:
+    """Build the registry from the ``mcp_idp_oauth_providers`` config block (a list of dicts).
+
+    Each entry is validated into an ``IdpOAuthProvider``; a malformed entry raises at load time (fail
+    fast at startup) rather than surfacing as a broken consent flow later. A missing/empty block yields
+    an empty registry, so the consent endpoints simply 404 until an IdP is configured.
+    """
+    if not isinstance(raw_providers, list):
+        return IdpOAuthProviderRegistry(())
+    return IdpOAuthProviderRegistry(_PROVIDERS_ADAPTER.validate_python(raw_providers))
+
+
+_PROVIDERS_ADAPTER: TypeAdapter[tuple[IdpOAuthProvider, ...]] = TypeAdapter(tuple[IdpOAuthProvider, ...])
+
+
+_registry = IdpOAuthProviderRegistry(())
+
+
+def set_idp_oauth_registry(registry: IdpOAuthProviderRegistry) -> None:
+    """Install the process-wide registry (called once from config load at startup)."""
+    global _registry  # noqa: PLW0603  # single install point for the startup-built registry
+    _registry = registry
+
+
+def get_idp_oauth_registry() -> IdpOAuthProviderRegistry:
+    return _registry

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -19,6 +19,7 @@ import functools
 import importlib
 import json
 import os
+import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Iterable, List, Literal, Optional, Set
@@ -34,7 +35,7 @@ from fastapi import (
     Response,
     status,
 )
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 
 try:
     from prisma.errors import RecordNotFoundError, UniqueViolationError
@@ -1728,6 +1729,131 @@ if MCP_AVAILABLE:
             refresh_token=refresh_token,
             scope=scope,
         )
+
+    # Module-scope Depends singleton so the param default is a name, not a call (B008); same dep the
+    # relay OAuth routes use (Authorization header or the SSO session cookie).
+    _idp_consent_auth_dep = Depends(_mcp_oauth_user_api_key_auth)
+
+    def _idp_callback_redirect_uri(request: Request) -> str:
+        from litellm.proxy._experimental.mcp_server.oauth_utils import (  # noqa: PLC0415  # lazy: avoids cycle
+            get_request_base_url,
+        )
+
+        return f"{get_request_base_url(request)}/v1/mcp/idp/callback"
+
+    @router.get("/idp/authorize", include_in_schema=False)
+    async def mcp_idp_authorize(
+        request: Request,
+        user_api_key_dict: UserAPIKeyAuth = _idp_consent_auth_dep,
+        token_url: str = "",
+    ):
+        """Start the delegated-OBO consent capture: redirect the signed-in user to their IdP to
+        authorize the gateway, so the callback can capture and store their IdP grant (Path B, 2.2)."""
+        from litellm.proxy._experimental.mcp_server.idp_consent import (  # noqa: PLC0415  # lazy: avoids cycle
+            CaptureState,
+            build_authorize_url,
+            generate_pkce,
+            seal_capture_state,
+        )
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.idp_oauth_config import (  # noqa: PLC0415  # lazy: avoids cycle
+            get_idp_oauth_registry,
+        )
+        from litellm.proxy.common_utils.encrypt_decrypt_utils import (
+            encrypt_value_helper,  # noqa: PLC0415  # lazy: avoids cycle
+        )
+
+        provider = get_idp_oauth_registry().get_by_token_url(token_url)
+        if provider is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"error": "No IdP provider configured for this token endpoint"},
+            )
+        user_id = user_api_key_dict.user_id
+        if not user_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail={"error": "No user id on the session; sign in first"}
+            )
+
+        code_verifier, code_challenge = generate_pkce()
+        state = seal_capture_state(
+            CaptureState(
+                user_id=user_id, token_url=provider.token_url, code_verifier=code_verifier, issued_at=time.time()
+            ),
+            encrypt_value_helper,
+        )
+        authorize_url = build_authorize_url(
+            provider,
+            redirect_uri=_idp_callback_redirect_uri(request),
+            state=state,
+            code_challenge=code_challenge,
+        )
+        return RedirectResponse(authorize_url)
+
+    @router.get("/idp/callback", include_in_schema=False)
+    async def mcp_idp_callback(
+        request: Request,
+        code: str | None = None,
+        state: str | None = None,
+        error: str | None = None,
+    ):
+        """Terminal callback for the consent capture: the gateway itself exchanges the code for the
+        user's IdP grant and stores it (server-terminal, unlike the relay callback). The user is
+        recovered from the sealed state, so this endpoint needs no session."""
+        from litellm.proxy._experimental.mcp_server.idp_consent import (  # noqa: PLC0415  # lazy: avoids cycle
+            default_token_post,
+            exchange_code_for_grant,
+            state_is_fresh,
+            unseal_capture_state,
+        )
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.idp_oauth_config import (  # noqa: PLC0415  # lazy: avoids cycle
+            get_idp_oauth_registry,
+        )
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.idp_subject_provider import (  # noqa: PLC0415  # lazy: avoids cycle
+            capture_user_idp_grant,
+        )
+        from litellm.proxy.common_utils.encrypt_decrypt_utils import (
+            decrypt_value_helper,  # noqa: PLC0415  # lazy: avoids cycle
+        )
+
+        if error:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail={"error": f"IdP returned an error: {error}"}
+            )
+        if not code or not state:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail={"error": "Missing code or state"})
+
+        capture_state = unseal_capture_state(state, lambda blob: decrypt_value_helper(blob, "oauth_state"))
+        if capture_state is None or not state_is_fresh(capture_state, now=time.time()):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail={"error": "Invalid, tampered, or expired state"}
+            )
+        provider = get_idp_oauth_registry().get_by_token_url(capture_state.token_url)
+        if provider is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail={"error": "IdP provider is no longer configured"}
+            )
+
+        grant = await exchange_code_for_grant(
+            provider,
+            code=code,
+            redirect_uri=_idp_callback_redirect_uri(request),
+            code_verifier=capture_state.code_verifier,
+            post=default_token_post,
+        )
+        if grant is None:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY, detail={"error": "IdP did not return a usable grant"}
+            )
+
+        await capture_user_idp_grant(
+            capture_state.user_id,
+            provider.token_url,
+            grant.access_token,
+            refresh_token=grant.refresh_token,
+            expires_in=grant.expires_in,
+            scopes=grant.scopes,
+        )
+        return JSONResponse({"status": "connected", "offline_access": grant.refresh_token is not None})
 
     @router.post(
         "/server/oauth/{server_id}/register",

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4992,6 +4992,16 @@ class ProxyConfig:
 
             await global_mcp_server_manager.load_servers_from_config(mcp_servers_config, mcp_aliases)
 
+        ## MCP IdP OAUTH PROVIDERS (delegated-OBO consent capture)
+        mcp_idp_oauth_providers = config.get("mcp_idp_oauth_providers", None)
+        if mcp_idp_oauth_providers:
+            from litellm.proxy._experimental.mcp_server.outbound_credentials.idp_oauth_config import (
+                load_idp_oauth_providers,
+                set_idp_oauth_registry,
+            )
+
+            set_idp_oauth_registry(load_idp_oauth_providers(mcp_idp_oauth_providers))
+
         ## VECTOR STORES
         vector_store_registry_config = config.get("vector_store_registry", None)
         if vector_store_registry_config:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_idp_consent.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_idp_consent.py
@@ -1,0 +1,160 @@
+"""Tests for the delegated-OBO consent-capture flow logic (Path B, item 2.2).
+
+Covers the pure core: PKCE generation, sealed-state round-trip and tamper rejection, authorize-URL
+building (offline_access + S256), and the server-side code->grant exchange with its fail-closed paths.
+The token POST and the crypto are injected, so no live IdP is needed.
+"""
+
+import base64
+import hashlib
+
+import pytest
+from pydantic import SecretStr
+
+from litellm.proxy._experimental.mcp_server.idp_consent import (
+    CaptureState,
+    build_authorize_url,
+    exchange_code_for_grant,
+    generate_pkce,
+    seal_capture_state,
+    unseal_capture_state,
+)
+from litellm.proxy._experimental.mcp_server.outbound_credentials.idp_oauth_config import (
+    IdpOAuthProvider,
+    IdpOAuthProviderRegistry,
+)
+from litellm.proxy._experimental.mcp_server.outbound_credentials.idp_subject_source import (
+    idp_grant_key,
+)
+
+_PROVIDER = IdpOAuthProvider(
+    token_url="https://idp.example.com/oauth2/v1/token",
+    authorize_url="https://idp.example.com/oauth2/v1/authorize",
+    client_id="gateway-client",
+    client_secret=SecretStr("gateway-secret"),
+    scopes=("openid", "offline_access"),
+)
+
+
+def test_generate_pkce_is_s256_of_the_verifier():
+    verifier, challenge = generate_pkce()
+    expected = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).decode().rstrip("=")
+    assert challenge == expected
+    assert "=" not in challenge  # base64url, unpadded
+    # Two calls produce different verifiers (not a constant).
+    assert generate_pkce()[0] != verifier
+
+
+def test_sealed_state_round_trips():
+    store: dict[str, str] = {}
+
+    def encrypt(plain):
+        token = f"sealed::{plain}"
+        store[token] = plain
+        return token
+
+    def decrypt(blob):
+        return store.get(blob)
+
+    state = CaptureState(user_id="alice", token_url=_PROVIDER.token_url, code_verifier="verifier-xyz", issued_at=1000.0)
+    sealed = seal_capture_state(state, encrypt)
+    assert unseal_capture_state(sealed, decrypt) == state
+
+
+def test_state_is_fresh_bounds_replay():
+    from litellm.proxy._experimental.mcp_server.idp_consent import state_is_fresh
+
+    state = CaptureState(user_id="a", token_url=_PROVIDER.token_url, code_verifier="v", issued_at=1000.0)
+    assert state_is_fresh(state, now=1000.0, max_age_seconds=600) is True
+    assert state_is_fresh(state, now=1599.0, max_age_seconds=600) is True
+    assert state_is_fresh(state, now=1601.0, max_age_seconds=600) is False  # expired
+    assert state_is_fresh(state, now=900.0, max_age_seconds=600) is False  # issued in the future (clock skew / forged)
+
+
+def test_unseal_rejects_tampered_or_undecryptable_state():
+    # decrypt returning None (bad/forged blob) -> None, never a partial/forged CaptureState.
+    assert unseal_capture_state("garbage", lambda _b: None) is None
+    # decrypts to non-CaptureState JSON -> None.
+    assert unseal_capture_state("x", lambda _b: '{"not":"a state"}') is None
+
+
+def test_build_authorize_url_carries_offline_access_and_s256():
+    url = build_authorize_url(
+        _PROVIDER,
+        redirect_uri="https://gw.example.com/v1/mcp/idp/callback",
+        state="sealed-state",
+        code_challenge="chal",
+    )
+    assert url.startswith("https://idp.example.com/oauth2/v1/authorize?")
+    assert "response_type=code" in url
+    assert "client_id=gateway-client" in url
+    assert "code_challenge=chal" in url
+    assert "code_challenge_method=S256" in url
+    assert "offline_access" in url
+    assert "redirect_uri=https%3A%2F%2Fgw.example.com%2Fv1%2Fmcp%2Fidp%2Fcallback" in url
+
+
+def test_build_authorize_url_preserves_existing_query():
+    provider = _PROVIDER.model_copy(update={"authorize_url": "https://idp.example.com/authorize?tenant=acme"})
+    url = build_authorize_url(provider, redirect_uri="https://gw/cb", state="s", code_challenge="c")
+    assert "tenant=acme" in url
+    assert "response_type=code" in url
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_for_grant_parses_the_grant():
+    captured_form: dict[str, str] = {}
+
+    async def post(url, form, headers):
+        captured_form.update(form)
+        return {"access_token": "user-at", "refresh_token": "user-rt", "expires_in": 3600, "scope": "openid offline_access"}
+
+    grant = await exchange_code_for_grant(
+        _PROVIDER, code="auth-code", redirect_uri="https://gw/cb", code_verifier="ver", post=post
+    )
+    assert grant is not None
+    assert grant.access_token == "user-at"
+    assert grant.refresh_token == "user-rt"
+    assert grant.expires_in == 3600
+    assert grant.scopes == ("openid", "offline_access")
+    # The authorization_code grant is posted with the PKCE verifier and the client id.
+    assert captured_form["grant_type"] == "authorization_code"
+    assert captured_form["code"] == "auth-code"
+    assert captured_form["code_verifier"] == "ver"
+    assert captured_form["client_id"] == "gateway-client"
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_falls_closed_on_missing_access_token_or_failure():
+    async def no_access_token(url, form, headers):
+        return {"refresh_token": "rt"}  # no access_token
+
+    async def transport_failure(url, form, headers):
+        return None
+
+    assert await exchange_code_for_grant(_PROVIDER, code="c", redirect_uri="r", code_verifier="v", post=no_access_token) is None
+    assert await exchange_code_for_grant(_PROVIDER, code="c", redirect_uri="r", code_verifier="v", post=transport_failure) is None
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_carries_forward_scopes_when_response_omits_scope():
+    async def post(url, form, headers):
+        return {"access_token": "at"}  # no scope, no refresh_token, no expires_in
+
+    grant = await exchange_code_for_grant(_PROVIDER, code="c", redirect_uri="r", code_verifier="v", post=post)
+    assert grant is not None
+    assert grant.scopes == ("openid", "offline_access")
+    assert grant.refresh_token is None
+    assert grant.expires_in is None
+
+
+def test_provider_grant_key_matches_the_mint_arm_key():
+    # The captured grant must land under the exact key the mint arm reads.
+    assert _PROVIDER.grant_key == idp_grant_key("https://idp.example.com/oauth2/v1/token")
+
+
+def test_registry_resolves_by_grant_key_and_token_url():
+    registry = IdpOAuthProviderRegistry((_PROVIDER,))
+    assert registry.get(_PROVIDER.grant_key) is _PROVIDER
+    assert registry.get_by_token_url("https://idp.example.com/oauth2/v1/token/") is _PROVIDER  # normalized
+    assert registry.get("idp::https://other/token") is None

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -4659,6 +4659,129 @@ class TestMCPServerManager:
             user_api_key_auth=user_auth,
         )
 
+    # ── delegated-user (agent-OBO) intersection enforcement ──────────────────────
+
+    @pytest.mark.asyncio
+    async def test_delegated_check_is_a_noop_for_a_non_delegated_call(self, monkeypatch):
+        """A call with no delegated_user_id must not resolve any user or change behavior."""
+        from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import MCPRequestHandler
+        from litellm.proxy._types import UserAPIKeyAuth
+
+        async def _must_not_run(user_id):
+            raise AssertionError("non-delegated calls must not resolve a delegated user")
+
+        monkeypatch.setattr(MCPRequestHandler, "resolve_delegated_user_contexts", _must_not_run)
+        manager = MCPServerManager()
+        server = MCPServer(server_id="srv-1", name="S", transport=MCPTransport.http)
+        # No raise, and _must_not_run is never called.
+        await manager.check_tool_permission_for_delegated_user(
+            tool_name="anything",
+            server=server,
+            user_api_key_auth=UserAPIKeyAuth(api_key="sk-agent", user_id="agent", delegated_user_id=None),
+        )
+
+    def _stub_delegated_user(self, monkeypatch, *, mcp_servers, mcp_tool_permissions):
+        from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import MCPRequestHandler
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable, UserAPIKeyAuth
+
+        own_context = UserAPIKeyAuth(
+            user_id="alice",
+            object_permission=LiteLLM_ObjectPermissionTable(
+                object_permission_id="perm-alice",
+                mcp_servers=mcp_servers,
+                mcp_tool_permissions=mcp_tool_permissions,
+            ),
+        )
+
+        async def _contexts(user_id):
+            assert user_id == "alice"
+            return [own_context]
+
+        monkeypatch.setattr(MCPRequestHandler, "resolve_delegated_user_contexts", _contexts)
+
+    @pytest.mark.asyncio
+    async def test_delegated_user_within_ceiling_passes(self, monkeypatch):
+        from litellm.proxy._types import UserAPIKeyAuth
+
+        self._stub_delegated_user(monkeypatch, mcp_servers=["srv-1"], mcp_tool_permissions={"srv-1": ["read"]})
+        manager = MCPServerManager()
+        server = MCPServer(server_id="srv-1", name="S", transport=MCPTransport.http)
+        agent = UserAPIKeyAuth(api_key="sk-agent", user_id="agent", delegated_user_id="alice")
+        # The delegated user may reach srv-1 and call read -> no raise.
+        await manager.check_tool_permission_for_delegated_user(tool_name="read", server=server, user_api_key_auth=agent)
+
+    @pytest.mark.asyncio
+    async def test_delegated_user_denied_tool_raises_403(self, monkeypatch):
+        from litellm.proxy._types import UserAPIKeyAuth
+
+        self._stub_delegated_user(monkeypatch, mcp_servers=["srv-1"], mcp_tool_permissions={"srv-1": ["read"]})
+        manager = MCPServerManager()
+        server = MCPServer(server_id="srv-1", name="S", transport=MCPTransport.http)
+        agent = UserAPIKeyAuth(api_key="sk-agent", user_id="agent", delegated_user_id="alice")
+        # The agent may permit write, but the delegated user does not -> intersection denies it.
+        with pytest.raises(HTTPException) as exc:
+            await manager.check_tool_permission_for_delegated_user(tool_name="write", server=server, user_api_key_auth=agent)
+        assert exc.value.status_code == 403
+        assert "write" in exc.value.detail["error"]
+
+    @pytest.mark.asyncio
+    async def test_delegated_user_cannot_reach_server_raises_403(self, monkeypatch):
+        from litellm.proxy._types import UserAPIKeyAuth
+
+        self._stub_delegated_user(monkeypatch, mcp_servers=["other-srv"], mcp_tool_permissions={"other-srv": ["read"]})
+        manager = MCPServerManager()
+        server = MCPServer(server_id="srv-1", name="S", transport=MCPTransport.http)
+        agent = UserAPIKeyAuth(api_key="sk-agent", user_id="agent", delegated_user_id="alice")
+        # The agent may reach srv-1, but the delegated user cannot -> intersection denies the server.
+        with pytest.raises(HTTPException) as exc:
+            await manager.check_tool_permission_for_delegated_user(tool_name="read", server=server, user_api_key_auth=agent)
+        assert exc.value.status_code == 403
+        assert "srv-1" in exc.value.detail["error"] or "S" in exc.value.detail["error"]
+
+    def test_delegated_reach_denial_unions_across_contexts(self):
+        """The pure union math: a delegated user's reach is the union across their contexts (own +
+        each team), so a grant from ANY team counts."""
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import _delegated_reach_denial
+
+        # team-A reaches srv-1/read; team-B reaches srv-2/write. The union reaches both.
+        servers = [["srv-1"], ["srv-2"]]
+        tools = [["read"], ["write"]]
+        assert _delegated_reach_denial("srv-1", "read", servers, tools) is None  # via team-A
+        assert _delegated_reach_denial("srv-2", "write", servers, tools) is None  # via team-B (union)
+        assert _delegated_reach_denial("srv-3", "read", servers, tools) == "server"  # no context reaches srv-3
+        # server reachable (union) but the tool is in no context's list.
+        assert _delegated_reach_denial("srv-1", "delete", [["srv-1"], ["srv-1"]], [["read"], ["write"]]) == "tool"
+        # a context with no tool restriction (None) means allow-all for that server.
+        assert _delegated_reach_denial("srv-1", "anything", [["srv-1"]], [None]) is None
+        # a context that CANNOT reach the server must not contribute its (unrestricted) tools as
+        # allow-all: here only the srv-1 context (tools ["read"]) counts, so write is denied even
+        # though the srv-2 context returned None for srv-1.
+        assert _delegated_reach_denial("srv-1", "write", [["srv-1"], ["srv-2"]], [["read"], None]) == "tool"
+
+    @pytest.mark.asyncio
+    async def test_resolve_delegated_user_contexts_includes_each_team(self, monkeypatch):
+        """resolve_delegated_user_contexts returns the own context plus one per team the user is in, so
+        the union covers team/group-granted access."""
+        from types import SimpleNamespace
+
+        import litellm.proxy.auth.auth_checks as auth_checks
+        from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import MCPRequestHandler
+        from litellm.proxy._types import UserAPIKeyAuth
+
+        async def _own(user_id):
+            return UserAPIKeyAuth(user_id=user_id, team_id=None)
+
+        async def _get_user_object(**kwargs):
+            return SimpleNamespace(user_id="alice", teams=["team-a", "team-b"])
+
+        monkeypatch.setattr(MCPRequestHandler, "reload_admitted_user", _own)
+        monkeypatch.setattr(auth_checks, "get_user_object", _get_user_object)
+
+        contexts = await MCPRequestHandler.resolve_delegated_user_contexts("alice")
+        assert len(contexts) == 3
+        assert contexts[0].team_id is None  # own context
+        assert sorted(c.team_id for c in contexts[1:]) == ["team-a", "team-b"]
+
     @pytest.mark.asyncio
     async def test_allowed_tools_with_mixed_prefixed_and_unprefixed_names(self):
         """

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_idp_consent_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_idp_consent_endpoints.py
@@ -1,0 +1,150 @@
+"""Tests for the delegated-OBO consent-capture endpoints (Path B, item 2.2).
+
+These pin the endpoint wiring on top of the (separately tested) flow logic: the authorize route seals
+the signed-in user into the redirect and points at the configured IdP, and the terminal callback
+unseals the user, exchanges the code, and stores the grant under the mint arm's key.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import SecretStr
+
+from litellm.proxy._experimental.mcp_server import idp_consent
+from litellm.proxy._experimental.mcp_server.idp_consent import CaptureState, seal_capture_state
+from litellm.proxy._experimental.mcp_server.outbound_credentials import idp_subject_provider
+from litellm.proxy._experimental.mcp_server.outbound_credentials.idp_oauth_config import (
+    IdpOAuthProvider,
+    IdpOAuthProviderRegistry,
+    set_idp_oauth_registry,
+)
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.common_utils.encrypt_decrypt_utils import encrypt_value_helper
+from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+    mcp_idp_authorize,
+    mcp_idp_callback,
+)
+
+_TOKEN_URL = "https://idp.example.com/oauth2/v1/token"
+_PROVIDER = IdpOAuthProvider(
+    token_url=_TOKEN_URL,
+    authorize_url="https://idp.example.com/oauth2/v1/authorize",
+    client_id="gateway-client",
+    client_secret=SecretStr("gateway-secret"),
+)
+
+
+@pytest.fixture(autouse=True)
+def _salt(monkeypatch):
+    monkeypatch.setenv("LITELLM_SALT_KEY", "test-salt-key-for-idp-consent-endpoint-tests")
+
+
+@pytest.fixture(autouse=True)
+def _registry():
+    set_idp_oauth_registry(IdpOAuthProviderRegistry((_PROVIDER,)))
+    yield
+    set_idp_oauth_registry(IdpOAuthProviderRegistry(()))
+
+
+@pytest.fixture(autouse=True)
+def _base_url(monkeypatch):
+    monkeypatch.setenv("PROXY_BASE_URL", "https://gw.example.com")
+
+
+@pytest.mark.asyncio
+async def test_authorize_redirects_to_the_idp_sealing_the_user():
+    resp = await mcp_idp_authorize(
+        MagicMock(), user_api_key_dict=UserAPIKeyAuth(user_id="alice"), token_url=_TOKEN_URL
+    )
+    location = resp.headers["location"]
+    assert location.startswith("https://idp.example.com/oauth2/v1/authorize?")
+    assert "code_challenge_method=S256" in location
+    assert "offline_access" in location
+    assert "redirect_uri=https%3A%2F%2Fgw.example.com%2Fv1%2Fmcp%2Fidp%2Fcallback" in location
+
+
+@pytest.mark.asyncio
+async def test_authorize_404_for_an_unconfigured_idp():
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        await mcp_idp_authorize(MagicMock(), user_api_key_dict=UserAPIKeyAuth(user_id="alice"), token_url="https://other/token")
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_authorize_400_without_a_user():
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        await mcp_idp_authorize(MagicMock(), user_api_key_dict=UserAPIKeyAuth(user_id=None), token_url=_TOKEN_URL)
+    assert exc.value.status_code == 400
+
+
+def _seal(user_id: str, *, issued_at: float | None = None) -> str:
+    import time
+
+    return seal_capture_state(
+        CaptureState(user_id=user_id, token_url=_TOKEN_URL, code_verifier="the-verifier", issued_at=issued_at or time.time()),
+        encrypt_value_helper,
+    )
+
+
+@pytest.mark.asyncio
+async def test_callback_exchanges_and_stores_the_grant_for_the_sealed_user(monkeypatch):
+    exchanges: list[dict[str, str]] = []
+    captures: list[tuple] = []
+
+    async def fake_post(url, form, headers):
+        exchanges.append(form)
+        return {"access_token": "alice-idp-at", "refresh_token": "alice-idp-rt", "expires_in": 3600}
+
+    async def fake_capture(user_id, token_exchange_endpoint, access_token, *, refresh_token=None, expires_in=None, scopes=None):
+        captures.append((user_id, token_exchange_endpoint, access_token, refresh_token))
+
+    monkeypatch.setattr(idp_consent, "default_token_post", fake_post)
+    monkeypatch.setattr(idp_subject_provider, "capture_user_idp_grant", fake_capture)
+
+    resp = await mcp_idp_callback(MagicMock(), code="auth-code", state=_seal("alice"))
+
+    # The code + PKCE verifier from the sealed state are exchanged, and the grant is stored under the
+    # sealed user + the IdP token endpoint (the mint arm's key), never a caller-supplied identity.
+    assert exchanges[0]["code"] == "auth-code"
+    assert exchanges[0]["code_verifier"] == "the-verifier"
+    assert captures == [("alice", _TOKEN_URL, "alice-idp-at", "alice-idp-rt")]
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_callback_rejects_a_tampered_state(monkeypatch):
+    from fastapi import HTTPException
+
+    captured = []
+    monkeypatch.setattr(idp_subject_provider, "capture_user_idp_grant", lambda *a, **k: captured.append(a))
+    with pytest.raises(HTTPException) as exc:
+        await mcp_idp_callback(MagicMock(), code="auth-code", state="not-a-valid-sealed-state")
+    assert exc.value.status_code == 400
+    assert captured == []  # nothing stored on a bad state
+
+
+@pytest.mark.asyncio
+async def test_callback_rejects_an_expired_state(monkeypatch):
+    from fastapi import HTTPException
+
+    captured = []
+    monkeypatch.setattr(idp_subject_provider, "capture_user_idp_grant", lambda *a, **k: captured.append(a))
+    # A state sealed well beyond the 600s lifetime must be rejected, bounding replay.
+    with pytest.raises(HTTPException) as exc:
+        await mcp_idp_callback(MagicMock(), code="auth-code", state=_seal("alice", issued_at=1.0))
+    assert exc.value.status_code == 400
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_callback_400_on_idp_error():
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        await mcp_idp_callback(MagicMock(), error="access_denied")
+    assert exc.value.status_code == 400


### PR DESCRIPTION
## Relevant issues

- MCP delegation build item 4 (dual-principal entitlement): a delegated (agent-on-behalf-of-user) MCP tool call was ceiling-enforced only against the agent key, so a delegated run could reach any tool the AGENT could, regardless of what the triggering user is allowed
- Stacks on the consent-capture PR (#33889); base is `litellm_lit4448_obo_consent_capture`, retarget down the stack as those merge

## Linear ticket

Part of LIT-4448 (build item 4; does not resolve the ticket)

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Against a real Postgres. A delegated user (alice) is seeded with a grant directly (server srv-1, tool `read`) and another via TEAM membership (team grants srv-2, tool `list`); the real `check_tool_permission_for_delegated_user` resolves alice's full reach across her own permission and her teams and enforces the intersection, even though the agent itself could reach everything.

```
Seeded alice: OWN grant srv-1/read; via TEAM grant srv-2/list
  read  on srv-1 (alice's own grant):       ALLOWED
  list  on srv-2 (alice's team grant):      ALLOWED   # counted via the team, not her own permission
  write on srv-1 (tool outside her union):  DENIED 403 (Delegated user is not allowed to call tool 'write' ...)
  read  on srv-3 (server in neither):       DENIED 403 (Delegated user is not allowed to reach server 'Srv3' ...)
```

## Type

🆕 New Feature

## Changes

- New `check_tool_permission_for_delegated_user` on the MCP server manager, called in `pre_call_tool_check` right after the existing key/team check. Because the agent key's ceiling is already enforced there, additionally requiring the delegated user to permit the server and tool makes the effective permission the intersection of the two principals; no explicit set-intersection is needed
- The delegated user's reach is resolved across ALL of their auth contexts (their own object-permission plus one per team they belong to) and unioned via `resolve_delegated_user_contexts`, so a user granted MCP access directly, through toolsets/access groups, or through team/group membership is counted rather than under-counted. The same `get_allowed_mcp_servers` / `get_allowed_tools_for_server` primitives the key path uses run per context, so no permission logic is duplicated
- Promoted `reload_admitted_user` (was `_reload_admitted_user`) to public so the check can reuse the same fail-closed user-admission resolver the bridge flow uses, rather than duplicating it
- A non-delegated call early-returns, so its behavior is byte-identical to today

## Things a reviewer will ask about

- Why no explicit intersection: the agent ceiling is enforced by the preceding `check_tool_permission_for_key_team`; requiring the user to independently permit the same server+tool is exactly `agent_perms AND user_perms`, so both checks passing is the intersection. This keeps the reuse of the existing per-principal primitives and avoids re-implementing set logic
- Cross-team union correctness: reach is unioned across the user's own + per-team contexts, but only a context that actually reaches a server contributes its tool grant; a context that cannot reach the server returns "no restriction" for it and would otherwise be misread as allow-all. `_delegated_reach_denial` is a pure function so this is unit-tested directly, including that exact leak case
- Fail-closed everywhere: an unresolvable delegated user raises (401 via `reload_admitted_user`), and empty allowed-sets deny; the deny surfaces as a 403 that both the REST and JSON-RPC tool-call paths already translate correctly. The one cost is per delegated call resolving the user + their teams' permissions (cached through the same `get_user_object` cache the key path uses)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
