### PR TITLE
fix(e2e): drop httpbin.org from passthrough headers test, use real Anthropic

### DIFF
--- a/tests/e2e/llm_translation/test_passthrough_headers_e2e.py
+++ b/tests/e2e/llm_translation/test_passthrough_headers_e2e.py
@@ -1,29 +1,32 @@
 """Live e2e: custom pass-through endpoints inject configured headers and honor
 x-pass-* client headers (prefix stripped) on the way to the upstream.
 
-The upstream is a real public echo service (httpbin.org/anything). Creating the
-route via POST /config/pass_through_endpoint, calling it with a virtual key, and
-asserting the echo body is the product path operators use; a mock would not
-prove the proxy actually rewrote the outbound request.
+The upstream is the real Anthropic Messages API rather than an echo service:
+Anthropic doesn't echo request headers back, but it does gate real behavior on
+two of them, which is enough to prove forwarding without a mock. A static
+x-api-key configured on the pass-through endpoint (the caller never supplies
+one) must reach upstream, or every call 401s; an invalid x-pass-anthropic-version
+sent by the caller must reach upstream with the prefix stripped, and Anthropic
+echoes the exact value back in its 400 body, so a unique-per-run marker proves
+this specific request's header - not a stale or cached one - got there.
 """
 
 from __future__ import annotations
 
 import pytest
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field
 
 from e2e_config import unique_marker
-from e2e_http import AuthHeaders, NoBody, StreamingResponse, require_successful_call, unwrap
+from e2e_http import AuthHeaders, NoBody, require_successful_call, unwrap
+from endpoints_client import MessagesResult
 from lifecycle import ResourceManager
-from models import KeyGenerateBody
+from models import ChatMessage, KeyGenerateBody
 from passthrough_client import PassthroughClient
 
 pytestmark = pytest.mark.e2e
 
-ECHO_TARGET = "https://httpbin.org/anything"
-STATIC_HEADER_NAME = "x-e2e-static-header"
-PASS_HEADER_STEM = "e2e-client-marker"
-PASS_HEADER_NAME = f"x-pass-{PASS_HEADER_STEM}"
+ANTHROPIC_MESSAGES_TARGET = "https://api.anthropic.com/v1/messages"
+MODEL = "claude-haiku-4-5-20251001"
 
 
 class PassThroughCreateBody(BaseModel):
@@ -48,30 +51,26 @@ class PassThroughDeleteParams(BaseModel):
     endpoint_id: str
 
 
-class EchoCallHeaders(AuthHeaders):
+class AnthropicPassThroughHeaders(AuthHeaders):
     content_type: str = Field(default="application/json", serialization_alias="Content-Type")
-    x_pass_e2e_client_marker: str = Field(serialization_alias="x-pass-e2e-client-marker")
+    x_pass_anthropic_version: str = Field(serialization_alias="x-pass-anthropic-version")
 
 
-class EchoBody(BaseModel):
-    ping: str
+class AnthropicMessagesBody(BaseModel):
+    model: str
+    max_tokens: int = 8
+    messages: list[ChatMessage]
 
 
-class EchoResponse(BaseModel):
-    headers: dict[str, str]
-
-
-def _create_passthrough(
-    client: PassthroughClient, *, path: str, static_value: str
-) -> PassThroughEndpoint:
+def _create_passthrough(client: PassthroughClient, *, path: str) -> PassThroughEndpoint:
     created = unwrap(
         client.proxy.transport.post(
             "/config/pass_through_endpoint",
             headers=client.proxy.transport.master,
             json=PassThroughCreateBody(
                 path=path,
-                target=ECHO_TARGET,
-                headers={STATIC_HEADER_NAME: static_value},
+                target=ANTHROPIC_MESSAGES_TARGET,
+                headers={"x-api-key": "os.environ/ANTHROPIC_API_KEY"},
             ),
             response_type=PassThroughCreateResponse,
         )
@@ -92,12 +91,8 @@ def _delete_passthrough(client: PassthroughClient, endpoint_id: str) -> None:
     )
 
 
-def _echo_headers(resp: StreamingResponse) -> dict[str, str]:
-    try:
-        echo = EchoResponse.model_validate_json(resp.body)
-    except ValidationError as exc:
-        pytest.fail(f"echo upstream did not return a headers map: {exc}; body={resp.body[:300]}")
-    return {k.lower(): v for k, v in echo.headers.items()}
+def _messages_body() -> AnthropicMessagesBody:
+    return AnthropicMessagesBody(model=MODEL, messages=[ChatMessage(role="user", content="Say hi.")])
 
 
 class TestPassthroughHeaders:
@@ -110,10 +105,8 @@ class TestPassthroughHeaders:
     ) -> None:
         marker = unique_marker()
         path = f"/e2e-passthrough-headers-{marker}"
-        static_value = f"static-{marker}"
-        client_value = f"client-{marker}"
 
-        endpoint = _create_passthrough(client, path=path, static_value=static_value)
+        endpoint = _create_passthrough(client, path=path)
         assert endpoint.id is not None
         resources.defer(lambda: _delete_passthrough(client, endpoint.id or ""))
 
