### PR TITLE
feat(dashscope): add multimodal embedding support with corrected pricing

### DIFF
--- a/litellm/llms/dashscope/cost_calculator.py
+++ b/litellm/llms/dashscope/cost_calculator.py
@@ -20,15 +20,19 @@ class TokenBreakdown:
     cached_tokens: int
     completion_tokens: int
     reasoning_tokens: int
+    image_tokens: int
 
 
 def _extract_token_breakdown(usage: Usage) -> TokenBreakdown:
     """Extract token counts from usage, handling cached and reasoning tokens."""
     cached_tokens = 0
+    image_tokens = 0
     if usage.prompt_tokens_details and hasattr(usage.prompt_tokens_details, "cached_tokens"):
         cached_tokens = usage.prompt_tokens_details.cached_tokens or 0
+    if usage.prompt_tokens_details and hasattr(usage.prompt_tokens_details, "image_tokens"):
+        image_tokens = usage.prompt_tokens_details.image_tokens or 0
 
-    text_tokens = usage.prompt_tokens - cached_tokens
+    text_tokens = max(0, usage.prompt_tokens - cached_tokens - image_tokens)
 
     reasoning_tokens = 0
     if (
@@ -40,7 +44,7 @@ def _extract_token_breakdown(usage: Usage) -> TokenBreakdown:
 
     completion_tokens = (usage.completion_tokens or 0) - reasoning_tokens
 
-    return TokenBreakdown(text_tokens, cached_tokens, completion_tokens, reasoning_tokens)
+    return TokenBreakdown(text_tokens, cached_tokens, completion_tokens, reasoning_tokens, image_tokens)
 
 
 def _calculate_prompt_cost(
@@ -107,6 +111,19 @@ def _calculate_completion_cost(
     return (breakdown.completion_tokens * output_cost) + (breakdown.reasoning_tokens * reasoning_cost)
 
 
+def _calculate_prompt_cost_embedding(
+    breakdown: TokenBreakdown, model_info: ModelInfo
+) -> float:
+    text_unit_price = float(model_info.get("input_cost_per_token") or 0.0)
+    image_token_price = model_info.get("input_cost_per_image_token")
+    if image_token_price is not None and breakdown.image_tokens:
+        image_unit_price = float(image_token_price)
+    else:
+        image_unit_price = text_unit_price
+
+    return breakdown.text_tokens * text_unit_price + breakdown.image_tokens * image_unit_price
+
+
 def cost_per_token(model: str, usage: Usage) -> Tuple[float, float]:
     """
     Calculate cost per token for Dashscope models.
@@ -120,8 +137,22 @@ def cost_per_token(model: str, usage: Usage) -> Tuple[float, float]:
     Returns:
         Tuple[float, float] - (prompt_cost_in_usd, completion_cost_in_usd)
     """
-    model_info = get_model_info(model=model, custom_llm_provider="dashscope")
+    try:
+        model_info = get_model_info(model=model, custom_llm_provider="dashscope")
+    except Exception:
+        import logging
+        logging.getLogger(__name__).warning(
+            "No pricing entry found for dashscope model=%s; returning 0 cost", model
+        )
+        return 0.0, 0.0
+
     breakdown = _extract_token_breakdown(usage)
+    mode = model_info.get("mode")
+
+    if mode == "embedding":
+        prompt_cost = _calculate_prompt_cost_embedding(breakdown, model_info)
+        return prompt_cost, 0.0
+
     tiered_pricing = model_info.get("tiered_pricing") if isinstance(model_info.get("tiered_pricing"), list) else None
 
     prompt_cost = _calculate_prompt_cost(breakdown=breakdown, model_info=model_info, tiered_pricing=tiered_pricing)

--- a/litellm/llms/dashscope/cost_calculator.py
+++ b/litellm/llms/dashscope/cost_calculator.py
@@ -111,9 +111,7 @@ def _calculate_completion_cost(
     return (breakdown.completion_tokens * output_cost) + (breakdown.reasoning_tokens * reasoning_cost)
 
 
-def _calculate_prompt_cost_embedding(
-    breakdown: TokenBreakdown, model_info: ModelInfo
-) -> float:
+def _calculate_prompt_cost_embedding(breakdown: TokenBreakdown, model_info: ModelInfo) -> float:
     text_unit_price = float(model_info.get("input_cost_per_token") or 0.0)
     image_token_price = model_info.get("input_cost_per_image_token")
     if image_token_price is not None and breakdown.image_tokens:
@@ -139,10 +137,11 @@ def cost_per_token(model: str, usage: Usage) -> Tuple[float, float]:
     """
     try:
         model_info = get_model_info(model=model, custom_llm_provider="dashscope")
-    except Exception:
+    except Exception as e:  # noqa: BLE001  # get_model_info raises bare Exception for unmapped models
         import logging
+
         logging.getLogger(__name__).warning(
-            "No pricing entry found for dashscope model=%s; returning 0 cost", model
+            "No pricing entry found for dashscope model=%s (%s); returning 0 cost", model, e
         )
         return 0.0, 0.0
 

--- a/litellm/llms/dashscope/embed/__init__.py
+++ b/litellm/llms/dashscope/embed/__init__.py
@@ -3,5 +3,6 @@ DashScope Embedding Module
 """
 
 from .transformation import DashScopeEmbeddingConfig
+from .transformation_multimodal import DashScopeMultimodalEmbeddingConfig
 
-__all__ = ["DashScopeEmbeddingConfig"]
+__all__ = ["DashScopeEmbeddingConfig", "DashScopeMultimodalEmbeddingConfig"]

--- a/litellm/llms/dashscope/embed/transformation_multimodal.py
+++ b/litellm/llms/dashscope/embed/transformation_multimodal.py
@@ -1,0 +1,182 @@
+"""
+Transform request/response for DashScope multimodal embeddings.
+Reference: https://help.aliyun.com/zh/model-studio/multimodal-embedding-api-reference
+"""
+
+from typing import List, Optional, Union
+import httpx
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+from litellm.llms.base_llm.embedding.transformation import BaseEmbeddingConfig
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.llms.openai import AllEmbeddingInputValues, AllMessageValues
+from litellm.types.utils import EmbeddingResponse, Usage
+from ..common_utils import DashScopeError
+
+DEFAULT_API_BASE = "https://dashscope.aliyuncs.com/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding"
+
+
+class DashScopeMultimodalEmbeddingConfig(BaseEmbeddingConfig):
+
+    @staticmethod
+    def is_multimodal_embedding(model: str) -> bool:
+        """Return True if the model name indicates a multimodal embedding model.
+
+        A model is considered multimodal when its name (after stripping the
+        provider prefix) contains any of the following signals:
+          - "multimodal"  (e.g. multimodal-embedding-v1)
+          - "vl"          (e.g. qwen3-vl-embedding, qwen2.5-vl-embedding)
+          - "vision"      (e.g. tongyi-embedding-vision-flash)
+
+        This avoids maintaining a hardcoded allowlist: any future DashScope
+        multimodal embedding model that follows the naming convention will be
+        routed correctly without a code change.
+        """
+        base = model.split("/")[-1].lower() if "/" in model else model.lower()
+        return any(kw in base for kw in ("multimodal", "vl", "vision"))
+
+    def get_supported_openai_params(self, model: str) -> List[str]:
+        return ["dimensions"]
+
+    def map_openai_params(self, non_default_params: dict, optional_params: dict,
+                          model: str, drop_params: bool = False) -> dict:
+        if "dimensions" in non_default_params:
+            optional_params["dimension"] = non_default_params["dimensions"]
+        return optional_params
+
+    def validate_environment(self, headers: dict, model: str,
+                             messages: List[AllMessageValues],
+                             optional_params: dict, litellm_params: dict,
+                             api_key: Optional[str] = None,
+                             api_base: Optional[str] = None) -> dict:
+        if api_key is None:
+            api_key = get_secret_str("DASHSCOPE_API_KEY")
+        if api_key is None:
+            raise ValueError("DashScope API key is required. "
+                             "Set 'DASHSCOPE_API_KEY' env var or pass api_key explicitly.")
+        return {"Content-Type": "application/json",
+                "Authorization": f"Bearer {api_key}", **headers}
+
+    def get_complete_url(self, api_base: Optional[str], api_key: Optional[str],
+                         model: str, optional_params: dict, litellm_params: dict,
+                         stream: Optional[bool] = None) -> str:
+        user_base = get_secret_str("DASHSCOPE_API_BASE")
+        if user_base:
+            return user_base
+        if api_base and "/compatible-mode/" in api_base:
+            return DEFAULT_API_BASE
+        if api_base:
+            base = api_base.rstrip("/")
+            if base.endswith("/multimodal-embedding/multimodal-embedding"):
+                return base
+            if base.endswith("/multimodal-embedding"):
+                return base
+            return f"{base}/services/embeddings/multimodal-embedding/multimodal-embedding"
+        return DEFAULT_API_BASE
+
+    def _normalize_content_blocks(self, content: list) -> list:
+        """Convert OpenAI content blocks to DashScope native format."""
+        result = []
+        for block in content:
+            block_type = block.get("type")
+            if block_type == "text":
+                result.append({"text": block.get("text", "")})
+            elif block_type == "image_url":
+                image_url = block.get("image_url", {})
+                if isinstance(image_url, dict):
+                    image_url = image_url.get("url", "")
+                result.append({"image": image_url})
+            else:
+                result.append(block)
+        return result
+
+    def _normalize_input_item(self, item: Union[str, list, dict]) -> dict:
+        if isinstance(item, str):
+            return {"text": item}
+        if isinstance(item, list):
+            blocks = self._normalize_content_blocks(item)
+            if len(blocks) == 1:
+                return blocks[0]
+            return {"content_list": blocks}
+        return item
+
+    def transform_embedding_request(self, model: str,
+                                    input: AllEmbeddingInputValues,
+                                    optional_params: dict,
+                                    headers: dict) -> dict:
+        inputs = input if isinstance(input, list) else [input]
+        contents = [self._normalize_input_item(item) for item in inputs]
+        body: dict = {"model": model, "input": {"contents": contents}}
+        params = {}
+        if "dimension" in optional_params:
+            params["dimension"] = optional_params["dimension"]
+        if "output_type" in optional_params:
+            params["output_type"] = optional_params["output_type"]
+        if params:
+            body["parameters"] = params
+        return body
+
+    def transform_embedding_response(self, model: str,
+                                     raw_response: httpx.Response,
+                                     model_response: EmbeddingResponse,
+                                     logging_obj: LiteLLMLoggingObj,
+                                     api_key: Optional[str],
+                                     request_data: dict,
+                                     optional_params: dict,
+                                     litellm_params: dict) -> EmbeddingResponse:
+        try:
+            response_json = raw_response.json()
+        except Exception as e:
+            raise DashScopeError(status_code=raw_response.status_code,
+                                 message=f"Failed to parse DashScope response as JSON: {str(e)}")
+        logging_obj.post_call(input=request_data.get("input"), api_key=api_key,
+                              additional_args={"complete_input_dict": request_data},
+                              original_response=response_json)
+        if "code" in response_json:
+            raise DashScopeError(status_code=raw_response.status_code,
+                                 message=response_json.get("message", str(response_json)))
+        output = response_json.get("output", {})
+        embeddings = output.get("embeddings", [])
+        model_response.object = "list"
+        model_response.data = [
+            {"object": "embedding", "index": emb.get("index", i),
+             "embedding": emb.get("embedding", [])}
+            for i, emb in enumerate(embeddings)
+        ]
+        model_response.model = model
+        usage = response_json.get("usage") or {}
+        input_tokens = usage.get("input_tokens", 0)
+        total_tokens = usage.get("total_tokens", input_tokens)
+
+        text_tokens = None
+        image_tokens = None
+        if "input_tokens_details" in usage:
+            image_tokens = usage["input_tokens_details"].get("image_tokens")
+            text_tokens = usage["input_tokens_details"].get("text_tokens")
+        elif "image_tokens" in usage:
+            image_tokens = usage["image_tokens"]
+            text_tokens = input_tokens
+            input_tokens = input_tokens + image_tokens
+            total_tokens = max(total_tokens, input_tokens)
+
+        prompt_tokens_details = None
+        if image_tokens is not None or text_tokens is not None:
+            from litellm.types.utils import PromptTokensDetailsWrapper
+            prompt_tokens_details = PromptTokensDetailsWrapper(
+                image_tokens=image_tokens,
+                text_tokens=text_tokens,
+            )
+
+        setattr(model_response, "usage",
+                Usage(prompt_tokens=input_tokens, completion_tokens=0,
+                      total_tokens=total_tokens,
+                      prompt_tokens_details=prompt_tokens_details))
+        if "request_id" in response_json:
+            setattr(model_response, "id", response_json["request_id"])
+        return model_response
+
+    def get_error_class(self, error_message: str, status_code: int,
+                        headers: Union[dict, httpx.Headers]) -> BaseLLMException:
+        if isinstance(headers, dict):
+            headers = httpx.Headers(headers)
+        return DashScopeError(status_code=status_code, message=error_message, headers=headers)

--- a/litellm/llms/dashscope/embed/transformation_multimodal.py
+++ b/litellm/llms/dashscope/embed/transformation_multimodal.py
@@ -3,21 +3,23 @@ Transform request/response for DashScope multimodal embeddings.
 Reference: https://help.aliyun.com/zh/model-studio/multimodal-embedding-api-reference
 """
 
-from typing import List, Optional, Union
+from typing import Optional, Union
+
 import httpx
+
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.base_llm.embedding.transformation import BaseEmbeddingConfig
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllEmbeddingInputValues, AllMessageValues
 from litellm.types.utils import EmbeddingResponse, Usage
+
 from ..common_utils import DashScopeError
 
 DEFAULT_API_BASE = "https://dashscope.aliyuncs.com/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding"
 
 
 class DashScopeMultimodalEmbeddingConfig(BaseEmbeddingConfig):
-
     @staticmethod
     def is_multimodal_embedding(model: str) -> bool:
         """Return True if the model name indicates a multimodal embedding model.
@@ -35,31 +37,43 @@ class DashScopeMultimodalEmbeddingConfig(BaseEmbeddingConfig):
         base = model.split("/")[-1].lower() if "/" in model else model.lower()
         return any(kw in base for kw in ("multimodal", "vl", "vision"))
 
-    def get_supported_openai_params(self, model: str) -> List[str]:
+    def get_supported_openai_params(self, model: str) -> list[str]:
         return ["dimensions"]
 
-    def map_openai_params(self, non_default_params: dict, optional_params: dict,
-                          model: str, drop_params: bool = False) -> dict:
+    def map_openai_params(
+        self, non_default_params: dict, optional_params: dict, model: str, drop_params: bool = False
+    ) -> dict:
         if "dimensions" in non_default_params:
             optional_params["dimension"] = non_default_params["dimensions"]
         return optional_params
 
-    def validate_environment(self, headers: dict, model: str,
-                             messages: List[AllMessageValues],
-                             optional_params: dict, litellm_params: dict,
-                             api_key: Optional[str] = None,
-                             api_base: Optional[str] = None) -> dict:
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        messages: list[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+    ) -> dict:
         if api_key is None:
             api_key = get_secret_str("DASHSCOPE_API_KEY")
         if api_key is None:
-            raise ValueError("DashScope API key is required. "
-                             "Set 'DASHSCOPE_API_KEY' env var or pass api_key explicitly.")
-        return {"Content-Type": "application/json",
-                "Authorization": f"Bearer {api_key}", **headers}
+            raise ValueError(
+                "DashScope API key is required. Set 'DASHSCOPE_API_KEY' env var or pass api_key explicitly."
+            )
+        return {"Content-Type": "application/json", "Authorization": f"Bearer {api_key}", **headers}
 
-    def get_complete_url(self, api_base: Optional[str], api_key: Optional[str],
-                         model: str, optional_params: dict, litellm_params: dict,
-                         stream: Optional[bool] = None) -> str:
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        api_key: Optional[str],
+        model: str,
+        optional_params: dict,
+        litellm_params: dict,
+        stream: Optional[bool] = None,
+    ) -> str:
         user_base = get_secret_str("DASHSCOPE_API_BASE")
         if user_base:
             return user_base
@@ -100,10 +114,9 @@ class DashScopeMultimodalEmbeddingConfig(BaseEmbeddingConfig):
             return {"content_list": blocks}
         return item
 
-    def transform_embedding_request(self, model: str,
-                                    input: AllEmbeddingInputValues,
-                                    optional_params: dict,
-                                    headers: dict) -> dict:
+    def transform_embedding_request(
+        self, model: str, input: AllEmbeddingInputValues, optional_params: dict, headers: dict
+    ) -> dict:
         inputs = input if isinstance(input, list) else [input]
         contents = [self._normalize_input_item(item) for item in inputs]
         body: dict = {"model": model, "input": {"contents": contents}}
@@ -116,31 +129,38 @@ class DashScopeMultimodalEmbeddingConfig(BaseEmbeddingConfig):
             body["parameters"] = params
         return body
 
-    def transform_embedding_response(self, model: str,
-                                     raw_response: httpx.Response,
-                                     model_response: EmbeddingResponse,
-                                     logging_obj: LiteLLMLoggingObj,
-                                     api_key: Optional[str],
-                                     request_data: dict,
-                                     optional_params: dict,
-                                     litellm_params: dict) -> EmbeddingResponse:
+    def transform_embedding_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        model_response: EmbeddingResponse,
+        logging_obj: LiteLLMLoggingObj,
+        api_key: Optional[str],
+        request_data: dict,
+        optional_params: dict,
+        litellm_params: dict,
+    ) -> EmbeddingResponse:
         try:
             response_json = raw_response.json()
-        except Exception as e:
-            raise DashScopeError(status_code=raw_response.status_code,
-                                 message=f"Failed to parse DashScope response as JSON: {str(e)}")
-        logging_obj.post_call(input=request_data.get("input"), api_key=api_key,
-                              additional_args={"complete_input_dict": request_data},
-                              original_response=response_json)
+        except ValueError as e:
+            raise DashScopeError(
+                status_code=raw_response.status_code, message=f"Failed to parse DashScope response as JSON: {str(e)}"
+            )
+        logging_obj.post_call(
+            input=request_data.get("input"),
+            api_key=api_key,
+            additional_args={"complete_input_dict": request_data},
+            original_response=response_json,
+        )
         if "code" in response_json:
-            raise DashScopeError(status_code=raw_response.status_code,
-                                 message=response_json.get("message", str(response_json)))
+            raise DashScopeError(
+                status_code=raw_response.status_code, message=response_json.get("message", str(response_json))
+            )
         output = response_json.get("output", {})
         embeddings = output.get("embeddings", [])
         model_response.object = "list"
         model_response.data = [
-            {"object": "embedding", "index": emb.get("index", i),
-             "embedding": emb.get("embedding", [])}
+            {"object": "embedding", "index": emb.get("index", i), "embedding": emb.get("embedding", [])}
             for i, emb in enumerate(embeddings)
         ]
         model_response.model = model
@@ -162,21 +182,29 @@ class DashScopeMultimodalEmbeddingConfig(BaseEmbeddingConfig):
         prompt_tokens_details = None
         if image_tokens is not None or text_tokens is not None:
             from litellm.types.utils import PromptTokensDetailsWrapper
+
             prompt_tokens_details = PromptTokensDetailsWrapper(
                 image_tokens=image_tokens,
                 text_tokens=text_tokens,
             )
 
-        setattr(model_response, "usage",
-                Usage(prompt_tokens=input_tokens, completion_tokens=0,
-                      total_tokens=total_tokens,
-                      prompt_tokens_details=prompt_tokens_details))
+        setattr(
+            model_response,
+            "usage",
+            Usage(
+                prompt_tokens=input_tokens,
+                completion_tokens=0,
+                total_tokens=total_tokens,
+                prompt_tokens_details=prompt_tokens_details,
+            ),
+        )
         if "request_id" in response_json:
             setattr(model_response, "id", response_json["request_id"])
         return model_response
 
-    def get_error_class(self, error_message: str, status_code: int,
-                        headers: Union[dict, httpx.Headers]) -> BaseLLMException:
+    def get_error_class(
+        self, error_message: str, status_code: int, headers: Union[dict, httpx.Headers]
+    ) -> BaseLLMException:
         if isinstance(headers, dict):
             headers = httpx.Headers(headers)
         return DashScopeError(status_code=status_code, message=error_message, headers=headers)

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -45299,5 +45299,41 @@
                 }
             }
         ]
