### PR TITLE
fix(ui): add tooltip to the Active key status badge

### DIFF
--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
@@ -498,8 +498,13 @@ describe("Status column reflects blocked / expiry / scim metadata", () => {
 
     renderWithProviders(<VirtualKeysTable />);
 
+    const tag = await screen.findByTestId(`key-status-${mockKey.token_id}`);
+    expect(tag).toHaveTextContent("Active");
+
+    const user = userEvent.setup();
+    await user.hover(tag);
     await waitFor(() => {
-      expect(screen.getByTestId(`key-status-${mockKey.token_id}`)).toHaveTextContent("Active");
+      expect(screen.getByText(/not blocked and has not expired/i)).toBeInTheDocument();
     });
   });
 

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/keyTableColumns.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/keyTableColumns.tsx
@@ -46,7 +46,11 @@ const getKeyStatus = (key: KeyResponse): KeyStatus => {
   if (!Number.isNaN(expiresAt) && expiresAt < Date.now()) {
     return { tone: "warning", label: "Expired", tooltip: "This key has passed its expiry date." };
   }
-  return { tone: "success", label: "Active" };
+  return {
+    tone: "success",
+    label: "Active",
+    tooltip: "This key is not blocked and has not expired.",
+  };
 };
 
 const UserPopoverCell = ({


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3422

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

UI change, verified with the dashboard dev server (`npm run dev` in `ui/litellm-dashboard`) against a local proxy on localhost:4000, comparing base `litellm_internal_staging` (`4a297dd611`) to this branch (`bf6c0949a2`) on the same non-blocked, non-expired key. The green "Active" badge label is unchanged; this PR adds a hover tooltip reading "This key is not blocked and has not expired."

To reproduce: run the proxy and the dashboard dev server, open the Virtual Keys page at http://localhost:3000/?page=api-keys, and hover the "Active" status badge on a key that is neither blocked nor expired

Before (base `4a297dd611`), hovering "Active" shows no tooltip

![before](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvYWJlMzYwODEtM2Q3ZC00NGMxLTgyM2YtMWM3YjBjMjkyMjcwIiwiaWF0IjoxNzg0NjYwMTY2LCJleHAiOjE3ODUyNjQ5NjYsImZpbGVuYW1lIjoic3Nfem9vbV8xNjczY2VjZS5wbmcifQ.gXu4Y0_tU3aU3r4BpWFwpEqj4TVAzwsujmaB4sQ5T4U)

After (this PR `bf6c0949a2`), hovering "Active" shows the tooltip

![after](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvZWVhNmE5NTktZDY4ZC00NjZkLWJmMjUtYmY2YzBhNTMyZDNiIiwiaWF0IjoxNzg0NjYwMTY3LCJleHAiOjE3ODUyNjQ5NjcsImZpbGVuYW1lIjoic3Nfem9vbV81M2U2YzJlNS5wbmcifQ.78GZ6d4tmEf_HR1a4x5-Vx9E9y3LQL_d2YDGSSgP_LU)

## Type

🐛 Bug Fix

## Changes

The status badge on the Virtual Keys table shows "Active" for any key that is neither blocked nor expired, but the badge had no explanation of what "Active" means, which misled a customer into reading it as a recent-usage signal. This adds a tooltip to the Active badge spelling out that the key is not blocked and has not expired. The label itself and the "Blocked" and "Expired" states are unchanged. The existing status-column test now also asserts the tooltip content

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


Link to Devin session: https://app.devin.ai/sessions/63337648882841d38357c44156757609