### PR TITLE
refactor(ui): migrate agents table onto the shared DataTable

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -12,14 +12,6 @@
       "count": 1
     }
   },
-  "src/app/(dashboard)/agents/_components/AgentsPanel.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
   "src/app/(dashboard)/agents/_components/add_agent_form.tsx": {
     "no-nested-ternary": {
       "count": 3

--- a/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/AgentsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/AgentsPanel.test.tsx
@@ -1,12 +1,13 @@
 import React from "react";
-import { render, screen, waitFor, act, fireEvent, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import AgentsPanel from "./AgentsPanel";
 import * as networking from "@/components/networking";
 
 vi.mock("@/components/networking", () => ({
   getAgentsList: vi.fn().mockResolvedValue({ agents: [] }),
-  deleteAgentCall: vi.fn(),
+  deleteAgentCall: vi.fn().mockResolvedValue({}),
 }));
 
 vi.mock("./add_agent_form", () => ({
@@ -20,55 +21,53 @@ vi.mock("./agent_info", () => ({
 describe("AgentsPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(networking.getAgentsList).mockResolvedValue({ agents: [] });
+    vi.mocked(networking.deleteAgentCall).mockResolvedValue({});
   });
 
-  it("should render the Agents panel title", async () => {
+  it("should render the Agents panel title", () => {
     render(<AgentsPanel accessToken="test-token" userRole="Admin" />);
     expect(screen.getByText("Agents")).toBeInTheDocument();
   });
 
-  it("should show Add New Agent button for admin users", async () => {
+  it("should show Add New Agent button for admin users", () => {
     render(<AgentsPanel accessToken="test-token" userRole="Admin" />);
-    expect(screen.getByText("+ Add New Agent")).toBeInTheDocument();
+    expect(screen.getByText("Add New Agent")).toBeInTheDocument();
   });
 
-  it("should show Add New Agent button for proxy_admin users", async () => {
+  it("should show Add New Agent button for proxy_admin users", () => {
     render(<AgentsPanel accessToken="test-token" userRole="proxy_admin" />);
-    expect(screen.getByText("+ Add New Agent")).toBeInTheDocument();
+    expect(screen.getByText("Add New Agent")).toBeInTheDocument();
   });
 
-  it("should not show Add New Agent button for internal_user role", async () => {
+  it("should not show Add New Agent button for internal_user role", () => {
     render(<AgentsPanel accessToken="test-token" userRole="Internal User" />);
-    expect(screen.queryByText("+ Add New Agent")).not.toBeInTheDocument();
+    expect(screen.queryByText("Add New Agent")).not.toBeInTheDocument();
   });
 
-  it("should not show Add New Agent button for internal_user_viewer role", async () => {
+  it("should not show Add New Agent button for internal_user_viewer role", () => {
     render(<AgentsPanel accessToken="test-token" userRole="Internal Viewer" />);
-    expect(screen.queryByText("+ Add New Agent")).not.toBeInTheDocument();
+    expect(screen.queryByText("Add New Agent")).not.toBeInTheDocument();
   });
 
-  it("should show Actions column header for admin role", async () => {
+  it("should show the Actions column for admin role", async () => {
     render(<AgentsPanel accessToken="test-token" userRole="Admin" />);
-    await waitFor(() => {
-      expect(screen.getByRole("columnheader", { name: /actions/i })).toBeInTheDocument();
-    });
+    expect(await screen.findByRole("columnheader", { name: /actions/i })).toBeInTheDocument();
   });
 
-  it("should not show Actions column header for internal user role", async () => {
+  it("should not show the Actions column for internal user role", async () => {
     render(<AgentsPanel accessToken="test-token" userRole="Internal User" />);
     await waitFor(() => {
       expect(screen.queryByRole("columnheader", { name: /actions/i })).not.toBeInTheDocument();
-      // confirm table is rendered (not still loading)
       expect(screen.getByRole("table")).toBeInTheDocument();
     });
   });
 
-  it("should render the Health Check toggle", async () => {
-    render(<AgentsPanel accessToken="test-token" userRole="Admin" />);
+  it("should render the Health Check toggle for admins and non-admins", () => {
+    const { unmount } = render(<AgentsPanel accessToken="test-token" userRole="Admin" />);
     expect(screen.getByText("Health Check")).toBeInTheDocument();
-  });
+    unmount();
 
-  it("should render the Health Check toggle for non-admin users too", async () => {
     render(<AgentsPanel accessToken="test-token" userRole="Internal User" />);
     expect(screen.getByText("Health Check")).toBeInTheDocument();
   });
@@ -108,19 +107,99 @@ describe("AgentsPanel", () => {
     expect(within(keylessRow).getByText("Needs Setup")).toBeInTheDocument();
   });
 
-  it("should call getAgentsList with health_check=true when toggle is enabled", async () => {
+  it("should refetch with health_check=true when the toggle is enabled", async () => {
+    const user = userEvent.setup();
     render(<AgentsPanel accessToken="test-token" userRole="Admin" />);
     await waitFor(() => {
       expect(networking.getAgentsList).toHaveBeenCalledWith("test-token", false);
     });
 
-    const toggle = screen.getByRole("switch");
-    await act(async () => {
-      fireEvent.click(toggle);
-    });
+    await user.click(screen.getByRole("switch"));
 
     await waitFor(() => {
       expect(networking.getAgentsList).toHaveBeenCalledWith("test-token", true);
+    });
+  });
+
+  it("should delete an agent through the ⋯ menu and confirm modal, then refetch", async () => {
+    const user = userEvent.setup();
+    vi.mocked(networking.getAgentsList).mockResolvedValue({
+      agents: [
+        {
+          agent_id: "agent-9",
+          agent_name: "Doomed Agent",
+          litellm_params: { model: "gpt-4" },
+          spend: 0,
+          keys: [],
+        },
+      ],
+    });
+
+    render(<AgentsPanel accessToken="test-token" userRole="Admin" />);
+
+    await user.click(await screen.findByTestId("agent-actions-agent-9"));
+    await user.click(await screen.findByTestId("agent-action-delete"));
+
+    const modal = await screen.findByRole("dialog");
+    await user.click(within(modal).getByRole("button", { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(networking.deleteAgentCall).toHaveBeenCalledWith("test-token", "agent-9");
+    });
+    // one initial load + one post-delete refetch
+    await waitFor(() => {
+      expect(vi.mocked(networking.getAgentsList).mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it("should show a loading skeleton on initial load and clear it once agents arrive", async () => {
+    render(<AgentsPanel accessToken="test-token" userRole="Admin" />);
+    expect(screen.getAllByTestId("skeleton-row").length).toBeGreaterThan(0);
+    await waitFor(() => {
+      expect(screen.queryByTestId("skeleton-row")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should clear the loading state when there is no access token rather than skeleton forever", async () => {
+    render(<AgentsPanel accessToken={null} userRole="Admin" />);
+    await waitFor(() => {
+      expect(screen.queryByTestId("skeleton-row")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("No agents yet")).toBeInTheDocument();
+    expect(networking.getAgentsList).not.toHaveBeenCalled();
+  });
+
+  it("should keep rows visible during a health-check refetch instead of re-showing the skeleton", async () => {
+    const user = userEvent.setup();
+    const agents = [
+      {
+        agent_id: "agent-1",
+        agent_name: "Stable Agent",
+        litellm_params: { model: "gpt-4" },
+        spend: 0,
+        keys: [],
+      },
+    ];
+    let resolveRefetch: (value: { agents: typeof agents }) => void = () => {};
+    vi.mocked(networking.getAgentsList)
+      .mockResolvedValueOnce({ agents })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRefetch = resolve;
+          }),
+      );
+
+    render(<AgentsPanel accessToken="test-token" userRole="Admin" />);
+    expect(await screen.findByText("Stable Agent")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("switch"));
+
+    expect(screen.getByText("Stable Agent")).toBeInTheDocument();
+    expect(screen.queryByTestId("skeleton-row")).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolveRefetch({ agents });
     });
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/AgentsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/AgentsPanel.test.tsx
@@ -20,9 +20,9 @@ vi.mock("./agent_info", () => ({
 
 describe("AgentsPanel", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    vi.mocked(networking.getAgentsList).mockResolvedValue({ agents: [] });
-    vi.mocked(networking.deleteAgentCall).mockResolvedValue({});
+    // mockReset (not mockClear) so an unconsumed *Once queue cannot leak into the next test
+    vi.mocked(networking.getAgentsList).mockReset().mockResolvedValue({ agents: [] });
+    vi.mocked(networking.deleteAgentCall).mockReset().mockResolvedValue({});
   });
 
   it("should render the Agents panel title", () => {
@@ -167,6 +167,94 @@ describe("AgentsPanel", () => {
     });
     expect(screen.getByText("No agents yet")).toBeInTheDocument();
     expect(networking.getAgentsList).not.toHaveBeenCalled();
+  });
+
+  it("should not show rows fetched with a previous access token after the token changes", async () => {
+    const agentFor = (name: string) => ({
+      agent_id: `id-${name}`,
+      agent_name: name,
+      litellm_params: { model: "gpt-4" },
+      spend: 0,
+      keys: [],
+    });
+    let resolveSecond: (value: { agents: ReturnType<typeof agentFor>[] }) => void = () => {};
+    vi.mocked(networking.getAgentsList)
+      .mockResolvedValueOnce({ agents: [agentFor("first-token-agent")] })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSecond = resolve;
+          }),
+      );
+
+    const { rerender } = render(<AgentsPanel accessToken="token-a" userRole="Admin" />);
+    expect(await screen.findByText("first-token-agent")).toBeInTheDocument();
+
+    rerender(<AgentsPanel accessToken="token-b" userRole="Admin" />);
+
+    // the previous token's rows must not linger while the new token loads
+    expect(screen.queryByText("first-token-agent")).not.toBeInTheDocument();
+    expect(screen.getAllByTestId("skeleton-row").length).toBeGreaterThan(0);
+
+    await act(async () => {
+      resolveSecond({ agents: [agentFor("second-token-agent")] });
+    });
+    expect(await screen.findByText("second-token-agent")).toBeInTheDocument();
+  });
+
+  it("should drop previous rows when the fetch for a new token fails", async () => {
+    vi.mocked(networking.getAgentsList)
+      .mockResolvedValueOnce({
+        agents: [
+          { agent_id: "stale", agent_name: "Stale Agent", litellm_params: { model: "gpt-4" }, spend: 0, keys: [] },
+        ],
+      })
+      .mockRejectedValueOnce(new Error("unauthorized"));
+
+    const { rerender } = render(<AgentsPanel accessToken="token-a" userRole="Admin" />);
+    expect(await screen.findByText("Stale Agent")).toBeInTheDocument();
+
+    rerender(<AgentsPanel accessToken="token-b" userRole="Admin" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No agents yet")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Stale Agent")).not.toBeInTheDocument();
+  });
+
+  it("should ignore a superseded response so it cannot overwrite the current token's rows", async () => {
+    let resolveFirst: (value: {
+      agents: { agent_id: string; agent_name: string; litellm_params: { model: string }; spend: number; keys: [] }[];
+    }) => void = () => {};
+    vi.mocked(networking.getAgentsList)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({
+        agents: [
+          { agent_id: "current", agent_name: "Current Agent", litellm_params: { model: "gpt-4" }, spend: 0, keys: [] },
+        ],
+      });
+
+    const { rerender } = render(<AgentsPanel accessToken="token-a" userRole="Admin" />);
+    rerender(<AgentsPanel accessToken="token-b" userRole="Admin" />);
+
+    expect(await screen.findByText("Current Agent")).toBeInTheDocument();
+
+    // the slow token-a response lands last and must be discarded
+    await act(async () => {
+      resolveFirst({
+        agents: [
+          { agent_id: "stale", agent_name: "Superseded Agent", litellm_params: { model: "gpt-4" }, spend: 0, keys: [] },
+        ],
+      });
+    });
+
+    expect(screen.queryByText("Superseded Agent")).not.toBeInTheDocument();
+    expect(screen.getByText("Current Agent")).toBeInTheDocument();
   });
 
   it("should keep rows visible during a health-check refetch instead of re-showing the skeleton", async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/AgentsPanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/AgentsPanel.tsx
@@ -1,27 +1,15 @@
 import React, { useState, useEffect } from "react";
-import {
-  Button,
-  Card,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeaderCell,
-  TableRow,
-  Badge,
-  Text,
-} from "@tremor/react";
-import { Modal, Alert, Tooltip, Skeleton, Switch } from "antd";
-import { CheckCircleOutlined } from "@ant-design/icons";
+import { Modal, Alert } from "antd";
+import { Plus } from "lucide-react";
 import { getAgentsList, deleteAgentCall } from "@/components/networking";
 import AddAgentForm from "./add_agent_form";
 import { isAdminRole } from "@/utils/roles";
 import AgentInfoView from "./agent_info";
+import AgentsTable from "./AgentsTable";
 import NotificationsManager from "@/components/molecules/notifications_manager";
 import { Agent } from "@/components/agents/types";
 import { Team } from "@/components/key_team_helpers/key_list";
-import { DateCell, IdCell, MoneyCell, StatusBadge } from "@/components/shared/table_cells";
-import TableIconActionButton from "@/components/common_components/IconActionButton/TableIconActionButtons/TableIconActionButton";
+import { Button } from "@/components/ui/button";
 
 interface AgentsPanelProps {
   accessToken: string | null;
@@ -36,37 +24,53 @@ interface AgentsResponse {
 const AgentsPanel: React.FC<AgentsPanelProps> = ({ accessToken, userRole, teams }) => {
   const [agentsList, setAgentsList] = useState<Agent[]>([]);
   const [isAddModalVisible, setIsAddModalVisible] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isHealthCheckLoading, setIsHealthCheckLoading] = useState(false);
   const [agentToDelete, setAgentToDelete] = useState<{ id: string; name: string } | null>(null);
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
   const [healthCheckEnabled, setHealthCheckEnabled] = useState(false);
 
   const isAdmin = userRole ? isAdminRole(userRole) : false;
 
-  const fetchAgents = async (healthCheck?: boolean) => {
+  useEffect(() => {
+    const fetchInitial = async () => {
+      if (!accessToken) {
+        setIsLoading(false);
+        return;
+      }
+      try {
+        const response: AgentsResponse = await getAgentsList(accessToken, false);
+        setAgentsList(response.agents || []);
+      } catch (error) {
+        console.error("Error fetching agents:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchInitial();
+  }, [accessToken]);
+
+  const refetchAgents = async (healthCheck: boolean) => {
     if (!accessToken) {
       return;
     }
-
-    setIsLoading(true);
     try {
-      const response: AgentsResponse = await getAgentsList(accessToken, healthCheck ?? healthCheckEnabled);
+      const response: AgentsResponse = await getAgentsList(accessToken, healthCheck);
       setAgentsList(response.agents || []);
     } catch (error) {
       console.error("Error fetching agents:", error);
-    } finally {
-      setIsLoading(false);
     }
   };
 
-  useEffect(() => {
-    fetchAgents();
-  }, [accessToken]);
-
-  const handleHealthCheckToggle = (checked: boolean) => {
+  const handleHealthCheckToggle = async (checked: boolean) => {
     setHealthCheckEnabled(checked);
-    fetchAgents(checked);
+    setIsHealthCheckLoading(true);
+    try {
+      await refetchAgents(checked);
+    } finally {
+      setIsHealthCheckLoading(false);
+    }
   };
 
   const handleAddAgent = () => {
@@ -81,7 +85,7 @@ const AgentsPanel: React.FC<AgentsPanelProps> = ({ accessToken, userRole, teams 
   };
 
   const handleSuccess = () => {
-    fetchAgents();
+    refetchAgents(healthCheckEnabled);
   };
 
   const handleDeleteClick = (agentId: string, agentName: string) => {
@@ -95,7 +99,7 @@ const AgentsPanel: React.FC<AgentsPanelProps> = ({ accessToken, userRole, teams 
     try {
       await deleteAgentCall(accessToken, agentToDelete.id);
       NotificationsManager.success(`Agent "${agentToDelete.name}" deleted successfully`);
-      fetchAgents();
+      await refetchAgents(healthCheckEnabled);
     } catch (error) {
       console.error("Error deleting agent:", error);
       NotificationsManager.fromBackend("Failed to delete agent");
@@ -108,14 +112,6 @@ const AgentsPanel: React.FC<AgentsPanelProps> = ({ accessToken, userRole, teams 
   const handleDeleteCancel = () => {
     setAgentToDelete(null);
   };
-
-  const sortedAgents = [...agentsList].sort((a, b) => {
-    const dateA = a.created_at ? new Date(a.created_at).getTime() : 0;
-    const dateB = b.created_at ? new Date(b.created_at).getTime() : 0;
-    return dateB - dateA;
-  });
-
-  const columnCount = isAdmin ? 7 : 6;
 
   return (
     <div className="w-full mx-auto flex-auto overflow-y-auto m-8 p-2">
@@ -132,25 +128,14 @@ const AgentsPanel: React.FC<AgentsPanelProps> = ({ accessToken, userRole, teams 
           showIcon
           className="mb-3"
         />
-        <div className="mt-2 flex items-center gap-4">
-          {isAdmin && (
+        {isAdmin && (
+          <div className="mt-2 flex items-center gap-4">
             <Button onClick={handleAddAgent} disabled={!accessToken}>
-              + Add New Agent
+              <Plus />
+              Add New Agent
             </Button>
-          )}
-          <Tooltip title="When enabled, only agents with reachable URLs are shown">
-            <div className="flex items-center gap-2">
-              <CheckCircleOutlined className={healthCheckEnabled ? "text-green-500" : "text-gray-400"} />
-              <span className="text-sm text-gray-600">Health Check</span>
-              <Switch
-                size="small"
-                checked={healthCheckEnabled}
-                onChange={handleHealthCheckToggle}
-                loading={isLoading && healthCheckEnabled}
-              />
-            </div>
-          </Tooltip>
-        </div>
+          </div>
+        )}
       </div>
 
       {selectedAgentId ? (
@@ -161,73 +146,16 @@ const AgentsPanel: React.FC<AgentsPanelProps> = ({ accessToken, userRole, teams 
           isAdmin={isAdmin}
         />
       ) : (
-        <Card>
-          {isLoading ? (
-            <Skeleton active paragraph={{ rows: 3 }} />
-          ) : (
-            <Table>
-              <TableHead>
-                <TableRow>
-                  <TableHeaderCell>Agent Name</TableHeaderCell>
-                  <TableHeaderCell>Agent ID</TableHeaderCell>
-                  <TableHeaderCell>Spend (USD)</TableHeaderCell>
-                  <TableHeaderCell>Model</TableHeaderCell>
-                  <TableHeaderCell>Created</TableHeaderCell>
-                  <TableHeaderCell>Status</TableHeaderCell>
-                  {isAdmin && <TableHeaderCell>Actions</TableHeaderCell>}
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {sortedAgents.length === 0 ? (
-                  <TableRow>
-                    <TableCell colSpan={columnCount}>
-                      <Text className="text-center">
-                        No agents found. Click &quot;+ Add New Agent&quot; to create one.
-                      </Text>
-                    </TableCell>
-                  </TableRow>
-                ) : (
-                  sortedAgents.map((agent) => (
-                    <TableRow key={agent.agent_id}>
-                      <TableCell>
-                        <Text>{agent.agent_name}</Text>
-                      </TableCell>
-                      <TableCell>
-                        <IdCell value={agent.agent_id} onClick={(id) => setSelectedAgentId(id)} />
-                      </TableCell>
-                      <TableCell>
-                        <MoneyCell value={agent.spend} decimals={4} />
-                      </TableCell>
-                      <TableCell>
-                        <Badge size="xs" color="blue">
-                          {agent.litellm_params?.model || "N/A"}
-                        </Badge>
-                      </TableCell>
-                      <TableCell>
-                        <DateCell value={agent.created_at} precision="date" />
-                      </TableCell>
-                      <TableCell>
-                        {(agent.keys?.length ?? 0) > 0 ? (
-                          <StatusBadge tone="success" label="Active" />
-                        ) : (
-                          <StatusBadge tone="warning" label="Needs Setup" />
-                        )}
-                      </TableCell>
-                      {isAdmin && (
-                        <TableCell>
-                          <TableIconActionButton
-                            variant="Delete"
-                            onClick={() => handleDeleteClick(agent.agent_id, agent.agent_name)}
-                          />
-                        </TableCell>
-                      )}
-                    </TableRow>
-                  ))
-                )}
-              </TableBody>
-            </Table>
-          )}
-        </Card>
+        <AgentsTable
+          agents={agentsList}
+          isLoading={isLoading}
+          isAdmin={isAdmin}
+          healthCheckEnabled={healthCheckEnabled}
+          isHealthCheckLoading={isHealthCheckLoading}
+          onHealthCheckToggle={handleHealthCheckToggle}
+          onAgentClick={(id) => setSelectedAgentId(id)}
+          onDeleteClick={handleDeleteClick}
+        />
       )}
 
       <AddAgentForm

--- a/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/AgentsPanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/AgentsPanel.tsx
@@ -34,21 +34,34 @@ const AgentsPanel: React.FC<AgentsPanelProps> = ({ accessToken, userRole, teams 
   const isAdmin = userRole ? isAdminRole(userRole) : false;
 
   useEffect(() => {
-    const fetchInitial = async () => {
+    let cancelled = false;
+    const loadForToken = async () => {
       if (!accessToken) {
+        setAgentsList([]);
         setIsLoading(false);
         return;
       }
+      setIsLoading(true);
       try {
         const response: AgentsResponse = await getAgentsList(accessToken, false);
-        setAgentsList(response.agents || []);
+        if (!cancelled) {
+          setAgentsList(response.agents || []);
+        }
       } catch (error) {
         console.error("Error fetching agents:", error);
+        if (!cancelled) {
+          setAgentsList([]);
+        }
       } finally {
-        setIsLoading(false);
+        if (!cancelled) {
+          setIsLoading(false);
+        }
       }
     };
-    fetchInitial();
+    loadForToken();
+    return () => {
+      cancelled = true;
+    };
   }, [accessToken]);
 
   const refetchAgents = async (healthCheck: boolean) => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/AgentsTable.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/AgentsTable.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+
+import AgentsTable from "./AgentsTable";
+import { Agent } from "@/components/agents/types";
+
+const baseProps = {
+  isLoading: false,
+  isAdmin: true,
+  healthCheckEnabled: false,
+  isHealthCheckLoading: false,
+  onHealthCheckToggle: vi.fn(),
+  onAgentClick: vi.fn(),
+  onDeleteClick: vi.fn(),
+};
+
+const makeAgent = (overrides: Partial<Agent> = {}): Agent => ({
+  agent_id: "agent-1",
+  agent_name: "Test Agent",
+  litellm_params: { model: "gpt-4" },
+  spend: 0,
+  keys: [{ token: "hash-1", key_alias: "primary", key_name: "sk-...1" }],
+  created_at: "2023-01-01T00:00:00Z",
+  ...overrides,
+});
+
+describe("AgentsTable", () => {
+  it("renders every column header", () => {
+    render(<AgentsTable agents={[]} {...baseProps} />);
+    for (const header of ["Agent Name", "Agent ID", "Spend (USD)", "Model", "Created", "Status"]) {
+      expect(screen.getByText(header)).toBeInTheDocument();
+    }
+  });
+
+  it("renders the agent's model and opens the detail view when the ID cell is clicked", async () => {
+    const user = userEvent.setup();
+    const onAgentClick = vi.fn();
+    const agent = makeAgent({ agent_id: "agent-xyz", agent_name: "Router", litellm_params: { model: "claude-3-5" } });
+    render(<AgentsTable agents={[agent]} {...baseProps} onAgentClick={onAgentClick} />);
+
+    expect(screen.getByText("claude-3-5")).toBeInTheDocument();
+
+    await user.click(screen.getByText("agent-xyz"));
+    expect(onAgentClick).toHaveBeenCalledWith("agent-xyz");
+  });
+
+  it("marks agents Active when they have keys and Needs Setup when they have none", () => {
+    render(
+      <AgentsTable
+        agents={[
+          makeAgent({ agent_id: "keyed", agent_name: "Keyed Agent", keys: [{ token: "k" }] }),
+          makeAgent({ agent_id: "keyless", agent_name: "Keyless Agent", keys: [] }),
+        ]}
+        {...baseProps}
+      />,
+    );
+
+    const keyedRow = screen.getByText("Keyed Agent").closest("tr")!;
+    const keylessRow = screen.getByText("Keyless Agent").closest("tr")!;
+    expect(within(keyedRow).getByText("Active")).toBeInTheDocument();
+    expect(within(keylessRow).getByText("Needs Setup")).toBeInTheDocument();
+  });
+
+  it("deletes an agent through the ⋯ actions menu", async () => {
+    const user = userEvent.setup();
+    const onDeleteClick = vi.fn();
+    const agent = makeAgent({ agent_id: "agent-9", agent_name: "Doomed Agent" });
+    render(<AgentsTable agents={[agent]} {...baseProps} onDeleteClick={onDeleteClick} />);
+
+    await user.click(screen.getByTestId("agent-actions-agent-9"));
+    await user.click(await screen.findByTestId("agent-action-delete"));
+
+    expect(onDeleteClick).toHaveBeenCalledWith("agent-9", "Doomed Agent");
+  });
+
+  it("hides the actions column entirely for non-admins", () => {
+    const agent = makeAgent({ agent_id: "agent-2" });
+    render(<AgentsTable agents={[agent]} {...baseProps} isAdmin={false} />);
+
+    expect(screen.queryByTestId("agent-actions-agent-2")).not.toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: /actions/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("table")).toBeInTheDocument();
+  });
+
+  it("shows the actions column for admins", () => {
+    render(<AgentsTable agents={[makeAgent({ agent_id: "agent-3" })]} {...baseProps} isAdmin />);
+    expect(screen.getByRole("columnheader", { name: /actions/i })).toBeInTheDocument();
+    expect(screen.getByTestId("agent-actions-agent-3")).toBeInTheDocument();
+  });
+
+  it("defaults to sorting by created_at descending (newest first)", () => {
+    render(
+      <AgentsTable
+        agents={[
+          makeAgent({ agent_id: "old", agent_name: "Alpha Agent", created_at: "2021-06-01T00:00:00Z" }),
+          makeAgent({ agent_id: "new", agent_name: "Beta Agent", created_at: "2023-06-01T00:00:00Z" }),
+        ]}
+        {...baseProps}
+      />,
+    );
+
+    const bodyRows = screen.getAllByRole("row").slice(1);
+    expect(bodyRows[0].textContent).toContain("Beta Agent");
+    expect(bodyRows[1].textContent).toContain("Alpha Agent");
+  });
+
+  it("shows a rich empty state when there are no agents", () => {
+    render(<AgentsTable agents={[]} {...baseProps} />);
+    expect(screen.getByText("No agents yet")).toBeInTheDocument();
+    expect(screen.queryByTestId("skeleton-row")).not.toBeInTheDocument();
+  });
+
+  it("renders loading skeleton rows on initial load instead of the empty state", () => {
+    render(<AgentsTable agents={[]} {...baseProps} isLoading />);
+    expect(screen.getAllByTestId("skeleton-row").length).toBeGreaterThan(0);
+    expect(screen.queryByText("No agents yet")).not.toBeInTheDocument();
+  });
+
+  it("invokes the health-check toggle from the toolbar", async () => {
+    const user = userEvent.setup();
+    const onHealthCheckToggle = vi.fn();
+    render(<AgentsTable agents={[]} {...baseProps} onHealthCheckToggle={onHealthCheckToggle} />);
+
+    expect(screen.getByText("Health Check")).toBeInTheDocument();
+    await user.click(screen.getByRole("switch"));
+    expect(onHealthCheckToggle).toHaveBeenCalledWith(true, expect.anything());
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/AgentsTable.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/AgentsTable.test.tsx
@@ -105,6 +105,24 @@ describe("AgentsTable", () => {
     expect(bodyRows[1].textContent).toContain("Alpha Agent");
   });
 
+  it("sorts agents with no created_at last, never ahead of dated ones", () => {
+    render(
+      <AgentsTable
+        agents={[
+          makeAgent({ agent_id: "old", agent_name: "Alpha Agent", created_at: "2021-06-01T00:00:00Z" }),
+          makeAgent({ agent_id: "undated", agent_name: "Undated Agent", created_at: undefined }),
+          makeAgent({ agent_id: "new", agent_name: "Beta Agent", created_at: "2023-06-01T00:00:00Z" }),
+        ]}
+        {...baseProps}
+      />,
+    );
+
+    const bodyRows = screen.getAllByRole("row").slice(1);
+    expect(bodyRows[0].textContent).toContain("Beta Agent");
+    expect(bodyRows[1].textContent).toContain("Alpha Agent");
+    expect(bodyRows[2].textContent).toContain("Undated Agent");
+  });
+
   it("shows a rich empty state when there are no agents", () => {
     render(<AgentsTable agents={[]} {...baseProps} />);
     expect(screen.getByText("No agents yet")).toBeInTheDocument();

--- a/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/AgentsTable.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/AgentsTable.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { SortingState } from "@tanstack/react-table";
+import { Tooltip, Switch } from "antd";
+import { CheckCircleOutlined } from "@ant-design/icons";
+import { Bot } from "lucide-react";
+import React, { useMemo, useState } from "react";
+
+import { Agent } from "@/components/agents/types";
+import { DataTable } from "@/components/shared/DataTable";
+
+import { getAgentsTableColumns } from "./AgentsTableColumns";
+
+interface AgentsTableProps {
+  agents: Agent[];
+  isLoading: boolean;
+  isAdmin: boolean;
+  healthCheckEnabled: boolean;
+  isHealthCheckLoading: boolean;
+  onHealthCheckToggle: (checked: boolean) => void;
+  onAgentClick: (agentId: string) => void;
+  onDeleteClick: (agentId: string, agentName: string) => void;
+}
+
+const DEFAULT_SORTING: SortingState = [{ id: "created_at", desc: true }];
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center gap-1 py-6">
+      <div className="mb-1 flex size-10 items-center justify-center rounded-lg bg-muted">
+        <Bot className="size-5 text-muted-foreground" />
+      </div>
+      <div className="text-sm font-medium text-foreground">No agents yet</div>
+      <div className="text-sm text-muted-foreground">Add an agent to make it available in your organization.</div>
+    </div>
+  );
+}
+
+const AgentsTable: React.FC<AgentsTableProps> = ({
+  agents,
+  isLoading,
+  isAdmin,
+  healthCheckEnabled,
+  isHealthCheckLoading,
+  onHealthCheckToggle,
+  onAgentClick,
+  onDeleteClick,
+}) => {
+  const [sorting, setSorting] = useState<SortingState>(DEFAULT_SORTING);
+
+  const columns = useMemo(
+    () => getAgentsTableColumns({ isAdmin, onAgentClick, onDeleteClick }),
+    [isAdmin, onAgentClick, onDeleteClick],
+  );
+
+  return (
+    <DataTable
+      data={agents}
+      columns={columns}
+      getRowId={(agent, index) => agent.agent_id || String(index)}
+      sortingMode="client"
+      sorting={sorting}
+      onSortingChange={setSorting}
+      isLoading={isLoading}
+      loadingMessage="Loading agents…"
+      noDataMessage={<EmptyState />}
+      size="compact"
+      toolbar={() => (
+        <div className="flex items-center justify-end">
+          <Tooltip title="When enabled, only agents with reachable URLs are shown">
+            <div className="flex items-center gap-2">
+              <CheckCircleOutlined className={healthCheckEnabled ? "text-green-500" : "text-muted-foreground"} />
+              <span className="text-sm text-muted-foreground">Health Check</span>
+              <Switch
+                size="small"
+                checked={healthCheckEnabled}
+                onChange={onHealthCheckToggle}
+                loading={isHealthCheckLoading}
+              />
+            </div>
+          </Tooltip>
+        </div>
+      )}
+    />
+  );
+};
+
+export default AgentsTable;

--- a/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/AgentsTableColumns.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/AgentsTableColumns.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { ColumnDef } from "@tanstack/react-table";
+import { MoreHorizontal, Trash2 } from "lucide-react";
+
+import { Agent } from "@/components/agents/types";
+import { DataTableSortHeader } from "@/components/shared/DataTable";
+import { DateCell, IdentityCell, MoneyCell, StatusBadge } from "@/components/shared/table_cells";
+import { Badge } from "@/components/ui/badge";
+import { buttonVariants } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/cva.config";
+
+interface AgentRowActionsProps {
+  agent: Agent;
+  onDeleteClick: (agentId: string, agentName: string) => void;
+}
+
+function AgentRowActions({ agent, onDeleteClick }: AgentRowActionsProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        aria-label="Open agent actions"
+        data-testid={`agent-actions-${agent.agent_id}`}
+        className={cn(buttonVariants({ variant: "ghost", size: "icon-sm" }), "text-muted-foreground")}
+      >
+        <MoreHorizontal className="size-4" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-44">
+        <DropdownMenuItem
+          variant="destructive"
+          data-testid="agent-action-delete"
+          onClick={() => onDeleteClick(agent.agent_id, agent.agent_name)}
+        >
+          <Trash2 />
+          Delete
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+interface AgentsTableColumnsDeps {
+  isAdmin: boolean;
+  onAgentClick: (agentId: string) => void;
+  onDeleteClick: (agentId: string, agentName: string) => void;
+}
+
+export const getAgentsTableColumns = ({
+  isAdmin,
+  onAgentClick,
+  onDeleteClick,
+}: AgentsTableColumnsDeps): ColumnDef<Agent>[] => [
+  {
+    id: "agent_name",
+    accessorKey: "agent_name",
+    meta: { title: "Agent Name" },
+    header: ({ column }) => <DataTableSortHeader column={column} title="Agent Name" />,
+    size: 200,
+    enableSorting: true,
+    cell: ({ row }) => {
+      const name = row.original.agent_name;
+      return (
+        <span className="block max-w-52 truncate text-sm font-medium text-foreground" title={name || undefined}>
+          {name || "-"}
+        </span>
+      );
+    },
+  },
+  {
+    id: "agent_id",
+    accessorKey: "agent_id",
+    meta: { title: "Agent ID" },
+    header: ({ column }) => <DataTableSortHeader column={column} title="Agent ID" />,
+    size: 200,
+    enableSorting: true,
+    cell: ({ row }) => (
+      <IdentityCell
+        title={row.original.agent_id}
+        titleClassName="font-mono text-xs font-normal"
+        onClick={() => onAgentClick(row.original.agent_id)}
+      />
+    ),
+  },
+  {
+    id: "spend",
+    accessorKey: "spend",
+    meta: { title: "Spend (USD)" },
+    header: ({ column }) => <DataTableSortHeader column={column} title="Spend (USD)" />,
+    size: 130,
+    enableSorting: true,
+    cell: ({ row }) => <MoneyCell value={row.original.spend} decimals={4} />,
+  },
+  {
+    id: "model",
+    meta: { title: "Model" },
+    header: "Model",
+    size: 170,
+    enableSorting: false,
+    cell: ({ row }) => {
+      const model = row.original.litellm_params?.model;
+      if (!model) {
+        return <span className="text-muted-foreground">N/A</span>;
+      }
+      return (
+        <Badge variant="outline" className="max-w-40 font-normal">
+          <span className="min-w-0 truncate" title={model}>
+            {model}
+          </span>
+        </Badge>
+      );
+    },
+  },
+  {
+    id: "created_at",
+    accessorKey: "created_at",
+    meta: { title: "Created" },
+    header: ({ column }) => <DataTableSortHeader column={column} title="Created" />,
+    size: 150,
+    enableSorting: true,
+    cell: ({ row }) => <DateCell value={row.original.created_at} precision="date" />,
+  },
+  {
+    id: "status",
+    meta: { title: "Status" },
+    header: "Status",
+    size: 130,
+    enableSorting: false,
+    cell: ({ row }) => {
+      const hasKeys = (row.original.keys?.length ?? 0) > 0;
+      return hasKeys ? (
+        <StatusBadge tone="success" label="Active" />
+      ) : (
+        <StatusBadge tone="warning" label="Needs Setup" />
+      );
+    },
+  },
+  ...(isAdmin
+    ? [
+        {
+          id: "actions",
+          meta: { className: "text-right", headerClassName: "text-right" },
+          header: () => <span className="sr-only">Actions</span>,
+          size: 64,
+          enableSorting: false,
+          enableHiding: false,
+          cell: ({ row }) => (
+            <div className="flex justify-end">
+              <AgentRowActions agent={row.original} onDeleteClick={onDeleteClick} />
+            </div>
+          ),
+        } satisfies ColumnDef<Agent>,
+      ]
+    : []),
+];

--- a/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/AgentsTableColumns.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/AgentsTableColumns.tsx
@@ -118,7 +118,10 @@ export const getAgentsTableColumns = ({
   },
   {
     id: "created_at",
-    accessorKey: "created_at",
+    accessorFn: (agent) => {
+      const timestamp = agent.created_at ? new Date(agent.created_at).getTime() : 0;
+      return Number.isNaN(timestamp) ? 0 : timestamp;
+    },
     meta: { title: "Created" },
     header: ({ column }) => <DataTableSortHeader column={column} title="Created" />,
     size: 150,


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

## Type

🧹 Refactoring

## Changes

The Agents table was hand-rolled `@tremor/react` markup living inside `AgentsPanel`, with its own pre-sort, its own empty state, and an inline delete icon button. This moves it onto the shared `DataTable` so it looks and behaves like Teams, Virtual Keys, and Guardrails

`AgentsPanel` stays the data owner and keeps everything stateful: the fetch, the health-check state, the delete confirmation modal, and the swap to `AgentInfoView`. The table itself is now a thin `AgentsTable` consumer of the shared `DataTable`, and the column set moved into `getAgentsTableColumns`, composed from the shared `IdentityCell`, `MoneyCell`, `DateCell` and `StatusBadge`

Behavior carried over unchanged: rows still default to newest-first by `created_at` (now client-side sorting through the shared table instead of a hardcoded pre-sort), the Agent ID cell still opens the detail view, delete still runs through the same confirmation modal and `deleteAgentCall`, and the actions column is still admin-only. The per-row delete icon became a "Delete" item in the row overflow menu, matching the other migrated tables. Agent Name, Agent ID, Spend and Created are now sortable, which the hand-rolled table could not do

The health-check toggle moved into the table's toolbar slot; it controls which rows the server returns rather than filtering client-side, so it stays a toolbar control instead of becoming a table filter

The loading skeleton is now initial-load-only. Refetches after a delete or a health-check toggle leave the current rows on screen instead of blanking the table, and the null-token path resolves the flag so a missing token shows the empty state rather than a permanent skeleton

A token change is treated as a fresh load rather than a refetch, so it shows the skeleton for the new token instead of leaving the previous token's rows on screen, drops the rows if that load fails, and ignores a superseded response so a slow earlier request cannot overwrite newer rows

Sorting on `created_at` goes through a derived timestamp rather than the raw field. TanStack orders `undefined` ahead of real values, which would have put an agent with no `created_at` at the top of a newest-first list; the pre-migration sort coerced a missing date to epoch 0 and sorted it last, and that behavior is preserved

This drops the last `@tremor/react` import from `AgentsPanel`, so its two grandfathered eslint suppressions are pruned from the baseline

### Tests

`AgentsTable.test.tsx` covers the table against the real `DataTable`, columns and cells: the column set, the ID cell opening the detail view, Active vs Needs Setup, delete through the overflow menu, the admin-only actions column, the newest-first default sort, undated agents sorting last, the empty state and the loading skeleton. `AgentsPanel.test.tsx` covers the panel wiring: role gating, initial load, the health-check refetch, the delete flow end to end, the loading-state paths, and the three token-change cases

Every one of these was mutation-checked. Flipping the default sort to ascending, sorting on the raw `created_at` field, inverting the admin gate, making the status condition always true, no-oping the ID click, initializing the loading flag to false, dropping the null-token guard's reset, re-showing the skeleton on refetch, dropping the skeleton on token change, and removing the staleness guard each fail the corresponding test

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