+    },
+    "dashscope/multimodal-embedding-v1": {
+        "input_cost_per_token": 1e-07,
+        "input_cost_per_image_token": 1.5e-07,
+        "litellm_provider": "dashscope",
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "source": "https://bailian.console.aliyun.com/cn-beijing/?tab=model#/model-market/detail/multimodal-embedding-v1",
+        "supports_embedding_image_input": true
+    },
+    "dashscope/tongyi-embedding-vision-plus": {
+        "input_cost_per_token": 9e-08,
+        "input_cost_per_image_token": 9e-08,
+        "litellm_provider": "dashscope",
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "source": "https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=doc#/doc/?type=model&modelId=tongyi-embedding-vision-plus",
+        "supports_embedding_image_input": true
+    },
+    "dashscope/tongyi-embedding-vision-flash": {
+        "input_cost_per_token": 9e-08,
+        "input_cost_per_image_token": 3e-08,
+        "litellm_provider": "dashscope",
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "source": "https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=doc#/doc/?type=model&modelId=tongyi-embedding-vision-flash",
+        "supports_embedding_image_input": true
+    },
+    "dashscope/qwen3-vl-embedding": {
+        "input_cost_per_token": 1e-07,
+        "input_cost_per_image_token": 3e-07,
+        "litellm_provider": "dashscope",
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "source": "https://bailian.console.aliyun.com/cn-beijing/?tab=model#/model-market/detail/qwen3-vl-embedding",
+        "supports_embedding_image_input": true
     }
 }

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7918,7 +7918,12 @@ class ProviderConfigManager:
             from litellm.llms.dashscope.embed.transformation import (
                 DashScopeEmbeddingConfig,
             )
