### PR TITLE
fix(elevenlabs): set duration on transcription response for cost tracking

### DIFF
--- a/litellm/llms/elevenlabs/audio_transcription/transformation.py
+++ b/litellm/llms/elevenlabs/audio_transcription/transformation.py
@@ -130,6 +130,8 @@ class ElevenLabsAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
             if "words" in response_json:
                 response["words"] = []
                 for word_data in response_json["words"]:
+                    if not isinstance(word_data, dict):
+                        continue
                     # Only include actual words, skip spacing and audio events
                     if word_data.get("type") == "word":
                         response["words"].append(
@@ -146,6 +148,8 @@ class ElevenLabsAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
             # instead of 0.
             duration = 0.0
             for word_data in response_json.get("words") or []:
+                if not isinstance(word_data, dict):
+                    continue
                 try:
                     duration = max(duration, float(word_data.get("end") or 0.0))
                 except (TypeError, ValueError):

--- a/litellm/llms/elevenlabs/audio_transcription/transformation.py
+++ b/litellm/llms/elevenlabs/audio_transcription/transformation.py
@@ -140,6 +140,19 @@ class ElevenLabsAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
                             }
                         )
 
+            # ElevenLabs does not return a top-level duration; derive it from
+            # the last timestamp so per-second cost tracking
+            # (input_cost_per_second x duration) bills the real audio length
+            # instead of 0.
+            duration = 0.0
+            for word_data in response_json.get("words") or []:
+                try:
+                    duration = max(duration, float(word_data.get("end") or 0.0))
+                except (TypeError, ValueError):
+                    continue
+            if duration > 0:
+                response["duration"] = duration
+
             # Store full response in hidden params
             response._hidden_params = response_json
 

--- a/tests/test_litellm/llms/elevenlabs/audio_transcription/test_elevenlabs_audio_transcription_transformation.py
+++ b/tests/test_litellm/llms/elevenlabs/audio_transcription/test_elevenlabs_audio_transcription_transformation.py
@@ -1,0 +1,66 @@
+import os
+import sys
+from unittest.mock import MagicMock
+
+sys.path.insert(
+    0, os.path.abspath("../../../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.llms.elevenlabs.audio_transcription.transformation import (
+    ElevenLabsAudioTranscriptionConfig,
+)
+
+
+def _mock_raw_response(response_json: dict) -> MagicMock:
+    raw = MagicMock()
+    raw.json.return_value = response_json
+    raw.text = str(response_json)
+    return raw
+
+
+class TestElevenLabsTransformResponse:
+    def test_sets_duration_from_last_timestamp(self):
+        """Duration must be derived from word timestamps so per-second cost
+        tracking (input_cost_per_second x duration) bills real audio length —
+        without it every ElevenLabs transcription logs $0 spend."""
+        config = ElevenLabsAudioTranscriptionConfig()
+        response = config.transform_audio_transcription_response(
+            _mock_raw_response(
+                {
+                    "text": "hello world",
+                    "language_code": "en",
+                    "words": [
+                        {"type": "word", "text": "hello", "start": 0.1, "end": 0.5},
+                        {"type": "spacing", "text": " ", "start": 0.5, "end": 0.6},
+                        {"type": "word", "text": "world", "start": 0.6, "end": 1.9},
+                        {"type": "audio_event", "text": "(door)", "start": 2.0, "end": 3.4},
+                    ],
+                }
+            )
+        )
+        assert response.text == "hello world"
+        assert response.duration == 3.4
+
+    def test_no_words_leaves_duration_unset(self):
+        config = ElevenLabsAudioTranscriptionConfig()
+        response = config.transform_audio_transcription_response(
+            _mock_raw_response({"text": "hello", "language_code": "en"})
+        )
+        assert getattr(response, "duration", None) is None
+
+    def test_malformed_word_timestamps_do_not_raise(self):
+        config = ElevenLabsAudioTranscriptionConfig()
+        response = config.transform_audio_transcription_response(
+            _mock_raw_response(
+                {
+                    "text": "hello",
+                    "language_code": "en",
+                    "words": [
+                        {"type": "word", "text": "hello", "start": 0.0, "end": None},
+                        {"type": "word", "text": "x", "start": 0.0, "end": "bad"},
+                        {"type": "word", "text": "y", "start": 0.0, "end": 2.5},
+                    ],
+                }
+            )
+        )
+        assert response.duration == 2.5

--- a/tests/test_litellm/llms/elevenlabs/audio_transcription/test_elevenlabs_audio_transcription_transformation.py
+++ b/tests/test_litellm/llms/elevenlabs/audio_transcription/test_elevenlabs_audio_transcription_transformation.py
@@ -58,6 +58,8 @@ class TestElevenLabsTransformResponse:
                     "words": [
                         {"type": "word", "text": "hello", "start": 0.0, "end": None},
                         {"type": "word", "text": "x", "start": 0.0, "end": "bad"},
+                        None,
+                        "not-a-dict",
                         {"type": "word", "text": "y", "start": 0.0, "end": 2.5},
                     ],
                 }


### PR DESCRIPTION
## What

`ElevenLabsAudioTranscriptionConfig.transform_audio_transcription_response` never sets `duration` on the `TranscriptionResponse`. The transcription cost path reads `response.duration` (falling back to 0.0) and multiplies it by `input_cost_per_second` — so **every ElevenLabs transcription logs $0 spend** and proxy budgets/spend tracking never see the usage. Found in production: all `elevenlabs/scribe_v2` rows in `LiteLLM_SpendLogs` at 0.0.

## Fix

Derive `duration` from the maximum `end` timestamp across the returned `words` array (ElevenLabs returns word/spacing/audio_event timings but no top-level duration). Malformed or missing timestamps degrade to the current behavior (no duration set) rather than raising.

## Tests

Added `tests/test_litellm/llms/elevenlabs/audio_transcription/test_elevenlabs_audio_transcription_transformation.py`: duration from last timestamp (including trailing audio events), no-words case, malformed-timestamp tolerance. All pass locally.