### PR TITLE
fix(ui): stop dashboard key-edit form 403ing on non-budget saves

### DIFF
--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
@@ -662,11 +662,14 @@ describe("KeyEditView", () => {
     });
   });
 
-  it("should resend existing budget windows on submit when they are left untouched", async () => {
+  it("should omit budget_limits when existing windows are left untouched (issue #33246)", async () => {
+    // The backend treats any budget_limits in the payload as an admin-only
+    // budget change, so re-sending untouched windows 403s a non-admin owner.
+    // Leaving the field off keeps the stored windows and passes the gate.
     const onSubmitMock = vi.fn().mockResolvedValue(undefined);
     const keyDataWithWindow = {
       ...MOCK_KEY_DATA,
-      budget_limits: [{ budget_duration: "30d", max_budget: 100 }],
+      budget_limits: [{ budget_duration: "30d", max_budget: 100, reset_at: "2026-08-01T00:00:00" }],
     };
     renderWithProviders(
       <KeyEditView
@@ -686,7 +689,66 @@ describe("KeyEditView", () => {
     await waitFor(() => {
       expect(onSubmitMock).toHaveBeenCalled();
       const callArgs = onSubmitMock.mock.calls[0][0];
-      expect(callArgs.budget_limits).toEqual([{ budget_duration: "30d", max_budget: 100 }]);
+      expect(callArgs.budget_limits).toBeUndefined();
+    });
+  });
+
+  it("should omit budget_limits on a key that has no windows (issue #33246 repro)", async () => {
+    // Core repro: a non-admin owner edits a non-budget field on a key with no
+    // budget windows. The form previously always sent budget_limits: [], which
+    // the backend read as a budget change and rejected.
+    const onSubmitMock = vi.fn().mockResolvedValue(undefined);
+    renderWithProviders(
+      <KeyEditView
+        keyData={MOCK_KEY_DATA} // no budget_limits
+        onCancel={() => {}}
+        onSubmit={onSubmitMock}
+        accessToken={"test-token"}
+        userID={"test-user"}
+        userRole={"admin"}
+        premiumUser={false}
+      />,
+    );
+
+    const submitButton = await screen.findByRole("button", { name: /save changes/i });
+    await userEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(onSubmitMock).toHaveBeenCalled();
+      const callArgs = onSubmitMock.mock.calls[0][0];
+      expect(callArgs.budget_limits).toBeUndefined();
+    });
+  });
+
+  it("should send budget_limits when a window's cap is changed", async () => {
+    const onSubmitMock = vi.fn().mockResolvedValue(undefined);
+    const keyDataWithWindow = {
+      ...MOCK_KEY_DATA,
+      budget_limits: [{ budget_duration: "30d", max_budget: 100 }],
+    };
+    renderWithProviders(
+      <KeyEditView
+        keyData={keyDataWithWindow}
+        onCancel={() => {}}
+        onSubmit={onSubmitMock}
+        accessToken={"test-token"}
+        userID={"test-user"}
+        userRole={"admin"}
+        premiumUser={false}
+      />,
+    );
+
+    const maxBudgetInput = await screen.findByPlaceholderText("Max spend ($)");
+    await userEvent.clear(maxBudgetInput);
+    await userEvent.type(maxBudgetInput, "200");
+
+    const submitButton = screen.getByRole("button", { name: /save changes/i });
+    await userEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(onSubmitMock).toHaveBeenCalled();
+      const callArgs = onSubmitMock.mock.calls[0][0];
+      expect(callArgs.budget_limits).toEqual([{ budget_duration: "30d", max_budget: 200 }]);
     });
   });
 

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -307,14 +307,29 @@ export function KeyEditView({
       }
 
       // Reconcile multi-window budget limits from the editor state, dropping
-      // incomplete entries (no max_budget). Sending [] tells the backend to clear
-      // all stored windows, so only send it when the user removed every window;
-      // when entries remain but are still incomplete, omit the field so the saved
-      // windows are left untouched (JSON.stringify drops the undefined key).
+      // incomplete entries (no max_budget). The backend treats any budget_limits
+      // in a /key/update request as an admin-only budget change, so re-sending
+      // the stored windows on an unrelated edit 403s a non-admin key owner
+      // (issue #33246). Only send the field when the user actually changed the
+      // windows, mirroring how allowed_routes is dropped above when unchanged:
+      // compare on (duration, cap), ignoring server-owned reset_at and order.
+      // Sending [] clears every window, so send it only when the user removed
+      // the last one; otherwise leave the field off (JSON.stringify drops the
+      // undefined key) so an unchanged or incomplete editor state never touches
+      // storage.
+      const windowSignature = (windows: Array<{ budget_duration: string; max_budget: number | null }> | undefined) =>
+        (windows ?? [])
+          .filter((w) => w.budget_duration && w.max_budget !== null && w.max_budget !== undefined)
+          .map((w) => `${w.budget_duration}:${w.max_budget}`)
+          .sort()
+          .join("|");
       const validWindows = budgetLimits.filter(
         (w) => w.budget_duration && w.max_budget !== null && w.max_budget !== undefined,
       );
-      if (validWindows.length > 0) {
+      const budgetLimitsUnchanged = windowSignature(keyData.budget_limits) === windowSignature(validWindows);
+      if (budgetLimitsUnchanged) {
+        // no-op: leave budget_limits off the payload
+      } else if (validWindows.length > 0) {
         values.budget_limits = validWindows;
       } else if (budgetLimits.length === 0) {
         values.budget_limits = [];


### PR DESCRIPTION
## Relevant issues

Fixes #33246

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Repro (before): log in to the dashboard as a non-admin `internal_user`, create a personal key with no team and no budget, open it, change a non-budget field (Models, MCP servers, or Key Alias), leave Budget Windows empty, and Save. It fails with `Only proxy admins, team admins, or org admins can call /key/update (max_budget/spend)`, because the form put `budget_limits: []` in the request and the backend reads any `budget_limits` in a `/key/update` body as an admin-only budget change

After this change the same edit saves. Open `http://localhost:4000/ui/?page=api-keys`, and with the browser Network panel open do the non-budget edit and Save; the `/key/update` request body no longer contains `budget_limits`, so it is not classified as a budget change and the owner is allowed. Editing an actual budget window still includes `budget_limits` and still requires admin, unchanged

### QA (e2e, non-admin internal user)

Ran a local proxy plus the dashboard dev server and logged into the UI as a non-admin `internal_user` (role `internal_user`, not the master key). For every case a `window.fetch` wrapper captured the exact `/key/update` request body and the HTTP status. Buggy build captured at `58ff0e32ba` (base `litellm_internal_staging`), fixed build captured at `8a8dc19c5b` (this branch); the two builds were swapped by copying the `key_edit_view.tsx` version into place and letting the dev server recompile

Verdict: the bug is fixed for internal users. Non-budget edits now save (200, no `budget_limits` in the body), and real budget changes still include `budget_limits` and stay admin-gated (403 for a non-admin owner), which is the intended, unchanged behavior

Before vs after, same action (non-admin owner opens a personal key with no budget window, edits only the Key Alias, Saves):

| | Before (`58ff0e32ba`) | After (`8a8dc19c5b`) |
|---|---|---|
| Result | 403 error toast | Key updated successfully |
| `/key/update` body | contains `budget_limits: []` | no `budget_limits` key |
| HTTP status | 403 | 200 |

All update variations as the non-admin owner on the fixed build:

| Case | Action | `/key/update` body | Status | Result |
|---|---|---|---|---|
| Alias only | edit Key Alias, no window | no `budget_limits` | 200 | pass |
| Models only | mock-gpt -> all-proxy-models | no `budget_limits` | 200 | pass |
| Tags only | edit tags | no `budget_limits` | 200 | pass |
| Incomplete window + non-budget edit | duration set, no max_budget | `budget_limits` omitted | 200 | pass |
| Add new window ($50) | real budget change | `budget_limits:[{budget_duration:"24h",max_budget:50}]` | 403 | pass (admin-gated, expected) |
| Edit existing window ($10 -> $20) | real budget change | changed `budget_limits` present | 403 | pass (expected) |
| Delete last window | clear all windows | `budget_limits: []` | 403 | pass (expected clear path) |
| MCP servers only | edit MCP servers | not captured | not run | untested (no MCP server configured for this user) |

The 403s on add/edit/delete window are expected and unchanged: real budget changes are admin-gated at the proxy regardless of client, so a non-admin owner cannot make them from any surface. The fix only stops non-budget edits from being swept into that gate. MCP-servers-only was the one requested variation not exercised because the environment had no MCP server for this user to attach; the MCP field goes through the same non-budget object-permission path as the fields that were verified

## Type

🐛 Bug Fix

## Changes

The dashboard key-edit form put `budget_limits` in the `/key/update` payload on every save; when the key had no windows it sent `budget_limits: []`, and when it had windows it echoed them back. The proxy treats any `budget_limits` present in a `/key/update` request as an admin-only budget change, so a non-admin key owner editing a non-budget field (models, MCP servers, alias) could never save; the owner bypass for non-budget edits was unreachable from the UI

The form now only includes `budget_limits` when the user actually changed the budget windows, mirroring how the same handler already drops an unchanged `allowed_routes` a few lines above. The comparison is on `(budget_duration, max_budget)`, ignoring the server-owned `reset_at` and window order, so echoing the stored windows back reads as unchanged and the field is omitted. When the user deletes the last window the form still sends `[]` so clearing keeps working, and a real budget edit still sends the change and still routes through the admin check

This is intentionally a UI-only fix; it does not change any backend or `/key/update` API behavior. An API client that sends `budget_limits` still has it treated as a budget change exactly as before

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


Link to Devin session: https://app.devin.ai/sessions/5910caa54abd4af08061f76bbc279287