### PR TITLE
fix(interactions): add queued to the Interaction status enum

### DIFF
--- a/litellm/types/interactions/generated.py
+++ b/litellm/types/interactions/generated.py
@@ -173,6 +173,7 @@ class Status1(Enum):
     cancelled = "cancelled"
     incomplete = "incomplete"
     budget_exceeded = "budget_exceeded"
+    queued = "queued"
 
 
 class InteractionStatusUpdate(BaseModel):
@@ -341,6 +342,7 @@ class Status3(Enum):
     CANCELLED = "cancelled"
     INCOMPLETE = "incomplete"
     BUDGET_EXCEEDED = "budget_exceeded"
+    QUEUED = "queued"
 
 
 class ModelOption(RootModel[str]):

--- a/tests/test_litellm/interactions/test_openapi_compliance.py
+++ b/tests/test_litellm/interactions/test_openapi_compliance.py
@@ -194,6 +194,7 @@ class TestResponseCompliance:
             "cancelled",
             "incomplete",
             "budget_exceeded",
+            "queued",
         ]
         assert status_prop["enum"] == expected_statuses
         print(f"✓ Status enum values: {expected_statuses}")


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The user-facing surface here is Google's published spec, so the proof is a live fetch of it rather than an LLM call; no proxy request is involved in what broke

Before, at `212a9213c4` (staging tip); the live spec already carries the new value, so the canary fails on every open PR:

```
$ curl -s https://ai.google.dev/static/api/interactions.openapi.json \
  | python3 -c "import json,sys; print(json.load(sys.stdin)['components']['schemas']['Interaction']['properties']['status']['enum'])"
['in_progress', 'requires_action', 'completed', 'failed', 'cancelled', 'incomplete', 'budget_exceeded', 'queued']

$ python -m pytest tests/test_litellm/interactions/test_openapi_compliance.py -q
E       AssertionError: assert ['in_progress...omplete', ...] == ['in_progress...omplete', ...]
E         Left contains one more item: 'queued'
1 failed, 12 passed in 0.58s
```

Google's own description for the new value, from the same fetch:

```
"The interaction is queued, waiting for processing."
```

After, at `6c31aab6f2`:

```
$ python -m pytest tests/test_litellm/interactions/test_openapi_compliance.py -q
13 passed in 0.43s
```

## Type

✅ Test

## Changes

Google added a `queued` value to `Interaction.status` in the live Interactions OpenAPI spec, which `test_status_enum_values` fetches at test time and asserts exact equality against, so the assertion started failing on every open PR in the repo

That exact-match assertion is deliberate; it is how we find out the spec moved. So this adds the new value to the expected list instead of loosening the check to a subset comparison, same as the previous spec drifts in #21943, #27432 and #30986

The `queued` value is also mirrored into the two generated `Status` enums that track the spec, one of which is exported as `InteractionStatus`. There is no runtime behavior change: `InteractionsAPIResponse.status` is a plain `Optional[str]`, so a `queued` status from Google already parsed fine

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
