### PR TITLE
fix(proxy): allow model JSON editors to delete keys on save

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -96,6 +96,20 @@ async def get_db_model(model_id: str, prisma_client: PrismaClient) -> Optional[D
     return deployment_pydantic_obj
 
 
+PROTECTED_MODEL_INFO_FIELDS = frozenset(
+    {
+        "id",
+        "db_model",
+        "team_id",
+        "team_public_model_name",
+        "created_at",
+        "created_by",
+        "updated_at",
+        "updated_by",
+    }
+)
+
+
 def update_db_model(db_model: Deployment, updated_patch: updateDeployment) -> PrismaCompatibleUpdateDBModel:
     merged_deployment_dict = DeploymentTypedDict(
         model_name=db_model.model_name,
@@ -127,20 +141,24 @@ def update_db_model(db_model: Deployment, updated_patch: updateDeployment) -> Pr
     # passes through (which today re-sends the OLD pricing on every save) cannot
     # silently undo a litellm_params clear via .update().
     #
-    # Restricted to SPECIAL_MODEL_INFO_PARAMS (input/output cost per token/character
-    # and cache read/write costs) so this path cannot be used to null out privileged
-    # model_info fields like team_id or access groups. SPECIAL_MODEL_INFO_PARAMS are
-    # mirrored between litellm_params and model_info by Deployment.__init__, so the
-    # clear propagates to both blobs.
+    # litellm_params: any key set to null is removed (JSON editors send null for deleted keys).
+    # SPECIAL_MODEL_INFO_PARAMS are mirrored between litellm_params and model_info by
+    # Deployment.__init__, so those clears propagate to both blobs.
+    #
+    # model_info: null clears apply only to non-privileged keys (not id/team_id/ownership).
     if updated_patch.litellm_params:
-        for field in updated_patch.litellm_params.model_fields_set:
-            if field in SPECIAL_MODEL_INFO_PARAMS and getattr(updated_patch.litellm_params, field) is None:
-                merged_deployment_dict["litellm_params"].pop(field, None)  # type: ignore
+        for field, value in updated_patch.litellm_params.model_dump(exclude_unset=True).items():
+            if value is not None:
+                continue
+            merged_deployment_dict["litellm_params"].pop(field, None)  # type: ignore
+            if field in SPECIAL_MODEL_INFO_PARAMS:
                 merged_deployment_dict.get("model_info", {}).pop(field, None)
     if updated_patch.model_info:
-        for field in updated_patch.model_info.model_fields_set:
-            if field in SPECIAL_MODEL_INFO_PARAMS and getattr(updated_patch.model_info, field) is None:
-                merged_deployment_dict["model_info"].pop(field, None)  # type: ignore
+        for field, value in updated_patch.model_info.model_dump(exclude_unset=True).items():
+            if value is not None or field in PROTECTED_MODEL_INFO_FIELDS:
+                continue
+            merged_deployment_dict["model_info"].pop(field, None)  # type: ignore
+            if field in SPECIAL_MODEL_INFO_PARAMS:
                 merged_deployment_dict.get("litellm_params", {}).pop(field, None)  # type: ignore
 
     # convert to prisma compatible format

--- a/tests/e2e/llm_translation/test_messages_mid_conversation_system_native_providers_e2e.py
+++ b/tests/e2e/llm_translation/test_messages_mid_conversation_system_native_providers_e2e.py
@@ -88,9 +88,9 @@ def _system_reminder_turn() -> RichMessage:
 
 
 def _post_messages(client: EndpointsClient, key: str, body: RichMessagesRequest) -> Result[MessagesResult]:
-    return client.gateway.transport.post(
+    return client.proxy.transport.post(
         "/v1/messages",
-        headers=client.gateway.transport.bearer(key),
+        headers=client.proxy.transport.bearer(key),
         json=body,
         response_type=MessagesResult,
     )

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -2644,12 +2644,11 @@ def _build_db_model_with_pricing():
 
 
 class TestUpdateDBModelClearPricing:
-    """Sending an explicit `null` for a pricing field must remove it from both
-    `litellm_params` and `model_info` (SPECIAL_MODEL_INFO_PARAMS are mirrored
-    between the two by Deployment.__init__).
+    """Sending an explicit `null` for a field must remove it from the merged blob.
 
-    Restricted to SPECIAL_MODEL_INFO_PARAMS so non-pricing fields (e.g. team_id)
-    cannot be cleared via this path.
+    Pricing fields (SPECIAL_MODEL_INFO_PARAMS) are mirrored between litellm_params
+    and model_info. Privileged model_info fields (team_id, id, ownership) cannot
+    be cleared via null.
     """
 
     def test_clear_input_cost_removes_from_both_blobs(self):
@@ -2725,11 +2724,8 @@ class TestUpdateDBModelClearPricing:
         assert params["input_cost_per_token"] == 0.000001
         assert params["output_cost_per_token"] == 0.000007
 
-    def test_null_on_non_pricing_field_does_not_clear(self):
-        """Security guard: only SPECIAL_MODEL_INFO_PARAMS can be cleared via null.
-        Privileged or unrelated model_info fields (e.g. team_id) must be unaffected
-        by the null-clearing path so a team admin can't ungate a team-scoped model.
-        """
+    def test_null_clears_non_pricing_litellm_params_key(self):
+        """JSON-editor deletes send null for removed litellm_params keys; those must pop."""
         from litellm.proxy.management_endpoints.model_management_endpoints import (
             update_db_model,
         )
@@ -2744,25 +2740,83 @@ class TestUpdateDBModelClearPricing:
             model_name="openai/*",
             litellm_params=LiteLLM_Params(
                 model="openai/*",
-                input_cost_per_token=0.000001,
+                api_base="https://example.com",
+                someKey=True,
             ),
             model_info=ModelInfo(id="dep-pricing-1", team_id="team-keep-me"),
         )
 
-        # Patch sends a null for api_base (non-SPECIAL field). Must NOT clear team_id
-        # or any other non-pricing field from the merged dict.
         result = update_db_model(
             db_model=db_model,
             updated_patch=updateDeployment(
-                litellm_params=updateLiteLLMParams(api_base=None)
+                litellm_params=updateLiteLLMParams(api_base=None, someKey=None)
+            ),
+        )
+
+        params = json.loads(result["litellm_params"])
+        info = json.loads(result["model_info"])
+        assert "api_base" not in params
+        assert "someKey" not in params
+        assert info.get("team_id") == "team-keep-me"
+
+    def test_null_on_protected_model_info_field_does_not_clear(self):
+        """Privileged model_info fields (e.g. team_id) must not be clearable via null."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            update_db_model,
+        )
+        from litellm.types.router import (
+            Deployment,
+            LiteLLM_Params,
+            ModelInfo,
+        )
+
+        db_model = Deployment(
+            model_name="openai/*",
+            litellm_params=LiteLLM_Params(
+                model="openai/*",
+                input_cost_per_token=0.000001,
+            ),
+            model_info=ModelInfo(id="dep-pricing-1", team_id="team-keep-me", someKey=True),
+        )
+
+        result = update_db_model(
+            db_model=db_model,
+            updated_patch=updateDeployment(
+                model_info=ModelInfo(id="dep-pricing-1", team_id=None, someKey=None)
             ),
         )
 
         info = json.loads(result["model_info"])
-        # Pricing still present (not part of this patch)
-        assert "input_cost_per_token" in info
-        # team_id must survive
         assert info.get("team_id") == "team-keep-me"
+        assert "someKey" not in info
+        assert "input_cost_per_token" in info
+
+    def test_null_clears_custom_model_info_key(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            update_db_model,
+        )
+        from litellm.types.router import (
+            Deployment,
+            LiteLLM_Params,
+            ModelInfo,
+        )
+
+        db_model = Deployment(
+            model_name="openai/*",
+            litellm_params=LiteLLM_Params(model="openai/*"),
+            model_info=ModelInfo(id="dep-1", abc=123, someKey=True),
+        )
+
+        result = update_db_model(
+            db_model=db_model,
+            updated_patch=updateDeployment(
+                model_info=ModelInfo(id="dep-1", abc=123, someKey=None)
+            ),
+        )
+
+        info = json.loads(result["model_info"])
+        assert info.get("abc") == 123
+        assert "someKey" not in info
 
     def test_clear_survives_model_info_passthrough_with_old_pricing(self):
         """Realistic UI submit shape: the patch carries BOTH blobs. The

--- a/ui/litellm-dashboard/src/components/model_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.test.tsx
@@ -607,24 +607,20 @@ describe("ModelInfoView", () => {
 
     const litellmParamsInput = screen
       .getAllByRole("textbox")
-      .find(
-        (input) =>
-          input.tagName === "TEXTAREA" && (input as HTMLTextAreaElement).value.includes('"someKey"'),
-      );
+      .find((input) => input.tagName === "TEXTAREA" && (input as HTMLTextAreaElement).value.includes('"someKey"'));
     expect(litellmParamsInput).toBeDefined();
     if (!litellmParamsInput) {
       return;
     }
 
+    const editedLitellmParams = {
+      model: "gpt-4",
+      api_base: "https://api.openai.com/v1",
+      custom_llm_provider: "openai",
+      abc: 123,
+    };
     await user.clear(litellmParamsInput);
-    await user.paste(
-      JSON.stringify({
-        model: "gpt-4",
-        api_base: "https://api.openai.com/v1",
-        custom_llm_provider: "openai",
-        abc: 123,
-      }),
-    );
+    await user.paste(JSON.stringify(editedLitellmParams));
 
     await user.click(screen.getByRole("button", { name: /save changes/i }));
 
@@ -635,6 +631,147 @@ describe("ModelInfoView", () => {
     const updatePayload = mockModelPatchUpdateCall.mock.calls[0][1];
     expect(updatePayload.litellm_params.someKey).toBeNull();
     expect(updatePayload.litellm_params.abc).toBe(123);
+  });
+
+  it("sends null when Existing Credentials is cleared (#34005)", async () => {
+    const user = userEvent.setup();
+    render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /edit settings/i })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /edit settings/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Existing Credentials")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("selected-credential"));
+    await user.click(await screen.findByText("None"));
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockModelPatchUpdateCall).toHaveBeenCalled();
+    });
+
+    const updatePayload = mockModelPatchUpdateCall.mock.calls[0][1];
+    expect(updatePayload.litellm_params.litellm_credential_name).toBeNull();
+  });
+
+  it("sends null when a masked secret key is removed from LiteLLM Params JSON (#34005)", async () => {
+    const maskedSecret = "azur********************************************BBCC";
+    const maskedModelData = {
+      ...defaultModelData,
+      litellm_params: {
+        model: "azure/gpt-4o",
+        api_base: "https://example-az.openai.azure.com",
+        custom_llm_provider: "azure",
+        azure_ad_token: maskedSecret,
+      },
+    };
+    mockUseModelsInfo.mockReturnValue({
+      data: { data: [maskedModelData] },
+      isLoading: false,
+      error: null,
+    });
+    mockModelInfoV1Call.mockResolvedValue({ data: [maskedModelData] });
+
+    const user = userEvent.setup();
+    render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /edit settings/i })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /edit settings/i }));
+
+    const litellmParamsInput = screen
+      .getAllByRole("textbox")
+      .find((input) => input.tagName === "TEXTAREA" && (input as HTMLTextAreaElement).value.includes("azure_ad_token"));
+    expect(litellmParamsInput).toBeDefined();
+    if (!litellmParamsInput) {
+      return;
+    }
+
+    const editedWithoutSecret = {
+      model: "azure/gpt-4o",
+      api_base: "https://example-az.openai.azure.com",
+      custom_llm_provider: "azure",
+    };
+    await user.clear(litellmParamsInput);
+    await user.paste(JSON.stringify(editedWithoutSecret));
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockModelPatchUpdateCall).toHaveBeenCalled();
+    });
+
+    const updatePayload = mockModelPatchUpdateCall.mock.calls[0][1];
+    expect(updatePayload.litellm_params.azure_ad_token).toBeNull();
+  });
+
+  it("keeps deleted model_info keys off the form after save so cancel cannot restore them (#34005)", async () => {
+    const modelWithExtraInfo = {
+      ...defaultModelData,
+      model_info: {
+        ...defaultModelData.model_info,
+        someKey: true,
+      },
+    };
+    mockUseModelsInfo.mockReturnValue({
+      data: { data: [modelWithExtraInfo] },
+      isLoading: false,
+      error: null,
+    });
+    mockModelInfoV1Call.mockResolvedValue({ data: [modelWithExtraInfo] });
+
+    const user = userEvent.setup();
+    render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /edit settings/i })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /edit settings/i }));
+
+    const modelInfoInput = screen
+      .getAllByRole("textbox")
+      .find(
+        (input) =>
+          input.tagName === "TEXTAREA" &&
+          (input as HTMLTextAreaElement).value.includes('"someKey"') &&
+          (input as HTMLTextAreaElement).value.includes('"db_model"'),
+      );
+    expect(modelInfoInput).toBeDefined();
+    if (!modelInfoInput) {
+      return;
+    }
+
+    const editedInfo = {
+      id: "123",
+      created_by: "123",
+      created_at: "2024-01-01T00:00:00Z",
+      db_model: true,
+      input_cost_per_token: 0.00003,
+      output_cost_per_token: 0.00006,
+    };
+    await user.clear(modelInfoInput);
+    await user.paste(JSON.stringify(editedInfo));
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockModelPatchUpdateCall).toHaveBeenCalled();
+    });
+
+    await user.click(screen.getByRole("button", { name: /edit settings/i }));
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    await user.click(screen.getByRole("button", { name: /edit settings/i }));
+
+    const modelInfoAfterCancel = screen
+      .getAllByRole("textbox")
+      .find((input) => input.tagName === "TEXTAREA" && (input as HTMLTextAreaElement).value.includes('"db_model"'));
+    expect(modelInfoAfterCancel).toBeDefined();
+    expect((modelInfoAfterCancel as HTMLTextAreaElement).value).not.toContain('"someKey"');
   });
 
   it("sends null for keys removed from Model Info JSON so PATCH merge deletes them (#34005)", async () => {

--- a/ui/litellm-dashboard/src/components/model_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.test.tsx
@@ -581,6 +581,123 @@ describe("ModelInfoView", () => {
     expect(updatePayload.litellm_params.litellm_credential_name).not.toBe("from-json");
   });
 
+  it("sends null for keys removed from LiteLLM Params JSON so PATCH merge deletes them (#34005)", async () => {
+    const modelWithExtraKey = {
+      ...defaultModelData,
+      litellm_params: {
+        ...defaultModelData.litellm_params,
+        someKey: true,
+        abc: 123,
+      },
+    };
+    mockUseModelsInfo.mockReturnValue({
+      data: { data: [modelWithExtraKey] },
+      isLoading: false,
+      error: null,
+    });
+    mockModelInfoV1Call.mockResolvedValue({ data: [modelWithExtraKey] });
+
+    const user = userEvent.setup();
+    render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /edit settings/i })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /edit settings/i }));
+
+    const litellmParamsInput = screen
+      .getAllByRole("textbox")
+      .find(
+        (input) =>
+          input.tagName === "TEXTAREA" && (input as HTMLTextAreaElement).value.includes('"someKey"'),
+      );
+    expect(litellmParamsInput).toBeDefined();
+    if (!litellmParamsInput) {
+      return;
+    }
+
+    await user.clear(litellmParamsInput);
+    await user.paste(
+      JSON.stringify({
+        model: "gpt-4",
+        api_base: "https://api.openai.com/v1",
+        custom_llm_provider: "openai",
+        abc: 123,
+      }),
+    );
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockModelPatchUpdateCall).toHaveBeenCalled();
+    });
+
+    const updatePayload = mockModelPatchUpdateCall.mock.calls[0][1];
+    expect(updatePayload.litellm_params.someKey).toBeNull();
+    expect(updatePayload.litellm_params.abc).toBe(123);
+  });
+
+  it("sends null for keys removed from Model Info JSON so PATCH merge deletes them (#34005)", async () => {
+    const modelWithExtraInfo = {
+      ...defaultModelData,
+      model_info: {
+        ...defaultModelData.model_info,
+        someKey: true,
+        abc: 123,
+      },
+    };
+    mockUseModelsInfo.mockReturnValue({
+      data: { data: [modelWithExtraInfo] },
+      isLoading: false,
+      error: null,
+    });
+    mockModelInfoV1Call.mockResolvedValue({ data: [modelWithExtraInfo] });
+
+    const user = userEvent.setup();
+    render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /edit settings/i })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /edit settings/i }));
+
+    const modelInfoInput = screen
+      .getAllByRole("textbox")
+      .find(
+        (input) =>
+          input.tagName === "TEXTAREA" &&
+          (input as HTMLTextAreaElement).value.includes('"someKey"') &&
+          (input as HTMLTextAreaElement).value.includes('"db_model"'),
+      );
+    expect(modelInfoInput).toBeDefined();
+    if (!modelInfoInput) {
+      return;
+    }
+
+    const editedInfo = {
+      id: "123",
+      created_by: "123",
+      created_at: "2024-01-01T00:00:00Z",
+      db_model: true,
+      input_cost_per_token: 0.00003,
+      output_cost_per_token: 0.00006,
+      abc: 123,
+    };
+    await user.clear(modelInfoInput);
+    await user.paste(JSON.stringify(editedInfo));
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockModelPatchUpdateCall).toHaveBeenCalled();
+    });
+
+    const updatePayload = mockModelPatchUpdateCall.mock.calls[0][1];
+    expect(updatePayload.model_info.someKey).toBeNull();
+    expect(updatePayload.model_info.abc).toBe(123);
+    expect(updatePayload.model_info.id).toBe("123");
+  });
+
   it("should not include vector_store_ids in update payload when model has none", async () => {
     // Regression: editing a model without vector stores used to inject
     // vector_store_ids: [] into litellm_params, which then propagated to

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -23,6 +23,7 @@ import { CheckIcon, CopyIcon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { copyToClipboard as utilCopyToClipboard } from "../utils/dataUtils";
 import { isMaskedSecret, stripMaskedSecrets } from "../utils/maskedSecretUtils";
+import { PROTECTED_MODEL_INFO_KEYS, withNullsForRemovedKeys } from "../utils/modelJsonPatchUtils";
 import { formItemValidateJSON, truncateString } from "../utils/textUtils";
 import AutoRouterConnectionTest from "./add_model/auto_router_connection_test";
 import { AutoRouterTestTarget, buildAutoRouterTestTargets } from "./add_model/build_auto_router_test_targets";
@@ -404,18 +405,15 @@ export default function ModelInfoView({
         delete updatedLitellmParams.cache_control_injection_points;
       }
 
-      // Parse the model_info from the form values
       let updatedModelInfo;
       try {
         updatedModelInfo = values.model_info ? JSON.parse(values.model_info) : modelData.model_info;
-        // Update access_groups from the form
         if (values.model_access_group) {
           updatedModelInfo = {
             ...updatedModelInfo,
             access_groups: values.model_access_group,
           };
         }
-        // Override health_check_model from the form
         if (values.health_check_model !== undefined) {
           updatedModelInfo = {
             ...updatedModelInfo,
@@ -427,26 +425,49 @@ export default function ModelInfoView({
         return;
       }
 
-      // Final guard: never PATCH a redacted secret. The /model/info snapshot that
-      // seeds this form masks secrets, and any save re-sends the whole params blob;
-      // without this strip a masked value would be re-encrypted over the real secret.
-      // Credential rotation has its own dedicated path (UpdateModelCredentialsModal).
-      const safeLitellmParams = stripMaskedSecrets(updatedLitellmParams);
+      const previousLitellmParams = (localModelData.litellm_params || {}) as Record<string, unknown>;
+      const skipLitellmNulls = new Set<string>(
+        Object.entries(previousLitellmParams)
+          .filter(([key, value]) => key === "litellm_credential_name" || isMaskedSecret(value))
+          .map(([key]) => key),
+      );
+      if (!values.litellm_credential_name) {
+        skipLitellmNulls.add("litellm_credential_name");
+      }
+
+      const safeLitellmParams = withNullsForRemovedKeys(
+        previousLitellmParams,
+        stripMaskedSecrets(updatedLitellmParams),
+        skipLitellmNulls,
+      );
+
+      const patchedModelInfo = withNullsForRemovedKeys(
+        (localModelData.model_info || {}) as Record<string, unknown>,
+        updatedModelInfo as Record<string, unknown>,
+        PROTECTED_MODEL_INFO_KEYS,
+      );
 
       const updateData = {
         model_name: values.model_name,
         litellm_params: safeLitellmParams,
-        model_info: updatedModelInfo,
+        model_info: patchedModelInfo,
       };
 
       await modelPatchUpdateCall(accessToken, updateData, modelId);
+
+      const displayLitellmParams = Object.fromEntries(
+        Object.entries(safeLitellmParams).filter(([, value]) => value !== null),
+      );
+      const displayModelInfo = Object.fromEntries(
+        Object.entries(patchedModelInfo).filter(([, value]) => value !== null),
+      );
 
       const updatedModelData = {
         ...localModelData,
         model_name: values.model_name,
         litellm_model_name: values.litellm_model_name,
-        litellm_params: safeLitellmParams,
-        model_info: updatedModelInfo,
+        litellm_params: displayLitellmParams,
+        model_info: displayModelInfo,
       };
 
       setLocalModelData(updatedModelData);
@@ -824,6 +845,7 @@ export default function ModelInfoView({
                       null,
                       2,
                     ),
+                    model_info: JSON.stringify(localModelData.model_info || {}, null, 2),
                   }}
                   layout="vertical"
                   onValuesChange={() => setIsDirty(true)}
@@ -1343,12 +1365,8 @@ export default function ModelInfoView({
                       <div>
                         <Text className="font-medium">Model Info</Text>
                         {isEditing ? (
-                          <Form.Item name="model_info" className="mb-0">
-                            <Input.TextArea
-                              rows={4}
-                              placeholder='{"gpt-4": 100, "claude-v1": 200}'
-                              defaultValue={JSON.stringify(modelData.model_info, null, 2)}
-                            />
+                          <Form.Item name="model_info" className="mb-0" rules={[{ validator: formItemValidateJSON }]}>
+                            <Input.TextArea rows={4} placeholder='{"gpt-4": 100, "claude-v1": 200}' />
                           </Form.Item>
                         ) : (
                           <div className="mt-1 p-2 bg-gray-50 rounded-sm">

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -84,6 +84,67 @@ interface ComplexityRouterModelData {
   };
 }
 
+const buildModelEditFormValues = (
+  model: {
+    model_name?: string;
+    litellm_model_name?: string;
+    litellm_params?: Record<string, any>;
+    model_info?: Record<string, any>;
+  },
+  isWildcardModel: boolean,
+) => {
+  const litellmParams = model.litellm_params || {};
+  const modelInfo = model.model_info || {};
+  return {
+    model_name: model.model_name,
+    litellm_model_name: model.litellm_model_name,
+    api_base: litellmParams.api_base,
+    custom_llm_provider: litellmParams.custom_llm_provider,
+    organization: litellmParams.organization,
+    tpm: litellmParams.tpm,
+    rpm: litellmParams.rpm,
+    max_retries: litellmParams.max_retries,
+    timeout: litellmParams.timeout,
+    stream_timeout: litellmParams.stream_timeout,
+    input_cost: litellmParams.input_cost_per_token
+      ? litellmParams.input_cost_per_token * 1_000_000
+      : modelInfo.input_cost_per_token * 1_000_000 || null,
+    output_cost: litellmParams.output_cost_per_token
+      ? litellmParams.output_cost_per_token * 1_000_000
+      : modelInfo.output_cost_per_token * 1_000_000 || null,
+    cache_read_cost:
+      litellmParams.cache_read_input_token_cost !== undefined && litellmParams.cache_read_input_token_cost !== null
+        ? litellmParams.cache_read_input_token_cost * 1_000_000
+        : modelInfo.cache_read_input_token_cost !== undefined && modelInfo.cache_read_input_token_cost !== null
+          ? modelInfo.cache_read_input_token_cost * 1_000_000
+          : null,
+    cache_write_cost:
+      litellmParams.cache_creation_input_token_cost !== undefined &&
+      litellmParams.cache_creation_input_token_cost !== null
+        ? litellmParams.cache_creation_input_token_cost * 1_000_000
+        : modelInfo.cache_creation_input_token_cost !== undefined && modelInfo.cache_creation_input_token_cost !== null
+          ? modelInfo.cache_creation_input_token_cost * 1_000_000
+          : null,
+    cache_control: litellmParams.cache_control_injection_points ? true : false,
+    cache_control_injection_points: litellmParams.cache_control_injection_points || [],
+    model_access_group: Array.isArray(modelInfo.access_groups) ? modelInfo.access_groups : [],
+    guardrails: Array.isArray(litellmParams.guardrails) ? litellmParams.guardrails : [],
+    vector_store_ids:
+      Array.isArray(litellmParams.vector_store_ids) && litellmParams.vector_store_ids.length > 0
+        ? litellmParams.vector_store_ids
+        : undefined,
+    tags: Array.isArray(litellmParams.tags) ? litellmParams.tags : [],
+    health_check_model: isWildcardModel ? modelInfo.health_check_model : null,
+    litellm_credential_name: litellmParams.litellm_credential_name || "",
+    litellm_extra_params: JSON.stringify(
+      Object.fromEntries(Object.entries(litellmParams).filter(([key]) => key !== "litellm_credential_name")),
+      null,
+      2,
+    ),
+    model_info: JSON.stringify(modelInfo, null, 2),
+  };
+};
+
 const buildComplexityRouterTestTargets = (
   modelData: ComplexityRouterModelData | null | undefined,
 ): AutoRouterTestTarget[] => {
@@ -383,6 +444,8 @@ export default function ModelInfoView({
 
       if (values.litellm_credential_name) {
         updatedLitellmParams.litellm_credential_name = values.litellm_credential_name;
+      } else if (localModelData.litellm_params?.litellm_credential_name) {
+        updatedLitellmParams.litellm_credential_name = null;
       } else {
         delete updatedLitellmParams.litellm_credential_name;
       }
@@ -428,12 +491,11 @@ export default function ModelInfoView({
       const previousLitellmParams = (localModelData.litellm_params || {}) as Record<string, unknown>;
       const skipLitellmNulls = new Set<string>(
         Object.entries(previousLitellmParams)
-          .filter(([key, value]) => key === "litellm_credential_name" || isMaskedSecret(value))
+          .filter(
+            ([key, value]) => isMaskedSecret(value) && Object.prototype.hasOwnProperty.call(parsedExtraParams, key),
+          )
           .map(([key]) => key),
       );
-      if (!values.litellm_credential_name) {
-        skipLitellmNulls.add("litellm_credential_name");
-      }
 
       const safeLitellmParams = withNullsForRemovedKeys(
         previousLitellmParams,
@@ -471,6 +533,9 @@ export default function ModelInfoView({
       };
 
       setLocalModelData(updatedModelData);
+      form.setFieldsValue(
+        buildModelEditFormValues(updatedModelData, Boolean(values.litellm_model_name?.includes("*"))),
+      );
 
       if (onModelUpdate) {
         onModelUpdate(updatedModelData);
@@ -787,66 +852,7 @@ export default function ModelInfoView({
                 <Form
                   form={form}
                   onFinish={handleModelUpdate}
-                  initialValues={{
-                    model_name: localModelData.model_name,
-                    litellm_model_name: localModelData.litellm_model_name,
-                    api_base: localModelData.litellm_params.api_base,
-                    custom_llm_provider: localModelData.litellm_params.custom_llm_provider,
-                    organization: localModelData.litellm_params.organization,
-                    tpm: localModelData.litellm_params.tpm,
-                    rpm: localModelData.litellm_params.rpm,
-                    max_retries: localModelData.litellm_params.max_retries,
-                    timeout: localModelData.litellm_params.timeout,
-                    stream_timeout: localModelData.litellm_params.stream_timeout,
-                    input_cost: localModelData.litellm_params.input_cost_per_token
-                      ? localModelData.litellm_params.input_cost_per_token * 1_000_000
-                      : localModelData.model_info?.input_cost_per_token * 1_000_000 || null,
-                    output_cost: localModelData.litellm_params?.output_cost_per_token
-                      ? localModelData.litellm_params.output_cost_per_token * 1_000_000
-                      : localModelData.model_info?.output_cost_per_token * 1_000_000 || null,
-                    cache_read_cost:
-                      localModelData.litellm_params?.cache_read_input_token_cost !== undefined &&
-                      localModelData.litellm_params?.cache_read_input_token_cost !== null
-                        ? localModelData.litellm_params.cache_read_input_token_cost * 1_000_000
-                        : localModelData.model_info?.cache_read_input_token_cost !== undefined &&
-                            localModelData.model_info?.cache_read_input_token_cost !== null
-                          ? localModelData.model_info.cache_read_input_token_cost * 1_000_000
-                          : null,
-                    cache_write_cost:
-                      localModelData.litellm_params?.cache_creation_input_token_cost !== undefined &&
-                      localModelData.litellm_params?.cache_creation_input_token_cost !== null
-                        ? localModelData.litellm_params.cache_creation_input_token_cost * 1_000_000
-                        : localModelData.model_info?.cache_creation_input_token_cost !== undefined &&
-                            localModelData.model_info?.cache_creation_input_token_cost !== null
-                          ? localModelData.model_info.cache_creation_input_token_cost * 1_000_000
-                          : null,
-                    cache_control: localModelData.litellm_params?.cache_control_injection_points ? true : false,
-                    cache_control_injection_points: localModelData.litellm_params?.cache_control_injection_points || [],
-                    model_access_group: Array.isArray(localModelData.model_info?.access_groups)
-                      ? localModelData.model_info.access_groups
-                      : [],
-                    guardrails: Array.isArray(localModelData.litellm_params?.guardrails)
-                      ? localModelData.litellm_params.guardrails
-                      : [],
-                    vector_store_ids:
-                      Array.isArray(localModelData.litellm_params?.vector_store_ids) &&
-                      localModelData.litellm_params.vector_store_ids.length > 0
-                        ? localModelData.litellm_params.vector_store_ids
-                        : undefined,
-                    tags: Array.isArray(localModelData.litellm_params?.tags) ? localModelData.litellm_params.tags : [],
-                    health_check_model: isWildcardModel ? localModelData.model_info?.health_check_model : null,
-                    litellm_credential_name: localModelData.litellm_params?.litellm_credential_name || "",
-                    litellm_extra_params: JSON.stringify(
-                      Object.fromEntries(
-                        Object.entries(localModelData.litellm_params || {}).filter(
-                          ([key, value]) => key !== "litellm_credential_name" && !isMaskedSecret(value),
-                        ),
-                      ),
-                      null,
-                      2,
-                    ),
-                    model_info: JSON.stringify(localModelData.model_info || {}, null, 2),
-                  }}
+                  initialValues={buildModelEditFormValues(localModelData, isWildcardModel)}
                   layout="vertical"
                   onValuesChange={() => setIsDirty(true)}
                 >
@@ -1422,7 +1428,7 @@ export default function ModelInfoView({
                         <TremorButton
                           variant="secondary"
                           onClick={() => {
-                            form.resetFields();
+                            form.setFieldsValue(buildModelEditFormValues(localModelData, isWildcardModel));
                             setIsDirty(false);
                             setIsEditing(false);
                           }}

--- a/ui/litellm-dashboard/src/utils/modelJsonPatchUtils.test.ts
+++ b/ui/litellm-dashboard/src/utils/modelJsonPatchUtils.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { PROTECTED_MODEL_INFO_KEYS, withNullsForRemovedKeys } from "./modelJsonPatchUtils";
+
+describe("withNullsForRemovedKeys", () => {
+  it("nulls keys removed from the edited JSON so PATCH merge deletes them", () => {
+    const previous = { abc: 123, someKey: true, keep: "yes" };
+    const next = { abc: 123, keep: "yes" };
+
+    expect(withNullsForRemovedKeys(previous, next)).toEqual({
+      abc: 123,
+      keep: "yes",
+      someKey: null,
+    });
+  });
+
+  it("does not null keys listed in skip (masked secrets / credential)", () => {
+    const previous = { api_key: "sk-****abcd", custom: 1 };
+    const next = { custom: 1 };
+
+    expect(withNullsForRemovedKeys(previous, next, new Set(["api_key"]))).toEqual({
+      custom: 1,
+    });
+  });
+
+  it("returns a copy of next when previous is missing", () => {
+    const next = { a: 1 };
+    expect(withNullsForRemovedKeys(undefined, next)).toEqual({ a: 1 });
+    expect(withNullsForRemovedKeys(null, next)).toEqual({ a: 1 });
+  });
+
+  it("protects model_info identity fields via PROTECTED_MODEL_INFO_KEYS", () => {
+    const previous = {
+      id: "dep-1",
+      team_id: "team-keep",
+      someKey: true,
+      abc: 1,
+    };
+    const next = { id: "dep-1", abc: 1 };
+
+    expect(withNullsForRemovedKeys(previous, next, PROTECTED_MODEL_INFO_KEYS)).toEqual({
+      id: "dep-1",
+      abc: 1,
+      someKey: null,
+    });
+  });
+});

--- a/ui/litellm-dashboard/src/utils/modelJsonPatchUtils.ts
+++ b/ui/litellm-dashboard/src/utils/modelJsonPatchUtils.ts
@@ -1,0 +1,31 @@
+export function withNullsForRemovedKeys(
+  previous: Record<string, unknown> | null | undefined,
+  next: Record<string, unknown>,
+  skip?: ReadonlySet<string>,
+): Record<string, unknown> {
+  if (!previous) {
+    return { ...next };
+  }
+
+  const result: Record<string, unknown> = { ...next };
+  for (const key of Object.keys(previous)) {
+    if (skip?.has(key)) {
+      continue;
+    }
+    if (!(key in result)) {
+      result[key] = null;
+    }
+  }
+  return result;
+}
+
+export const PROTECTED_MODEL_INFO_KEYS = new Set([
+  "id",
+  "db_model",
+  "team_id",
+  "team_public_model_name",
+  "created_at",
+  "created_by",
+  "updated_at",
+  "updated_by",
+]);


### PR DESCRIPTION
PATCH /model/{id}/update kept omitted keys via shallow merge, so removing a key in the Admin UI JSON editors did nothing. This sends explicit nulls for deleted keys and honors them in update_db_model, while protecting privileged model_info fields (id, team_id, ownership, timestamps).

Fixes #34005