### PR TITLE
chore(deps): bump pypdf to 6.14.2 and pyasn1 to 0.6.4

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-15T21:54:47.972166Z"
+exclude-newer = "2026-07-18T19:44:23.519632Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -6816,11 +6816,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]
@@ -7140,14 +7140,14 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "6.13.3"
+version = "6.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/18/9947cc201af9ccf76720fd3347bf4f70eb882ce3fcf4cb05f7443e4cf871/pypdf-6.13.3.tar.gz", hash = "sha256:f3cb822769725f1bac658c406cfc9460399043f3750c2d3e4650e0a85eacabd7", size = 6484063, upload-time = "2026-06-17T15:22:00.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/56/2967e621598987905fb8cdfadd8f8de6b5c68c9351f0523c4df8409f28f1/pypdf-6.13.3-py3-none-any.whl", hash = "sha256:c6e3f86afb625791510b02ad5480e94b63970bb957df75d44657c282ecc52224", size = 347288, upload-time = "2026-06-17T15:21:59.512Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Relevant issues

Pairs with #34136, which is what makes these findings visible to the image scan in the first place. The two are independent and can merge in either order; merging both is what returns Image Scan to green

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

There is no test to add for a lockfile move; the proof below is a before and after scan of the lock itself

One thing a reviewer should know rather than infer: the Image Scan job on this PR will pass, but it does not demonstrate anything. This branch is cut from `litellm_internal_staging`, which does not yet carry the matcher change from #34136, so the scan here cannot see the findings this PR removes whether they are present or not. That is exactly why the proof below runs the scan with the flag set manually

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Scanning the lockfile itself with grype v0.114.0, CPE matching on, which is the configuration #34136 establishes. Before is `uv.lock` at the base commit, after is `uv.lock` at `2d3e5e4a18`:

```
$ GRYPE_MATCH_PYTHON_USING_CPES=true grype dir:before --only-fixed -o table | grep -E "NAME|pypdf|pyasn1"
NAME      INSTALLED  FIXED IN  TYPE    VULNERABILITY   SEVERITY  EPSS          RISK
pypdf     6.13.3     6.14.2    python  CVE-2026-59935  High      0.4% (27th)   0.3
pypdf     6.13.3     6.14.1    python  CVE-2026-59936  High      0.3% (26th)   0.3
pyasn1    0.6.3      0.6.4     python  CVE-2026-59884  High      0.4% (27th)   0.3
pyasn1    0.6.3      0.6.4     python  CVE-2026-59885  High      0.3% (26th)   0.3
pyasn1    0.6.3      0.6.4     python  CVE-2026-59886  High      0.3% (26th)   0.3
pypdf     6.13.3     6.14.0    python  CVE-2026-59937  High      0.3% (26th)   0.3
pypdf     6.13.3     6.14.0    python  CVE-2026-59938  Medium    0.3% (22nd)   0.2

$ GRYPE_MATCH_PYTHON_USING_CPES=true grype dir:after --only-fixed -o table | grep -E "pypdf|pyasn1"
(no matches)
```

Seven to zero, six of which were High and would otherwise trip the gate's `--fail-on high` once #34136 lands

The resolution touched nothing else. Comparing every name and version pair across the whole lock rather than reading the diff size:

```
packages with changed version: 2
  pyasn1: 0.6.3 -> 0.6.4
  pypdf: 6.13.3 -> 6.14.2
```

## Type

🚄 Infrastructure

## Changes

`uv lock --upgrade-package pypdf --upgrade-package pyasn1`, nothing else. `pypdf` moves 6.13.3 to 6.14.2 and stays inside the existing `>=6.12.0,<7.0` constraint, and `pyasn1` moves 0.6.3 to 0.6.4 as a transitive dependency, so `pyproject.toml` is untouched and the change is confined to `uv.lock`

The pypdf entries are CVE-2026-59935, 59936, 59937 and 59938, fixed across 6.14.0 through 6.14.2. Three are unbounded loops or long runtimes during page content and cross-reference parsing and one is a memory-usage issue from declared image dimensions. These are reachable from `litellm/rag/ingestion/file_parsers/pdf_parser.py`, which builds a `PdfReader` over caller-supplied bytes and calls `extract_text` per page, so the input that triggers them is exactly the input that path accepts

The pyasn1 entries are CVE-2026-59884, 59885 and 59886, fixed in 0.6.4, all resource exhaustion in the BER/CER/DER decoder

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

Not applicable as written, since this PR adds no tests. On regression risk, both moves are patch or minor upgrades within the existing constraint, and the scan comparison above confirms the resolution moved only these two packages and pulled nothing else in