+            from litellm.llms.dashscope.embed.transformation_multimodal import (
+                DashScopeMultimodalEmbeddingConfig,
+            )
 
+            if DashScopeMultimodalEmbeddingConfig.is_multimodal_embedding(model):
+                return DashScopeMultimodalEmbeddingConfig()
             return DashScopeEmbeddingConfig()
         elif litellm.LlmProviders.OVHCLOUD == provider:
             return litellm.OVHCloudEmbeddingConfig()

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -45421,5 +45421,41 @@
                 }
             }
         ]
+    },
+    "dashscope/multimodal-embedding-v1": {
+        "input_cost_per_token": 1e-07,
+        "input_cost_per_image_token": 1.5e-07,
+        "litellm_provider": "dashscope",
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "source": "https://bailian.console.aliyun.com/cn-beijing/?tab=model#/model-market/detail/multimodal-embedding-v1",
+        "supports_embedding_image_input": true
+    },
+    "dashscope/tongyi-embedding-vision-plus": {
+        "input_cost_per_token": 9e-08,
+        "input_cost_per_image_token": 9e-08,
+        "litellm_provider": "dashscope",
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "source": "https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=doc#/doc/?type=model&modelId=tongyi-embedding-vision-plus",
+        "supports_embedding_image_input": true
+    },
+    "dashscope/tongyi-embedding-vision-flash": {
+        "input_cost_per_token": 9e-08,
+        "input_cost_per_image_token": 3e-08,
+        "litellm_provider": "dashscope",
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "source": "https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=doc#/doc/?type=model&modelId=tongyi-embedding-vision-flash",
+        "supports_embedding_image_input": true
+    },
+    "dashscope/qwen3-vl-embedding": {
+        "input_cost_per_token": 1e-07,
+        "input_cost_per_image_token": 3e-07,
+        "litellm_provider": "dashscope",
+        "mode": "embedding",
+        "output_cost_per_token": 0.0,
+        "source": "https://bailian.console.aliyun.com/cn-beijing/?tab=model#/model-market/detail/qwen3-vl-embedding",
+        "supports_embedding_image_input": true
     }
 }

