### PR TITLE
fix(batches): handle completed all-error batches with no output file

### DIFF
--- a/litellm/batches/batch_utils.py
+++ b/litellm/batches/batch_utils.py
@@ -55,7 +55,7 @@ async def _handle_completed_batch(
         litellm_params: Optional litellm parameters containing credentials (api_key, api_base, etc.)
     """
     # All-error batches can complete with output_file_id=None and only an error_file_id.
-    if batch.output_file_id is None:
+    if batch.output_file_id is None and getattr(batch, "error_file_id", None) is not None:
         return 0.0, Usage(), []
 
     # Get batch results

--- a/litellm/batches/batch_utils.py
+++ b/litellm/batches/batch_utils.py
@@ -54,6 +54,10 @@ async def _handle_completed_batch(
         model_name: Optional model name
         litellm_params: Optional litellm parameters containing credentials (api_key, api_base, etc.)
     """
+    # All-error batches can complete with output_file_id=None and only an error_file_id.
+    if batch.output_file_id is None:
+        return 0.0, Usage(), []
+
     # Get batch results
     file_content_dictionary = await _get_batch_output_file_content_as_dictionary(
         batch, custom_llm_provider, litellm_params=litellm_params

--- a/tests/test_litellm/batches/test_batch_utils.py
+++ b/tests/test_litellm/batches/test_batch_utils.py
@@ -600,7 +600,7 @@ async def test_calculate_batch_cost_and_usage_orchestration(monkeypatch):
 # =========================================================================== #
 
 
-def _batch(output_file_id):
+def _batch(output_file_id, error_file_id=None):
     from litellm.types.llms.openai import Batch
 
     return Batch(
@@ -612,6 +612,7 @@ def _batch(output_file_id):
         object="batch",
         status="completed",
         output_file_id=output_file_id,
+        error_file_id=error_file_id,
     )
 
 
@@ -720,7 +721,10 @@ async def test_handle_completed_batch_all_error_batch_no_output_file(monkeypatch
 
     monkeypatch.setattr(bu, "_get_batch_output_file_content_as_dictionary", fake_get_content)
 
-    cost, usage, models = await bu._handle_completed_batch(_batch(None), custom_llm_provider="openai")
+    cost, usage, models = await bu._handle_completed_batch(
+        _batch(None, error_file_id="file-err"),
+        custom_llm_provider="openai",
+    )
 
     assert cost == 0.0
     assert usage.total_tokens == 0
@@ -728,6 +732,13 @@ async def test_handle_completed_batch_all_error_batch_no_output_file(monkeypatch
     assert usage.completion_tokens == 0
     assert models == []
     assert called is False
+
+
+@pytest.mark.asyncio
+async def test_handle_completed_batch_missing_output_without_error_file_still_raises():
+    """Completed batches with no output and no error file keep the explicit fetch error."""
+    with pytest.raises(ValueError, match="Output file id is None"):
+        await bu._handle_completed_batch(_batch(None), custom_llm_provider="openai")
 
 
 # =========================================================================== #

--- a/tests/test_litellm/batches/test_batch_utils.py
+++ b/tests/test_litellm/batches/test_batch_utils.py
@@ -708,6 +708,28 @@ async def test_handle_completed_batch_orchestration(monkeypatch):
     assert models == ["gpt-4o"]
 
 
+@pytest.mark.asyncio
+async def test_handle_completed_batch_all_error_batch_no_output_file(monkeypatch):
+    """All-error batches complete with output_file_id=None; logging must not crash."""
+    called = False
+
+    async def fake_get_content(*args, **kwargs):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr(bu, "_get_batch_output_file_content_as_dictionary", fake_get_content)
+
+    cost, usage, models = await bu._handle_completed_batch(_batch(None), custom_llm_provider="openai")
+
+    assert cost == 0.0
+    assert usage.total_tokens == 0
+    assert usage.prompt_tokens == 0
+    assert usage.completion_tokens == 0
+    assert models == []
+    assert called is False
+
+
 # =========================================================================== #
 # Remaining branch: vertex usage disable-transform path.
 #
@@ -809,7 +831,10 @@ def test_anthropic_response_body_is_result_message():
 
 
 def test_anthropic_usage_conversion_includes_cache_tokens():
-    body = {"model": "claude-sonnet-4-5-20250929", "usage": _anthropic_usage(1000, 200, cache_creation=2000, cache_read=8000)}
+    body = {
+        "model": "claude-sonnet-4-5-20250929",
+        "usage": _anthropic_usage(1000, 200, cache_creation=2000, cache_read=8000),
+    }
     usage = bu._get_batch_job_usage_from_response_body(body, custom_llm_provider="anthropic")
     assert usage.prompt_tokens == 11000
     assert usage.completion_tokens == 200
@@ -824,7 +849,9 @@ def test_bedrock_model_output_line_success_check():
         "modelOutput": {"model": "claude-sonnet-4-6", "usage": {"input_tokens": 13, "output_tokens": 5}},
     }
     assert bu._batch_response_was_successful(row, custom_llm_provider="bedrock") is True
-    assert bu._get_response_from_batch_job_output_file(row, custom_llm_provider="bedrock")["model"] == "claude-sonnet-4-6"
+    assert (
+        bu._get_response_from_batch_job_output_file(row, custom_llm_provider="bedrock")["model"] == "claude-sonnet-4-6"
+    )
 
 
 def test_bedrock_cost_uses_deployment_model_name():
@@ -868,7 +895,13 @@ def test_total_usage_without_cache_tokens_has_no_prompt_details():
     rows = [
         {
             "custom_id": "req-1",
-            "response": {"status_code": 200, "body": {"model": "gpt-5.2", "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}}},
+            "response": {
+                "status_code": 200,
+                "body": {
+                    "model": "gpt-5.2",
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+                },
+            },
         }
     ]
     usage = bu._get_batch_job_total_usage_from_file_content(rows, custom_llm_provider="openai")
@@ -910,9 +943,7 @@ def test_anthropic_cost_without_model_info_uses_batch_cost_calculator(monkeypatc
         lambda **kw: pytest.fail("anthropic rows must not go through completion_cost"),
     )
 
-    total = bu._get_batch_job_cost_from_file_content(
-        [_anthropic_succeeded_row()], custom_llm_provider="anthropic"
-    )
+    total = bu._get_batch_job_cost_from_file_content([_anthropic_succeeded_row()], custom_llm_provider="anthropic")
 
     assert total == pytest.approx(0.3)
     assert seen[0]["model"] == "claude-sonnet-4-5-20250929"


### PR DESCRIPTION
## Relevant issues

Fixes #33987

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

**Commit:** `e332ebed6e`

**Before (on `litellm_internal_staging` without this fix):** calling `_handle_completed_batch` on a completed all-error batch (`output_file_id=None`, `error_file_id` set) raises:

```
ValueError: Output file id is None cannot retrieve file content
```

**After (with this fix):** the all-error batch returns zero cost/usage and an empty model list without raising:

```
./.venv/bin/python -m pytest \
  tests/test_litellm/batches/test_batch_utils.py::test_handle_completed_batch_all_error_batch_no_output_file \
  tests/test_litellm/batches/test_batch_utils.py::test_handle_completed_batch_missing_output_without_error_file_still_raises \
  tests/test_litellm/batches/test_batch_utils.py::test_output_file_content_no_output_file_id_raises \
  -q
...                                                                      [100%]
3 passed
```

Other completed batches that lack an output file but also have no `error_file_id` (e.g. Bedrock jobs with an unpredictable output URI) still flow through the explicit fetch helper and raise as before (`test_handle_completed_batch_missing_output_without_error_file_still_raises`).

## Type

🐛 Bug Fix
✅ Test

## Changes

- In `_handle_completed_batch`, short-circuit only for the all-error completion shape: `output_file_id is None` **and** `error_file_id is not None`. Return `0.0`, empty `Usage()`, and `[]` models.
- Add regression test `test_handle_completed_batch_all_error_batch_no_output_file` for the all-error batch logging path.
- Add regression test `test_handle_completed_batch_missing_output_without_error_file_still_raises` to lock in the existing explicit-fetch error contract for other missing-output cases.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR