### PR TITLE
fix(ui): serve /ui/assets from the nginx image instead of SPA fallback

### DIFF
--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -49,6 +49,9 @@ http {
       expires 1y;
       add_header Cache-Control "public, immutable";
     }
+    location ^~ /ui/assets/ {
+      alias /usr/share/nginx/html/assets/;
+    }
     location = /favicon.ico {
       try_files $uri =404;
       expires 1d;


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

First observed on a live deployment of the split chart: every provider logo on the models page rendered as the gray letter-avatar, and DevTools showed each `/ui/assets/logos/*.svg` request answered 200 `text/html` at an identical 24,860 bytes (index.html)

Local reproduction runs the real image built from `ui/Dockerfile` at 8fcf9b1d35, twice from the same build so the config is the only variable: "before" mounts the baseline `ui/nginx.conf` extracted from 731efafbca over the container, "after" runs the image as built

```
$ docker build -f ui/Dockerfile -t litellm-ui-nginx-fix .
$ git show 731efafbca:ui/nginx.conf > /tmp/nginx_before.conf
$ docker run -d --rm --name ui-before -p 3101:3000 -v /tmp/nginx_before.conf:/etc/nginx/nginx.conf:ro litellm-ui-nginx-fix
$ docker run -d --rm --name ui-after -p 3102:3000 litellm-ui-nginx-fix

== BEFORE (baseline conf, commit 731efafbca) ==
GET /ui/assets/logos/bedrock.svg -> 200 text/html 24860 bytes

== AFTER (fixed conf, commit 8fcf9b1d35) ==
GET /ui/assets/logos/bedrock.svg -> 200 image/svg+xml 2268 bytes
GET /ui/assets/logos/anthropic.svg -> 200 image/svg+xml
GET /ui/assets/logos/missing.svg -> 404
GET /ui -> 200 text/html
GET /ui/login -> 200 text/html
GET /ui/some-client-route -> 200 text/html
GET /litellm-asset-prefix/_next/static/media/1bffadaabf893a1e-s.16ipb6fqu393i.woff2 -> 200 font/woff2
```

The before run reproduces the exact live signature (200 text/html, 24,860 bytes). After the fix the SVG bytes are served, a genuinely missing asset returns a visible 404 instead of masked HTML, and the SPA fallback, login route, and asset-prefix routing all still behave

## Type

🐛 Bug Fix

## Changes

In the split helm deployment (`helm/litellm`), the dashboard is served by the standalone nginx image built from `ui/Dockerfile`. Every provider logo in the UI renders as the gray letter-avatar fallback there because `ui/nginx.conf` cannot serve `/ui/assets/*`: the SPA fallback regex `location ~ ^/ui/(.+)$` matches those requests and its `try_files /$1.html /$1/index.html /index.html` chain answers with `index.html` (HTTP 200, `text/html`) instead of the image bytes. The browser cannot decode HTML as an image, the `onError` fallback fires, and every logo silently degrades. The asset files themselves are present in the image all along; `COPY --from=builder /app/out /usr/share/nginx/html` includes `out/assets/`

The existing `location /assets/` block never fires for these requests for two reasons: the app requests logos under `/ui/assets/` (the dashboard hardcodes that prefix, mirroring the monolithic proxy's `/ui` StaticFiles mount), and nginx regex locations take priority over plain prefix locations anyway

The fix adds a `location ^~ /ui/assets/` block that aliases to the assets directory. The `^~` modifier is required: without it the `^/ui/(.+)$` regex would keep winning. The block deliberately omits the `expires 1y` + `immutable` headers used by the content-hashed `_next` locations because logo filenames are stable across releases, so aggressive caching would pin stale files

No test is checked above because nothing in CI builds or exercises the nginx image today (`test-litellm-ui-build.yml` only builds the Next.js export); the proof below runs the real image before and after. A routing smoke test workflow for `ui/nginx.conf` would be a reasonable follow-up

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
