### PR TITLE
feat(bedrock): add aws_session_tags support for STS AssumeRole

### DIFF
--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -50,7 +50,9 @@ _STS_REGION_FROM_ENDPOINT_PATTERN = re.compile(
     r"(?:^|\.)sts(?:-fips)?\.([a-z0-9-]+)\.(?:amazonaws\.com(?:\.cn)?|vpce\.amazonaws\.com)"
 )
 
-SIGV4_COMPUTED_HEADERS = frozenset({"authorization", "x-amz-date", "x-amz-security-token", "date"})
+SIGV4_COMPUTED_HEADERS = frozenset(
+    {"authorization", "x-amz-date", "x-amz-security-token", "date"}
+)
 
 
 class Boto3CredentialsInfo(BaseModel):
@@ -68,9 +70,13 @@ class AwsAuthError(Exception):
     def __init__(self, status_code, message):
         self.status_code = status_code
         self.message = message
-        self.request = httpx.Request(method="POST", url="https://us-west-2.console.aws.amazon.com/bedrock")
+        self.request = httpx.Request(
+            method="POST", url="https://us-west-2.console.aws.amazon.com/bedrock"
+        )
         self.response = httpx.Response(status_code=status_code, request=self.request)
-        super().__init__(self.message)  # Call the base class constructor with the parameters it needs
+        super().__init__(
+            self.message
+        )  # Call the base class constructor with the parameters it needs
 
 
 class BaseAWSLLM:
@@ -158,7 +164,11 @@ class BaseAWSLLM:
         aws_role_name: Optional[str],
         aws_session_name: Optional[str],
     ) -> bool:
-        return aws_web_identity_token is not None and aws_role_name is not None and aws_session_name is not None
+        return (
+            aws_web_identity_token is not None
+            and aws_role_name is not None
+            and aws_session_name is not None
+        )
 
     @staticmethod
     def _is_auth_with_aws_role(aws_role_name: Optional[str]) -> bool:
@@ -174,7 +184,11 @@ class BaseAWSLLM:
         aws_secret_access_key: Optional[str],
         aws_session_token: Optional[str],
     ) -> bool:
-        return aws_access_key_id is not None and aws_secret_access_key is not None and aws_session_token is not None
+        return (
+            aws_access_key_id is not None
+            and aws_secret_access_key is not None
+            and aws_session_token is not None
+        )
 
     @staticmethod
     def _is_auth_with_access_key_and_secret_key(
@@ -182,7 +196,11 @@ class BaseAWSLLM:
         aws_secret_access_key: Optional[str],
         aws_region_name: Optional[str],
     ) -> bool:
