### PR TITLE
fix(guardrails): extract tool names from additional_tools input items on Responses API

### DIFF
--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -198,16 +198,27 @@ class OpenAIResponsesHandler(BaseTranslation):
 
     def extract_request_tool_names(self, data: dict) -> List[str]:
         """Extract tool names from Responses API request (tools[].name for function
-        and custom, tools[].server_label for mcp)."""
-        names: List[str] = []
-        for tool in data.get("tools") or []:
-            if not isinstance(tool, dict):
-                continue
-            if tool.get("type") in ("function", "custom") and tool.get("name"):
-                names.append(str(tool["name"]))
-            elif tool.get("type") == "mcp" and tool.get("server_label"):
-                names.append(str(tool["server_label"]))
-        return names
+        and custom, tools[].server_label for mcp), including tools nested in
+        additional_tools input items (Codex CLI ships its tool definitions there)."""
+        input_items = data.get("input")
+        additional_tools = (
+            tool
+            for item in (input_items if isinstance(input_items, list) else ())
+            if isinstance(item, dict) and item.get("type") == "additional_tools"
+            for tool in (item.get("tools") or ())
+        )
+        names = (self._responses_tool_name(tool) for tool in (*(data.get("tools") or ()), *additional_tools))
+        return [name for name in names if name]
+
+    @staticmethod
+    def _responses_tool_name(tool: object) -> str | None:
+        if not isinstance(tool, dict):
+            return None
+        if tool.get("type") in ("function", "custom") and tool.get("name"):
+            return str(tool["name"])
+        if tool.get("type") == "mcp" and tool.get("server_label"):
+            return str(tool["server_label"])
+        return None
 
     def _extract_and_transform_tools(
         self,

--- a/tests/test_litellm/proxy/test_tools_allowlist_enforcement.py
+++ b/tests/test_litellm/proxy/test_tools_allowlist_enforcement.py
@@ -86,6 +86,40 @@ class TestExtractRequestToolNames:
             "get_current_weather",
         ]
 
+    def test_openai_responses_additional_tools_input_items(self):
+        """Codex CLI 0.143+ ships tool definitions inside an additional_tools
+        input item instead of (or alongside) top-level tools; those nested tools
+        must be extracted too or a restricted key could smuggle a disallowed
+        tool past allowlist enforcement (VERIA finding on PR #33228)."""
+        data = {
+            "tools": [{"type": "function", "name": "get_current_weather"}],
+            "input": [
+                {"role": "user", "content": "hi"},
+                {
+                    "type": "additional_tools",
+                    "role": "developer",
+                    "tools": [
+                        {"type": "custom", "name": "exec", "description": "x"},
+                        {"type": "mcp", "server_label": "dmcp", "server_url": "http://x"},
+                    ],
+                },
+            ],
+        }
+        assert extract_request_tool_names("/v1/responses", data) == [
+            "get_current_weather",
+            "exec",
+            "dmcp",
+        ]
+
+    def test_openai_responses_string_input_ignored(self):
+        data = {
+            "tools": [{"type": "function", "name": "get_current_weather"}],
+            "input": "hi",
+        }
+        assert extract_request_tool_names("/v1/responses", data) == [
+            "get_current_weather"
+        ]
+
     def test_anthropic_tools(self):
         data = {"tools": [{"name": "get_weather"}, {"name": "run_sql"}]}
         assert extract_request_tool_names("/v1/messages", data) == [
@@ -172,6 +206,28 @@ class TestCheckToolsAllowlist:
             )
         assert exc_info.value.type == ProxyErrorTypes.tool_access_denied
         assert "restricted_tool" in str(exc_info.value.message)
+
+    @pytest.mark.asyncio
+    async def test_disallowed_additional_tools_input_item_raises_on_responses_route(self):
+        token = _token(metadata={"allowed_tools": ["other_tool"]})
+        body = {
+            "input": [
+                {
+                    "type": "additional_tools",
+                    "role": "developer",
+                    "tools": [{"type": "custom", "name": "exec"}],
+                },
+            ],
+        }
+        with pytest.raises(ProxyException) as exc_info:
+            await check_tools_allowlist(
+                request_body=body,
+                valid_token=token,
+                team_object=None,
+                route="/v1/responses",
+            )
+        assert exc_info.value.type == ProxyErrorTypes.tool_access_denied
+        assert "exec" in str(exc_info.value.message)
 
     @pytest.mark.asyncio
     async def test_team_allowlist_used_when_key_empty(self):


### PR DESCRIPTION
## Relevant issues

Closes the tool allowlist gap flagged by the Veria security review on #33228: tools declared inside `additional_tools` input items (the shape Codex CLI 0.143+ sends on the Responses API) were invisible to allowlist enforcement. The gap pre-exists #33228 on the plain OpenAI path, since api.openai.com honors `additional_tools` natively

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All runs hit the real OpenAI API (real spend) through a DB-backed local proxy with this config, using a virtual key generated with `"metadata": {"allowed_tools": ["get_current_weather"]}`

```yaml
model_list:
  - model_name: gpt-5.6-sol
    litellm_params:
      model: openai/gpt-5.6-sol
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
  database_url: os.environ/DATABASE_URL
```

**Before**, at commit 9ad8698aab (the direct parent of this branch), the restricted key smuggles the disallowed `exec` tool past the allowlist by declaring it inside an `additional_tools` input item; the request sails through to OpenAI and completes

```bash
curl -s http://localhost:27461/v1/responses -H "Authorization: Bearer $RESTRICTED_KEY" -H "Content-Type: application/json" -d '{
  "model": "gpt-5.6-sol",
  "stream": false,
  "store": false,
  "tools": [{"type": "function", "name": "get_current_weather", "description": "Get the weather", "parameters": {"type": "object", "properties": {}}}],
  "input": [
    {"type": "additional_tools", "role": "developer", "tools": [{"type": "custom", "name": "exec", "description": "Runs a shell command and returns its output"}]},
    {"role": "user", "content": "Reply with exactly: ok"}
  ]
}'
```

```json
{"id": "resp_G3T2mo6T...", "status": "completed", "model": "gpt-5.6-sol", "error": null}
HTTP 200
```

Control at the same commit proving the allowlist itself works and `additional_tools` is the hole: the identical `exec` tool declared in top-level `tools` is rejected

```json
{"error":{"message":"Tool(s) ['exec'] are not in the allowed tools list for this key/team.","type":"tool_access_denied","param":"tools","code":"403"}}
HTTP 403
```

**After**, at commit ab912c963d, the same smuggled body with the same restricted key is blocked

```json
{"error":{"message":"Tool(s) ['exec'] are not in the allowed tools list for this key/team.","type":"tool_access_denied","param":"tools","code":"403"}}
HTTP 403
```

and a key whose allowlist includes `exec` (`"allowed_tools": ["get_current_weather", "exec"]`) still completes the identical request, so nothing is falsely blocked

```json
{"status": "completed", "model": "gpt-5.6-sol", "output_text": ["ok"]}
```

## Type

🐛 Bug Fix

## Changes

The shared Responses API tool name extraction (`extract_request_tool_names` in the OpenAI Responses guardrail translation handler) only read top-level `tools`, but Codex CLI 0.143+ ships its tool definitions inside a `{"type": "additional_tools", "role": "developer", "tools": [...]}` input item, a variant api.openai.com accepts. Both consumers of the extraction inherited the blind spot: `check_tools_allowlist` (key/team `allowed_tools` metadata) and `ToolPolicyGuardrail`, so a restricted key could invoke any tool by declaring it in an `additional_tools` input item instead of `tools`

`extract_request_tool_names` now also walks `input` items of type `additional_tools` and extracts their nested tools with the same rules as top-level ones (`name` for function and custom tools, `server_label` for mcp), via a shared `_responses_tool_name` helper. Non-list `input` (the string form) and non-dict items are ignored as before

Unit tests cover extraction of function, custom, and mcp tools nested in `additional_tools` alongside top-level tools, the string `input` form staying inert, and end-to-end allowlist enforcement raising `tool_access_denied` for a disallowed tool smuggled in an `additional_tools` item; the two regression tests fail on the parent commit

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
