### PR TITLE
feat(rust): honor pre-computed Entra ID auth for Azure /messages

### DIFF
--- a/litellm-rust/crates/ai-gateway/src/messages/common_utils.rs
+++ b/litellm-rust/crates/ai-gateway/src/messages/common_utils.rs
@@ -50,3 +50,15 @@ pub(super) fn has_header(headers: &[(String, String)], name: &str) -> bool {
         .iter()
         .any(|(key, _)| key.eq_ignore_ascii_case(name))
 }
+
+pub(super) fn has_bearer_auth(headers: &[(String, String)]) -> bool {
+    headers.iter().any(|(name, value)| {
+        if !name.eq_ignore_ascii_case("authorization") {
+            return false;
+        }
+        let value = value.trim();
+        value.len() > 7
+            && value[..7].eq_ignore_ascii_case("bearer ")
+            && !value[7..].trim().is_empty()
+    })
+}

--- a/litellm-rust/crates/ai-gateway/src/messages/prepare.rs
+++ b/litellm-rust/crates/ai-gateway/src/messages/prepare.rs
@@ -33,7 +33,9 @@ pub(super) fn prepare_messages_call(
     let mut headers = string_headers(request.extra_headers)?;
 
     let auth_strategy = config.auth_strategy();
-    if !has_header(&headers, auth_strategy.header_name()) {
+    let already_authorized = has_header(&headers, auth_strategy.header_name())
+        || (config.accepts_bearer_auth() && has_header(&headers, "authorization"));
+    if !already_authorized {
         let api_key = config.resolve_api_key(request.api_key, &env_lookup)?;
         let auth_header = match auth_strategy {
             MessagesAuthStrategy::Bearer => {

--- a/litellm-rust/crates/ai-gateway/src/messages/prepare.rs
+++ b/litellm-rust/crates/ai-gateway/src/messages/prepare.rs
@@ -3,7 +3,7 @@ use litellm_core::CoreResult;
 use litellm_core::messages::transformation::MessagesAuthStrategy;
 use litellm_core::routing_utils::provider::{CustomLlmProvider, get_custom_llm_provider};
 
-use super::common_utils::{has_header, messages_provider_config, string_headers};
+use super::common_utils::{has_bearer_auth, has_header, messages_provider_config, string_headers};
 use super::types::{MessagesRequest, ProviderMessagesRequest};
 
 pub(super) fn prepare_messages_call(
@@ -34,7 +34,7 @@ pub(super) fn prepare_messages_call(
 
     let auth_strategy = config.auth_strategy();
     let already_authorized = has_header(&headers, auth_strategy.header_name())
-        || (config.accepts_bearer_auth() && has_header(&headers, "authorization"));
+        || (config.accepts_bearer_auth() && has_bearer_auth(&headers));
     if !already_authorized {
         let api_key = config.resolve_api_key(request.api_key, &env_lookup)?;
         let auth_header = match auth_strategy {

--- a/litellm-rust/crates/ai-gateway/src/messages/tests.rs
+++ b/litellm-rust/crates/ai-gateway/src/messages/tests.rs
@@ -253,6 +253,68 @@ async fn messages_does_not_duplicate_auth_when_x_api_key_supplied() {
 }
 
 #[tokio::test]
+async fn messages_forwards_entra_id_bearer_without_requiring_api_key() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("binds");
+    let addr = listener.local_addr().expect("addr");
+
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accepts request");
+        let request = read_http_request(&mut socket).await;
+        let response_body =
+            r#"{"id":"msg_3","type":"message","role":"assistant","content":[],"model":"m"}"#;
+        socket
+            .write_all(write_response(response_body).as_bytes())
+            .await
+            .expect("writes response");
+        request
+    });
+
+    let mut headers = Map::new();
+    headers.insert(
+        "Authorization".to_string(),
+        Value::String("Bearer entra-token".to_string()),
+    );
+
+    messages(MessagesRequest {
+        model: "claude-sonnet-4-5",
+        body: json!({"model": "claude-sonnet-4-5", "max_tokens": 8, "messages": []}),
+        api_key: None,
+        api_base: Some(&format!("http://{addr}")),
+        custom_llm_provider: Some("azure_ai"),
+        extra_headers: Some(headers),
+        timeout: Some(Duration::from_secs(5)),
+    })
+    .await
+    .expect("entra id request succeeds without api key");
+
+    let request = server.await.expect("server task completes");
+    let head = request
+        .split_once("\r\n\r\n")
+        .expect("has body")
+        .0
+        .to_ascii_lowercase();
+    assert!(head.contains("authorization: bearer entra-token"), "{head}");
+    assert!(!head.contains("x-api-key"), "{head}");
+}
+
+#[tokio::test]
+async fn messages_requires_auth_when_no_key_and_no_header() {
+    let err = messages(MessagesRequest {
+        model: "claude-sonnet-4-5",
+        body: json!({"model": "claude-sonnet-4-5", "max_tokens": 8, "messages": []}),
+        api_key: None,
+        api_base: Some("http://127.0.0.1:1"),
+        custom_llm_provider: Some("azure_ai"),
+        extra_headers: None,
+        timeout: Some(Duration::from_millis(50)),
+    })
+    .await
+    .expect_err("missing auth errors");
+
+    assert!(matches!(err, CoreError::Auth(_)));
+}
+
+#[tokio::test]
 async fn messages_maps_provider_error_status_to_http_error() {
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("binds");
     let addr = listener.local_addr().expect("addr");

--- a/litellm-rust/crates/ai-gateway/src/messages/tests.rs
+++ b/litellm-rust/crates/ai-gateway/src/messages/tests.rs
@@ -6,7 +6,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
 use super::common_utils::{
-    has_header, messages_provider_config, string_headers, truncate_error_body,
+    has_bearer_auth, has_header, messages_provider_config, string_headers, truncate_error_body,
 };
 use super::{MessagesRequest, messages};
 
@@ -83,6 +83,34 @@ fn has_header_is_case_insensitive() {
     let headers = vec![("X-Api-Key".to_string(), "secret".to_string())];
     assert!(has_header(&headers, "x-api-key"));
     assert!(!has_header(&headers, "authorization"));
+}
+
+#[test]
+fn has_bearer_auth_requires_a_nonempty_bearer_token() {
+    assert!(has_bearer_auth(&[(
+        "Authorization".to_string(),
+        "Bearer tok".to_string()
+    )]));
+    assert!(has_bearer_auth(&[(
+        "authorization".to_string(),
+        "bearer tok".to_string()
+    )]));
+    assert!(!has_bearer_auth(&[(
+        "authorization".to_string(),
+        "Bearer ".to_string()
+    )]));
+    assert!(!has_bearer_auth(&[(
+        "authorization".to_string(),
+        String::new()
+    )]));
+    assert!(!has_bearer_auth(&[(
+        "authorization".to_string(),
+        "Basic abc".to_string()
+    )]));
+    assert!(!has_bearer_auth(&[(
+        "x-api-key".to_string(),
+        "sk".to_string()
+    )]));
 }
 
 #[tokio::test]
@@ -312,6 +340,50 @@ async fn messages_requires_auth_when_no_key_and_no_header() {
     .expect_err("missing auth errors");
 
     assert!(matches!(err, CoreError::Auth(_)));
+}
+
+#[tokio::test]
+async fn messages_ignores_malformed_authorization_and_uses_api_key() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("binds");
+    let addr = listener.local_addr().expect("addr");
+
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accepts request");
+        let request = read_http_request(&mut socket).await;
+        let response_body =
+            r#"{"id":"msg_4","type":"message","role":"assistant","content":[],"model":"m"}"#;
+        socket
+            .write_all(write_response(response_body).as_bytes())
+            .await
+            .expect("writes response");
+        request
+    });
+
+    let mut headers = Map::new();
+    headers.insert(
+        "Authorization".to_string(),
+        Value::String("Bearer ".to_string()),
+    );
+
+    messages(MessagesRequest {
+        model: "claude-sonnet-4-5",
+        body: json!({"model": "claude-sonnet-4-5", "max_tokens": 8, "messages": []}),
+        api_key: Some("sk-azure"),
+        api_base: Some(&format!("http://{addr}")),
+        custom_llm_provider: Some("azure_ai"),
+        extra_headers: Some(headers),
+        timeout: Some(Duration::from_secs(5)),
+    })
+    .await
+    .expect("falls back to api key");
+
+    let request = server.await.expect("server task completes");
+    let head = request
+        .split_once("\r\n\r\n")
+        .expect("has body")
+        .0
+        .to_ascii_lowercase();
+    assert!(head.contains("x-api-key: sk-azure"), "{head}");
 }
 
 #[tokio::test]

--- a/litellm-rust/crates/core/src/messages/transformation.rs
+++ b/litellm-rust/crates/core/src/messages/transformation.rs
@@ -35,6 +35,10 @@ pub trait AnthropicMessagesProviderConfig: Sync {
         MessagesAuthStrategy::Header("x-api-key")
     }
 
+    fn accepts_bearer_auth(&self) -> bool {
+        false
+    }
+
     fn default_headers(&self) -> &'static [(&'static str, &'static str)] {
         &[
             ("anthropic-version", "2023-06-01"),

--- a/litellm-rust/crates/core/src/providers/azure_ai/messages/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/azure_ai/messages/transformation.rs
@@ -163,6 +163,10 @@ impl AnthropicMessagesProviderConfig for AzureAnthropicMessagesConfig {
         self.anthropic.auth_strategy()
     }
 
+    fn accepts_bearer_auth(&self) -> bool {
+        true
+    }
+
     fn default_headers(&self) -> &'static [(&'static str, &'static str)] {
         self.anthropic.default_headers()
     }
@@ -292,6 +296,11 @@ mod tests {
                 .header_name(),
             "x-api-key"
         );
+    }
+
+    #[test]
+    fn accepts_bearer_auth_for_entra_id() {
+        assert!(AZURE_ANTHROPIC_MESSAGES_CONFIG.accepts_bearer_auth());
     }
 
     #[test]


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4645

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Verified live against a real Azure AI Foundry Claude deployment (`azure_ai/claude-sonnet-4-6`) through the compiled Rust path (`rust: true`), with two deployments that differ only in auth: `claude-apikey` uses an `x-api-key`, and `claude-entra` uses Entra ID from a service principal (`tenant_id` / `client_id` / `client_secret`, no api key). Both return a real 200 from Claude and carry `x-litellm-rust: true`, which the Rust path sets only when it served the request.

The Entra ID deployment (the case this PR fixes) has no api key; Python resolves the Entra bearer token and the Rust gateway now forwards the `Authorization` header. Before this change that request errored in the gateway with "Missing Azure API Key".

```
$ curl -sS -D - -o /dev/null -X POST http://localhost:4177/v1/messages \
    -H "Authorization: Bearer sk-1234" -H "content-type: application/json" \
    -d '{"model":"claude-entra","max_tokens":16,"messages":[{"role":"user","content":"reply with the single word: pong"}]}'
HTTP/1.1 200 OK
x-litellm-rust: true

# body: {"content":[{"type":"text","text":"pong"}], ...}
```

The `claude-apikey` deployment returns the same `HTTP 200` + `x-litellm-rust: true`, confirming the api-key path is unchanged.

Also driven end to end with the real Claude Code CLI (2.1.216) pointed at the proxy (`ANTHROPIC_BASE_URL` + gateway model discovery), on the Entra ID deployment:

```
$ ANTHROPIC_BASE_URL=http://localhost:4177 ANTHROPIC_AUTH_TOKEN=sk-1234 \
    claude -p "Write a Python one-liner that returns the number of vowels in a string s" --model claude-entra
sum(1 for c in s if c.lower() in 'aeiou')
```

Across the Claude Code runs the proxy logged zero "falling back to Python" events and zero "Missing Azure API Key" errors, so Rust served every request including the Entra ID one (no api key), and a Claude-Code-shaped request (the extra `role: system` message plus tools) comes back with `x-litellm-rust: true`.

Backed by the cargo suite; the regression test fails before the fix (`resolve_api_key(None)` returns `CoreError::Auth`) and passes after it:

```
$ cargo test --workspace
test messages::tests::messages_forwards_entra_id_bearer_without_requiring_api_key ... ok
test messages::tests::messages_requires_auth_when_no_key_and_no_header ... ok
test providers::azure_ai::messages::transformation::tests::accepts_bearer_auth_for_entra_id ... ok
ai-gateway: 52 passed; 0 failed
core:       79 passed; 0 failed
```

`cargo fmt --check` and `cargo clippy --workspace --all-targets` are clean.

## Type

🆕 New Feature

## Changes

Closes the auth-parity gap on the Rust Azure Anthropic `/messages` path so it accepts Entra ID (Azure AD) auth, not only API keys. This is the parity item that gates removing the Python Azure path.

Entra ID tokens are already resolved on the Python side: `validate_anthropic_messages_environment` runs `BaseAzureLLM._base_validate_azure_environment` -> `get_azure_ad_token` (client credentials, username/password, OIDC, or DefaultAzureCredential / managed identity) and puts `Authorization: Bearer <token>` into the request headers, which the handler forwards to the Rust bridge in `extra_headers`. So Rust does not acquire tokens; it only has to honor the pre-computed header.

The gateway `prepare_messages_call` previously treated a request as authorized only when it carried the strategy header (`x-api-key`). An Entra ID request carries `Authorization` and no `api_key`, so it fell through to `resolve_api_key` and failed with "Missing Azure API Key". Now a request is treated as already-authorized when it carries a caller-supplied `Authorization` header for a provider that accepts bearer auth, and that header is forwarded unchanged.

- `MessagesAuthStrategy::Bearer` already existed; added `accepts_bearer_auth()` on the provider config (default false, `azure_ai` returns true)
- `prepare_messages_call` skips `x-api-key` resolution when an accepted `Authorization` header is present
- Requests with neither an auth header nor an `api_key` still error as before

## QA runbook

Not applicable; this is a Rust-internal auth-handling change covered by cargo tests. End-to-end Entra ID coverage needs live Azure AD credentials in the stage cluster and is tracked separately.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