-        return aws_access_key_id is not None and aws_secret_access_key is not None and aws_region_name is not None
+        return (
+            aws_access_key_id is not None
+            and aws_secret_access_key is not None
+            and aws_region_name is not None
+        )
 
     @tracer.wrap()
     def get_credentials(
@@ -197,7 +215,7 @@ class BaseAWSLLM:
         aws_web_identity_token: Optional[str] = None,
         aws_sts_endpoint: Optional[str] = None,
         aws_external_id: Optional[str] = None,
-        aws_session_tags: Optional[List[dict]] = None,
+        aws_session_tags: Optional[list[dict]] = None,
         ssl_verify: Optional[Union[bool, str]] = None,
     ):
         """
@@ -259,7 +277,11 @@ class BaseAWSLLM:
             aws_external_id,
         )
 
-        args = {k: v for k, v in locals().items() if k.startswith("aws_") or k == "ssl_verify"}
+        args = {
+            k: v
+            for k, v in locals().items()
+            if k.startswith("aws_") or k == "ssl_verify"
+        }
 
         #########################################################
         # Handle diff boto3 auth flows
@@ -288,12 +310,16 @@ class BaseAWSLLM:
         elif self._is_auth_with_aws_role(aws_role_name):
             # Same role (IRSA/ECS/EC2): ambient creds via _get_or_set_cached_credentials like the
             # default env branch; never pre-read cache (must run _is_already_running_as_role first).
-            if self._is_already_running_as_role(cast(str, aws_role_name), ssl_verify=ssl_verify):
+            if self._is_already_running_as_role(
+                cast(str, aws_role_name), ssl_verify=ssl_verify
+            ):
                 verbose_logger.debug(
                     "Already running as target role %s, using ambient credentials",
                     aws_role_name,
                 )
-                return self._get_or_set_cached_credentials(args, self._auth_with_env_vars)
+                return self._get_or_set_cached_credentials(
+                    args, self._auth_with_env_vars
+                )
             verbose_logger.debug("Using role assumption: calling _auth_with_aws_role")
             # If aws_session_name is not provided, generate a default one
             if aws_session_name is None:
@@ -313,7 +339,9 @@ class BaseAWSLLM:
             return credentials
 
         elif self._is_auth_with_aws_profile(aws_profile_name):
-            credentials, _cache_ttl = self._auth_with_aws_profile(cast(str, aws_profile_name))
+            credentials, _cache_ttl = self._auth_with_aws_profile(
+                cast(str, aws_profile_name)
+            )
             return credentials
         elif self._is_auth_with_aws_session_token_tuple(
             aws_access_key_id,
@@ -454,23 +482,41 @@ class BaseAWSLLM:
 
         model_id = model_id.replace("invoke/", "", 1)
         if provider == "llama" and "llama/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(model_id, spec="llama")
+            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
+                model_id, spec="llama"
+            )
         elif provider == "deepseek_r1" and "deepseek_r1/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(model_id, spec="deepseek_r1")
+            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
+                model_id, spec="deepseek_r1"
+            )
         elif provider == "openai" and "openai/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(model_id, spec="openai")
+            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
+                model_id, spec="openai"
+            )
         elif provider == "qwen2" and "qwen2/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(model_id, spec="qwen2")
+            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
+                model_id, spec="qwen2"
+            )
         elif provider == "qwen3" and "qwen3/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(model_id, spec="qwen3")
+            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
+                model_id, spec="qwen3"
+            )
         elif provider == "stability" and "stability/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(model_id, spec="stability")
+            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
+                model_id, spec="stability"
+            )
         elif provider == "moonshot" and "moonshot/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(model_id, spec="moonshot")
+            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
+                model_id, spec="moonshot"
+            )
         elif "nova-2/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(model_id, spec="nova-2")
+            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
+                model_id, spec="nova-2"
+            )
         elif "nova/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(model_id, spec="nova")
+            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
+                model_id, spec="nova"
+            )
         return model_id
 
     @staticmethod
@@ -520,12 +566,16 @@ class BaseAWSLLM:
             parts = model.split(".")
             # Check if the second part (after potential region) is a known provider
             if len(parts) >= 2:
-                potential_provider = parts[1]  # e.g., "twelvelabs" from "us.twelvelabs.marengo-embed-2-7-v1:0"
+                potential_provider = parts[
+                    1
+                ]  # e.g., "twelvelabs" from "us.twelvelabs.marengo-embed-2-7-v1:0"
                 if potential_provider in get_args(BEDROCK_EMBEDDING_PROVIDERS_LITERAL):
                     return cast(BEDROCK_EMBEDDING_PROVIDERS_LITERAL, potential_provider)
 
             # Check if the first part is a known provider (standard format)
-            potential_provider = parts[0]  # e.g., "cohere" from "cohere.embed-english-v3:0"
+            potential_provider = parts[
+                0
+            ]  # e.g., "cohere" from "cohere.embed-english-v3:0"
             if potential_provider in get_args(BEDROCK_EMBEDDING_PROVIDERS_LITERAL):
                 return cast(BEDROCK_EMBEDDING_PROVIDERS_LITERAL, potential_provider)
 
@@ -604,7 +654,9 @@ class BaseAWSLLM:
         """
         if aws_region_name is None:
             return
