### PR TITLE
feat(ui): add block/unblock key action to key info page

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useSetKeyBlockedState.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useSetKeyBlockedState.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React, { ReactNode } from "react";
+import { useSetKeyBlockedState, setKeyBlockedState } from "./useSetKeyBlockedState";
+import { apiClient } from "@/components/networking";
+
+vi.mock("@/components/networking", () => ({
+  apiClient: { post: vi.fn() },
+}));
+
+const mockUseAuthorized = vi.fn();
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
+  default: () => mockUseAuthorized(),
+}));
+
+const mockPost = vi.mocked(apiClient.post);
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return { queryClient, wrapper };
+};
+
+describe("setKeyBlockedState", () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+  });
+
+  it("POSTs the key hash to /key/block when blocking", async () => {
+    mockPost.mockResolvedValueOnce({ blocked: true });
+
+    const result = await setKeyBlockedState("sk-access", { keyToken: "hashed-token", blocked: true });
+
+    expect(mockPost).toHaveBeenCalledWith("/key/block", {
+      accessToken: "sk-access",
+      body: { key: "hashed-token" },
+    });
+    expect(result).toEqual({ blocked: true });
+  });
+
+  it("POSTs the key hash to /key/unblock when unblocking", async () => {
+    mockPost.mockResolvedValueOnce({ blocked: false });
+
+    const result = await setKeyBlockedState("sk-access", { keyToken: "hashed-token", blocked: false });
+
+    expect(mockPost).toHaveBeenCalledWith("/key/unblock", {
+      accessToken: "sk-access",
+      body: { key: "hashed-token" },
+    });
+    expect(result).toEqual({ blocked: false });
+  });
+
+  it("falls back to the requested state when the response has no blocked field", async () => {
+    mockPost.mockResolvedValueOnce(null);
+
+    const result = await setKeyBlockedState("sk-access", { keyToken: "hashed-token", blocked: true });
+
+    expect(result).toEqual({ blocked: true });
+  });
+});
+
+describe("useSetKeyBlockedState", () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+    mockUseAuthorized.mockReturnValue({ accessToken: "sk-access" });
+  });
+
+  it("invalidates key queries after a successful mutation", async () => {
+    mockPost.mockResolvedValueOnce({ blocked: true });
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useSetKeyBlockedState(), { wrapper });
+    result.current.mutate({ keyToken: "hashed-token", blocked: true });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["keys"] });
+  });
+
+  it("surfaces request failures as mutation errors", async () => {
+    mockPost.mockRejectedValueOnce(new Error("Key not found."));
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSetKeyBlockedState(), { wrapper });
+    result.current.mutate({ keyToken: "missing", blocked: true });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe("Key not found.");
+  });
+
+  it("errors without an access token", async () => {
+    mockUseAuthorized.mockReturnValue({ accessToken: null });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSetKeyBlockedState(), { wrapper });
+    result.current.mutate({ keyToken: "hashed-token", blocked: true });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useSetKeyBlockedState.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useSetKeyBlockedState.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "@/components/networking";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import { keyKeys } from "./useKeys";
+
+export interface SetKeyBlockedStateInput {
+  keyToken: string;
+  blocked: boolean;
+}
+
+export interface SetKeyBlockedStateResult {
+  blocked: boolean;
+}
+
+interface BlockKeyResponse {
+  blocked?: boolean | null;
+}
+
+export const setKeyBlockedState = async (
+  accessToken: string,
+  { keyToken, blocked }: SetKeyBlockedStateInput,
+): Promise<SetKeyBlockedStateResult> => {
+  const response = await apiClient.post<BlockKeyResponse | null>(blocked ? "/key/block" : "/key/unblock", {
+    accessToken,
+    body: { key: keyToken },
+  });
+  return { blocked: response?.blocked ?? blocked };
+};
+
+export const useSetKeyBlockedState = () => {
+  const { accessToken } = useAuthorized();
+  const queryClient = useQueryClient();
+
+  return useMutation<SetKeyBlockedStateResult, Error, SetKeyBlockedStateInput>({
+    mutationFn: async (input) => {
+      if (!accessToken) {
+        throw new Error("Access token is required");
+      }
+      return setKeyBlockedState(accessToken, input);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: keyKeys.all });
+    },
+  });
+};

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -372,7 +372,7 @@ export function getGlobalLitellmHeaderName(): string {
   return globalLitellmHeaderName;
 }
 