@@ -128,23 +121,32 @@ class TestPassthroughHeaders:
 
         result = client.proxy.transport.send(
             path,
-            headers=EchoCallHeaders(
+            headers=AnthropicPassThroughHeaders(
                 authorization=f"Bearer {key}",
-                x_pass_e2e_client_marker=client_value,
+                x_pass_anthropic_version="2023-06-01",
             ),
-            json=EchoBody(ping=marker),
+            json=_messages_body(),
         )
         require_successful_call(result)
+        completion = MessagesResult.model_validate_json(result.body)
+        assert completion.text.strip(), (
+            f"static x-api-key must reach Anthropic for the call to succeed at all; got {result.body[:300]}"
+        )
 
-        upstream = _echo_headers(result)
-        assert upstream.get(STATIC_HEADER_NAME) == static_value, (
-            f"configured pass-through header {STATIC_HEADER_NAME!r} not on upstream "
-            f"request; got {upstream}"
+        invalid_version = f"e2e-passhdr-{unique_marker()}"
+        blocked = client.proxy.transport.send(
+            path,
+            headers=AnthropicPassThroughHeaders(
+                authorization=f"Bearer {key}",
+                x_pass_anthropic_version=invalid_version,
+            ),
+            json=_messages_body(),
         )
-        assert upstream.get(PASS_HEADER_STEM) == client_value, (
-            f"x-pass-* header should strip the prefix and forward as {PASS_HEADER_STEM!r}; "
-            f"got {upstream}"
+        assert blocked.status_code == 400, (
+            f"expected Anthropic to reject the invalid anthropic-version, got "
+            f"{blocked.status_code}: {blocked.body[:300]}"
         )
-        assert PASS_HEADER_NAME not in upstream, (
-            "upstream must not see the x-pass- prefix; proxy should strip it"
+        assert invalid_version in blocked.body, (
+            f"x-pass-anthropic-version must reach upstream with the prefix stripped; "
+            f"marker missing from Anthropic's error body: {blocked.body[:300]}"
         )


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Verified live against a proxy running from this branch's commit (`15d8c6a938`) and the real Anthropic API, no mocks

Create the pass-through endpoint pointed at the real Anthropic Messages API with a static `x-api-key` the caller never sees:

```bash
curl -s -X POST http://localhost:4000/config/pass_through_endpoint \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"path":"/e2e-passthrough-headers-test","target":"https://api.anthropic.com/v1/messages","headers":{"x-api-key":"os.environ/ANTHROPIC_API_KEY"}}'
# {"endpoints":[{"id":"ca49833f-5d4d-43d0-a079-683f6d390ced","path":"/e2e-passthrough-headers-test","target":"https://api.anthropic.com/v1/messages", ...}]}
```

Generate a scoped key, then call the route with a valid `x-pass-anthropic-version` and no client-supplied `x-api-key` at all - success proves the static header reached upstream:

```bash
curl -s -X POST http://localhost:4000/v1/messages... # via the custom path, key omitted for brevity
-H "x-pass-anthropic-version: 2023-06-01" -d '{"model":"claude-haiku-4-5-20251001","max_tokens":8,"messages":[{"role":"user","content":"Say hi."}]}'
# HTTP 200
# {"model":"claude-haiku-4-5-20251001","id":"msg_011CdFtui9dg1r6tkFjeG6KQ","type":"message","role":"assistant","content":[{"type":"text","text":"Hi! 👋 How can"}], ...}
```

Same call with a deliberately invalid `x-pass-anthropic-version` marker - Anthropic's 400 body echoes the exact marker verbatim, proving the `x-pass-` prefix was stripped and the caller's own header (not a cached or default one) reached upstream:

```bash
curl -s -X POST http://localhost:4000/v1/messages... \
-H "x-pass-anthropic-version: e2e-passhdr-d5923e3aef45" -d '{"model":"claude-haiku-4-5-20251001","max_tokens":8,"messages":[{"role":"user","content":"Say hi."}]}'
# HTTP 400
# {"type":"error","error":{"type":"invalid_request_error","message":"anthropic-version: \"e2e-passhdr-d5923e3aef45\" is not a valid version"},"request_id":"req_011CdFtunDTE9MFSKJq9W16d"}
```

## Type

🐛 Bug Fix
✅ Test

## Changes

The stage e2e failure was `httpbin.org` (an external echo service the test used as the pass-through target) returning a transient 503, unrelated to any litellm bug. Beyond the flakiness, the test also never exercised a real LLM provider

This swaps the target to the real Anthropic Messages API. Anthropic doesn't echo request headers back the way httpbin did, so the assertions had to change shape: a static `x-api-key` configured on the pass-through endpoint (the caller never supplies one) must reach upstream or the call 401s, and Anthropic's error body for an invalid `anthropic-version` echoes the exact value sent, which lets a unique-per-run marker sent via `x-pass-anthropic-version` prove the `x-pass-` stripping-and-forwarding mechanism attributably, without needing an echo service at all

## QA runbook

- tests/e2e/llm_translation/test_passthrough_headers_e2e.py::TestPassthroughHeaders::test_static_and_x_pass_headers_reach_upstream - a custom pass-through endpoint's static header reaches the real Anthropic API, and a client's `x-pass-*` header is forwarded with the prefix stripped
  - [x] Create a pass-through endpoint: `curl -X POST http://localhost:4000/config/pass_through_endpoint -H "Authorization: Bearer sk-1234" -d '{"path":"/anthropic-passthrough-demo","target":"https://api.anthropic.com/v1/messages","headers":{"x-api-key":"os.environ/ANTHROPIC_API_KEY"}}'`
  - [x] Generate a key scoped to that route: `curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"models":[],"allowed_passthrough_routes":["/anthropic-passthrough-demo"]}'`
  - [x] Call the route with the key and `x-pass-anthropic-version: 2023-06-01`, plus a minimal Anthropic Messages body - expect a 200 with real assistant content
  - [x] Call it again with `x-pass-anthropic-version: some-garbage-value` - expect a 400 whose body contains the exact string `some-garbage-value`
  - [x] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR