### PR TITLE
refactor(ui): migrate access groups table to shared DataTable

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/access-groups/_components/AccessGroupsPage.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/access-groups/_components/AccessGroupsPage.test.tsx
@@ -38,6 +38,7 @@ const mockAccessGroups: AccessGroupResponse[] = [
 const mockUseAccessGroups = vi.fn();
 const mockUseDeleteAccessGroup = vi.fn();
 const mockMutate = vi.fn();
+const mockUseAuthorized = vi.fn();
 
 vi.mock("@/app/(dashboard)/hooks/accessGroups/useAccessGroups", () => ({
   useAccessGroups: () => mockUseAccessGroups(),
@@ -45,6 +46,10 @@ vi.mock("@/app/(dashboard)/hooks/accessGroups/useAccessGroups", () => ({
 
 vi.mock("@/app/(dashboard)/hooks/accessGroups/useDeleteAccessGroup", () => ({
   useDeleteAccessGroup: () => mockUseDeleteAccessGroup(),
+}));
+
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
+  default: () => mockUseAuthorized(),
 }));
 
 vi.mock("./AccessGroupsDetailsPage", () => ({
@@ -65,49 +70,31 @@ vi.mock("./AccessGroupsModal/AccessGroupCreateModal", () => ({
     ) : null,
 }));
 
-vi.mock("@/components/common_components/IconActionButton/TableIconActionButtons/TableIconActionButton", () => ({
-  default: ({ variant, tooltipText, onClick }: { variant: string; tooltipText: string; onClick: () => void }) => (
-    <button data-testid={`action-button-${variant.toLowerCase()}`} aria-label={tooltipText} onClick={onClick}>
-      {variant}
-    </button>
-  ),
-}));
+const openRowMenu = async (user: ReturnType<typeof userEvent.setup>, groupId: string) => {
+  await user.click(screen.getByTestId(`access-group-actions-${groupId}`));
+  return screen.findByTestId("access-group-action-delete");
+};
 
 describe("AccessGroupsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseAccessGroups.mockReturnValue({
-      data: mockAccessGroups,
-      isLoading: false,
-    });
-    mockUseDeleteAccessGroup.mockReturnValue({
-      mutate: mockMutate,
-      isPending: false,
-    });
+    mockUseAccessGroups.mockReturnValue({ data: mockAccessGroups, isLoading: false });
+    mockUseDeleteAccessGroup.mockReturnValue({ mutate: mockMutate, isPending: false });
+    mockUseAuthorized.mockReturnValue({ userRole: "Admin", accessToken: "sk-test" });
   });
 
-  it("should render", () => {
-    renderWithProviders(<AccessGroupsPage />);
-    expect(screen.getByRole("heading", { name: "Access Groups" })).toBeInTheDocument();
-  });
-
-  it("should display page title and subtitle", () => {
+  it("renders the page title and subtitle", () => {
     renderWithProviders(<AccessGroupsPage />);
     expect(screen.getByRole("heading", { name: "Access Groups" })).toBeInTheDocument();
     expect(screen.getByText("Manage resource permissions for your organization")).toBeInTheDocument();
   });
 
-  it("should display Create Access Group button", () => {
+  it("shows the Create Access Group button for an admin", () => {
     renderWithProviders(<AccessGroupsPage />);
     expect(screen.getByRole("button", { name: /create access group/i })).toBeInTheDocument();
   });
 
-  it("should display search input with placeholder", () => {
-    renderWithProviders(<AccessGroupsPage />);
-    expect(screen.getByPlaceholderText("Search groups by name, ID, or description...")).toBeInTheDocument();
-  });
-
-  it("should display access groups in table", () => {
+  it("renders every access group row", () => {
     renderWithProviders(<AccessGroupsPage />);
     expect(screen.getByText("ag-1")).toBeInTheDocument();
     expect(screen.getByText("Admin Group")).toBeInTheDocument();
@@ -115,57 +102,70 @@ describe("AccessGroupsPage", () => {
     expect(screen.getByText("Read Only")).toBeInTheDocument();
   });
 
-  it("should display resource counts for each group", () => {
+  it("renders resource counts for each group", () => {
     renderWithProviders(<AccessGroupsPage />);
-    const table = screen.getByRole("table");
-    expect(table).toHaveTextContent("2");
-    expect(table).toHaveTextContent("1");
+    // ag-1 has 2 models, 1 mcp server, 1 agent.
+    const adminRow = screen.getByText("ag-1").closest("tr") as HTMLElement;
+    expect(within(adminRow).getByTitle("2 Models")).toHaveTextContent("2");
+    expect(within(adminRow).getByTitle("1 MCP Servers")).toHaveTextContent("1");
+    expect(within(adminRow).getByTitle("1 Agents")).toHaveTextContent("1");
   });
 
-  it("should filter groups by search text matching name", async () => {
+  it("shows the expected column headers", () => {
+    renderWithProviders(<AccessGroupsPage />);
+    expect(screen.getByRole("columnheader", { name: /^ID$/i })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /Name/i })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /Resources/i })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /Created/i })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: /Updated/i })).toBeInTheDocument();
+  });
+
+  it("filters by name", async () => {
     const user = userEvent.setup();
     renderWithProviders(<AccessGroupsPage />);
-    const searchInput = screen.getByPlaceholderText("Search groups by name, ID, or description...");
-    await user.type(searchInput, "Admin");
+    await user.type(screen.getByPlaceholderText("Search groups by name, ID, or description..."), "Admin");
     expect(screen.getByText("Admin Group")).toBeInTheDocument();
     expect(screen.queryByText("Read Only")).not.toBeInTheDocument();
   });
 
-  it("should filter groups by search text matching ID", async () => {
+  it("filters by ID", async () => {
     const user = userEvent.setup();
     renderWithProviders(<AccessGroupsPage />);
-    const searchInput = screen.getByPlaceholderText("Search groups by name, ID, or description...");
-    await user.type(searchInput, "ag-2");
+    await user.type(screen.getByPlaceholderText("Search groups by name, ID, or description..."), "ag-2");
     expect(screen.getByText("Read Only")).toBeInTheDocument();
     expect(screen.queryByText("Admin Group")).not.toBeInTheDocument();
   });
 
-  it("should filter groups by search text matching description", async () => {
+  it("filters by description", async () => {
     const user = userEvent.setup();
     renderWithProviders(<AccessGroupsPage />);
-    const searchInput = screen.getByPlaceholderText("Search groups by name, ID, or description...");
-    await user.type(searchInput, "read-only");
+    await user.type(screen.getByPlaceholderText("Search groups by name, ID, or description..."), "read-only");
     expect(screen.getByText("Read Only")).toBeInTheDocument();
     expect(screen.queryByText("Admin Group")).not.toBeInTheDocument();
   });
 
-  it("should reset to first page when search text changes", async () => {
+  it("shows the filtered empty state when nothing matches", async () => {
     const user = userEvent.setup();
     renderWithProviders(<AccessGroupsPage />);
-    const searchInput = screen.getByPlaceholderText("Search groups by name, ID, or description...");
-    await user.type(searchInput, "Admin");
-    const pagination = screen.getByText(/groups/);
-    expect(pagination).toHaveTextContent("1 groups");
+    await user.type(screen.getByPlaceholderText("Search groups by name, ID, or description..."), "no-such-group");
+    expect(screen.getByText("No matching access groups")).toBeInTheDocument();
+    expect(screen.queryByText("Admin Group")).not.toBeInTheDocument();
   });
 
-  it("should open create modal when Create Access Group button is clicked", async () => {
-    const user = userEvent.setup();
+  it("shows the empty state when there are no groups", () => {
+    mockUseAccessGroups.mockReturnValue({ data: [], isLoading: false });
     renderWithProviders(<AccessGroupsPage />);
-    await user.click(screen.getByRole("button", { name: /create access group/i }));
-    expect(screen.getByTestId("create-access-group-modal")).toBeInTheDocument();
+    expect(screen.getByText("No access groups yet")).toBeInTheDocument();
   });
 
-  it("should close create modal when cancel is clicked", async () => {
+  it("renders loading skeletons on the initial load", () => {
+    mockUseAccessGroups.mockReturnValue({ data: undefined, isLoading: true });
+    renderWithProviders(<AccessGroupsPage />);
+    expect(screen.getAllByTestId("skeleton-row").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Admin Group")).not.toBeInTheDocument();
+  });
+
+  it("opens and closes the create modal", async () => {
     const user = userEvent.setup();
     renderWithProviders(<AccessGroupsPage />);
     await user.click(screen.getByRole("button", { name: /create access group/i }));
@@ -174,33 +174,22 @@ describe("AccessGroupsPage", () => {
     expect(screen.queryByTestId("create-access-group-modal")).not.toBeInTheDocument();
   });
 
-  it("should navigate to detail view when group ID is clicked", async () => {
+  it("opens the detail view when the ID cell is clicked and returns via Back", async () => {
     const user = userEvent.setup();
     renderWithProviders(<AccessGroupsPage />);
     await user.click(screen.getByText("ag-1"));
     expect(screen.getByTestId("access-group-detail")).toBeInTheDocument();
     expect(screen.getByText("Detail for ag-1")).toBeInTheDocument();
-  });
-
-  it("should return to list view when Back is clicked from detail", async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<AccessGroupsPage />);
-    await user.click(screen.getByText("ag-1"));
-    expect(screen.getByTestId("access-group-detail")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Back" }));
     expect(screen.queryByTestId("access-group-detail")).not.toBeInTheDocument();
     expect(screen.getByText("Admin Group")).toBeInTheDocument();
   });
 
-  it("should open delete modal when delete action is clicked", async () => {
+  it("opens the delete modal from the row actions menu", async () => {
     const user = userEvent.setup();
     renderWithProviders(<AccessGroupsPage />);
-    const deleteButtons = screen.getAllByRole("button", {
-      name: "Delete access group",
-    });
-    await user.click(deleteButtons[0]);
+    await user.click(await openRowMenu(user, "ag-1"));
     const dialog = screen.getByRole("dialog", { name: "Delete Access Group" });
-    expect(dialog).toBeInTheDocument();
     expect(
       within(dialog).getByText("Are you sure you want to delete this access group? This action cannot be undone."),
     ).toBeInTheDocument();
@@ -209,71 +198,34 @@ describe("AccessGroupsPage", () => {
     expect(within(dialog).getByText("Admin Group")).toBeInTheDocument();
   });
 
-  it("should close delete modal when cancel is clicked", async () => {
+  it("closes the delete modal on cancel without deleting", async () => {
     const user = userEvent.setup();
     renderWithProviders(<AccessGroupsPage />);
-    const deleteButtons = screen.getAllByRole("button", {
-      name: "Delete access group",
-    });
-    await user.click(deleteButtons[0]);
+    await user.click(await openRowMenu(user, "ag-1"));
     const dialog = screen.getByRole("dialog", { name: "Delete Access Group" });
     await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
     expect(screen.queryByRole("dialog", { name: "Delete Access Group" })).not.toBeInTheDocument();
+    expect(mockMutate).not.toHaveBeenCalled();
   });
 
-  it("should call delete mutation when delete is confirmed", async () => {
+  it("calls the delete mutation with the group ID when confirmed", async () => {
     const user = userEvent.setup();
     mockMutate.mockImplementation((_id: string, opts?: { onSuccess?: () => void }) => {
       opts?.onSuccess?.();
     });
     renderWithProviders(<AccessGroupsPage />);
-    const deleteButtons = screen.getAllByRole("button", {
-      name: "Delete access group",
-    });
-    await user.click(deleteButtons[0]);
+    await user.click(await openRowMenu(user, "ag-1"));
     const dialog = screen.getByRole("dialog", { name: "Delete Access Group" });
-    const deleteConfirmButton = within(dialog).getByRole("button", { name: /delete/i });
-    await user.click(deleteConfirmButton);
+    await user.click(within(dialog).getByRole("button", { name: /delete/i }));
     expect(mockMutate).toHaveBeenCalledWith("ag-1", expect.any(Object));
   });
 
-  it("should display pagination with total count", () => {
+  it("hides the Create button and row actions for a non-admin", () => {
+    mockUseAuthorized.mockReturnValue({ userRole: "Admin Viewer", accessToken: "sk-test" });
     renderWithProviders(<AccessGroupsPage />);
-    expect(screen.getByText("2 groups")).toBeInTheDocument();
-  });
-
-  it("should show table headers for ID, Name, Resources, and Actions", () => {
-    renderWithProviders(<AccessGroupsPage />);
-    expect(screen.getByRole("columnheader", { name: /ID/i })).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: /Name/i })).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: /Resources/i })).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: /Actions/i })).toBeInTheDocument();
-  });
-
-  it("should display loading state when data is loading", () => {
-    mockUseAccessGroups.mockReturnValue({
-      data: undefined,
-      isLoading: true,
-    });
-    renderWithProviders(<AccessGroupsPage />);
-    const table = screen.getByRole("table");
-    expect(table).toBeInTheDocument();
-  });
-
-  it("should display empty state when no groups match search", async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<AccessGroupsPage />);
-    const searchInput = screen.getByPlaceholderText("Search groups by name, ID, or description...");
-    await user.type(searchInput, "nonexistent-group-xyz");
-    expect(screen.getByRole("table")).toBeInTheDocument();
-  });
-
-  it("should display empty data when useAccessGroups returns empty array", () => {
-    mockUseAccessGroups.mockReturnValue({
-      data: [],
-      isLoading: false,
-    });
-    renderWithProviders(<AccessGroupsPage />);
-    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /create access group/i })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("access-group-actions-ag-1")).not.toBeInTheDocument();
+    // The read-only view still lists the groups.
+    expect(screen.getByText("Admin Group")).toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/access-groups/_components/AccessGroupsPage.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/access-groups/_components/AccessGroupsPage.test.tsx
@@ -70,6 +70,17 @@ vi.mock("./AccessGroupsModal/AccessGroupCreateModal", () => ({
     ) : null,
 }));
 
+const makeGroups = (count: number): AccessGroupResponse[] =>
+  Array.from({ length: count }, (_, index) => {
+    const suffix = String(index + 1).padStart(2, "0");
+    return {
+      ...mockAccessGroups[0],
+      access_group_id: `ag-${suffix}`,
+      access_group_name: `Group ${suffix}`,
+      description: `Group ${suffix} description`,
+    };
+  });
+
 const openRowMenu = async (user: ReturnType<typeof userEvent.setup>, groupId: string) => {
   await user.click(screen.getByTestId(`access-group-actions-${groupId}`));
   return screen.findByTestId("access-group-action-delete");
@@ -218,6 +229,21 @@ describe("AccessGroupsPage", () => {
     const dialog = screen.getByRole("dialog", { name: "Delete Access Group" });
     await user.click(within(dialog).getByRole("button", { name: /delete/i }));
     expect(mockMutate).toHaveBeenCalledWith("ag-1", expect.any(Object));
+  });
+
+  it("still shows matches when searching from a later page", async () => {
+    const user = userEvent.setup();
+    mockUseAccessGroups.mockReturnValue({ data: makeGroups(25), isLoading: false });
+    renderWithProviders(<AccessGroupsPage />);
+
+    await user.click(screen.getByTestId("pagination-next"));
+    expect(screen.getByText("ag-11")).toBeInTheDocument();
+    expect(screen.queryByText("ag-01")).not.toBeInTheDocument();
+
+    // The only match lives on page 1, so the page index must reset or the table reads as empty.
+    await user.type(screen.getByPlaceholderText("Search groups by name, ID, or description..."), "ag-01");
+    expect(await screen.findByText("ag-01")).toBeInTheDocument();
+    expect(screen.queryByText("No matching access groups")).not.toBeInTheDocument();
   });
 
   it("hides the Create button and row actions for a non-admin", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/access-groups/_components/AccessGroupsPage.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/access-groups/_components/AccessGroupsPage.tsx
@@ -1,37 +1,16 @@
 import { AccessGroupResponse, useAccessGroups } from "@/app/(dashboard)/hooks/accessGroups/useAccessGroups";
 import { useDeleteAccessGroup } from "@/app/(dashboard)/hooks/accessGroups/useDeleteAccessGroup";
 import { PlusOutlined } from "@ant-design/icons";
-import {
-  ColumnDef,
-  flexRender,
-  getCoreRowModel,
-  getSortedRowModel,
-  Row,
-  SortingState,
-  useReactTable,
-} from "@tanstack/react-table";
-import { Button, Card, Flex, Input, Layout, Pagination, Space, Table, Tag, theme, Tooltip, Typography } from "antd";
-import { BotIcon, LayersIcon, SearchIcon, ServerIcon } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { Button, Flex, Input, Layout, Space, theme, Typography } from "antd";
+import { SearchIcon } from "lucide-react";
+import { useMemo, useState } from "react";
 import DeleteResourceModal from "@/components/common_components/DeleteResourceModal";
-import TableIconActionButton from "@/components/common_components/IconActionButton/TableIconActionButtons/TableIconActionButton";
-import {
-  SortState,
-  TableHeaderSortDropdown,
-} from "@/components/common_components/TableHeaderSortDropdown/TableHeaderSortDropdown";
-import { DateCell, IdCell } from "@/components/shared/table_cells";
 import { AccessGroupDetail } from "./AccessGroupsDetailsPage";
 import { AccessGroupCreateModal } from "./AccessGroupsModal/AccessGroupCreateModal";
+import { AccessGroupsTable } from "./AccessGroupsTable";
 import { AccessGroup } from "./types";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { isProxyAdminRole } from "@/utils/roles";
-
-declare module "@tanstack/react-table" {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  interface ColumnMeta<TData, TValue> {
-    responsive?: string[];
-  }
-}
 
 const { Title, Text } = Typography;
 const { Content } = Layout;
@@ -52,55 +31,6 @@ function mapResponseToAccessGroup(r: AccessGroupResponse): AccessGroup {
     updatedBy: r.updated_by ?? "",
   };
 }
-function buildAntdColumns(
-  table: ReturnType<typeof useReactTable<AccessGroup>>,
-  rowLookup: Map<string, Row<AccessGroup>>,
-  onSortingChange: (s: SortingState) => void,
-) {
-  const headers = table.getHeaderGroups()[0]?.headers ?? [];
-
-  return headers.map((header) => {
-    const canSort = header.column.getCanSort();
-    const isSorted = header.column.getIsSorted();
-    const meta = header.column.columnDef.meta as { responsive?: string[] } | undefined;
-
-    const col: Record<string, unknown> = {
-      title: (
-        <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
-          {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
-          {canSort && (
-            <TableHeaderSortDropdown
-              sortState={isSorted === false ? false : (isSorted as SortState)}
-              onSortChange={(newState) => {
-                if (newState === false) {
-                  onSortingChange([]);
-                } else {
-                  onSortingChange([{ id: header.column.id, desc: newState === "desc" }]);
-                }
-              }}
-              columnId={header.column.id}
-            />
-          )}
-        </div>
-      ),
-      key: header.id,
-      width: header.column.columnDef.size,
-      render: (_: unknown, record: AccessGroup) => {
-        const row = rowLookup.get(record.id);
-        if (!row) return null;
-        const cell = row.getVisibleCells().find((c) => c.column.id === header.id);
-        if (!cell) return null;
-        return flexRender(cell.column.columnDef.cell, cell.getContext());
-      },
-    };
-
-    if (meta?.responsive) {
-      col.responsive = meta.responsive;
-    }
-
-    return col;
-  });
-}
 
 export function AccessGroupsPage() {
   const { token } = theme.useToken();
@@ -113,151 +43,19 @@ export function AccessGroupsPage() {
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
   const [isCreateModalVisible, setIsCreateModalVisible] = useState(false);
   const [searchText, setSearchText] = useState("");
-  const [currentPage, setCurrentPage] = useState(1);
-  const [sorting, setSorting] = useState<SortingState>([]);
   const [groupToDelete, setGroupToDelete] = useState<AccessGroup | null>(null);
   const deleteMutation = useDeleteAccessGroup();
-  const pageSize = 10;
 
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [searchText]);
-
-  // ---------- filtered data ----------
-  const filteredGroups = useMemo(
-    () =>
-      groups.filter(
-        (group) =>
-          group.name.toLowerCase().includes(searchText.toLowerCase()) ||
-          group.id.toLowerCase().includes(searchText.toLowerCase()) ||
-          group.description.toLowerCase().includes(searchText.toLowerCase()),
-      ),
-    [groups, searchText],
-  );
-
-  // ---------- TanStack column definitions ----------
-  const columnDefs = useMemo<ColumnDef<AccessGroup>[]>(
-    () => [
-      {
-        id: "id",
-        accessorKey: "id",
-        header: () => <span>ID</span>,
-        enableSorting: false,
-        size: 170,
-        cell: ({ row }) => <IdCell value={row.original.id} onClick={setSelectedGroupId} />,
-      },
-      {
-        id: "name",
-        accessorKey: "name",
-        header: () => <span>Name</span>,
-        enableSorting: true,
-        cell: ({ getValue }) => getValue() as string,
-      },
-      {
-        id: "resources",
-        header: () => <span>Resources</span>,
-        enableSorting: false,
-        cell: ({ row }) => {
-          const record = row.original;
-          const modelIds = record.modelIds ?? [];
-          const mcpServerIds = record.mcpServerIds ?? [];
-          const agentIds = record.agentIds ?? [];
-          return (
-            <Flex gap={12} align="center">
-              <Tooltip title={`${modelIds?.length} Models`}>
-                <Tag color="blue" style={{ fontSize: 14, padding: "2px 8px", margin: 0 }}>
-                  <Flex align="center" gap={6}>
-                    <LayersIcon size={14} />
-                    {modelIds?.length}
-                  </Flex>
-                </Tag>
-              </Tooltip>
-              <Tooltip title={`${mcpServerIds?.length} MCP Servers`}>
-                <Tag color="cyan" style={{ fontSize: 14, padding: "2px 8px", margin: 0 }}>
-                  <Flex align="center" gap={6}>
-                    <ServerIcon size={14} />
-                    {mcpServerIds?.length}
-                  </Flex>
-                </Tag>
-              </Tooltip>
-              <Tooltip title={`${agentIds?.length} Agents`}>
-                <Tag color="purple" style={{ fontSize: 14, padding: "2px 8px", margin: 0 }}>
-                  <Flex align="center" gap={6}>
-                    <BotIcon size={14} />
-                    {agentIds?.length}
-                  </Flex>
-                </Tag>
-              </Tooltip>
-            </Flex>
-          );
-        },
-      },
-      {
-        id: "createdAt",
-        accessorKey: "createdAt",
-        header: () => <span>Created</span>,
-        enableSorting: true,
-        sortingFn: "datetime",
-        cell: ({ getValue }) => <DateCell value={getValue() as string} precision="date" />,
-        meta: { responsive: ["lg"] },
-      },
-      {
-        id: "updatedAt",
-        accessorKey: "updatedAt",
-        header: () => <span>Updated</span>,
-        enableSorting: false,
-        cell: ({ getValue }) => <DateCell value={getValue() as string} precision="date" />,
-        meta: { responsive: ["xl"] },
-      },
-      ...(canModify
-        ? [
-            {
-              id: "actions",
-              header: () => <span>Actions</span>,
-              enableSorting: false,
-              cell: ({ row }: { row: Row<AccessGroup> }) => (
-                <Space>
-                  <TableIconActionButton
-                    variant="Delete"
-                    tooltipText="Delete access group"
-                    onClick={() => setGroupToDelete(row.original)}
-                  />
-                </Space>
-              ),
-            },
-          ]
-        : []),
-    ],
-    // setSelectedGroup is stable (useState setter)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [canModify],
-  );
-
-  // ---------- TanStack table instance ----------
-  const table = useReactTable<AccessGroup>({
-    data: filteredGroups,
-    columns: columnDefs,
-    state: { sorting },
-    onSortingChange: setSorting,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    getRowId: (row) => row.id,
-  });
-
-  // All sorted rows from TanStack
-  const sortedRows = table.getRowModel().rows;
-
-  // Paginated slice
-  const paginatedRows = sortedRows.slice((currentPage - 1) * pageSize, currentPage * pageSize);
-
-  // Map for O(1) lookup by record id in antd render()
-  const rowLookup = useMemo(() => new Map(paginatedRows.map((row) => [row.original.id, row])), [paginatedRows]);
-
-  // Convert TanStack headers → antd columns
-  const antdColumns = buildAntdColumns(table, rowLookup, setSorting);
-
-  // antd dataSource (just the originals for the current page)
-  const dataSource = paginatedRows.map((row) => row.original);
+  const filteredGroups = useMemo(() => {
+    const query = searchText.trim().toLowerCase();
+    if (!query) return groups;
+    return groups.filter(
+      (group) =>
+        group.name.toLowerCase().includes(query) ||
+        group.id.toLowerCase().includes(query) ||
+        group.description.toLowerCase().includes(query),
+    );
+  }, [groups, searchText]);
 
   if (selectedGroupId) {
     return <AccessGroupDetail accessGroupId={selectedGroupId} onBack={() => setSelectedGroupId(null)} />;
@@ -279,34 +77,25 @@ export function AccessGroupsPage() {
         )}
       </Flex>
 
-      <Card styles={{ body: { padding: 0 } }}>
-        <Flex
-          justify="space-between"
-          align="center"
-          style={{
-            padding: "12px 16px",
-          }}
-        >
-          <Input
-            prefix={<SearchIcon size={16} />}
-            placeholder="Search groups by name, ID, or description..."
-            style={{ maxWidth: 400 }}
-            value={searchText}
-            onChange={(e) => setSearchText(e.target.value)}
-            allowClear
-          />
-          <Pagination
-            current={currentPage}
-            total={sortedRows?.length}
-            pageSize={pageSize}
-            onChange={(page) => setCurrentPage(page)}
-            size="small"
-            showTotal={(total) => `${total} groups`}
-            showSizeChanger={false}
-          />
-        </Flex>
-        <Table columns={antdColumns} dataSource={dataSource} rowKey="id" loading={isLoading} pagination={false} />
-      </Card>
+      <Flex align="center" style={{ marginBottom: 12 }}>
+        <Input
+          prefix={<SearchIcon size={16} />}
+          placeholder="Search groups by name, ID, or description..."
+          style={{ maxWidth: 400 }}
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          allowClear
+        />
+      </Flex>
+
+      <AccessGroupsTable
+        groups={filteredGroups}
+        isLoading={isLoading}
+        isFiltered={searchText.trim().length > 0}
+        canModify={canModify}
+        onGroupClick={setSelectedGroupId}
+        onDeleteClick={setGroupToDelete}
+      />
 
       <AccessGroupCreateModal visible={isCreateModalVisible} onCancel={() => setIsCreateModalVisible(false)} />
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/access-groups/_components/AccessGroupsTable.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/access-groups/_components/AccessGroupsTable.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { SortingState } from "@tanstack/react-table";
+import { Layers } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { DataTable } from "@/components/shared/DataTable";
+
+import { getAccessGroupsTableColumns } from "./AccessGroupsTableColumns";
+import { AccessGroup } from "./types";
+
+interface AccessGroupsTableProps {
+  groups: AccessGroup[];
+  isLoading: boolean;
+  isFiltered: boolean;
+  canModify: boolean;
+  onGroupClick: (id: string) => void;
+  onDeleteClick: (group: AccessGroup) => void;
+}
+
+const PAGE_SIZE_OPTIONS = [10, 25, 50];
+
+function EmptyState({ isFiltered }: { isFiltered: boolean }) {
+  return (
+    <div className="flex flex-col items-center gap-1 py-6">
+      <div className="mb-1 flex size-10 items-center justify-center rounded-lg bg-muted">
+        <Layers className="size-5 text-muted-foreground" />
+      </div>
+      <div className="text-sm font-medium text-foreground">
+        {isFiltered ? "No matching access groups" : "No access groups yet"}
+      </div>
+      <div className="text-sm text-muted-foreground">
+        {isFiltered
+          ? "Try a different search term."
+          : "Create an access group to manage resource permissions for your organization."}
+      </div>
+    </div>
+  );
+}
+
+export function AccessGroupsTable({
+  groups,
+  isLoading,
+  isFiltered,
+  canModify,
+  onGroupClick,
+  onDeleteClick,
+}: AccessGroupsTableProps) {
+  const [sorting, setSorting] = useState<SortingState>([]);
+
+  const columns = useMemo(() => {
+    const deps = { canModify, onGroupClick, onDeleteClick };
+    return getAccessGroupsTableColumns(deps);
+  }, [canModify, onGroupClick, onDeleteClick]);
+
+  return (
+    <DataTable
+      data={groups}
+      columns={columns}
+      getRowId={(group, index) => group.id || String(index)}
+      sortingMode="client"
+      sorting={sorting}
+      onSortingChange={setSorting}
+      paginationMode="client"
+      pageSizeOptions={PAGE_SIZE_OPTIONS}
+      isLoading={isLoading}
+      loadingMessage="Loading access groups…"
+      noDataMessage={<EmptyState isFiltered={isFiltered} />}
+      size="compact"
+    />
+  );
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/access-groups/_components/AccessGroupsTableColumns.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/access-groups/_components/AccessGroupsTableColumns.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { ColumnDef } from "@tanstack/react-table";
+import { Bot, Layers, MoreHorizontal, Server, Trash2 } from "lucide-react";
+
+import { DataTableSortHeader } from "@/components/shared/DataTable";
+import { DateCell, IdentityCell } from "@/components/shared/table_cells";
+import { buttonVariants } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/cva.config";
+
+import { AccessGroup } from "./types";
+
+interface ResourceTone {
+  icon: typeof Layers;
+  className: string;
+}
+
+const RESOURCE_TONES: Record<"models" | "mcpServers" | "agents", ResourceTone> = {
+  models: { icon: Layers, className: "bg-blue-50 text-blue-700 ring-blue-600/20" },
+  mcpServers: { icon: Server, className: "bg-cyan-50 text-cyan-700 ring-cyan-600/20" },
+  agents: { icon: Bot, className: "bg-purple-50 text-purple-700 ring-purple-600/20" },
+};
+
+function ResourcesCell({ group }: { group: AccessGroup }) {
+  const items = [
+    { key: "models" as const, label: "Models", count: group.modelIds.length },
+    { key: "mcpServers" as const, label: "MCP Servers", count: group.mcpServerIds.length },
+    { key: "agents" as const, label: "Agents", count: group.agentIds.length },
+  ];
+
+  return (
+    <div className="flex items-center gap-1.5">
+      {items.map((item) => {
+        const tone = RESOURCE_TONES[item.key];
+        const Icon = tone.icon;
+        return (
+          <span
+            key={item.key}
+            title={`${item.count} ${item.label}`}
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset [&_svg]:size-3.5",
+              tone.className,
+            )}
+          >
+            <Icon />
+            <span className="tabular-nums">{item.count}</span>
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+function AccessGroupRowActions({
+  group,
+  onDeleteClick,
+}: {
+  group: AccessGroup;
+  onDeleteClick: (group: AccessGroup) => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        aria-label="Open access group actions"
+        data-testid={`access-group-actions-${group.id}`}
+        className={cn(buttonVariants({ variant: "ghost", size: "icon-sm" }), "text-muted-foreground")}
+      >
+        <MoreHorizontal className="size-4" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-44">
+        <DropdownMenuItem
+          variant="destructive"
+          data-testid="access-group-action-delete"
+          onClick={() => onDeleteClick(group)}
+        >
+          <Trash2 />
+          Delete access group
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+interface AccessGroupsTableColumnsDeps {
+  canModify: boolean;
+  onGroupClick: (id: string) => void;
+  onDeleteClick: (group: AccessGroup) => void;
+}
+
+export const getAccessGroupsTableColumns = ({
+  canModify,
+  onGroupClick,
+  onDeleteClick,
+}: AccessGroupsTableColumnsDeps): ColumnDef<AccessGroup>[] => {
+  const columns: ColumnDef<AccessGroup>[] = [
+    {
+      id: "id",
+      accessorKey: "id",
+      meta: { title: "ID" },
+      header: "ID",
+      size: 200,
+      enableSorting: false,
+      cell: ({ row }) => (
+        <IdentityCell
+          title={row.original.id}
+          titleClassName="font-mono text-xs font-normal"
+          onClick={() => onGroupClick(row.original.id)}
+        />
+      ),
+    },
+    {
+      id: "name",
+      accessorKey: "name",
+      meta: { title: "Name" },
+      header: ({ column }) => <DataTableSortHeader column={column} title="Name" />,
+      size: 220,
+      enableSorting: true,
+      cell: ({ row }) => {
+        const name = row.original.name;
+        return (
+          <span className="block max-w-72 truncate text-sm font-medium" title={name}>
+            {name || "-"}
+          </span>
+        );
+      },
+    },
+    {
+      id: "resources",
+      meta: { title: "Resources" },
+      header: "Resources",
+      size: 220,
+      enableSorting: false,
+      cell: ({ row }) => <ResourcesCell group={row.original} />,
+    },
+    {
+      id: "createdAt",
+      accessorKey: "createdAt",
+      meta: { title: "Created" },
+      header: ({ column }) => <DataTableSortHeader column={column} title="Created" />,
+      size: 150,
+      enableSorting: true,
+      sortingFn: "datetime",
+      cell: ({ row }) => <DateCell value={row.original.createdAt} precision="date" />,
+    },
+    {
+      id: "updatedAt",
+      accessorKey: "updatedAt",
+      meta: { title: "Updated" },
+      header: "Updated",
+      size: 150,
+      enableSorting: false,
+      cell: ({ row }) => <DateCell value={row.original.updatedAt} precision="date" />,
+    },
+  ];
+
+  if (!canModify) {
+    return columns;
+  }
+
+  return [
+    ...columns,
+    {
+      id: "actions",
+      meta: { className: "text-right", headerClassName: "text-right" },
+      header: () => <span className="sr-only">Actions</span>,
+      size: 64,
+      enableSorting: false,
+      enableHiding: false,
+      cell: ({ row }) => (
+        <div className="flex justify-end">
+          <AccessGroupRowActions group={row.original} onDeleteClick={onDeleteClick} />
+        </div>
+      ),
+    },
+  ];
+};


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a UI-only refactor of the Access Groups list with no backend or LLM calls, so there is no curl proof to capture. The route compiles clean on the dev server (`GET /access-groups/` returns 200 with no build error) and every render state is pinned by unit tests against the real shared DataTable, columns, and cells. I did not capture live browser screenshots because the page is auth-gated and I had no proxy running to log in against

To grab before/after screenshots against a live proxy, start the proxy on `:4000` and the dashboard dev server, then open http://localhost:4000/ui/?page=access-groups (or the Access Groups entry in the sidebar) and:

1. Confirm the list renders with the ID, Name, Resources, Created, and Updated columns and the resource count chips
2. Click a Name/Created header to sort, and use the rows-per-page control and pager in the table footer
3. Type in the search box (name, ID, or description) and confirm the list filters and shows the rich empty state on no match
4. Click a row's ID cell to open the detail view, then Back to return to the list
5. As an admin, open a row's ⋯ menu and click Delete to confirm the delete modal still opens; sign in as Admin Viewer to confirm the Create button and the ⋯ menu are absent

## Type

🧹 Refactoring

## Changes

Access Groups was on the migration audit's "complex" list only because of a scary looking TanStack-to-antd column bridge. That bridge turned out to be deletable glue over a column set that was already a clean `ColumnDef[]`, so this moves the table onto the shared `DataTable` and `table_cells` like Guardrails and Teams rather than needing bespoke handling.

The old `buildAntdColumns` adapter, the `rowLookup` map, the manual `.slice()` pagination, and the antd `Table` / `Pagination` are gone. The table now runs in client mode with native sorting and pagination, and the name/ID/description search stays in the parent and feeds the table its filtered rows. The one self-contained page file is split into three: `AccessGroupsPage` still owns the data hook, the detail-view swap, the create and delete modals, and the search box; `AccessGroupsTable` is a thin `DataTable` consumer; and `getAccessGroupsTableColumns` holds the columns.

Interaction affordances unify to the shared pattern. The inline delete icon becomes a row overflow (⋯) menu, still gated to proxy admins by rendering the actions column only for them, so a non-admin sees neither the Create button nor the menu. The clickable ID cell moves from the blue `IdCell` pill to the monospace `IdentityCell` used by the other migrated tables and still opens the detail view. Detail view and modals stay in the parent; the table takes `onGroupClick` and `onDeleteClick` callbacks and never owns a detail surface, and no whole-row click is wired.

One judgment call: the antd `meta.responsive` breakpoints that hid Created below `lg` and Updated below `xl` have no shared DataTable equivalent, so both columns are now always visible, matching how Guardrails and Teams show created/updated. Loading is initial-load-only via the React Query `isLoading` flag, and the empty state branches its copy for the filtered vs empty cases.

The unit test is rewritten for the new structure and covers rendering, per-resource counts, search by name/ID/description, the filtered and empty states, initial-load skeletons, the create-modal flow, ID-cell detail navigation, the ⋯ menu delete flow (open, cancel, confirm calls the mutation with the group id), and the non-admin gating of the Create button and row actions. I mutation-checked the admin gating, the delete wiring, and the resource counts and confirmed each mutation makes the relevant test fail

A follow-up commit adds one more regression test covering search from a later page. The old page reset the pager to page 1 on every search; the shared DataTable gets that for free because TanStack's `autoResetPageIndex` defaults on for client pagination, and the test pins it so a future change to that option or to the pagination mode cannot silently regress the search. It was checked in both directions: it fails when `autoResetPageIndex` is forced off and passes with the default

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
