### PR TITLE
fix(mcp): attach resolved OAuth credentials to OpenAPI spec_path tool calls

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -4755,12 +4755,19 @@ class MCPServerManager:
         back with any header the resolver claimed already dropped. Unmigrated (v1) servers resolve
         through the stored-token lookup instead, and a missing per-user credential raises the same
         discovery challenge the MCPClient path serves, rather than egressing unauthenticated.
+
+        The resolved headers carry only credentials the gateway itself resolved (a stored per-user
+        token, a minted or exchanged token). Caller-supplied ``oauth2_headers`` are never promoted
+        into them: on the v2 arm they feed only subject-token extraction (the designed RFC 8693
+        input), and on the v1 arm their presence disables the stored lookup entirely, so a
+        caller's gateway credential can never displace a per-server BYOK header or leak upstream
+        as the resolved credential.
         """
         spec = to_server_spec(mcp_server)
         if spec is None:
-            stored_headers = await self._resolve_oauth2_headers_for_tool_call(
-                mcp_server, oauth2_headers, user_api_key_auth
-            )
+            if oauth2_headers:
+                return None, forwarded_headers
+            stored_headers = await self._resolve_oauth2_headers_for_tool_call(mcp_server, None, user_api_key_auth)
             return stored_headers, forwarded_headers
 
         subject_token: str | None = None
@@ -4872,6 +4879,7 @@ class MCPServerManager:
             )
             tasks.append(during_hook_task)
 
+        caller_oauth2_headers = oauth2_headers
         oauth2_headers = await self._resolve_oauth2_headers_for_tool_call(mcp_server, oauth2_headers, user_api_key_auth)
 
         # For OpenAPI servers, call the tool handler directly instead of via MCP client
@@ -4891,7 +4899,7 @@ class MCPServerManager:
             )
             resolved_auth_headers, forwarded_headers = await self.resolve_openapi_upstream_auth(
                 mcp_server=mcp_server,
-                oauth2_headers=oauth2_headers,
+                oauth2_headers=caller_oauth2_headers,
                 raw_headers=raw_headers,
                 mcp_auth_header=mcp_auth_header,
                 user_api_key_auth=user_api_key_auth,

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -610,6 +610,34 @@ def _passthrough_token_from_mcp_auth_header(
     return None
 
 
+async def _materialize_auth_headers(auth: httpx.Auth | None) -> dict[str, str] | None:
+    """Extract the header a resolved ``httpx.Auth`` would set, as a plain dict, or None.
+
+    OpenAPI tool closures egress through ``AsyncHTTPHandler`` methods that accept headers but no
+    ``auth``, so a resolved credential must be materialized into a header value. Driving one step
+    of the auth's own flow (against a throwaway request that is never sent) keeps this generic
+    across every auth shape without per-class branching; ``header_name`` is the resolver-arm
+    convention for "this auth sets a header" (``NoOpAuth`` has none and yields nothing to apply).
+    The materialized value is point-in-time: flow behaviors past the first request, like the M2M
+    one-shot 401 refetch, do not apply on this arm.
+    """
+    if auth is None:
+        return None
+    header_name = getattr(auth, "header_name", None)
+    if not isinstance(header_name, str) or not header_name:
+        return None
+    probe = httpx.Request("GET", "http://localhost/")
+    flow = auth.async_auth_flow(probe)
+    try:
+        first_request = await flow.__anext__()
+    except StopAsyncIteration:
+        return None
+    finally:
+        await flow.aclose()
+    header_value = first_request.headers.get(header_name)
+    return {header_name: header_value} if header_value else None
+
+
 def _consumes_caller_authorization(server: MCPServer) -> bool:
     """True when this server's egress forwards the caller's request-wide ``Authorization`` upstream:
     the client-forwarded token modes, legacy OAuth pass-through, and legacy upstream-delegated
@@ -4705,6 +4733,54 @@ class MCPServerManager:
             )
         return oauth2_headers
 
