### PR TITLE
refactor(auth): derive temp budget increase without mutating the token

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1011,7 +1011,7 @@ def _ensure_parent_otel_span_on_request_state(request: Request) -> None:
         return
     if getattr(request.state, "parent_otel_span", None) is not None:
         return
-    start_time = datetime.now()
+    start_time = datetime.now(timezone.utc)
     try:
         request.state.litellm_received_at = start_time
     except Exception:
@@ -1061,7 +1061,7 @@ async def _user_api_key_auth_builder(
     # Prefer the receive-instant stamped by the early helper in
     # user_api_key_auth (before body parse) — overwriting it would shorten
     # the preprocessing-duration measurement by the body-parse window.
-    start_time = getattr(request.state, "litellm_received_at", None) or datetime.now()
+    start_time = getattr(request.state, "litellm_received_at", None) or datetime.now(timezone.utc)
     try:
         request.state.litellm_received_at = start_time
     except Exception:
@@ -2607,7 +2607,7 @@ async def _return_user_api_key_auth_obj(
     start_time: datetime,
     user_role: Optional[LitellmUserRoles] = None,
 ) -> UserAPIKeyAuth:
-    end_time = datetime.now()
+    end_time = datetime.now(timezone.utc)
 
     asyncio.create_task(
         user_api_key_service_logger_obj.async_service_success_hook(
@@ -2696,9 +2696,10 @@ def _update_key_budget_with_temp_budget_increase(
 ) -> UserAPIKeyAuth:
     if valid_token.max_budget is None:
         return valid_token
-    temp_budget_increase = _get_temp_budget_increase(valid_token) or 0.0
-    valid_token.max_budget = valid_token.max_budget + temp_budget_increase
-    return valid_token
+    temp_budget_increase = _get_temp_budget_increase(valid_token)
+    if not temp_budget_increase:
+        return valid_token
+    return valid_token.model_copy(update={"max_budget": valid_token.max_budget + temp_budget_increase})
 
 
 async def _lookup_end_user_and_apply_budget(

--- a/ruff-strict-budget.json
+++ b/ruff-strict-budget.json
@@ -93,7 +93,7 @@
     "limit": 33
   },
   "DTZ005": {
-    "limit": 244
+    "limit": 241
   },
   "DTZ006": {
     "limit": 13

--- a/tests/proxy_unit_tests/test_proxy_utils.py
+++ b/tests/proxy_unit_tests/test_proxy_utils.py
@@ -1780,7 +1780,10 @@ def test_update_key_budget_with_temp_budget_increase():
             "temp_budget_expiry": expiry_in_isoformat,
         },
     )
-    assert _update_key_budget_with_temp_budget_increase(valid_token).max_budget == 200
+    result = _update_key_budget_with_temp_budget_increase(valid_token)
+    assert result.max_budget == 200
+    assert result is not valid_token
+    assert valid_token.max_budget == 100
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -4529,6 +4529,9 @@ async def test_temp_budget_increase_applied_for_cached_key():
     Seed the auth cache with a key whose spend (5.0) exceeds its original
     max_budget (2.0) but is under the effective budget (2.0 + 100.0). The cache-hit
     request must not raise and the resolved token must carry max_budget == 102.0.
+
+    Resolving twice must yield 102.0 both times and leave the cached object at the
+    original 2.0: the increase is derived per request, never compounded or persisted.
     """
     from datetime import datetime, timedelta
 
@@ -4574,14 +4577,22 @@ async def test_temp_budget_increase_applied_for_cached_key():
             new_callable=AsyncMock,
         ),
     ):
-        result = await _user_api_key_auth_builder(
-            request=mock_request,
-            api_key=f"Bearer {api_key}",
-            azure_api_key_header="",
-            anthropic_api_key_header=None,
-            google_ai_studio_api_key_header=None,
-            azure_apim_header=None,
-            request_data={"model": "gpt-4o-mini"},
+        results = tuple(
+            [
+                await _user_api_key_auth_builder(
+                    request=mock_request,
+                    api_key=f"Bearer {api_key}",
+                    azure_api_key_header="",
+                    anthropic_api_key_header=None,
+                    google_ai_studio_api_key_header=None,
+                    azure_apim_header=None,
+                    request_data={"model": "gpt-4o-mini"},
+                )
+                for _ in range(2)
+            ]
         )
 
-    assert result.max_budget == 102.0
+    assert all(result.max_budget == 102.0 for result in results)
+
+    cached_after = await user_api_key_cache.async_get_cache(key=hashed_token)
+    assert cached_after.max_budget == 2.0


### PR DESCRIPTION
## Relevant issues

Follow-up hardening of #33841 (issue #25760)

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Run live at commit `1b456994de` against a local proxy from this branch (Postgres-backed, `dev_config.yaml`). The budget gate decision this PR touches happens at auth time, before any provider call, so the proof drives it directly: a key is given `spend` far over its `max_budget` via `/key/update`, then requests are sent while varying `temp_budget_increase`. A 429 naming "Budget has been exceeded" means the gate blocked; any other error (this environment has no provider key wired) means the request cleared the gate

```bash
MASTER=sk-1234; BASE=http://localhost:4000

KEY=$(curl -s -X POST $BASE/key/generate -H "Authorization: Bearer $MASTER" \
  -H "Content-Type: application/json" \
  -d '{"max_budget": 0.0001, "models": ["anthropic-haiku-4-5"]}' \
  | python3 -c "import sys,json;print(json.load(sys.stdin)['key'])")

curl -s -X POST $BASE/key/update -H "Authorization: Bearer $MASTER" \
  -H "Content-Type: application/json" -d "{\"key\": \"$KEY\", \"spend\": 0.05}"

# phase 1: no temp increase, spend 0.05 > max_budget 0.0001 -> expect block
# phase 2: temp_budget_increase 100 (effective 100.0001) -> expect gate pass
# phase 3: temp_budget_increase 0.01 (effective 0.0101 < spend) -> expect block at exactly 0.0101 on every repeat
```

Output:

```text
--- phase 1: spend 0.05 > max_budget 0.0001, no temp increase ---
Request 1: HTTP 429 Budget has been exceeded! Current cost: 0.05, Max budget: 0.0001
Request 2: HTTP 429 Budget has been exceeded! Current cost: 0.05, Max budget: 0.0001
Request 3: HTTP 429 Budget has been exceeded! Current cost: 0.05, Max budget: 0.0001

--- phase 2: temp_budget_increase 100 (effective 100.0001 > spend 0.05) ---
Request 1: PASSED budget gate
Request 2: PASSED budget gate
Request 3: PASSED budget gate

--- phase 3: temp_budget_increase 0.01 (effective 0.0101 < spend 0.05) ---
Request 1: blocked, effective max budget = 0.0101
Request 2: blocked, effective max budget = 0.0101
Request 3: blocked, effective max budget = 0.0101
Request 4: blocked, effective max budget = 0.0101
Request 5: blocked, effective max budget = 0.0101

key/info after all phases: spend = 0.05 | max_budget = 0.0001 | metadata = {'temp_budget_expiry': '2027-01-01T00:00:00', 'temp_budget_increase': 0.01}
```

Phase 3 is the purity proof: five consecutive cache-hit requests all report the effective budget as exactly 0.0101. Under a compounding bug (mutated token leaking back into the cache) that number would grow by 0.01 per request. `key/info` confirms the stored `max_budget` is still the original 0.0001 after everything

## Type

🧹 Refactoring

## Changes

`_update_key_budget_with_temp_budget_increase` mutated `valid_token.max_budget` in place. That is only safe because every auth resolution path happens to hand it a fresh copy of the cached token (cache reads return `model_copy()`, `_cache_key_object` copies before storing). If any future change re-caches a live token or drops one of those copies, the increase would compound into shared state by `+increase` per request. The helper now returns `model_copy(update={"max_budget": ...})` instead, so no caller can leak an increased budget anywhere, regardless of what the cache does

The regression test from #33841 is extended to pin this as an observable invariant: resolving the same cached key twice must yield the effective budget (102.0) both times, and the cached object must still hold the original 2.0 afterwards. Adversarial mutation-testing during review showed that alone was not enough; reverting the helper to in-place mutation still passed because the cache's copy-on-read layer masks it, so the direct unit test in test_proxy_utils.py now also asserts the input object is left unmutated and the result is a distinct object

While in the file, the three remaining `DTZ005` naive `datetime.now()` calls are fixed (auth span start, builder `start_time`, service-log `end_time`); all their consumers either convert to epoch via `.timestamp()` or subtract same-pair datetimes, so switching to `datetime.now(timezone.utc)` is behavior-preserving. The `DTZ005` strict-budget ceiling ratchets 244 -> 241

Note for reviewers: `make pre-commit` currently fails on staging in `lint-e2e-basedpyright` because `tests/e2e/llm_translation/test_messages_mid_conversation_system_native_providers_e2e.py` references a `gateway` attribute that `EndpointsClient` does not have (introduced in 23b5b7d199); that is unrelated to this diff and tracked separately

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