--- a/tests/test_litellm/llms/dashscope/test_dashscope_cost_calculator.py
+++ b/tests/test_litellm/llms/dashscope/test_dashscope_cost_calculator.py
@@ -222,3 +222,72 @@ class TestDashscopeCostCalculator:
         )
 
         assert math.isclose(prompt_cost, expected_prompt_cost, rel_tol=1e-10)
+
+    def test_multimodal_text_only(self):
+        usage = Usage(
+            prompt_tokens=100, completion_tokens=0,
+            prompt_tokens_details=PromptTokensDetailsWrapper(image_tokens=0)
+        )
+        prompt_cost, _ = dashscope_cost_per_token(
+            model="multimodal-embedding-v1", usage=usage
+        )
+        model_info = litellm.get_model_info("dashscope/multimodal-embedding-v1")
+        expected = 100 * model_info["input_cost_per_token"]
+        assert math.isclose(prompt_cost, expected, rel_tol=1e-10)
+
+    def test_multimodal_image_tokens(self):
+        usage = Usage(
+            prompt_tokens=996, completion_tokens=0,
+            prompt_tokens_details=PromptTokensDetailsWrapper(image_tokens=896)
+        )
+        prompt_cost, _ = dashscope_cost_per_token(
+            model="multimodal-embedding-v1", usage=usage
+        )
+        model_info = litellm.get_model_info("dashscope/multimodal-embedding-v1")
+        text_cost = 100 * model_info["input_cost_per_token"]
+        image_cost = 896 * model_info["input_cost_per_image_token"]
+        expected = text_cost + image_cost
+        assert math.isclose(prompt_cost, expected, rel_tol=1e-10)
+
+    def test_tongyi_image_tokens_same_price(self):
+        usage = Usage(
+            prompt_tokens=100, completion_tokens=0,
+            prompt_tokens_details=PromptTokensDetailsWrapper(image_tokens=50)
+        )
+        prompt_cost, _ = dashscope_cost_per_token(
+            model="tongyi-embedding-vision-plus", usage=usage
+        )
+        model_info = litellm.get_model_info("dashscope/tongyi-embedding-vision-plus")
+        expected = 100 * model_info["input_cost_per_token"]
+        assert math.isclose(prompt_cost, expected, rel_tol=1e-10)
+
+    def test_top_level_image_tokens(self):
+        usage = Usage(
+            prompt_tokens=903, completion_tokens=0,
+            prompt_tokens_details=PromptTokensDetailsWrapper(image_tokens=896)
+        )
+        prompt_cost, _ = dashscope_cost_per_token(
+            model="qwen3-vl-embedding", usage=usage
+        )
+        model_info = litellm.get_model_info("dashscope/qwen3-vl-embedding")
+        text_cost = 7 * model_info["input_cost_per_token"]
+        image_cost = 896 * model_info["input_cost_per_image_token"]
+        expected = text_cost + image_cost
+        assert math.isclose(prompt_cost, expected, rel_tol=1e-10)
+
+    def test_missing_pricing_entry(self):
+        usage = Usage(prompt_tokens=100, completion_tokens=0)
+        prompt_cost, completion_cost = dashscope_cost_per_token(
+            model="unknown-model", usage=usage
+        )
+        assert prompt_cost == 0.0
+        assert completion_cost == 0.0
+
+    def test_no_prompt_tokens_details(self):
+        usage = Usage(prompt_tokens=100, completion_tokens=0)
+        prompt_cost, _ = dashscope_cost_per_token(
+            model="multimodal-embedding-v1", usage=usage
+        )
+        model_info = litellm.get_model_info("dashscope/multimodal-embedding-v1")
+        expected = 100 * model_info["input_cost_per_token"]
+        assert math.isclose(prompt_cost, expected, rel_tol=1e-10)

