### PR TITLE
test(e2e): cover key management routes for Management/UI coverage

### DIFF
--- a/tests/e2e/management/test_key_management_e2e.py
+++ b/tests/e2e/management/test_key_management_e2e.py
@@ -1,0 +1,251 @@
+"""Live e2e: the /key management routes' persistence, health, bulk-update, and
+admin-only contracts.
+
+Each test creates its keys under the master key with unique aliases (deleted on
+teardown) and asserts the real contract: the info route reflects the write
+(persistence), the health route reports the calling key, bulk_update applies to
+the target key, and the write routes refuse a non-admin caller. Key writes reach
+the auth cache eventually, so the read-backs poll to a deadline instead of
+asserting once.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Literal
+
+import pytest
+
+from e2e_config import unique_marker
+from e2e_http import NoBody, unwrap
+from lifecycle import ResourceManager
+from management_client import ManagementClient
+from models import KeyDeleteBody, KeyGenerateBody, KeyUpdateBody
+from pydantic import BaseModel
+
+pytestmark = pytest.mark.e2e
+
+
+class KeyToggleBlockBody(BaseModel):
+    key: str
+
+
+class LoggingCallbackStatus(BaseModel):
+    callbacks: list[str] | None = None
+    status: str | None = None
+    details: str | None = None
+
+
+class KeyHealthResponse(BaseModel):
+    key: Literal["healthy", "unhealthy"]
+    logging_callbacks: LoggingCallbackStatus | None = None
+
+
+class BulkKeyUpdateItem(BaseModel):
+    key: str
+    max_budget: float | None = None
+
+
+class BulkKeyUpdateBody(BaseModel):
+    keys: list[BulkKeyUpdateItem]
+
+
+class BulkKeyUpdateSuccess(BaseModel):
+    key: str
+
+
+class BulkKeyUpdateFailure(BaseModel):
+    key: str
+    failed_reason: str
+
+
+class BulkKeyUpdateResponse(BaseModel):
+    total_requested: int
+    successful_updates: list[BulkKeyUpdateSuccess]
+    failed_updates: list[BulkKeyUpdateFailure]
+
+
+def _poll[T](client: ManagementClient, attempt: Callable[[], T | None], failure: str) -> T:
+    deadline = time.monotonic() + client.proxy.poll_timeout
+    while time.monotonic() < deadline:
+        found = attempt()
+        if found is not None:
+            return found
+        time.sleep(client.proxy.poll_interval)
+    pytest.fail(failure)
+
+
+def _generate_key(client: ManagementClient, resources: ResourceManager, body: KeyGenerateBody) -> str:
+    key = client.proxy.generate_key(body)
+    resources.defer(lambda: client.proxy.delete_key(key))
+    return key
+
+
+def _block(client: ManagementClient, key: str) -> None:
+    _ = unwrap(
+        client.proxy.transport.post(
+            "/key/block",
+            headers=client.proxy.transport.master,
+            json=KeyToggleBlockBody(key=key),
+            response_type=NoBody,
+        )
+    )
+
+
+def _unblock(client: ManagementClient, key: str) -> None:
+    _ = unwrap(
+        client.proxy.transport.post(
+            "/key/unblock",
+            headers=client.proxy.transport.master,
+            json=KeyToggleBlockBody(key=key),
+            response_type=NoBody,
+        )
+    )
+
+
+class TestKeyManagementRoutes:
+    @pytest.mark.covers("mgmt.key.info.persists")
+    def test_info_reflects_the_fields_the_key_was_created_with(
+        self, client: ManagementClient, resources: ResourceManager
+    ) -> None:
+        alias = f"e2e-mgmt-keyinfo-{unique_marker()}"
+        key = _generate_key(
+            client,
+            resources,
+            KeyGenerateBody(
+                models=["gpt-5.5", "gemini-2.5-flash"],
+                key_alias=alias,
+                tpm_limit=131313,
+                rpm_limit=141414,
+            ),
+        )
+
+        info = client.proxy.key_info(key)
+        assert info.key_alias == alias, f"/key/info reports key_alias {info.key_alias!r}, configured {alias!r}"
+        assert info.models == ["gpt-5.5", "gemini-2.5-flash"], (
+            f"/key/info reports models {info.models}, configured ['gpt-5.5', 'gemini-2.5-flash']"
+        )
+        assert info.tpm_limit == 131313, f"/key/info reports tpm_limit {info.tpm_limit}, configured 131313"
+        assert info.rpm_limit == 141414, f"/key/info reports rpm_limit {info.rpm_limit}, configured 141414"
+
+    @pytest.mark.covers("mgmt.key.unblock.persists")
+    def test_unblock_flips_key_info_blocked_back(
+        self, client: ManagementClient, resources: ResourceManager
+    ) -> None:
+        key = _generate_key(client, resources, KeyGenerateBody(models=["gpt-5.5"]))
+
+        _block(client, key)
+        _ = _poll(
+            client,
+            lambda: True if client.proxy.key_info(key).blocked else None,
+            "/key/info never reported the key blocked after /key/block before the deadline",
+        )
+
+        _unblock(client, key)
+        _ = _poll(
+            client,
+            lambda: True if client.proxy.key_info(key).blocked is False else None,
+            "/key/info never reported the key unblocked after /key/unblock before the deadline",
+        )
+
+    @pytest.mark.covers("mgmt.key.health.happy_path")
+    def test_health_reports_the_calling_key_healthy(
+        self, client: ManagementClient, resources: ResourceManager
+    ) -> None:
+        key = _generate_key(client, resources, KeyGenerateBody(models=["gpt-5.5"]))
+
+        health = unwrap(
+            client.proxy.transport.post(
+                "/key/health",
+                headers=client.proxy.transport.bearer(key),
+                json=NoBody(),
+                response_type=KeyHealthResponse,
+            )
+        )
+        assert health.key == "healthy", f"/key/health reports {health.key!r} for a key with no logging configured"
+        assert health.logging_callbacks is None, (
+            f"/key/health reports logging_callbacks {health.logging_callbacks!r} for a key with no logging configured"
+        )
+
+    @pytest.mark.covers("mgmt.key.bulk_update.happy_path")
+    def test_bulk_update_applies_max_budget_to_target_key(
+        self, client: ManagementClient, resources: ResourceManager
+    ) -> None:
+        key = _generate_key(client, resources, KeyGenerateBody(models=["gpt-5.5"], max_budget=5.0))
+        assert client.proxy.key_info(key).max_budget == 5.0, (
+            f"/key/info reports max_budget {client.proxy.key_info(key).max_budget}, configured 5.0"
+        )
+
+        result = unwrap(
+            client.proxy.transport.post(
+                "/key/bulk_update",
+                headers=client.proxy.transport.master,
+                json=BulkKeyUpdateBody(keys=[BulkKeyUpdateItem(key=key, max_budget=42.0)]),
+                response_type=BulkKeyUpdateResponse,
+            )
+        )
+        assert result.total_requested == 1, f"/key/bulk_update reports total_requested {result.total_requested}, sent 1"
+        assert result.failed_updates == [], f"/key/bulk_update reported failed updates: {result.failed_updates}"
+        assert [entry.key for entry in result.successful_updates] == [key], (
+            f"/key/bulk_update successful_updates {[entry.key for entry in result.successful_updates]} did not target {key}"
+        )
+
+        _ = _poll(
+            client,
+            lambda: True if client.proxy.key_info(key).max_budget == 42.0 else None,
+            "/key/info never reported max_budget 42.0 after /key/bulk_update before the deadline",
+        )
+
+    @pytest.mark.covers("mgmt.key.generate.admin_only")
+    def test_generate_forbidden_for_non_admin_key(
+        self, client: ManagementClient, resources: ResourceManager
+    ) -> None:
+        nonadmin = _generate_key(client, resources, KeyGenerateBody(models=["gpt-5.5"]))
+
+        outcome = client.proxy.transport.send(
+            "/key/generate",
+            headers=client.proxy.transport.bearer(nonadmin),
+            json=KeyGenerateBody(models=["gpt-5.5"], key_alias=f"e2e-mgmt-forbidden-{unique_marker()}"),
+        )
+        assert outcome.status_code in (401, 403), (
+            f"non-admin key POSTing /key/generate must be denied 401/403, got {outcome.status_code}: {outcome.body[:300]}"
+        )
+
+    @pytest.mark.covers("mgmt.key.delete.admin_only")
+    def test_delete_forbidden_for_non_admin_key(
+        self, client: ManagementClient, resources: ResourceManager
+    ) -> None:
+        nonadmin = _generate_key(client, resources, KeyGenerateBody(models=["gpt-5.5"]))
+        victim = _generate_key(client, resources, KeyGenerateBody(models=["gpt-5.5"]))
+
+        outcome = client.proxy.transport.send(
+            "/key/delete",
+            headers=client.proxy.transport.bearer(nonadmin),
+            json=KeyDeleteBody(keys=[victim]),
+        )
+        assert outcome.status_code in (401, 403), (
+            f"non-admin key POSTing /key/delete must be denied 401/403, got {outcome.status_code}: {outcome.body[:300]}"
+        )
+        assert client.proxy.key_info(victim).blocked in (None, False), (
+            "victim key should be unaffected by the denied /key/delete"
+        )
+
+    @pytest.mark.covers("mgmt.key.update.admin_only")
+    def test_update_forbidden_for_non_admin_key(
+        self, client: ManagementClient, resources: ResourceManager
+    ) -> None:
+        nonadmin = _generate_key(client, resources, KeyGenerateBody(models=["gpt-5.5"]))
+        target = _generate_key(client, resources, KeyGenerateBody(models=["gpt-5.5"]))
+
+        outcome = client.proxy.transport.send(
+            "/key/update",
+            headers=client.proxy.transport.bearer(nonadmin),
+            json=KeyUpdateBody(key=target, models=["gemini-2.5-flash"]),
+        )
+        assert outcome.status_code in (401, 403), (
+            f"non-admin key POSTing /key/update must be denied 401/403, got {outcome.status_code}: {outcome.body[:300]}"
+        )
+        assert client.proxy.key_info(target).models == ["gpt-5.5"], (
+            f"target key models changed to {client.proxy.key_info(target).models} despite the denied /key/update"
+        )


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Proof captured at commit d812ffc79a against a live proxy on http://localhost:4091

Live pytest run (all 7 cells pass, no mocks, real proxy):

```
$ PYTHONPATH=. python -m pytest management/test_key_management_e2e.py -v -p no:cacheprovider
platform darwin -- Python 3.12.13, pytest-9.1.1
collected 7 items

management/test_key_management_e2e.py::TestKeyManagementRoutes::test_info_reflects_the_fields_the_key_was_created_with PASSED [ 14%]
management/test_key_management_e2e.py::TestKeyManagementRoutes::test_unblock_flips_key_info_blocked_back PASSED [ 28%]
management/test_key_management_e2e.py::TestKeyManagementRoutes::test_health_reports_the_calling_key_healthy PASSED [ 42%]
management/test_key_management_e2e.py::TestKeyManagementRoutes::test_bulk_update_applies_max_budget_to_target_key PASSED [ 57%]
management/test_key_management_e2e.py::TestKeyManagementRoutes::test_generate_forbidden_for_non_admin_key PASSED [ 71%]
management/test_key_management_e2e.py::TestKeyManagementRoutes::test_delete_forbidden_for_non_admin_key PASSED [ 85%]
management/test_key_management_e2e.py::TestKeyManagementRoutes::test_update_forbidden_for_non_admin_key PASSED [100%]

============================== 7 passed in 0.21s ===============================
```

Persistence and block/unblock behavior against the live proxy:

```
$ K=$(curl -s -X POST "$B/key/generate" -H "Authorization: Bearer $MASTER" -d '{"models":["gpt-5.5"],"key_alias":"e2e-probe","tpm_limit":12345,"rpm_limit":678}' | jq -r .key)
$ curl -s "$B/key/info?key=$K" -H "Authorization: Bearer $MASTER" | jq '.info | {models,key_alias,tpm_limit,rpm_limit}'
{ "models": ["gpt-5.5"], "key_alias": "e2e-probe", "tpm_limit": 12345, "rpm_limit": 678 }

$ curl -s -X POST "$B/key/block"   -H "Authorization: Bearer $MASTER" -d "{\"key\":\"$K\"}" -o /dev/null; curl -s "$B/key/info?key=$K" -H "Authorization: Bearer $MASTER" | jq '.info.blocked'
true
$ curl -s -X POST "$B/key/unblock" -H "Authorization: Bearer $MASTER" -d "{\"key\":\"$K\"}" -o /dev/null; curl -s "$B/key/info?key=$K" -H "Authorization: Bearer $MASTER" | jq '.info.blocked'
false
```

Admin-only denial with a non-admin (master-minted, user_role unknown) key:

```
$ N=$(curl -s -X POST "$B/key/generate" -H "Authorization: Bearer $MASTER" -d '{"models":["gpt-5.5"]}' | jq -r .key)
$ curl -s -o /dev/null -w "%{http_code}\n" -X POST "$B/key/generate" -H "Authorization: Bearer $N" -d '{"models":[]}'
401
$ curl -s -o /dev/null -w "%{http_code}\n" -X POST "$B/key/delete"   -H "Authorization: Bearer $N" -d '{"keys":["sk-nope"]}'
401
$ curl -s -o /dev/null -w "%{http_code}\n" -X POST "$B/key/update"   -H "Authorization: Bearer $N" -d '{"key":"sk-nope","models":[]}'
401
```

## Type

✅ Test

## Changes

Adds one self-contained live e2e file, tests/e2e/management/test_key_management_e2e.py, covering seven Management/UI coverage-registry cells for the /key routes. It touches no shared harness file; every pydantic model and helper it needs for the health, block/unblock, and bulk_update shapes lives inside the new file, while key info read-backs and cleanup ride the existing shared ProxyClient. All routes are driven through the shared transport and asserted against the real contract, with read-backs polling to a deadline for the proxy's eventual consistency

Cells covered

- mgmt.key.info.persists
- mgmt.key.unblock.persists
- mgmt.key.health.happy_path
- mgmt.key.bulk_update.happy_path
- mgmt.key.generate.admin_only
- mgmt.key.delete.admin_only
- mgmt.key.update.admin_only

## QA runbook

- tests/e2e/management/test_key_management_e2e.py::TestKeyManagementRoutes::test_info_reflects_the_fields_the_key_was_created_with - a key created with models, alias, and tpm/rpm limits reports those same values on /key/info
  - [x] POST /key/info?key=... with the master key after creating a key via /key/generate with models, key_alias, tpm_limit, rpm_limit
  - [x] Expect /key/info to echo the same models, key_alias, tpm_limit, and rpm_limit
  - [x] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky
- tests/e2e/management/test_key_management_e2e.py::TestKeyManagementRoutes::test_unblock_flips_key_info_blocked_back - /key/block then /key/unblock leaves the key's blocked flag back at false on /key/info
  - [x] POST /key/block then GET /key/info and expect blocked true
  - [x] POST /key/unblock then GET /key/info and expect blocked false
  - [x] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky
- tests/e2e/management/test_key_management_e2e.py::TestKeyManagementRoutes::test_health_reports_the_calling_key_healthy - /key/health reports the calling key healthy when no logging is configured
  - [x] POST /key/health under a freshly created key's bearer token
  - [x] Expect {"key": "healthy", "logging_callbacks": null}
  - [x] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky
- tests/e2e/management/test_key_management_e2e.py::TestKeyManagementRoutes::test_bulk_update_applies_max_budget_to_target_key - /key/bulk_update applies a new max_budget to the target key, reflected on /key/info
  - [x] POST /key/bulk_update with {"keys":[{"key":"<key>","max_budget":42.0}]} under the master key
  - [x] Expect total_requested 1, no failed_updates, and the target key in successful_updates, then GET /key/info and expect max_budget 42.0
  - [x] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky
- tests/e2e/management/test_key_management_e2e.py::TestKeyManagementRoutes::test_generate_forbidden_for_non_admin_key - a non-admin key cannot POST /key/generate
  - [x] Mint a non-admin key with the master key (no user_id), then POST /key/generate under that key's bearer token
  - [x] Expect 401 or 403
  - [x] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky
- tests/e2e/management/test_key_management_e2e.py::TestKeyManagementRoutes::test_delete_forbidden_for_non_admin_key - a non-admin key cannot POST /key/delete and the target key is unaffected
  - [x] POST /key/delete under a non-admin key's bearer token targeting another key
  - [x] Expect 401 or 403 and confirm the target key still resolves on /key/info
  - [x] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky
- tests/e2e/management/test_key_management_e2e.py::TestKeyManagementRoutes::test_update_forbidden_for_non_admin_key - a non-admin key cannot POST /key/update and the target key's models are unchanged
  - [x] POST /key/update under a non-admin key's bearer token targeting another key
  - [x] Expect 401 or 403 and confirm the target key's models are unchanged on /key/info
  - [x] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
