### PR TITLE
test(e2e): fix EndpointsClient gateway attribute left behind by the ProxyClient rename

### DIFF
--- a/tests/e2e/llm_translation/test_messages_mid_conversation_system_native_providers_e2e.py
+++ b/tests/e2e/llm_translation/test_messages_mid_conversation_system_native_providers_e2e.py
@@ -88,9 +88,9 @@ def _system_reminder_turn() -> RichMessage:
 
 
 def _post_messages(client: EndpointsClient, key: str, body: RichMessagesRequest) -> Result[MessagesResult]:
-    return client.gateway.transport.post(
+    return client.proxy.transport.post(
         "/v1/messages",
-        headers=client.gateway.transport.bearer(key),
+        headers=client.proxy.transport.bearer(key),
         json=body,
         response_type=MessagesResult,
     )


### PR DESCRIPTION
## Relevant issues

- Fixes the `lint-e2e-basedpyright` gate that is currently red on `litellm_internal_staging` itself, failing that CI job for every open PR
- Updates the one call site the Gateway to ProxyClient rename (#33750) left behind: `client.gateway.transport` becomes `client.proxy.transport` in the mid-conversation-system e2e test

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

`make lint-e2e-basedpyright` on current `litellm_internal_staging` fails for every PR with 9 errors in `tests/e2e/llm_translation/test_messages_mid_conversation_system_native_providers_e2e.py`, all cascading from `EndpointsClient` having no `gateway` attribute

```
tests/e2e/llm_translation/test_messages_mid_conversation_system_native_providers_e2e.py:91:19 - error: Cannot access attribute "gateway" for class "EndpointsClient"
    Attribute "gateway" is unknown (reportAttributeAccessIssue)
...
9 errors, 0 warnings, 0 notes
make: *** [lint-e2e-basedpyright] Error 1
```

With this change

```
uv run --no-sync basedpyright tests/e2e
0 errors, 0 warnings, 0 notes
```

## Type

🐛 Bug Fix

## Changes

PR #33750 renamed the e2e harness `Gateway` to `ProxyClient`, exposed on `EndpointsClient` as `.proxy`. The mid-conversation-system test merged around the same time (#33807 landing commit 23b5b7d199) still reads `client.gateway.transport`, which no longer exists, so the zero-error `lint-e2e-basedpyright` gate is red on the base branch and every open PR fails that job through no fault of its own. This updates the one stale call site, `_post_messages`, to `client.proxy.transport`, the same surface every other test in the suite uses

## QA runbook

Run `make lint-e2e-basedpyright` on this branch and confirm it reports zero errors; run it on `litellm_internal_staging` to see the 9 pre-existing errors this removes

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