--- a/tests/test_litellm/llms/dashscope/test_dashscope_multimodal_embedding_integration.py
+++ b/tests/test_litellm/llms/dashscope/test_dashscope_multimodal_embedding_integration.py
@@ -1,0 +1,205 @@
+"""
+Integration tests for DashScope multimodal embedding end-to-end flow.
+"""
+
+import asyncio
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+import litellm
+from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+from litellm.llms.dashscope.common_utils import DashScopeError
+from litellm.llms.dashscope.embed.transformation_multimodal import DEFAULT_API_BASE
+from litellm.types.utils import EmbeddingResponse
+
+MOCK_SUCCESS_RESPONSE = {
+    "output": {
+        "embeddings": [
+            {"index": 0, "embedding": [0.1, 0.2, 0.3], "type": "text"}
+        ]
+    },
+    "usage": {"input_tokens": 10, "total_tokens": 10},
+    "request_id": "mock-request-id",
+}
+
+MOCK_ERROR_RESPONSE = {
+    "code": "InvalidParameter",
+    "message": "dimension must be between 1 and 2048",
+    "request_id": "mock-request-id",
+}
+
+
+def _make_mock_response(payload: dict, status_code: int = 200) -> httpx.Response:
+    return httpx.Response(
+        status_code=status_code,
+        content=json.dumps(payload).encode("utf-8"),
+        request=httpx.Request("POST", DEFAULT_API_BASE),
+    )
+
+
+# === 1. 同步完整流程 ===
+
+
+def test_sync_multimodal_embedding():
+    handler = BaseLLMHTTPHandler()
+    mock_response = _make_mock_response(MOCK_SUCCESS_RESPONSE)
+
+    mock_http_handler = MagicMock()
+    mock_http_handler.post.return_value = mock_response
+
+    with patch(
+        "litellm.llms.custom_httpx.llm_http_handler._get_httpx_client",
+        return_value=mock_http_handler,
+    ):
+        with patch(
+            "litellm.llms.dashscope.embed.transformation_multimodal.get_secret_str",
+            return_value=None,
+        ):
+            result = handler.embedding(
+                model="tongyi-embedding-vision-flash",
+                input=["hello world"],
+                timeout=30.0,
+                custom_llm_provider="dashscope",
+                logging_obj=MagicMock(),
+                api_base=None,
+                optional_params={},
+                litellm_params={},
+                model_response=EmbeddingResponse(),
+                api_key="sk-test",
+            )
+
+    call_args = mock_http_handler.post.call_args
+    assert "/multimodal-embedding" in call_args.kwargs.get("url", call_args.args[0] if call_args.args else "")
+    assert result.data[0]["embedding"] == [0.1, 0.2, 0.3]
+    assert result.usage.prompt_tokens == 10
+    assert result.id == "mock-request-id"
+
+
+# === 2. 异步完整流程 ===
+
+
+def test_async_multimodal_embedding():
+    async def _run():
+        handler = BaseLLMHTTPHandler()
+        mock_response = _make_mock_response(MOCK_SUCCESS_RESPONSE)
+
+        mock_async_handler = AsyncMock()
+        mock_async_handler.post.return_value = mock_response
+
+        with patch(
+            "litellm.llms.custom_httpx.llm_http_handler.get_async_httpx_client",
+            return_value=mock_async_handler,
+        ):
+            with patch(
+                "litellm.llms.dashscope.embed.transformation_multimodal.get_secret_str",
+                return_value=None,
+            ):
+                result = await handler.aembedding(
+                    request_data={
+                        "model": "tongyi-embedding-vision-flash",
+                        "input": {"contents": [{"text": "hello world"}]},
+                    },
+                    api_base=DEFAULT_API_BASE,
+                    headers={
+                        "Authorization": "Bearer sk-test",
+                        "Content-Type": "application/json",
+                    },
+                    model="tongyi-embedding-vision-flash",
+                    custom_llm_provider="dashscope",
+                    provider_config=litellm.utils.ProviderConfigManager.get_provider_embedding_config(
+                        model="tongyi-embedding-vision-flash",
+                        provider=litellm.LlmProviders.DASHSCOPE,
+                    ),
+                    model_response=EmbeddingResponse(),
+                    logging_obj=MagicMock(),
+                    api_key="sk-test",
+                    timeout=30.0,
+                    optional_params={},
+                    litellm_params={},
+                )
+        return result
+
+    result = asyncio.run(_run())
+    assert result.data[0]["embedding"] == [0.1, 0.2, 0.3]
+    assert result.usage.total_tokens == 10
+
+
+# === 3. 错误响应 ===
+
+
+def test_multimodal_embedding_api_error():
+    handler = BaseLLMHTTPHandler()
+    mock_response = _make_mock_response(MOCK_ERROR_RESPONSE, status_code=400)
+
+    mock_http_handler = MagicMock()
+    mock_http_handler.post.return_value = mock_response
+
+    with patch(
+        "litellm.llms.custom_httpx.llm_http_handler._get_httpx_client",
+        return_value=mock_http_handler,
+    ):
+        with patch(
+            "litellm.llms.dashscope.embed.transformation_multimodal.get_secret_str",
+            return_value=None,
+        ):
+            with pytest.raises(DashScopeError) as exc:
+                handler.embedding(
+                    model="tongyi-embedding-vision-flash",
+                    input=["hello world"],
+                    timeout=30.0,
+                    custom_llm_provider="dashscope",
+                    logging_obj=MagicMock(),
+                    api_base=None,
+                    optional_params={},
+                    litellm_params={},
+                    model_response=EmbeddingResponse(),
+                    api_key="sk-test",
+                )
+    assert exc.value.status_code == 400
+    assert "dimension must be between 1 and 2048" in exc.value.message
+
+
+# === 4. 自定义 api_base ===
+
+
+def test_multimodal_embedding_custom_api_base():
+    handler = BaseLLMHTTPHandler()
+    mock_response = _make_mock_response(MOCK_SUCCESS_RESPONSE)
+
+    mock_http_handler = MagicMock()
+    mock_http_handler.post.return_value = mock_response
+
+    vpc_base = "https://vpc.maas.aliyuncs.com/api/v1"
+
+    with patch(
+        "litellm.llms.custom_httpx.llm_http_handler._get_httpx_client",
+        return_value=mock_http_handler,
+    ):
+        with patch(
+            "litellm.llms.dashscope.embed.transformation_multimodal.get_secret_str",
+            return_value=None,
+        ):
+            result = handler.embedding(
+                model="tongyi-embedding-vision-flash",
+                input=["hello world"],
+                timeout=30.0,
+                custom_llm_provider="dashscope",
+                logging_obj=MagicMock(),
+                api_base=vpc_base,
+                optional_params={},
+                litellm_params={},
+                model_response=EmbeddingResponse(),
+                api_key="sk-test",
+            )
+
+    call_args = mock_http_handler.post.call_args
+    posted_url = call_args.kwargs.get("url", call_args.args[0] if call_args.args else "")
+    assert posted_url == f"{vpc_base}/services/embeddings/multimodal-embedding/multimodal-embedding"
+    assert result.data[0]["embedding"] == [0.1, 0.2, 0.3]