-        if not isinstance(aws_region_name, str) or not _VALID_AWS_REGION_PATTERN.match(aws_region_name):
+        if not isinstance(aws_region_name, str) or not _VALID_AWS_REGION_PATTERN.match(
+            aws_region_name
+        ):
             raise ValueError(
                 f"Invalid AWS region format: {aws_region_name!r}. "
                 "Region names must contain only lowercase letters, digits, and hyphens."
@@ -660,11 +712,15 @@ class BaseAWSLLM:
             # check env #
             litellm_aws_region_name = get_secret("AWS_REGION_NAME", None)
 
-            if litellm_aws_region_name is not None and isinstance(litellm_aws_region_name, str):
+            if litellm_aws_region_name is not None and isinstance(
+                litellm_aws_region_name, str
+            ):
                 aws_region_name = litellm_aws_region_name
 
             standard_aws_region_name = get_secret("AWS_REGION", None)
-            if standard_aws_region_name is not None and isinstance(standard_aws_region_name, str):
+            if standard_aws_region_name is not None and isinstance(
+                standard_aws_region_name, str
+            ):
                 aws_region_name = standard_aws_region_name
 
             if aws_region_name is None:
@@ -747,7 +803,9 @@ class BaseAWSLLM:
             import boto3
 
             with tracer.trace("boto3.client(sts).get_caller_identity"):
-                sts_client = boto3.client("sts", verify=self._get_ssl_verify(ssl_verify))
+                sts_client = boto3.client(
+                    "sts", verify=self._get_ssl_verify(ssl_verify)
+                )
                 identity = sts_client.get_caller_identity()
                 caller_arn = identity.get("Arn", "")
 
@@ -766,7 +824,9 @@ class BaseAWSLLM:
                     return True
 
         except Exception as e:
-            verbose_logger.debug("Could not determine current role identity: %s", str(e))
+            verbose_logger.debug(
+                "Could not determine current role identity: %s", str(e)
+            )
 
         return False
 
@@ -814,7 +874,10 @@ class BaseAWSLLM:
         # references are expanded at load time, so such a reference reaching here is
         # caller-supplied input; reject it rather than expanding a process-environment
         # value for use as the token.
-        if aws_web_identity_token.startswith("os.environ/") or aws_web_identity_token in os.environ:
+        if (
+            aws_web_identity_token.startswith("os.environ/")
+            or aws_web_identity_token in os.environ
+        ):
             raise AwsAuthError(
                 message="Invalid web identity token reference.",
                 status_code=400,
@@ -904,9 +967,15 @@ class BaseAWSLLM:
             assume_role_params["ExternalId"] = aws_external_id
 
         try:
-            sts_response = sts_client.assume_role_with_web_identity(**assume_role_params)
+            sts_response = sts_client.assume_role_with_web_identity(
+                **assume_role_params
+            )
         except sts_client.exceptions.InvalidIdentityTokenException as e:
-            audience = self._unverified_web_identity_audience(oidc_token) if isinstance(oidc_token, str) else None
+            audience = (
+                self._unverified_web_identity_audience(oidc_token)
+                if isinstance(oidc_token, str)
+                else None
+            )
             detail = f" Token {audience}" if audience else ""
             raise AwsAuthError(
                 status_code=401,
@@ -938,7 +1007,7 @@ class BaseAWSLLM:
         aws_session_name: str,
         web_identity_token_file: str,
         aws_external_id: Optional[str] = None,
-        aws_session_tags: Optional[List[dict]] = None,
+        aws_session_tags: Optional[list[dict]] = None,
         aws_sts_endpoint: Optional[str] = None,
         ssl_verify: Optional[Union[bool, str]] = None,
     ) -> dict:
@@ -961,7 +1030,9 @@ class BaseAWSLLM:
             sts_client = boto3.client("sts", **irsa_sts_kwargs)
 
         # Manually assume the IRSA role with the session name
-        verbose_logger.debug(f"Manually assuming IRSA role {irsa_role_arn} with session {aws_session_name}")
+        verbose_logger.debug(
+            f"Manually assuming IRSA role {irsa_role_arn} with session {aws_session_name}"
+        )
         irsa_response = sts_client.assume_role_with_web_identity(
             RoleArn=irsa_role_arn,
             RoleSessionName=aws_session_name,
@@ -991,7 +1062,9 @@ class BaseAWSLLM:
             verbose_logger.debug(f"Failed to get caller identity: {e}")
 
         # Now assume the target role
-        verbose_logger.debug(f"Attempting to assume target role: {aws_role_name} with session: {aws_session_name}")
+        verbose_logger.debug(
+            f"Attempting to assume target role: {aws_role_name} with session: {aws_session_name}"
+        )
         assume_role_params = {
             "RoleArn": aws_role_name,
             "RoleSessionName": aws_session_name,
@@ -1009,7 +1082,7 @@ class BaseAWSLLM:
         aws_role_name: str,
         aws_session_name: str,
         aws_external_id: Optional[str] = None,
-        aws_session_tags: Optional[List[dict]] = None,
+        aws_session_tags: Optional[list[dict]] = None,
         aws_sts_endpoint: Optional[str] = None,
         ssl_verify: Optional[Union[bool, str]] = None,
     ) -> dict:
@@ -1028,12 +1101,16 @@ class BaseAWSLLM:
         # Get current caller identity for debugging
         try:
             caller_identity = sts_client.get_caller_identity()
-            verbose_logger.debug(f"Current IRSA identity: {caller_identity.get('Arn', 'unknown')}")
+            verbose_logger.debug(
+                f"Current IRSA identity: {caller_identity.get('Arn', 'unknown')}"
+            )
         except Exception as e:
             verbose_logger.debug(f"Failed to get caller identity: {e}")
 
         # Assume the role
-        verbose_logger.debug(f"Attempting to assume role: {aws_role_name} with session: {aws_session_name}")
+        verbose_logger.debug(
+            f"Attempting to assume role: {aws_role_name} with session: {aws_session_name}"
+        )
         assume_role_params = {
             "RoleArn": aws_role_name,
             "RoleSessionName": aws_session_name,
@@ -1046,7 +1123,9 @@ class BaseAWSLLM:
 
         return sts_client.assume_role(**assume_role_params)
 
-    def _extract_credentials_and_ttl(self, sts_response: dict) -> Tuple[Credentials, Optional[int]]:
+    def _extract_credentials_and_ttl(
+        self, sts_response: dict
+    ) -> Tuple[Credentials, Optional[int]]:
         """Extract credentials and TTL from STS response."""
         from botocore.credentials import Credentials
 
@@ -1058,7 +1137,9 @@ class BaseAWSLLM:
         )
 
         expiration_time = sts_credentials["Expiration"]
-        ttl = int((expiration_time - datetime.now(expiration_time.tzinfo)).total_seconds())
+        ttl = int(
+            (expiration_time - datetime.now(expiration_time.tzinfo)).total_seconds()
+        )
 
         return credentials, ttl
 
@@ -1073,7 +1154,7 @@ class BaseAWSLLM:
         aws_region_name: Optional[str] = None,
         aws_sts_endpoint: Optional[str] = None,
         aws_external_id: Optional[str] = None,
-        aws_session_tags: Optional[List[dict]] = None,
+        aws_session_tags: Optional[list[dict]] = None,
         ssl_verify: Optional[Union[bool, str]] = None,
     ) -> Tuple[Credentials, Optional[int]]:
         """
@@ -1088,10 +1169,17 @@ class BaseAWSLLM:
 
         # If we have IRSA environment variables and no explicit credentials,
         # we need to use the web identity token flow
-        if web_identity_token_file and irsa_role_arn and aws_access_key_id is None and aws_secret_access_key is None:
+        if (
+            web_identity_token_file
+            and irsa_role_arn
+            and aws_access_key_id is None
+            and aws_secret_access_key is None
+        ):
             # For cross-account role assumption with specific session names,
             # we need to manually assume the IRSA role first with the correct session name
-            verbose_logger.debug(f"IRSA detected: using web identity token from {web_identity_token_file}")
+            verbose_logger.debug(
+                f"IRSA detected: using web identity token from {web_identity_token_file}"
+            )
 
             try:
                 # Check if we need to do cross-account role assumption
@@ -1120,7 +1208,9 @@ class BaseAWSLLM:
 
             except Exception as e:
                 verbose_logger.debug(f"Failed to assume role via IRSA: {e}")
-                if "AccessDenied" in str(e) and "is not authorized to perform: sts:AssumeRole" in str(e):
+                if "AccessDenied" in str(
+                    e
+                ) and "is not authorized to perform: sts:AssumeRole" in str(e):
                     # Provide a more helpful error message for trust policy issues
                     verbose_logger.error(
                         f"Access denied when trying to assume role {aws_role_name}. "
@@ -1169,7 +1259,9 @@ class BaseAWSLLM:
                 # partition, and role name).  This avoids silently using the
                 # wrong identity when there is a genuine trust-policy or
                 # permission misconfiguration.
-                if self._is_already_running_as_role(aws_role_name, ssl_verify=ssl_verify):
+                if self._is_already_running_as_role(
+                    aws_role_name, ssl_verify=ssl_verify
+                ):
                     verbose_logger.warning(
                         "AssumeRole failed for %s (%s). "
                         "Caller is already running as this role; "
@@ -1201,7 +1293,9 @@ class BaseAWSLLM:
         return credentials, sts_ttl
 
     @tracer.wrap()
-    def _auth_with_aws_profile(self, aws_profile_name: str) -> Tuple[Credentials, Optional[int]]:
+    def _auth_with_aws_profile(
+        self, aws_profile_name: str
+    ) -> Tuple[Credentials, Optional[int]]:
         """
         Authenticate with AWS profile
         """
@@ -1289,9 +1383,13 @@ class BaseAWSLLM:
         env_aws_bedrock_runtime_endpoint = get_secret("AWS_BEDROCK_RUNTIME_ENDPOINT")
         if api_base is not None:
             endpoint_url = api_base
-        elif aws_bedrock_runtime_endpoint is not None and isinstance(aws_bedrock_runtime_endpoint, str):
+        elif aws_bedrock_runtime_endpoint is not None and isinstance(
+            aws_bedrock_runtime_endpoint, str
+        ):
             endpoint_url = aws_bedrock_runtime_endpoint
-        elif env_aws_bedrock_runtime_endpoint and isinstance(env_aws_bedrock_runtime_endpoint, str):
+        elif env_aws_bedrock_runtime_endpoint and isinstance(
+            env_aws_bedrock_runtime_endpoint, str
+        ):
             endpoint_url = env_aws_bedrock_runtime_endpoint
         else:
             endpoint_url = self._select_default_endpoint_url(
@@ -1300,9 +1398,13 @@ class BaseAWSLLM:
             )
 
         # Determine proxy_endpoint_url
-        if aws_bedrock_runtime_endpoint is not None and isinstance(aws_bedrock_runtime_endpoint, str):
+        if aws_bedrock_runtime_endpoint is not None and isinstance(
+            aws_bedrock_runtime_endpoint, str
+        ):
             proxy_endpoint_url = aws_bedrock_runtime_endpoint
-        elif env_aws_bedrock_runtime_endpoint and isinstance(env_aws_bedrock_runtime_endpoint, str):
+        elif env_aws_bedrock_runtime_endpoint and isinstance(
+            env_aws_bedrock_runtime_endpoint, str
+        ):
             proxy_endpoint_url = env_aws_bedrock_runtime_endpoint
         else:
             proxy_endpoint_url = endpoint_url
@@ -1400,15 +1502,21 @@ class BaseAWSLLM:
             try:
                 from botocore.awsrequest import AWSRequest
             except ImportError:
-                raise ImportError("Missing boto3 to call bedrock. Run 'pip install boto3'.")
+                raise ImportError(
+                    "Missing boto3 to call bedrock. Run 'pip install boto3'."
+                )
             headers["Authorization"] = f"Bearer {aws_bearer_token}"
-            request = AWSRequest(method="POST", url=endpoint_url, data=data, headers=headers)
+            request = AWSRequest(
+                method="POST", url=endpoint_url, data=data, headers=headers
+            )
         else:
             try:
                 from botocore.auth import SigV4Auth
                 from botocore.awsrequest import AWSRequest
             except ImportError:
-                raise ImportError("Missing boto3 to call bedrock. Run 'pip install boto3'.")
+                raise ImportError(
+                    "Missing boto3 to call bedrock. Run 'pip install boto3'."
+                )
 
             # Filter headers for AWS signature calculation
             # AWS SigV4 only includes specific headers in signature calculation
@@ -1424,7 +1532,10 @@ class BaseAWSLLM:
 
             # Add back all original headers (including forwarded ones) after signature calculation
             for header_name, header_value in headers.items():
-                if header_value is not None and header_name.lower() not in SIGV4_COMPUTED_HEADERS:
+                if (
+                    header_value is not None
+                    and header_name.lower() not in SIGV4_COMPUTED_HEADERS
+                ):
                     request.headers[header_name] = header_value
 
             if (
@@ -1460,7 +1571,11 @@ class BaseAWSLLM:
             if header_value is None:
                 continue
             header_lower = header_name.lower()
-            if header_lower in aws_headers or header_lower.startswith("x-amz-") or header_lower.startswith("x-amzn-"):
+            if (
+                header_lower in aws_headers
+                or header_lower.startswith("x-amz-")
+                or header_lower.startswith("x-amzn-")
+            ):
                 aws_signature_headers[header_name] = header_value
 
         return aws_signature_headers
@@ -1520,7 +1635,9 @@ class BaseAWSLLM:
         aws_web_identity_token = optional_params.get("aws_web_identity_token", None)
         aws_sts_endpoint = optional_params.get("aws_sts_endpoint", None)
         aws_external_id = optional_params.get("aws_external_id", None)
-        aws_region_name = self._get_aws_region_name(optional_params=optional_params, model=model)
+        aws_region_name = self._get_aws_region_name(
+            optional_params=optional_params, model=model
+        )
 
         credentials: Credentials = self.get_credentials(
             aws_access_key_id=aws_access_key_id,
@@ -1553,14 +1670,22 @@ class BaseAWSLLM:
         # Add back original headers after signing. Only headers in SignedHeaders
         # are integrity-protected; forwarded headers (x-forwarded-*) must remain unsigned.
         for header_name, header_value in headers.items():
-            if header_value is not None and header_name.lower() not in SIGV4_COMPUTED_HEADERS:
+            if (
+                header_value is not None
+                and header_name.lower() not in SIGV4_COMPUTED_HEADERS
+            ):
                 request_headers_dict[header_name] = header_value
         incoming_authorization = next(
-            (value for name, value in headers.items() if name.lower() == "authorization" and value is not None),
+            (
+                value
+                for name, value in headers.items()
+                if name.lower() == "authorization" and value is not None
+            ),
             None,
         )
-        if incoming_authorization is not None and not incoming_authorization.startswith(
-            "AWS4-HMAC-SHA256"
+        if (
+            incoming_authorization is not None
+            and not incoming_authorization.startswith("AWS4-HMAC-SHA256")
         ):  # prevent sigv4 from overwriting the auth header
             request_headers_dict["Authorization"] = incoming_authorization
 

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -97,6 +97,7 @@ class BaseAWSLLM:
             "aws_sts_endpoint",
             "aws_bedrock_runtime_endpoint",
             "aws_external_id",
+            "aws_session_tags",
         ]
 
     def _get_ssl_verify(self, ssl_verify: Optional[Union[bool, str]] = None):
@@ -196,6 +197,7 @@ class BaseAWSLLM:
         aws_web_identity_token: Optional[str] = None,
         aws_sts_endpoint: Optional[str] = None,
         aws_external_id: Optional[str] = None,
+        aws_session_tags: Optional[List[dict]] = None,
         ssl_verify: Optional[Union[bool, str]] = None,
     ):
         """
@@ -305,6 +307,7 @@ class BaseAWSLLM:
                 aws_region_name=aws_region_name,
                 aws_sts_endpoint=aws_sts_endpoint,
                 aws_external_id=aws_external_id,
+                aws_session_tags=aws_session_tags,
                 ssl_verify=ssl_verify,
             )
             return credentials
@@ -935,6 +938,7 @@ class BaseAWSLLM:
         aws_session_name: str,
         web_identity_token_file: str,
         aws_external_id: Optional[str] = None,
+        aws_session_tags: Optional[List[dict]] = None,
         aws_sts_endpoint: Optional[str] = None,
         ssl_verify: Optional[Union[bool, str]] = None,
     ) -> dict:
