### PR TITLE
fix(ui): distinguish response cache from provider prompt caching

### DIFF
--- a/ui/litellm-dashboard/e2e_tests/fixtures/menuMappings.ts
+++ b/ui/litellm-dashboard/e2e_tests/fixtures/menuMappings.ts
@@ -26,7 +26,8 @@ export const menuLabelToPage: Record<string, Page> = {
   "Cost Tracking": Page.CostTracking,
   "UI Theme": Page.UiTheme,
   // Experimental submenu items
-  Caching: Page.Caching,
+  "Response Cache": Page.Caching,
+  Caching: Page.Caching, // Legacy label support
   Prompts: Page.Prompts,
   Budgets: Page.Budgets,
   "API Playground": Page.TransformRequest,

--- a/ui/litellm-dashboard/e2e_tests/tests/navigation/sidebar.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/navigation/sidebar.spec.ts
@@ -8,7 +8,16 @@ import { MIGRATED_E2E_PAGES } from "../../fixtures/migratedPages";
 import type { Page as PlaywrightPage } from "@playwright/test";
 
 const sidebarButtons = {
-  [Role.ProxyAdmin]: ["Virtual Keys", "Playground", "Models", "Usage", "Teams", "Internal Users", "AI Hub"],
+  [Role.ProxyAdmin]: [
+    "Virtual Keys",
+    "Playground",
+    "Models",
+    "Usage",
+    "Teams",
+    "Internal Users",
+    "AI Hub",
+    "Response Cache",
+  ],
 };
 
 /** Migrated pages live at a path route; legacy pages keep the ?page= query param. */

--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -2207,7 +2207,7 @@
   },
   "src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx": {
     "no-nested-ternary": {
-      "count": 4
+      "count": 3
     }
   },
   "src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx": {

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.test.tsx
@@ -79,7 +79,15 @@ describe("CacheDashboard cache analytics charts", () => {
   it("scopes the analytics tab to the response cache, not provider prompt caching", async () => {
     renderDashboard();
 
-    expect(await screen.findByText(/Provider-side prompt caching/)).toBeInTheDocument();
+    expect(await screen.findByText(/is not shown here/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "response cache" })).toHaveAttribute(
+      "href",
+      "https://docs.litellm.ai/docs/proxy/caching",
+    );
+    expect(screen.getByRole("link", { name: "prompt caching" })).toHaveAttribute(
+      "href",
+      "https://docs.litellm.ai/docs/completion/prompt_caching",
+    );
     expect(screen.queryByText("Cached Tokens")).not.toBeInTheDocument();
     expect(screen.getAllByText("Cached Completion Tokens").length).toBeGreaterThan(0);
   });

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.test.tsx
@@ -76,6 +76,14 @@ describe("CacheDashboard cache analytics charts", () => {
     expect(screen.getByText("Cached Completion Tokens vs Generated Completion Tokens")).toBeInTheDocument();
   });
 
+  it("scopes the analytics tab to the response cache, not provider prompt caching", async () => {
+    renderDashboard();
+
+    expect(await screen.findByText(/Provider-side prompt caching/)).toBeInTheDocument();
+    expect(screen.queryByText("Cached Tokens")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Cached Completion Tokens").length).toBeGreaterThan(0);
+  });
+
   it("renders the requests chart with each category legend-bound to its fill and stacked in order", async () => {
     renderDashboard();
     const { requestsCard } = await findChartCards();

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.tsx
@@ -282,6 +282,12 @@ const CacheDashboard: React.FC<CachePageProps> = ({ accessToken, token, userRole
       <TabPanels>
         <TabPanel>
           <Card>
+            <Text className="text-tremor-content dark:text-dark-tremor-content">
+              Analytics for LiteLLM&apos;s response cache (e.g. Redis / in-memory): requests answered from cache without
+              calling the LLM provider. Provider-side prompt caching (cached input tokens from Anthropic, OpenAI, etc.)
+              is not shown here; see &quot;Prompt Caching Metrics&quot; on the Usage page or individual requests in the
+              Logs page.
+            </Text>
             <Grid numItems={3} className="gap-4 mt-4">
               <Col>
                 <MultiSelect
@@ -340,7 +346,7 @@ const CacheDashboard: React.FC<CachePageProps> = ({ accessToken, token, userRole
 
               <Card>
                 <p className="text-tremor-default font-medium text-tremor-content dark:text-dark-tremor-content">
-                  Cached Tokens
+                  Cached Completion Tokens
                 </p>
                 <div className="mt-2 flex items-baseline space-x-2.5">
                   <p className="text-tremor-metric font-semibold text-tremor-content-strong dark:text-dark-tremor-content-strong">

--- a/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/caching/_components/cache_dashboard.tsx
@@ -283,10 +283,26 @@ const CacheDashboard: React.FC<CachePageProps> = ({ accessToken, token, userRole
         <TabPanel>
           <Card>
             <Text className="text-tremor-content dark:text-dark-tremor-content">
-              Analytics for LiteLLM&apos;s response cache (e.g. Redis / in-memory): requests answered from cache without
-              calling the LLM provider. Provider-side prompt caching (cached input tokens from Anthropic, OpenAI, etc.)
-              is not shown here; see &quot;Prompt Caching Metrics&quot; on the Usage page or individual requests in the
-              Logs page.
+              Analytics for LiteLLM&apos;s{" "}
+              <a
+                href="https://docs.litellm.ai/docs/proxy/caching"
+                target="_blank"
+                rel="noreferrer"
+                className="underline"
+              >
+                response cache
+              </a>{" "}
+              (e.g. Redis / in-memory): requests answered from cache without calling the LLM provider. Provider-side{" "}
+              <a
+                href="https://docs.litellm.ai/docs/completion/prompt_caching"
+                target="_blank"
+                rel="noreferrer"
+                className="underline"
+              >
+                prompt caching
+              </a>{" "}
+              (cached input tokens from Anthropic, OpenAI, etc.) is not shown here; see &quot;Prompt Caching
+              Metrics&quot; on the Usage page or individual requests in the Logs page.
             </Text>
             <Grid numItems={3} className="gap-4 mt-4">
               <Col>

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -244,7 +244,13 @@ const menuGroups: MenuGroup[] = [
         icon: <BookOpen {...ICON} />,
         external_url: "https://models.litellm.ai/cookbook",
       },
-      { key: "caching", page: "caching", label: "Caching", icon: <Database {...ICON} />, roles: all_admin_roles },
+      {
+        key: "caching",
+        page: "caching",
+        label: "Response Cache",
+        icon: <Database {...ICON} />,
+        roles: all_admin_roles,
+      },
       {
         key: "experimental",
         page: "experimental",

--- a/ui/litellm-dashboard/src/components/view_logs/CostBreakdownViewer.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/CostBreakdownViewer.test.tsx
@@ -174,6 +174,27 @@ describe("CostBreakdownViewer", () => {
     expect(screen.getByText("Azure Model Router Flat Cost:")).toBeInTheDocument();
   });
 
+  it("labels provider prompt cache line items as Prompt Cache Read/Write Cost", async () => {
+    renderWithProviders(
+      <CostBreakdownViewer
+        costBreakdown={{
+          input_cost: 0.01,
+          output_cost: 0.02,
+          cache_read_cost: 0.001,
+          cache_creation_cost: 0.002,
+        }}
+        totalSpend={0.03}
+        cacheReadTokens={100}
+        cacheCreationTokens={50}
+      />,
+    );
+
+    await expandCostBreakdown();
+
+    expect(screen.getByText("Prompt Cache Read Cost:")).toBeInTheDocument();
+    expect(screen.getByText("Prompt Cache Write Cost:")).toBeInTheDocument();
+  });
+
   it("shows '(Cached)' in the header when cacheHit is true", () => {
     const breakdown: CostBreakdown = {
       input_cost: 0.001,

--- a/ui/litellm-dashboard/src/components/view_logs/CostBreakdownViewer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/CostBreakdownViewer.tsx
@@ -136,7 +136,7 @@ export const CostBreakdownViewer: React.FC<CostBreakdownViewerProps> = ({
                           </div>
                           {(costBreakdown?.cache_read_cost ?? 0) > 0 && (
                             <div className="flex text-sm">
-                              <span className="text-gray-600 font-medium w-1/3">Cache Read Cost:</span>
+                              <span className="text-gray-600 font-medium w-1/3">Prompt Cache Read Cost:</span>
                               <span className="text-gray-900">
                                 {formatCost(isCached ? 0 : costBreakdown?.cache_read_cost)}
                                 {(cacheReadTokens ?? 0) > 0 && (
@@ -149,7 +149,7 @@ export const CostBreakdownViewer: React.FC<CostBreakdownViewerProps> = ({
                           )}
                           {(costBreakdown?.cache_creation_cost ?? 0) > 0 && (
                             <div className="flex text-sm">
-                              <span className="text-gray-600 font-medium w-1/3">Cache Write Cost:</span>
+                              <span className="text-gray-600 font-medium w-1/3">Prompt Cache Write Cost:</span>
                               <span className="text-gray-900">
                                 {formatCost(isCached ? 0 : costBreakdown?.cache_creation_cost)}
                                 {(cacheCreationTokens ?? 0) > 0 && (

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.test.tsx
@@ -255,26 +255,61 @@ describe("LogDetailContent", () => {
     expect(screen.getByText("2 masked")).toBeInTheDocument();
   });
 
-  it("should display cache hit information when cache_hit is true", () => {
+  it("should display a green Response Cache 'Hit' tag when the response cache served the request", () => {
+    render(<LogDetailContent logEntry={createLogEntry({ cache_hit: "True" })} />);
+
+    expect(screen.getByText("Response Cache")).toBeInTheDocument();
+    expect(screen.getByText("Hit").closest(".ant-tag")).toHaveClass("ant-tag-green");
+  });
+
+  it("should show prompt cache tokens without an alarming red tag when only provider prompt caching occurred", () => {
     render(
       <LogDetailContent
         logEntry={createLogEntry({
-          cache_hit: "true",
+          cache_hit: "False",
           metadata: {
             status: "success",
             additional_usage_values: {
-              cache_read_input_tokens: 100,
-              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 34462,
+              cache_creation_input_tokens: 83,
             },
           },
         })}
       />,
     );
 
-    expect(screen.getByText("Cache Hit")).toBeInTheDocument();
-    expect(screen.getByText("true")).toBeInTheDocument();
-    expect(screen.getByText("Cache Read Tokens")).toBeInTheDocument();
-    expect(screen.getByText("100")).toBeInTheDocument();
+    expect(screen.getByText("Prompt Cache Read Tokens")).toBeInTheDocument();
+    expect(screen.getByText("34,462")).toBeInTheDocument();
+    expect(screen.getByText("Prompt Cache Creation Tokens")).toBeInTheDocument();
+    expect(screen.getByText("83")).toBeInTheDocument();
+    expect(screen.getByText("Miss").closest(".ant-tag")).not.toHaveClass("ant-tag-red");
+    expect(screen.queryByText("Cache Hit")).not.toBeInTheDocument();
+  });
+
+  it("should display Prompt Cache Creation Tokens even when there are no cache read tokens", () => {
+    render(
+      <LogDetailContent
+        logEntry={createLogEntry({
+          cache_hit: "None",
+          metadata: {
+            status: "success",
+            additional_usage_values: {
+              cache_read_input_tokens: 0,
+              cache_creation_input_tokens: 83,
+            },
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Prompt Cache Creation Tokens")).toBeInTheDocument();
+    expect(screen.getByText("83")).toBeInTheDocument();
+  });
+
+  it("should hide the Response Cache row when cache_hit is not a true/false value", () => {
+    render(<LogDetailContent logEntry={createLogEntry({ cache_hit: "None" })} />);
+
+    expect(screen.queryByText("Response Cache")).not.toBeInTheDocument();
   });
 
   it("should display LiteLLM Overhead when litellm_overhead_time_ms is in metadata", () => {

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.test.tsx
@@ -306,6 +306,42 @@ describe("LogDetailContent", () => {
     expect(screen.getByText("83")).toBeInTheDocument();
   });
 
+  it("should link the Response Cache tooltip to the response caching docs", async () => {
+    const user = userEvent.setup();
+    render(<LogDetailContent logEntry={createLogEntry({ cache_hit: "True" })} />);
+
+    const label = screen.getByText("Response Cache").closest(".ant-space") as HTMLElement;
+    await user.hover(within(label).getByRole("img", { name: "info-circle" }));
+
+    expect(await screen.findByRole("link", { name: "Docs" })).toHaveAttribute(
+      "href",
+      "https://docs.litellm.ai/docs/proxy/caching",
+    );
+  });
+
+  it("should link the prompt cache tooltips to the prompt caching docs", async () => {
+    const user = userEvent.setup();
+    render(
+      <LogDetailContent
+        logEntry={createLogEntry({
+          cache_hit: "None",
+          metadata: {
+            status: "success",
+            additional_usage_values: { cache_read_input_tokens: 100 },
+          },
+        })}
+      />,
+    );
+
+    const label = screen.getByText("Prompt Cache Read Tokens").closest(".ant-space") as HTMLElement;
+    await user.hover(within(label).getByRole("img", { name: "info-circle" }));
+
+    expect(await screen.findByRole("link", { name: "Docs" })).toHaveAttribute(
+      "href",
+      "https://docs.litellm.ai/docs/completion/prompt_caching",
+    );
+  });
+
   it("should hide the Response Cache row when cache_hit is not a true/false value", () => {
     render(<LogDetailContent logEntry={createLogEntry({ cache_hit: "None" })} />);
 

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { Typography, Descriptions, Card, Tag, Tabs, Alert, Collapse, Radio, Space, Spin } from "antd";
+import { Typography, Descriptions, Card, Tag, Tabs, Alert, Collapse, Radio, Space, Spin, Tooltip } from "antd";
+import { InfoCircleOutlined } from "@ant-design/icons";
 import moment from "moment";
 import { LogEntry } from "../columns";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
@@ -278,6 +279,24 @@ function getUncachedInputTextTokens(metadata: Record<string, any>): number | und
   return Number.isFinite(n) ? n : undefined;
 }
 
+const RESPONSE_CACHE_TOOLTIP =
+  "Whether this request was served from LiteLLM's response cache (e.g. Redis / in-memory), skipping the LLM provider call entirely. This is separate from provider prompt caching; a Miss here does not mean prompt caching failed.";
+const PROMPT_CACHE_READ_TOOLTIP =
+  "Input tokens read from the LLM provider's prompt cache (e.g. Anthropic / OpenAI), billed at a discounted rate. Reported by the provider.";
+const PROMPT_CACHE_CREATION_TOOLTIP =
+  "Input tokens written to the LLM provider's prompt cache for reuse by later requests.";
+
+function MetricLabel({ label, tooltip }: { label: string; tooltip: string }) {
+  return (
+    <Space size={4}>
+      {label}
+      <Tooltip title={tooltip}>
+        <InfoCircleOutlined style={{ color: "#8c8c8c" }} />
+      </Tooltip>
+    </Space>
+  );
+}
+
 function MetricsSection({ logEntry, metadata }: { logEntry: LogEntry; metadata: Record<string, any> }) {
   const completionStartTime = logEntry.completionStartTime;
   const ttftMs =
@@ -285,14 +304,11 @@ function MetricsSection({ logEntry, metadata }: { logEntry: LogEntry; metadata: 
       ? new Date(completionStartTime).getTime() - new Date(logEntry.startTime).getTime()
       : null;
 
-  const hasCacheActivity =
-    logEntry.cache_hit ||
-    (metadata?.additional_usage_values?.cache_read_input_tokens &&
-      metadata.additional_usage_values.cache_read_input_tokens > 0);
-
-  const cacheHitValue = String(logEntry.cache_hit ?? "None");
-  const cacheHitColor =
-    cacheHitValue.toLowerCase() === "true" ? "green" : cacheHitValue.toLowerCase() === "false" ? "red" : "default";
+  const responseCacheValue = String(logEntry.cache_hit ?? "").toLowerCase();
+  const isResponseCacheHit = responseCacheValue === "true";
+  const showResponseCache = isResponseCacheHit || responseCacheValue === "false";
+  const promptCacheReadTokens = Number(metadata?.additional_usage_values?.cache_read_input_tokens) || 0;
+  const promptCacheCreationTokens = Number(metadata?.additional_usage_values?.cache_creation_input_tokens) || 0;
 
   const uncachedInputTokens = getUncachedInputTextTokens(metadata);
   const showAnthropicMessagesInputOutput =
@@ -326,22 +342,24 @@ function MetricsSection({ logEntry, metadata }: { logEntry: LogEntry; metadata: 
             <Descriptions.Item label="Time to First Token">{(ttftMs / 1000).toFixed(3)} s</Descriptions.Item>
           )}
 
-          {hasCacheActivity && (
-            <>
-              <Descriptions.Item label="Cache Hit">
-                <Tag color={cacheHitColor}>{cacheHitValue}</Tag>
-              </Descriptions.Item>
-              {metadata?.additional_usage_values?.cache_read_input_tokens > 0 && (
-                <Descriptions.Item label="Cache Read Tokens">
-                  {formatNumberWithCommas(metadata.additional_usage_values.cache_read_input_tokens)}
-                </Descriptions.Item>
-              )}
-              {metadata?.additional_usage_values?.cache_creation_input_tokens > 0 && (
-                <Descriptions.Item label="Cache Creation Tokens">
-                  {formatNumberWithCommas(metadata.additional_usage_values.cache_creation_input_tokens)}
-                </Descriptions.Item>
-              )}
-            </>
+          {showResponseCache && (
+            <Descriptions.Item label={<MetricLabel label="Response Cache" tooltip={RESPONSE_CACHE_TOOLTIP} />}>
+              <Tag color={isResponseCacheHit ? "green" : "default"}>{isResponseCacheHit ? "Hit" : "Miss"}</Tag>
+            </Descriptions.Item>
+          )}
+          {promptCacheReadTokens > 0 && (
+            <Descriptions.Item
+              label={<MetricLabel label="Prompt Cache Read Tokens" tooltip={PROMPT_CACHE_READ_TOOLTIP} />}
+            >
+              {formatNumberWithCommas(promptCacheReadTokens)}
+            </Descriptions.Item>
+          )}
+          {promptCacheCreationTokens > 0 && (
+            <Descriptions.Item
+              label={<MetricLabel label="Prompt Cache Creation Tokens" tooltip={PROMPT_CACHE_CREATION_TOOLTIP} />}
+            >
+              {formatNumberWithCommas(promptCacheCreationTokens)}
+            </Descriptions.Item>
           )}
 
           {metadata?.litellm_overhead_time_ms !== undefined && metadata.litellm_overhead_time_ms !== null && (

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx
@@ -285,12 +285,28 @@ const PROMPT_CACHE_READ_TOOLTIP =
   "Input tokens read from the LLM provider's prompt cache (e.g. Anthropic / OpenAI), billed at a discounted rate. Reported by the provider.";
 const PROMPT_CACHE_CREATION_TOOLTIP =
   "Input tokens written to the LLM provider's prompt cache for reuse by later requests.";
+const RESPONSE_CACHE_DOCS_URL = "https://docs.litellm.ai/docs/proxy/caching";
+const PROMPT_CACHE_DOCS_URL = "https://docs.litellm.ai/docs/completion/prompt_caching";
 
-function MetricLabel({ label, tooltip }: { label: string; tooltip: string }) {
+function MetricLabel({ label, tooltip, docsUrl }: { label: string; tooltip: string; docsUrl: string }) {
   return (
     <Space size={4}>
       {label}
-      <Tooltip title={tooltip}>
+      <Tooltip
+        title={
+          <>
+            {tooltip}{" "}
+            <a
+              href={docsUrl}
+              target="_blank"
+              rel="noreferrer"
+              style={{ color: "#91caff", textDecoration: "underline" }}
+            >
+              Docs
+            </a>
+          </>
+        }
+      >
         <InfoCircleOutlined style={{ color: "#8c8c8c" }} />
       </Tooltip>
     </Space>
@@ -343,20 +359,40 @@ function MetricsSection({ logEntry, metadata }: { logEntry: LogEntry; metadata: 
           )}
 
           {showResponseCache && (
-            <Descriptions.Item label={<MetricLabel label="Response Cache" tooltip={RESPONSE_CACHE_TOOLTIP} />}>
+            <Descriptions.Item
+              label={
+                <MetricLabel
+                  label="Response Cache"
+                  tooltip={RESPONSE_CACHE_TOOLTIP}
+                  docsUrl={RESPONSE_CACHE_DOCS_URL}
+                />
+              }
+            >
               <Tag color={isResponseCacheHit ? "green" : "default"}>{isResponseCacheHit ? "Hit" : "Miss"}</Tag>
             </Descriptions.Item>
           )}
           {promptCacheReadTokens > 0 && (
             <Descriptions.Item
-              label={<MetricLabel label="Prompt Cache Read Tokens" tooltip={PROMPT_CACHE_READ_TOOLTIP} />}
+              label={
+                <MetricLabel
+                  label="Prompt Cache Read Tokens"
+                  tooltip={PROMPT_CACHE_READ_TOOLTIP}
+                  docsUrl={PROMPT_CACHE_DOCS_URL}
+                />
+              }
             >
               {formatNumberWithCommas(promptCacheReadTokens)}
             </Descriptions.Item>
           )}
           {promptCacheCreationTokens > 0 && (
             <Descriptions.Item
-              label={<MetricLabel label="Prompt Cache Creation Tokens" tooltip={PROMPT_CACHE_CREATION_TOOLTIP} />}
+              label={
+                <MetricLabel
+                  label="Prompt Cache Creation Tokens"
+                  tooltip={PROMPT_CACHE_CREATION_TOOLTIP}
+                  docsUrl={PROMPT_CACHE_DOCS_URL}
+                />
+              }
             >
               {formatNumberWithCommas(promptCacheCreationTokens)}
             </Descriptions.Item>


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

UI-only change, captured with the dashboard dev server against a local proxy on localhost:4000, comparing base `litellm_internal_staging` (`4a297dd611`) to this branch (`7ff7b4ff40`) on the same persisted log with a live `anthropic/claude-sonnet-5` request. To surface the red "Cache Hit: False" state you need `cache_hit=false`, which only happens when a response cache is configured; the log used had a local response cache enabled, a >1024-token `cache_control: ephemeral` system prompt, and a unique user message, so it recorded a response-cache miss plus a provider prompt-cache read (`cache_read_input_tokens=5403`)

**Area 1: log detail Metrics card**

Before (base `4a297dd611`), a red "Cache Hit: False" tag sits directly above "Cache Read Tokens", which reads as prompt caching being broken

![area1 before](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvZjI1ZGQyMjgtMmUzMC00ODZkLTkxNmItNDkyNTU0YmYzNDRlIiwiaWF0IjoxNzg0NjYyMjE1LCJleHAiOjE3ODUyNjcwMTUsImZpbGVuYW1lIjoic3Nfem9vbV80OWE1ZGZmYS5wbmcifQ.unBKi1YYciK4V54YoGdntB6aV1cYD1cDU1tsTgLwwiI)

After (this PR `7ff7b4ff40`), a neutral gray "Response Cache: Miss" tag with the token row relabeled "Prompt Cache Read Tokens", plus an info tooltip clarifying it refers to LiteLLM's response cache and is separate from provider prompt caching

![area1 after](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvMDYzZGI1NjktNzMxNS00MDQ3LThjY2QtNmRkNzM2ZmZiOTI1IiwiaWF0IjoxNzg0NjYyMjE1LCJleHAiOjE3ODUyNjcwMTUsImZpbGVuYW1lIjoic3Nfem9vbV84NzFhOGRhYi5wbmcifQ.Mvcv2dUSsQ7JjonDj0rgW_IjT0UIdOP4CZxPvUHBxYg)

![area1 tooltip](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvNzZjMjU3ZjYtY2JkMS00NDZjLTg5N2EtMjNiMTYwZmFhYzQwIiwiaWF0IjoxNzg0NjYyMjE1LCJleHAiOjE3ODUyNjcwMTUsImZpbGVuYW1lIjoic3NfMmEzZWViMzEucG5nIn0.fQCpYbgh5zcSwF7e5-ER5ETUs5WgLDvF2_nSX6pmnLA)

**Area 2: sidebar and Cache Analytics page**

Before, the sidebar item reads "Caching", the page has no scope note, and the stat card reads "Cached Tokens"

![area2 before sidebar](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvNTUyNDczOWMtZWJkYS00ZDYwLTg2MTgtMGQxNmQ3MTJmMjFjIiwiaWF0IjoxNzg0NjYyMjE1LCJleHAiOjE3ODUyNjcwMTUsImZpbGVuYW1lIjoic3Nfem9vbV9lYjMzYjNhYi5wbmcifQ.WvJkG7df4GF3dmzRx6rGDGmT9Y5RtN_4W8QDj4Jfw-w)

![area2 before card](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvNTNkNWZhMmUtMmQ4Ny00ZDNlLTg5ZmUtNDcyYTc0YjhkMDI3IiwiaWF0IjoxNzg0NjYyMjE1LCJleHAiOjE3ODUyNjcwMTUsImZpbGVuYW1lIjoic3Nfem9vbV9iMjRmZGQ0NC5wbmcifQ.CHYdmezi-fkk8T7aAGyradhPLwBLMX9qlyiRUv5RCCs)

After, the sidebar item reads "Response Cache", the tab opens with a scope description pointing to the Usage page and Logs for prompt caching, and the stat card reads "Cached Completion Tokens"

![area2 after sidebar](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvZGIzMGJmZTgtOTBkMi00ZmVmLTkyYjAtN2JjOWMzNTVmZmM2IiwiaWF0IjoxNzg0NjYyMjE2LCJleHAiOjE3ODUyNjcwMTYsImZpbGVuYW1lIjoic3Nfem9vbV82MTI2MWVlZS5wbmcifQ.0OZRREtfcnDRRW88JmBCnW0AZK-DOJ-NJS7Xska3KxM)

![area2 after description](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvZTVhNTQ5NzMtZGUxYS00ZTFkLWI4ODUtZGYzNTUwYTUwZDFlIiwiaWF0IjoxNzg0NjYyMjE2LCJleHAiOjE3ODUyNjcwMTYsImZpbGVuYW1lIjoic3Nfem9vbV9kMzk3N2I2Ni5wbmcifQ.2bZTbUQqscjy9LbDE7S4YCdPsqQBL_M0Lokg86kZiWY)

![area2 after card](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvYThkNmY3YmEtM2Q2Ny00YWQ5LWJiMzItYWRkZTBiOGI4NGY0IiwiaWF0IjoxNzg0NjYyMjE2LCJleHAiOjE3ODUyNjcwMTYsImZpbGVuYW1lIjoic3Nfem9vbV80NThmOTdhOC5wbmcifQ.jVpLrQUmvUMTBschELl7iMbURmAcKuMnVJmHUh9rzNQ)

One note for reviewers: the red-vs-neutral tag comparison only applies when `cache_hit` is a boolean (response cache configured); with no response cache, `cache_hit` logs as `None` and renders gray on the old UI too, and this PR simply omits the Response Cache row. The token-row relabel and the page/sidebar copy changes always apply

## Type

🐛 Bug Fix

## Changes

LiteLLM has two unrelated caches and the dashboard labeled both as just "cache". The `cache_hit` field on spend logs is set only by LiteLLM's response cache (Redis / in-memory replay); provider prompt caching is reported separately via cached input token counts. The log detail drawer rendered `cache_hit` as a red "Cache Hit: false" tag right next to the prompt cache token counts, and users read that as prompt caching not working. The Caching dashboard page has the same problem at page scope: it aggregates only response cache stats but never says so, and its "Cached Tokens" card actually means cached completion tokens from response cache replays

In the log drawer (`LogDetailContent.tsx`), the row is renamed to "Response Cache" with a tooltip, renders a green "Hit" or neutral gray "Miss" tag instead of red, and is hidden when the backend reports no boolean value. The prompt cache rows are renamed to "Prompt Cache Read Tokens" and "Prompt Cache Creation Tokens" with tooltips, and now render independently of the response cache field (previously a creation-only request displayed nothing). The cost breakdown line items become "Prompt Cache Read Cost" and "Prompt Cache Write Cost". The sidebar entry is renamed to "Response Cache", the Cache Analytics tab gains a scope description, and the stat card is renamed to "Cached Completion Tokens". Each tooltip and the dashboard description link to the relevant docs page (proxy response caching or provider prompt caching) so users can jump straight to the explanation of the mechanism they are looking at

Unit tests cover the new labels, the green hit tag, the absence of a red tag on prompt-cache-only requests, the hidden row when `cache_hit` is not boolean, the creation-only case, and the dashboard scope description. The Playwright sidebar spec now clicks the renamed "Response Cache" item and asserts it routes to /ui/caching, with the menu label fixture keeping "Caching" as a legacy alias; verified by running sidebar.spec.ts through run_e2e.sh against the built UI and a seeded postgres, 2 passed

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


Link to Devin session: https://app.devin.ai/sessions/63337648882841d38357c44156757609

