### PR TITLE
ci(image-scan): match Python packages against CPE data

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -58,6 +58,8 @@ jobs:
       # free OSS, run as a pinned, checksum-verified binary; no GitHub Action
       # dependency and no vendor SaaS callout.
       - name: Scan image for fixable HIGH/CRITICAL CVEs
+        env:
+          GRYPE_MATCH_PYTHON_USING_CPES: "true"
         run: |
           "$RUNNER_TEMP/grype" litellm-image-scan:${{ github.sha }} \
             --only-fixed \


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

Two boxes are deliberately left unchecked, and both are worth a reviewer's attention.

There is no test to add; this is a scanner configuration flag, and the behaviour it changes is only observable by running the scanner, so the dispatch run linked below is the verification

Image Scan will be red on this PR, and that is the intended result rather than a defect. The gate is green on `litellm_internal_staging` today only because it cannot see these findings. Once it can, the seven that were already present become visible and six of them are High, which trips the existing `--fail-on high`. A follow-up PR bumps `pypdf` to 6.14.2 and `pyasn1` to 0.6.4 in `uv.lock`, both lock-only and in range, which returns the gate to green. Merging this one first is a deliberate ordering choice so the detection change and the dependency change stay reviewable on their own

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live workflow run on this branch at commit `cd6a0619f9`, dispatched before opening the PR: https://github.com/BerriAI/litellm/actions/runs/29859145558

The step env confirms the flag reached grype, and the scan surfaced findings the same job reports nothing for without it:

```
env:
  GRYPE_MATCH_PYTHON_USING_CPES: true

[0063] ERROR discovered vulnerabilities at or above the severity threshold
NAME      INSTALLED  FIXED IN  TYPE    VULNERABILITY   SEVERITY  EPSS         RISK
pypdf     6.13.3     6.14.2    python  CVE-2026-59935  High      0.4% (27th)  0.3
pypdf     6.13.3     6.14.1    python  CVE-2026-59936  High      0.3% (26th)  0.3
pyasn1    0.6.3      0.6.4     python  CVE-2026-59884  High      0.4% (27th)  0.3
pyasn1    0.6.3      0.6.4     python  CVE-2026-59885  High      0.3% (26th)  0.3
pyasn1    0.6.3      0.6.4     python  CVE-2026-59886  High      0.3% (26th)  0.3
pypdf     6.13.3     6.14.0    python  CVE-2026-59937  High      0.3% (26th)  0.3
pypdf     6.13.3     6.14.0    python  CVE-2026-59938  Medium    0.3% (22nd)  0.2
pydantic  2.13.4     2.14.2    python  CVE-2026-58203  Medium    0.1% (3rd)   < 0.1
Process completed with exit code 2
```

Nothing else in that output is new, so the failure is attributable to this flag alone and not to base-layer drift

Before and after locally against the published `ghcr.io/berriai/litellm:v1.91.1` image, same grype v0.114.0 and same flags the workflow uses:

```
$ grype ghcr.io/berriai/litellm:v1.91.1 --platform linux/amd64 --only-fixed --fail-on high --output table | grep -cE "pypdf|pyasn1"
0

$ GRYPE_MATCH_PYTHON_USING_CPES=true grype ghcr.io/berriai/litellm:v1.91.1 --platform linux/amd64 --only-fixed --fail-on high --output table | grep -E "pypdf|pyasn1"
pypdf   6.13.3  6.14.2  python  CVE-2026-59935  High    0.4% (27th)  0.3
pypdf   6.13.3  6.14.1  python  CVE-2026-59936  High    0.3% (26th)  0.3
pyasn1  0.6.3   0.6.4   python  CVE-2026-59884  High    0.4% (27th)  0.3
pyasn1  0.6.3   0.6.4   python  CVE-2026-59885  High    0.3% (26th)  0.3
pyasn1  0.6.3   0.6.4   python  CVE-2026-59886  High    0.3% (26th)  0.3
pypdf   6.13.3  6.14.0  python  CVE-2026-59937  High    0.3% (26th)  0.3
pypdf   6.13.3  6.14.0  python  CVE-2026-59938  Medium  0.3% (22nd)  0.2
```

## Type

🚄 Infrastructure

## Changes

grype ships `match.python.using-cpes` defaulting to false, so PyPI packages are matched only against the GitHub Advisory Database. That is a reasonable noise-reduction default, but it makes the ecosystem matcher the single source of truth for every Python package in the image. When a CVE is published to NVD and its GHSA has not propagated to the global advisory database, the scan reports clean

The `pypdf` CVEs are the case that exposed this. They have been analyzed in NVD since 2026-07-08 with correct CPE version ranges, and those NVD records are already present in the grype database the workflow downloads, but the four GHSA IDs are still repo-level and return 404 from the global advisory API, so the ecosystem matcher had nothing to match on and the gate stayed silent. Setting the flag lets grype use data it had already fetched

I checked the cost of the extra matching rather than assuming it. Against a v1.91.1 build the finding count goes from 28 to 38. Seven of the ten additions are actionable. The remaining three are cross-product CPE collisions worth knowing about when reading future output: `CVE-2026-58203` is against `pydantic-settings` rather than `pydantic` and the image already carries the fixed 2.14.2, `CVE-2025-9799` is the Langfuse server rather than the Python SDK, and `CVE-2026-40217` is an old LiteLLM entry whose NVD record encodes a date as the version ceiling. None of the three can fail the build, because `--only-fixed` drops the two that carry no fix version and the third is Medium, which sits below the `--fail-on high` threshold

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

Not applicable as written, since this PR adds no tests. The equivalent claim I can make is that the change is a single scanner flag with no runtime effect on the shipped image, and the dispatch run above confirms both that it takes effect and that it changes the gate result only through the findings it newly surfaces