@@ -993,9 +997,10 @@ class BaseAWSLLM:
             "RoleSessionName": aws_session_name,
         }
 
-        # Add ExternalId parameter if provided
         if aws_external_id is not None:
             assume_role_params["ExternalId"] = aws_external_id
+        if aws_session_tags:
+            assume_role_params["Tags"] = aws_session_tags
 
         return sts_client_with_creds.assume_role(**assume_role_params)
 
@@ -1004,6 +1009,7 @@ class BaseAWSLLM:
         aws_role_name: str,
         aws_session_name: str,
         aws_external_id: Optional[str] = None,
+        aws_session_tags: Optional[List[dict]] = None,
         aws_sts_endpoint: Optional[str] = None,
         ssl_verify: Optional[Union[bool, str]] = None,
     ) -> dict:
@@ -1033,9 +1039,10 @@ class BaseAWSLLM:
             "RoleSessionName": aws_session_name,
         }
 
-        # Add ExternalId parameter if provided
         if aws_external_id is not None:
             assume_role_params["ExternalId"] = aws_external_id
+        if aws_session_tags:
+            assume_role_params["Tags"] = aws_session_tags
 
         return sts_client.assume_role(**assume_role_params)
 
@@ -1066,6 +1073,7 @@ class BaseAWSLLM:
         aws_region_name: Optional[str] = None,
         aws_sts_endpoint: Optional[str] = None,
         aws_external_id: Optional[str] = None,
