### PR TITLE
fix(proxy): expand access groups in user direct-access model list

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -272,6 +272,7 @@ from litellm.proxy.auth.auth_utils import (
 from litellm.proxy.auth.handle_jwt import JWTHandler
 from litellm.proxy.auth.litellm_license import LicenseCheck
 from litellm.proxy.auth.model_checks import (
+    _get_models_from_access_groups,
     expand_wildcard_deployments_for_model_info,
     get_all_fallbacks,
     get_complete_model_list,
@@ -11122,13 +11123,20 @@ def get_direct_access_models(
 
     The 'all-proxy-models' sentinel grants direct access to every non-team
     deployment, mirroring how get_key_models expands it for the key/team path.
+    Model access group names in the user's model list are expanded to their
+    member models the same way get_key_models/get_team_models resolve them, so a
+    user granted access by group is not treated as having no accessible models.
     """
     if SpecialModelNames.all_proxy_models.value in user_db_object.models:
         return llm_router.get_model_ids(exclude_team_models=True)
 
+    accessible_models = _get_models_from_access_groups(
+        model_access_groups=llm_router.get_model_access_groups(),
+        all_models=list(user_db_object.models),
+    )
     return [
         model_id
-        for model in user_db_object.models
+        for model in accessible_models
         for deployment in (llm_router.get_model_list(model_name=model) or [])
         if (model_id := deployment.get("model_info", {}).get("id", None)) is not None
     ]

--- a/tests/test_litellm/proxy/proxy_server/test_routes_model_info.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_model_info.py
@@ -166,6 +166,69 @@ def test_v1_model_info_star_wildcard_filter_keeps_provider_expansion(monkeypatch
     assert [model["model_name"] for model in result] == ["openai/gpt-4o"]
 
 
+def test_get_direct_access_models_expands_access_group():
+    """User granted models by access-group name resolves to the group's members.
+
+    Regression for issue #34096: ``/v2/model/info`` reported "No models found" for
+    users whose model list is an access group (e.g. ``economy``) because
+    ``get_direct_access_models`` matched the group name literally instead of
+    expanding it the way ``get_key_models``/``get_team_models`` do.
+    """
+    import litellm
+    from litellm.proxy._types import LiteLLM_UserTable
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "openai/gpt-4", "api_key": "sk-fake"},
+                "model_info": {"id": "id-gpt4", "access_groups": ["economy"]},
+            },
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {"model": "openai/gpt-3.5-turbo", "api_key": "sk-fake"},
+                "model_info": {"id": "id-gpt35", "access_groups": ["economy"]},
+            },
+            {
+                "model_name": "gpt-4o",
+                "litellm_params": {"model": "openai/gpt-4o", "api_key": "sk-fake"},
+                "model_info": {"id": "id-gpt4o", "access_groups": ["premium"]},
+            },
+        ]
+    )
+    user = LiteLLM_UserTable(user_id="u1", max_budget=None, spend=0.0, models=["economy"])
+
+    result = proxy_server.get_direct_access_models(user_db_object=user, llm_router=router)
+
+    assert set(result) == {"id-gpt4", "id-gpt35"}
+
+
+def test_get_direct_access_models_mixes_group_and_explicit_models():
+    """A model list mixing an access group with an explicit model resolves both."""
+    import litellm
+    from litellm.proxy._types import LiteLLM_UserTable
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "openai/gpt-4", "api_key": "sk-fake"},
+                "model_info": {"id": "id-gpt4", "access_groups": ["economy"]},
+            },
+            {
+                "model_name": "gpt-4o",
+                "litellm_params": {"model": "openai/gpt-4o", "api_key": "sk-fake"},
+                "model_info": {"id": "id-gpt4o", "access_groups": ["premium"]},
+            },
+        ]
+    )
+    user = LiteLLM_UserTable(user_id="u1", max_budget=None, spend=0.0, models=["economy", "gpt-4o"])
+
+    result = proxy_server.get_direct_access_models(user_db_object=user, llm_router=router)
+
+    assert set(result) == {"id-gpt4", "id-gpt4o"}
+
+
 # ---------------------------------------------------------------------------
 # GET /model/info — team BYOK scoping (issue #30983)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Relevant issues

Fixes #34096

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

The bug lives entirely in `get_direct_access_models`, the helper behind `/v2/model/info?include_team_models=true` that the "Models + Endpoints" page reads. Before this change it matched each entry in a user's model list literally against the router deployments, so a user whose access is granted by a model access group name (for example `economy`) matched no deployment and the page showed "No models found"

With a router holding two deployments tagged `access_groups: ["economy"]` and a user whose `models` is `["economy"]`:

before the change `get_direct_access_models(...)` returns `[]`, so `/v2/model/info` reports no accessible models

after the change it returns the ids of the two `economy` deployments, so the page lists them, matching what the Playground and the key-creation dropdown already showed for the same user

The QA runbook below reproduces this end to end against a running proxy

## Type

🐛 Bug Fix

## Changes

`get_key_models` and `get_team_models` already expand model access group names to their member models through `_get_models_from_access_groups`, but the user direct-access path did not, so group grants resolved inconsistently across the UI. This routes `get_direct_access_models` through the same shared helper before mapping names to deployment ids, so a user granted access by group is no longer treated as having no models. Users granted access by explicit model names are unaffected, and the `all-proxy-models` sentinel keeps its existing behavior

Coverage: two regression tests in `test_routes_model_info.py` build a real `Router` with `economy`/`premium` access groups and assert that a group-only user and a mixed group-plus-explicit user both resolve to the right deployment ids; both fail on the pre-fix code

## QA runbook

Config with a model access group shared by two models:

```yaml
model_list:
  - model_name: gpt-4
    litellm_params:
      model: openai/gpt-4
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      access_groups: ["economy"]
  - model_name: gpt-3.5-turbo
    litellm_params:
      model: openai/gpt-3.5-turbo
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      access_groups: ["economy"]
```

1. Start the proxy: `litellm --config config.yaml`
2. Create an internal user whose access is the group, and generate a key for them:

```bash
curl -X POST 'http://localhost:4000/user/new' \
  -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' \
  -d '{"user_role": "internal_user", "models": ["economy"]}'
```

3. Read the models that user can see, using the key returned above:

```bash
curl 'http://localhost:4000/v2/model/info?include_team_models=true' \
  -H 'Authorization: Bearer <user-key-from-step-2>'
```

Before the change the `data` array is empty. After the change it lists `gpt-4` and `gpt-3.5-turbo`, so the "Models + Endpoints" page renders them for the user

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