+    async def resolve_openapi_upstream_auth(
+        self,
+        *,
+        mcp_server: MCPServer,
+        oauth2_headers: dict[str, str] | None,
+        raw_headers: dict[str, str] | None,
+        mcp_auth_header: str | dict[str, str] | None,
+        user_api_key_auth: UserAPIKeyAuth | None,
+        forwarded_headers: dict[str, str] | None,
+    ) -> tuple[dict[str, str] | None, dict[str, str] | None]:
+        """Resolve the gateway-owned upstream credential for a spec_path (OpenAPI) tool call.
+
+        OpenAPI tools egress through a plain httpx call assembled from ContextVars, never through
+        ``_create_mcp_client``, so the v2 resolver graft there does not run for them and a resolved
+        credential (authorization_code's stored per-user token, client_credentials' minted M2M
+        token, token_exchange's exchanged token, passthrough's forwarded caller token) must be
+        materialized into headers here. Returns ``(resolved_auth_headers, forwarded_headers)``:
+        the resolved headers are authoritative over every other Authorization source (the same
+        rule ``_resolve_v2_auth`` applies on the MCPClient path) and ``forwarded_headers`` comes
+        back with any header the resolver claimed already dropped. Unmigrated (v1) servers resolve
+        through the stored-token lookup instead, and a missing per-user credential raises the same
+        discovery challenge the MCPClient path serves, rather than egressing unauthenticated.
+        """
+        spec = to_server_spec(mcp_server)
+        if spec is None:
+            stored_headers = await self._resolve_oauth2_headers_for_tool_call(
+                mcp_server, oauth2_headers, user_api_key_auth
+            )
+            return stored_headers, forwarded_headers
+
+        subject_token: str | None = None
+        if isinstance(spec.config, (TokenExchangeConfig, IdJagConfig)):
+            subject_token = self._extract_bearer_token(oauth2_headers, raw_headers)
+        elif isinstance(spec.config, PassthroughConfig):
+            inbound_token, forwarded_headers = _take_forwarded_authorization(forwarded_headers)
+            per_server_token = _passthrough_token_from_mcp_auth_header(mcp_auth_header)
+            subject_token = per_server_token if per_server_token is not None else inbound_token
+
+        resolved_auth, forwarded_headers = await self._resolve_v2_auth(
+            server=mcp_server,
+            spec=spec,
+            provider=self._cred_provider,
+            subject_token=subject_token,
+            user_api_key_auth=user_api_key_auth,
+            extra_headers=forwarded_headers,
+        )
+        return await _materialize_auth_headers(resolved_auth), forwarded_headers
+
     async def _gather_openapi_tool_tasks(
         self,
         tasks: list[Any],
@@ -4813,22 +4889,32 @@ class MCPServerManager:
             auth_header_value = (
                 _format_byok_openapi_auth_header(mcp_server, mcp_auth_header) if mcp_auth_header else None
             )
-            forwarded_headers = _openapi_forwarded_extra_headers(mcp_server, raw_headers, user_api_key_auth)
+            resolved_auth_headers, forwarded_headers = await self.resolve_openapi_upstream_auth(
+                mcp_server=mcp_server,
+                oauth2_headers=oauth2_headers,
+                raw_headers=raw_headers,
+                mcp_auth_header=mcp_auth_header,
+                user_api_key_auth=user_api_key_auth,
+                forwarded_headers=_openapi_forwarded_extra_headers(mcp_server, raw_headers, user_api_key_auth),
+            )
 
             async def _call_openapi_via_handler():
                 from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
                     _request_auth_header,
                     _request_extra_headers,
+                    _request_resolved_auth_headers,
                 )
 
                 auth_token = _request_auth_header.set(auth_header_value)
                 extra_token = _request_extra_headers.set(forwarded_headers)
+                resolved_token = _request_resolved_auth_headers.set(resolved_auth_headers)
                 try:
                     async with self._limit_outbound_concurrency(mcp_server):
                         return await self._call_openapi_tool_handler(mcp_server, name, arguments)
                 finally:
                     _request_auth_header.reset(auth_token)
                     _request_extra_headers.reset(extra_token)
+                    _request_resolved_auth_headers.reset(resolved_token)
 
             tasks.append(asyncio.create_task(_call_openapi_via_handler()))
         else:

