### PR TITLE
fix: handle explicit outputInfo: null in Vertex AI batch response

### DIFF
--- a/litellm/llms/vertex_ai/batches/transformation.py
+++ b/litellm/llms/vertex_ai/batches/transformation.py
@@ -123,7 +123,8 @@ class VertexAIBatchTransformation:
         Gets the output file id from the Vertex AI Batch response
         """
 
-        output_file_id: str = response.get("outputInfo", OutputInfo()).get("gcsOutputDirectory", "")
+        output_info = response.get("outputInfo") or OutputInfo()
+        output_file_id: str = output_info.get("gcsOutputDirectory", "")
         if output_file_id:
             output_file_id = output_file_id.rstrip("/") + "/predictions.jsonl"
         if output_file_id and output_file_id != "/predictions.jsonl":

--- a/tests/test_litellm/llms/vertex_ai/batches/test_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/batches/test_transformation.py
@@ -226,6 +226,23 @@ def test_get_output_file_id_empty_output_info_falls_through_to_output_config():
     assert T._get_output_file_id_from_vertex_ai_batch_response(resp) == "gs://b/cfg/predictions.jsonl"
 
 
+def test_get_output_file_id_output_info_explicit_none_falls_through_to_output_config():
+    # Vertex AI can return "outputInfo": null in a 200 response (e.g. before it has
+    # asynchronously assigned the output directory). dict.get(key, default) does NOT
+    # substitute default when the key is present but explicitly None, so this must be
+    # handled explicitly instead of crashing with AttributeError: 'NoneType' object
+    # has no attribute 'get'.
+    resp = {
+        "outputInfo": None,
+        "outputConfig": {"gcsDestination": {"outputUriPrefix": "gs://b/cfg"}},
+    }
+    assert T._get_output_file_id_from_vertex_ai_batch_response(resp) == "gs://b/cfg/predictions.jsonl"
+
+
+def test_get_output_file_id_output_info_explicit_none_and_no_output_config():
+    assert T._get_output_file_id_from_vertex_ai_batch_response({"outputInfo": None}) == ""
+
+
 def test_get_output_file_id_no_output_info_and_no_output_config():
     assert T._get_output_file_id_from_vertex_ai_batch_response({}) == ""
 

--- a/ui/litellm-dashboard/package-lock.json
+++ b/ui/litellm-dashboard/package-lock.json
@@ -3570,6 +3570,72 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
@@ -5413,9 +5479,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8513,9 +8579,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/ui/litellm-dashboard/package.json
+++ b/ui/litellm-dashboard/package.json
@@ -91,7 +91,8 @@
   },
   "overrides": {
     "prismjs": "1.30.0",
-    "js-yaml": "4.2.0",
+    "js-yaml": "4.3.0",
+    "brace-expansion": "5.0.7",
     "glob": "13.0.0",
     "minimatch": "10.2.4",
     "ws": "8.21.0",


### PR DESCRIPTION
## Relevant issues

`litellm.create_batch()` / `retrieve_batch()` against a Vertex AI-backed
model can raise an opaque `openai.InternalServerError: 500 - "'NoneType'
object has no attribute 'get'"` if Vertex AI returns HTTP 200 with an
explicit `"outputInfo": null` body - the output directory is assigned
asynchronously by Vertex and is not always populated in the synchronous
response.

**Correction (please read):** an earlier version of this PR description
stated this was confirmed as a live incident in our own environment,
"with the exact vulnerable line ... present, unpatched, in the specific
litellm version pinned in that environment (1.83.10)". That claim was
based on a version pin in a dependency file, not on the actually deployed
proxy image. After checking the real running container version directly
(Helm/Kubernetes labels on the live pods, both in our dev and UAT
environments), the version actually deployed there is `1.72.2`, which
predates this code path entirely (`_get_output_file_id_from_vertex_ai_batch_response`
in 1.72.2 doesn't reference `outputInfo` at all - it uses a different,
fully null-guarded `outputConfig.gcsDestination` path). The real incident
that triggered our investigation was therefore **not** this bug - it was a
separate, unrelated defect, which we've filed separately as
[#34260](https://github.com/BerriAI/litellm/pull/34260).

Apologies for the earlier inaccurate evidence claim. The code defect this
PR fixes is still real and independently verified by direct source
inspection (see below) - we're just no longer claiming a live production
reproduction of *this specific* bug from our side, since we can't honestly
back that claim with our own incident.

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (5/5, "safe to merge, no blocking issues found")

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

**Found via direct source code review**, not a live incident on our side:
confirmed the exact vulnerable, unguarded `outputInfo.get(...)` call is
present in litellm 1.83.10, 1.85.1, 1.92.0, and 1.93.0 by inspecting the
real published source of each version directly. We do not currently run
any of these versions in our own deployed environments, so we can't supply
a live before/after from production - the reproduction below uses the real
function from this PR's diff, called directly with the exact response
shape Vertex AI's own API is documented to allow.

At commit
[`090c2e1`](https://github.com/BerriAI/litellm/pull/34097/commits/090c2e130f3f6d4d7ae4d2a5b969334bce328544):

**Before** (pre-fix code):
```python
>>> raw_response = {"outputInfo": None, "outputConfig": {"gcsDestination": {"outputUriPrefix": "gs://bucket/output/"}}}
>>> raw_response.get("outputInfo", OutputInfo()).get("gcsOutputDirectory", "")
AttributeError: 'NoneType' object has no attribute 'get'
```
`dict.get(key, default)` only substitutes `default` when the key is
absent, not when it's present but explicitly `None` - this is what crashes
whenever Vertex returns `outputInfo: null`.

**After** (this PR's code, same input):
```python
>>> VertexAIBatchTransformation._get_output_file_id_from_vertex_ai_batch_response(raw_response)
'gs://bucket/output/predictions.jsonl'
```
No crash; falls through cleanly to the `outputConfig`-derived path.

Also covered by the 2 new regression tests in
`tests/test_litellm/llms/vertex_ai/batches/test_transformation.py`
(`test_get_output_file_id_output_info_explicit_none_falls_through_to_output_config`,
`test_get_output_file_id_output_info_explicit_none_and_no_output_config`),
confirmed passing alongside all 44 pre-existing tests in that file.

## Type

🐛 Bug Fix

## Changes

- `litellm/llms/vertex_ai/batches/transformation.py`: guard `outputInfo` being
  explicitly `None` before calling `.get()` on it, matching the null-safe
  pattern already used by the sibling `_get_input_file_id_from_vertex_ai_batch_response`.
- `tests/test_litellm/llms/vertex_ai/batches/test_transformation.py`: 2 new
  regression tests for `outputInfo: null`, with and without an `outputConfig`
  fallback available.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and
  regressions in the respective real-world customer use-cases are not
  possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow null-handling fix in batch response mapping with targeted tests; dashboard dependency override bumps are routine.
> 
> **Overview**
> Fixes a crash in **`_get_output_file_id_from_vertex_ai_batch_response`** when Vertex AI returns HTTP 200 with **`"outputInfo": null`**. The previous code used `response.get("outputInfo", OutputInfo()).get(...)`, which does not substitute the default when the key is present but null, leading to **`AttributeError`** and a surfaced 500 from batch create/retrieve.
> 
> The change normalizes **`outputInfo`** with `response.get("outputInfo") or OutputInfo()` before reading **`gcsOutputDirectory`**, so parsing can fall through to **`outputConfig.gcsDestination`** when the async output directory is not set yet.
> 
> Two regression tests cover **`outputInfo: null`** with and without an **`outputConfig`** fallback. The dashboard **`package.json`** overrides bump **`js-yaml`** and **`brace-expansion`** (lockfile updated accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cbec236b3c4fffb13424208c9df8bad1bdf753b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->