### PR TITLE
feat(proxy): auto-enable drop_params for Codex user agents

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -457,12 +457,20 @@ def is_claude_code_user_agent(user_agent: str) -> bool:
     return user_agent.startswith("claude-cli/")
 
 
-def should_auto_drop_params_for_claude_code(user_agent: str, data: dict, proxy_config: ProxyConfig) -> bool:
-    """drop_params defaults to on for Claude Code so its Anthropic-specific
-    params (e.g. thinking) don't fail requests routed to non-Anthropic
-    providers. An explicit drop_params from the caller or in the operator's
-    ``litellm_settings`` always wins over this default."""
-    if not is_claude_code_user_agent(user_agent):
+def is_codex_user_agent(user_agent: str) -> bool:
+    """Codex identifies itself as ``codex_cli_rs/<version> ...`` (TUI),
+    ``codex_exec/<version> ...`` (exec mode), or ``codex_vscode/<version> ...``
+    (IDE extension); all share the ``codex_`` prefix."""
+    return user_agent.startswith("codex_")
+
+
+def should_auto_drop_params_for_agentic_cli(user_agent: str, data: dict, proxy_config: ProxyConfig) -> bool:
+    """drop_params defaults to on for agentic CLIs so their client-specific
+    params (e.g. Claude Code's thinking, Codex's service_tier) don't fail
+    requests routed to providers that reject them. An explicit drop_params
+    from the caller or in the operator's ``litellm_settings`` always wins
+    over this default."""
+    if not (is_claude_code_user_agent(user_agent) or is_codex_user_agent(user_agent)):
         return False
     if "drop_params" in data:
         return False
@@ -1687,7 +1695,7 @@ async def add_litellm_data_to_request(
         user_agent = request.headers["user-agent"]
     data[_metadata_variable_name]["user_agent"] = user_agent
 
-    if should_auto_drop_params_for_claude_code(user_agent, data, proxy_config):
+    if should_auto_drop_params_for_agentic_cli(user_agent, data, proxy_config):
         data["drop_params"] = True
 
     # Merge caller-supplied tags (x-litellm-tags header, data["tags"] root-level)

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -5094,17 +5094,23 @@ def _make_request_mock(path: str, headers: dict) -> MagicMock:
         ("claude-cli/2.0.69 (external, cli)", False, None, False),
         ("claude-cli/2.0.69 (external, cli)", None, False, None),
         ("claude-cli/2.0.69 (external, cli)", None, True, None),
+        ("codex_cli_rs/0.144.5 (Mac OS 26.4.0; arm64) WezTerm", None, None, True),
+        ("codex_exec/0.144.5 (Mac OS 26.4.0; arm64) WarpTerminal (codex_exec; 0.144.5)", None, None, True),
+        ("codex_vscode/0.144.5 (Mac OS 26.4.0; arm64) vscode/1.104.1", None, None, True),
+        ("codex_exec/0.144.5 (Mac OS 26.4.0; arm64)", False, None, False),
+        ("codex_exec/0.144.5 (Mac OS 26.4.0; arm64)", None, True, None),
         ("PostmanRuntime/7.53.0", None, None, None),
         (None, None, None, None),
     ],
 )
-async def test_add_litellm_data_to_request_claude_code_drop_params(
+async def test_add_litellm_data_to_request_agentic_cli_drop_params(
     user_agent, request_drop_params, operator_drop_params, expected_drop_params
 ):
-    """Claude Code sends Anthropic-specific params that fail on non-Anthropic
-    providers, so its user agent must turn on drop_params automatically,
-    without overriding an explicit caller value, an explicit operator-level
-    litellm_settings value, or affecting other clients.
+    """Claude Code sends Anthropic-specific params and Codex sends
+    service_tier, both of which fail on providers that reject them, so those
+    user agents must turn on drop_params automatically, without overriding an
+    explicit caller value, an explicit operator-level litellm_settings value,
+    or affecting other clients.
     """
     headers = {"Content-Type": "application/json"}
     if user_agent is not None:


### PR DESCRIPTION
## Relevant issues

Complements #33228 and #34058 (Codex CLI against `bedrock_mantle/` Responses deployments)

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All runs below were captured at commit d2b573c37d against the real OpenAI API (real spend), proxy booted with

```yaml
model_list:
  - model_name: gpt-5.6-sol
    litellm_params:
      model: openai/gpt-5.6-sol
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
```

Control at the same commit: a non-Codex client sending a param OpenAI does not accept still gets the normal error, so nothing changed for other clients

```bash
curl -s http://localhost:26433/v1/chat/completions -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.6-sol","thinking":{"type":"enabled","budget_tokens":1024},"messages":[{"role":"user","content":"Reply with exactly: ok"}]}'
```

```json
{"error":{"message":"litellm.UnsupportedParamsError: openai does not support parameters: ['thinking'], for model=gpt-5.6-sol. To drop these, set `litellm.drop_params=True` or for proxy:\n\n`litellm_settings:\n drop_params: true`\n...","code":"400"}}
```

The identical body with a Codex user agent succeeds because the proxy now injects `drop_params: true` for it

```bash
curl -s http://localhost:26433/v1/chat/completions -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
  -H "User-Agent: codex_exec/0.144.5 (Mac OS 26.4.0; arm64) WarpTerminal (codex_exec; 0.144.5)" \
  -d '{"model":"gpt-5.6-sol","thinking":{"type":"enabled","budget_tokens":1024},"messages":[{"role":"user","content":"Reply with exactly: ok"}]}'
```

```json
{"id":"chatcmpl-E3uvt26pRA1GDsOTQrxQuLOvn64R1","model":"gpt-5.6-sol","choices":[{"finish_reason":"stop","message":{"content":"ok","role":"assistant"}}]}
```

Real Codex CLI end to end through the same proxy

```
$ npx -y @openai/codex@0.144.5 exec --skip-git-repo-check -s read-only \
    -c model_provider=litellm \
    -c 'model_providers.litellm.name="litellm"' \
    -c 'model_providers.litellm.base_url="http://localhost:26433/v1"' \
    -c 'model_providers.litellm.wire_api="responses"' \
    -c 'model_providers.litellm.env_key="LITELLM_KEY"' \
    -m gpt-5.6-sol "Reply with exactly: codex ua auto drop works"
codex
codex ua auto drop works
tokens used
10,570
```

Proxy debug log from those runs, showing the genuine Codex user agent and the injected flag

```
'user_agent': 'codex_exec/0.144.5 (Mac OS 26.4.0; arm64) WarpTerminal (codex_exec; 0.144.5)'
'drop_params': True
```

## Type

🆕 New Feature

## Changes

Claude Code user agents already get `drop_params` enabled automatically by the proxy so client-specific params do not fail requests routed to providers that reject them. Codex has the same problem: since 0.144 it sends `service_tier: "priority"` whenever a speed tier is selected in `~/.codex/config.toml`, which some providers reject (Bedrock Mantle only accepts `auto` and `default`, see #34058)

This PR extends the existing mechanism to Codex. `is_codex_user_agent` matches the shared `codex_` prefix of `codex_cli_rs/` (TUI), `codex_exec/` (exec mode), and `codex_vscode/` (IDE extension), and `should_auto_drop_params_for_claude_code` is renamed to `should_auto_drop_params_for_agentic_cli` and covers both clients. Precedence is unchanged: an explicit `drop_params` from the caller or in the operator's `litellm_settings` always wins over the default, and non-matching user agents are untouched

Together with #33228 and #34058 this makes Codex against `bedrock_mantle/` Responses deployments work with zero extra proxy configuration

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