--- a/tests/test_litellm/llms/dashscope/test_dashscope_multimodal_embedding_transformation.py
+++ b/tests/test_litellm/llms/dashscope/test_dashscope_multimodal_embedding_transformation.py
@@ -1,0 +1,365 @@
+"""
+Unit tests for DashScope multimodal embedding transformation.
+"""
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+from litellm.llms.dashscope.common_utils import DashScopeError
+from litellm.llms.dashscope.embed.transformation_multimodal import (
+    DEFAULT_API_BASE,
+    DashScopeMultimodalEmbeddingConfig,
+)
+from litellm.types.utils import EmbeddingResponse
+
+
+# === 1. 模型识别 ===
+
+
+def test_is_multimodal_embedding_vision_flash():
+    assert DashScopeMultimodalEmbeddingConfig.is_multimodal_embedding(
+        "tongyi-embedding-vision-flash"
+    ) is True
+
+
+def test_is_multimodal_embedding_vision_plus():
+    assert DashScopeMultimodalEmbeddingConfig.is_multimodal_embedding(
+        "tongyi-embedding-vision-plus"
+    ) is True
+
+
+def test_is_multimodal_embedding_text():
+    assert DashScopeMultimodalEmbeddingConfig.is_multimodal_embedding(
+        "text-embedding-v4"
+    ) is False
+
+
+def test_is_multimodal_embedding_with_prefix():
+    assert DashScopeMultimodalEmbeddingConfig.is_multimodal_embedding(
+        "host/tongyi-embedding-vision-flash"
+    ) is True
+
+
+# === 2. URL 拼接 ===
+
+
+def test_get_complete_url_default():
+    config = DashScopeMultimodalEmbeddingConfig()
+    with patch(
+        "litellm.llms.dashscope.embed.transformation_multimodal.get_secret_str",
+        return_value=None,
+    ):
+        url = config.get_complete_url(
+            api_base=None,
+            api_key="sk-test",
+            model="tongyi-embedding-vision-flash",
+            optional_params={},
+            litellm_params={},
+        )
+    assert url == DEFAULT_API_BASE
+
+
+def test_get_complete_url_custom_base():
+    config = DashScopeMultimodalEmbeddingConfig()
+    with patch(
+        "litellm.llms.dashscope.embed.transformation_multimodal.get_secret_str",
+        return_value=None,
+    ):
+        url = config.get_complete_url(
+            api_base="https://xxx.maas.aliyuncs.com/api/v1",
+            api_key="sk-test",
+            model="tongyi-embedding-vision-flash",
+            optional_params={},
+            litellm_params={},
+        )
+    assert url == "https://xxx.maas.aliyuncs.com/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding"
+
+
+def test_get_complete_url_compatible_mode():
+    config = DashScopeMultimodalEmbeddingConfig()
+    with patch(
+        "litellm.llms.dashscope.embed.transformation_multimodal.get_secret_str",
+        return_value=None,
+    ):
+        url = config.get_complete_url(
+            api_base="https://dashscope.aliyuncs.com/compatible-mode/v1",
+            api_key="sk-test",
+            model="tongyi-embedding-vision-flash",
+            optional_params={},
+            litellm_params={},
+        )
+    assert url == DEFAULT_API_BASE
+
+
+def test_get_complete_url_env_var():
+    config = DashScopeMultimodalEmbeddingConfig()
+    custom_url = "https://custom.endpoint.com/api/v1/multimodal"
+    with patch(
+        "litellm.llms.dashscope.embed.transformation_multimodal.get_secret_str",
+        return_value=custom_url,
+    ):
+        url = config.get_complete_url(
+            api_base=None,
+            api_key="sk-test",
+            model="tongyi-embedding-vision-flash",
+            optional_params={},
+            litellm_params={},
+        )
+    assert url == custom_url
+
+
+def test_get_complete_url_already_has_path():
+    config = DashScopeMultimodalEmbeddingConfig()
+    with patch(
+        "litellm.llms.dashscope.embed.transformation_multimodal.get_secret_str",
+        return_value=None,
+    ):
+        url = config.get_complete_url(
+            api_base="https://xxx.maas.aliyuncs.com/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding",
+            api_key="sk-test",
+            model="tongyi-embedding-vision-flash",
+            optional_params={},
+            litellm_params={},
+        )
+    assert url == "https://xxx.maas.aliyuncs.com/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding"
+
+
+# === 3. 输入归一化 ===
+
+
+def test_normalize_input_item_string():
+    config = DashScopeMultimodalEmbeddingConfig()
+    result = config._normalize_input_item("hello")
+    assert result == {"text": "hello"}
+
+
+def test_normalize_input_item_dict_text():
+    config = DashScopeMultimodalEmbeddingConfig()
+    result = config._normalize_input_item([{"type": "text", "text": "hi"}])
+    assert result == {"text": "hi"}
+
+
+def test_normalize_input_item_dict_image():
+    config = DashScopeMultimodalEmbeddingConfig()
+    result = config._normalize_input_item(
+        [{"type": "image_url", "image_url": {"url": "https://img.jpg"}}]
+    )
+    assert result == {"image": "https://img.jpg"}
+
+
+def test_normalize_input_item_mixed():
+    config = DashScopeMultimodalEmbeddingConfig()
+    result = config._normalize_input_item(
+        [
+            {"type": "text", "text": "describe this image"},
+            {"type": "image_url", "image_url": {"url": "https://img.jpg"}},
+        ]
+    )
+    assert result == {
+        "content_list": [
+            {"text": "describe this image"},
+            {"image": "https://img.jpg"},
+        ]
+    }
+
+
+# === 4. 请求转换 ===
+
+
+def test_transform_embedding_request_string_input():
+    config = DashScopeMultimodalEmbeddingConfig()
+    result = config.transform_embedding_request(
+        model="tongyi-embedding-vision-flash",
+        input=["hello"],
+        optional_params={},
+        headers={},
+    )
+    assert result == {
+        "model": "tongyi-embedding-vision-flash",
+        "input": {"contents": [{"text": "hello"}]},
+    }
+
+
+def test_transform_embedding_request_mixed_input():
+    config = DashScopeMultimodalEmbeddingConfig()
+    result = config.transform_embedding_request(
+        model="tongyi-embedding-vision-flash",
+        input=[
+            [
+                {"type": "text", "text": "描述"},
+                {"type": "image_url", "image_url": {"url": "https://img.jpg"}},
+            ]
+        ],
+        optional_params={},
+        headers={},
+    )
+    assert result == {
+        "model": "tongyi-embedding-vision-flash",
+        "input": {
+            "contents": [
+                {
+                    "content_list": [
+                        {"text": "描述"},
+                        {"image": "https://img.jpg"},
+                    ]
+                }
+            ]
+        },
+    }
+
+
+def test_transform_embedding_request_with_dimension():
+    config = DashScopeMultimodalEmbeddingConfig()
+    result = config.transform_embedding_request(
+        model="tongyi-embedding-vision-flash",
+        input=["hello"],
+        optional_params={"dimension": 512},
+        headers={},
+    )
+    assert result["parameters"] == {"dimension": 512}
+
+
+# === 5. 响应解析 ===
+
+
+def test_transform_embedding_response_success():
+    config = DashScopeMultimodalEmbeddingConfig()
+    payload = {
+        "output": {
+            "embeddings": [
+                {"index": 0, "embedding": [0.1, 0.2, 0.3], "type": "text"}
+            ]
+        },
+        "usage": {"input_tokens": 10, "total_tokens": 10},
+        "request_id": "mock-request-id",
+    }
+    raw = httpx.Response(
+        status_code=200,
+        content=json.dumps(payload).encode("utf-8"),
+        request=httpx.Request("POST", "https://example.com"),
+    )
+    result = config.transform_embedding_response(
+        model="tongyi-embedding-vision-flash",
+        raw_response=raw,
+        model_response=EmbeddingResponse(),
+        logging_obj=MagicMock(),
+        api_key="sk-test",
+        request_data={"input": {"contents": [{"text": "hello"}]}},
+        optional_params={},
+        litellm_params={},
+    )
+    assert result.object == "list"
+    assert len(result.data) == 1
+    assert result.data[0]["embedding"] == [0.1, 0.2, 0.3]
+    assert result.data[0]["index"] == 0
+    assert result.model == "tongyi-embedding-vision-flash"
+    assert result.usage.prompt_tokens == 10
+    assert result.usage.total_tokens == 10
+    assert result.id == "mock-request-id"
+
+
+def test_transform_embedding_response_error():
+    config = DashScopeMultimodalEmbeddingConfig()
+    payload = {
+        "code": "InvalidParameter",
+        "message": "dimension must be between 1 and 2048",
+        "request_id": "mock-request-id",
+    }
+    raw = httpx.Response(
+        status_code=400,
+        content=json.dumps(payload).encode("utf-8"),
+        request=httpx.Request("POST", "https://example.com"),
+    )
+    with pytest.raises(DashScopeError) as exc:
+        config.transform_embedding_response(
+            model="tongyi-embedding-vision-flash",
+            raw_response=raw,
+            model_response=EmbeddingResponse(),
+            logging_obj=MagicMock(),
+            api_key="sk-test",
+            request_data={},
+            optional_params={},
+            litellm_params={},
+        )
+    assert exc.value.status_code == 400
+    assert "dimension must be between 1 and 2048" in exc.value.message
+
+
+def test_transform_embedding_response_non_200():
+    config = DashScopeMultimodalEmbeddingConfig()
+    payload = {
+        "code": "Unauthorized",
+        "message": "Invalid API key",
+        "request_id": "mock-request-id",
+    }
+    raw = httpx.Response(
+        status_code=401,
+        content=json.dumps(payload).encode("utf-8"),
+        request=httpx.Request("POST", "https://example.com"),
+    )
+    with pytest.raises(DashScopeError) as exc:
+        config.transform_embedding_response(
+            model="tongyi-embedding-vision-flash",
+            raw_response=raw,
+            model_response=EmbeddingResponse(),
+            logging_obj=MagicMock(),
+            api_key="sk-bad",
+            request_data={},
+            optional_params={},
+            litellm_params={},
+        )
+    assert exc.value.status_code == 401
+
+
+# === 6. 参数映射 ===
+
+
+def test_map_openai_params_dimensions():
+    config = DashScopeMultimodalEmbeddingConfig()
+    result = config.map_openai_params(
+        non_default_params={"dimensions": 512},
+        optional_params={},
+        model="tongyi-embedding-vision-flash",
+    )
+    assert result == {"dimension": 512}
+
+
+# === 7. 环境验证 ===
+
+
+def test_validate_environment():
+    config = DashScopeMultimodalEmbeddingConfig()
+    headers = config.validate_environment(
+        headers={},
+        model="tongyi-embedding-vision-flash",
+        messages=[],
+        optional_params={},
+        litellm_params={},
+        api_key="sk-test",
+    )
+    assert headers["Authorization"] == "Bearer sk-test"
+    assert headers["Content-Type"] == "application/json"
+
+
+def test_validate_environment_missing_key():
+    config = DashScopeMultimodalEmbeddingConfig()
+    with patch(
+        "litellm.llms.dashscope.embed.transformation_multimodal.get_secret_str",
+        return_value=None,
+    ):
+        with pytest.raises(ValueError, match="DASHSCOPE_API_KEY"):
+            config.validate_environment(
+                headers={},
+                model="tongyi-embedding-vision-flash",
+                messages=[],
+                optional_params={},
+                litellm_params={},
+                api_key=None,
+            )


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Pending — will be added after running a live proxy instance against the DashScope multimodal embedding endpoint.

## Type

🆕 New Feature

## Changes

DashScope's multimodal embedding API (`/v1/services/embeddings/multimodal-embedding/multimodal-embedding`) requires a distinct request shape and response structure from the text-only embedding endpoint. The existing code path routed all embedding calls through the text endpoint, causing 404s for multimodal input and incorrect cost calculation.

`litellm/llms/dashscope/embed/transformation_multimodal.py` (new): dedicated transformation class for multimodal embedding; handles input encoding (image URL/base64/text items), URL routing, and response parsing into a standard `EmbeddingResponse`.

`litellm/llms/dashscope/embed/__init__.py`: exposes `is_multimodal_embedding` as an explicit keyword argument so callers opt in without relying on positional detection.

`litellm/llms/dashscope/cost_calculator.py`: splits chat and embedding cost paths; fixes multimodal token-pricing keys that were mapped to wrong model names in the cost map.

`litellm/utils.py`: routes multimodal model IDs to the new config class via `ProviderConfigManager`.

Tests cover transformation logic, URL routing, input encoding, cost calculation, and an integration test against the live DashScope API.