### PR TITLE
fix(bedrock): pass through Qwen reasoning effort

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -410,16 +410,22 @@ class AmazonConverseConfig(BaseConfig):
         """
         Handle the reasoning_effort parameter based on the model type.
 
-        - GPT-OSS models: passed through unchanged via additionalModelRequestFields.
+        - Non-Anthropic reasoning models: passed through unchanged via additionalModelRequestFields.
         - Nova 2 models: transformed to reasoningConfig.
         - Anthropic models: mapped to ``thinking`` (and ``output_config.effort`` on
           adaptive Claude 4.6 / 4.7).
         """
+        base_model = BedrockModelInfo.get_base_model(model)
         if "gpt-oss" in model:
             optional_params["reasoning_effort"] = reasoning_effort
         elif self._is_nova_2_model(model):
             reasoning_config = self._transform_reasoning_effort_to_reasoning_config(reasoning_effort)
             optional_params.update(reasoning_config)
+        elif not base_model.startswith("anthropic") and (
+            supports_reasoning(model=model, custom_llm_provider=self.custom_llm_provider)
+            or supports_reasoning(model=base_model, custom_llm_provider=self.custom_llm_provider)
+        ):
+            optional_params["reasoning_effort"] = reasoning_effort
         else:
             mapped_thinking = AnthropicConfig._map_reasoning_effort(
                 reasoning_effort=reasoning_effort,
@@ -942,9 +948,7 @@ class AmazonConverseConfig(BaseConfig):
                         optional_params=optional_params, tools=[grounding_tool]
                     )
 
-        # Only update thinking tokens for non-GPT-OSS models and non-Nova-Lite-2 models
-        # Nova 2 handles token budgeting differently through reasoningConfig
-        if "gpt-oss" not in model and not self._is_nova_2_model(model):
+        if "thinking" in optional_params:
             self.update_optional_params_with_thinking_tokens(
                 non_default_params=non_default_params, optional_params=optional_params
             )

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -311,6 +311,34 @@ def test_reasoning_effort_none_omits_thinking_for_anthropic_converse(model):
 
 
 @pytest.mark.parametrize(
+    "model",
+    [
+        "bedrock/qwen.qwen3-32b-v1:0",
+        "bedrock/converse/qwen.qwen3-32b-v1:0",
+    ],
+)
+def test_reasoning_effort_passes_through_for_qwen3_converse(model):
+    config = AmazonConverseConfig()
+
+    optional_params = config.map_openai_params(
+        non_default_params={"reasoning_effort": "high"},
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+    result = config._transform_request(
+        model=model,
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert result["additionalModelRequestFields"]["reasoning_effort"] == "high"
+    assert "thinking" not in result["additionalModelRequestFields"]
+
+
+@pytest.mark.parametrize(
     "model,effort,expected_effort",
     [
         ("bedrock/converse/us.anthropic.claude-opus-4-7", "low", "low"),


### PR DESCRIPTION
## Relevant issues

Fixes #34105

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Live verification was run against `qwen.qwen3-32b-v1:0` in Bedrock `eu-central-1` on 2026-07-21 at 22:34 UTC. Credentials are omitted. All three calls used this prompt and `reasoning_effort="high"`:

```text
23 * 47 - 128 / 4, show your work
```

The direct control used `boto3.client("bedrock-runtime").converse(..., additionalModelRequestFields={"reasoning_effort": "high"})`. The before/after runs used:

```python
litellm.completion(
    model="bedrock/converse/qwen.qwen3-32b-v1:0",
    messages=[{"role": "user", "content": prompt}],
    reasoning_effort="high",
    aws_region_name="eu-central-1",
    max_tokens=512,
)
```

| Run | Commit | Call | Reasoning result |
|---|---|---:|---|
| Direct boto3 control | n/a | succeeded | `reasoningContent` present, 1,384 characters |
| LiteLLM before fix | `f9300d43120d446bf534a96a1c05868f86855bad` | succeeded | `reasoning_content` absent; 0 reasoning tokens |
| LiteLLM after fix | `225a639f698c1bf209b83cb319344c8309d183b4` | succeeded | `reasoning_content` present, 1,409 characters; 432 reasoning tokens |

This reproduces the silent drop on the parent commit and shows the same LiteLLM request returning Bedrock reasoning content on the PR head.

## Type

Bug Fix

## Changes

Bedrock Converse treated every reasoning model outside GPT-OSS and Nova 2 as Anthropic, so Qwen3 `reasoning_effort` became an Anthropic `thinking` block instead of reaching `additionalModelRequestFields`

This change keeps Anthropic and Nova mappings intact while passing native reasoning controls through for non-Anthropic models that advertise reasoning support. The token-budget adjustment now runs only when an Anthropic-style `thinking` block is actually present

The regression test covers both `bedrock/` and `bedrock/converse/` Qwen3 routing prefixes and verifies that the final Bedrock request contains `reasoning_effort` without an Anthropic `thinking` block

## Validation

`make pre-commit` passed, including formatting, Ruff, import safety, strict-rule budgets and basedpyright gates

The full Bedrock Converse transformation file passed with 164 tests. Nova 2 passed with 51 tests, and the GPT-OSS reasoning transformation tests passed with both model variants

The repository-wide unit run reached 5,797 passed and 40 skipped before stopping on an unrelated A2A proxy-base-url assertion caused by the local custom proxy path

GitHub CI is green apart from OSV scanning the unchanged upstream `uv.lock`; that check reports GitPython 3.1.50 while the advisory database now requires 3.1.51. This PR does not modify dependency or lock files

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