+        aws_session_tags: Optional[List[dict]] = None,
         ssl_verify: Optional[Union[bool, str]] = None,
     ) -> Tuple[Credentials, Optional[int]]:
         """
@@ -1094,6 +1102,7 @@ class BaseAWSLLM:
                         aws_session_name,
                         web_identity_token_file,
                         aws_external_id,
+                        aws_session_tags=aws_session_tags,
                         aws_sts_endpoint=aws_sts_endpoint,
                         ssl_verify=ssl_verify,
                     )
@@ -1102,6 +1111,7 @@ class BaseAWSLLM:
                         aws_role_name,
                         aws_session_name,
                         aws_external_id,
+                        aws_session_tags=aws_session_tags,
                         aws_sts_endpoint=aws_sts_endpoint,
                         ssl_verify=ssl_verify,
                     )
@@ -1144,9 +1154,10 @@ class BaseAWSLLM:
             "RoleSessionName": aws_session_name,
         }
 
-        # Add ExternalId parameter if provided
         if aws_external_id is not None:
             assume_role_params["ExternalId"] = aws_external_id
+        if aws_session_tags:
+            assume_role_params["Tags"] = aws_session_tags
 
         try:
             sts_response = sts_client.assume_role(**assume_role_params)
@@ -1347,6 +1358,7 @@ class BaseAWSLLM:
             "aws_bedrock_runtime_endpoint", None
         )  # https://bedrock-runtime.{region_name}.amazonaws.com
         aws_external_id = optional_params.pop("aws_external_id", None)
+        aws_session_tags = optional_params.pop("aws_session_tags", None)
 
         credentials: Credentials = self.get_credentials(
             aws_access_key_id=aws_access_key_id,
@@ -1359,6 +1371,7 @@ class BaseAWSLLM:
             aws_web_identity_token=aws_web_identity_token,
             aws_sts_endpoint=aws_sts_endpoint,
             aws_external_id=aws_external_id,
+            aws_session_tags=aws_session_tags,
         )
 
         return Boto3CredentialsInfo(

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -277,6 +277,9 @@ class BaseAWSLLM:
             aws_external_id,
         )
 
+        if aws_session_tags:
+            aws_session_tags = sorted(aws_session_tags, key=lambda t: t["Key"])
+
         args = {
             k: v
             for k, v in locals().items()

--- a/litellm/llms/bedrock/chat/converse_handler.py
+++ b/litellm/llms/bedrock/chat/converse_handler.py
@@ -317,6 +317,7 @@ class BedrockConverseLLM(BaseAWSLLM):
         aws_web_identity_token = optional_params.pop("aws_web_identity_token", None)
         aws_sts_endpoint = optional_params.pop("aws_sts_endpoint", None)
         aws_external_id = optional_params.pop("aws_external_id", None)
+        aws_session_tags = optional_params.pop("aws_session_tags", None)
         optional_params.pop("aws_region_name", None)
 
         litellm_params["aws_region_name"] = aws_region_name  # [DO NOT DELETE] important for async calls
@@ -332,6 +333,7 @@ class BedrockConverseLLM(BaseAWSLLM):
             aws_web_identity_token=aws_web_identity_token,
             aws_sts_endpoint=aws_sts_endpoint,
             aws_external_id=aws_external_id,
+            aws_session_tags=aws_session_tags,
         )
 
         ### SET RUNTIME ENDPOINT ###

--- a/litellm/llms/bedrock/embed/embedding.py
+++ b/litellm/llms/bedrock/embed/embedding.py
@@ -57,6 +57,7 @@ class BedrockEmbedding(BaseAWSLLM):
         aws_profile_name = optional_params.pop("aws_profile_name", None)
         aws_web_identity_token = optional_params.pop("aws_web_identity_token", None)
         aws_sts_endpoint = optional_params.pop("aws_sts_endpoint", None)
+        aws_session_tags = optional_params.pop("aws_session_tags", None)
 
         ### SET REGION NAME ###
         if aws_region_name is None:
@@ -83,6 +84,7 @@ class BedrockEmbedding(BaseAWSLLM):
             aws_role_name=aws_role_name,
             aws_web_identity_token=aws_web_identity_token,
             aws_sts_endpoint=aws_sts_endpoint,
+            aws_session_tags=aws_session_tags,
         )
         return credentials, aws_region_name
 


### PR DESCRIPTION
## Summary

Adds `aws_session_tags` support to Bedrock's STS role assumption flow, enabling per-user/per-team cost attribution in CUR 2.0 billing data.

**Problem:** When `aws_session_tags` is passed in `optional_params`, it is not recognized as an AWS authentication parameter. It falls through to `additional_request_params` and gets forwarded in the Bedrock request body, causing:
```
BedrockException: aws_session_tags: Extra inputs are not permitted
```

**Fix:** Pop `aws_session_tags` from `optional_params` (same pattern as `aws_external_id`) and pass it as `Tags` in the `sts:AssumeRole` call. Session tags then propagate into CloudTrail and — after activation as cost allocation tags — into CUR 2.0 as `iamPrincipal/<TagKey>` columns.

## Changes

- `litellm/llms/bedrock/base_aws_llm.py`: add `aws_session_tags` to `aws_authentication_params`, `get_credentials()`, `_auth_with_aws_role()`, `_handle_irsa_cross_account()`, `_handle_irsa_same_account()`, and `get_boto3_credentials_from_optional_params()`
- `litellm/llms/bedrock/chat/converse_handler.py`: pop `aws_session_tags` and pass to `get_credentials()`

## Usage

```python
import litellm

response = litellm.completion(
    model="bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
    messages=[{"role": "user", "content": "Hello"}],
    aws_role_name="arn:aws:iam::123456789:role/bedrock-role",
    aws_session_name="litellm-gateway",
    aws_session_tags=[
        {"Key": "user_id", "Value": "alice@example.com"},
        {"Key": "team", "Value": "platform"},
    ],
)
```

## AWS reference

- [AssumeRole Tags parameter](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)
- [Session tags in CUR 2.0](https://aws.amazon.com/blogs/machine-learning/introducing-granular-cost-attribution-for-amazon-bedrock/) (Scenario 4)

Closes #34069