--- a/litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py
+++ b/litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py
@@ -62,6 +62,14 @@ _request_extra_headers: contextvars.ContextVar[Optional[Dict[str, str]]] = conte
     "_request_extra_headers", default=None
 )
 
+# Per-request headers carrying the gateway-resolved upstream credential
+# (stored per-user OAuth token, minted M2M token, exchanged OBO token).
+# Set from MCPServerManager.resolve_openapi_upstream_auth; authoritative
+# over every other Authorization source in _merge_openapi_tool_request_headers.
+_request_resolved_auth_headers: contextvars.ContextVar[dict[str, str] | None] = contextvars.ContextVar(
+    "_request_resolved_auth_headers", default=None
+)
+
 
 def _sanitize_path_parameter_value(param_value: Any, param_name: str) -> str:
     """Ensure path params cannot introduce directory traversal."""
@@ -294,10 +302,15 @@ def _merge_openapi_tool_request_headers(
     """Merge static closure headers with per-request ContextVar overrides.
 
     Precedence (highest to lowest):
-        1. ``_request_auth_header`` — BYOK override of ``Authorization``
-        2. ``static_headers`` — operator-configured headers baked into the
+        1. ``_request_resolved_auth_headers`` — the gateway-resolved upstream
+           credential (stored per-user OAuth token, minted M2M token,
+           exchanged OBO token). The resolver is authoritative: a BYOK or
+           forwarded ``Authorization`` must not shadow it, mirroring
+           ``_resolve_v2_auth`` on the MCPClient path
+        2. ``_request_auth_header`` — BYOK override of ``Authorization``
+        3. ``static_headers`` — operator-configured headers baked into the
            tool closure at registration time
-        3. ``_request_extra_headers`` — per-request headers forwarded from
+        4. ``_request_extra_headers`` — per-request headers forwarded from
            the MCP caller (allowlisted by ``MCPServer.extra_headers``)
 
     This matches the existing MCP invariant in
@@ -322,6 +335,12 @@ def _merge_openapi_tool_request_headers(
         for existing in [k for k in effective_headers if k.lower() == "authorization"]:
             del effective_headers[existing]
         effective_headers["Authorization"] = override_auth
+
+    resolved_auth_headers = _request_resolved_auth_headers.get() or {}
+    for name, value in resolved_auth_headers.items():
+        for existing in [k for k in effective_headers if k.lower() == name.lower()]:
+            del effective_headers[existing]
+        effective_headers[name] = value
 
     return effective_headers
 

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2788,7 +2788,10 @@ if MCP_AVAILABLE:
 
             resolved_auth_headers: dict[str, str] | None = None
             if mcp_server:
-                resolved_auth_headers, forwarded_headers = await global_mcp_server_manager.resolve_openapi_upstream_auth(
+                (
+                    resolved_auth_headers,
+                    forwarded_headers,
+                ) = await global_mcp_server_manager.resolve_openapi_upstream_auth(
                     mcp_server=mcp_server,
                     oauth2_headers=oauth2_headers,
                     raw_headers=raw_headers,

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -376,6 +376,7 @@ if MCP_AVAILABLE:
     from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
         _request_auth_header,
         _request_extra_headers,
+        _request_resolved_auth_headers,
     )
     from litellm.proxy._experimental.mcp_server.sse_transport import SseServerTransport
     from litellm.proxy._experimental.mcp_server.tool_registry import (
@@ -2785,13 +2786,26 @@ if MCP_AVAILABLE:
                             forwarded_headers = {}
                         forwarded_headers[header_name] = value
 
+            resolved_auth_headers: dict[str, str] | None = None
+            if mcp_server:
+                resolved_auth_headers, forwarded_headers = await global_mcp_server_manager.resolve_openapi_upstream_auth(
+                    mcp_server=mcp_server,
+                    oauth2_headers=oauth2_headers,
+                    raw_headers=raw_headers,
+                    mcp_auth_header=mcp_auth_header,
+                    user_api_key_auth=user_api_key_auth,
+                    forwarded_headers=forwarded_headers,
+                )
+
             _auth_token = _request_auth_header.set(auth_header_value)
             _extra_token = _request_extra_headers.set(forwarded_headers)
+            _resolved_token = _request_resolved_auth_headers.set(resolved_auth_headers)
             try:
                 local_content = await _handle_local_mcp_tool(name, arguments)
             finally:
                 _request_auth_header.reset(_auth_token)
                 _request_extra_headers.reset(_extra_token)
+                _request_resolved_auth_headers.reset(_resolved_token)
             response = CallToolResult(content=cast(Any, local_content), isError=False)
 
         # Try managed MCP server tool (pass the full prefixed name)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_hook_extra_headers.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_hook_extra_headers.py
@@ -1033,3 +1033,89 @@ class TestResolveByokMcpAuthHeader:
 
         check_mock.assert_awaited_once_with(server, user_auth)
         assert result == "caller-header"
+
+
+class TestOpenApiResolvedUpstreamAuth:
+    """LIT-4629: spec_path servers egress through plain httpx, so the manager's OpenAPI arm must
+    materialize the v2-resolved credential into the `_request_resolved_auth_headers` ContextVar;
+    before the fix the resolved token never reached the upstream API."""
+
+    def _oauth_server(self, **overrides: Any) -> MCPServer:
+        fields: Dict[str, Any] = dict(
+            server_id="srv-sheets",
+            name="google_sheets",
+            server_name="google_sheets",
+            url=None,
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2,
+            spec_path="https://example.com/sheets-openapi.yaml",
+        )
+        fields.update(overrides)
+        return MCPServer(**fields)
+
+    @pytest.mark.asyncio
+    async def test_call_tool_openapi_injects_v2_resolved_token_contextvar(self):
+        """The managed spec_path arm resolves the v2 credential and sets the ContextVar; kills
+        the mutant that drops the resolve_openapi_upstream_auth call in call_tool."""
+        from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
+            _request_resolved_auth_headers,
+        )
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.httpx_auth import (
+            StaticHeaderAuth,
+        )
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.result import Ok
+
+        manager = MCPServerManager()
+        server = self._oauth_server()
+        user_auth = UserAPIKeyAuth(user_id="alice", api_key="sk-user")
+        captured: Dict[str, Any] = {}
+
+        async def fake_openapi_handler(_server, _name, _arguments):
+            captured["resolved"] = _request_resolved_auth_headers.get()
+            return MagicMock()
+
+        with patch.object(manager, "_resolve_mcp_server_for_tool_call", return_value=server):
+            with patch.object(
+                manager._cred_provider,
+                "resolve_credentials",
+                new=AsyncMock(return_value=Ok(StaticHeaderAuth("Bearer stored-user-token"))),
+            ):
+                with patch.object(manager, "_call_openapi_tool_handler", side_effect=fake_openapi_handler):
+                    await manager.call_tool(
+                        server_name=server.server_name,
+                        name="get_values",
+                        arguments={},
+                        user_api_key_auth=user_auth,
+                    )
+
+        assert captured["resolved"] == {"Authorization": "Bearer stored-user-token"}
+        assert _request_resolved_auth_headers.get() is None
+
+    @pytest.mark.asyncio
+    async def test_call_tool_openapi_m2m_missing_token_url_fails_closed(self):
+        """A url-less M2M spec server with no token_url must fail with a typed error instead of
+        egressing unauthenticated (the pre-#32259 silent failure this arm previously preserved).
+        Drives the real adapter/resolver chain: ClientCredentialsConfig with missing grant fields
+        resolves to a misconfigured CredError, raised as an HTTPException."""
+        from fastapi import HTTPException
+
+        manager = MCPServerManager()
+        server = self._oauth_server(
+            oauth2_flow="client_credentials",
+            client_id="m2m-client",
+            client_secret="m2m-secret",
+            token_url=None,
+        )
+        called = AsyncMock()
+
+        with patch.object(manager, "_resolve_mcp_server_for_tool_call", return_value=server):
+            with patch.object(manager, "_call_openapi_tool_handler", new=called):
+                with pytest.raises(HTTPException):
+                    await manager.call_tool(
+                        server_name=server.server_name,
+                        name="get_values",
+                        arguments={},
+                        user_api_key_auth=UserAPIKeyAuth(user_id="alice", api_key="sk-user"),
+                    )
+
+        called.assert_not_awaited()

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_hook_extra_headers.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_hook_extra_headers.py
@@ -1119,3 +1119,80 @@ class TestOpenApiResolvedUpstreamAuth:
                     )
 
         called.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_caller_oauth2_headers_never_become_resolved_for_byok_server(self):
+        """Greptile P1 regression: BYOK servers defer to v1 (to_server_spec None), and the v1 arm
+        must never promote caller-supplied oauth2 headers into the resolved-auth slot, where they
+        would override the per-server BYOK credential and leak the caller's gateway Authorization
+        upstream."""
+        manager = MCPServerManager()
+        server = MCPServer(
+            server_id="byok-spec",
+            name="byok_spec",
+            server_name="byok_spec",
+            url=None,
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.api_key,
+            spec_path="https://example.com/openapi.yaml",
+            is_byok=True,
+        )
+
+        resolved, forwarded = await manager.resolve_openapi_upstream_auth(
+            mcp_server=server,
+            oauth2_headers={"Authorization": "Bearer sk-litellm-gateway-key"},
+            raw_headers=None,
+            mcp_auth_header="user-byok-key",
+            user_api_key_auth=UserAPIKeyAuth(user_id="alice", api_key="sk-user"),
+            forwarded_headers=None,
+        )
+
+        assert resolved is None
+        assert forwarded is None
+
+    @pytest.mark.asyncio
+    async def test_v1_server_threads_stored_headers_only_without_caller_headers(self):
+        """The v1 (unmigrated) arm resolves the stored per-user token only when the caller sent no
+        oauth2 headers of their own; with caller headers present the stored lookup is skipped and
+        nothing is promoted to resolved."""
+        manager = MCPServerManager()
+        server = MCPServer(
+            server_id="v1-spec",
+            name="v1_spec",
+            server_name="v1_spec",
+            url=None,
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2,
+            spec_path="https://example.com/openapi.yaml",
+            delegate_auth_to_upstream=True,
+        )
+        stored = {"Authorization": "Bearer stored-v1-token"}
+        user_auth = UserAPIKeyAuth(user_id="alice", api_key="sk-user")
+
+        with patch.object(
+            manager, "_resolve_oauth2_headers_for_tool_call", new=AsyncMock(return_value=stored)
+        ) as lookup:
+            resolved, _ = await manager.resolve_openapi_upstream_auth(
+                mcp_server=server,
+                oauth2_headers=None,
+                raw_headers=None,
+                mcp_auth_header=None,
+                user_api_key_auth=user_auth,
+                forwarded_headers=None,
+            )
+        assert resolved == stored
+        lookup.assert_awaited_once_with(server, None, user_auth)
+
+        with patch.object(
+            manager, "_resolve_oauth2_headers_for_tool_call", new=AsyncMock(return_value=stored)
+        ) as lookup:
+            resolved, _ = await manager.resolve_openapi_upstream_auth(
+                mcp_server=server,
+                oauth2_headers={"Authorization": "Bearer caller-supplied"},
+                raw_headers=None,
+                mcp_auth_header=None,
+                user_api_key_auth=user_auth,
+                forwarded_headers=None,
+            )
+        assert resolved is None
+        lookup.assert_not_awaited()

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -8891,3 +8891,48 @@ async def test_resolve_toolset_tool_permissions_single_db_fetch_across_checks():
     assert first == {"server-a": ["lookup_status"]}
     assert second == first
     list_toolsets_mock.assert_awaited_once()
+
+
+class TestMaterializeAuthHeaders:
+    """_materialize_auth_headers drives one step of a resolved httpx.Auth's own flow to turn it
+    into a header dict for the OpenAPI egress arm, which sends plain headers and cannot carry an
+    httpx.Auth. Generic across auth shapes via the resolver-arm header_name convention."""
+
+    @pytest.mark.asyncio
+    async def test_static_header_auth_materializes_its_header(self):
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            _materialize_auth_headers,
+        )
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.httpx_auth import (
+            StaticHeaderAuth,
+        )
+
+        headers = await _materialize_auth_headers(StaticHeaderAuth("Bearer stored-token"))
+        assert headers == {"Authorization": "Bearer stored-token"}
+
+    @pytest.mark.asyncio
+    async def test_client_credentials_bearer_auth_materializes_bearer(self):
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            _materialize_auth_headers,
+        )
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.client_credentials import (
+            ClientCredentialsBearerAuth,
+        )
+
+        async def _refetch(_stale: str):
+            return None
+
+        headers = await _materialize_auth_headers(ClientCredentialsBearerAuth("m2m-token", _refetch))
+        assert headers == {"Authorization": "Bearer m2m-token"}
+
+    @pytest.mark.asyncio
+    async def test_noop_and_none_materialize_to_none(self):
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            _materialize_auth_headers,
+        )
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.httpx_auth import (
+            NoOpAuth,
+        )
+
+        assert await _materialize_auth_headers(None) is None
+        assert await _materialize_auth_headers(NoOpAuth()) is None

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_to_mcp_generator.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_to_mcp_generator.py
@@ -17,6 +17,7 @@ import pytest
 from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
     _request_auth_header,
     _request_extra_headers,
+    _request_resolved_auth_headers,
     _resolve_param_list,
     _resolve_ref,
     build_input_schema,
@@ -1207,3 +1208,61 @@ class TestRequestExtraHeaders:
             call_args = async_client.get.call_args
             headers_sent = call_args[1]["headers"]
             assert "X-TOKEN" not in headers_sent
+
+    @pytest.mark.asyncio
+    async def test_resolved_auth_headers_win_over_every_other_authorization_source(self):
+        """The gateway-resolved credential (stored per-user OAuth / minted M2M token) is
+        authoritative: it must override the BYOK override, static headers, and forwarded caller
+        headers on the Authorization name, case-insensitively, mirroring _resolve_v2_auth's rule
+        on the MCPClient path. Without this, a spec_path oauth2 server's completed OAuth flow
+        stores a token that never reaches the upstream API (LIT-4629)."""
+        operation = {}
+        func = create_tool_function(
+            path="/secure",
+            method="get",
+            operation=operation,
+            base_url="https://api.example.com",
+            headers={"authorization": "Bearer static-operator"},
+        )
+
+        with patch(GET_ASYNC_CLIENT_TARGET) as mock_client:
+            async_client = _create_mock_client("get", "secure-data")
+            mock_client.return_value = async_client
+
+            extra_token = _request_extra_headers.set({"Authorization": "Bearer caller-forwarded"})
+            auth_token = _request_auth_header.set("Bearer byok-credential")
+            resolved_token = _request_resolved_auth_headers.set({"Authorization": "Bearer resolved-oauth"})
+            try:
+                result = await func()
+            finally:
+                _request_auth_header.reset(auth_token)
+                _request_extra_headers.reset(extra_token)
+                _request_resolved_auth_headers.reset(resolved_token)
+
+            assert result == "secure-data"
+            headers_sent = async_client.get.call_args[1]["headers"]
+            authorization_values = [v for k, v in headers_sent.items() if k.lower() == "authorization"]
+            assert authorization_values == ["Bearer resolved-oauth"]
+
+    @pytest.mark.asyncio
+    async def test_resolved_auth_headers_not_leaked_between_calls(self):
+        """After resetting the resolved-auth ContextVar, subsequent calls send no credential."""
+        operation = {}
+        func = create_tool_function(
+            path="/data",
+            method="get",
+            operation=operation,
+            base_url="https://api.example.com",
+        )
+
+        with patch(GET_ASYNC_CLIENT_TARGET) as mock_client:
+            async_client = _create_mock_client("get", "ok")
+            mock_client.return_value = async_client
+
+            token = _request_resolved_auth_headers.set({"Authorization": "Bearer resolved-oauth"})
+            _request_resolved_auth_headers.reset(token)
+
+            await func()
+
+            headers_sent = async_client.get.call_args[1]["headers"]
+            assert "Authorization" not in headers_sent

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_tool_auth.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_tool_auth.py
@@ -218,3 +218,86 @@ async def test_openapi_local_tool_denied_when_server_not_resolvable():
     assert exc.value.status_code == 503
     pre_call.assert_not_awaited()
     handle_local.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_openapi_local_tool_injects_resolved_oauth_token():
+    """LIT-4629: the local-registry (OpenAPI) dispatch is the primary egress for spec_path
+    tools, and before the fix it dropped the gateway-resolved OAuth credential entirely, so a
+    user's completed OAuth flow stored a token that never reached the upstream API. The resolved
+    credential must land in the `_request_resolved_auth_headers` ContextVar the tool closure
+    reads. Kills the mutant that deletes the resolve_openapi_upstream_auth call in server.py."""
+    from litellm.proxy._experimental.mcp_server import server as mcp_module
+    from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
+        _request_resolved_auth_headers,
+    )
+    from litellm.proxy._experimental.mcp_server.outbound_credentials.httpx_auth import (
+        StaticHeaderAuth,
+    )
+    from litellm.proxy._experimental.mcp_server.outbound_credentials.result import Ok
+    from litellm.types.mcp import MCPAuth, MCPTransport
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    user = UserAPIKeyAuth(
+        api_key="sk-user",
+        user_id="alice",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+    )
+    oauth_server = MCPServer(
+        server_id="srv-sheets",
+        name="google_sheets",
+        server_name="google_sheets",
+        url=None,
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2,
+        spec_path="https://example.com/sheets-openapi.yaml",
+    )
+
+    fake_tool = MagicMock()
+    fake_tool.name = "get_values"
+    captured: dict = {}
+
+    async def handle_local(_name, _arguments):
+        captured["resolved"] = _request_resolved_auth_headers.get()
+        return []
+
+    with (
+        patch.object(
+            mcp_module.global_mcp_server_manager,
+            "_get_mcp_server_from_tool_name",
+            return_value=oauth_server,
+        ),
+        patch.object(
+            mcp_module.global_mcp_server_manager,
+            "pre_call_tool_check",
+            new=AsyncMock(return_value={}),
+        ),
+        patch.object(
+            mcp_module.global_mcp_tool_registry,
+            "get_tool",
+            return_value=fake_tool,
+        ),
+        patch.object(
+            mcp_module.global_mcp_server_manager._cred_provider,
+            "resolve_credentials",
+            new=AsyncMock(return_value=Ok(StaticHeaderAuth("Bearer stored-user-token"))),
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server._handle_local_mcp_tool",
+            new=handle_local,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.MCPRequestHandler.is_tool_allowed",
+            return_value=True,
+        ),
+    ):
+        await mcp_module.execute_mcp_tool(
+            name="get_values",
+            arguments={},
+            allowed_mcp_servers=[oauth_server],
+            start_time=datetime.now(timezone.utc),
+            user_api_key_auth=user,
+        )
+
+    assert captured["resolved"] == {"Authorization": "Bearer stored-user-token"}
+    assert _request_resolved_auth_headers.get() is None


### PR DESCRIPTION
## Relevant issues

OpenAPI (spec_path) MCP servers egress through a plain httpx call assembled from ContextVars, never through `_create_mcp_client`, so the v2 credential resolver never ran for them. A user could complete the full OAuth flow and the stored token was simply never attached: every tool call reached the upstream API with no Authorization header and failed with the upstream's 401. The same applied to client_credentials (M2M) servers, which minted tokens that were never used, and to OBO. OAuth on spec servers was effectively decorative

## Linear ticket

Resolves LIT-4629

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy, config-declared OpenAPI server (`spec_path` pointing at a stub API on :9631) with `auth_type: oauth2`, `oauth2_flow: client_credentials`, and `token_url` pointing at a stub IdP that counts every token mint and records the Authorization header the API receives, so the credential path is directly observable with one curl

Before (base), the tool call succeeds but the upstream receives no credential; the gateway even minted tokens on other paths and never used them:

```
$ curl -sL -X POST "http://127.0.0.1:4631/sheets_stub/mcp" -H "x-litellm-api-key: Bearer sk-..." \
    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
    -H "mcp-session-id: $SESSION" \
    -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"sheets_stub-get_data","arguments":{}}}'
data: {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"rows\":[1,2,3]}"}],"isError":false}}

$ curl -s http://127.0.0.1:9631/stats
{"mints":3,"last_auth":"<none>","calls":1}
```

After (this branch), the identical call arrives with the gateway-minted M2M token attached:

```
$ curl -s http://127.0.0.1:9631/stats
{"mints":4,"last_auth":"Bearer minted-4","calls":2}
```

## Type

🐛 Bug Fix

## Changes

`MCPServerManager.resolve_openapi_upstream_auth` resolves the upstream credential for a spec_path tool call through the same `_resolve_v2_auth` chokepoint the MCPClient path uses, so every v2 mode (authorization_code stored per-user token, client_credentials mint, token_exchange, passthrough) behaves identically on both egress paths, including the discovery challenge on a missing per-user token and the rule that the resolved credential is authoritative over conflicting caller headers. Unmigrated servers fall back to the existing stored-token lookup. `_materialize_auth_headers` turns the resolved `httpx.Auth` into a header dict by driving one step of the auth's own flow, since the OpenAPI closures send plain headers and cannot carry an `httpx.Auth`

Both OpenAPI dispatch arms are wired: the local-registry branch in `server.py` (the primary path) and the managed `call_tool` spec_path branch in `mcp_server_manager.py`. The resolved headers travel in a new `_request_resolved_auth_headers` ContextVar that `_merge_openapi_tool_request_headers` applies above the BYOK override, static headers, and forwarded caller headers

Behavior change to be aware of: an interactive oauth2 spec server whose user has no stored token now raises the per-server browser OAuth challenge instead of silently calling the upstream unauthenticated, and a misconfigured M2M spec server (missing token_url) now fails with a typed error instead of unauthenticated egress. Both match what the managed MCPClient path already does. Nothing changes for api_key, none, or BYOK spec servers, for any non-spec server, or for the M2M one-shot 401 refetch on the MCPClient path (the materialized header is point-in-time on the OpenAPI arm)

Regression tests cover both arms end to end (ContextVar observed inside the dispatched handler), the merge precedence, the materializer across auth shapes, and the M2M fail-closed case; each was mutation-checked by deleting the corresponding wiring and watching the test fail

## QA runbook

1. Declare an OpenAPI MCP server in config with `spec_path`, `auth_type: oauth2`, `oauth2_flow: client_credentials`, `client_id`, `client_secret`, and `token_url` pointing at your IdP
2. Call one of its tools through `POST /{alias}/mcp` (initialize, then tools/call)
3. On the upstream API, confirm the request now carries `Authorization: Bearer <token minted from your IdP>`; before this PR it arrived with no Authorization header
4. For the interactive case: create a spec server with `oauth2` interactive, complete the OAuth flow from the Admin UI, call a tool as that user, and confirm the stored token reaches the upstream; with no stored token the call now returns the browser OAuth challenge

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MCP proxy OAuth egress and header precedence (credential leakage vs missing auth); behavior changes for unmigrated servers (challenge/errors instead of silent unauthenticated egress).
> 
> **Overview**
> **OpenAPI (`spec_path`) MCP tools now run the same v2 upstream credential resolution as the managed MCP client path**, so stored OAuth tokens, M2M mints, token exchange, and passthrough modes actually reach the upstream HTTP API instead of egressing without `Authorization`.
> 
> Adds `resolve_openapi_upstream_auth` and `_materialize_auth_headers` (turns resolved `httpx.Auth` into header dicts for plain httpx egress), wires both the local-registry path in `server.py` and the managed `call_tool` spec_path branch, and introduces `_request_resolved_auth_headers` so `_merge_openapi_tool_request_headers` applies gateway-resolved credentials **above** BYOK, static, and forwarded caller headers. Unmigrated v1 servers keep stored-token lookup; caller `oauth2_headers` are not promoted into resolved auth (BYOK regression guard).
> 
> **Fail-closed alignment:** missing per-user OAuth on interactive spec servers now surfaces the browser challenge instead of silent unauthenticated calls; misconfigured M2M (e.g. missing `token_url`) raises a typed error instead of calling upstream bare.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8441ff3a6caff5945bff024ba641035ca3bbb5a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
