### PR TITLE
fix(ui): stop cloning body-carrying requests into stream uploads in fetchClient middleware

### DIFF
--- a/ui/litellm-dashboard/src/lib/http/api.test.ts
+++ b/ui/litellm-dashboard/src/lib/http/api.test.ts
@@ -19,6 +19,21 @@ const capturingFetch = (response: Response) => {
   return { fetch, requests };
 };
 
+const spyOnRequestConstruction = () => {
+  const NativeRequest = globalThis.Request;
+  const inits: Array<RequestInit | Request | undefined> = [];
+  class SpyingRequest extends NativeRequest {
+    constructor(input: RequestInfo | URL, init?: RequestInit) {
+      inits.push(init);
+      super(input, init);
+    }
+  }
+  vi.stubGlobal("Request", SpyingRequest);
+  const streamBodiedInits = () =>
+    inits.filter((init) => (init instanceof NativeRequest ? init.body !== null : init?.body instanceof ReadableStream));
+  return { streamBodiedInits };
+};
+
 describe("typed api client middleware", () => {
   beforeEach(() => {
     registerBaseUrlGetter(() => "");
@@ -29,6 +44,7 @@ describe("typed api client middleware", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("injects the bearer token under the registered auth header name", async () => {
@@ -60,6 +76,35 @@ describe("typed api client middleware", () => {
     expect(url.origin).toBe("https://proxy.example.com");
     expect(url.pathname).toBe("/model_group/info");
     expect(url.searchParams.get("model_group")).toBe("gpt-4o");
+  });
+
+  it("sends a POST body as bytes, never as a ReadableStream (Chromium rejects stream uploads over HTTP/1.1)", async () => {
+    registerAuthTokenGetter(() => "sk-test");
+    const { streamBodiedInits } = spyOnRequestConstruction();
+    const { fetch, requests } = capturingFetch(jsonResponse(200, { key: "sk-new" }));
+
+    await fetchClient.POST("/key/generate", { fetch, body: { key_alias: "my-key" } });
+
+    expect(streamBodiedInits()).toEqual([]);
+    expect(requests[0].headers.get("Authorization")).toBe("Bearer sk-test");
+    expect(await requests[0].text()).toBe(JSON.stringify({ key_alias: "my-key" }));
+  });
+
+  it("keeps the POST body as bytes when rebasing onto a runtime base url", async () => {
+    registerBaseUrlGetter(() => "https://proxy.example.com");
+    registerAuthTokenGetter(() => "sk-test");
+    const { streamBodiedInits } = spyOnRequestConstruction();
+    const { fetch, requests } = capturingFetch(jsonResponse(200, { key: "sk-new" }));
+
+    await fetchClient.POST("/key/generate", { fetch, body: { key_alias: "my-key" } });
+
+    expect(streamBodiedInits()).toEqual([]);
+    const sent = requests[0];
+    expect(new URL(sent.url).origin).toBe("https://proxy.example.com");
+    expect(sent.method).toBe("POST");
+    expect(sent.headers.get("Authorization")).toBe("Bearer sk-test");
+    expect(sent.headers.get("Content-Type")).toBe("application/json");
+    expect(await sent.text()).toBe(JSON.stringify({ key_alias: "my-key" }));
   });
 
   it("maps a non-2xx response to an ApiError carrying status and the derived message", async () => {

--- a/ui/litellm-dashboard/src/lib/http/api.ts
+++ b/ui/litellm-dashboard/src/lib/http/api.ts
@@ -19,6 +19,7 @@ const rebaseRequest = async (request: Request, url: string): Promise<Request> =>
     cache: request.cache,
     redirect: request.redirect,
     referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
     integrity: request.integrity,
     keepalive: request.keepalive,
     signal: request.signal,

--- a/ui/litellm-dashboard/src/lib/http/api.ts
+++ b/ui/litellm-dashboard/src/lib/http/api.ts
@@ -9,10 +9,27 @@ const rebaseUrl = (requestUrl: string, base: string): string => {
   return `${base.replace(/\/+$/, "")}${pathname}${search}`;
 };
 
+const rebaseRequest = async (request: Request, url: string): Promise<Request> => {
+  const init: RequestInit = {
+    method: request.method,
+    headers: request.headers,
+    body: request.body ? await request.arrayBuffer() : undefined,
+    mode: request.mode,
+    credentials: request.credentials,
+    cache: request.cache,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    integrity: request.integrity,
+    keepalive: request.keepalive,
+    signal: request.signal,
+  };
+  return new Request(url, init);
+};
+
 const middleware: Middleware = {
-  onRequest({ request }) {
+  async onRequest({ request }) {
     const base = getRequestBaseUrl();
-    const next = new Request(base ? rebaseUrl(request.url, base) : request.url, request);
+    const next = base ? await rebaseRequest(request, rebaseUrl(request.url, base)) : request;
     const token = getAuthToken();
     if (token) {
       next.headers.set(getAuthHeaderName(), `Bearer ${token}`);


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The bug is a browser network-layer failure, so the proof is captured in Chromium against a live HTTP/1.1 server (`python3 -m http.server 47831`, same protocol uvicorn speaks), running the middleware's exact old and new request constructions from the page's console

Before (old construction, parent commit 212a9213c4): a plain `fetch` POST with a string body reaches the server, while the middleware's `new Request(url, request)` clone of the identical request turns the body into a stream and dies at the network layer

```js
const url = "http://localhost:47831/post-target";
const orig = new Request(url, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ a: 1 }) });
await fetch(orig.clone());                    // reached server, status 501
const cloned = new Request(url, orig);
Object.prototype.toString.call(cloned.body);  // [object ReadableStream], duplex=half
await fetch(cloned);                          // TypeError: Failed to fetch (net::ERR_ALPN_NEGOTIATION_FAILED)
```

After (new construction from this PR, commit 979e869f9c): rebuilding with the body materialized as bytes reaches the server like the plain fetch does

```js
const rebased = new Request(url, { method: orig.method, headers: orig.headers, body: await orig.arrayBuffer(), mode: orig.mode, credentials: orig.credentials, cache: orig.cache, redirect: orig.redirect, referrer: orig.referrer, integrity: orig.integrity, keepalive: orig.keepalive, signal: orig.signal });
await fetch(rebased);                         // reached server, status 501
```

(501 is python http.server declining POST; the point is the request reaches the server instead of failing before it leaves the browser)

To see it in the product: run the proxy over plain http on localhost:4000, run the dashboard dev server on localhost:3000, open the MCP Servers page, pick a server and use the "connect with your API key" credential modal. On the parent commit the save fails with "Failed to fetch"; on this branch it completes

## Type

🐛 Bug Fix

## Changes

The openapi-fetch middleware in `ui/litellm-dashboard/src/lib/http/api.ts` rebuilt every outgoing request with `new Request(url, request)`. Per the fetch spec that converts a string JSON body into a `ReadableStream` with `duplex: "half"`, i.e. a streaming upload, which Chromium only allows over HTTP/2 or HTTP/3. LiteLLM's uvicorn server only speaks HTTP/1.1, so on any deployment where the browser reaches the proxy over plain http (docker `-p 4000:4000`, an HTTP/1.1-only edge) every body-carrying request failed with `net::ERR_ALPN_NEGOTIATION_FAILED`, surfaced to the user as "Failed to fetch"

The middleware landed in #29884 with only GET callers (null body, unaffected), which is why nothing broke in v1.93.0. #33103 added the first POST caller (the MCP BYOK credential modal), so that flow is broken on plain-http deployments in the v1.94.0 RCs. https deployments behind an h2 edge never saw it

The fix removes the unconditional clone. When no runtime base url is registered the middleware now injects the auth header on the original request in place; when a rebase is needed it rebuilds the request with the body read out as bytes via `arrayBuffer()`, which fetch sends with Content-Length instead of a streaming upload, carrying over method, headers, credentials, signal and the other standard init fields

The regression test spies on the global `Request` constructor and asserts no construction receives a body-carrying `Request` as init or a `ReadableStream` body, for both the no-rebase and rebase paths, plus that the body round-trips as the exact JSON string with the auth header applied. Both tests fail on the parent commit and pass here. Existing coverage for header injection, url rebasing and ApiError mapping still passes

Note #34116 deliberately kept `useSetKeyBlockedState` on the legacy `apiClient` because of this bug; with this fix it can move back to `fetchClient`, left out of here to keep the scope isolated

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
