### PR TITLE
refactor(ui): migrate memory table onto shared DataTable

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -639,11 +639,6 @@
       "count": 2
     }
   },
-  "src/app/(dashboard)/memory/_components/MemoryView.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
   "src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.tsx": {
     "no-restricted-imports": {
       "count": 1

--- a/ui/litellm-dashboard/src/app/(dashboard)/memory/_components/MemoryDetailDrawer.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/memory/_components/MemoryDetailDrawer.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { Drawer, Space, Typography } from "antd";
+import React from "react";
+
+import { MemoryRow } from "@/components/networking";
+
+const { Text, Paragraph } = Typography;
+
+interface MemoryDetailDrawerProps {
+  row: MemoryRow | null;
+  onClose: () => void;
+}
+
+function formatTimestamp(ts?: string): string {
+  if (!ts) return "—";
+  try {
+    const d = new Date(ts);
+    return d.toLocaleString();
+  } catch {
+    return ts;
+  }
+}
+
+export function MemoryDetailDrawer({ row, onClose }: MemoryDetailDrawerProps) {
+  return (
+    <Drawer
+      open={!!row}
+      onClose={onClose}
+      title={
+        row ? (
+          <Space>
+            <Text code>{row.key}</Text>
+          </Space>
+        ) : (
+          "Memory"
+        )
+      }
+      width={720}
+      destroyOnClose
+    >
+      {row && (
+        <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+          <Space size="large" wrap>
+            <div>
+              <Text strong style={{ display: "block" }}>
+                Memory ID
+              </Text>
+              <Text code style={{ fontSize: 12 }}>
+                {row.memory_id}
+              </Text>
+            </div>
+            <div>
+              <Text strong style={{ display: "block" }}>
+                User ID
+              </Text>
+              <Text type={row.user_id ? undefined : "secondary"}>{row.user_id ?? "-"}</Text>
+            </div>
+            <div>
+              <Text strong style={{ display: "block" }}>
+                Team ID
+              </Text>
+              <Text type={row.team_id ? undefined : "secondary"}>{row.team_id ?? "-"}</Text>
+            </div>
+          </Space>
+          <div>
+            <Text strong>Value</Text>
+            <Paragraph
+              style={{
+                background: "#fafafa",
+                padding: 12,
+                borderRadius: 6,
+                whiteSpace: "pre-wrap",
+                fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+                fontSize: 13,
+              }}
+            >
+              {row.value}
+            </Paragraph>
+          </div>
+          {row.metadata !== undefined && row.metadata !== null && (
+            <div>
+              <Text strong>Metadata</Text>
+              <Paragraph
+                style={{
+                  background: "#fafafa",
+                  padding: 12,
+                  borderRadius: 6,
+                  whiteSpace: "pre-wrap",
+                  fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+                  fontSize: 12,
+                }}
+              >
+                {JSON.stringify(row.metadata, null, 2)}
+              </Paragraph>
+            </div>
+          )}
+          <Space split={<Text type="secondary">·</Text>} wrap size="small" style={{ color: "rgba(0,0,0,0.45)" }}>
+            <Text type="secondary">
+              Created {formatTimestamp(row.created_at)}
+              {row.created_by ? ` by ${row.created_by}` : ""}
+            </Text>
+            <Text type="secondary">
+              Updated {formatTimestamp(row.updated_at)}
+              {row.updated_by ? ` by ${row.updated_by}` : ""}
+            </Text>
+          </Space>
+        </Space>
+      )}
+    </Drawer>
+  );
+}
+
+export default MemoryDetailDrawer;

--- a/ui/litellm-dashboard/src/app/(dashboard)/memory/_components/MemoryTable.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/memory/_components/MemoryTable.test.tsx
@@ -1,6 +1,7 @@
 import { PaginationState } from "@tanstack/react-table";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import React, { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import { MemoryRow } from "@/components/networking";
@@ -132,6 +133,31 @@ describe("MemoryTable", () => {
 
     await user.click(screen.getByTestId("datatable-refresh"));
     expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the page in range when the rows-per-page selector shrinks the page count", async () => {
+    const user = userEvent.setup();
+    const rowCount = 120;
+    const seen: PaginationState[] = [];
+
+    function Harness() {
+      const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 4, pageSize: 25 });
+      seen.push(pagination);
+      return (
+        <MemoryTable {...baseProps} rowCount={rowCount} pagination={pagination} onPaginationChange={setPagination} />
+      );
+    }
+
+    render(<Harness />);
+    expect(screen.getByTestId("pagination-page")).toHaveTextContent("Page 5 of 5");
+
+    await user.click(screen.getByTestId("pagination-page-size"));
+    await user.click(await screen.findByRole("option", { name: "100" }));
+
+    const final = seen[seen.length - 1];
+    expect(final.pageSize).toBe(100);
+    expect(final.pageIndex).toBeLessThanOrEqual(Math.ceil(rowCount / final.pageSize) - 1);
+    expect(screen.getByTestId("pagination-page")).toHaveTextContent("Page 2 of 2");
   });
 
   it("renders secondary id and date cells for the row", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/memory/_components/MemoryTable.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/memory/_components/MemoryTable.test.tsx
@@ -1,0 +1,144 @@
+import { PaginationState } from "@tanstack/react-table";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { MemoryRow } from "@/components/networking";
+
+import { MemoryTable } from "./MemoryTable";
+
+const makeMemory = (overrides: Partial<MemoryRow> = {}): MemoryRow => ({
+  memory_id: "mem-1",
+  key: "user:profile",
+  value: "The user prefers concise answers.",
+  metadata: null,
+  user_id: "user-42",
+  team_id: "team-7",
+  updated_at: "2024-05-01T12:00:00Z",
+  ...overrides,
+});
+
+const baseProps = {
+  data: [makeMemory()],
+  isLoading: false,
+  rowCount: 1,
+  pagination: { pageIndex: 0, pageSize: 50 } as PaginationState,
+  onPaginationChange: vi.fn(),
+  searchValue: "",
+  onSearchChange: vi.fn(),
+  isRefreshing: false,
+  onRefresh: vi.fn(),
+  hasActiveSearch: false,
+  onViewClick: vi.fn(),
+  onEditClick: vi.fn(),
+  onDeleteClick: vi.fn(),
+};
+
+describe("MemoryTable", () => {
+  it("renders every column header", () => {
+    render(<MemoryTable {...baseProps} />);
+    for (const header of ["ID", "Name", "Preview", "User ID", "Team ID", "Updated"]) {
+      expect(screen.getByText(header)).toBeInTheDocument();
+    }
+  });
+
+  it("opens the detail view when the ID identity cell is clicked", async () => {
+    const user = userEvent.setup();
+    const onViewClick = vi.fn();
+    const row = makeMemory({ memory_id: "mem-click" });
+    render(<MemoryTable {...baseProps} data={[row]} onViewClick={onViewClick} />);
+
+    await user.click(screen.getByText("mem-click"));
+
+    expect(onViewClick).toHaveBeenCalledTimes(1);
+    expect(onViewClick).toHaveBeenCalledWith(row);
+  });
+
+  it("routes each overflow-menu action to its callback with the row", async () => {
+    const user = userEvent.setup();
+    const onViewClick = vi.fn();
+    const onEditClick = vi.fn();
+    const onDeleteClick = vi.fn();
+    const row = makeMemory({ memory_id: "mem-9" });
+    render(
+      <MemoryTable
+        {...baseProps}
+        data={[row]}
+        onViewClick={onViewClick}
+        onEditClick={onEditClick}
+        onDeleteClick={onDeleteClick}
+      />,
+    );
+
+    await user.click(screen.getByTestId("memory-actions-mem-9"));
+    await user.click(await screen.findByTestId("memory-action-edit"));
+    expect(onEditClick).toHaveBeenCalledWith(row);
+    expect(onViewClick).not.toHaveBeenCalled();
+    expect(onDeleteClick).not.toHaveBeenCalled();
+
+    await user.click(screen.getByTestId("memory-actions-mem-9"));
+    await user.click(await screen.findByTestId("memory-action-delete"));
+    expect(onDeleteClick).toHaveBeenCalledWith(row);
+
+    await user.click(screen.getByTestId("memory-actions-mem-9"));
+    await user.click(await screen.findByTestId("memory-action-view"));
+    expect(onViewClick).toHaveBeenCalledWith(row);
+  });
+
+  it("shows the empty-only copy when there is no data and no active search", () => {
+    render(<MemoryTable {...baseProps} data={[]} rowCount={0} hasActiveSearch={false} />);
+    expect(screen.getByText("No memories stored yet")).toBeInTheDocument();
+    expect(screen.queryByText("No matching memories")).not.toBeInTheDocument();
+  });
+
+  it("shows the filtered-empty copy when a search is active", () => {
+    render(<MemoryTable {...baseProps} data={[]} rowCount={0} hasActiveSearch={true} />);
+    expect(screen.getByText("No matching memories")).toBeInTheDocument();
+    expect(screen.queryByText("No memories stored yet")).not.toBeInTheDocument();
+  });
+
+  it("renders loading skeleton rows instead of the empty state while loading", () => {
+    render(<MemoryTable {...baseProps} data={[]} rowCount={0} isLoading={true} />);
+    expect(screen.getAllByTestId("skeleton-row").length).toBeGreaterThan(0);
+    expect(screen.queryByText("No memories stored yet")).not.toBeInTheDocument();
+  });
+
+  it("drives the pagination footer from the server rowCount, not the page's row length", () => {
+    render(<MemoryTable {...baseProps} data={[makeMemory()]} rowCount={120} />);
+    const range = screen.getByTestId("pagination-range");
+    expect(range).toHaveTextContent("Showing 1-50 of 120");
+    expect(screen.getByTestId("pagination-page")).toHaveTextContent("Page 1 of 3");
+    expect(screen.getByTestId("pagination-next")).toBeEnabled();
+  });
+
+  it("advances the page through the server pagination handler", async () => {
+    const user = userEvent.setup();
+    const onPaginationChange = vi.fn();
+    render(<MemoryTable {...baseProps} rowCount={120} onPaginationChange={onPaginationChange} />);
+
+    await user.click(screen.getByTestId("pagination-next"));
+
+    expect(onPaginationChange).toHaveBeenCalled();
+  });
+
+  it("forwards toolbar search input and refresh to their callbacks", async () => {
+    const user = userEvent.setup();
+    const onSearchChange = vi.fn();
+    const onRefresh = vi.fn();
+    render(<MemoryTable {...baseProps} onSearchChange={onSearchChange} onRefresh={onRefresh} />);
+
+    await user.type(screen.getByTestId("datatable-search"), "u");
+    expect(onSearchChange).toHaveBeenCalledWith("u");
+
+    await user.click(screen.getByTestId("datatable-refresh"));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders secondary id and date cells for the row", () => {
+    render(<MemoryTable {...baseProps} data={[makeMemory({ user_id: "user-42", team_id: "team-7" })]} />);
+    const table = screen.getByRole("table");
+    expect(within(table).getByText("user-42")).toBeInTheDocument();
+    expect(within(table).getByText("team-7")).toBeInTheDocument();
+    expect(within(table).getByText("user:profile")).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/memory/_components/MemoryTable.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/memory/_components/MemoryTable.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { OnChangeFn, PaginationState } from "@tanstack/react-table";
+import { Database } from "lucide-react";
+import React, { useMemo } from "react";
+
+import { MemoryRow } from "@/components/networking";
+import { DataTable, DataTableToolbar } from "@/components/shared/DataTable";
+
+import { getMemoryTableColumns } from "./MemoryTableColumns";
+
+interface MemoryTableProps {
+  data: MemoryRow[];
+  isLoading: boolean;
+  rowCount: number;
+  pagination: PaginationState;
+  onPaginationChange: OnChangeFn<PaginationState>;
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  isRefreshing: boolean;
+  onRefresh: () => void;
+  hasActiveSearch: boolean;
+  onViewClick: (row: MemoryRow) => void;
+  onEditClick: (row: MemoryRow) => void;
+  onDeleteClick: (row: MemoryRow) => void;
+}
+
+function MemoryEmptyState({ hasActiveSearch }: { hasActiveSearch: boolean }) {
+  return (
+    <div className="flex flex-col items-center gap-1 py-6">
+      <div className="mb-1 flex size-10 items-center justify-center rounded-lg bg-muted">
+        <Database className="size-5 text-muted-foreground" />
+      </div>
+      <div className="text-sm font-medium text-foreground">
+        {hasActiveSearch ? "No matching memories" : "No memories stored yet"}
+      </div>
+      <div className="text-sm text-muted-foreground">
+        {hasActiveSearch
+          ? "No memories have keys starting with your search."
+          : "Memories your agents store under /v1/memory will appear here."}
+      </div>
+    </div>
+  );
+}
+
+export function MemoryTable({
+  data,
+  isLoading,
+  rowCount,
+  pagination,
+  onPaginationChange,
+  searchValue,
+  onSearchChange,
+  isRefreshing,
+  onRefresh,
+  hasActiveSearch,
+  onViewClick,
+  onEditClick,
+  onDeleteClick,
+}: MemoryTableProps) {
+  const columns = useMemo(() => {
+    const columnDeps = { onViewClick, onEditClick, onDeleteClick };
+    return getMemoryTableColumns(columnDeps);
+  }, [onViewClick, onEditClick, onDeleteClick]);
+
+  return (
+    <DataTable
+      data={data}
+      columns={columns}
+      getRowId={(row) => row.memory_id}
+      paginationMode="server"
+      pagination={pagination}
+      onPaginationChange={onPaginationChange}
+      rowCount={rowCount}
+      isLoading={isLoading}
+      loadingMessage="Loading memories…"
+      noDataMessage={<MemoryEmptyState hasActiveSearch={hasActiveSearch} />}
+      size="compact"
+      toolbar={(table) => (
+        <DataTableToolbar
+          table={table}
+          searchValue={searchValue}
+          onSearchChange={onSearchChange}
+          searchPlaceholder='Filter by key prefix, e.g. "user:"'
+          onRefresh={onRefresh}
+          isRefreshing={isRefreshing}
+          showViewOptions={false}
+        />
+      )}
+    />
+  );
+}
+
+export default MemoryTable;

--- a/ui/litellm-dashboard/src/app/(dashboard)/memory/_components/MemoryTableColumns.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/memory/_components/MemoryTableColumns.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { ColumnDef } from "@tanstack/react-table";
+import { Eye, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+
+import { MemoryRow } from "@/components/networking";
+import { DateCell, IdCell, IdentityCell } from "@/components/shared/table_cells";
+import { buttonVariants } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/cva.config";
+
+interface MemoryRowActionsProps {
+  row: MemoryRow;
+  onViewClick: (row: MemoryRow) => void;
+  onEditClick: (row: MemoryRow) => void;
+  onDeleteClick: (row: MemoryRow) => void;
+}
+
+function MemoryRowActions({ row, onViewClick, onEditClick, onDeleteClick }: MemoryRowActionsProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        aria-label="Open memory actions"
+        data-testid={`memory-actions-${row.memory_id}`}
+        className={cn(buttonVariants({ variant: "ghost", size: "icon-sm" }), "text-muted-foreground")}
+      >
+        <MoreHorizontal className="size-4" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-40">
+        <DropdownMenuItem data-testid="memory-action-view" onClick={() => onViewClick(row)}>
+          <Eye />
+          View
+        </DropdownMenuItem>
+        <DropdownMenuItem data-testid="memory-action-edit" onClick={() => onEditClick(row)}>
+          <Pencil />
+          Edit
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem variant="destructive" data-testid="memory-action-delete" onClick={() => onDeleteClick(row)}>
+          <Trash2 />
+          Delete
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export interface MemoryTableColumnsDeps {
+  onViewClick: (row: MemoryRow) => void;
+  onEditClick: (row: MemoryRow) => void;
+  onDeleteClick: (row: MemoryRow) => void;
+}
+
+export const getMemoryTableColumns = ({
+  onViewClick,
+  onEditClick,
+  onDeleteClick,
+}: MemoryTableColumnsDeps): ColumnDef<MemoryRow>[] => [
+  {
+    id: "memory_id",
+    accessorKey: "memory_id",
+    meta: { title: "ID" },
+    header: "ID",
+    size: 180,
+    enableSorting: false,
+    cell: ({ row }) => (
+      <IdentityCell
+        title={row.original.memory_id}
+        titleClassName="font-mono text-xs font-normal"
+        onClick={() => onViewClick(row.original)}
+      />
+    ),
+  },
+  {
+    id: "key",
+    accessorKey: "key",
+    meta: { title: "Name" },
+    header: "Name",
+    size: 200,
+    enableSorting: false,
+    cell: ({ row }) => (
+      <span className="block max-w-52 truncate font-mono text-xs" title={row.original.key}>
+        {row.original.key}
+      </span>
+    ),
+  },
+  {
+    id: "value",
+    accessorKey: "value",
+    meta: { title: "Preview" },
+    header: "Preview",
+    enableSorting: false,
+    cell: ({ row }) => (
+      <span className="block max-w-72 truncate text-sm text-muted-foreground" title={row.original.value}>
+        {row.original.value || "-"}
+      </span>
+    ),
+  },
+  {
+    id: "user_id",
+    accessorKey: "user_id",
+    meta: { title: "User ID" },
+    header: "User ID",
+    size: 160,
+    enableSorting: false,
+    cell: ({ row }) => <IdCell value={row.original.user_id} />,
+  },
+  {
+    id: "team_id",
+    accessorKey: "team_id",
+    meta: { title: "Team ID" },
+    header: "Team ID",
+    size: 160,
+    enableSorting: false,
+    cell: ({ row }) => <IdCell value={row.original.team_id} />,
+  },
+  {
+    id: "updated_at",
+    accessorKey: "updated_at",
+    meta: { title: "Updated" },
+    header: "Updated",
+    size: 170,
+    enableSorting: false,
+    cell: ({ row }) => <DateCell value={row.original.updated_at} />,
+  },
+  {
+    id: "actions",
+    meta: { className: "text-right", headerClassName: "text-right" },
+    header: () => <span className="sr-only">Actions</span>,
+    size: 64,
+    enableSorting: false,
+    enableHiding: false,
+    cell: ({ row }) => (
+      <div className="flex justify-end">
+        <MemoryRowActions
+          row={row.original}
+          onViewClick={onViewClick}
+          onEditClick={onEditClick}
+          onDeleteClick={onDeleteClick}
+        />
+      </div>
+    ),
+  },
+];

--- a/ui/litellm-dashboard/src/app/(dashboard)/memory/_components/MemoryView.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/memory/_components/MemoryView.test.tsx
@@ -1,0 +1,45 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { MemoryRow } from "@/components/networking";
+
+import { MemoryView } from "./MemoryView";
+
+interface CapturedTableProps {
+  isLoading: boolean;
+  rowCount: number;
+  data: MemoryRow[];
+  hasActiveSearch: boolean;
+}
+
+const captured = vi.hoisted(() => ({ current: null as CapturedTableProps | null }));
+
+vi.mock("./MemoryTable", () => ({
+  MemoryTable: function MemoryTableMock(props: CapturedTableProps) {
+    captured.current = props;
+    return <div data-testid="memory-table-mock" />;
+  },
+}));
+
+const renderView = (accessToken: string | null) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryView accessToken={accessToken} userID={null} userRole={null} />
+    </QueryClientProvider>,
+  );
+};
+
+describe("MemoryView", () => {
+  it("keeps the table out of the skeleton state when the token is null (disabled query)", () => {
+    renderView(null);
+
+    expect(captured.current).not.toBeNull();
+    expect(captured.current?.isLoading).toBe(false);
+    expect(captured.current?.data).toEqual([]);
+    expect(captured.current?.rowCount).toBe(0);
+    expect(captured.current?.hasActiveSearch).toBe(false);
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/memory/_components/MemoryView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/memory/_components/MemoryView.tsx
@@ -1,21 +1,19 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
+import { useDebouncedValue } from "@tanstack/react-pacer/debouncer";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Button, Card, Drawer, Empty, Input, Space, Table, Typography, message } from "antd";
-import type { ColumnsType } from "antd/es/table";
-import {
-  DeleteOutlined,
-  EditOutlined,
-  EyeOutlined,
-  PlusOutlined,
-  ReloadOutlined,
-  SearchOutlined,
-} from "@ant-design/icons";
+import type { PaginationState } from "@tanstack/react-table";
+import { PlusOutlined } from "@ant-design/icons";
+import { Button, Space, Typography, message } from "antd";
+import React, { useCallback, useMemo, useState } from "react";
+
 import { MemoryRow, createMemory, deleteMemory, fetchMemoryList, updateMemory } from "@/components/networking";
-import { DateCell, IdCell } from "@/components/shared/table_cells";
-import { MemoryEditModal } from "./MemoryEditModal";
 import DeleteResourceModal from "@/components/common_components/DeleteResourceModal";
+import { DEBOUNCE_WAIT_MS } from "@/utils/debounceConstants";
+
+import { MemoryDetailDrawer } from "./MemoryDetailDrawer";
+import { MemoryEditModal } from "./MemoryEditModal";
+import { MemoryTable } from "./MemoryTable";
 
 const { Text, Paragraph, Title } = Typography;
 
@@ -25,38 +23,16 @@ interface MemoryViewProps {
   userRole: string | null;
 }
 
-function previewValue(value: string, max = 120): string {
-  if (!value) return "";
-  const trimmed = value.trim();
-  if (trimmed.length <= max) return trimmed;
-  return `${trimmed.slice(0, max)}…`;
-}
-
-function formatTimestamp(ts?: string): string {
-  if (!ts) return "—";
-  try {
-    const d = new Date(ts);
-    return d.toLocaleString();
-  } catch {
-    return ts;
-  }
-}
-
-const PAGE_SIZE = 50;
+const DEFAULT_PAGE_SIZE = 50;
 
 export const MemoryView: React.FC<MemoryViewProps> = ({ accessToken }) => {
   const [searchInput, setSearchInput] = useState("");
-  const [appliedSearch, setAppliedSearch] = useState("");
+  const [debouncedSearch] = useDebouncedValue(searchInput, { wait: DEBOUNCE_WAIT_MS });
+  const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: DEFAULT_PAGE_SIZE });
   const [detailRow, setDetailRow] = useState<MemoryRow | null>(null);
   const [editRow, setEditRow] = useState<MemoryRow | null>(null);
   const [deleteRow, setDeleteRow] = useState<MemoryRow | null>(null);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
-  const [currentPage, setCurrentPage] = useState(1);
-
-  // Reset to page 1 whenever the filter changes.
-  React.useEffect(() => {
-    setCurrentPage(1);
-  }, [appliedSearch]);
 
   const queryClient = useQueryClient();
   // React Query key prefix for all memory-list variants (paged + filtered).
@@ -65,15 +41,15 @@ export const MemoryView: React.FC<MemoryViewProps> = ({ accessToken }) => {
   const MEMORY_LIST_KEY = "memoryList" as const;
 
   const { data, isLoading, isFetching } = useQuery({
-    queryKey: [MEMORY_LIST_KEY, appliedSearch, currentPage],
+    queryKey: [MEMORY_LIST_KEY, debouncedSearch, pagination.pageIndex, pagination.pageSize],
     queryFn: () => {
       if (!accessToken) throw new Error("Access token required");
       // Prefix search matches the Redis-style mental model (namespace scan):
       // typing "user:" finds "user:profile", "user:prefs", etc.
       return fetchMemoryList(accessToken, {
-        keyPrefix: appliedSearch || undefined,
-        page: currentPage,
-        pageSize: PAGE_SIZE,
+        keyPrefix: debouncedSearch || undefined,
+        page: pagination.pageIndex + 1,
+        pageSize: pagination.pageSize,
       });
     },
     enabled: !!accessToken,
@@ -88,7 +64,10 @@ export const MemoryView: React.FC<MemoryViewProps> = ({ accessToken }) => {
   //     refetches from scratch (pagination + filter-aware).
   //   - on error: surface the message via antd `message.error`.
 
-  const invalidateList = () => queryClient.invalidateQueries({ queryKey: [MEMORY_LIST_KEY] });
+  const invalidateList = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: [MEMORY_LIST_KEY] }),
+    [queryClient],
+  );
 
   const createMutation = useMutation({
     mutationFn: (args: { key: string; value: string; metadata: unknown }) => {
@@ -133,9 +112,14 @@ export const MemoryView: React.FC<MemoryViewProps> = ({ accessToken }) => {
     },
   });
 
-  const handleDelete = (row: MemoryRow) => {
-    setDeleteRow(row);
-  };
+  const handleSearchChange = useCallback((value: string) => {
+    setSearchInput(value);
+    setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+  }, []);
+
+  const handleView = useCallback((row: MemoryRow) => setDetailRow(row), []);
+  const handleEdit = useCallback((row: MemoryRow) => setEditRow(row), []);
+  const handleDelete = useCallback((row: MemoryRow) => setDeleteRow(row), []);
 
   const confirmDelete = async () => {
     if (!deleteRow) return;
@@ -192,242 +176,43 @@ export const MemoryView: React.FC<MemoryViewProps> = ({ accessToken }) => {
     }
   };
 
-  const columns: ColumnsType<MemoryRow> = [
-    {
-      title: "ID",
-      dataIndex: "memory_id",
-      key: "memory_id",
-      width: 140,
-      render: (_: unknown, r: MemoryRow) => <IdCell value={r.memory_id} onClick={() => setDetailRow(r)} />,
-    },
-    {
-      title: "Name",
-      dataIndex: "key",
-      key: "key",
-      width: 200,
-      render: (k: string) => <Text code>{k}</Text>,
-      // No client-side sorter: pagination is server-side, so a client sort
-      // would only reorder the current page and mislead users into thinking
-      // the whole list is sorted. Backend returns rows ordered by
-      // `updated_at DESC`; use the prefix filter for discovery by name.
-    },
-    {
-      title: "Preview",
-      dataIndex: "value",
-      key: "value",
-      render: (v: string) => (
-        <Text type="secondary" style={{ whiteSpace: "pre-wrap" }}>
-          {previewValue(v)}
-        </Text>
-      ),
-    },
-    {
-      title: "User ID",
-      dataIndex: "user_id",
-      key: "user_id",
-      width: 160,
-      render: (uid?: string | null) => <IdCell value={uid} />,
-    },
-    {
-      title: "Team ID",
-      dataIndex: "team_id",
-      key: "team_id",
-      width: 160,
-      render: (tid?: string | null) => <IdCell value={tid} />,
-    },
-    {
-      title: "Updated",
-      dataIndex: "updated_at",
-      key: "updated_at",
-      width: 180,
-      render: (ts?: string) => <DateCell value={ts} />,
-      // No sorter — backend already returns rows in `updated_at DESC` order,
-      // and a client-side sorter on a paginated view would only affect the
-      // current page.
-    },
-    {
-      title: "",
-      key: "actions",
-      width: 140,
-      render: (_: unknown, r: MemoryRow) => (
-        <Space size={4}>
-          <Button size="small" type="text" icon={<EyeOutlined />} onClick={() => setDetailRow(r)} aria-label="View" />
-          <Button size="small" type="text" icon={<EditOutlined />} onClick={() => setEditRow(r)} aria-label="Edit" />
-          <Button
-            size="small"
-            type="text"
-            danger
-            icon={<DeleteOutlined />}
-            onClick={() => handleDelete(r)}
-            aria-label="Delete"
-          />
-        </Space>
-      ),
-    },
-  ];
-
   return (
     <div className="w-full" style={{ padding: 24 }}>
       <Space direction="vertical" size="large" style={{ width: "100%" }}>
-        <div>
-          <Title level={3} style={{ marginBottom: 4 }}>
-            Memory
-          </Title>
-          <Paragraph type="secondary" style={{ marginBottom: 0 }}>
-            Inspect what your agents have stored under <Text code>/v1/memory</Text>. Scoped to memories visible to your
-            user / team (admins see all).
-          </Paragraph>
+        <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 16 }}>
+          <div>
+            <Title level={3} style={{ marginBottom: 4 }}>
+              Memory
+            </Title>
+            <Paragraph type="secondary" style={{ marginBottom: 0 }}>
+              Inspect what your agents have stored under <Text code>/v1/memory</Text>. Scoped to memories visible to
+              your user / team (admins see all).
+            </Paragraph>
+          </div>
+          <Button type="primary" icon={<PlusOutlined />} onClick={() => setIsCreateOpen(true)}>
+            New memory
+          </Button>
         </div>
 
-        <Card>
-          <Space
-            style={{
-              width: "100%",
-              justifyContent: "space-between",
-              marginBottom: 16,
-            }}
-            wrap
-          >
-            <Space>
-              <Input
-                allowClear
-                placeholder='Filter by key prefix, e.g. "user:"'
-                prefix={<SearchOutlined />}
-                value={searchInput}
-                onChange={(e) => setSearchInput(e.target.value)}
-                onPressEnter={() => setAppliedSearch(searchInput.trim())}
-                onClear={() => {
-                  setSearchInput("");
-                  setAppliedSearch("");
-                }}
-                style={{ width: 280 }}
-              />
-              <Button type="primary" ghost onClick={() => setAppliedSearch(searchInput.trim())}>
-                Search
-              </Button>
-              <Button icon={<ReloadOutlined />} onClick={() => invalidateList()} loading={isFetching && !isLoading}>
-                Refresh
-              </Button>
-            </Space>
-            <Button type="primary" icon={<PlusOutlined />} onClick={() => setIsCreateOpen(true)}>
-              New memory
-            </Button>
-          </Space>
-
-          <Table
-            rowKey="memory_id"
-            loading={isLoading}
-            dataSource={rows}
-            columns={columns}
-            // Server-side pagination: we fetch one page at a time so we never
-            // silently truncate large stores. `total` drives the page count;
-            // changing page/pageSize retriggers the query via `currentPage`.
-            pagination={{
-              current: currentPage,
-              pageSize: PAGE_SIZE,
-              total,
-              showSizeChanger: false,
-              showTotal: (n, range) => `${range[0]}–${range[1]} of ${n}`,
-              onChange: (page) => setCurrentPage(page),
-            }}
-            locale={{
-              emptyText: (
-                <Empty
-                  description={
-                    appliedSearch ? `No memories with keys starting with "${appliedSearch}"` : "No memories stored yet"
-                  }
-                />
-              ),
-            }}
-          />
-        </Card>
+        <MemoryTable
+          data={rows}
+          isLoading={isLoading}
+          rowCount={total}
+          pagination={pagination}
+          onPaginationChange={setPagination}
+          searchValue={searchInput}
+          onSearchChange={handleSearchChange}
+          isRefreshing={isFetching && !isLoading}
+          onRefresh={invalidateList}
+          hasActiveSearch={!!debouncedSearch}
+          onViewClick={handleView}
+          onEditClick={handleEdit}
+          onDeleteClick={handleDelete}
+        />
       </Space>
 
       {/* Detail drawer */}
-      <Drawer
-        open={!!detailRow}
-        onClose={() => setDetailRow(null)}
-        title={
-          detailRow ? (
-            <Space>
-              <Text code>{detailRow.key}</Text>
-            </Space>
-          ) : (
-            "Memory"
-          )
-        }
-        width={720}
-        destroyOnClose
-      >
-        {detailRow && (
-          <Space direction="vertical" size="middle" style={{ width: "100%" }}>
-            <Space size="large" wrap>
-              <div>
-                <Text strong style={{ display: "block" }}>
-                  Memory ID
-                </Text>
-                <Text code style={{ fontSize: 12 }}>
-                  {detailRow.memory_id}
-                </Text>
-              </div>
-              <div>
-                <Text strong style={{ display: "block" }}>
-                  User ID
-                </Text>
-                <Text type={detailRow.user_id ? undefined : "secondary"}>{detailRow.user_id ?? "-"}</Text>
-              </div>
-              <div>
-                <Text strong style={{ display: "block" }}>
-                  Team ID
-                </Text>
-                <Text type={detailRow.team_id ? undefined : "secondary"}>{detailRow.team_id ?? "-"}</Text>
-              </div>
-            </Space>
-            <div>
-              <Text strong>Value</Text>
-              <Paragraph
-                style={{
-                  background: "#fafafa",
-                  padding: 12,
-                  borderRadius: 6,
-                  whiteSpace: "pre-wrap",
-                  fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
-                  fontSize: 13,
-                }}
-              >
-                {detailRow.value}
-              </Paragraph>
-            </div>
-            {detailRow.metadata !== undefined && detailRow.metadata !== null && (
-              <div>
-                <Text strong>Metadata</Text>
-                <Paragraph
-                  style={{
-                    background: "#fafafa",
-                    padding: 12,
-                    borderRadius: 6,
-                    whiteSpace: "pre-wrap",
-                    fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
-                    fontSize: 12,
-                  }}
-                >
-                  {JSON.stringify(detailRow.metadata, null, 2)}
-                </Paragraph>
-              </div>
-            )}
-            <Space split={<Text type="secondary">·</Text>} wrap size="small" style={{ color: "rgba(0,0,0,0.45)" }}>
-              <Text type="secondary">
-                Created {formatTimestamp(detailRow.created_at)}
-                {detailRow.created_by ? ` by ${detailRow.created_by}` : ""}
-              </Text>
-              <Text type="secondary">
-                Updated {formatTimestamp(detailRow.updated_at)}
-                {detailRow.updated_by ? ` by ${detailRow.updated_by}` : ""}
-              </Text>
-            </Space>
-          </Space>
-        )}
-      </Drawer>
+      <MemoryDetailDrawer row={detailRow} onClose={() => setDetailRow(null)} />
 
       {/* Create / edit modal */}
       <MemoryEditModal


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

I did not live-eyeball this against a running proxy. The Memory page is auth-gated, so without a booted proxy the dev server bounces to the login before the page renders, and I want to be upfront that no runtime screenshot was captured on my side. Automated coverage stands in for the runtime check: the two new test files exercise the real DataTable, columns, and cells rather than mocks, and every assertion was mutation-checked to confirm it fails when the wiring breaks (footer wired to the page's row length instead of the server total, an overflow item routed to the wrong callback, and the parent feeding `isPending` instead of `isLoading` were all caught)

To capture the screenshots yourself, run the proxy and the dashboard dev server, then open the Memory item in the left nav (http://localhost:4000/ui/memory) and check:

1. The loaded table: ID, Name, Preview, User ID, Team ID, Updated columns, with the shared pagination footer and its rows-per-page selector at the bottom
2. The key-prefix search in the toolbar (type e.g. `user:`) narrows the list and snaps back to the first page
3. The row overflow menu (the three-dots button) offers View, Edit, and Delete, and each opens the same drawer/modal the old buttons did
4. The empty state (a store with no memories, and a search that matches nothing) shows the two different copies
5. The New memory button, the edit modal, and the delete confirmation still behave as before

## Type

🧹 Refactoring

## Changes

Migrates the admin dashboard Memory table off its hand-rolled antd `<Table>` onto the shared `DataTable` and `table_cells`, so it looks and behaves like the already-migrated Teams, Virtual Keys, and Guardrails tables. This is a completeness migration for one of the remaining tables; the behavior is preserved, only the renderer changes

`MemoryView` stays the data-owning parent (server `useQuery`, the create/update/delete mutations, and the detail drawer, edit modal, and delete modal all live here) and now renders a thin `MemoryTable` consumer plus a `getMemoryTableColumns` columns file. A few specifics worth calling out:

Server pagination moves the full `PaginationState` up to the parent and feeds `DataTable` in `paginationMode="server"` with `rowCount` from the response total, so the shared footer's rows-per-page selector works and replaces the old antd `<Pagination>`. The single key-prefix search runs through the shared toolbar, is debounced into the query, and resets the page to the first page on change. Sorting stays off because the backend already returns rows in `updated_at DESC` order, so there are no sortable headers. Per-row view/edit/delete collapse into a single overflow (three-dots) menu with stable test ids, and the ID cell becomes a monospace `IdentityCell` that opens the detail drawer

The old effect that reset the page on filter change is gone (the page now resets inside the search handler), so its `react-hooks/set-state-in-effect` suppression is pruned from the baseline. The detail drawer moved into its own `MemoryDetailDrawer` component to keep the parent within the dashboard complexity budget

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
