### PR TITLE
fix(proxy): reject model writes that corrupt an auto-router pseudo-model

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -57,10 +57,15 @@ from litellm.router import Router
 from litellm.types.proxy.management_endpoints.model_management_endpoints import (
     UpdateUsefulLinksRequest,
 )
+from litellm.router_utils.auto_router_model_naming import (
+    STRATEGY_ROUTER_PARAM_FIELDS,
+    validate_strategy_router_model_write,
+)
 from litellm.types.router import (
     SPECIAL_MODEL_INFO_PARAMS,
     Deployment,
     DeploymentTypedDict,
+    GenericLiteLLMParams,
     LiteLLMParamsTypedDict,
     updateDeployment,
 )
@@ -96,6 +101,45 @@ async def get_db_model(model_id: str, prisma_client: PrismaClient) -> Optional[D
 
     deployment_pydantic_obj = Deployment(**db_model.model_dump(exclude_none=True))
     return deployment_pydantic_obj
+
+
+def _strategy_router_write_violation(
+    incoming_params: GenericLiteLLMParams | None,
+    existing_params: GenericLiteLLMParams | None,
+) -> str | None:
+    """Reject writes that would corrupt a strategy router's pseudo-model.
+
+    An auto-router deployment's ``litellm_params.model`` (``auto_router/...``) is
+    the discriminator the router loads it by; a write that mangles it makes the
+    router drop the deployment silently under ``ignore_invalid_deployments``.
+    Only writes that supply ``litellm_params.model`` are judged, against the
+    merged (stored + incoming) params, so partial patches and restores of an
+    already-corrupted row stay legal. Returns the violation, or None.
+    """
+    if incoming_params is None or incoming_params.model is None:
+        return None
+    present_fields = frozenset(
+        field
+        for field in STRATEGY_ROUTER_PARAM_FIELDS
+        for source in (incoming_params, existing_params)
+        if source is not None and getattr(source, field, None) is not None
+    )
+    return validate_strategy_router_model_write(model=incoming_params.model, present_fields=present_fields)
+
+
+def _raise_on_strategy_router_write_violation(
+    incoming_params: GenericLiteLLMParams | None,
+    existing_params: GenericLiteLLMParams | None,
+) -> None:
+    violation = _strategy_router_write_violation(incoming_params=incoming_params, existing_params=existing_params)
+    if violation is None:
+        return
+    raise ProxyException(
+        message=violation,
+        type=ProxyErrorTypes.validation_error.value,
+        code=status.HTTP_400_BAD_REQUEST,
+        param="litellm_params.model",
+    )
 
 
 def update_db_model(db_model: Deployment, updated_patch: updateDeployment) -> PrismaCompatibleUpdateDBModel:
@@ -254,6 +298,11 @@ async def patch_model(
                 code=status.HTTP_403_FORBIDDEN,
                 param="blocked",
             )
+
+        _raise_on_strategy_router_write_violation(
+            incoming_params=patch_data.litellm_params,
+            existing_params=db_model.litellm_params,
+        )
 
         # Handle team model updates with proper alias management
         update_data = await _update_team_model_in_db(
@@ -1292,6 +1341,11 @@ async def add_new_model(
             premium_user=premium_user,
         )
 
+        _raise_on_strategy_router_write_violation(
+            incoming_params=model_params.litellm_params,
+            existing_params=None,
+        )
+
         model_response: Optional[LiteLLM_ProxyModelTable] = None
         # update DB
         if store_model_in_db is True:
@@ -1444,6 +1498,11 @@ async def update_model(
             user_api_key_dict=user_api_key_dict,
             prisma_client=prisma_client,
             premium_user=premium_user,
+        )
+
+        _raise_on_strategy_router_write_violation(
+            incoming_params=model_params.litellm_params,
+            existing_params=deployment.litellm_params,
         )
 
         # update DB

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -110,6 +110,9 @@ from litellm.router_utils.batch_utils import (
     replace_model_in_jsonl,
     should_replace_model_in_jsonl,
 )
+from litellm.router_utils.auto_router_model_naming import (
+    classify_strategy_router_model,
+)
 from litellm.router_utils.client_initalization_utils import InitalizeCachedClient
 from litellm.router_utils.clientside_credential_handler import (
     get_dynamic_litellm_params,
@@ -7623,15 +7626,7 @@ class Router:
         but NOT "auto_router/complexity_router" or "auto_router/adaptive_router"
         (which use the complexity-router and adaptive-router strategies).
         """
-        if litellm_params.model.startswith("auto_router/complexity_router"):
-            return False  # This is handled by complexity_router
-        if litellm_params.model.startswith("auto_router/adaptive_router"):
-            return False  # This is handled by adaptive_router
-        if litellm_params.model.startswith("auto_router/quality_router"):
-            return False  # This is handled by quality_router
-        if litellm_params.model.startswith("auto_router/"):
-            return True
-        return False
+        return classify_strategy_router_model(litellm_params.model) == "semantic"
 
     @staticmethod
     def _deployment_tags(deployment: Deployment) -> tuple[str, ...]:
@@ -7686,9 +7681,7 @@ class Router:
 
         Returns True if the litellm_params model starts with "auto_router/complexity_router"
         """
-        if litellm_params.model.startswith("auto_router/complexity_router"):
-            return True
-        return False
+        return classify_strategy_router_model(litellm_params.model) == "complexity"
 
     def init_complexity_router_deployment(self, deployment: Deployment):
         """
@@ -7738,7 +7731,7 @@ class Router:
 
     def _is_adaptive_router_deployment(self, litellm_params: LiteLLM_Params) -> bool:
         """True when this deployment opts in via the `auto_router/adaptive_router` model prefix."""
-        return litellm_params.model.startswith("auto_router/adaptive_router")
+        return classify_strategy_router_model(litellm_params.model) == "adaptive"
 
     def _deployment_participates_in_adaptive_routing(self, litellm_params: LiteLLM_Params) -> bool:
         """True when this deployment owns an `adaptive_routers` entry once finalized:
@@ -7964,9 +7957,7 @@ class Router:
 
         Returns True if the litellm_params model starts with "auto_router/quality_router".
         """
-        if litellm_params.model.startswith("auto_router/quality_router"):
-            return True
-        return False
+        return classify_strategy_router_model(litellm_params.model) == "quality"
 
     def init_quality_router_deployment(self, deployment: Deployment):
         """

--- a/litellm/router_utils/auto_router_model_naming.py
+++ b/litellm/router_utils/auto_router_model_naming.py
@@ -1,0 +1,101 @@
+"""Naming contract for strategy-router (auto-router) pseudo-models.
+
+A deployment whose ``litellm_params.model`` starts with ``auto_router/`` does not
+name a provider model; the string is the discriminator that selects which
+pre-routing strategy owns the deployment. This module is the single source of
+truth for classifying that string (``Router._is_*_router_deployment`` delegates
+here) and for checking that a client-supplied write leaves the deployment
+coherent, so management endpoints can reject corruption with a 400 instead of
+the router silently dropping the deployment at load time under
+``ignore_invalid_deployments``.
+"""
+
+from typing import Literal, Mapping
+
+AUTO_ROUTER_MODEL_PREFIX = "auto_router/"
+
+StrategyRouterKind = Literal["semantic", "complexity", "adaptive", "quality"]
+
+STRATEGY_ROUTER_PARAM_FIELDS: frozenset[str] = frozenset(
+    {
+        "auto_router_config",
+        "auto_router_config_path",
+        "auto_router_default_model",
+        "auto_router_embedding_model",
+        "complexity_router_config",
+        "complexity_router_default_model",
+        "adaptive_router_config",
+        "quality_router_config",
+        "quality_router_default_model",
+    }
+)
+
+_REQUIRED_FIELD_GROUPS: Mapping[StrategyRouterKind, tuple[tuple[str, ...], ...]] = {
+    "semantic": (
+        ("auto_router_config", "auto_router_config_path"),
+        ("auto_router_default_model",),
+        ("auto_router_embedding_model",),
+    ),
+    "complexity": (("complexity_router_config", "complexity_router_default_model"),),
+    "adaptive": (("adaptive_router_config",),),
+    "quality": (("quality_router_config", "quality_router_default_model"),),
+}
+
+
+def classify_strategy_router_model(model: str) -> StrategyRouterKind | None:
+    """Classify a ``litellm_params.model`` string the way the Router does.
+
+    Returns None for regular provider models. Mirrors Router registration
+    exactly: reserved names are matched by prefix, everything else under
+    ``auto_router/`` is a semantic router.
+    """
+    if not model.startswith(AUTO_ROUTER_MODEL_PREFIX):
+        return None
+    remainder = model[len(AUTO_ROUTER_MODEL_PREFIX) :]
+    if remainder.startswith("complexity_router"):
+        return "complexity"
+    if remainder.startswith("adaptive_router"):
+        return "adaptive"
+    if remainder.startswith("quality_router"):
+        return "quality"
+    return "semantic"
+
+
+def validate_strategy_router_model_write(model: str, present_fields: frozenset[str]) -> str | None:
+    """Check that writing ``model`` leaves a deployment the router can load.
+
+    ``present_fields`` is the set of strategy-router param fields that are
+    non-None on the deployment after the write (stored fields merged with the
+    incoming ones). Returns a human-readable violation, or None when coherent.
+    """
+    kind = classify_strategy_router_model(model)
+    if kind is None:
+        offending = sorted(present_fields & STRATEGY_ROUTER_PARAM_FIELDS)
+        if offending:
+            return (
+                f"litellm_params.model='{model}' does not start with '{AUTO_ROUTER_MODEL_PREFIX}' but the "
+                f"deployment carries auto-router settings ({', '.join(offending)}), so the router could not "
+                f"load it. Keep the '{AUTO_ROUTER_MODEL_PREFIX}' prefix; to change the name clients call, "
+                "edit the public model_name instead."
+            )
+        return None
+    remainder = model[len(AUTO_ROUTER_MODEL_PREFIX) :]
+    if remainder.startswith(AUTO_ROUTER_MODEL_PREFIX):
+        return (
+            f"litellm_params.model='{model}' repeats the '{AUTO_ROUTER_MODEL_PREFIX}' prefix, so the router "
+            f"could not load it. Use '{remainder}'; to change the name clients call, edit the public "
+            "model_name instead."
+        )
+    if not remainder:
+        return (
+            f"litellm_params.model='{model}' is missing the router name after the '{AUTO_ROUTER_MODEL_PREFIX}' prefix."
+        )
+    missing = tuple(
+        " or ".join(group) for group in _REQUIRED_FIELD_GROUPS[kind] if not any(f in present_fields for f in group)
+    )
+    if missing:
+        return (
+            f"litellm_params.model='{model}' selects the {kind} router, which requires "
+            f"{'; '.join(missing)} in litellm_params."
+        )
+    return None

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -3330,3 +3330,216 @@ class TestModelInfoAsMapping:
         assert model_info_as_mapping("{not json") is None
         assert model_info_as_mapping('["a", "b"]') is None
         assert model_info_as_mapping(42) is None
+
+
+class TestStrategyRouterWriteValidation:
+    """Management write paths must reject litellm_params.model values that would
+    corrupt a strategy router's pseudo-model (LIT-4663). The router loads these
+    deployments by the auto_router/ discriminator, so a mangled string makes it
+    drop the deployment silently under ignore_invalid_deployments; the mistake
+    has to fail loudly at the API boundary instead."""
+
+    def _stored_complexity_params(self) -> LiteLLM_Params:
+        return LiteLLM_Params(
+            model="auto_router/complexity_router",
+            complexity_router_config={"tiers": {"SIMPLE": "gpt-4o-mini"}},
+        )
+
+    def _db_complexity_router(self, model_id: str) -> Deployment:
+        return Deployment(
+            model_name="my-auto-router",
+            litellm_params=self._stored_complexity_params(),
+            model_info={"id": model_id},
+        )
+
+    def test_double_prefix_rejected_against_stored_params(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _strategy_router_write_violation,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        violation = _strategy_router_write_violation(
+            incoming_params=updateLiteLLMParams(model="auto_router/auto_router/complexity_router"),
+            existing_params=self._stored_complexity_params(),
+        )
+        assert violation is not None
+        assert "repeats" in violation
+
+    def test_prefix_strip_rejected_against_stored_params(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _strategy_router_write_violation,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        violation = _strategy_router_write_violation(
+            incoming_params=updateLiteLLMParams(model="complexity_router"),
+            existing_params=self._stored_complexity_params(),
+        )
+        assert violation is not None
+        assert "does not start with" in violation
+
+    def test_patch_without_model_is_not_judged(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _strategy_router_write_violation,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        assert (
+            _strategy_router_write_violation(
+                incoming_params=updateLiteLLMParams(rpm=10),
+                existing_params=self._stored_complexity_params(),
+            )
+            is None
+        )
+        assert _strategy_router_write_violation(incoming_params=None, existing_params=None) is None
+
+    def test_restore_of_corrupted_row_is_allowed(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _strategy_router_write_violation,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        corrupted = LiteLLM_Params(
+            model="auto_router/auto_router/complexity_router",
+            complexity_router_config={"tiers": {"SIMPLE": "gpt-4o-mini"}},
+        )
+        assert (
+            _strategy_router_write_violation(
+                incoming_params=updateLiteLLMParams(model="auto_router/complexity_router"),
+                existing_params=corrupted,
+            )
+            is None
+        )
+
+    def test_create_semantic_router_missing_embedding_rejected(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _strategy_router_write_violation,
+        )
+
+        violation = _strategy_router_write_violation(
+            incoming_params=LiteLLM_Params(
+                model="auto_router/my-router",
+                auto_router_config="{}",
+                auto_router_default_model="gpt-4o-mini",
+            ),
+            existing_params=None,
+        )
+        assert violation is not None
+        assert "auto_router_embedding_model" in violation
+
+    @pytest.mark.asyncio
+    async def test_patch_model_rejects_double_prefix(self):
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            patch_model,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        model_id = "strategy-router-patch-test"
+        admin = UserAPIKeyAuth(user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN)
+
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+            patch("litellm.proxy.proxy_server.llm_router", MagicMock()),
+            patch("litellm.proxy.proxy_server.store_model_in_db", True),
+            patch("litellm.proxy.proxy_server.premium_user", True),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints.get_db_model",
+                new=AsyncMock(return_value=self._db_complexity_router(model_id)),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints._update_team_model_in_db",
+                new=AsyncMock(),
+            ) as mock_update,
+        ):
+            with pytest.raises(ProxyException) as exc_info:
+                await patch_model(
+                    model_id=model_id,
+                    patch_data=updateDeployment(
+                        litellm_params=updateLiteLLMParams(model="auto_router/auto_router/complexity_router")
+                    ),
+                    user_api_key_dict=admin,
+                )
+            assert "repeats" in str(exc_info.value.message)
+            mock_update.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_add_new_model_rejects_prefixed_model_without_config(self):
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            add_new_model,
+        )
+
+        admin = UserAPIKeyAuth(user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN)
+        mock_prisma = MagicMock()
+
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+            patch("litellm.proxy.proxy_server.store_model_in_db", True),
+            patch("litellm.proxy.proxy_server.premium_user", True),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            with pytest.raises(ProxyException) as exc_info:
+                await add_new_model(
+                    model_params=Deployment(
+                        model_name="my-auto-router",
+                        litellm_params=LiteLLM_Params(model="auto_router/complexity_router"),
+                        model_info={"id": "strategy-router-create-test"},
+                    ),
+                    user_api_key_dict=admin,
+                )
+            assert "requires" in str(exc_info.value.message)
+            mock_prisma.db.litellm_proxymodeltable.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_model_rejects_prefix_strip(self):
+        from litellm.proxy._types import ProxyException
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            update_model,
+        )
+        from litellm.types.router import ModelInfo, updateLiteLLMParams
+
+        model_id = "strategy-router-update-test"
+        admin = UserAPIKeyAuth(user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN)
+
+        existing_row = MagicMock()
+        existing_row.model_dump.return_value = {
+            "model_name": "my-auto-router",
+            "litellm_params": {
+                "model": "auto_router/complexity_router",
+                "complexity_router_config": {"tiers": {"SIMPLE": "gpt-4o-mini"}},
+            },
+            "model_info": {"id": model_id},
+        }
+
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_proxymodeltable.find_unique = AsyncMock(return_value=existing_row)
+        mock_prisma.db.litellm_proxymodeltable.update = AsyncMock()
+
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+            patch("litellm.proxy.proxy_server.llm_router", MagicMock()),
+            patch("litellm.proxy.proxy_server.store_model_in_db", True),
+            patch("litellm.proxy.proxy_server.premium_user", True),
+            patch(
+                "litellm.proxy.management_endpoints.model_management_endpoints.ModelManagementAuthChecks.can_user_make_model_call",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            with pytest.raises(ProxyException) as exc_info:
+                await update_model(
+                    model_params=updateDeployment(
+                        litellm_params=updateLiteLLMParams(model="complexity_router"),
+                        model_info=ModelInfo(id=model_id),
+                    ),
+                    user_api_key_dict=admin,
+                )
+            assert "does not start with" in str(exc_info.value.message)
+            mock_prisma.db.litellm_proxymodeltable.update.assert_not_awaited()

--- a/tests/test_litellm/router_utils/test_auto_router_model_naming.py
+++ b/tests/test_litellm/router_utils/test_auto_router_model_naming.py
@@ -1,0 +1,77 @@
+import pytest
+
+from litellm.router_utils.auto_router_model_naming import (
+    classify_strategy_router_model,
+    validate_strategy_router_model_write,
+)
+
+COMPLEXITY_FIELDS = frozenset({"complexity_router_config"})
+SEMANTIC_FIELDS = frozenset(
+    {"auto_router_config", "auto_router_default_model", "auto_router_embedding_model"}
+)
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("anthropic/claude-sonnet-5", None),
+        ("complexity_router", None),
+        ("autorouter/complexity_router", None),
+        ("auto_router/my-router", "semantic"),
+        ("auto_router/complexity_router", "complexity"),
+        ("auto_router/complexity_router-eu", "complexity"),
+        ("auto_router/adaptive_router", "adaptive"),
+        ("auto_router/quality_router", "quality"),
+        ("auto_router/auto_router/complexity_router", "semantic"),
+        ("auto_router/", "semantic"),
+    ],
+)
+def test_classify_strategy_router_model(model, expected):
+    assert classify_strategy_router_model(model) == expected
+
+
+@pytest.mark.parametrize(
+    "model,present_fields,expected_fragment",
+    [
+        ("auto_router/auto_router/complexity_router", COMPLEXITY_FIELDS, "repeats"),
+        ("complexity_router", COMPLEXITY_FIELDS, "does not start with"),
+        ("anthropic/claude-sonnet-5", COMPLEXITY_FIELDS, "does not start with"),
+        ("auto_router/", frozenset(), "missing the router name"),
+        ("auto_router/complexity_router", frozenset(), "requires"),
+        ("auto_router/my-router", frozenset({"auto_router_config"}), "requires"),
+        ("auto_router/adaptive_router", frozenset(), "requires"),
+        ("auto_router/quality_router", frozenset(), "requires"),
+    ],
+)
+def test_validate_rejects_incoherent_writes(model, present_fields, expected_fragment):
+    violation = validate_strategy_router_model_write(model=model, present_fields=present_fields)
+    assert violation is not None
+    assert expected_fragment in violation
+
+
+@pytest.mark.parametrize(
+    "model,present_fields",
+    [
+        ("anthropic/claude-sonnet-5", frozenset()),
+        ("openai/gpt-4o-mini", frozenset({"api_key"})),
+        ("auto_router/complexity_router", COMPLEXITY_FIELDS),
+        ("auto_router/complexity_router", frozenset({"complexity_router_default_model"})),
+        ("auto_router/complexity_router-eu", COMPLEXITY_FIELDS),
+        ("auto_router/my-router", SEMANTIC_FIELDS),
+        (
+            "auto_router/my-router",
+            frozenset(
+                {
+                    "auto_router_config_path",
+                    "auto_router_default_model",
+                    "auto_router_embedding_model",
+                }
+            ),
+        ),
+        ("auto_router/adaptive_router", frozenset({"adaptive_router_config"})),
+        ("auto_router/quality_router", frozenset({"quality_router_default_model"})),
+        ("auto_router/quality_router", frozenset({"quality_router_config"})),
+    ],
+)
+def test_validate_accepts_coherent_writes(model, present_fields):
+    assert validate_strategy_router_model_write(model=model, present_fields=present_fields) is None


### PR DESCRIPTION
## Relevant issues

- Rejects `/model/new`, `/model/update`, and `/model/{model_id}/update` writes that would mangle an auto-router deployment's `litellm_params.model` discriminator (doubled prefix, stripped prefix, or missing required strategy config), returning an actionable 400 instead of letting the router silently void the model
- Extracts the strategy-router classification (semantic / complexity / adaptive / quality by `auto_router/` prefix) into a shared `router_utils/auto_router_model_naming.py` helper that both `Router._is_*_router_deployment` and the new write validation use, so the naming contract is single-sourced
- Public `model_name` renames (including to `auto_router/<name>`) stay legal, and already-corrupted rows stay healable by writing the correct pseudo-model back through the same field

## Linear ticket

Resolves LIT-4663

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

One CI red is inherited from the base branch, not this diff: osv-scan (pyasn1 0.6.3 in uv.lock, GHSA-8ppf-4f7h-5ppj; fails identically on sibling PRs, the lockfile bump belongs in its own PR). Locally, `make pre-commit` also reds on the pre-existing e2e basedpyright errors in tests/e2e/llm_translation (fix open in #34090); that gate does not run in CI. Everything this diff touches is green: ruff format, strict/LIT budgets, basedpyright budget, gen:api sync, and both mapped test files

## Screenshots / Proof of Fix

A customer edited the "LiteLLM Model Name" field of a working complexity auto-router in the dashboard. That field is `litellm_params.model`, which for auto-routers is not a provider model at all; it is the internal discriminator (`auto_router/complexity_router`) the router loads the deployment by. The edit persisted `auto_router/auto_router/complexity_router` verbatim, router init then failed on the next load, `ignore_invalid_deployments` swallowed the failure, and the model vanished: calls fail "no healthy deployments", and after a restart the model is gone from `/v1/models` entirely. There is no guard on this field in the UI or the API, so one keystroke in a free-text box silently destroys a working router

Repro and verify below ran against a live proxy (port 4663, real Postgres, real Anthropic calls), config: three claude tier models plus a DB-stored complexity auto-router created via `/model/new`

Before the fix (staging HEAD 01d624e860):

```bash
# baseline: auto-router routes fine
curl -sX POST localhost:4663/v1/chat/completions -H "Authorization: Bearer $MASTER_KEY" \
  -d '{"model": "router-a", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 5}'
# -> 200, routed to a tier model

# the customer's edit: add the prefix to the "LiteLLM Model Name" (litellm_params.model)
curl -sX PATCH localhost:4663/model/$ID/update -H "Authorization: Bearer $MASTER_KEY" \
  -d '{"litellm_params": {"model": "auto_router/auto_router/complexity_router"}}'
# -> HTTP 200 (accepted verbatim)

curl -sX POST localhost:4663/v1/chat/completions ... '{"model": "router-a", ...}'
# -> "litellm.BadRequestError: You passed in model=router-a. There are no healthy
#     deployments for this model. Received Model Group=router-a"

# after proxy restart the row is silently dropped at load: router-a is gone from /v1/models
```

The stripped variant (`"model": "complexity_router"`) voids the model the same way

After the fix (same commands):

```bash
curl -sX PATCH localhost:4663/model/$ID/update ... '{"litellm_params": {"model": "auto_router/auto_router/complexity_router"}}'
# -> HTTP 400 {"error": {"message": "litellm_params.model='auto_router/auto_router/complexity_router'
#    repeats the 'auto_router/' prefix, so the router could not load it. Use
#    'auto_router/complexity_router'; to change the name clients call, edit the public
#    model_name instead.", "param": "litellm_params.model"}}

curl -sX PATCH localhost:4663/model/$ID/update ... '{"litellm_params": {"model": "complexity_router"}}'
# -> HTTP 400 "... does not start with 'auto_router/' but the deployment carries auto-router
#    settings (complexity_router_config, complexity_router_default_model) ..."

# the router keeps working after the rejected edits
curl -sX POST localhost:4663/v1/chat/completions ... '{"model": "router-a", ...}'   # -> 200

# renaming what clients call still works: PATCH model_name (public name) to auto_router/router-a
curl -sX PATCH localhost:4663/model/$ID/update ... '{"model_name": "auto_router/router-a"}'  # -> 200
curl -sX POST localhost:4663/v1/chat/completions ... '{"model": "auto_router/router-a", ...}'  # -> 200

# a row corrupted before the fix heals through the same field
curl -sX PATCH localhost:4663/model/$CORRUPTED_ID/update ... '{"litellm_params": {"model": "auto_router/complexity_router"}}'  # -> 200, calls route again

# creates are validated too, on both malformed strings and missing required config
curl -sX POST localhost:4663/model/new ... '{"litellm_params": {"model": "auto_router/auto_router/x", ...}}'  # -> 400
curl -sX POST localhost:4663/model/new ... '{"litellm_params": {"model": "auto_router/sem-router", "auto_router_config": "{}", "auto_router_default_model": "claude-haiku"}}'
# -> 400 "... selects the semantic router, which requires auto_router_embedding_model in litellm_params."

# the legacy POST /model/update endpoint enforces the same rule
curl -sX POST localhost:4663/model/update ... '{"litellm_params": {"model": "complexity_router"}, "model_info": {"id": "$ID"}}'  # -> 400
```

## Type

🐛 Bug Fix

## Changes

- New `litellm/router_utils/auto_router_model_naming.py`: `classify_strategy_router_model` (faithful to existing Router registration semantics) and `validate_strategy_router_model_write`, which checks a written `litellm_params.model` against the strategy fields present on the merged deployment
- `litellm/router.py`: the four `_is_*_router_deployment` predicates now delegate to the shared classifier; no behavior change
- `litellm/proxy/management_endpoints/model_management_endpoints.py`: `add_new_model`, `update_model`, and `patch_model` reject incoherent writes with a 400 naming the violation and the fix; only writes that supply `litellm_params.model` are judged, so partial patches and restores of corrupted rows stay legal
- Tests: new `tests/test_litellm/router_utils/test_auto_router_model_naming.py` (classification + malformed/coherent write families) and `TestStrategyRouterWriteValidation` in the mapped management-endpoints test file (all three endpoint seams, restore path, patch-without-model)

What does not change: routing and dispatch, the strategy registries, the dedicated Edit Auto Router modal (it never touches `litellm_params.model`), config-file loading, and public `model_name` renames

Things a reviewer will ask about: the validator judges the merged final state rather than the transition, which is what keeps a restore of an already-corrupted row legal while still blocking every corruption; and it only runs when the write supplies `litellm_params.model`, so it needs no decryption of stored values (presence of strategy fields is unaffected by encryption at rest)

## QA runbook

1. Start a proxy with a DB and three real models; create a complexity auto-router in the UI (Add Model, Auto Router tab) and confirm a chat completion against it returns 200
2. Models page, open the auto-router, Edit, change "LiteLLM Model Name" to `auto_router/auto_router/complexity_router`, Save: expect a red toast with the "repeats the 'auto_router/' prefix" message, and the model keeps serving requests
3. Same edit but set it to `complexity_router`: expect the "does not start with 'auto_router/'" toast
4. Change the public "Model Name" to `auto_router/my-router` instead and Save: expect success, and `{"model": "auto_router/my-router"}` chat completions return 200
5. `curl -X POST /model/new` with `litellm_params.model="auto_router/sem-router"` and no `auto_router_embedding_model`: expect 400 naming the missing field

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches proxy model-management write paths for all DB-backed models; logic is narrow (only when `litellm_params.model` is supplied) but incorrect validation could block legitimate creates/updates.
> 
> **Overview**
> Prevents silent loss of auto-router deployments when admins edit **`litellm_params.model`** (the internal `auto_router/...` discriminator) via **`/model/new`**, **`/model/update`**, or **`PATCH /model/{id}/update`**. Invalid values—doubled prefix, stripped prefix, missing router name, or strategy config that does not match the chosen router kind—now fail with a **400** and an actionable message instead of persisting a row the router drops under **`ignore_invalid_deployments`**.
> 
> Introduces **`litellm/router_utils/auto_router_model_naming.py`** as the single source for **`classify_strategy_router_model`** and **`validate_strategy_router_model_write`**. **`Router._is_*_router_deployment`** delegates to the classifier (behavior unchanged). Management endpoints merge stored and incoming strategy-router fields and only validate when the write includes **`litellm_params.model`**, so partial patches and fixing already-corrupted rows stay allowed; public **`model_name`** renames are unaffected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e04aee089e2495a2917ab0f7972fffd6959e167. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->