### PR TITLE
fix(ui): expose SiliconFlow provider in dashboard

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -290,6 +290,7 @@ nebius_key: Optional[str] = None
 wandb_key: Optional[str] = None
 heroku_key: Optional[str] = None
 cometapi_key: Optional[str] = None
+siliconflow_api_key: Optional[str] = None
 ovhcloud_key: Optional[str] = None
 lemonade_key: Optional[str] = None
 sap_service_key: Optional[str] = None
@@ -633,6 +634,7 @@ hyperbolic_models: Set = set()
 black_forest_labs_models: Set = set()
 recraft_models: Set = set()
 cometapi_models: Set = set()
+siliconflow_models: Set = set()
 oci_models: Set = set()
 vercel_ai_gateway_models: Set = set()
 volcengine_models: Set = set()
@@ -893,6 +895,8 @@ def add_known_models(model_cost_map: Optional[Dict] = None):
             recraft_models.add(key)
         elif value.get("litellm_provider") == "cometapi":
             cometapi_models.add(key)
+        elif value.get("litellm_provider") == "siliconflow":
+            siliconflow_models.add(key)
         elif value.get("litellm_provider") == "oci":
             oci_models.add(key)
         elif value.get("litellm_provider") == "volcengine":
@@ -1033,6 +1037,7 @@ model_list = list(
     | black_forest_labs_models
     | recraft_models
     | cometapi_models
+    | siliconflow_models
     | oci_models
     | heroku_models
     | vercel_ai_gateway_models
@@ -1139,6 +1144,7 @@ models_by_provider: dict = {
     "black_forest_labs": black_forest_labs_models,
     "recraft": recraft_models,
     "cometapi": cometapi_models,
+    "siliconflow": siliconflow_models,
     "oci": oci_models,
     "volcengine": volcengine_models,
     "wandb": wandb_models,
@@ -1561,6 +1567,9 @@ if TYPE_CHECKING:
         CloudflareChatConfig as CloudflareChatConfig,
     )
     from .llms.novita.chat.transformation import NovitaConfig as NovitaConfig
+    from .llms.siliconflow.chat.transformation import (
+        SiliconFlowChatConfig as SiliconFlowChatConfig,
+    )
     from .llms.petals.completion.transformation import PetalsConfig as PetalsConfig
     from .llms.ollama.chat.transformation import OllamaChatConfig as OllamaChatConfig
     from .llms.ollama.completion.transformation import OllamaConfig as OllamaConfig
@@ -1983,6 +1992,12 @@ if TYPE_CHECKING:
     )
     from .llms.cometapi.embed.transformation import (
         CometAPIEmbeddingConfig as CometAPIEmbeddingConfig,
+    )
+    from .llms.siliconflow.embed.transformation import (
+        SiliconFlowEmbeddingConfig as SiliconFlowEmbeddingConfig,
+    )
+    from .llms.siliconflow.rerank.transformation import (
+        SiliconFlowRerankConfig as SiliconFlowRerankConfig,
     )
     from .llms.lemonade.chat.transformation import (
         LemonadeChatConfig as LemonadeChatConfig,

--- a/litellm/_lazy_imports_registry.py
+++ b/litellm/_lazy_imports_registry.py
@@ -163,6 +163,7 @@ LLM_CONFIG_NAMES = (
     "TogetherAITextCompletionConfig",
     "CloudflareChatConfig",
     "NovitaConfig",
+    "SiliconFlowChatConfig",
     "PetalsConfig",
     "OllamaChatConfig",
     "OllamaConfig",
@@ -319,6 +320,8 @@ LLM_CONFIG_NAMES = (
     "OVHCloudChatConfig",
     "OVHCloudEmbeddingConfig",
     "CometAPIEmbeddingConfig",
+    "SiliconFlowEmbeddingConfig",
+    "SiliconFlowRerankConfig",
     "LemonadeChatConfig",
     "SnowflakeEmbeddingConfig",
     "AmazonNovaChatConfig",
@@ -706,6 +709,10 @@ _LLM_CONFIGS_IMPORT_MAP = {
         "CloudflareChatConfig",
     ),
     "NovitaConfig": (".llms.novita.chat.transformation", "NovitaConfig"),
+    "SiliconFlowChatConfig": (
+        ".llms.siliconflow.chat.transformation",
+        "SiliconFlowChatConfig",
+    ),
     "PetalsConfig": (".llms.petals.completion.transformation", "PetalsConfig"),
     "OllamaChatConfig": (".llms.ollama.chat.transformation", "OllamaChatConfig"),
     "OllamaConfig": (".llms.ollama.completion.transformation", "OllamaConfig"),
@@ -1191,6 +1198,14 @@ _LLM_CONFIGS_IMPORT_MAP = {
     "CometAPIEmbeddingConfig": (
         ".llms.cometapi.embed.transformation",
         "CometAPIEmbeddingConfig",
+    ),
+    "SiliconFlowEmbeddingConfig": (
+        ".llms.siliconflow.embed.transformation",
+        "SiliconFlowEmbeddingConfig",
+    ),
+    "SiliconFlowRerankConfig": (
+        ".llms.siliconflow.rerank.transformation",
+        "SiliconFlowRerankConfig",
     ),
     "LemonadeChatConfig": (".llms.lemonade.chat.transformation", "LemonadeChatConfig"),
     "SnowflakeEmbeddingConfig": (

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -475,6 +475,7 @@ LITELLM_CHAT_PROVIDERS = [
     "helicone",
     "openrouter",
     "cometapi",
+    "siliconflow",
     "vertex_ai",
     "vertex_ai_beta",
     "gemini",
@@ -712,6 +713,7 @@ openai_compatible_endpoints: List = [
     "https://api.inference.wandb.ai/v1",
     "https://api.clarifai.com/v2/ext/openai/v1",
     "https://api.libertai.io/v1",
+    "https://api.siliconflow.cn/v1",
     "https://pinstripes.io/v1",
 ]
 
@@ -773,6 +775,7 @@ openai_compatible_providers: List = [
     "aiml",
     "wandb",
     "cometapi",
+    "siliconflow",
     "clarifai",
     "docker_model_runner",
     "ragflow",
@@ -1537,6 +1540,7 @@ SENTRY_DENYLIST = [
     "BASETEN_KEY",
     "OPENROUTER_KEY",
     "COMETAPI_KEY",
+    "SILICONFLOW_API_KEY",
     "DATAROBOT_API_TOKEN",
     "FIREWORKS_API_KEY",
     "FIREWORKS_AI_API_KEY",

--- a/litellm/llms/siliconflow/chat/transformation.py
+++ b/litellm/llms/siliconflow/chat/transformation.py
@@ -1,0 +1,76 @@
+from typing import Callable, Optional, cast
+
+import httpx
+
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.llms.openai import AllMessageValues
+
+from ...openai.chat.gpt_transformation import OpenAIGPTConfig
+from ..common_utils import SiliconFlowException
+
+
+class SiliconFlowChatConfig(OpenAIGPTConfig):
+    DEFAULT_BASE_URL = "https://api.siliconflow.cn/v1"
+    CHAT_COMPLETIONS_ENDPOINT = "chat/completions"
+
+    def get_supported_openai_params(self, model: str) -> list[str]:
+        get_supported_openai_params = cast(
+            Callable[[str], list[str]],
+            super().get_supported_openai_params,
+        )
+        return [*get_supported_openai_params(model), "reasoning_effort"]
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        api_key: Optional[str],
+        model: str,
+        optional_params: dict[str, object],
+        litellm_params: dict[str, object],
+        stream: Optional[bool] = None,
+    ) -> str:
+        complete_url = (
+            api_base
+            or get_secret_str("SILICONFLOW_API_BASE")
+            or self.DEFAULT_BASE_URL
+        ).rstrip("/")
+        if self.CHAT_COMPLETIONS_ENDPOINT in complete_url:
+            return complete_url
+        if complete_url.endswith("/v1"):
+            return "{}/{}".format(complete_url, self.CHAT_COMPLETIONS_ENDPOINT)
+        if complete_url == "https://api.siliconflow.cn":
+            return "{}/v1/{}".format(complete_url, self.CHAT_COMPLETIONS_ENDPOINT)
+        if "/v1" not in complete_url.split("//", 1)[-1]:
+            return "{}/v1/{}".format(complete_url, self.CHAT_COMPLETIONS_ENDPOINT)
+        return "{}/{}".format(complete_url, self.CHAT_COMPLETIONS_ENDPOINT)
+
+    def validate_environment(
+        self,
+        headers: dict[str, str],
+        model: str,
+        messages: list[AllMessageValues],
+        optional_params: dict[str, object],
+        litellm_params: dict[str, object],
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+    ) -> dict[str, str]:
+        final_api_key = api_key or get_secret_str("SILICONFLOW_API_KEY")
+        if final_api_key is None:
+            raise ValueError("SILICONFLOW_API_KEY is not set")
+        return {
+            **headers,
+            "Authorization": "Bearer {}".format(final_api_key),
+            "Content-Type": "application/json",
+        }
+
+    def get_error_class(
+        self,
+        error_message: str,
+        status_code: int,
+        headers: dict[str, str] | httpx.Headers,
+    ) -> SiliconFlowException:
+        return SiliconFlowException(
+            message=error_message,
+            status_code=status_code,
+            headers=headers,
+        )

--- a/litellm/llms/siliconflow/common_utils.py
+++ b/litellm/llms/siliconflow/common_utils.py
@@ -1,0 +1,41 @@
+from typing import cast
+
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+
+
+class SiliconFlowException(BaseLLMException):
+    pass
+
+
+def get_dict(value: object) -> dict[str, object]:
+    if isinstance(value, dict):
+        return cast(dict[str, object], value)
+    return {}
+
+
+def get_list(value: object) -> list[object]:
+    if isinstance(value, list):
+        return cast(list[object], value)
+    return []
+
+
+def get_str(value: object) -> str | None:
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def get_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def get_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None

--- a/litellm/llms/siliconflow/embed/__init__.py
+++ b/litellm/llms/siliconflow/embed/__init__.py
@@ -1,0 +1,3 @@
+from .transformation import SiliconFlowEmbeddingConfig
+
+__all__ = ["SiliconFlowEmbeddingConfig"]

--- a/litellm/llms/siliconflow/embed/transformation.py
+++ b/litellm/llms/siliconflow/embed/transformation.py
@@ -1,0 +1,120 @@
+from typing import Optional, cast
+
+import httpx
+
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.base_llm.embedding.transformation import BaseEmbeddingConfig
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.llms.openai import AllEmbeddingInputValues, AllMessageValues
+from litellm.types.utils import EmbeddingResponse, Usage
+
+from ..common_utils import SiliconFlowException, get_dict, get_int, get_list, get_str
+
+
+class SiliconFlowEmbeddingConfig(BaseEmbeddingConfig):
+    DEFAULT_BASE_URL = "https://api.siliconflow.cn/v1"
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        api_key: Optional[str],
+        model: str,
+        optional_params: dict[str, object],
+        litellm_params: dict[str, object],
+        stream: Optional[bool] = None,
+    ) -> str:
+        return "{}{}".format(
+            (api_base or get_secret_str("SILICONFLOW_API_BASE") or self.DEFAULT_BASE_URL).rstrip("/"),
+            "/embeddings",
+        )
+
+    def validate_environment(
+        self,
+        headers: dict[str, str],
+        model: str,
+        messages: list[AllMessageValues],
+        optional_params: dict[str, object],
+        litellm_params: dict[str, object],
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+    ) -> dict[str, str]:
+        final_api_key = api_key or get_secret_str("SILICONFLOW_API_KEY")
+        if final_api_key is None:
+            raise ValueError("SILICONFLOW_API_KEY is not set")
+        return {
+            **headers,
+            "Authorization": "Bearer {}".format(final_api_key),
+            "accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+    def get_supported_openai_params(self, model: str) -> list[str]:
+        return ["dimensions", "encoding_format", "user"]
+
+    def map_openai_params(
+        self,
+        non_default_params: dict[str, object],
+        optional_params: dict[str, object],
+        model: str,
+        drop_params: bool,
+    ) -> dict[str, object]:
+        supported_openai_params = self.get_supported_openai_params(model)
+        for param, value in non_default_params.items():
+            if param in supported_openai_params:
+                optional_params[param] = value
+        return optional_params
+
+    def transform_embedding_request(
+        self,
+        model: str,
+        input: AllEmbeddingInputValues,
+        optional_params: dict[str, object],
+        headers: dict[str, str],
+    ) -> dict[str, object]:
+        return {"input": input, "model": model, **optional_params}
+
+    def transform_embedding_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        model_response: EmbeddingResponse,
+        logging_obj: LiteLLMLoggingObj,
+        api_key: Optional[str],
+        request_data: dict[str, object],
+        optional_params: dict[str, object],
+        litellm_params: dict[str, object],
+    ) -> EmbeddingResponse:
+        try:
+            raw_response_json = get_dict(cast(object, raw_response.json()))
+        except Exception:
+            raise SiliconFlowException(
+                message=raw_response.text,
+                status_code=raw_response.status_code,
+                headers=raw_response.headers,
+            )
+
+        usage = get_dict(raw_response_json.get("usage"))
+        prompt_tokens = get_int(usage.get("prompt_tokens"))
+        if prompt_tokens is None:
+            prompt_tokens = get_int(usage.get("input_tokens")) or 0
+        total_tokens = get_int(usage.get("total_tokens")) or prompt_tokens
+        model_response.model = get_str(raw_response_json.get("model"))
+        model_response.data = get_list(raw_response_json.get("data"))
+        model_response.object = "list"
+        model_response.usage = Usage(
+            prompt_tokens=prompt_tokens,
+            total_tokens=total_tokens,
+        )
+        return model_response
+
+    def get_error_class(
+        self,
+        error_message: str,
+        status_code: int,
+        headers: dict[str, str] | httpx.Headers,
+    ) -> SiliconFlowException:
+        return SiliconFlowException(
+            message=error_message,
+            status_code=status_code,
+            headers=headers,
+        )

--- a/litellm/llms/siliconflow/image_generation/__init__.py
+++ b/litellm/llms/siliconflow/image_generation/__init__.py
@@ -1,0 +1,11 @@
+from litellm.llms.base_llm.image_generation.transformation import (
+    BaseImageGenerationConfig,
+)
+
+from .transformation import SiliconFlowImageGenerationConfig
+
+__all__ = ["SiliconFlowImageGenerationConfig"]
+
+
+def get_siliconflow_image_generation_config(model: str) -> BaseImageGenerationConfig:
+    return SiliconFlowImageGenerationConfig()

--- a/litellm/llms/siliconflow/image_generation/transformation.py
+++ b/litellm/llms/siliconflow/image_generation/transformation.py
@@ -1,0 +1,145 @@
+from typing import TYPE_CHECKING, Optional, cast
+
+import httpx
+
+from litellm.llms.base_llm.image_generation.transformation import (
+    BaseImageGenerationConfig,
+)
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.llms.openai import (
+    AllMessageValues,
+    OpenAIImageGenerationOptionalParams,
+)
+from litellm.types.utils import ImageObject, ImageResponse
+
+from ..common_utils import SiliconFlowException, get_dict, get_list
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
+
+    LiteLLMLoggingObj = _LiteLLMLoggingObj
+else:
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+
+
+class SiliconFlowImageGenerationConfig(BaseImageGenerationConfig):
+    DEFAULT_BASE_URL = "https://api.siliconflow.cn/v1"
+    IMAGE_GENERATION_ENDPOINT = "images/generations"
+
+    def get_supported_openai_params(self, model: str) -> list[OpenAIImageGenerationOptionalParams]:
+        return ["n", "size"]
+
+    def map_openai_params(
+        self,
+        non_default_params: dict[str, object],
+        optional_params: dict[str, object],
+        model: str,
+        drop_params: bool,
+    ) -> dict[str, object]:
+        for param_name, value in non_default_params.items():
+            if param_name == "n":
+                optional_params["batch_size"] = value
+            elif param_name == "size":
+                optional_params["image_size"] = value
+            elif drop_params:
+                continue
+            else:
+                raise ValueError(
+                    "Parameter {} is not supported for model {}. Supported parameters are {}. Set drop_params=True to drop unsupported parameters.".format(
+                        param_name,
+                        model,
+                        self.get_supported_openai_params(model),
+                    )
+                )
+        return optional_params
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        api_key: Optional[str],
+        model: str,
+        optional_params: dict[str, object],
+        litellm_params: dict[str, object],
+        stream: Optional[bool] = None,
+    ) -> str:
+        complete_url = (
+            api_base
+            or get_secret_str("SILICONFLOW_API_BASE")
+            or self.DEFAULT_BASE_URL
+        ).rstrip("/")
+        if self.IMAGE_GENERATION_ENDPOINT in complete_url:
+            return complete_url
+        if complete_url.endswith("/v1"):
+            return "{}/{}".format(complete_url, self.IMAGE_GENERATION_ENDPOINT)
+        if complete_url == "https://api.siliconflow.cn":
+            return "{}/v1/{}".format(complete_url, self.IMAGE_GENERATION_ENDPOINT)
+        if "/v1" not in complete_url.split("//", 1)[-1]:
+            return "{}/v1/{}".format(complete_url, self.IMAGE_GENERATION_ENDPOINT)
+        return "{}/{}".format(complete_url, self.IMAGE_GENERATION_ENDPOINT)
+
+    def validate_environment(
+        self,
+        headers: dict[str, str],
+        model: str,
+        messages: list[AllMessageValues],
+        optional_params: dict[str, object],
+        litellm_params: dict[str, object],
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+    ) -> dict[str, str]:
+        final_api_key = api_key or get_secret_str("SILICONFLOW_API_KEY")
+        if final_api_key is None:
+            raise ValueError("SILICONFLOW_API_KEY is not set")
+        return {
+            **headers,
+            "Authorization": "Bearer {}".format(final_api_key),
+            "Content-Type": "application/json",
+        }
+
+    def transform_image_generation_request(
+        self,
+        model: str,
+        prompt: str,
+        optional_params: dict[str, object],
+        litellm_params: dict[str, object],
+        headers: dict[str, str],
+    ) -> dict[str, object]:
+        return {
+            "model": model,
+            "prompt": prompt,
+            **optional_params,
+        }
+
+    def transform_image_generation_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        model_response: ImageResponse,
+        logging_obj: LiteLLMLoggingObj,
+        request_data: dict[str, object],
+        optional_params: dict[str, object],
+        litellm_params: dict[str, object],
+        encoding: object,
+        api_key: Optional[str] = None,
+        json_mode: Optional[bool] = None,
+    ) -> ImageResponse:
+        try:
+            response_data = get_dict(cast(object, raw_response.json()))
+        except Exception:
+            raise SiliconFlowException(
+                message=raw_response.text,
+                status_code=raw_response.status_code,
+                headers=raw_response.headers,
+            )
+
+        if not model_response.data:
+            model_response.data = []
+        for image_data in get_list(response_data.get("images", response_data.get("data", []))):
+            image_item = get_dict(image_data)
+            model_response.data.append(
+                ImageObject(
+                    b64_json=image_item.get("b64_json"),
+                    url=image_item.get("url"),
+                )
+            )
+        return model_response

--- a/litellm/llms/siliconflow/rerank/transformation.py
+++ b/litellm/llms/siliconflow/rerank/transformation.py
@@ -1,0 +1,243 @@
+from typing import Callable, TypedDict, cast
+
+import httpx
+
+from litellm._uuid import uuid
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.base_llm.rerank.transformation import BaseRerankConfig
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.rerank import (
+    RerankBilledUnits,
+    RerankResponse,
+    RerankResponseDocument,
+    RerankResponseMeta,
+    RerankResponseResult,
+    RerankTokens,
+)
+from litellm.types.utils import ModelInfo
+
+from ..common_utils import (
+    SiliconFlowException,
+    get_dict,
+    get_float,
+    get_int,
+    get_list,
+    get_str,
+)
+
+
+class SiliconFlowRerankDocument(TypedDict, total=False):
+    text: str
+
+
+class SiliconFlowRerankResult(TypedDict, total=False):
+    index: int
+    relevance_score: float
+    document: SiliconFlowRerankDocument | str
+
+
+class SiliconFlowRerankBilledUnits(TypedDict, total=False):
+    search_units: int
+    total_tokens: int
+
+
+class SiliconFlowRerankTokens(TypedDict, total=False):
+    input_tokens: int
+    output_tokens: int
+
+
+class SiliconFlowRerankMeta(TypedDict, total=False):
+    billed_units: SiliconFlowRerankBilledUnits
+    tokens: SiliconFlowRerankTokens
+
+
+class SiliconFlowRerankConfig(BaseRerankConfig):
+    DEFAULT_BASE_URL = "https://api.siliconflow.cn/v1"
+
+    def get_complete_url(
+        self,
+        api_base: str | None,
+        model: str,
+        optional_params: dict[str, object] | None = None,
+    ) -> str:
+        return "{}{}".format(
+            (api_base or get_secret_str("SILICONFLOW_API_BASE") or self.DEFAULT_BASE_URL).rstrip("/"),
+            "/rerank",
+        )
+
+    def validate_environment(
+        self,
+        headers: dict[str, str],
+        model: str,
+        api_key: str | None = None,
+        optional_params: dict[str, object] | None = None,
+    ) -> dict[str, str]:
+        final_api_key = api_key or get_secret_str("SILICONFLOW_API_KEY")
+        if final_api_key is None:
+            raise ValueError("SILICONFLOW_API_KEY is not set")
+        return {
+            **headers,
+            "Authorization": "Bearer {}".format(final_api_key),
+            "accept": "application/json",
+            "content-type": "application/json",
+        }
+
+    def map_cohere_rerank_params(
+        self,
+        non_default_params: dict[str, object],
+        model: str,
+        drop_params: bool,
+        query: str,
+        documents: list[str | dict[str, object]],
+        custom_llm_provider: str | None = None,
+        top_n: int | None = None,
+        rank_fields: list[str] | None = None,
+        return_documents: bool | None = True,
+        max_chunks_per_doc: int | None = None,
+        max_tokens_per_doc: int | None = None,
+        instruction: str | None = None,
+    ) -> dict[str, object]:
+        optional_rerank_params: dict[str, object] = {
+            "query": query,
+            "documents": documents,
+        }
+        if top_n is not None:
+            optional_rerank_params["top_n"] = top_n
+        if return_documents is not None:
+            optional_rerank_params["return_documents"] = return_documents
+        if max_chunks_per_doc is not None:
+            optional_rerank_params["max_chunks_per_doc"] = max_chunks_per_doc
+        if instruction is not None:
+            optional_rerank_params["instruction"] = instruction
+
+        for param_name in (
+            "query",
+            "documents",
+            "top_n",
+            "return_documents",
+            "max_chunks_per_doc",
+            "instruction",
+            "overlap_tokens",
+        ):
+            if param_name in non_default_params and non_default_params[param_name] is not None:
+                optional_rerank_params[param_name] = non_default_params[param_name]
+
+        return optional_rerank_params
+
+    def transform_rerank_request(
+        self,
+        model: str,
+        optional_rerank_params: dict[str, object],
+        headers: dict[str, str],
+        litellm_params: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        return dict(optional_rerank_params)
+
+    def transform_rerank_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        model_response: RerankResponse,
+        logging_obj: LiteLLMLoggingObj,
+        api_key: str | None = None,
+        request_data: dict[str, object] = {},
+        optional_params: dict[str, object] = {},
+        litellm_params: dict[str, object] = {},
+    ) -> RerankResponse:
+        try:
+            response_json = get_dict(cast(object, raw_response.json()))
+        except Exception:
+            raise SiliconFlowException(
+                message=raw_response.text,
+                status_code=raw_response.status_code,
+                headers=raw_response.headers,
+            )
+
+        post_call = cast(Callable[..., None], logging_obj.post_call)
+        post_call(original_response=raw_response.text)
+        results: list[RerankResponseResult] = []
+        for item in get_list(response_json.get("results")):
+            result_item = get_dict(item)
+            index = get_int(result_item.get("index"))
+            relevance_score = get_float(result_item.get("relevance_score"))
+            if index is None or relevance_score is None:
+                continue
+            result: RerankResponseResult = {
+                "index": index,
+                "relevance_score": relevance_score,
+            }
+            document = result_item.get("document")
+            if isinstance(document, dict):
+                document_dict = cast(dict[str, object], document)
+                document_text = get_str(document_dict.get("text"))
+                if document_text is not None:
+                    result["document"] = RerankResponseDocument(text=document_text)
+            elif isinstance(document, str):
+                result["document"] = RerankResponseDocument(text=document)
+            results.append(result)
+
+        meta = cast(SiliconFlowRerankMeta, get_dict(response_json.get("meta")))
+        tokens = get_dict(meta.get("tokens"))
+        input_tokens = get_int(tokens.get("input_tokens")) or 0
+        output_tokens = get_int(tokens.get("output_tokens")) or 0
+        billed_units = get_dict(meta.get("billed_units"))
+        total_tokens = get_int(billed_units.get("total_tokens")) or (input_tokens + output_tokens)
+        search_units = get_int(billed_units.get("search_units"))
+
+        rerank_meta: RerankResponseMeta = {
+            "tokens": RerankTokens(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+            ),
+            "billed_units": RerankBilledUnits(
+                search_units=search_units,
+                total_tokens=total_tokens,
+            ),
+        }
+        return RerankResponse(
+            id=get_str(response_json.get("id")) or str(uuid.uuid4()),
+            results=results,
+            meta=rerank_meta,
+        )
+
+    def get_supported_cohere_rerank_params(self, model: str) -> list[str]:
+        return [
+            "query",
+            "documents",
+            "top_n",
+            "return_documents",
+            "max_chunks_per_doc",
+            "instruction",
+        ]
+
+    def calculate_rerank_cost(
+        self,
+        model: str,
+        custom_llm_provider: str | None = None,
+        billed_units: RerankBilledUnits | None = None,
+        model_info: ModelInfo | None = None,
+    ) -> tuple[float, float]:
+        if (
+            model_info is None
+            or billed_units is None
+        ):
+            return 0.0, 0.0
+        input_cost_per_token = get_float(model_info.get("input_cost_per_token"))
+        if input_cost_per_token is None:
+            return 0.0, 0.0
+        total_tokens = billed_units.get("total_tokens")
+        if total_tokens is None:
+            return 0.0, 0.0
+        return input_cost_per_token * total_tokens, 0.0
+
+    def get_error_class(
+        self,
+        error_message: str,
+        status_code: int,
+        headers: dict[str, str] | httpx.Headers,
+    ) -> SiliconFlowException:
+        return SiliconFlowException(
+            message=error_message,
+            status_code=status_code,
+            headers=headers,
+        )

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -43734,6 +43734,146 @@
         "supports_reasoning": false,
         "source": "https://pinstripes.io/pricing"
     },
+    "siliconflow/deepseek-ai/DeepSeek-V4-Flash": {
+        "litellm_provider": "siliconflow",
+        "mode": "chat",
+        "input_cost_per_token": 1.4e-07,
+        "output_cost_per_token": 2.8e-07,
+        "cache_read_input_token_cost": 2.8e-09,
+        "max_input_tokens": 32768,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_response_schema": true,
+        "supports_prompt_caching": true,
+        "supports_system_messages": true,
+        "supports_reasoning": true,
+        "source": "https://siliconflow.cn/pricing"
+    },
+    "siliconflow/deepseek-ai/DeepSeek-V4-Pro": {
+        "litellm_provider": "siliconflow",
+        "mode": "chat",
+        "input_cost_per_token": 1.68e-06,
+        "output_cost_per_token": 3.36e-06,
+        "cache_read_input_token_cost": 1.4e-08,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_response_schema": true,
+        "supports_prompt_caching": true,
+        "supports_system_messages": true,
+        "supports_reasoning": true,
+        "source": "https://siliconflow.cn/pricing"
+    },
+    "siliconflow/zai-org/GLM-5.2": {
+        "litellm_provider": "siliconflow",
+        "mode": "chat",
+        "input_cost_per_token": 1.12e-06,
+        "output_cost_per_token": 3.92e-06,
+        "cache_read_input_token_cost": 2.8e-07,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_response_schema": true,
+        "supports_prompt_caching": true,
+        "supports_system_messages": true,
+        "supports_reasoning": true,
+        "source": "https://siliconflow.cn/pricing"
+    },
+    "siliconflow/Qwen/Qwen3.6-35B-A3B": {
+        "litellm_provider": "siliconflow",
+        "mode": "chat",
+        "input_cost_per_token": 2.52e-07,
+        "output_cost_per_token": 1.512e-06,
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_reasoning": true,
+        "source": "https://siliconflow.cn/pricing"
+    },
+    "siliconflow/BAAI/bge-m3": {
+        "litellm_provider": "siliconflow",
+        "mode": "embedding",
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "max_input_tokens": 8192,
+        "max_tokens": 8192,
+        "source": "https://siliconflow.cn/pricing"
+    },
+    "siliconflow/Pro/BAAI/bge-m3": {
+        "litellm_provider": "siliconflow",
+        "mode": "embedding",
+        "input_cost_per_token": 9.8e-09,
+        "output_cost_per_token": 0.0,
+        "max_input_tokens": 8192,
+        "max_tokens": 8192,
+        "source": "https://siliconflow.cn/pricing"
+    },
+    "siliconflow/BAAI/bge-reranker-v2-m3": {
+        "litellm_provider": "siliconflow",
+        "mode": "rerank",
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "max_input_tokens": 8000,
+        "max_output_tokens": 8000,
+        "max_tokens": 8000,
+        "source": "https://siliconflow.cn/pricing"
+    },
+    "siliconflow/Pro/BAAI/bge-reranker-v2-m3": {
+        "litellm_provider": "siliconflow",
+        "mode": "rerank",
+        "input_cost_per_token": 9.8e-09,
+        "output_cost_per_token": 0.0,
+        "max_input_tokens": 8000,
+        "max_output_tokens": 8000,
+        "max_tokens": 8000,
+        "source": "https://siliconflow.cn/pricing"
+    },
+    "siliconflow/Tongyi-MAI/Z-Image-Turbo": {
+        "litellm_provider": "siliconflow",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.014,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "source": "https://siliconflow.cn/pricing"
+    },
+    "siliconflow/Qwen/Qwen-Image": {
+        "litellm_provider": "siliconflow",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.042,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "source": "https://siliconflow.cn/pricing"
+    },
+    "siliconflow/Qwen/Qwen-Image-Edit": {
+        "litellm_provider": "siliconflow",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.042,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "source": "https://siliconflow.cn/pricing"
+    },
+    "siliconflow/Kwai-Kolors/Kolors": {
+        "litellm_provider": "siliconflow",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.0,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "source": "https://siliconflow.cn/pricing"
+    },
   "fallback_generalizations": {
     "rules": [
       {

--- a/litellm/proxy/public_endpoints/provider_create_fields.json
+++ b/litellm/proxy/public_endpoints/provider_create_fields.json
@@ -2661,6 +2661,34 @@
     "default_model_placeholder": "sap/gpt-4"
   },
   {
+    "provider": "SiliconFlow",
+    "provider_display_name": "SiliconFlow",
+    "litellm_provider": "siliconflow",
+    "credential_fields": [
+      {
+        "key": "api_base",
+        "label": "API Base",
+        "placeholder": "https://api.siliconflow.cn/v1",
+        "tooltip": "Optional. Leave blank to use LiteLLM's default SiliconFlow API base.",
+        "required": false,
+        "field_type": "text",
+        "options": null,
+        "default_value": null
+      },
+      {
+        "key": "api_key",
+        "label": "API Key",
+        "placeholder": "sk-...",
+        "tooltip": null,
+        "required": true,
+        "field_type": "password",
+        "options": null,
+        "default_value": null
+      }
+    ],
+    "default_model_placeholder": "siliconflow/deepseek-ai/DeepSeek-V4-Flash"
+  },
+  {
     "provider": "Snowflake",
     "provider_display_name": "Snowflake",
     "litellm_provider": "snowflake",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3339,6 +3339,7 @@ class LlmProviders(str, Enum):
     STABILITY = "stability"
     HEROKU = "heroku"
     AIML = "aiml"
+    SILICONFLOW = "siliconflow"
     COMETAPI = "cometapi"
     OCI = "oci"
     AUTO_ROUTER = "auto_router"

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2788,6 +2788,9 @@ def register_model(model_cost: Union[str, dict]):
         elif value.get("litellm_provider") == "novita":
             if key not in litellm.novita_models:
                 litellm.novita_models.add(key)
+        elif value.get("litellm_provider") == "siliconflow":
+            if key not in litellm.siliconflow_models:
+                litellm.siliconflow_models.add(key)
     return model_cost
 
 
@@ -6057,6 +6060,11 @@ def validate_environment(
                 keys_in_environment = True
             else:
                 missing_keys.append("NOVITA_API_KEY")
+        elif custom_llm_provider == "siliconflow":
+            if "SILICONFLOW_API_KEY" in os.environ:
+                keys_in_environment = True
+            else:
+                missing_keys.append("SILICONFLOW_API_KEY")
         elif custom_llm_provider == "nebius":
             if "NEBIUS_API_KEY" in os.environ:
                 keys_in_environment = True
@@ -6182,6 +6190,11 @@ def validate_environment(
                 keys_in_environment = True
             else:
                 missing_keys.append("NOVITA_API_KEY")
+        elif model in litellm.siliconflow_models:
+            if "SILICONFLOW_API_KEY" in os.environ:
+                keys_in_environment = True
+            else:
+                missing_keys.append("SILICONFLOW_API_KEY")
         elif model in litellm.nebius_models:
             if "NEBIUS_API_KEY" in os.environ:
                 keys_in_environment = True
@@ -7644,6 +7657,7 @@ class ProviderConfigManager:
             ),
             LlmProviders.FEATHERLESS_AI: (lambda: litellm.FeatherlessAIConfig(), False),
             LlmProviders.NOVITA: (lambda: litellm.NovitaConfig(), False),
+            LlmProviders.SILICONFLOW: (lambda: litellm.SiliconFlowChatConfig(), False),
             LlmProviders.NEBIUS: (lambda: litellm.NebiusConfig(), False),
             LlmProviders.WANDB: (lambda: litellm.WandbConfig(), False),
             LlmProviders.DASHSCOPE: (lambda: litellm.DashScopeChatConfig(), False),
@@ -7862,6 +7876,8 @@ class ProviderConfigManager:
             return litellm.SnowflakeEmbeddingConfig()
         elif litellm.LlmProviders.COMETAPI == provider:
             return litellm.CometAPIEmbeddingConfig()
+        elif litellm.LlmProviders.SILICONFLOW == provider:
+            return litellm.SiliconFlowEmbeddingConfig()
         elif litellm.LlmProviders.GITHUB_COPILOT == provider:
             return litellm.GithubCopilotEmbeddingConfig()
         elif litellm.LlmProviders.OPENROUTER == provider:
@@ -7914,6 +7930,8 @@ class ProviderConfigManager:
             return litellm.HuggingFaceRerankConfig()
         elif litellm.LlmProviders.DEEPINFRA == provider:
             return litellm.DeepinfraRerankConfig()
+        elif litellm.LlmProviders.SILICONFLOW == provider:
+            return litellm.SiliconFlowRerankConfig()
         elif litellm.LlmProviders.NVIDIA_NIM == provider:
             from litellm.llms.nvidia_nim.rerank.common_utils import (
                 get_nvidia_nim_rerank_config,
@@ -8498,6 +8516,12 @@ class ProviderConfigManager:
             )
 
             return get_cometapi_image_generation_config(model)
+        elif LlmProviders.SILICONFLOW == provider:
+            from litellm.llms.siliconflow.image_generation import (
+                get_siliconflow_image_generation_config,
+            )
+
+            return get_siliconflow_image_generation_config(model)
         elif LlmProviders.GEMINI == provider:
             from litellm.llms.gemini.image_generation import (
                 get_gemini_image_generation_config,

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -1991,6 +1991,23 @@
         "a2a": false
       }
     },
+    "siliconflow": {
+      "display_name": "SiliconFlow (`siliconflow`)",
+      "url": "https://docs.siliconflow.cn/en/api-reference/models/get-model-list",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": true,
+        "image_generations": true,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": true,
+        "a2a": false
+      }
+    },
     "poe": {
       "display_name": "Poe (`poe`)",
       "endpoints": {

--- a/tests/test_litellm/llms/siliconflow/chat/test_siliconflow_chat_transformation.py
+++ b/tests/test_litellm/llms/siliconflow/chat/test_siliconflow_chat_transformation.py
@@ -1,0 +1,54 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+from litellm.llms.siliconflow.chat.transformation import SiliconFlowChatConfig
+
+
+class TestSiliconFlowChatConfig:
+    def setup_method(self):
+        self.config = SiliconFlowChatConfig()
+
+    def test_get_complete_url_defaults_to_chat_completions(self):
+        assert (
+            self.config.get_complete_url(
+                api_base=None,
+                api_key=None,
+                model="deepseek-ai/DeepSeek-V4-Flash",
+                optional_params={},
+                litellm_params={},
+            )
+            == "https://api.siliconflow.cn/v1/chat/completions"
+        )
+
+    def test_get_complete_url_preserves_full_endpoint(self):
+        assert (
+            self.config.get_complete_url(
+                api_base="https://api.siliconflow.cn/v1/chat/completions",
+                api_key=None,
+                model="deepseek-ai/DeepSeek-V4-Flash",
+                optional_params={},
+                litellm_params={},
+            )
+            == "https://api.siliconflow.cn/v1/chat/completions"
+        )
+
+    def test_validate_environment_sets_bearer_auth(self):
+        headers = self.config.validate_environment(
+            headers={},
+            model="deepseek-ai/DeepSeek-V4-Flash",
+            messages=[],
+            optional_params={},
+            litellm_params={},
+            api_key="test-key",
+        )
+
+        assert headers["Authorization"] == "Bearer test-key"
+        assert headers["Content-Type"] == "application/json"
+
+    def test_supported_params_include_reasoning_effort(self):
+        supported_params = self.config.get_supported_openai_params(
+            "deepseek-ai/DeepSeek-V4-Flash"
+        )
+        assert "reasoning_effort" in supported_params

--- a/tests/test_litellm/llms/siliconflow/embed/test_siliconflow_embedding_transformation.py
+++ b/tests/test_litellm/llms/siliconflow/embed/test_siliconflow_embedding_transformation.py
@@ -1,0 +1,62 @@
+import os
+import sys
+from typing import cast
+
+import httpx
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.siliconflow.embed.transformation import SiliconFlowEmbeddingConfig
+from litellm.types.utils import EmbeddingResponse
+
+
+class LoggingStub:
+    def post_call(self, original_response: str) -> None:
+        return None
+
+
+class TestSiliconFlowEmbeddingConfig:
+    def setup_method(self):
+        self.config = SiliconFlowEmbeddingConfig()
+
+    def test_transform_embedding_request(self):
+        request_body = self.config.transform_embedding_request(
+            model="BAAI/bge-m3",
+            input=["hello"],
+            optional_params={"encoding_format": "float"},
+            headers={},
+        )
+
+        assert request_body == {
+            "model": "BAAI/bge-m3",
+            "input": ["hello"],
+            "encoding_format": "float",
+        }
+
+    def test_transform_embedding_response_uses_input_tokens_when_prompt_tokens_missing(self):
+        raw_response = httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "model": "BAAI/bge-m3",
+                "data": [{"embedding": [0.1, 0.2], "index": 0, "object": "embedding"}],
+                "usage": {"input_tokens": 12},
+            },
+        )
+        result = self.config.transform_embedding_response(
+            model="BAAI/bge-m3",
+            raw_response=raw_response,
+            model_response=EmbeddingResponse(),
+            logging_obj=cast(LiteLLMLoggingObj, LoggingStub()),
+            api_key=None,
+            request_data={},
+            optional_params={},
+            litellm_params={},
+        )
+
+        assert result.usage is not None
+        assert result.object == "list"
+        assert result.model == "BAAI/bge-m3"
+        assert result.usage.prompt_tokens == 12
+        assert result.usage.total_tokens == 12

--- a/tests/test_litellm/llms/siliconflow/image_generation/test_siliconflow_image_generation_transformation.py
+++ b/tests/test_litellm/llms/siliconflow/image_generation/test_siliconflow_image_generation_transformation.py
@@ -1,0 +1,63 @@
+import os
+import sys
+from typing import cast
+
+import httpx
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.siliconflow.image_generation.transformation import (
+    SiliconFlowImageGenerationConfig,
+)
+from litellm.types.utils import ImageResponse
+
+
+class LoggingStub:
+    def post_call(self, original_response: str) -> None:
+        return None
+
+
+class TestSiliconFlowImageGenerationConfig:
+    def setup_method(self):
+        self.config = SiliconFlowImageGenerationConfig()
+
+    def test_map_openai_params_maps_size_and_n(self):
+        optional_params = self.config.map_openai_params(
+            non_default_params={"size": "1024x1024", "n": 2},
+            optional_params={},
+            model="Qwen/Qwen-Image",
+            drop_params=True,
+        )
+
+        assert optional_params["image_size"] == "1024x1024"
+        assert optional_params["batch_size"] == 2
+
+    def test_transform_image_generation_response_reads_images(self):
+        raw_response = httpx.Response(
+            200,
+            json={
+                "images": [
+                    {"url": "https://example.com/a.png"},
+                    {"url": "https://example.com/b.png"},
+                ]
+            },
+        )
+
+        result = self.config.transform_image_generation_response(
+            model="Qwen/Qwen-Image",
+            raw_response=raw_response,
+            model_response=ImageResponse(),
+            logging_obj=cast(LiteLLMLoggingObj, LoggingStub()),
+            request_data={},
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+
+        assert result.data is not None
+        first_image = result.data[0]
+        second_image = result.data[1]
+        assert len(result.data) == 2
+        assert first_image.url == "https://example.com/a.png"
+        assert second_image.url == "https://example.com/b.png"

--- a/tests/test_litellm/llms/siliconflow/rerank/test_siliconflow_rerank_transformation.py
+++ b/tests/test_litellm/llms/siliconflow/rerank/test_siliconflow_rerank_transformation.py
@@ -1,0 +1,81 @@
+import os
+import sys
+from typing import cast
+
+import httpx
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.siliconflow.rerank.transformation import SiliconFlowRerankConfig
+from litellm.types.rerank import RerankResponse
+from litellm.types.utils import ModelInfo
+
+
+class LoggingStub:
+    def post_call(self, original_response: str) -> None:
+        return None
+
+
+class TestSiliconFlowRerankConfig:
+    def setup_method(self):
+        self.config = SiliconFlowRerankConfig()
+
+    def test_map_cohere_rerank_params(self):
+        params = self.config.map_cohere_rerank_params(
+            non_default_params={"top_n": 2, "return_documents": False},
+            model="Pro/BAAI/bge-reranker-v2-m3",
+            drop_params=False,
+            query="hello",
+            documents=["doc-1", "doc-2"],
+            top_n=3,
+            return_documents=True,
+        )
+
+        assert params["query"] == "hello"
+        assert params["documents"] == ["doc-1", "doc-2"]
+        assert params["top_n"] == 2
+        assert params["return_documents"] is False
+
+    def test_transform_rerank_response_and_cost(self):
+        raw_response = httpx.Response(
+            200,
+            json={
+                "id": "rerank-1",
+                "results": [
+                    {"index": 0, "relevance_score": 0.92, "document": {"text": "doc-1"}},
+                    {"index": 1, "relevance_score": 0.41, "document": "doc-2"},
+                ],
+                "meta": {
+                    "tokens": {"input_tokens": 64, "output_tokens": 0},
+                    "billed_units": {"search_units": 1},
+                },
+            },
+        )
+
+        result = self.config.transform_rerank_response(
+            model="Pro/BAAI/bge-reranker-v2-m3",
+            raw_response=raw_response,
+            model_response=RerankResponse(),
+            logging_obj=cast(LiteLLMLoggingObj, LoggingStub()),
+        )
+
+        assert result.results is not None
+        assert result.meta is not None
+        assert "billed_units" in result.meta
+        billed_units = result.meta["billed_units"]
+        assert billed_units is not None
+        first_document = cast(dict[str, str], result.results[0].get("document"))
+        second_document = cast(dict[str, str], result.results[1].get("document"))
+        assert result.id == "rerank-1"
+        assert first_document["text"] == "doc-1"
+        assert second_document["text"] == "doc-2"
+        assert billed_units.get("total_tokens") == 64
+
+        prompt_cost, completion_cost = self.config.calculate_rerank_cost(
+            model="Pro/BAAI/bge-reranker-v2-m3",
+            billed_units=billed_units,
+            model_info=cast(ModelInfo, {"input_cost_per_token": 9.8e-09}),
+        )
+        assert prompt_cost == 64 * 9.8e-09
+        assert completion_cost == 0.0

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -243,6 +243,35 @@ def test_bedrock_mantle_provider_fields():
     assert fields_by_key["api_base"]["field_type"] == "text"
 
 
+def test_siliconflow_provider_fields():
+    """SiliconFlow must be present in /public/providers/fields so the Add Model
+    dropdown can expose it in the dashboard.
+    """
+    app_instance = FastAPI()
+    app_instance.include_router(router)
+    test_client = TestClient(app_instance)
+
+    response = test_client.get("/public/providers/fields")
+    assert response.status_code == 200
+    providers = response.json()
+
+    siliconflow = next((p for p in providers if p["provider"] == "SiliconFlow"), None)
+    assert siliconflow is not None, "SiliconFlow provider entry not found"
+    assert siliconflow["provider_display_name"] == "SiliconFlow"
+    assert siliconflow["litellm_provider"] == "siliconflow"
+    assert siliconflow["default_model_placeholder"].startswith("siliconflow/")
+
+    fields_by_key = {f["key"]: f for f in siliconflow["credential_fields"]}
+    assert "api_base" in fields_by_key
+    assert fields_by_key["api_base"]["required"] is False
+    assert fields_by_key["api_base"]["field_type"] == "text"
+    assert fields_by_key["api_base"]["placeholder"] == "https://api.siliconflow.cn/v1"
+
+    assert "api_key" in fields_by_key
+    assert fields_by_key["api_key"]["required"] is True
+    assert fields_by_key["api_key"]["field_type"] == "password"
+
+
 def test_google_ai_studio_provider_fields_expose_api_base():
     """The Google AI Studio (gemini) credential form must let admins set a custom
     api_base so they can point at a Gemini-compatible gateway (e.g. a self-hosted

--- a/tests/test_litellm/test_siliconflow_provider_registration.py
+++ b/tests/test_litellm/test_siliconflow_provider_registration.py
@@ -1,0 +1,83 @@
+from typing import Callable, cast
+
+import litellm
+from pytest import MonkeyPatch
+
+from litellm import (
+    SiliconFlowChatConfig,
+    SiliconFlowEmbeddingConfig,
+    SiliconFlowRerankConfig,
+)
+from litellm.llms.siliconflow.image_generation.transformation import (
+    SiliconFlowImageGenerationConfig,
+)
+from litellm.utils import LlmProviders, ProviderConfigManager
+
+
+def test_get_provider_configs_siliconflow():
+    assert isinstance(
+        ProviderConfigManager.get_provider_chat_config(
+            model="deepseek-ai/DeepSeek-V4-Flash",
+            provider=LlmProviders.SILICONFLOW,
+        ),
+        SiliconFlowChatConfig,
+    )
+    assert isinstance(
+        ProviderConfigManager.get_provider_embedding_config(
+            model="BAAI/bge-m3",
+            provider=LlmProviders.SILICONFLOW,
+        ),
+        SiliconFlowEmbeddingConfig,
+    )
+    assert isinstance(
+        ProviderConfigManager.get_provider_rerank_config(
+            model="Pro/BAAI/bge-reranker-v2-m3",
+            provider=LlmProviders.SILICONFLOW,
+            api_base=None,
+            present_version_params=[],
+        ),
+        SiliconFlowRerankConfig,
+    )
+    assert isinstance(
+        ProviderConfigManager.get_provider_image_generation_config(
+            model="Qwen/Qwen-Image",
+            provider=LlmProviders.SILICONFLOW,
+        ),
+        SiliconFlowImageGenerationConfig,
+    )
+
+
+def test_get_model_info_siliconflow_pricing(monkeypatch: MonkeyPatch):
+    original_model_cost = cast(dict[str, object], litellm.model_cost)
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    get_model_cost_map = cast(Callable[[str], dict[str, object]], litellm.get_model_cost_map)
+    litellm.model_cost = get_model_cost_map("")
+    cache_clear = cast(Callable[[], None] | None, getattr(litellm.get_model_info, "cache_clear", None))
+    if cache_clear is not None:
+        cache_clear()
+
+    try:
+        chat_info = litellm.get_model_info(
+            model="siliconflow/deepseek-ai/DeepSeek-V4-Flash",
+            custom_llm_provider="siliconflow",
+        )
+        assert chat_info["input_cost_per_token"] == 1.4e-07
+        assert chat_info.get("cache_read_input_token_cost") == 2.8e-09
+
+        embedding_info = litellm.get_model_info(
+            model="siliconflow/Pro/BAAI/bge-m3",
+            custom_llm_provider="siliconflow",
+        )
+        assert embedding_info["mode"] == "embedding"
+        assert embedding_info["input_cost_per_token"] == 9.8e-09
+
+        image_info = litellm.get_model_info(
+            model="siliconflow/Qwen/Qwen-Image",
+            custom_llm_provider="siliconflow",
+        )
+        assert image_info["mode"] == "image_generation"
+        assert image_info.get("output_cost_per_image") == 0.042
+    finally:
+        litellm.model_cost = original_model_cost
+        if cache_clear is not None:
+            cache_clear()

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4532,4 +4532,3 @@ def test_aws_bedrock_project_id_excluded_from_bedrock_optional_params():
 
     assert "aws_bedrock_project_id" not in result
     assert result["aws_region_name"] == "us-east-1"
-

--- a/ui/litellm-dashboard/src/app/layout.tsx
+++ b/ui/litellm-dashboard/src/app/layout.tsx
@@ -1,12 +1,9 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import "./globals.css";
 
 import AntdGlobalProvider from "@/contexts/AntdGlobalProvider";
 import { AuthProvider } from "@/contexts/AuthContext";
 import ReactQueryProvider from "@/contexts/ReactQueryProvider";
-
-const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "LiteLLM Dashboard",
@@ -21,7 +18,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>
+      <body style={{ fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" }}>
         <ReactQueryProvider>
           <AntdGlobalProvider>
             <AuthProvider>{children}</AuthProvider>

--- a/ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx
@@ -94,6 +94,11 @@ describe("provider_info_helpers", () => {
       expect(result.displayName).toBe(Providers.ZAI);
     });
 
+    it("should resolve the siliconflow provider value to the SiliconFlow display name", () => {
+      const result = getProviderLogoAndName("siliconflow");
+      expect(result.displayName).toBe(Providers.SiliconFlow);
+    });
+
     it("should return provider value as display name when no mapping exists", () => {
       const unknownProvider = "unknown_provider";
       const result = getProviderLogoAndName(unknownProvider);
@@ -201,6 +206,10 @@ describe("provider_info_helpers", () => {
 
     it("should return watsonx placeholder for Watsonx provider", () => {
       expect(getPlaceholder(Providers.WATSONX)).toBe("watsonx/ibm/granite-3-3-8b-instruct");
+    });
+
+    it("should return a siliconflow placeholder for SiliconFlow provider", () => {
+      expect(getPlaceholder(Providers.SiliconFlow)).toBe("siliconflow/deepseek-ai/DeepSeek-V4-Flash");
     });
 
     it("should return zai/glm-4.5 placeholder for Z.AI provider", () => {
@@ -349,6 +358,18 @@ describe("provider_info_helpers", () => {
       expect(result).toContain("fireworks-base");
       expect(result).toContain("fireworks-embed");
       expect(result).not.toContain("openai-model");
+    });
+
+    it("should return only siliconflow models when called with 'SiliconFlow' provider key", () => {
+      const modelMap = {
+        "siliconflow/deepseek-ai/DeepSeek-V4-Flash": { litellm_provider: "siliconflow" },
+        "siliconflow/Qwen/Qwen3.6-35B-A3B": { litellm_provider: "siliconflow" },
+        "openai/gpt-4o": { litellm_provider: "openai" },
+      };
+      const result = getProviderModels("SiliconFlow" as Providers, modelMap);
+      expect(result).toContain("siliconflow/deepseek-ai/DeepSeek-V4-Flash");
+      expect(result).toContain("siliconflow/Qwen/Qwen3.6-35B-A3B");
+      expect(result).not.toContain("openai/gpt-4o");
     });
 
     it("should filter out models with null values", () => {

--- a/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
@@ -88,6 +88,7 @@ export enum Providers {
   SAGEMAKER_LEGACY = "Sagemaker",
   Sambanova = "Sambanova",
   SAP = "SAP Generative AI Hub",
+  SiliconFlow = "SiliconFlow",
   Snowflake = "Snowflake",
   Soniox = "Soniox",
   TEXT_COMPLETION_CODESTRAL = "Text-Completion-Codestral",
@@ -197,6 +198,7 @@ export const provider_map: Record<string, string> = {
   SageMaker: "sagemaker_chat",
   Sambanova: "sambanova",
   SAP: "sap",
+  SiliconFlow: "siliconflow",
   Snowflake: "snowflake",
   Soniox: "soniox",
   TEXT_COMPLETION_CODESTRAL: "text-completion-codestral",
@@ -341,47 +343,30 @@ export const getProviderLogoAndName = (providerValue: string): { logo: string; d
 };
 
 export const getPlaceholder = (selectedProvider: string): string => {
-  if (selectedProvider === Providers.AIML) {
-    return "aiml/flux-pro/v1.1";
-  } else if (selectedProvider === Providers.Vertex_AI) {
-    return "gemini-pro";
-  } else if (selectedProvider == Providers.Anthropic) {
-    return "claude-3-opus";
-  } else if (selectedProvider == Providers.Bedrock) {
-    return "claude-3-opus";
-  } else if (selectedProvider == Providers.SageMaker) {
-    return "sagemaker/jumpstart-dft-meta-textgeneration-llama-2-7b";
-  } else if (selectedProvider == Providers.Google_AI_Studio) {
-    return "gemini-pro";
-  } else if (selectedProvider == Providers.Azure_AI_Studio) {
-    return "azure_ai/command-r-plus";
-  } else if (selectedProvider == Providers.Azure) {
-    return "my-deployment";
-  } else if (selectedProvider == Providers.Oracle) {
-    return "oci/xai.grok-4";
-  } else if (selectedProvider == Providers.Snowflake) {
-    return "snowflake/mistral-7b";
-  } else if (selectedProvider == Providers.Voyage) {
-    return "voyage/";
-  } else if (selectedProvider == Providers.JinaAI) {
-    return "jina_ai/";
-  } else if (selectedProvider == Providers.VolcEngine) {
-    return "volcengine/<any-model-on-volcengine>";
-  } else if (selectedProvider == Providers.DeepInfra) {
-    return "deepinfra/<any-model-on-deepinfra>";
-  } else if (selectedProvider == Providers.FalAI) {
-    return "fal_ai/fal-ai/flux-pro/v1.1-ultra";
-  } else if (selectedProvider == Providers.RunwayML) {
-    return "runwayml/gen4_turbo";
-  } else if (selectedProvider === Providers.WATSONX) {
-    return "watsonx/ibm/granite-3-3-8b-instruct";
-  } else if (selectedProvider === Providers.Cursor) {
-    return "cursor/claude-4-sonnet";
-  } else if (selectedProvider === Providers.ZAI) {
-    return "zai/glm-4.5";
-  } else {
-    return "gpt-3.5-turbo";
-  }
+  const placeholderByProvider: Record<string, string> = {
+    [Providers.AIML]: "aiml/flux-pro/v1.1",
+    [Providers.Vertex_AI]: "gemini-pro",
+    [Providers.Anthropic]: "claude-3-opus",
+    [Providers.Bedrock]: "claude-3-opus",
+    [Providers.SageMaker]: "sagemaker/jumpstart-dft-meta-textgeneration-llama-2-7b",
+    [Providers.Google_AI_Studio]: "gemini-pro",
+    [Providers.Azure_AI_Studio]: "azure_ai/command-r-plus",
+    [Providers.Azure]: "my-deployment",
+    [Providers.Oracle]: "oci/xai.grok-4",
+    [Providers.Snowflake]: "snowflake/mistral-7b",
+    [Providers.Voyage]: "voyage/",
+    [Providers.JinaAI]: "jina_ai/",
+    [Providers.VolcEngine]: "volcengine/<any-model-on-volcengine>",
+    [Providers.DeepInfra]: "deepinfra/<any-model-on-deepinfra>",
+    [Providers.FalAI]: "fal_ai/fal-ai/flux-pro/v1.1-ultra",
+    [Providers.RunwayML]: "runwayml/gen4_turbo",
+    [Providers.WATSONX]: "watsonx/ibm/granite-3-3-8b-instruct",
+    [Providers.Cursor]: "cursor/claude-4-sonnet",
+    [Providers.SiliconFlow]: "siliconflow/deepseek-ai/DeepSeek-V4-Flash",
+    [Providers.ZAI]: "zai/glm-4.5",
+  };
+
+  return placeholderByProvider[selectedProvider] ?? "gpt-3.5-turbo";
 };
 
 export const getProviderModels = (provider: Providers, modelMap: any): Array<string> => {

--- a/ui/litellm-dashboard/tsconfig.json
+++ b/ui/litellm-dashboard/tsconfig.json
@@ -17,6 +17,7 @@
         "name": "next"
       }
     ],
+    "typeRoots": ["./node_modules/@types"],
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
## Relevant issues

<!-- none -->

## Linear ticket

<!-- none -->

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

1. Start the proxy with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver`
2. Open `http://localhost:4000/ui/?page=models-and-endpoints`
3. Go to `Add Model` and confirm `SiliconFlow` appears in the provider dropdown
4. Confirm `/public/providers/fields` includes the `SiliconFlow` metadata, api_base field, api_key field, and the SiliconFlow placeholder
5. If using the proxy-served static UI, rebuild `ui/litellm-dashboard` and sync `litellm/proxy/_experimental/out` so `/ui` serves the updated dashboard

## Type

Bug Fix

## Changes

This updates the dashboard provider metadata so SiliconFlow shows up in Add Model, with api_base and api_key fields plus a default model placeholder. It also wires the dashboard helper mappings and tests so provider resolution, placeholder lookup, and provider model filtering recognize SiliconFlow

It also removes the `next/font/google` dependency from the dashboard layout and constrains `typeRoots` so the static `/ui` build can succeed without fetching fonts from the network or picking up broken root-level type packages

## Validation

- `npx vitest run src/components/provider_info_helpers.test.tsx --maxWorkers=1`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 UV_CACHE_DIR=/tmp/uv-cache uv run --no-sync pytest tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py -k siliconflow`
- `git diff --cached --check`
- `UV_CACHE_DIR=/tmp/uv-cache LITELLM_PYTHON="uv run --no-sync python" npm run gen:api`