### PR TITLE
feat(ui): add a can-delegate toggle to the agent form for MCP OBO

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/add_agent_form.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/add_agent_form.tsx
@@ -265,14 +265,19 @@ const AddAgentForm: React.FC<AddAgentFormProps> = ({ visible, onClose, accessTok
       const mcpToolPermissions = values.mcp_tool_permissions || {};
       const entitlementModels = values.entitlement_models || [];
       const entitlementAgents = values.entitlement_agents || [];
+      const canDelegate = values.mcp_can_delegate === true;
       const hasObjectPermission =
         mcpServersAndGroups?.servers?.length > 0 ||
         mcpServersAndGroups?.accessGroups?.length > 0 ||
         Object.keys(mcpToolPermissions).length > 0 ||
         entitlementModels.length > 0 ||
-        entitlementAgents.length > 0;
+        entitlementAgents.length > 0 ||
+        canDelegate;
       if (hasObjectPermission) {
         agentData.object_permission = {};
+        if (canDelegate) {
+          agentData.object_permission.mcp_can_delegate = true;
+        }
         if (mcpServersAndGroups?.servers?.length > 0) {
           agentData.object_permission.mcp_servers = mcpServersAndGroups.servers;
         }
@@ -466,6 +471,22 @@ const AddAgentForm: React.FC<AddAgentFormProps> = ({ visible, onClose, accessTok
             />
           </div>
         )}
+      </Form.Item>
+      <Form.Item
+        label={
+          <span>
+            Can act on behalf of users (delegation)
+            <InfoCircleOutlined
+              title="Allow this agent to make MCP tool calls on behalf of a user who has consented. The call is limited to the intersection of the agent's and the user's access."
+              style={{ marginLeft: "4px" }}
+            />
+          </span>
+        }
+        name="mcp_can_delegate"
+        valuePropName="checked"
+        initialValue={false}
+      >
+        <Switch />
       </Form.Item>
     </div>
   );

--- a/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/agent_info.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/agents/_components/agent_info.tsx
@@ -285,11 +285,15 @@ const AgentInfoView: React.FC<AgentInfoViewProps> = ({ agentId, onClose, accessT
             {agent.object_permission &&
               (agent.object_permission.mcp_servers?.length ||
                 agent.object_permission.mcp_access_groups?.length ||
+                agent.object_permission.mcp_can_delegate ||
                 (agent.object_permission.mcp_tool_permissions &&
                   Object.keys(agent.object_permission.mcp_tool_permissions).length > 0)) && (
                 <div style={{ marginTop: 24 }}>
                   <Title>MCP Tool Permissions</Title>
                   <Descriptions bordered column={1} style={{ marginTop: 16 }}>
+                    {agent.object_permission.mcp_can_delegate && (
+                      <Descriptions.Item label="Can act on behalf of users (delegation)">Yes</Descriptions.Item>
+                    )}
                     {agent.object_permission.mcp_servers && agent.object_permission.mcp_servers.length > 0 && (
                       <Descriptions.Item label="MCP Servers">
                         {agent.object_permission.mcp_servers.join(", ")}

--- a/ui/litellm-dashboard/src/components/agents/types.ts
+++ b/ui/litellm-dashboard/src/components/agents/types.ts
@@ -8,6 +8,7 @@ export interface AgentObjectPermission {
   mcp_servers?: string[];
   mcp_access_groups?: string[];
   mcp_tool_permissions?: Record<string, string[]>;
+  mcp_can_delegate?: boolean;
 }
 
 export interface Agent {


### PR DESCRIPTION
## Relevant issues

- MCP agent-OBO delegation needs an agent to carry `mcp_can_delegate` on its object-permission, but there was no way to set it from the dashboard
- Stacks on the delegation core (#33735), which defines `mcp_can_delegate`; base is `litellm_lit4448_obo_delegation`, retarget to staging once it merges

## Linear ticket

Part of LIT-4448

## Pre-Submission checklist

- [ ] I have added meaningful tests (UI-only toggle; verified via the QA runbook, and the persistence goes through the existing, already-tested object-permission path rather than new logic)
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

UI change; run the dashboard and follow the QA runbook below to reproduce. Screenshots to follow.

## Type

🆕 New Feature

## Changes

- New "Can act on behalf of users (delegation)" switch in the Agents create form's MCP section; when on, it writes `object_permission.mcp_can_delegate = true`, which the existing agent-create path (`handle_update_object_permission_common`) already persists, so there is no backend change
- The agent view surfaces the capability when set (a "Can act on behalf of users (delegation): Yes" row alongside the MCP servers/tools it already shows)
- `AgentObjectPermission` gains the optional `mcp_can_delegate` field so the view type-checks

## QA runbook

1. Run the proxy against a database and the dashboard dev server (`npm run dev` in `ui/litellm-dashboard`, on :3000)
2. Go to Agentic > Agents > add an agent; in the MCP Tool Permissions step, turn on "Can act on behalf of users (delegation)" and create the agent
3. Confirm it persisted: `SELECT object_permission_id FROM "LiteLLM_AgentsTable" WHERE ...` then `SELECT mcp_can_delegate FROM "LiteLLM_ObjectPermissionTable" WHERE object_permission_id = '<id>'` should be `true`
4. Open the agent's view; it shows "Can act on behalf of users (delegation): Yes"
5. Negative: create an agent without the toggle; its row has `mcp_can_delegate` false/null and the view omits the delegation row

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
