### PR TITLE
fix(e2e): pin harness Python and surface proxy boot crash output

### DIFF
--- a/ui/litellm-dashboard/e2e_tests/run_e2e.sh
+++ b/ui/litellm-dashboard/e2e_tests/run_e2e.sh
@@ -124,6 +124,7 @@ echo "UI build copied and restructured"
 # --- Python environment ---
 echo "=== Setting up Python environment ==="
 cd "$REPO_ROOT"
+export UV_PYTHON="${UV_PYTHON:-3.13}"
 uv sync --group dev --group proxy-dev --extra proxy --frozen --quiet
 uv run --no-sync python -m prisma generate --schema litellm/proxy/schema.prisma
 
@@ -143,16 +144,18 @@ done
 # --- LiteLLM proxy ---
 echo "=== Starting LiteLLM proxy ==="
 cd "$REPO_ROOT"
+PROXY_LOG="${TMPDIR:-/tmp}/litellm-e2e-proxy-$$.log"
 uv run --no-sync python -m litellm.proxy.proxy_cli \
   --config "$SCRIPT_DIR/fixtures/config.yml" \
-  --port 4000 &
+  --port 4000 >"$PROXY_LOG" 2>&1 &
 PROXY_PID=$!
 
-echo "Waiting for proxy..."
+echo "Waiting for proxy (logs: $PROXY_LOG)..."
 PROXY_READY=0
 for i in $(seq 1 180); do
   if ! kill -0 "$PROXY_PID" 2>/dev/null; then
-    echo "Error: proxy process exited unexpectedly"
+    echo "Error: proxy process exited unexpectedly. Proxy output:"
+    tail -n 100 "$PROXY_LOG"
     exit 1
   fi
   HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:4000/health -H "Authorization: Bearer $LITELLM_MASTER_KEY" 2>/dev/null || true)
@@ -163,7 +166,8 @@ for i in $(seq 1 180); do
   sleep 1
 done
 if [ "$PROXY_READY" -ne 1 ]; then
-  echo "Error: proxy did not become healthy within 180 seconds"
+  echo "Error: proxy did not become healthy within 180 seconds. Proxy output:"
+  tail -n 100 "$PROXY_LOG"
   exit 1
 fi
 echo "Proxy is ready."

--- a/ui/litellm-dashboard/e2e_tests/run_e2e.sh
+++ b/ui/litellm-dashboard/e2e_tests/run_e2e.sh
@@ -26,6 +26,7 @@ IS_CI="${CI:-false}"
 CONTAINER_NAME="litellm-e2e-postgres-$$"
 MOCK_PID=""
 PROXY_PID=""
+PROXY_LOG=""
 
 # --- Ensure common tool paths are available (local dev only) ---
 if [ "$IS_CI" = "false" ]; then
@@ -40,6 +41,7 @@ cleanup() {
   echo "Cleaning up..."
   [ -n "$MOCK_PID" ] && kill "$MOCK_PID" 2>/dev/null || true
   [ -n "$PROXY_PID" ] && kill "$PROXY_PID" 2>/dev/null || true
+  [ -n "$PROXY_LOG" ] && rm -f "$PROXY_LOG" || true
   if [ "$IS_CI" = "false" ]; then
     docker stop "$CONTAINER_NAME" 2>/dev/null || true
   fi


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before (captured at pre-fix commit 1d36290551, on a machine where uv resolves Python 3.14): the exact sync the script runs lands on 3.14 and the locked uvloop cannot be imported, which is what kills the proxy during uvicorn's loop setup

```
$ uv sync --group dev --group proxy-dev --extra proxy --frozen
$ .venv/bin/python --version
Python 3.14.5
$ .venv/bin/python -c "import uvloop"
  File ".venv/lib/python3.14/site-packages/uvloop/__init__.py", line 6, in <module>
    from asyncio.events import BaseDefaultEventLoopPolicy as __BasePolicy
ImportError: cannot import name 'BaseDefaultEventLoopPolicy' from 'asyncio.events' (/Users/ryan/.local/share/uv/python/cpython-3.14.5-macos-aarch64-none/lib/python3.14/asyncio/events.py)
```

Booting the real proxy with the harness's exact command on that 3.14 venv dies after 14 seconds, and the ImportError only shows up if you capture the process output, which the harness previously discarded; it reported a misleading "proxy did not become healthy within 180 seconds" instead

```
$ uv run --no-sync python -m litellm.proxy.proxy_cli --config ui/litellm-dashboard/e2e_tests/fixtures/config.yml --port 4023 > "$PROXY_LOG" 2>&1 &
proxy exited after 14s
$ tail "$PROXY_LOG"
    from asyncio.events import BaseDefaultEventLoopPolicy as __BasePolicy
ImportError: cannot import name 'BaseDefaultEventLoopPolicy' from 'asyncio.events' (...)
```

After (captured at 730e6d5f5b): the pinned sync from the updated script resolves 3.13, uvloop imports, and the proxy CLI runs

```
$ UV_PYTHON=3.13 uv sync --group dev --group proxy-dev --extra proxy --frozen
$ .venv/bin/python --version
Python 3.13.13
$ .venv/bin/python -c "import uvloop; print('uvloop', uvloop.__version__, 'imports OK')"
uvloop 0.21.0 imports OK
$ uv run --no-sync python -m litellm.proxy.proxy_cli --version
LiteLLM: Current Version = 1.94.0
```

The new failure path was exercised with a proxy process that exits at boot; the harness now prints the captured output instead of only the timeout message

```
Waiting for proxy (logs: /var/folders/.../litellm-e2e-proxy-10000.log)...
Error: proxy process exited unexpectedly. Proxy output:
ImportError: cannot import name BaseDefaultEventLoopPolicy from asyncio.events
```

## Type

🐛 Bug Fix

## Changes

`run_e2e.sh` ran `uv sync` without pinning an interpreter, so uv picked whatever Python it resolved on the machine. On hosts where that is 3.14, the locked uvloop 0.21.0 imports `BaseDefaultEventLoopPolicy` from `asyncio.events`, which was removed in 3.14, so the proxy crashes the moment uvicorn sets up its event loop. Because the proxy's output went straight to the console buffer and was never inspected, the harness surfaced this as "proxy did not become healthy within 180 seconds", sending anyone debugging it in the wrong direction

This pins the harness to Python 3.13 via `UV_PYTHON` (still overridable from the environment, so a future lockfile bump to a 3.14-compatible uvloop can be tested with `UV_PYTHON=3.14 ./run_e2e.sh`). It also redirects proxy stdout and stderr to a log file, prints the log path while waiting, and tails the last 100 lines whenever the proxy exits early or fails to become healthy, so the real crash reason is visible in the harness output. The log file is removed in the cleanup trap on every exit path, so repeated runs do not accumulate log files in the temp directory; on failure the tail has already been printed to the console before cleanup runs

