### PR TITLE
fix(rust): route agentic-hook /messages requests to Python for all stream modes

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2107,8 +2107,7 @@ class BaseLLMHTTPHandler:
         rust_messages_response = await self._maybe_rust_anthropic_messages(
             custom_llm_provider=custom_llm_provider,
             litellm_params=litellm_params,
-            stream=stream or False,
-            rust_stream_eligible=bool(stream) and not self._has_agentic_completion_hook(logging_obj),
+            has_agentic_hook=self._has_agentic_completion_hook(logging_obj),
             model=model,
             api_key=api_key,
             api_base=api_base,
@@ -2266,8 +2265,7 @@ class BaseLLMHTTPHandler:
         *,
         custom_llm_provider: str,
         litellm_params: GenericLiteLLMParams,
-        stream: bool,
-        rust_stream_eligible: bool,
+        has_agentic_hook: bool,
         model: str,
         api_key: str | None,
         api_base: str | None,
@@ -2279,7 +2277,7 @@ class BaseLLMHTTPHandler:
             return None
         if litellm_params.get("rust") is not True and not BaseLLMHTTPHandler._rust_env_enabled():
             return None
-        if stream and not rust_stream_eligible:
+        if has_agentic_hook:
             return None
 
         from litellm.rust_bridge import messages as rust_messages_bridge

--- a/tests/test_litellm/anthropic_interface/test_rust_bridge_messages.py
+++ b/tests/test_litellm/anthropic_interface/test_rust_bridge_messages.py
@@ -219,8 +219,7 @@ def _gate(**overrides):
     kwargs = {
         "custom_llm_provider": "azure_ai",
         "litellm_params": GenericLiteLLMParams(api_key="sk-azure", rust=True),
-        "stream": False,
-        "rust_stream_eligible": False,
+        "has_agentic_hook": False,
         "model": "claude-sonnet-4-5",
         "api_key": "sk-azure",
         "api_base": "https://resource.services.ai.azure.com/anthropic",
@@ -345,11 +344,11 @@ async def test_gate_skips_rust_for_unsupported_provider():
 
 
 @pytest.mark.asyncio
-async def test_gate_skips_rust_when_streaming_but_not_eligible():
+async def test_gate_skips_rust_for_agentic_hook():
     bridge = ExplodingAsyncMessages()
     litellm.use_litellm_rust(True, amessages=bridge)
 
-    response = await _gate(stream=True, rust_stream_eligible=False)
+    response = await _gate(has_agentic_hook=True)
 
     assert response is None
     assert bridge.calls == 0
@@ -362,8 +361,7 @@ async def test_gate_streams_through_rust_when_eligible_and_strips_stream_flag():
 
     streaming_body = {**REQUEST_BODY, "stream": True}
     response = await _gate(
-        stream=True,
-        rust_stream_eligible=True,
+        has_agentic_hook=False,
         request_body=streaming_body,
     )
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4654

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The Rust `/messages` gate only excluded agentic-completion-hook requests from the Rust path when they were streaming. A non-streaming request carrying an agentic hook (e.g. websearch interception, which makes a follow-up LLM call) fell through to Rust, which cannot run Python agentic completion hooks, silently bypassing them. This is latent on trunk today for any `rust: true` deployment and would become the default on the `litellm-rust` package.

The regression test fails before the fix (a non-streaming agentic request reached the Rust bridge) and passes after it:

```
$ pytest tests/test_litellm/anthropic_interface/test_rust_bridge_messages.py -q
19 passed
```

`test_gate_skips_rust_for_agentic_hook` asserts a non-streaming agentic request does not reach the Rust bridge (routes to Python). `ruff check` is clean and the `test_llm_http_handler.py` anthropic-messages handler tests still pass.

## Type

🐛 Bug Fix

## Changes

Routes any `/messages` request that carries an agentic completion hook to the Python path regardless of stream mode, because the Rust bridge cannot run Python agentic completion hooks.

The gate previously took `stream` and `rust_stream_eligible` (`bool(stream) and not _has_agentic_completion_hook(...)`) and only skipped Rust via `if stream and not rust_stream_eligible`, so a non-streaming agentic request was served by Rust. The gate now takes an explicit `has_agentic_hook` and returns `None` (Python path) whenever it is set. Non-agentic streaming still routes through Rust's buffered stream, and the `stream` flag is still stripped from the upstream body.

## QA runbook

Not applicable; this is a routing-gate change with unit coverage, no new e2e tests.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
