### PR TITLE
fix(router): stop per-deployment num_retries from double-counting as provider max_retries

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5111,7 +5111,7 @@ def completion(  # type: ignore
     try:
         if base_url is not None:
             api_base = base_url
-        is_router_call = "model_group" in (kwargs.get("metadata") or kwargs.get("litellm_metadata") or {})
+        is_router_call = any("model_group" in (kwargs.get(k) or ()) for k in ("metadata", "litellm_metadata"))
         if is_router_call:
             max_retries = 0
         elif num_retries is not None:

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5111,7 +5111,10 @@ def completion(  # type: ignore
     try:
         if base_url is not None:
             api_base = base_url
-        if num_retries is not None:
+        is_router_call = "model_group" in (kwargs.get("metadata") or kwargs.get("litellm_metadata") or {})
+        if is_router_call:
+            max_retries = 0
+        elif num_retries is not None:
             max_retries = num_retries
         logging: LiteLLMLoggingObj = cast(LiteLLMLoggingObj, litellm_logging_obj)
         fallbacks = fallbacks or litellm.model_fallbacks

--- a/tests/test_litellm/test_router_per_deployment_num_retries.py
+++ b/tests/test_litellm/test_router_per_deployment_num_retries.py
@@ -5,6 +5,7 @@ GitHub Issue: #18968 - Per-deployment max_retries/num_retries in litellm_params 
 
 import httpx
 import pytest
+import pytest_asyncio
 from unittest.mock import patch
 
 import litellm
@@ -355,12 +356,15 @@ class TestNoProviderRetryAmplification:
         litellm.aclient_session = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         return counter
 
-    @pytest.fixture(autouse=True)
-    def _isolate_clients(self):
+    @pytest_asyncio.fixture(autouse=True)
+    async def _isolate_clients(self):
         litellm.in_memory_llm_clients_cache.flush_cache()
         yield
+        session = litellm.aclient_session
         litellm.aclient_session = None
         litellm.in_memory_llm_clients_cache.flush_cache()
+        if session is not None:
+            await session.aclose()
 
     @staticmethod
     def _router(api_base: str, litellm_params: dict, **router_kwargs) -> Router:

--- a/tests/test_litellm/test_router_per_deployment_num_retries.py
+++ b/tests/test_litellm/test_router_per_deployment_num_retries.py
@@ -3,11 +3,13 @@ Unit tests for per-deployment num_retries in litellm_params
 GitHub Issue: #18968 - Per-deployment max_retries/num_retries in litellm_params is not used in retry logic
 """
 
+import httpx
 import pytest
 from unittest.mock import patch
 
 import litellm
 from litellm import Router
+from litellm.types.router import RetryPolicy
 
 
 class TestPerDeploymentNumRetries:
@@ -319,3 +321,142 @@ class TestNumRetriesNoneGuard:
 
         # 1 initial attempt + at least 1 retry -> proves None fell back to a positive int
         assert calls["n"] >= 2
+
+
+class TestNoProviderRetryAmplification:
+    """
+    A routed request must reach the upstream provider exactly ``1 + <router retries>``
+    times. The Router is the sole retry owner for routed calls, so the provider SDK
+    must never retry on top of it. Otherwise a per-deployment ``num_retries`` set in
+    ``litellm_params`` is applied twice - once by the Router loop and once as the
+    provider client's ``max_retries`` - turning one request into ``(1 + num_retries) ** 2``
+    upstream requests.
+
+    These tests count actual upstream HTTP requests through the full Router completion
+    path by injecting a counting transport via ``litellm.aclient_session`` (the
+    documented seam the OpenAI client builder reads), so both Router-level and any
+    provider-SDK-level retries are observed.
+    """
+
+    @staticmethod
+    def _install_counting_upstream() -> dict:
+        """Route every upstream POST to a 500 and count it. ``retry-after: 0`` keeps
+        provider-SDK backoff at zero so a mutated (double-retrying) build stays fast."""
+        counter = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            counter["n"] += 1
+            return httpx.Response(
+                500,
+                headers={"retry-after": "0"},
+                json={"error": {"message": "boom", "type": "server_error"}},
+            )
+
+        litellm.aclient_session = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        return counter
+
+    @pytest.fixture(autouse=True)
+    def _isolate_clients(self):
+        litellm.in_memory_llm_clients_cache.flush_cache()
+        yield
+        litellm.aclient_session = None
+        litellm.in_memory_llm_clients_cache.flush_cache()
+
+    @staticmethod
+    def _router(api_base: str, litellm_params: dict, **router_kwargs) -> Router:
+        params = {"model": "openai/gpt-4o-mini", "api_base": api_base, "api_key": "sk-fake"}
+        params.update(litellm_params)
+        return Router(model_list=[{"model_name": "mock", "litellm_params": params}], **router_kwargs)
+
+    async def _call_and_count(self, router: Router, **call_kwargs) -> int:
+        counter = self._install_counting_upstream()
+        with patch("asyncio.sleep", return_value=None):
+            with pytest.raises(litellm.InternalServerError):
+                await router.acompletion(
+                    model="mock", messages=[{"role": "user", "content": "hi"}], **call_kwargs
+                )
+        return counter["n"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("num_retries", [2, 5])
+    async def test_deployment_num_retries_sends_no_extra_provider_requests(self, num_retries):
+        """
+        Deployment ``num_retries=N`` (every attempt failing) must send exactly ``N + 1``
+        upstream requests, not ``(N + 1) ** 2``. This is the amplification regression:
+        an unfixed build sends 9 (N=2) or 36 (N=5).
+        """
+        counter = self._install_counting_upstream()
+        router = self._router(
+            f"https://amp-{num_retries}.local/v1", {"num_retries": num_retries}, num_retries=1
+        )
+        with patch("asyncio.sleep", return_value=None):
+            with pytest.raises(litellm.InternalServerError):
+                await router.acompletion(model="mock", messages=[{"role": "user", "content": "hi"}])
+        assert counter["n"] == num_retries + 1
+
+    @pytest.mark.asyncio
+    async def test_request_max_retries_does_not_nest_with_router_retries(self):
+        """
+        A request-body ``max_retries`` must not make the provider SDK retry on top of the
+        Router. With deployment ``num_retries=5`` and request ``max_retries=3`` the count
+        stays ``6``; a build that lets either value reach the provider SDK sends 24 or 36.
+        """
+        router = self._router("https://nest-req.local/v1", {"num_retries": 5}, num_retries=1)
+        assert await self._call_and_count(router, max_retries=3) == 6
+
+    @pytest.mark.asyncio
+    async def test_deployment_max_retries_does_not_nest_with_router_retries(self):
+        """
+        A deployment-level ``max_retries`` is likewise never applied on top of the Router's
+        retries for a routed call: deployment ``num_retries=5`` plus ``max_retries=3`` still
+        sends exactly ``6`` upstream requests.
+        """
+        router = self._router(
+            "https://nest-dep.local/v1", {"num_retries": 5, "max_retries": 3}, num_retries=1
+        )
+        assert await self._call_and_count(router) == 6
+
+    @pytest.mark.asyncio
+    async def test_retry_policy_configured_does_not_reintroduce_amplification(self):
+        """
+        With a retry policy configured alongside a per-deployment ``num_retries=5``, the
+        provider SDK still must not retry: exactly ``6`` upstream requests, not 36.
+        """
+        router = self._router(
+            "https://policy.local/v1",
+            {"num_retries": 5},
+            num_retries=1,
+            retry_policy=RetryPolicy(InternalServerErrorRetries=2),
+        )
+        assert await self._call_and_count(router) == 6
+
+    @pytest.mark.asyncio
+    async def test_global_num_retries_not_amplified(self):
+        """
+        Global ``num_retries`` (no per-deployment setting) already behaves correctly and
+        must stay that way: ``num_retries=3`` sends ``4`` upstream requests.
+        """
+        router = self._router("https://global.local/v1", {}, num_retries=3)
+        assert await self._call_and_count(router) == 4
+
+    @pytest.mark.asyncio
+    async def test_direct_completion_still_forwards_num_retries_to_provider(self):
+        """
+        For a NON-routed direct ``litellm.acompletion`` call, ``num_retries`` remains an
+        alias for the provider client's ``max_retries`` (the instructor use case). The
+        provider SDK therefore retries in addition to litellm's own retry wrapper, so the
+        upstream count exceeds ``num_retries + 1`` - proving the routed-call fix did not
+        change direct-call behaviour.
+        """
+        counter = self._install_counting_upstream()
+        num_retries = 2
+        with patch("asyncio.sleep", return_value=None):
+            with pytest.raises(litellm.InternalServerError):
+                await litellm.acompletion(
+                    model="openai/gpt-4o-mini",
+                    api_base="https://direct.local/v1",
+                    api_key="sk-fake",
+                    messages=[{"role": "user", "content": "hi"}],
+                    num_retries=num_retries,
+                )
+        assert counter["n"] > num_retries + 1


### PR DESCRIPTION
## Relevant issues

Regression from #18975 (which resolved #18968). That change taught the Router to read a per-deployment `num_retries` from `litellm_params`, but the same value also reached `litellm.completion` and became the provider client's `max_retries`, so the two retry layers multiplied

## Linear ticket

Resolves LIT-4385

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This is a retry-counting bug, so the proof counts the actual upstream requests one proxy call produces. A real provider cannot be made to fail deterministically on every attempt, so (exactly as the ticket's own reproduction does) the deployment points at a tiny local upstream that returns 500 on every `POST /v1/chat/completions` and keeps a request counter. The proxy is real, the OpenAI SDK path is real, only the upstream is a controllable failing stand-in

Config used for both runs (matches the ticket: global `num_retries: 1`, deployment `num_retries: 5`):

```yaml
model_list:
  - model_name: mock
    litellm_params:
      model: openai/mock
      api_base: http://127.0.0.1:8885/v1
      api_key: sk-fake
      num_retries: 5
litellm_settings:
  num_retries: 1
general_settings:
  master_key: sk-litfix-4385
```

### Before (unfixed, commit `212a9213c4`)

```
$ curl -s -X POST http://127.0.0.1:4785/v1/chat/completions \
    -H "Authorization: Bearer sk-litfix-4385" -H "Content-Type: application/json" \
    -d '{"model":"mock","messages":[{"role":"user","content":"Hello!"}]}'
{"error":{"message":"litellm.InternalServerError: ... mock upstream always fails ...","code":"500"}}

$ curl -s http://127.0.0.1:8885/count
{"count": 36}
```

One proxy request produced 36 upstream requests, which is `(1 + 5) ** 2`

### After (this PR, commit `d10a956cab`)

```
$ curl -s -X POST http://127.0.0.1:4785/v1/chat/completions \
    -H "Authorization: Bearer sk-litfix-4385" -H "Content-Type: application/json" \
    -d '{"model":"mock","messages":[{"role":"user","content":"Hello!"}]}'
{"error":{"message":"litellm.InternalServerError: ... mock upstream always fails ...","code":"500"}}

$ curl -s http://127.0.0.1:8885/count
{"count": 6}
```

One proxy request produced exactly 6 upstream requests, which is `1 + num_retries`. The Router owns the retries and the provider SDK no longer retries on top of it

Edge case on the same fixed proxy, proving retries do not nest when a `max_retries` is also supplied in the request body:

```
# request body adds "max_retries": 3 on top of deployment num_retries: 5
# upstream counter delta for this single request: 6 (not 24)
```

### Independent e2e verification

Devin independently reproduced the same before/after on a fresh clone: one proxy call against an always-500 counting mock upstream produced exactly 36 upstream requests on the unfixed base and exactly 6 on this branch, same config and same single curl, only the code differing

![num_retries amplification before/after](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/lit-4385/num_retries_amplification.gif)

Full-resolution recording: https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/lit-4385/num_retries_amplification.mp4

## Type

🐛 Bug Fix

## Changes

For a routed call, `litellm.completion` previously copied the incoming `num_retries` onto `max_retries` unconditionally, and `max_retries` is what gets written onto the provider client (`_set_dynamic_params_on_client`). A deployment `num_retries: 5` therefore drove both the Router's retry loop and the provider SDK's internal retries, so every one of the Router's `1 + num_retries` attempts fanned out into `1 + num_retries` upstream calls

The Router is the sole retry owner for routed requests, so `completion` now forces the provider-SDK `max_retries` to 0 whenever the call originates from the Router or proxy (detected via `model_group` in the request metadata, the same signal the `@client` wrapper already uses). The `num_retries` to `max_retries` alias is kept only for direct, non-routed `litellm` calls, which is the documented instructor use case. Because `max_retries` is forced to 0 for routed calls, a `max_retries` set at the request or deployment level can no longer nest provider-SDK retries under the Router either, so `num_retries` (Router-owned) and `max_retries` (provider-SDK, direct calls only) now have distinct, non-overlapping meanings

Tests extend the existing mapped file and count real upstream requests through the full Router completion path by injecting a counting transport via `litellm.aclient_session`. They cover the deployment, request, deployment-`max_retries`, retry-policy-present, and global-`num_retries` cases, and assert the direct-call alias is preserved

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
