### PR TITLE
fix(responses): honor caller stream flag when provider forces SSE

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2523,6 +2523,7 @@ class BaseLLMHTTPHandler:
 
         # Check if streaming is requested
         stream = response_api_optional_request_params.get("stream", False)
+        caller_requested_stream = bool(stream)
 
         api_base = responses_api_provider_config.get_complete_url(
             api_base=litellm_params.api_base,
@@ -2597,8 +2598,20 @@ class BaseLLMHTTPHandler:
                     stream=stream,
                     **body_kwargs,
                 )
-                if fake_stream is True:
-                    return MockResponsesAPIStreamingIterator(
+                if caller_requested_stream:
+                    if fake_stream is True:
+                        return MockResponsesAPIStreamingIterator(
+                            response=response,
+                            model=model,
+                            logging_obj=logging_obj,
+                            responses_api_provider_config=responses_api_provider_config,
+                            litellm_metadata=litellm_metadata,
+                            custom_llm_provider=custom_llm_provider,
+                            request_data=request_context,
+                            call_type=CallTypes.responses.value,
+                        )
+
+                    return SyncResponsesAPIStreamingIterator(
                         response=response,
                         model=model,
                         logging_obj=logging_obj,
@@ -2608,17 +2621,7 @@ class BaseLLMHTTPHandler:
                         request_data=request_context,
                         call_type=CallTypes.responses.value,
                     )
-
-                return SyncResponsesAPIStreamingIterator(
-                    response=response,
-                    model=model,
-                    logging_obj=logging_obj,
-                    responses_api_provider_config=responses_api_provider_config,
-                    litellm_metadata=litellm_metadata,
-                    custom_llm_provider=custom_llm_provider,
-                    request_data=request_context,
-                    call_type=CallTypes.responses.value,
-                )
+                response.read()
             else:
                 response = sync_httpx_client.post(
                     url=api_base,
@@ -2700,6 +2703,7 @@ class BaseLLMHTTPHandler:
 
         # Check if streaming is requested
         stream = response_api_optional_request_params.get("stream", False)
+        caller_requested_stream = bool(stream)
 
         api_base = responses_api_provider_config.get_complete_url(
             api_base=litellm_params.api_base,
@@ -2772,8 +2776,21 @@ class BaseLLMHTTPHandler:
                     **body_kwargs,
                 )
 
-                if fake_stream is True:
-                    return MockResponsesAPIStreamingIterator(
+                if caller_requested_stream:
+                    if fake_stream is True:
+                        return MockResponsesAPIStreamingIterator(
+                            response=response,
+                            model=model,
+                            logging_obj=logging_obj,
+                            responses_api_provider_config=responses_api_provider_config,
+                            litellm_metadata=litellm_metadata,
+                            custom_llm_provider=custom_llm_provider,
+                            request_data=request_context,
+                            call_type=CallTypes.responses.value,
+                        )
+
+                    # Return the streaming iterator
+                    return ResponsesAPIStreamingIterator(
                         response=response,
                         model=model,
                         logging_obj=logging_obj,
@@ -2783,18 +2800,7 @@ class BaseLLMHTTPHandler:
                         request_data=request_context,
                         call_type=CallTypes.responses.value,
                     )
-
-                # Return the streaming iterator
-                return ResponsesAPIStreamingIterator(
-                    response=response,
-                    model=model,
-                    logging_obj=logging_obj,
-                    responses_api_provider_config=responses_api_provider_config,
-                    litellm_metadata=litellm_metadata,
-                    custom_llm_provider=custom_llm_provider,
-                    request_data=request_context,
-                    call_type=CallTypes.responses.value,
-                )
+                await response.aread()
             else:
                 response = await async_httpx_client.post(
                     url=api_base,

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -23,7 +23,10 @@ from litellm.llms.custom_httpx.llm_http_handler import (
     BaseLLMHTTPHandler,
     _google_genai_streaming_hidden_params,
 )
-from litellm.responses.streaming_iterator import BaseResponsesAPIStreamingIterator
+from litellm.responses.streaming_iterator import (
+    BaseResponsesAPIStreamingIterator,
+    MockResponsesAPIStreamingIterator,
+)
 from litellm.types.llms.openai import ResponsesAPIResponse
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import TranscriptionResponse
@@ -400,6 +403,34 @@ async def test_async_response_api_handler_returns_iterator_when_the_caller_reque
 
     assert isinstance(result, BaseResponsesAPIStreamingIterator)
     config.transform_response_api_response.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_response_api_handler_fake_stream_still_returns_mock_iterator():
+    handler = BaseLLMHTTPHandler()
+    config = _chatgpt_style_config(ResponsesAPIResponse(id="resp_fake", created_at=0, output=[], status="completed"))
+    client = AsyncHTTPHandler()
+    client.post = AsyncMock(
+        return_value=httpx.Response(
+            200,
+            request=httpx.Request("POST", "https://chatgpt.example.com/responses"),
+        )
+    )
+
+    result = await handler.async_response_api_handler(
+        model="gpt-5.3-codex",
+        input="hi",
+        responses_api_provider_config=config,
+        response_api_optional_request_params={"stream": True},
+        custom_llm_provider="chatgpt",
+        litellm_params=GenericLiteLLMParams(),
+        logging_obj=_responses_logging_obj(),
+        client=client,
+        fake_stream=True,
+    )
+
+    assert isinstance(result, MockResponsesAPIStreamingIterator)
+    assert client.post.call_args.kwargs["json"].get("stream") is None
 
 
 def test_get_agentic_loop_settings_defaults_and_overrides():

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -23,6 +23,7 @@ from litellm.llms.custom_httpx.llm_http_handler import (
     BaseLLMHTTPHandler,
     _google_genai_streaming_hidden_params,
 )
+from litellm.responses.streaming_iterator import BaseResponsesAPIStreamingIterator
 from litellm.types.llms.openai import ResponsesAPIResponse
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import TranscriptionResponse
@@ -250,6 +251,7 @@ async def test_async_response_api_handler_streams_when_provider_transform_adds_s
         )
     )
     logging_obj = Mock()
+    logging_obj.dynamic_success_callbacks = None
 
     await handler.async_response_api_handler(
         model="gpt-5.3-codex",
@@ -264,6 +266,140 @@ async def test_async_response_api_handler_streams_when_provider_transform_adds_s
 
     assert client.post.call_args.kwargs["stream"] is True
     assert client.post.call_args.kwargs["json"]["stream"] is True
+
+
+def _responses_logging_obj():
+    logging_obj = Mock()
+    logging_obj.dynamic_success_callbacks = None
+    return logging_obj
+
+
+def _chatgpt_style_config(aggregated):
+    config = Mock()
+    config.validate_environment.return_value = {}
+    config.get_complete_url.return_value = "https://chatgpt.example.com/responses"
+    config.transform_responses_api_request.return_value = {
+        "model": "gpt-5.3-codex",
+        "input": "hi",
+        "stream": True,
+    }
+    config.sign_request.return_value = ({}, None)
+    config.transform_response_api_response.return_value = aggregated
+    return config
+
+
+@pytest.mark.parametrize("caller_params", [{}, {"stream": False}])
+def test_response_api_handler_aggregates_when_only_the_provider_requires_stream(caller_params):
+    handler = BaseLLMHTTPHandler()
+    aggregated = Mock(spec=ResponsesAPIResponse)
+    config = _chatgpt_style_config(aggregated)
+    client = HTTPHandler(client=httpx.Client())
+    client.post = Mock(
+        return_value=httpx.Response(
+            200,
+            request=httpx.Request("POST", "https://chatgpt.example.com/responses"),
+        )
+    )
+
+    result = handler.response_api_handler(
+        model="gpt-5.3-codex",
+        input="hi",
+        responses_api_provider_config=config,
+        response_api_optional_request_params=caller_params,
+        custom_llm_provider="chatgpt",
+        litellm_params=GenericLiteLLMParams(),
+        logging_obj=_responses_logging_obj(),
+        client=client,
+    )
+
+    assert client.post.call_args.kwargs["json"]["stream"] is True
+    assert not isinstance(result, BaseResponsesAPIStreamingIterator)
+    assert result is aggregated
+    config.transform_response_api_response.assert_called_once()
+
+
+def test_response_api_handler_returns_iterator_when_the_caller_requests_stream():
+    handler = BaseLLMHTTPHandler()
+    config = _chatgpt_style_config(Mock(spec=ResponsesAPIResponse))
+    client = HTTPHandler(client=httpx.Client())
+    client.post = Mock(
+        return_value=httpx.Response(
+            200,
+            request=httpx.Request("POST", "https://chatgpt.example.com/responses"),
+        )
+    )
+
+    result = handler.response_api_handler(
+        model="gpt-5.3-codex",
+        input="hi",
+        responses_api_provider_config=config,
+        response_api_optional_request_params={"stream": True},
+        custom_llm_provider="chatgpt",
+        litellm_params=GenericLiteLLMParams(),
+        logging_obj=_responses_logging_obj(),
+        client=client,
+    )
+
+    assert isinstance(result, BaseResponsesAPIStreamingIterator)
+    config.transform_response_api_response.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("caller_params", [{}, {"stream": False}])
+async def test_async_response_api_handler_aggregates_when_only_the_provider_requires_stream(caller_params):
+    handler = BaseLLMHTTPHandler()
+    aggregated = Mock(spec=ResponsesAPIResponse)
+    config = _chatgpt_style_config(aggregated)
+    client = AsyncHTTPHandler()
+    client.post = AsyncMock(
+        return_value=httpx.Response(
+            200,
+            request=httpx.Request("POST", "https://chatgpt.example.com/responses"),
+        )
+    )
+
+    result = await handler.async_response_api_handler(
+        model="gpt-5.3-codex",
+        input="hi",
+        responses_api_provider_config=config,
+        response_api_optional_request_params=caller_params,
+        custom_llm_provider="chatgpt",
+        litellm_params=GenericLiteLLMParams(),
+        logging_obj=_responses_logging_obj(),
+        client=client,
+    )
+
+    assert client.post.call_args.kwargs["json"]["stream"] is True
+    assert not isinstance(result, BaseResponsesAPIStreamingIterator)
+    assert result is aggregated
+    config.transform_response_api_response.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_response_api_handler_returns_iterator_when_the_caller_requests_stream():
+    handler = BaseLLMHTTPHandler()
+    config = _chatgpt_style_config(Mock(spec=ResponsesAPIResponse))
+    client = AsyncHTTPHandler()
+    client.post = AsyncMock(
+        return_value=httpx.Response(
+            200,
+            request=httpx.Request("POST", "https://chatgpt.example.com/responses"),
+        )
+    )
+
+    result = await handler.async_response_api_handler(
+        model="gpt-5.3-codex",
+        input="hi",
+        responses_api_provider_config=config,
+        response_api_optional_request_params={"stream": True},
+        custom_llm_provider="chatgpt",
+        litellm_params=GenericLiteLLMParams(),
+        logging_obj=_responses_logging_obj(),
+        client=client,
+    )
+
+    assert isinstance(result, BaseResponsesAPIStreamingIterator)
+    config.transform_response_api_response.assert_not_called()
 
 
 def test_get_agentic_loop_settings_defaults_and_overrides():


### PR DESCRIPTION
## TLDR

Problem this solves:

- `chatgpt/*` ignores a caller's `stream: false` since v1.90.0
- `/v1/responses` hands back raw SSE instead of JSON
- `/v1/chat/completions` and `/v1/messages` fail with `Unknown items in responses API response: []`

How it solves it:

- Transport streaming and response shape are decided separately
- Only the caller's own `stream` value picks the shape
- Providers that force SSE are still read as streams
- Handler tests inject the ChatGPT authenticator, so CI never logs in

## User Flow

Before: a developer calling a ChatGPT subscription model without streaming gets back something they cannot parse

1. They send POST https://litellm-domain/v1/responses with `"stream": false` and a ChatGPT subscription model
2. A 200 comes back, but `content-type` is `text/event-stream` and the body is a dozen SSE frames instead of one JSON object
3. Their client breaks on the string, reporting `Cannot use 'in' operator to search for 'object' in data:` followed by the whole stream
4. They try the same model at POST https://litellm-domain/v1/chat/completions with no streaming
5. That returns 500 with `Unknown items in responses API response: []`
6. They try POST https://litellm-domain/v1/messages with no streaming and get the same 500, so no endpoint serves a plain response

After: the same requests come back in the shape the caller asked for

1. They send the same POST https://litellm-domain/v1/responses with `"stream": false`
2. A 200 comes back with `content-type: application/json` and a single response object whose `status` is `completed`
3. Their client parses it normally, with no SSE frames in the body
4. They send the same POST https://litellm-domain/v1/chat/completions
5. That returns 200 with an assistant message and a `finish_reason` of `stop`
6. POST https://litellm-domain/v1/messages returns 200 with a single `message` object and a `stop_reason` of `end_turn`
7. Sending any of the three with `"stream": true` still streams exactly as before

## Relevant issues

Fixes #34094

## Affected release

Regression since v1.90.0 (introduced by #30189), still present in v1.102.0-rc.1, so the `backport-stable` label is on

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both legs boot a no-DB proxy from the named commit with `--num_workers 2` on a random free port (`$PORT` below), the master key as `$KEY`, and this `config.yaml`, which points `m-terra` at the real ChatGPT subscription backend (the provider reads the stored subscription token, so there is no `api_key`):

```yaml
model_list:
  - model_name: m-terra
    litellm_params:
      model: chatgpt/gpt-5.6-terra
      reasoning_effort: low

general_settings:
  master_key: sk-1234
```

The same seven requests hit both proxies back to back against the same account. Each leg ran twice with identical results and the second pass is shown. Response and item ids are scrubbed to `"id": "..."` because they are account-scoped, the first body line is cut at 170 characters, and SSE bodies are summarized by frame count plus the last two frame types

### Before (3ed6c19b8d)

#### /v1/responses with stream false

1. Send the request

   ```bash
   curl -sS -i http://localhost:$PORT/v1/responses -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
     -d '{"model":"m-terra","input":[{"role":"user","content":"say hi in 3 words"}],"stream":false}'
   ```

2. Observe the response

   ```text
   HTTP/1.1 200 OK
   content-type: text/event-stream; charset=utf-8
   data: {"type":"response.created","response":{"id": "...","created_at":1789474792,"instructions":"You are Codex, based on GPT-5. You are running as a coding agent in the C ...
   data: {"type":"response.in_progress","response":{"id": "...","created_at":1789474792,"instructions":"You are Codex, based on GPT-5. You are running as a coding agent in t ...
   data: {"type":"response.output_item.added","output_index":0,"item":{"id": "...","type":"message","status":"in_progress","content":[],"phase":"final_answer","role":"assist ...
   ... 14 SSE data frames in total, the last two being `response.completed` and `[DONE]`
   ```

#### /v1/responses with stream omitted

1. Send the request

   ```bash
   curl -sS -i http://localhost:$PORT/v1/responses -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
     -d '{"model":"m-terra","input":[{"role":"user","content":"say hi in 3 words"}]}'
   ```

2. Observe the response

   ```text
   HTTP/1.1 200 OK
   content-type: text/event-stream; charset=utf-8
   data: {"type":"response.created","response":{"id": "...","created_at":1789474795,"instructions":"You are Codex, based on GPT-5. You are running as a coding agent in the C ...
   data: {"type":"response.in_progress","response":{"id": "...","created_at":1789474795,"instructions":"You are Codex, based on GPT-5. You are running as a coding agent in t ...
   data: {"type":"response.output_item.added","output_index":0,"item":{"id": "...","type":"message","status":"in_progress","content":[],"phase":"final_answer","role":"assist ...
   ... 14 SSE data frames in total, the last two being `response.completed` and `[DONE]`
   ```

#### /v1/responses with stream true

1. Send the request

   ```bash
   curl -sS -i http://localhost:$PORT/v1/responses -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
     -d '{"model":"m-terra","input":[{"role":"user","content":"say hi in 3 words"}],"stream":true}'
   ```

2. Observe the response

   ```text
   HTTP/1.1 200 OK
   content-type: text/event-stream; charset=utf-8
   data: {"type":"response.created","response":{"id": "...","created_at":1789474798,"instructions":"You are Codex, based on GPT-5. You are running as a coding agent in the C ...
   data: {"type":"response.in_progress","response":{"id": "...","created_at":1789474798,"instructions":"You are Codex, based on GPT-5. You are running as a coding agent in t ...
   data: {"type":"response.output_item.added","output_index":0,"item":{"id": "...","type":"message","status":"in_progress","content":[],"phase":"final_answer","role":"assist ...
   ... 15 SSE data frames in total, the last two being `response.completed` and `[DONE]`
   ```

#### /v1/chat/completions with stream false

1. Send the request

   ```bash
   curl -sS -i http://localhost:$PORT/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
     -d '{"model":"m-terra","messages":[{"role":"user","content":"say hi in 3 words"}],"stream":false}'
   ```

2. Observe the response

   ```text
   HTTP/1.1 500 Internal Server Error
   content-type: application/json
   {"error":{"message":"litellm.APIConnectionError: APIConnectionError: ChatgptException - Unknown items in responses API response: []. Received Model Group=m-terra\nAvailab ...
   (259 bytes, a single JSON document)
   ```

#### /v1/chat/completions with stream true

1. Send the request

   ```bash
   curl -sS -i http://localhost:$PORT/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
     -d '{"model":"m-terra","messages":[{"role":"user","content":"say hi in 3 words"}],"stream":true}'
   ```

2. Observe the response

   ```text
   HTTP/1.1 200 OK
   content-type: text/event-stream; charset=utf-8
   data: {"id": "...","object":"chat.completion.chunk","created":1789474812,"model":"m-terra","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"}}]}
   data: {"id": "...","object":"chat.completion.chunk","created":1789474812,"model":"m-terra","choices":[{"index":0,"delta":{"content":" there"}}]}
   data: {"id": "...","object":"chat.completion.chunk","created":1789474812,"model":"m-terra","choices":[{"index":0,"delta":{"content":","}}]}
   ... 7 SSE data frames in total, the last two being `chat.completion.chunk` and `[DONE]`
   ```

#### /v1/messages with stream false

1. Send the request

   ```bash
   curl -sS -i http://localhost:$PORT/v1/messages -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
     -d '{"model":"m-terra","max_tokens":64,"messages":[{"role":"user","content":"say hi in 3 words"}],"stream":false}'
   ```

2. Observe the response

   ```text
   HTTP/1.1 500 Internal Server Error
   content-type: application/json
   {"type":"error","error":{"type":"api_error","message":"litellm.APIConnectionError: APIConnectionError: ChatgptException - Unknown items in responses API response: []. Rec ...
   (236 bytes, a single JSON document)
   ```

#### /v1/messages with stream true

1. Send the request

   ```bash
   curl -sS -i http://localhost:$PORT/v1/messages -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
     -d '{"model":"m-terra","max_tokens":64,"messages":[{"role":"user","content":"say hi in 3 words"}],"stream":true}'
   ```

2. Observe the response

   ```text
   HTTP/1.1 200 OK
   content-type: text/event-stream; charset=utf-8
   event: message_start
   data: {"type":"message_start","message":{"id": "...","type":"message","role":"assistant","content":[],"model":"m-terra","stop_reason":null,"stop_sequence":null,"usage":{" ...
   event: content_block_start
   ... 10 SSE data frames in total, the last two being `message_delta` and `message_stop`
   ```

### After (04e164bcc2)

#### /v1/responses with stream false

1. Send the request

   ```bash
   curl -sS -i http://localhost:$PORT/v1/responses -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
     -d '{"model":"m-terra","input":[{"role":"user","content":"say hi in 3 words"}],"stream":false}'
   ```

2. Observe the response

   ```text
   HTTP/1.1 200 OK
   content-type: application/json
   {"id": "...","created_at":1789475509,"error":null,"incomplete_details":null,"instructions":"You are Codex, based on GPT-5. You are running as a coding agent in the Codex  ...
   (10325 bytes, a single JSON document: object `response`, status `completed`, 1 output item, text 'Hi there, friend!')
   ```

#### /v1/responses with stream omitted

1. Send the request

   ```bash
   curl -sS -i http://localhost:$PORT/v1/responses -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
     -d '{"model":"m-terra","input":[{"role":"user","content":"say hi in 3 words"}]}'
   ```

2. Observe the response

   ```text
   HTTP/1.1 200 OK
   content-type: application/json
   {"id": "...","created_at":1789475512,"error":null,"incomplete_details":null,"instructions":"You are Codex, based on GPT-5. You are running as a coding agent in the Codex  ...
   (10325 bytes, a single JSON document: object `response`, status `completed`, 1 output item, text 'Hi there, friend!')
   ```

#### /v1/responses with stream true

1. Send the request

   ```bash
   curl -sS -i http://localhost:$PORT/v1/responses -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
     -d '{"model":"m-terra","input":[{"role":"user","content":"say hi in 3 words"}],"stream":true}'
   ```

2. Observe the response

   ```text
   HTTP/1.1 200 OK
   content-type: text/event-stream; charset=utf-8
   data: {"type":"response.created","response":{"id": "...","created_at":1789475515,"instructions":"You are Codex, based on GPT-5. You are running as a coding agent in the C ...
   data: {"type":"response.in_progress","response":{"id": "...","created_at":1789475515,"instructions":"You are Codex, based on GPT-5. You are running as a coding agent in t ...
   data: {"type":"response.output_item.added","output_index":0,"item":{"id": "...","type":"message","status":"in_progress","content":[],"phase":"final_answer","role":"assist ...
   ... 15 SSE data frames in total, the last two being `response.completed` and `[DONE]`
   ```

#### /v1/chat/completions with stream false

1. Send the request

   ```bash
   curl -sS -i http://localhost:$PORT/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
     -d '{"model":"m-terra","messages":[{"role":"user","content":"say hi in 3 words"}],"stream":false}'
   ```

2. Observe the response

   ```text
   HTTP/1.1 200 OK
   content-type: application/json
   {"id": "...","created":1789475516,"model":"m-terra","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Hi there, welcome!","rol ...
   (1351 bytes, a single JSON document: object `chat.completion`, finish_reason `stop`, content 'Hi there, welcome!')
   ```

#### /v1/chat/completions with stream true

1. Send the request

   ```bash
   curl -sS -i http://localhost:$PORT/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
     -d '{"model":"m-terra","messages":[{"role":"user","content":"say hi in 3 words"}],"stream":true}'
   ```

2. Observe the response

   ```text
   HTTP/1.1 200 OK
   content-type: text/event-stream; charset=utf-8
   data: {"id": "...","object":"chat.completion.chunk","created":1789475520,"model":"m-terra","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"}}]}
   data: {"id": "...","object":"chat.completion.chunk","created":1789475520,"model":"m-terra","choices":[{"index":0,"delta":{"content":" there"}}]}
   data: {"id": "...","object":"chat.completion.chunk","created":1789475520,"model":"m-terra","choices":[{"index":0,"delta":{"content":","}}]}
   ... 7 SSE data frames in total, the last two being `chat.completion.chunk` and `[DONE]`
   ```

#### /v1/messages with stream false

1. Send the request

   ```bash
   curl -sS -i http://localhost:$PORT/v1/messages -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
     -d '{"model":"m-terra","max_tokens":64,"messages":[{"role":"user","content":"say hi in 3 words"}],"stream":false}'
   ```

2. Observe the response

   ```text
   HTTP/1.1 200 OK
   content-type: application/json
   {"id": "...","type":"message","role":"assistant","model":"m-terra","stop_sequence":null,"usage":{"input_tokens":1636,"output_tokens":9},"content":[{"type":"text","text":" ...
   (287 bytes, a single JSON document: type `message`, stop_reason `end_turn`, text 'Hi there, friend!')
   ```

#### /v1/messages with stream true

1. Send the request

   ```bash
   curl -sS -i http://localhost:$PORT/v1/messages -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
     -d '{"model":"m-terra","max_tokens":64,"messages":[{"role":"user","content":"say hi in 3 words"}],"stream":true}'
   ```

2. Observe the response

   ```text
   HTTP/1.1 200 OK
   content-type: text/event-stream; charset=utf-8
   event: message_start
   data: {"type":"message_start","message":{"id": "...","type":"message","role":"assistant","content":[],"model":"m-terra","stop_reason":null,"stop_sequence":null,"usage":{" ...
   event: content_block_start
   ... 11 SSE data frames in total, the last two being `message_delta` and `message_stop`
   ```

Observations from the run:

- `/v1/messages` non-stream fails before and passes after, same as chat
- Streaming frame counts differ by one across runs; model output length varies
- Non-stream bodies echo the provider's Codex `instructions`; pre-existing, unchanged

## Type

🐛 Bug Fix

## Changes

The two Responses handlers in `litellm/llms/custom_httpx/llm_http_handler.py` decided whether to hand the caller a streaming iterator by reading `stream` off the provider payload:

```python
stream = bool(stream or data.get("stream"))
...
is_stream_request = bool(stream)
```

`data` there is what goes out to the provider, not what the caller sent. `ChatGPTResponsesAPIConfig.transform_responses_api_request` sets `request["stream"] = True` unconditionally because the Codex backend only serves SSE, so `data.get("stream")` is always true for this provider and a caller that sent `stream: false` was silently moved onto the streaming path. Other Responses providers are unaffected; chatgpt is the only one whose transform touches `stream` at all

On `/v1/responses` that meant a raw SSE body was returned to a caller expecting one JSON object. On `/v1/chat/completions` and `/v1/messages` the Responses bridge fell into `_collect_response_from_stream`, which keeps only the `response` from the `response.completed` event; when the Codex backend emits that event with an empty `output` the request failed with `Unknown items in responses API response: []`. The recovery path for that case in `_recover_output_items_from_raw_sse` re-parses the raw SSE from `logging_obj.model_call_details["original_response"]`, and the only place that populates it for this provider is `transform_response_api_response`, which lives on the non-streaming path and was no longer being reached

That merge line came from #30189, which set out to stop provider transforms that force `stream: true` from being sent through the non-streaming branch, ChatGPT Codex models included. The transport half of that is right and this PR keeps it. The problem is that a single `stream` variable was carrying two decisions at once: what to pass to httpx, and whether to return an iterator or an aggregated body. Merging the provider payload into it fixed the transport half and silently changed the response shape along with it

This keeps transport streaming exactly as it was, so a provider that only serves SSE is still read as a stream, and narrows the response-shape decision to the caller's own `stream` value, captured before the transform runs. When the provider forces SSE for a non-streaming caller the body is read and aggregated through the existing path. The bridge half of #30189, which preserves a top-level `stream=True` into the Responses request, is untouched

Tests drive both handlers through the real `ChatGPTResponsesAPIConfig` and a real SSE body, so the aggregation that turns `response.output_item.done` frames into one completed response actually runs and the returned text is asserted. A caller sending `stream: false`, and one omitting it, gets an aggregated `ResponsesAPIResponse`; a caller asking for streaming still gets an iterator that yields through `response.completed`; and `fake_stream` produces a mock iterator only for a streaming caller. Reverting the handler fix fails six of them. The two existing `..._streams_when_provider_transform_adds_stream` tests from #30189 keep their transport-level assertions. `ChatGPTResponsesAPIConfig` now takes its `Authenticator` through the constructor (defaulting to a real one), so the handler tests pass a mock and never start the device-code login that hung the `All Other Providers` CI job

## Caveats (if any)

### Low

- Non-stream callers still cost a full SSE read server-side; provider only serves SSE
- Non-stream bodies carry the provider's Codex `instructions` text; pre-existing
- Assumes no other Responses provider transform sets `stream`; one that did would now aggregate for non-stream callers, which is the intended shape

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
