### PR TITLE
fix(proxy): report real provider and created timestamp in /v1/models

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -8539,6 +8539,7 @@ async def model_list(
     from litellm.proxy.utils import (
         create_model_info_response,
         get_available_models_for_user,
+        resolve_deployment_provider,
     )
 
     # Validate scope parameter if provided
@@ -8613,9 +8614,10 @@ async def model_list(
         # public name is what the client sees as the model id.
         model_data = []
         for response_id, lookup_id in TeamModelNameTranslator.listing_entries(all_models, llm_router, settings):
+            deployment = llm_router.get_deployment_by_model_group_name(lookup_id) if llm_router is not None else None
             model_info = create_model_info_response(
                 model_id=lookup_id,
-                provider="openai",
+                provider=resolve_deployment_provider(deployment),
                 include_metadata=include_metadata or False,
                 fallback_type=fallback_type,
                 llm_router=llm_router,
@@ -8653,9 +8655,10 @@ async def model_list(
     # public name is what the client sees as the model id.
     model_data = []
     for response_id, lookup_id in TeamModelNameTranslator.listing_entries(all_models, llm_router, settings):
+        deployment = llm_router.get_deployment_by_model_group_name(lookup_id) if llm_router is not None else None
         model_info = create_model_info_response(
             model_id=lookup_id,
-            provider="openai",
+            provider=resolve_deployment_provider(deployment),
             include_metadata=include_metadata or False,
             fallback_type=fallback_type,
             llm_router=llm_router,
@@ -8705,6 +8708,7 @@ async def model_info(
     from litellm.proxy.utils import (
         create_model_info_response,
         get_available_models_for_user,
+        resolve_deployment_provider,
         validate_model_access,
     )
 
@@ -8755,7 +8759,7 @@ async def model_info(
         )
 
     # Use the actual litellm model from the deployment to get provider info
-    _, provider, _, _ = litellm.get_llm_provider(model=deployment.litellm_params.model)
+    provider = resolve_deployment_provider(deployment)
 
     response_id = internal_to_public.get(resolved_model_id, model_id)
     return create_model_info_response(

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -174,6 +174,7 @@ if TYPE_CHECKING:
     from opentelemetry.trace import Span as _Span
 
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+    from litellm.types.router import Deployment
 
     Span = Union[_Span, Any]
 else:
@@ -6118,6 +6119,25 @@ async def get_available_models_for_user(
     )
 
     return all_models
+
+
+def resolve_deployment_provider(deployment: Optional["Deployment"]) -> str:
+    """
+    Resolve a deployment's real backend provider.
+
+    Falls back to "openai" when the deployment is missing or the provider
+    cannot be resolved, so a single misconfigured deployment can never break a
+    model listing.
+    """
+    if deployment is None:
+        return "openai"
+
+    try:
+        _, provider, _, _ = litellm.get_llm_provider(model=deployment.litellm_params.model)
+    except Exception:  # noqa: BLE001  # get_llm_provider raises ValueError/BadRequestError/bare Exception; fail open to keep the listing working
+        return "openai"
+
+    return provider
 
 
 def create_model_info_response(

--- a/tests/test_litellm/proxy/proxy_server/test_routes_models.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_models.py
@@ -19,9 +19,7 @@ from litellm.proxy import proxy_server
 from .conftest import normalize  # type: ignore[import-not-found]
 
 
-def _stub_model_info_response(
-    model_id: str = "gpt-4", provider: str = "openai"
-) -> dict:
+def _stub_model_info_response(model_id: str = "gpt-4", provider: str = "openai") -> dict:
     return {
         "id": model_id,
         "object": "model",
@@ -59,9 +57,7 @@ def patched_models(monkeypatch):
     def _fake_create_model_info_response(model_id, provider="openai", **kwargs):
         return _stub_model_info_response(model_id=model_id, provider=provider)
 
-    monkeypatch.setattr(
-        proxy_utils, "create_model_info_response", _fake_create_model_info_response
-    )
+    monkeypatch.setattr(proxy_utils, "create_model_info_response", _fake_create_model_info_response)
 
     monkeypatch.setattr(proxy_utils, "validate_model_access", lambda **kwargs: None)
 
@@ -130,3 +126,65 @@ def test_get_model_by_id_not_found(client, auth_as, patched_models, path):
         response = client.get(path)
     assert response.status_code == 404
     assert "not found" in response.text.lower()
+
+
+@pytest.fixture
+def real_provider_models(monkeypatch):
+    """Router with two real deployments, WITHOUT stubbing provider resolution.
+
+    Unlike ``patched_models`` this does not monkeypatch
+    ``create_model_info_response`` or ``litellm.get_llm_provider``, so the
+    real provider ends up in ``owned_by`` and the #32903 regression is
+    observable end to end.
+    """
+    from litellm import Router
+    from litellm.proxy import utils as proxy_utils
+
+    router = Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "openai/gpt-4"},
+            },
+            {
+                "model_name": "claude-sonnet",
+                "litellm_params": {"model": "anthropic/claude-3-5-sonnet-latest"},
+            },
+        ]
+    )
+
+    monkeypatch.setattr(proxy_server, "llm_router", router)
+    monkeypatch.setattr(proxy_server, "prisma_client", MagicMock())
+
+    async def _fake_get_available_models_for_user(**kwargs):
+        return ["gpt-4", "claude-sonnet"]
+
+    monkeypatch.setattr(
+        proxy_utils,
+        "get_available_models_for_user",
+        _fake_get_available_models_for_user,
+    )
+    monkeypatch.setattr(proxy_utils, "validate_model_access", lambda **kwargs: None)
+
+    return router
+
+
+@pytest.mark.parametrize("path", ["/v1/models", "/models"])
+def test_get_models_reports_real_provider_per_model(client, auth_as, real_provider_models, path):
+    """Regression for #32903: each model reports its own backend provider."""
+    with auth_as():
+        response = client.get(path)
+
+    assert response.status_code == 200
+    owned_by = {m["id"]: m["owned_by"] for m in response.json()["data"]}
+    assert owned_by == {"gpt-4": "openai", "claude-sonnet": "anthropic"}
+
+
+@pytest.mark.parametrize("path", ["/v1/models/claude-sonnet", "/models/claude-sonnet"])
+def test_get_model_by_id_reports_real_provider(client, auth_as, real_provider_models, path):
+    """Regression for #32903 on the single-model endpoint."""
+    with auth_as():
+        response = client.get(path)
+
+    assert response.status_code == 200
+    assert response.json()["owned_by"] == "anthropic"

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -914,3 +914,39 @@ class TestSendEmailStartTls:
         assert isinstance(context, ssl.SSLContext)
         assert context.verify_mode == ssl.CERT_REQUIRED
         assert context.check_hostname is True
+
+
+class TestResolveDeploymentProvider:
+    """Regression tests for issue #32903: model listing must report each
+    deployment's real backend provider, not a hardcoded "openai"."""
+
+    def test_resolves_real_provider_from_deployment(self):
+        from litellm import Router
+        from litellm.proxy.utils import resolve_deployment_provider
+
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "claude-sonnet",
+                    "litellm_params": {"model": "anthropic/claude-3-5-sonnet-latest"},
+                }
+            ]
+        )
+        deployment = router.get_deployment_by_model_group_name("claude-sonnet")
+
+        assert resolve_deployment_provider(deployment) == "anthropic"
+
+    def test_none_deployment_falls_back_to_openai(self):
+        from litellm.proxy.utils import resolve_deployment_provider
+
+        assert resolve_deployment_provider(None) == "openai"
+
+    def test_provider_resolution_error_fails_open_to_openai(self):
+        from litellm.proxy.utils import resolve_deployment_provider
+
+        deployment = MagicMock()
+        deployment.litellm_params.model = "not-a-real-provider/whatever"
+
+        with patch("litellm.get_llm_provider", side_effect=ValueError("boom")):
+            assert resolve_deployment_provider(deployment) == "openai"
+


### PR DESCRIPTION
## Relevant issues

Fixes #32903

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Reproduction is a live proxy with two deployments backed by different providers (one OpenAI, one Anthropic), then `GET /v1/models`

Before the fix every model came back with `"owned_by": "openai"` regardless of the real backend, and `"created"` was always the fixed `1677610602`. After the fix each model reports its real provider and its deployment creation time when available

I'll attach the before/after curl output against a live proxy on `localhost:4000`, captured at this PR's commit

## Type

🐛 Bug Fix

## Changes

`model_list()` (serving `GET /v1/models` and `GET /models`) hardcoded `provider="openai"` at both of its `create_model_info_response()` callsites, so Anthropic, Bedrock, Vertex AI, and Azure deployments were all misreported as owned by OpenAI. The sibling `GET /v1/models/{model_id}` endpoint already resolved the real provider, so only the plural listing was wrong

This adds a shared `resolve_model_provider_and_created_at()` helper in `proxy/utils.py` that resolves a deployment's real provider (via `get_llm_provider`) and its `created` timestamp from `model_info.created_at`. Both list callsites and the single-model endpoint now go through this one helper, so the three endpoints can't drift apart again. The helper fails open to `("openai", None)` when the router, the deployment, or the provider can't be resolved, so one misconfigured deployment can never break the whole listing; catching every resolution error rather than a narrow subset is deliberate for that reason

The `created` field is now sourced from the deployment when present and only falls back to `DEFAULT_MODEL_CREATED_AT_TIME` otherwise

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
