### PR TITLE
fix(router): honor request-level num_retries over global litellm_settings.num_retries

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -1864,7 +1864,9 @@ def client(original_function):
                     except Exception:
                         pass
 
-            setattr(e, "num_retries", num_retries)  ## IMPORTANT: returns the deployment's num_retries to the router
+            deployment_num_retries = kwargs.get("num_retries")
+            if deployment_num_retries is not None:
+                setattr(e, "num_retries", deployment_num_retries)
 
             timeout = _get_wrapper_timeout(kwargs=kwargs, exception=e)
             setattr(e, "timeout", timeout)

--- a/tests/test_litellm/test_router_per_deployment_num_retries.py
+++ b/tests/test_litellm/test_router_per_deployment_num_retries.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 import litellm
 from litellm import Router
 from litellm.types.router import RetryPolicy
+from litellm.integrations.custom_logger import CustomLogger
 
 
 class TestPerDeploymentNumRetries:
@@ -464,3 +465,113 @@ class TestNoProviderRetryAmplification:
                     num_retries=num_retries,
                 )
         assert counter["n"] > num_retries + 1
+
+
+class _AttemptCounter(CustomLogger):
+    """Counts upstream call attempts via the pre-call hook (one per attempt)."""
+
+    def __init__(self):
+        self.attempts = 0
+
+    def log_pre_api_call(self, model, messages, kwargs):
+        self.attempts += 1
+
+
+class TestRequestNumRetriesBeatsGlobal:
+    """
+    A per-request num_retries (request body or the x-litellm-num-retries header, both of
+    which arrive as the num_retries kwarg) must take precedence over the global
+    litellm.num_retries (litellm_settings.num_retries on the proxy) during retry handling.
+
+    The regression: the @client wrapper stamped the global litellm.num_retries onto the
+    raised exception, and async_function_with_retries then adopted that stamped value,
+    overwriting the request-level num_retries it had already resolved. This exercises the
+    real retry loop end to end (the failing call flows through the wrapped litellm.acompletion),
+    which the kwargs-merge-only test above does not.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _restore_litellm_globals(self):
+        prev_num_retries = litellm.num_retries
+        prev_callbacks = litellm.callbacks
+        yield
+        litellm.num_retries = prev_num_retries
+        litellm.callbacks = prev_callbacks
+
+    @staticmethod
+    def _router(global_num_retries):
+        return Router(
+            model_list=[
+                {
+                    "model_name": "mock",
+                    "litellm_params": {
+                        "model": "openai/mock",
+                        "api_key": "sk-fake",
+                        "mock_response": "litellm.InternalServerError",
+                    },
+                }
+            ],
+            num_retries=global_num_retries,
+        )
+
+    async def _count_attempts(self, *, global_num_retries, request_num_retries):
+        counter = _AttemptCounter()
+        litellm.callbacks = [counter]
+        litellm.num_retries = global_num_retries
+        router = self._router(global_num_retries)
+        kwargs = {"model": "mock", "messages": [{"role": "user", "content": "hi"}]}
+        if request_num_retries is not None:
+            kwargs["num_retries"] = request_num_retries
+        with patch("asyncio.sleep", return_value=None):
+            with pytest.raises(litellm.InternalServerError):
+                await router.acompletion(**kwargs)
+        return counter.attempts
+
+    @pytest.mark.asyncio
+    async def test_request_num_retries_overrides_global(self):
+        """global=3 + request=1 -> 2 attempts (1 initial + 1 retry), not 4 (1 + global 3)."""
+        attempts = await self._count_attempts(global_num_retries=3, request_num_retries=1)
+        assert attempts == 2
+
+    @pytest.mark.asyncio
+    async def test_request_num_retries_zero_disables_retries_despite_global(self):
+        """global=3 + request=0 -> a single attempt (retries disabled by the request)."""
+        attempts = await self._count_attempts(global_num_retries=3, request_num_retries=0)
+        assert attempts == 1
+
+    @pytest.mark.asyncio
+    async def test_global_num_retries_applies_when_request_omits_it(self):
+        """No request num_retries -> the global still applies: 1 initial + 3 retries = 4."""
+        attempts = await self._count_attempts(global_num_retries=3, request_num_retries=None)
+        assert attempts == 4
+
+    @pytest.mark.asyncio
+    async def test_deployment_num_retries_reaches_wrapper_when_no_request_value(self):
+        """
+        With no request value and the router default at 0, a deployment's
+        litellm_params.num_retries reaches the wrapped call, is carried on the raised
+        exception, and is applied: deployment 2 -> 1 initial + 2 retries = 3 (not 1).
+        """
+        counter = _AttemptCounter()
+        litellm.callbacks = [counter]
+        litellm.num_retries = None
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "mock",
+                    "litellm_params": {
+                        "model": "openai/mock",
+                        "api_key": "sk-fake",
+                        "mock_response": "litellm.InternalServerError",
+                        "num_retries": 2,
+                    },
+                }
+            ],
+            num_retries=0,
+        )
+        with patch("asyncio.sleep", return_value=None):
+            with pytest.raises(litellm.InternalServerError):
+                await router.acompletion(
+                    model="mock", messages=[{"role": "user", "content": "hi"}]
+                )
+        assert counter.attempts == 3


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4516

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

A per-request `num_retries` (request body, or the `x-litellm-num-retries` header) was ignored whenever `litellm_settings.num_retries` was set: the configured global value won instead. Backend retryable failures were counted against a mock OpenAI-compatible upstream that always returns HTTP 500, so backend hits equal total attempts (1 initial + N retries). The mock is a controllable failing upstream, which is required to count retry attempts deterministically; a real provider will not reliably return a retryable error on every call.

Config A (`litellm_settings.num_retries: 3`, deployment `max_retries: 0`, no per-deployment `num_retries`):

| Request | Before (`212a9213c4`) | After (`56633ef72d`) | Expected |
| -- | -- | -- | -- |
| body `num_retries: 1` | 4 hits | 2 hits | 2 |
| header `x-litellm-num-retries: 1` | 4 hits | 2 hits | 2 |
| body `num_retries: 0` | 4 hits | 1 hit | 1 |
| no per-request value | 4 hits | 4 hits | 4 (global still applies) |

Config B (`litellm_settings.num_retries` unset), control, body `num_retries: 1`: 2 hits before and after.

Before (`212a9213c4`), body `num_retries: 1` with global `3`:
```
$ curl -sS http://127.0.0.1:4516/v1/chat/completions -H "Authorization: Bearer sk-123" \
    -H "Content-Type: application/json" \
    -d '{"model":"mock","messages":[{"role":"user","content":"hi"}],"num_retries":1}'
$ curl -s http://127.0.0.1:9516/count
{"chat": 4}
```
proxy debug log:
```
router.py:6474 - async function w/ retries: ... num_retries - 1
router.py:6543 - Retrying request with num_retries: 3
```

After (`56633ef72d`), same request:
```
$ curl -sS http://127.0.0.1:4516/v1/chat/completions -H "Authorization: Bearer sk-123" \
    -H "Content-Type: application/json" \
    -d '{"model":"mock","messages":[{"role":"user","content":"hi"}],"num_retries":1}'
$ curl -s http://127.0.0.1:9516/count
{"chat": 2}
```
proxy debug log:
```
router.py:6474 - async function w/ retries: ... num_retries - 1
router.py:6543 - Retrying request with num_retries: 1
```

### Independent e2e verification (Devin)

An independent end-to-end run reproduced the before/after on a live proxy against a mock upstream that always returns HTTP 500, toggling code by git checkout and confirming the listening PID changed each restart. All counts matched with no discrepancies.

![num_retries request precedence walkthrough](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/pr34124/walkthrough.gif)

Before the fix, body `num_retries: 1` with global `3` yields 4 backend hits:

![before: 4 hits](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/pr34124/before_4hits.png)

After the fix, the same request yields 2:

![after: 2 hits](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/pr34124/after_2hits.png)

Full-resolution screen recording: [walkthrough.mp4](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/pr34124/walkthrough.mp4)

## Type

🐛 Bug Fix

## Changes

On the proxy, a request flows through the Router. `async_function_with_retries` pops and resolves the request-level `num_retries` (request value, else the router default) and then calls `litellm.acompletion`. When that inner call fails, the `@client` async wrapper resolved `num_retries` as `kwargs.get("num_retries") or litellm.num_retries` and stamped it on the exception with `setattr(e, "num_retries", ...)`. Because the router had already popped the request value, the wrapper fell back to the global `litellm.num_retries` and stamped that. Back in the retry handler, the router adopted `getattr(e, "num_retries")`, overwriting the request-level value it had correctly resolved. The debug log showed the tell: it started at the request value then flipped to the global on the first retry.

The fix stamps `num_retries` on the exception only when the call itself carried one, meaning an explicit request value or a deployment's `litellm_params.num_retries`, never the `litellm.num_retries` global. The router already accounts for the global through `self.num_retries`, so leaving the exception unset preserves the request-level value, and the per-deployment path still sets it when a deployment configures its own `num_retries`. Precedence becomes request over global, with the per-deployment setting still overriding the global when no request value is present.

This is a router-wide retry path, so the same precedence fix applies to the sibling async endpoints (embeddings, image generation, transcription, responses) that retry through the same wrapper.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