-const apiClient = createApiClient({
+export const apiClient = createApiClient({
   getBaseUrl: getProxyBaseUrl,
   getAuthHeaderName: getGlobalLitellmHeaderName,
   onError: handleError,

--- a/ui/litellm-dashboard/src/components/templates/KeyInfoHeader.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeyInfoHeader.test.tsx
@@ -60,22 +60,16 @@ describe("KeyInfoHeader", () => {
   });
 
   describe("action buttons", () => {
-    it("should show Regenerate and Delete buttons by default", () => {
+    it("should show Regenerate button and actions dropdown by default", () => {
       render(<KeyInfoHeader data={MOCK_DATA} />);
       expect(screen.getByRole("button", { name: /regenerate key/i })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: /delete key/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /more key actions/i })).toBeInTheDocument();
     });
 
-    it("should show Regenerate and Delete buttons when canModifyKey is true", () => {
-      render(<KeyInfoHeader data={MOCK_DATA} canModifyKey={true} />);
-      expect(screen.getByRole("button", { name: /regenerate key/i })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: /delete key/i })).toBeInTheDocument();
-    });
-
-    it("should hide Regenerate and Delete buttons when canModifyKey is false", () => {
+    it("should hide Regenerate button and actions dropdown when canModifyKey is false", () => {
       render(<KeyInfoHeader data={MOCK_DATA} canModifyKey={false} />);
       expect(screen.queryByRole("button", { name: /regenerate key/i })).not.toBeInTheDocument();
-      expect(screen.queryByRole("button", { name: /delete key/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /more key actions/i })).not.toBeInTheDocument();
     });
 
     it("should call onRegenerate when Regenerate Key is clicked", async () => {
@@ -83,13 +77,6 @@ describe("KeyInfoHeader", () => {
       render(<KeyInfoHeader data={MOCK_DATA} onRegenerate={onRegenerate} />);
       await userEvent.click(screen.getByRole("button", { name: /regenerate key/i }));
       expect(onRegenerate).toHaveBeenCalledTimes(1);
-    });
-
-    it("should call onDelete when Delete Key is clicked", async () => {
-      const onDelete = vi.fn();
-      render(<KeyInfoHeader data={MOCK_DATA} onDelete={onDelete} />);
-      await userEvent.click(screen.getByRole("button", { name: /delete key/i }));
-      expect(onDelete).toHaveBeenCalledTimes(1);
     });
 
     it("should disable Regenerate button when regenerateDisabled is true", () => {
@@ -100,6 +87,79 @@ describe("KeyInfoHeader", () => {
     it("should not disable Regenerate button by default", () => {
       render(<KeyInfoHeader data={MOCK_DATA} />);
       expect(screen.getByRole("button", { name: /regenerate key/i })).not.toBeDisabled();
+    });
+  });
+
+  describe("destructive actions dropdown", () => {
+    const openDropdown = async () => {
+      await userEvent.click(screen.getByRole("button", { name: /more key actions/i }));
+    };
+
+    it("should list Block Key, Reset Spend, and Delete Key when all handlers are provided", async () => {
+      render(<KeyInfoHeader data={MOCK_DATA} onToggleBlocked={vi.fn()} onResetSpend={vi.fn()} onDelete={vi.fn()} />);
+      await openDropdown();
+      expect(await screen.findByRole("menuitem", { name: /block key/i })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: /reset spend/i })).toBeInTheDocument();
+      expect(screen.getByRole("menuitem", { name: /delete key/i })).toBeInTheDocument();
+    });
+
+    it("should omit Block Key and Reset Spend when their handlers are not provided", async () => {
+      render(<KeyInfoHeader data={MOCK_DATA} onDelete={vi.fn()} />);
+      await openDropdown();
+      expect(await screen.findByRole("menuitem", { name: /delete key/i })).toBeInTheDocument();
+      expect(screen.queryByRole("menuitem", { name: /block key/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole("menuitem", { name: /reset spend/i })).not.toBeInTheDocument();
+    });
+
+    it("should show Unblock Key instead of Block Key when the key is blocked", async () => {
+      render(<KeyInfoHeader data={MOCK_DATA} onToggleBlocked={vi.fn()} isBlocked />);
+      await openDropdown();
+      expect(await screen.findByRole("menuitem", { name: /unblock key/i })).toBeInTheDocument();
+      expect(screen.queryByRole("menuitem", { name: /^block key/i })).not.toBeInTheDocument();
+    });
+
+    it("should call onToggleBlocked when Block Key is clicked", async () => {
+      const onToggleBlocked = vi.fn();
+      render(<KeyInfoHeader data={MOCK_DATA} onToggleBlocked={onToggleBlocked} />);
+      await openDropdown();
+      await userEvent.click(await screen.findByRole("menuitem", { name: /block key/i }));
+      expect(onToggleBlocked).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call onToggleBlocked when Unblock Key is clicked", async () => {
+      const onToggleBlocked = vi.fn();
+      render(<KeyInfoHeader data={MOCK_DATA} onToggleBlocked={onToggleBlocked} isBlocked />);
+      await openDropdown();
+      await userEvent.click(await screen.findByRole("menuitem", { name: /unblock key/i }));
+      expect(onToggleBlocked).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call onResetSpend when Reset Spend is clicked", async () => {
+      const onResetSpend = vi.fn();
+      render(<KeyInfoHeader data={MOCK_DATA} onResetSpend={onResetSpend} />);
+      await openDropdown();
+      await userEvent.click(await screen.findByRole("menuitem", { name: /reset spend/i }));
+      expect(onResetSpend).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call onDelete when Delete Key is clicked", async () => {
+      const onDelete = vi.fn();
+      render(<KeyInfoHeader data={MOCK_DATA} onDelete={onDelete} />);
+      await openDropdown();
+      await userEvent.click(await screen.findByRole("menuitem", { name: /delete key/i }));
+      expect(onDelete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("blocked tag", () => {
+    it("should show a Blocked tag when isBlocked is true", () => {
+      render(<KeyInfoHeader data={MOCK_DATA} isBlocked />);
+      expect(screen.getByText("Blocked")).toBeInTheDocument();
+    });
+
+    it("should not show a Blocked tag by default", () => {
+      render(<KeyInfoHeader data={MOCK_DATA} />);
+      expect(screen.queryByText("Blocked")).not.toBeInTheDocument();
     });
   });
 

--- a/ui/litellm-dashboard/src/components/templates/KeyInfoHeader.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeyInfoHeader.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { Button, Typography, Tooltip, Space, Divider, Flex, Popover } from "antd";
+import { Button, Typography, Tooltip, Space, Divider, Flex, Popover, Dropdown, Tag } from "antd";
+import type { MenuProps } from "antd";
 import {
   ArrowLeftOutlined,
   SyncOutlined,
@@ -12,6 +13,9 @@ import {
   SafetyCertificateOutlined,
   TransactionOutlined,
   FieldTimeOutlined,
+  MoreOutlined,
+  StopOutlined,
+  CheckCircleOutlined,
 } from "@ant-design/icons";
 import LabeledField from "../common_components/LabeledField";
 import DefaultProxyAdminTag from "../common_components/DefaultProxyAdminTag";
@@ -38,6 +42,8 @@ interface KeyInfoHeaderProps {
   onRegenerate?: () => void;
   onDelete?: () => void;
   onResetSpend?: () => void;
+  onToggleBlocked?: () => void;
+  isBlocked?: boolean;
   canModifyKey?: boolean;
   backButtonText?: string;
   regenerateDisabled?: boolean;
@@ -133,11 +139,33 @@ export function KeyInfoHeader({
   onRegenerate,
   onDelete,
   onResetSpend,
+  onToggleBlocked,
+  isBlocked = false,
   canModifyKey = true,
   backButtonText = "Back to Keys",
   regenerateDisabled = false,
   regenerateTooltip,
 }: KeyInfoHeaderProps) {
+  const destructiveActionItems: MenuProps["items"] = [
+    ...(onToggleBlocked
+      ? [
+          isBlocked
+            ? { key: "unblock", label: "Unblock Key", icon: <CheckCircleOutlined /> }
+            : { key: "block", label: "Block Key", icon: <StopOutlined />, danger: true },
+        ]
+      : []),
+    ...(onResetSpend
+      ? [{ key: "reset-spend", label: "Reset Spend", icon: <TransactionOutlined />, danger: true }]
+      : []),
+    { key: "delete", label: "Delete Key", icon: <DeleteOutlined />, danger: true },
+  ];
+
+  const handleDestructiveActionClick: MenuProps["onClick"] = ({ key }) => {
+    if (key === "block" || key === "unblock") onToggleBlocked?.();
+    if (key === "reset-spend") onResetSpend?.();
+    if (key === "delete") onDelete?.();
+  };
+
   return (
     <div>
       {onCreateNew && (
@@ -156,9 +184,16 @@ export function KeyInfoHeader({
 
       <Flex justify="space-between" align="start" style={{ marginBottom: 20 }}>
         <div>
-          <Title level={3} copyable={{ tooltips: ["Copy Key Alias", "Copied!"] }} style={{ margin: 0 }}>
-            {data.keyName}
-          </Title>
+          <Space align="center">
+            <Title level={3} copyable={{ tooltips: ["Copy Key Alias", "Copied!"] }} style={{ margin: 0 }}>
+              {data.keyName}
+            </Title>
+            {isBlocked && (
+              <Tag color="red" icon={<StopOutlined />}>
+                Blocked
+              </Tag>
+            )}
+          </Space>
           <Text type="secondary" copyable={{ text: data.keyId, tooltips: ["Copy Key ID", "Copied!"] }}>
             Key ID: {data.keyId}
           </Text>
@@ -172,14 +207,12 @@ export function KeyInfoHeader({
                 </Button>
               </span>
             </Tooltip>
-            {onResetSpend && (
-              <Button danger icon={<TransactionOutlined />} onClick={onResetSpend}>
-                Reset Spend
-              </Button>
-            )}
-            <Button danger icon={<DeleteOutlined />} onClick={onDelete}>
-              Delete Key
-            </Button>
+            <Dropdown
+              menu={{ items: destructiveActionItems, onClick: handleDestructiveActionClick }}
+              trigger={["click"]}
+            >
+              <Button icon={<MoreOutlined />} aria-label="More key actions" />
+            </Dropdown>
           </Space>
         )}
       </Flex>

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -19,6 +19,7 @@ import LoggingSettingsView from "../logging_settings_view";
 import NotificationManager from "../molecules/notifications_manager";
 import { getPolicyInfoWithGuardrails, keyDeleteCall, keyUpdateCall } from "../networking";
 import { useResetKeySpend } from "@/app/(dashboard)/hooks/keys/useResetKeySpend";
+import { useSetKeyBlockedState } from "@/app/(dashboard)/hooks/keys/useSetKeyBlockedState";
 import { keyKeys } from "@/app/(dashboard)/hooks/keys/useKeys";
 import { useQueryClient } from "@tanstack/react-query";
 import ObjectPermissionsView from "../object_permissions_view";
@@ -79,7 +80,9 @@ export default function KeyInfoView({
   const [deleteConfirmInput, setDeleteConfirmInput] = useState("");
   const [isRegenerateModalOpen, setIsRegenerateModalOpen] = useState(false);
   const [isResetSpendModalOpen, setIsResetSpendModalOpen] = useState(false);
+  const [isBlockModalOpen, setIsBlockModalOpen] = useState(false);
   const { mutate: resetKeySpend, isPending: resetSpendLoading } = useResetKeySpend();
+  const { mutate: setKeyBlockedState, isPending: blockLoading } = useSetKeyBlockedState();
   // Add local state to maintain key data and track regeneration
   const [currentKeyData, setCurrentKeyData] = useState<KeyResponse | undefined>(keyData);
   const [lastRegeneratedAt, setLastRegeneratedAt] = useState<Date | null>(null);
@@ -390,13 +393,18 @@ export default function KeyInfoView({
       )) ||
     (userID === currentKeyData.user_id && userRole !== "Internal Viewer");
 
-  const canResetSpend =
+  const isKeyAdmin =
     isProxyAdminRole(userRole || "") ||
-    (teamsData &&
-      isUserTeamAdminForSingleTeam(
-        teamsData?.filter((team) => team.team_id === currentKeyData.team_id)[0]?.members_with_roles,
-        userID || "",
-      ));
+    Boolean(
+      teamsData &&
+        isUserTeamAdminForSingleTeam(
+          teamsData?.filter((team) => team.team_id === currentKeyData.team_id)[0]?.members_with_roles,
+          userID || "",
+        ),
+    );
+
+  const canResetSpend = isKeyAdmin;
+  const canBlockKey = isKeyAdmin;
 
   const handleResetSpend = () => {
     resetKeySpend(currentKeyData.token || currentKeyData.token_id, {
@@ -413,6 +421,29 @@ export default function KeyInfoView({
         console.error("Error resetting key spend:", error);
       },
     });
+  };
+
+  const isBlocked = currentKeyData.blocked === true;
+
+  const handleToggleBlocked = () => {
+    setKeyBlockedState(
+      { keyToken: currentKeyData.token || currentKeyData.token_id, blocked: !isBlocked },
+      {
+        onSuccess: (response) => {
+          const blocked = response.blocked === true;
+          setCurrentKeyData((prevData) => (prevData ? { ...prevData, blocked } : undefined));
+          if (onKeyDataUpdate) {
+            onKeyDataUpdate({ blocked });
+          }
+          NotificationManager.success(blocked ? "Key blocked" : "Key unblocked");
+          setIsBlockModalOpen(false);
+        },
+        onError: (error) => {
+          NotificationManager.fromBackend(parseErrorMessage(error));
+          console.error("Error updating key blocked state:", error);
+        },
+      },
+    );
   };
 
   const parentTeam = currentKeyData.team_id ? teamsData?.find((team) => team.team_id === currentKeyData.team_id) : null;
@@ -447,6 +478,8 @@ export default function KeyInfoView({
         onRegenerate={() => setIsRegenerateModalOpen(true)}
         onDelete={() => setIsDeleteModalOpen(true)}
         onResetSpend={canResetSpend ? () => setIsResetSpendModalOpen(true) : undefined}
+        onToggleBlocked={canBlockKey ? () => setIsBlockModalOpen(true) : undefined}
+        isBlocked={isBlocked}
         canModifyKey={canModifyKey}
         backButtonText={backButtonText}
         regenerateDisabled={!premiumUser}
@@ -516,6 +549,26 @@ export default function KeyInfoView({
         <p style={{ color: "#666", fontSize: "0.875rem", marginTop: 8 }}>
           Current spend: <strong>${formatNumberWithCommas(currentKeyData.spend, 4)}</strong>. Spend history is preserved
           in logs. This resets the current period spend counter, the same as an automatic budget reset.
+        </p>
+      </Modal>
+
+      <Modal
+        title={isBlocked ? "Unblock Key" : "Block Key"}
+        open={isBlockModalOpen}
+        onOk={handleToggleBlocked}
+        onCancel={() => setIsBlockModalOpen(false)}
+        okText={isBlocked ? "Unblock" : "Block"}
+        okButtonProps={isBlocked ? undefined : { danger: true }}
+        confirmLoading={blockLoading}
+      >
+        <p>
+          {isBlocked ? "Unblock" : "Block"}{" "}
+          <strong>{currentKeyData?.key_alias || currentKeyData?.token_id || "this key"}</strong>?
+        </p>
+        <p style={{ color: "#666", fontSize: "0.875rem", marginTop: 8 }}>
+          {isBlocked
+            ? "Requests using this key will be accepted again."
+            : "Requests using this key will be rejected with a 401 error until it is unblocked. The key is not deleted and can be unblocked at any time."}
         </p>
       </Modal>
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Verified end to end at commit 75d708cf64 against a live proxy on localhost:4000 with the dashboard dev server on localhost:3000. UI flow, with screenshots to follow in a comment:

1. Create a throwaway key: `curl -X POST http://localhost:4000/key/generate -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"key_alias": "block-ui-test-key", "models": []}'`
2. Open http://localhost:3000/?login=success&page=api-keys, click the key to open its info page
3. Click the "..." button next to Regenerate Key; the dropdown shows Block Key, Reset Spend, and Delete Key
4. Click Block Key, confirm in the modal; a "Key blocked" toast appears and a red Blocked tag shows next to the key alias
5. Prove the key is dead against the live proxy:

```
$ curl -s http://localhost:4000/v1/chat/completions \
    -H 'Authorization: Bearer sk-iPeheIaL8WT7KToTjKT7pA' -H 'Content-Type: application/json' \
    -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"ping"}]}'
{"error":{"message":"Authentication Error, Key is blocked. Update via `/key/unblock` if you're an admin.","type":"auth_error","param":"None","code":"401"}}
```

6. Reopen the dropdown; the item now reads Unblock Key. Click it and confirm; a "Key unblocked" toast appears, the Blocked tag disappears, and the same curl returns 200 again
7. Delete Key from the same dropdown still walks through the existing type-the-alias confirmation modal and removes the key

## Type

🆕 New Feature

## Changes

The proxy has had `/key/block` and `/key/unblock` endpoints for a long time, but the Admin UI never exposed them; the keys table can render a Blocked status (e.g., for SCIM-deactivated users) yet there was no way to set it. This PR adds the action to the key info page

The Reset Spend and Delete Key buttons in the key info header are replaced by a "..." overflow dropdown next to Regenerate Key holding the three destructive actions: Block Key (or Unblock Key when the key is already blocked), Reset Spend, and Delete Key. Blocking asks for confirmation and explains that requests will be rejected with a 401 until unblocked; unblocking asks for a lighter confirmation. While blocked, a red Blocked tag renders next to the key alias

The new `useSetKeyBlockedState` hook posts to `/key/block` or `/key/unblock` through the shared `apiClient` (raw `fetch` is lint-banned outside `src/lib/http/`) and invalidates the keys query cache on success so the table status badge stays in sync. Blocking is offered to proxy admins and team admins, matching the reset spend gating and the admin-only check the backend enforces on these routes. `apiClient` in `networking.tsx` is now exported so hooks can use it

Of note, I first wired the hook to the typed openapi-fetch `fetchClient`, but its rebase middleware clones the outgoing `Request`, which turns the JSON body into a streaming upload that Chrome only allows over HTTP/2; against the plain HTTP/1.1 dev proxy the POST dies with `ERR_ALPN_NEGOTIATION_FAILED`. The plain `apiClient` sends a string body and works everywhere

Tests: `KeyInfoHeader.test.tsx` covers the dropdown (all three items render and fire their handlers, Block flips to Unblock based on blocked state, items hide when the caller lacks the corresponding permission callback, Blocked tag rendering) and `useSetKeyBlockedState.test.ts` covers endpoint selection per direction, the request payload, cache invalidation, error surfacing, and the missing-token guard

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
