### PR TITLE
feat: add TrustedRouter as a JSON-configured OpenAI-compatible provider

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -723,6 +723,7 @@ openai_compatible_endpoints: List = [
     "https://api.inference.wandb.ai/v1",
     "https://api.clarifai.com/v2/ext/openai/v1",
     "https://api.libertai.io/v1",
+    "https://api.trustedrouter.com/v1",
     "https://pinstripes.io/v1",
     "https://api.meta.ai/v1",
 ]
@@ -770,6 +771,7 @@ openai_compatible_providers: List = [
     "chutes",  # Chutes - JSON-configured provider
     "parasail",  # Parasail - JSON-configured provider
     "libertai",  # LibertAI - JSON-configured provider
+    "trustedrouter",  # TrustedRouter - JSON-configured provider
     "featherless_ai",
     "nscale",
     "nebius",

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -183,5 +183,11 @@
       "max_completion_tokens": "max_tokens"
     },
     "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/embeddings"]
+  },
+  "trustedrouter": {
+    "base_url": "https://api.trustedrouter.com/v1",
+    "api_key_env": "TRUSTEDROUTER_API_KEY",
+    "api_base_env": "TRUSTEDROUTER_API_BASE",
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
   }
 }

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3492,6 +3492,7 @@ class LlmProviders(str, Enum):
     XIAOMI_MIMO = "xiaomi_mimo"
     TENSORMESH = "tensormesh"
     LIBERTAI = "libertai"
+    TRUSTEDROUTER = "trustedrouter"
     PINSTRIPES = "pinstripes"
     DARKBLOOM = "darkbloom"
     META = "meta"

--- a/tests/test_litellm/llms/trustedrouter/test_trustedrouter.py
+++ b/tests/test_litellm/llms/trustedrouter/test_trustedrouter.py
@@ -1,0 +1,59 @@
+import os
+from unittest.mock import patch
+
+TRUSTEDROUTER_API_BASE = "https://api.trustedrouter.com/v1"
+
+
+def test_trustedrouter_json_registry():
+    import litellm
+    from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+    assert litellm.LlmProviders.TRUSTEDROUTER.value == "trustedrouter"
+    assert litellm.LlmProviders("trustedrouter") == litellm.LlmProviders.TRUSTEDROUTER
+    assert JSONProviderRegistry.exists("trustedrouter")
+    config = JSONProviderRegistry.get("trustedrouter")
+    assert config is not None
+    assert config.base_url == TRUSTEDROUTER_API_BASE
+    assert config.api_key_env == "TRUSTEDROUTER_API_KEY"
+    assert config.api_base_env == "TRUSTEDROUTER_API_BASE"
+    assert "/v1/chat/completions" in config.supported_endpoints
+    assert "/v1/responses" in config.supported_endpoints
+
+
+def test_trustedrouter_listed_in_openai_compatible_providers():
+    from litellm.constants import (
+        openai_compatible_endpoints,
+        openai_compatible_providers,
+    )
+
+    assert "trustedrouter" in openai_compatible_providers
+    assert TRUSTEDROUTER_API_BASE in openai_compatible_endpoints
+
+
+def test_trustedrouter_dynamic_config_env_vars():
+    from litellm.llms.openai_like.dynamic_config import create_config_class
+    from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+    config = create_config_class(JSONProviderRegistry.get("trustedrouter"))()
+
+    with patch.dict(
+        os.environ,
+        {
+            "TRUSTEDROUTER_API_KEY": "test-key",
+            "TRUSTEDROUTER_API_BASE": "https://example.com/v1",
+        },
+    ):
+        api_base, api_key = config._get_openai_compatible_provider_info(None, None)
+
+    assert api_base == "https://example.com/v1"
+    assert api_key == "test-key"
+
+
+def test_trustedrouter_provider_detection_by_prefix():
+    from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+    model, provider, _, api_base = get_llm_provider("trustedrouter/zdr")
+
+    assert model == "zdr"
+    assert provider == "trustedrouter"
+    assert api_base == TRUSTEDROUTER_API_BASE


### PR DESCRIPTION
## Relevant issues

Companion docs PR: BerriAI/litellm-docs#426

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Provider resolution verified locally without mocks:

```
$ python -c "import litellm; print(litellm.get_llm_provider('trustedrouter/auto'))"
('auto', 'trustedrouter', None, 'https://api.trustedrouter.com/v1')
```

The QA runbook below hits the live provider through a local proxy

## Type

🆕 New Feature

## Changes

Adds TrustedRouter (https://trustedrouter.com), an OpenAI-compatible LLM router, via the JSON provider registry following the parasail/libertai pattern. One entry in `litellm/llms/openai_like/providers.json` (base url, `TRUSTEDROUTER_API_KEY`, `TRUSTEDROUTER_API_BASE`, chat completions and responses endpoints), list membership in `openai_compatible_providers` and `openai_compatible_endpoints`, the `LlmProviders.TRUSTEDROUTER` enum member, and unit tests in `tests/test_litellm/llms/trustedrouter/test_trustedrouter.py` covering the registry entry, constants membership, env-var dynamic config, and `trustedrouter/` prefix routing

## QA runbook

1. `export TRUSTEDROUTER_API_KEY=<key>` (keys at https://trustedrouter.com)
2. Start the proxy: `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug`
3. `curl http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model": "trustedrouter/auto", "messages": [{"role": "user", "content": "Say hi"}]}'`
4. Expect a completion routed through api.trustedrouter.com with usage reported

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR