### PR TITLE
refactor(ui): migrate MCP, callback, guardrail, SSO, and search tool logos to the shared Logo component

### DIFF
--- a/ui/litellm-dashboard/public/assets/logos/promptguard.svg
+++ b/ui/litellm-dashboard/public/assets/logos/promptguard.svg
@@ -1,5 +1,5 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100%" viewBox="0 0 1024 1024" enable-background="new 0 0 1024 1024" xml:space="preserve">
+	 viewBox="0 0 1024 1024" enable-background="new 0 0 1024 1024" xml:space="preserve">
 <path fill="#000000" opacity="1.000000" stroke="none"
 	d="
 M793.182983,619.000000

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/add_guardrail_form.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/add_guardrail_form.test.tsx
@@ -41,3 +41,17 @@ describe("AddGuardrailForm close behavior", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("AddGuardrailForm provider options", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders provider options with logos from the bundled guardrail logo map", async () => {
+    renderForm();
+    fireEvent.mouseDown(screen.getByLabelText("Guardrail Provider"));
+
+    const logo = await screen.findByAltText("Presidio PII logo");
+    expect(logo.getAttribute("src")).toContain("microsoft_azure.svg");
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/add_guardrail_form.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/add_guardrail_form.tsx
@@ -12,10 +12,10 @@ import { type CompetitorIntentConfig } from "./content_filter/CompetitorIntentCo
 import {
   choiceToSkipSystemForCreate,
   choiceToSkipToolForCreate,
+  getGuardrailLogo,
   getGuardrailProviders,
   getSupportedModesForProvider,
   guardrail_provider_map,
-  guardrailLogoMap,
   populateGuardrailProviderMap,
   populateGuardrailProviders,
   shouldRenderContentFilterConfigSettings,
@@ -23,7 +23,7 @@ import {
   shouldRenderPIIConfigSettings,
   toModeArray,
 } from "./guardrail_info_helpers";
-import { resolveLogoSrc } from "@/lib/assetPaths";
+import { Logo } from "@/components/molecules/logo/Logo";
 import GuardrailOptionalParams from "./guardrail_optional_params";
 import GuardrailProviderFields from "./guardrail_provider_fields";
 import LLMJudgeFields from "./llm_judge/LLMJudgeFields";
@@ -725,53 +725,19 @@ const AddGuardrailForm: React.FC<AddGuardrailFormProps> = ({ visible, onClose, a
             dropdownRender={(menu) => menu}
             showSearch={true}
           >
-            {Object.entries(getGuardrailProviders()).map(([key, value]) => (
-              <Option
-                key={key}
-                value={key}
-                label={
-                  <div style={{ display: "flex", alignItems: "center" }}>
-                    {guardrailLogoMap[value] && (
-                      <img
-                        src={resolveLogoSrc(guardrailLogoMap[value])}
-                        alt=""
-                        style={{
-                          height: "20px",
-                          width: "20px",
-                          marginRight: "8px",
-                          objectFit: "contain",
-                        }}
-                        onError={(e) => {
-                          // Hide broken image icon if image fails to load
-                          e.currentTarget.style.display = "none";
-                        }}
-                      />
-                    )}
-                    <span>{value}</span>
-                  </div>
-                }
-              >
+            {Object.entries(getGuardrailProviders()).map(([key, value]) => {
+              const optionContent = (
                 <div style={{ display: "flex", alignItems: "center" }}>
-                  {guardrailLogoMap[value] && (
-                    <img
-                      src={resolveLogoSrc(guardrailLogoMap[value])}
-                      alt=""
-                      style={{
-                        height: "20px",
-                        width: "20px",
-                        marginRight: "8px",
-                        objectFit: "contain",
-                      }}
-                      onError={(e) => {
-                        // Hide broken image icon if image fails to load
-                        e.currentTarget.style.display = "none";
-                      }}
-                    />
-                  )}
+                  <Logo src={getGuardrailLogo(value)} label={value} className="h-5 w-5 mr-2 object-contain shrink-0" />
                   <span>{value}</span>
                 </div>
-              </Option>
-            ))}
+              );
+              return (
+                <Option key={key} value={key} label={optionContent}>
+                  {optionContent}
+                </Option>
+              );
+            })}
           </Select>
         </Form.Item>
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrailTableColumns.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrailTableColumns.tsx
@@ -16,6 +16,7 @@ import {
 import { cn } from "@/lib/cva.config";
 
 import { getGuardrailLogoAndName } from "./guardrail_info_helpers";
+import { Logo } from "@/components/molecules/logo/Logo";
 
 const CONFIG_DELETE_HINT = "Config guardrails are defined in the config file and cannot be deleted from the dashboard.";
 
@@ -23,16 +24,7 @@ function GuardrailProviderCell({ provider }: { provider: string }) {
   const { logo, displayName } = getGuardrailLogoAndName(provider);
   return (
     <div className="flex items-center gap-2">
-      {logo ? (
-        <img
-          src={logo}
-          alt=""
-          className="size-4 shrink-0"
-          onError={(event) => {
-            (event.currentTarget as HTMLImageElement).style.display = "none";
-          }}
-        />
-      ) : null}
+      <Logo src={logo} label={displayName} className="size-4 shrink-0" />
       <span className="truncate text-sm">{displayName}</span>
     </div>
   );

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_garden_card.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_garden_card.test.tsx
@@ -53,15 +53,28 @@ describe("GuardrailCard", () => {
     expect(screen.queryByText(/F1:/)).not.toBeInTheDocument();
   });
 
+  it("should render the logo through the shared Logo component with the card src", () => {
+    render(<GuardrailCard card={baseCard} onClick={vi.fn()} />);
+    const img = screen.getByAltText("Test Guardrail logo");
+    expect(img.getAttribute("src")).toContain("/logos/test.svg");
+  });
+
+  it("should pass a bundled static-import src through unchanged", () => {
+    const bundledCard: GuardrailCardInfo = { ...baseCard, logo: "/_next/static/media/akto.svg" };
+    render(<GuardrailCard card={bundledCard} onClick={vi.fn()} />);
+    expect(screen.getByAltText("Test Guardrail logo")).toHaveAttribute("src", "/_next/static/media/akto.svg");
+  });
+
   it("should show fallback initial when logo fails to load", () => {
     render(<GuardrailCard card={baseCard} onClick={vi.fn()} />);
-    const img = screen.getByRole("presentation");
+    const img = screen.getByAltText("Test Guardrail logo");
 
     act(() => {
       fireEvent.error(img);
     });
 
     expect(screen.getByText("T")).toBeInTheDocument();
+    expect(screen.queryByAltText("Test Guardrail logo")).not.toBeInTheDocument();
   });
 
   it("should show fallback initial when logo src is empty", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_garden_card.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_garden_card.tsx
@@ -1,42 +1,7 @@
 import React, { useState } from "react";
 import { CheckCircleFilled } from "@ant-design/icons";
 import { GuardrailCardInfo } from "./guardrail_garden_data";
-import { resolveLogoSrc } from "@/lib/assetPaths";
-
-const LogoWithFallback: React.FC<{ src: string; name: string }> = ({ src, name }) => {
-  const [hasError, setHasError] = useState(false);
-
-  if (hasError || !src) {
-    return (
-      <div
-        style={{
-          width: 28,
-          height: 28,
-          borderRadius: 6,
-          backgroundColor: "#e5e7eb",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          fontSize: 13,
-          fontWeight: 600,
-          color: "#6b7280",
-          flexShrink: 0,
-        }}
-      >
-        {name?.charAt(0) || "?"}
-      </div>
-    );
-  }
-
-  return (
-    <img
-      src={resolveLogoSrc(src)}
-      alt=""
-      style={{ width: 28, height: 28, borderRadius: 6, objectFit: "contain", flexShrink: 0 }}
-      onError={() => setHasError(true)}
-    />
-  );
-};
+import { Logo } from "@/components/molecules/logo/Logo";
 
 const GuardrailCard: React.FC<{ card: GuardrailCardInfo; onClick: () => void }> = ({ card, onClick }) => {
   const [hovered, setHovered] = useState(false);
@@ -61,7 +26,7 @@ const GuardrailCard: React.FC<{ card: GuardrailCardInfo; onClick: () => void }> 
     >
       {/* Icon + Name row */}
       <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 10 }}>
-        <LogoWithFallback src={card.logo} name={card.name} />
+        <Logo src={card.logo} label={card.name} className="w-7 h-7 rounded-md object-contain shrink-0" />
         <span style={{ fontSize: 14, fontWeight: 600, color: "#111827", lineHeight: 1.3 }}>{card.name}</span>
       </div>
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_garden_data.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_garden_data.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { ALL_CARDS, LITELLM_CONTENT_FILTER_CARDS, PARTNER_GUARDRAIL_CARDS } from "./guardrail_garden_data";
+
+const EXPECTED_PARTNER_LOGO_FILES: Record<string, string> = {
+  presidio: "microsoft_azure.svg",
+  bedrock: "bedrock.svg",
+  lakera: "lakeraai.jpeg",
+  openai_moderation: "openai_small.svg",
+  google_model_armor: "google.svg",
+  guardrails_ai: "guardrails_ai.jpeg",
+  zscaler: "zscaler.svg",
+  panw: "palo_alto_networks.jpeg",
+  cisco_ai_defense: "cisco.png",
+  noma: "noma_security.png",
+  aporia: "aporia.png",
+  aim: "aim_security.jpeg",
+  cato_networks: "cato_networks.svg",
+  prompt_security: "prompt_security.png",
+  lasso: "lasso.png",
+  pangea: "pangea.png",
+  enkryptai: "enkrypt_ai.avif",
+  javelin: "javelin.png",
+  pillar: "pillar.jpeg",
+  akto: "akto.svg",
+  promptguard: "promptguard.svg",
+  xecguard: "xecguard.svg",
+  deepkeep: "deepkeep.svg",
+  repelloai: "repelloai.png",
+  straiker: "straiker.svg",
+};
+
+describe("guardrail_garden_data logos", () => {
+  it("points every partner card at its own provider's bundled logo file", () => {
+    expect(new Set(PARTNER_GUARDRAIL_CARDS.map((card) => card.id))).toEqual(
+      new Set(Object.keys(EXPECTED_PARTNER_LOGO_FILES)),
+    );
+    for (const card of PARTNER_GUARDRAIL_CARDS) {
+      expect(card.logo, `card ${card.id}`).toContain(EXPECTED_PARTNER_LOGO_FILES[card.id]);
+    }
+  });
+
+  it("uses the LiteLLM logo for every content filter card", () => {
+    for (const card of LITELLM_CONTENT_FILTER_CARDS) {
+      expect(card.logo, `card ${card.id}`).toContain("litellm_logo.jpg");
+    }
+  });
+
+  it("bundles every card logo instead of referencing runtime /ui asset paths", () => {
+    for (const card of ALL_CARDS) {
+      expect(card.logo, `card ${card.id}`).not.toBe("");
+      expect(card.logo, `card ${card.id}`).not.toContain("/ui/assets/logos/");
+    }
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_garden_data.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_garden_data.ts
@@ -1,3 +1,5 @@
+import { guardrailLogoMap } from "./guardrail_info_helpers";
+
 export interface GuardrailCardInfo {
   id: string;
   name: string;
@@ -16,7 +18,7 @@ export interface GuardrailCardInfo {
   providerKey?: string;
 }
 
-const ASSET_PREFIX = "/ui/assets/logos/";
+const litellmContentFilterLogo = guardrailLogoMap["LiteLLM Content Filter"];
 
 export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
   {
@@ -26,7 +28,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
       "Detects requests for personalized financial advice, investment recommendations, or financial planning.",
     category: "litellm",
     subcategory: "Content Category",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["Content Category", "Topic Blocker"],
     eval: {
       f1: 100.0,
@@ -42,7 +44,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
     description: "Detects insults, name-calling, and personal attacks directed at the chatbot, staff, or other people.",
     category: "litellm",
     subcategory: "Content Category",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["Content Category", "Topic Blocker"],
     eval: {
       f1: 100.0,
@@ -58,7 +60,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
     description: "Detects requests for unauthorized legal advice, case analysis, or legal recommendations.",
     category: "litellm",
     subcategory: "Content Category",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["Content Category", "Topic Blocker"],
   },
   {
@@ -67,7 +69,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
     description: "Detects requests for medical diagnosis, treatment recommendations, or health advice.",
     category: "litellm",
     subcategory: "Content Category",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["Content Category", "Topic Blocker"],
   },
   {
@@ -76,7 +78,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
     description: "Detects content related to violence, criminal planning, attacks, and violent threats.",
     category: "litellm",
     subcategory: "Content Category",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["Content Category", "Safety"],
   },
   {
@@ -85,7 +87,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
     description: "Detects content related to self-harm, suicide, and dangerous self-destructive behavior.",
     category: "litellm",
     subcategory: "Content Category",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["Content Category", "Safety"],
   },
   {
@@ -94,7 +96,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
     description: "Detects content that could endanger child safety or exploit minors.",
     category: "litellm",
     subcategory: "Content Category",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["Content Category", "Safety"],
   },
   {
@@ -103,7 +105,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
     description: "Detects content related to illegal weapons manufacturing, distribution, or acquisition.",
     category: "litellm",
     subcategory: "Content Category",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["Content Category", "Safety"],
   },
   {
@@ -112,7 +114,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
     description: "Detects gender-based discrimination, stereotypes, and biased language.",
     category: "litellm",
     subcategory: "Content Category",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["Content Category", "Bias"],
   },
   {
@@ -121,7 +123,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
     description: "Detects racial discrimination, stereotypes, and racially biased content.",
     category: "litellm",
     subcategory: "Content Category",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["Content Category", "Bias"],
   },
   {
@@ -130,7 +132,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
     description: "Detects religious discrimination, intolerance, and religiously biased content.",
     category: "litellm",
     subcategory: "Content Category",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["Content Category", "Bias"],
   },
   {
@@ -139,7 +141,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
     description: "Detects discrimination based on sexual orientation and related biased content.",
     category: "litellm",
     subcategory: "Content Category",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["Content Category", "Bias"],
   },
   {
@@ -148,7 +150,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
     description: "Detects jailbreak attempts designed to bypass AI safety guidelines and restrictions.",
     category: "litellm",
     subcategory: "Content Category",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["Content Category", "Prompt Injection"],
   },
   {
@@ -157,7 +159,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
     description: "Detects attempts to extract sensitive data through prompt manipulation.",
     category: "litellm",
     subcategory: "Content Category",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["Content Category", "Prompt Injection"],
   },
   {
@@ -166,7 +168,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
     description: "Detects SQL injection attempts embedded in prompts.",
     category: "litellm",
     subcategory: "Content Category",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["Content Category", "Prompt Injection"],
   },
   {
@@ -175,7 +177,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
     description: "Detects attempts to inject malicious code through prompts.",
     category: "litellm",
     subcategory: "Content Category",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["Content Category", "Prompt Injection"],
   },
   {
@@ -184,7 +186,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
     description: "Detects attempts to extract or override system prompts.",
     category: "litellm",
     subcategory: "Content Category",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["Content Category", "Prompt Injection"],
   },
   {
@@ -193,7 +195,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
     description: "Detects toxic, abusive, and hateful language across multiple languages (EN, AU, DE, ES, FR).",
     category: "litellm",
     subcategory: "Content Category",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["Content Category", "Toxicity"],
   },
   {
@@ -203,7 +205,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
       "Detect and block sensitive data patterns like SSNs, credit card numbers, API keys, and custom regex patterns.",
     category: "litellm",
     subcategory: "Patterns",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["PII", "Regex", "Data Protection"],
   },
   {
@@ -213,7 +215,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
       "Block or mask content containing specific keywords or phrases. Upload custom word lists or add individual terms.",
     category: "litellm",
     subcategory: "Keywords",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["Keywords", "Blocklist"],
   },
   {
@@ -223,7 +225,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
       "Detects markdown fenced code blocks in requests and responses. Block or mask executable code (e.g. Python, JavaScript, Bash) by language with configurable confidence.",
     category: "litellm",
     subcategory: "Code Safety",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["Code", "Safety", "Prompt Injection"],
   },
   {
@@ -233,7 +235,7 @@ export const LITELLM_CONTENT_FILTER_CARDS: GuardrailCardInfo[] = [
       "Block or reframe competitor comparison and ranking intent. Detect when users ask to compare or recommend competitors (airline or generic competitor lists).",
     category: "litellm",
     subcategory: "Content Category",
-    logo: `${ASSET_PREFIX}litellm_logo.jpg`,
+    logo: litellmContentFilterLogo,
     tags: ["Content Category", "Competitor", "Topic Blocker"],
   },
 ];
@@ -245,7 +247,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     description:
       "Microsoft Presidio for PII detection and anonymization. Supports 30+ entity types with configurable actions.",
     category: "partner",
-    logo: `${ASSET_PREFIX}microsoft_azure.svg`,
+    logo: guardrailLogoMap["Presidio PII"],
     tags: ["PII", "Microsoft"],
     providerKey: "PresidioPII",
   },
@@ -254,7 +256,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     name: "Bedrock Guardrail",
     description: "AWS Bedrock Guardrails for content filtering, topic avoidance, and sensitive information detection.",
     category: "partner",
-    logo: `${ASSET_PREFIX}bedrock.svg`,
+    logo: guardrailLogoMap["Bedrock Guardrail"],
     tags: ["AWS", "Content Safety"],
     providerKey: "Bedrock",
   },
@@ -263,7 +265,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     name: "Lakera",
     description: "AI security platform protecting against prompt injections, data leakage, and harmful content.",
     category: "partner",
-    logo: `${ASSET_PREFIX}lakeraai.jpeg`,
+    logo: guardrailLogoMap["Lakera"],
     tags: ["Security", "Prompt Injection"],
     providerKey: "Lakera",
   },
@@ -272,7 +274,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     name: "OpenAI Moderation",
     description: "OpenAI's content moderation API for detecting harmful content across multiple categories.",
     category: "partner",
-    logo: `${ASSET_PREFIX}openai_small.svg`,
+    logo: guardrailLogoMap["OpenAI Moderation"],
     tags: ["Content Moderation", "OpenAI"],
   },
   {
@@ -280,7 +282,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     name: "Google Cloud Model Armor",
     description: "Google Cloud's model protection service for safe and responsible AI deployments.",
     category: "partner",
-    logo: `${ASSET_PREFIX}google.svg`,
+    logo: guardrailLogoMap["Google Cloud Model Armor"],
     tags: ["Google Cloud", "Safety"],
   },
   {
@@ -288,7 +290,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     name: "Guardrails AI",
     description: "Open-source framework for adding structural, type, and quality guarantees to LLM outputs.",
     category: "partner",
-    logo: `${ASSET_PREFIX}guardrails_ai.jpeg`,
+    logo: guardrailLogoMap["Guardrails AI"],
     tags: ["Open Source", "Validation"],
   },
   {
@@ -296,7 +298,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     name: "Zscaler AI Guard",
     description: "Enterprise AI security from Zscaler for monitoring and protecting AI/ML workloads.",
     category: "partner",
-    logo: `${ASSET_PREFIX}zscaler.svg`,
+    logo: guardrailLogoMap["Zscaler AI Guard"],
     tags: ["Enterprise", "Security"],
   },
   {
@@ -304,7 +306,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     name: "PANW Prisma AIRS",
     description: "Palo Alto Networks Prisma AI Runtime Security for securing AI applications in production.",
     category: "partner",
-    logo: `${ASSET_PREFIX}palo_alto_networks.jpeg`,
+    logo: guardrailLogoMap["PANW Prisma AIRS"],
     tags: ["Enterprise", "Security"],
   },
   {
@@ -313,7 +315,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     description:
       "Cisco AI Defense Inspection API for runtime protection: prompt injection, PII/PCI/PHI, harassment, hate speech, profanity, violence, and code detection.",
     category: "partner",
-    logo: `${ASSET_PREFIX}cisco.png`,
+    logo: guardrailLogoMap["Cisco AI Defense"],
     tags: ["Enterprise", "Security", "Prompt Injection", "PII"],
     providerKey: "CiscoAiDefense",
   },
@@ -322,7 +324,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     name: "Noma Security",
     description: "AI security platform for detecting and preventing AI-specific threats and vulnerabilities.",
     category: "partner",
-    logo: `${ASSET_PREFIX}noma_security.png`,
+    logo: guardrailLogoMap["Noma Security"],
     tags: ["Security", "Threat Detection"],
   },
   {
@@ -330,7 +332,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     name: "Aporia AI",
     description: "Real-time AI guardrails for hallucination detection, topic control, and policy enforcement.",
     category: "partner",
-    logo: `${ASSET_PREFIX}aporia.png`,
+    logo: guardrailLogoMap["Aporia AI"],
     tags: ["Hallucination", "Policy"],
   },
   {
@@ -338,7 +340,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     name: "AIM Guardrail",
     description: "AIM Security guardrails for comprehensive AI threat detection and mitigation.",
     category: "partner",
-    logo: `${ASSET_PREFIX}aim_security.jpeg`,
+    logo: guardrailLogoMap["AIM Guardrail"],
     tags: ["Security", "Threat Detection"],
   },
   {
@@ -346,7 +348,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     name: "Cato Networks Guardrail",
     description: "Cato Networks guardrails for comprehensive AI threat detection and mitigation.",
     category: "partner",
-    logo: `${ASSET_PREFIX}cato_networks.svg`,
+    logo: guardrailLogoMap["Cato Networks Guardrail"],
     tags: ["Security", "Threat Detection"],
   },
   {
@@ -354,7 +356,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     name: "Prompt Security",
     description: "Protect against prompt injection attacks, data leakage, and other LLM security threats.",
     category: "partner",
-    logo: `${ASSET_PREFIX}prompt_security.png`,
+    logo: guardrailLogoMap["Prompt Security"],
     tags: ["Prompt Injection", "Security"],
   },
   {
@@ -362,7 +364,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     name: "Lasso Guardrail",
     description: "Content moderation and safety guardrails for responsible AI deployments.",
     category: "partner",
-    logo: `${ASSET_PREFIX}lasso.png`,
+    logo: guardrailLogoMap["Lasso Guardrail"],
     tags: ["Content Moderation"],
   },
   {
@@ -370,7 +372,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     name: "Pangea Guardrail",
     description: "Pangea's AI guardrails for secure, compliant, and trustworthy AI applications.",
     category: "partner",
-    logo: `${ASSET_PREFIX}pangea.png`,
+    logo: guardrailLogoMap["Pangea Guardrail"],
     tags: ["Compliance", "Security"],
   },
   {
@@ -378,7 +380,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     name: "EnkryptAI",
     description: "AI security and governance platform for enterprise AI safety and compliance.",
     category: "partner",
-    logo: `${ASSET_PREFIX}enkrypt_ai.avif`,
+    logo: guardrailLogoMap["EnkryptAI"],
     tags: ["Enterprise", "Governance"],
   },
   {
@@ -386,7 +388,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     name: "Javelin Guardrails",
     description: "AI gateway with built-in guardrails for secure and compliant AI operations.",
     category: "partner",
-    logo: `${ASSET_PREFIX}javelin.png`,
+    logo: guardrailLogoMap["Javelin Guardrails"],
     tags: ["Gateway", "Security"],
   },
   {
@@ -394,7 +396,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     name: "Pillar Guardrail",
     description: "AI safety platform for monitoring, testing, and securing AI systems.",
     category: "partner",
-    logo: `${ASSET_PREFIX}pillar.jpeg`,
+    logo: guardrailLogoMap["Pillar Guardrail"],
     tags: ["Monitoring", "Safety"],
   },
   {
@@ -402,7 +404,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     name: "Akto Guardrail",
     description: "AI security platform from Akto.io with automatic monitoring and guardrails for AI/ML applications.",
     category: "partner",
-    logo: `${ASSET_PREFIX}akto.svg`,
+    logo: guardrailLogoMap["Akto"],
     tags: ["Security", "Safety", "Monitoring"],
   },
   {
@@ -411,7 +413,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     description:
       "AI security gateway with prompt injection detection, PII redaction, topic filtering, entity blocklists, and hallucination detection. Self-hostable with drop-in proxy integration.",
     category: "partner",
-    logo: `${ASSET_PREFIX}promptguard.svg`,
+    logo: guardrailLogoMap["PromptGuard"],
     tags: ["Security", "Prompt Injection", "PII"],
     providerKey: "Promptguard",
     eval: {
@@ -428,7 +430,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     description:
       "CyCraft XecGuard AI security gateway. Multi-policy scanning (prompt injection, harmful content, PII, system-prompt enforcement) plus RAG context grounding.",
     category: "partner",
-    logo: `${ASSET_PREFIX}xecguard.svg`,
+    logo: guardrailLogoMap["XecGuard"],
     tags: ["Security", "Policy", "Grounding", "RAG"],
     providerKey: "Xecguard",
   },
@@ -438,7 +440,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     description:
       "DeepKeep AI Firewall for comprehensive LLM security — prompt injection detection, PII protection, content moderation, and policy enforcement with configurable guardrail pipelines.",
     category: "partner",
-    logo: `${ASSET_PREFIX}deepkeep.svg`,
+    logo: guardrailLogoMap["DeepKeep AI Firewall"],
     tags: ["Security", "Prompt Injection", "PII", "Firewall"],
     providerKey: "Deepkeep",
   },
@@ -448,7 +450,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     description:
       "RepelloAI Argus scans prompts and responses against policies configured per asset in the Repello dashboard.",
     category: "partner",
-    logo: `${ASSET_PREFIX}repelloai.png`,
+    logo: guardrailLogoMap["RepelloAI Argus"],
     tags: ["Security", "Policy", "Prompt Injection"],
     providerKey: "Repelloai",
   },
@@ -458,7 +460,7 @@ export const PARTNER_GUARDRAIL_CARDS: GuardrailCardInfo[] = [
     description:
       "Defend AI Agentic Guardrails: Indirect/Direct Prompt Injection, Tool Misuse, Malicious MCP and Skills",
     category: "partner",
-    logo: `${ASSET_PREFIX}straiker.svg`,
+    logo: guardrailLogoMap["Straiker"],
     tags: ["Agentic", "Prompt Injection", "Tool Misuse", "MCP", "Skills"],
     providerKey: "Straiker",
   },

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_garden_detail.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_garden_detail.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import GuardrailDetailView from "./guardrail_garden_detail";
+import type { GuardrailCardInfo } from "./guardrail_garden_data";
+
+vi.mock("./add_guardrail_form", () => ({ default: () => null }));
+
+const makeCard = (overrides: Partial<GuardrailCardInfo> = {}): GuardrailCardInfo => ({
+  id: "bedrock",
+  name: "Bedrock Guardrail",
+  description: "AWS Bedrock Guardrails for content filtering.",
+  category: "partner",
+  logo: "/_next/static/media/bedrock.svg",
+  tags: ["AWS"],
+  ...overrides,
+});
+
+const renderDetail = (card: GuardrailCardInfo) =>
+  render(<GuardrailDetailView card={card} onBack={vi.fn()} accessToken={null} onGuardrailCreated={vi.fn()} />);
+
+describe("GuardrailDetailView logo", () => {
+  it("renders the card logo through the shared Logo component with the bundled src", () => {
+    renderDetail(makeCard());
+    expect(screen.getByAltText("Bedrock Guardrail logo")).toHaveAttribute("src", "/_next/static/media/bedrock.svg");
+  });
+
+  it("falls back to a letter avatar when the card has no logo", () => {
+    renderDetail(makeCard({ logo: "" }));
+    expect(screen.queryByAltText("Bedrock Guardrail logo")).not.toBeInTheDocument();
+    expect(screen.getByText("B")).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_garden_detail.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_garden_detail.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Button } from "antd";
 import { ArrowLeftOutlined } from "@ant-design/icons";
 import AddGuardrailForm from "./add_guardrail_form";
-import { resolveLogoSrc } from "@/lib/assetPaths";
+import { Logo } from "@/components/molecules/logo/Logo";
 import { GUARDRAIL_PRESETS } from "./guardrail_garden_configs";
 import { GuardrailCardInfo } from "./guardrail_garden_data";
 
@@ -60,14 +60,7 @@ const GuardrailDetailView: React.FC<GuardrailDetailViewProps> = ({ card, onBack,
 
       {/* ── Header block (Vertex-style) ── */}
       <div style={{ display: "flex", alignItems: "center", gap: 16, marginBottom: 8 }}>
-        <img
-          src={resolveLogoSrc(card.logo)}
-          alt=""
-          style={{ width: 40, height: 40, borderRadius: 8, objectFit: "contain" }}
-          onError={(e) => {
-            (e.target as HTMLImageElement).style.display = "none";
-          }}
-        />
+        <Logo src={card.logo} label={card.name} className="w-10 h-10 rounded-lg object-contain shrink-0" />
         <h1 style={{ fontSize: 28, fontWeight: 400, color: "#202124", margin: 0, lineHeight: 1.2 }}>{card.name}</h1>
       </div>
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info.test.tsx
@@ -81,6 +81,37 @@ describe("Guardrail Info", () => {
     expect(getByText("Settings")).toBeInTheDocument();
   });
 
+  it("should render the provider logo from the bundled guardrail logo map", async () => {
+    vi.mocked(networking.getGuardrailInfo).mockResolvedValue({
+      guardrail_id: "123",
+      guardrail_name: "Test Guardrail",
+      litellm_params: {
+        guardrail: "presidio",
+        mode: "pre_call",
+        default_on: true,
+      },
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
+      guardrail_definition_location: "database",
+    });
+
+    vi.mocked(networking.getGuardrailUISettings).mockResolvedValue({
+      supported_entities: [],
+      supported_actions: [],
+      pii_entity_categories: [],
+      supported_modes: ["pre_call", "post_call"],
+    });
+
+    vi.mocked(networking.getGuardrailProviderSpecificParams).mockResolvedValue({});
+
+    const { findByAltText } = render(
+      <GuardrailInfoView guardrailId="123" onClose={() => {}} accessToken="123" isAdmin={true} />,
+    );
+
+    const logo = await findByAltText("Presidio PII logo");
+    expect(logo.getAttribute("src")).toContain("microsoft_azure.svg");
+  });
+
   it("should not render the edit button for config guardrails", async () => {
     // Mock the network responses
     vi.mocked(networking.getGuardrailInfo).mockResolvedValue({

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info.tsx
@@ -12,6 +12,7 @@ import { Button, Divider, Form, Input, Select, Tooltip } from "antd";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import React, { useCallback, useEffect, useState } from "react";
 import NotificationsManager from "@/components/molecules/notifications_manager";
+import { Logo } from "@/components/molecules/logo/Logo";
 import ContentFilterManager, { formatContentFilterDataForAPI } from "./content_filter/ContentFilterManager";
 import CustomCodeModal, { EditGuardrailData } from "./custom_code/CustomCodeModal";
 import {
@@ -524,17 +525,7 @@ const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({ guardrailId, onClose,
               <Card>
                 <Text>Provider</Text>
                 <div className="mt-2 flex items-center space-x-2">
-                  {logo && (
-                    <img
-                      src={logo}
-                      alt={`${displayName} logo`}
-                      className="w-6 h-6"
-                      onError={(e) => {
-                        // Hide broken image
-                        (e.target as HTMLImageElement).style.display = "none";
-                      }}
-                    />
-                  )}
+                  <Logo src={logo} label={displayName} className="w-6 h-6" />
                   <Title>{displayName}</Title>
                 </div>
               </Card>

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info_helpers.tsx
@@ -1,4 +1,30 @@
-import { resolveLogoSrc } from "@/lib/assetPaths";
+import aimSecurityLogo from "../../../../../public/assets/logos/aim_security.jpeg";
+import aktoLogo from "../../../../../public/assets/logos/akto.svg";
+import aporiaLogo from "../../../../../public/assets/logos/aporia.png";
+import bedrockLogo from "../../../../../public/assets/logos/bedrock.svg";
+import catoNetworksLogo from "../../../../../public/assets/logos/cato_networks.svg";
+import ciscoLogo from "../../../../../public/assets/logos/cisco.png";
+import deepkeepLogo from "../../../../../public/assets/logos/deepkeep.svg";
+import enkryptAiLogo from "../../../../../public/assets/logos/enkrypt_ai.avif";
+import googleLogo from "../../../../../public/assets/logos/google.svg";
+import guardrailsAiLogo from "../../../../../public/assets/logos/guardrails_ai.jpeg";
+import javelinLogo from "../../../../../public/assets/logos/javelin.png";
+import lakeraAiLogo from "../../../../../public/assets/logos/lakeraai.jpeg";
+import lassoLogo from "../../../../../public/assets/logos/lasso.png";
+import litellmLogo from "../../../../../public/assets/logos/litellm_logo.jpg";
+import microsoftAzureLogo from "../../../../../public/assets/logos/microsoft_azure.svg";
+import nomaSecurityLogo from "../../../../../public/assets/logos/noma_security.png";
+import openaiSmallLogo from "../../../../../public/assets/logos/openai_small.svg";
+import paloAltoNetworksLogo from "../../../../../public/assets/logos/palo_alto_networks.jpeg";
+import pangeaLogo from "../../../../../public/assets/logos/pangea.png";
+import pillarLogo from "../../../../../public/assets/logos/pillar.jpeg";
+import promptSecurityLogo from "../../../../../public/assets/logos/prompt_security.png";
+import promptguardLogo from "../../../../../public/assets/logos/promptguard.svg";
+import qohashLogo from "../../../../../public/assets/logos/qohash.jpg";
+import repelloAiLogo from "../../../../../public/assets/logos/repelloai.png";
+import straikerLogo from "../../../../../public/assets/logos/straiker.svg";
+import xecguardLogo from "../../../../../public/assets/logos/xecguard.svg";
+import zscalerLogo from "../../../../../public/assets/logos/zscaler.svg";
 
 // Legacy enum - keeping for backward compatibility
 export enum GuardrailProviders {
@@ -136,40 +162,43 @@ export const shouldRenderLLMJudgeFields = (provider: string | null) => {
   return guardrail_provider_map[provider] === "llm_as_a_judge";
 };
 
-const asset_logos_folder = "/ui/assets/logos/";
+export const guardrailLogoMap = {
+  "Zscaler AI Guard": zscalerLogo.src,
+  "Presidio PII": microsoftAzureLogo.src,
+  "Bedrock Guardrail": bedrockLogo.src,
+  Lakera: lakeraAiLogo.src,
+  "Azure Content Safety Prompt Shield": microsoftAzureLogo.src,
+  "Azure Content Safety Text Moderation": microsoftAzureLogo.src,
+  "Aporia AI": aporiaLogo.src,
+  "PANW Prisma AIRS": paloAltoNetworksLogo.src,
+  "Cisco AI Defense": ciscoLogo.src,
+  "Noma Security": nomaSecurityLogo.src,
+  "Javelin Guardrails": javelinLogo.src,
+  "Pillar Guardrail": pillarLogo.src,
+  "Google Cloud Model Armor": googleLogo.src,
+  "Guardrails AI": guardrailsAiLogo.src,
+  "Lasso Guardrail": lassoLogo.src,
+  "Pangea Guardrail": pangeaLogo.src,
+  "AIM Guardrail": aimSecurityLogo.src,
+  "Cato Networks Guardrail": catoNetworksLogo.src,
+  "OpenAI Moderation": openaiSmallLogo.src,
+  EnkryptAI: enkryptAiLogo.src,
+  "Prompt Security": promptSecurityLogo.src,
+  PromptGuard: promptguardLogo.src,
+  XecGuard: xecguardLogo.src,
+  "LiteLLM Content Filter": litellmLogo.src,
+  "LiteLLM LLM as a Judge": litellmLogo.src,
+  Akto: aktoLogo.src,
+  "DeepKeep AI Firewall": deepkeepLogo.src,
+  "Qostodian Nexus": qohashLogo.src,
+  "RepelloAI Argus": repelloAiLogo.src,
+  Straiker: straikerLogo.src,
+} satisfies Record<string, string>;
 
-export const guardrailLogoMap: Record<string, string> = {
-  "Zscaler AI Guard": `${asset_logos_folder}zscaler.svg`,
-  "Presidio PII": `${asset_logos_folder}microsoft_azure.svg`,
-  "Bedrock Guardrail": `${asset_logos_folder}bedrock.svg`,
-  Lakera: `${asset_logos_folder}lakeraai.jpeg`,
-  "Azure Content Safety Prompt Shield": `${asset_logos_folder}microsoft_azure.svg`,
-  "Azure Content Safety Text Moderation": `${asset_logos_folder}microsoft_azure.svg`,
-  "Aporia AI": `${asset_logos_folder}aporia.png`,
-  "PANW Prisma AIRS": `${asset_logos_folder}palo_alto_networks.jpeg`,
-  "Cisco AI Defense": `${asset_logos_folder}cisco.png`,
-  "Noma Security": `${asset_logos_folder}noma_security.png`,
-  "Javelin Guardrails": `${asset_logos_folder}javelin.png`,
-  "Pillar Guardrail": `${asset_logos_folder}pillar.jpeg`,
-  "Google Cloud Model Armor": `${asset_logos_folder}google.svg`,
-  "Guardrails AI": `${asset_logos_folder}guardrails_ai.jpeg`,
-  "Lasso Guardrail": `${asset_logos_folder}lasso.png`,
-  "Pangea Guardrail": `${asset_logos_folder}pangea.png`,
-  "AIM Guardrail": `${asset_logos_folder}aim_security.jpeg`,
-  "Cato Networks Guardrail": `${asset_logos_folder}cato_networks.svg`,
-  "OpenAI Moderation": `${asset_logos_folder}openai_small.svg`,
-  EnkryptAI: `${asset_logos_folder}enkrypt_ai.avif`,
-  "Prompt Security": `${asset_logos_folder}prompt_security.png`,
-  PromptGuard: `${asset_logos_folder}promptguard.svg`,
-  XecGuard: `${asset_logos_folder}xecguard.svg`,
-  "LiteLLM Content Filter": `${asset_logos_folder}litellm_logo.jpg`,
-  "LiteLLM LLM as a Judge": `${asset_logos_folder}litellm_logo.jpg`,
-  Akto: `${asset_logos_folder}akto.svg`,
-  "DeepKeep AI Firewall": `${asset_logos_folder}deepkeep.svg`,
-  "Qostodian Nexus": `${asset_logos_folder}qohash.jpg`,
-  "RepelloAI Argus": `${asset_logos_folder}repelloai.png`,
-  Straiker: `${asset_logos_folder}straiker.svg`,
-};
+export const getGuardrailLogo = (displayName: string): string | undefined =>
+  Object.prototype.hasOwnProperty.call(guardrailLogoMap, displayName)
+    ? guardrailLogoMap[displayName as keyof typeof guardrailLogoMap]
+    : undefined;
 
 export const getGuardrailLogoAndName = (guardrailValue: string): { logo: string; displayName: string } => {
   if (!guardrailValue) {
@@ -188,7 +217,7 @@ export const getGuardrailLogoAndName = (guardrailValue: string): { logo: string;
   // Get the display name from current GuardrailProviders and logo from map
   const currentProviders = getGuardrailProviders();
   const displayName = currentProviders[enumKey as keyof typeof currentProviders];
-  const logo = resolveLogoSrc(guardrailLogoMap[displayName as keyof typeof guardrailLogoMap]) ?? "";
+  const logo = getGuardrailLogo(displayName ?? "") ?? "";
 
   return { logo, displayName: displayName || guardrailValue };
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_table.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_table.test.tsx
@@ -30,6 +30,22 @@ describe("GuardrailTable", () => {
     }
   });
 
+  it("renders the provider logo from the bundled guardrail logo map", () => {
+    render(<GuardrailTable guardrailsList={[makeGuardrail()]} {...baseProps} />);
+    const logo = screen.getByAltText("Presidio PII logo");
+    expect(logo.getAttribute("src")).toContain("microsoft_azure.svg");
+  });
+
+  it("falls back to a letter avatar for an unknown provider slug", () => {
+    const guardrail = makeGuardrail({
+      litellm_params: { guardrail: "mystery_guard", mode: "pre_call", default_on: false },
+    });
+    render(<GuardrailTable guardrailsList={[guardrail]} {...baseProps} />);
+    expect(screen.getByText("mystery_guard")).toBeInTheDocument();
+    expect(screen.queryByAltText("mystery_guard logo")).not.toBeInTheDocument();
+    expect(screen.getByText("m")).toBeInTheDocument();
+  });
+
   it("deletes a DB guardrail through the actions menu", async () => {
     const user = userEvent.setup();
     const onDeleteClick = vi.fn();

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPLogoSelector.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPLogoSelector.test.tsx
@@ -52,4 +52,23 @@ describe("MCPLogoSelector", () => {
     await user.click(githubButton);
     expect(onChange).toHaveBeenCalledWith(undefined);
   });
+
+  it("should render grid logos from bundled static assets instead of public paths", () => {
+    render(<MCPLogoSelector />);
+    const src = screen.getByAltText("GitHub").getAttribute("src");
+    expect(src).toMatch(/^\/_next\//);
+    expect(src).toContain("github.svg");
+  });
+
+  it("should preview a stored well-known path via its bundled asset", () => {
+    render(<MCPLogoSelector value="/ui/assets/logos/github.svg" />);
+    const src = screen.getByAltText("Selected logo").getAttribute("src");
+    expect(src).toMatch(/^\/_next\//);
+    expect(src).toContain("github.svg");
+  });
+
+  it("should preview a custom external URL untouched", () => {
+    render(<MCPLogoSelector value="https://cdn.example.com/logo.png" />);
+    expect(screen.getByAltText("Selected logo").getAttribute("src")).toBe("https://cdn.example.com/logo.png");
+  });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPLogoSelector.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPLogoSelector.tsx
@@ -1,31 +1,51 @@
-import React, { useState } from "react";
+import React from "react";
 import { Input, Tooltip } from "antd";
 import { InfoCircleOutlined, LinkOutlined } from "@ant-design/icons";
-import { resolveLogoSrc } from "@/lib/assetPaths";
+import { Logo } from "@/components/molecules/logo/Logo";
+import githubLogo from "../../../../../public/assets/logos/github.svg";
+import slackLogo from "../../../../../public/assets/logos/slack.svg";
+import notionLogo from "../../../../../public/assets/logos/notion.svg";
+import linearLogo from "../../../../../public/assets/logos/linear.svg";
+import jiraLogo from "../../../../../public/assets/logos/jira.svg";
+import figmaLogo from "../../../../../public/assets/logos/figma.svg";
+import gmailLogo from "../../../../../public/assets/logos/gmail.svg";
+import googleDriveLogo from "../../../../../public/assets/logos/google_drive.svg";
+import stripeLogo from "../../../../../public/assets/logos/stripe.svg";
+import shopifyLogo from "../../../../../public/assets/logos/shopify.svg";
+import salesforceLogo from "../../../../../public/assets/logos/salesforce.svg";
+import hubspotLogo from "../../../../../public/assets/logos/hubspot.svg";
+import twilioLogo from "../../../../../public/assets/logos/twilio.svg";
+import cloudflareLogo from "../../../../../public/assets/logos/cloudflare.svg";
+import sentryLogo from "../../../../../public/assets/logos/sentry.svg";
+import postgresqlLogo from "../../../../../public/assets/logos/postgresql.svg";
+import snowflakeLogo from "../../../../../public/assets/logos/snowflake.svg";
+import zapierLogo from "../../../../../public/assets/logos/zapier.svg";
+import googleLogo from "../../../../../public/assets/logos/google.svg";
+import gitlabLogo from "../../../../../public/assets/logos/gitlab.svg";
 
 const logos = "/ui/assets/logos/";
 
-const WELL_KNOWN_LOGOS: { name: string; url: string }[] = [
-  { name: "GitHub", url: `${logos}github.svg` },
-  { name: "Slack", url: `${logos}slack.svg` },
-  { name: "Notion", url: `${logos}notion.svg` },
-  { name: "Linear", url: `${logos}linear.svg` },
-  { name: "Jira", url: `${logos}jira.svg` },
-  { name: "Figma", url: `${logos}figma.svg` },
-  { name: "Gmail", url: `${logos}gmail.svg` },
-  { name: "Google Drive", url: `${logos}google_drive.svg` },
-  { name: "Stripe", url: `${logos}stripe.svg` },
-  { name: "Shopify", url: `${logos}shopify.svg` },
-  { name: "Salesforce", url: `${logos}salesforce.svg` },
-  { name: "HubSpot", url: `${logos}hubspot.svg` },
-  { name: "Twilio", url: `${logos}twilio.svg` },
-  { name: "Cloudflare", url: `${logos}cloudflare.svg` },
-  { name: "Sentry", url: `${logos}sentry.svg` },
-  { name: "PostgreSQL", url: `${logos}postgresql.svg` },
-  { name: "Snowflake", url: `${logos}snowflake.svg` },
-  { name: "Zapier", url: `${logos}zapier.svg` },
-  { name: "Google", url: `${logos}google.svg` },
-  { name: "GitLab", url: `${logos}gitlab.svg` },
+const WELL_KNOWN_LOGOS: { name: string; url: string; src: string }[] = [
+  { name: "GitHub", url: `${logos}github.svg`, src: githubLogo.src },
+  { name: "Slack", url: `${logos}slack.svg`, src: slackLogo.src },
+  { name: "Notion", url: `${logos}notion.svg`, src: notionLogo.src },
+  { name: "Linear", url: `${logos}linear.svg`, src: linearLogo.src },
+  { name: "Jira", url: `${logos}jira.svg`, src: jiraLogo.src },
+  { name: "Figma", url: `${logos}figma.svg`, src: figmaLogo.src },
+  { name: "Gmail", url: `${logos}gmail.svg`, src: gmailLogo.src },
+  { name: "Google Drive", url: `${logos}google_drive.svg`, src: googleDriveLogo.src },
+  { name: "Stripe", url: `${logos}stripe.svg`, src: stripeLogo.src },
+  { name: "Shopify", url: `${logos}shopify.svg`, src: shopifyLogo.src },
+  { name: "Salesforce", url: `${logos}salesforce.svg`, src: salesforceLogo.src },
+  { name: "HubSpot", url: `${logos}hubspot.svg`, src: hubspotLogo.src },
+  { name: "Twilio", url: `${logos}twilio.svg`, src: twilioLogo.src },
+  { name: "Cloudflare", url: `${logos}cloudflare.svg`, src: cloudflareLogo.src },
+  { name: "Sentry", url: `${logos}sentry.svg`, src: sentryLogo.src },
+  { name: "PostgreSQL", url: `${logos}postgresql.svg`, src: postgresqlLogo.src },
+  { name: "Snowflake", url: `${logos}snowflake.svg`, src: snowflakeLogo.src },
+  { name: "Zapier", url: `${logos}zapier.svg`, src: zapierLogo.src },
+  { name: "Google", url: `${logos}google.svg`, src: googleLogo.src },
+  { name: "GitLab", url: `${logos}gitlab.svg`, src: gitlabLogo.src },
 ];
 
 interface MCPLogoSelectorProps {
@@ -34,14 +54,10 @@ interface MCPLogoSelectorProps {
 }
 
 const MCPLogoSelector: React.FC<MCPLogoSelectorProps> = ({ value, onChange }) => {
-  const [imgErrors, setImgErrors] = useState<Set<string>>(new Set());
+  const selectedWellKnown = WELL_KNOWN_LOGOS.find((l) => l.url === value);
 
   const handleSelect = (url: string) => {
     onChange?.(value === url ? undefined : url);
-  };
-
-  const handleImgError = (url: string) => {
-    setImgErrors((prev) => new Set(prev).add(url));
   };
 
   return (
@@ -56,13 +72,10 @@ const MCPLogoSelector: React.FC<MCPLogoSelectorProps> = ({ value, onChange }) =>
       {/* Preview */}
       {value && (
         <div className="flex items-center gap-3 mb-3 p-3 bg-gray-50 rounded-lg border border-gray-200">
-          <img
-            src={resolveLogoSrc(value)}
-            alt="Selected logo"
+          <Logo
+            src={selectedWellKnown?.src ?? value}
+            label="Selected"
             className="w-10 h-10 object-contain rounded-sm"
-            onError={(e) => {
-              (e.target as HTMLImageElement).style.display = "none";
-            }}
           />
           <div className="flex-1 min-w-0">
             <div className="text-xs text-gray-500 truncate">{value}</div>
@@ -81,8 +94,6 @@ const MCPLogoSelector: React.FC<MCPLogoSelectorProps> = ({ value, onChange }) =>
       <div className="grid grid-cols-10 gap-1.5 mb-3">
         {WELL_KNOWN_LOGOS.map((logo) => {
           const isSelected = value === logo.url;
-          const hasFailed = imgErrors.has(logo.url);
-          if (hasFailed) return null;
           return (
             <Tooltip key={logo.name} title={logo.name}>
               <button
@@ -96,12 +107,7 @@ const MCPLogoSelector: React.FC<MCPLogoSelectorProps> = ({ value, onChange }) =>
                   }`}
                 style={{ width: 40, height: 40 }}
               >
-                <img
-                  src={resolveLogoSrc(logo.url)}
-                  alt={logo.name}
-                  className="w-5 h-5 object-contain"
-                  onError={() => handleImgError(logo.url)}
-                />
+                <img src={logo.src} alt={logo.name} className="w-5 h-5 object-contain" />
               </button>
             </Tooltip>
           );
@@ -112,7 +118,7 @@ const MCPLogoSelector: React.FC<MCPLogoSelectorProps> = ({ value, onChange }) =>
       <Input
         prefix={<LinkOutlined className="text-gray-400" />}
         placeholder="Or paste a custom logo URL..."
-        value={value && !WELL_KNOWN_LOGOS.some((l) => l.url === value) ? value : ""}
+        value={value && !selectedWellKnown ? value : ""}
         onChange={(e) => {
           const v = e.target.value.trim();
           onChange?.(v || undefined);

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPServerCard.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPServerCard.test.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import MCPServerCard from "./MCPServerCard";
 import type { MCPServer } from "@/components/mcp_tools/types";
+import { setServerRootPath } from "@/lib/serverRootPath";
 
 const baseServer: MCPServer = {
   server_id: "srv-1",
@@ -41,5 +42,28 @@ describe("MCPServerCard OAuth flow indicator", () => {
   it("does not show the badge for a delegate (PKCE passthrough) server", () => {
     renderCard({ auth_type: "oauth2", oauth2_flow: null, delegate_auth_to_upstream: true });
     expect(screen.queryByText("OAuth flow not set")).not.toBeInTheDocument();
+  });
+});
+
+describe("MCPServerCard logo", () => {
+  afterEach(() => {
+    setServerRootPath("/");
+  });
+
+  it("passes an external logo_url through untouched", () => {
+    renderCard({ mcp_info: { server_name: "demo_server", logo_url: "https://cdn.example.com/logo.png" } });
+    expect(screen.getByAltText("demo_server logo").getAttribute("src")).toBe("https://cdn.example.com/logo.png");
+  });
+
+  it("prefixes a stored asset path with the server root path under a non-root mount", () => {
+    setServerRootPath("/litellm");
+    renderCard({ mcp_info: { server_name: "demo_server", logo_url: "/ui/assets/logos/github.svg" } });
+    expect(screen.getByAltText("demo_server logo").getAttribute("src")).toBe("/litellm/ui/assets/logos/github.svg");
+  });
+
+  it("renders a letter avatar when no logo_url is set", () => {
+    renderCard({ mcp_info: { server_name: "demo_server" } });
+    expect(screen.queryByAltText("demo_server logo")).not.toBeInTheDocument();
+    expect(screen.getByText("DE")).toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPServerCard.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPServerCard.tsx
@@ -1,4 +1,4 @@
-import { useState, type FC, type KeyboardEvent, type MouseEvent } from "react";
+import { type FC, type KeyboardEvent, type MouseEvent } from "react";
 import { Dropdown, Tooltip, Typography, Tag } from "antd";
 import type { MenuProps } from "antd";
 import {
@@ -9,6 +9,7 @@ import {
   ThunderboltOutlined,
 } from "@ant-design/icons";
 import { AUTH_TYPE, type MCPServer } from "@/components/mcp_tools/types";
+import { Logo } from "@/components/molecules/logo/Logo";
 import { getMaskedAndFullUrl } from "./utils";
 
 const { Text } = Typography;
@@ -52,8 +53,6 @@ const MCPServerCard: FC<MCPServerCardProps> = ({
   const name = server.server_name || alias || server.server_id;
   // Logo is sourced exclusively from the admin-set `mcp_info.logo_url`.
   const candidateLogo = server.mcp_info?.logo_url ?? undefined;
-  const [failedLogoUrl, setFailedLogoUrl] = useState<string | null>(null);
-  const logoUrl = candidateLogo && failedLogoUrl !== candidateLogo ? candidateLogo : undefined;
   const transport = server.transport || "http";
   const displayTransport = server.spec_path && transport !== "stdio" ? "openapi" : transport;
   const authType = server.auth_type || "none";
@@ -148,13 +147,8 @@ const MCPServerCard: FC<MCPServerCardProps> = ({
       className={`group relative flex h-full cursor-pointer flex-col gap-3 rounded-lg p-4 transition-all duration-150 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-blue-400 ${cardClass}`}
     >
       <div className="flex items-start gap-3">
-        {logoUrl ? (
-          <img
-            src={logoUrl}
-            alt={`${name} logo`}
-            className="h-10 w-10 shrink-0 rounded-sm object-contain"
-            onError={() => setFailedLogoUrl(logoUrl)}
-          />
+        {candidateLogo ? (
+          <Logo src={candidateLogo} label={name} className="h-10 w-10 shrink-0 rounded-sm object-contain" />
         ) : (
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-sm bg-gray-100 font-semibold text-gray-500">
             {(name || "?").slice(0, 2).toUpperCase()}

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/create_mcp_server.tsx
@@ -39,10 +39,9 @@ import NotificationsManager from "@/components/molecules/notifications_manager";
 import { useMcpOAuthFlow } from "@/hooks/useMcpOAuthFlow";
 import { useTestMCPConnection } from "@/hooks/useTestMCPConnection";
 import { getSecureItem, setSecureItem } from "@/utils/secureStorage";
-import { resolveLogoSrc } from "@/lib/assetPaths";
+import mcpLogo from "../../../../../public/assets/logos/mcp_logo.png";
 
-const asset_logos_folder = "/ui/assets/logos/";
-export const mcpLogoImg = `${asset_logos_folder}mcp_logo.png`;
+export const mcpLogoImg = mcpLogo.src;
 
 interface CreateMCPServerProps {
   userRole: string;
@@ -791,7 +790,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
             </button>
           )}
           <img
-            src={resolveLogoSrc(mcpLogoImg)}
+            src={mcpLogoImg}
             alt="MCP Logo"
             className="w-8 h-8 object-contain"
             style={{

--- a/ui/litellm-dashboard/src/app/(dashboard)/search-tools/_components/CreateSearchTools.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/search-tools/_components/CreateSearchTools.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SearchProviderLabel } from "./CreateSearchTools";
+
+describe("SearchProviderLabel", () => {
+  it("renders the tavily logo from the static bundle, untouched by server-root prefixing", () => {
+    render(<SearchProviderLabel providerName="tavily" displayName="Tavily" />);
+    const img = screen.getByRole("img", { name: "Tavily logo" });
+    expect(img).toHaveAttribute("src", "/_next/static/media/tavily.png");
+  });
+
+  it("renders the exa_ai logo file for the exa_ai slug", () => {
+    render(<SearchProviderLabel providerName="exa_ai" displayName="Exa AI" />);
+    const img = screen.getByRole("img", { name: "Exa AI logo" });
+    expect(img.getAttribute("src")).toContain("exa_ai.png");
+  });
+
+  it("renders the google_pse logo file for the google_pse slug", () => {
+    render(<SearchProviderLabel providerName="google_pse" displayName="Google PSE" />);
+    expect(screen.getByRole("img", { name: "Google PSE logo" }).getAttribute("src")).toContain("google_pse.png");
+  });
+
+  it("falls back to a letter avatar for a provider with no bundled logo", () => {
+    render(<SearchProviderLabel providerName="brave" displayName="Brave Search" />);
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(screen.getByText("B")).toBeInTheDocument();
+    expect(screen.getByText("Brave Search")).toBeInTheDocument();
+  });
+
+  it("does not guess a legacy /ui/assets/logos/<slug>.png url for unknown providers", () => {
+    const { container } = render(<SearchProviderLabel providerName="searxng" displayName="SearXNG" />);
+    expect(container.querySelector("img")).toBeNull();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/search-tools/_components/CreateSearchTools.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/search-tools/_components/CreateSearchTools.tsx
@@ -4,44 +4,37 @@ import { useQuery } from "@tanstack/react-query";
 import { Button, TextInput } from "@tremor/react";
 import { Form, Input, Modal, Select, Tooltip, Typography } from "antd";
 import React, { useState } from "react";
-import { resolveLogoSrc } from "@/lib/assetPaths";
+import { Logo } from "@/components/molecules/logo/Logo";
 import NotificationsManager from "@/components/molecules/notifications_manager";
 import { createSearchTool, fetchAvailableSearchProviders } from "@/components/networking";
 import SearchConnectionTest from "./SearchConnectionTest";
 import { AvailableSearchProvider, SearchTool } from "./types";
+import dataforseoLogo from "../../../../../public/assets/logos/dataforseo.png";
+import exaAiLogo from "../../../../../public/assets/logos/exa_ai.png";
+import googlePseLogo from "../../../../../public/assets/logos/google_pse.png";
+import parallelAiLogo from "../../../../../public/assets/logos/parallel_ai.png";
+import perplexityLogo from "../../../../../public/assets/logos/perplexity.png";
+import tavilyLogo from "../../../../../public/assets/logos/tavily.png";
 
 const { TextArea } = Input;
 
-// Search provider logos folder path (matches existing provider logo pattern)
-const searchProviderLogosFolder = "/ui/assets/logos/";
-
-// Helper function to get logo path for a search provider
-const getSearchProviderLogo = (providerName: string): string => {
-  return `${searchProviderLogosFolder}${providerName}.png`;
+const searchProviderLogoMap: Record<string, string> = {
+  perplexity: perplexityLogo.src,
+  tavily: tavilyLogo.src,
+  parallel_ai: parallelAiLogo.src,
+  exa_ai: exaAiLogo.src,
+  google_pse: googlePseLogo.src,
+  dataforseo: dataforseoLogo.src,
 };
 
-// Component to display search provider logo and name
 interface SearchProviderLabelProps {
   providerName: string;
   displayName: string;
 }
 
-const SearchProviderLabel: React.FC<SearchProviderLabelProps> = ({ providerName, displayName }) => (
-  <div style={{ display: "flex", alignItems: "center" }}>
-    {/* eslint-disable-next-line @next/next/no-img-element */}
-    <img
-      src={resolveLogoSrc(getSearchProviderLogo(providerName))}
-      alt=""
-      style={{
-        width: "20px",
-        height: "20px",
-        marginRight: "8px",
-        objectFit: "contain",
-      }}
-      onError={(e) => {
-        e.currentTarget.style.display = "none";
-      }}
-    />
+export const SearchProviderLabel: React.FC<SearchProviderLabelProps> = ({ providerName, displayName }) => (
+  <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+    <Logo src={searchProviderLogoMap[providerName]} label={displayName} className="w-5 h-5 object-contain" />
     <span>{displayName}</span>
   </div>
 );

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.test.tsx
@@ -765,4 +765,37 @@ describe("EntityUsage", () => {
     });
     expect(screen.queryByText(userUuid)).not.toBeInTheDocument();
   });
+
+  it("renders the provider spend table logo from the bundled provider map", async () => {
+    render(<EntityUsage {...defaultProps} />);
+
+    const logo = await screen.findByAltText("openai logo");
+    expect(logo.getAttribute("src")).toContain("openai_small");
+  });
+
+  it("renders a letter avatar instead of an img for an unknown provider slug", async () => {
+    const spendDataUnknownProvider = {
+      ...mockSpendData,
+      results: [
+        {
+          ...mockSpendData.results[0],
+          breakdown: {
+            ...mockSpendData.results[0].breakdown,
+            providers: {
+              "zzz-internal": mockSpendData.results[0].breakdown.providers.openai,
+            },
+          },
+        },
+      ],
+    };
+    mockTagDailyActivityCall.mockResolvedValue(spendDataUnknownProvider);
+
+    render(<EntityUsage {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("zzz-internal").length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByAltText("zzz-internal logo")).not.toBeInTheDocument();
+    expect(screen.getByText("z")).toBeInTheDocument();
+  });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.tsx
@@ -38,7 +38,7 @@ import {
   teamDailyActivityCall,
   userDailyActivityCall,
 } from "@/components/networking";
-import { getProviderLogoAndName } from "@/components/provider_info_helpers";
+import { Logo } from "@/components/molecules/logo/Logo";
 import { usePaginatedDailyActivity } from "../../hooks/usePaginatedDailyActivity";
 import {
   BreakdownMetrics,
@@ -774,24 +774,7 @@ const EntityUsage: React.FC<EntityUsageProps> = ({ accessToken, entityType, enti
                               <TableRow key={provider.provider}>
                                 <TableCell>
                                   <div className="flex items-center space-x-2">
-                                    {provider.provider && (
-                                      <img
-                                        src={getProviderLogoAndName(provider.provider).logo}
-                                        alt={`${provider.provider} logo`}
-                                        className="w-4 h-4"
-                                        onError={(e) => {
-                                          const target = e.target as HTMLImageElement;
-                                          const parent = target.parentElement;
-                                          if (parent) {
-                                            const fallbackDiv = document.createElement("div");
-                                            fallbackDiv.className =
-                                              "w-4 h-4 rounded-full bg-gray-200 flex items-center justify-center text-xs";
-                                            fallbackDiv.textContent = provider.provider?.charAt(0) || "-";
-                                            parent.replaceChild(fallbackDiv, target);
-                                          }
-                                        }}
-                                      />
-                                    )}
+                                    {provider.provider && <Logo provider={provider.provider} className="w-4 h-4" />}
                                     <span>{provider.provider}</span>
                                   </div>
                                 </TableCell>

--- a/ui/litellm-dashboard/src/components/SSOModals.test.tsx
+++ b/ui/litellm-dashboard/src/components/SSOModals.test.tsx
@@ -472,4 +472,43 @@ describe("SSOModals", () => {
     expect(NotificationsManager.success).toHaveBeenCalledWith("SSO settings cleared successfully");
     expect(mockHandleAddSSOOk).toHaveBeenCalled();
   });
+
+  it("renders provider logos in the SSO provider dropdown", async () => {
+    const TestWrapper = () => {
+      const [form] = Form.useForm();
+      return (
+        <SSOModals
+          isAddSSOModalVisible={true}
+          isInstructionsModalVisible={false}
+          handleAddSSOOk={() => {}}
+          handleAddSSOCancel={() => {}}
+          handleShowInstructions={() => {}}
+          handleInstructionsOk={() => {}}
+          handleInstructionsCancel={() => {}}
+          form={form}
+          accessToken={null}
+          ssoConfigured={false}
+        />
+      );
+    };
+
+    render(<TestWrapper />);
+
+    fireEvent.mouseDown(screen.getByLabelText("SSO Provider"));
+
+    await waitFor(() => {
+      expect(screen.getAllByAltText("Google SSO logo").length).toBeGreaterThan(0);
+    });
+
+    expect(screen.getAllByAltText("Google SSO logo")[0]).toHaveAttribute("src", expect.stringContaining("google.svg"));
+    expect(screen.getAllByAltText("Microsoft SSO logo")[0]).toHaveAttribute(
+      "src",
+      expect.stringContaining("microsoft_azure.svg"),
+    );
+    expect(screen.getAllByAltText("Okta / Auth0 SSO logo")[0]).toHaveAttribute(
+      "src",
+      expect.stringContaining("https://www.okta.com/"),
+    );
+    expect(screen.queryByAltText("Generic SSO logo")).not.toBeInTheDocument();
+  });
 });

--- a/ui/litellm-dashboard/src/components/SSOModals.tsx
+++ b/ui/litellm-dashboard/src/components/SSOModals.tsx
@@ -4,6 +4,8 @@ import { Text, TextInput } from "@tremor/react";
 import { getSSOSettings, updateSSOSettings } from "./networking";
 import NotificationsManager from "./molecules/notifications_manager";
 import { parseErrorMessage } from "./shared/errorUtils";
+import { Logo } from "@/components/molecules/logo/Logo";
+import { ssoProviderDisplayNames, ssoProviderLogoMap } from "./Settings/AdminSettings/SSOSettings/constants";
 
 interface SSOModalsProps {
   isAddSSOModalVisible: boolean;
@@ -17,13 +19,6 @@ interface SSOModalsProps {
   accessToken: string | null;
   ssoConfigured?: boolean; // Add optional prop to indicate if SSO is configured
 }
-
-const ssoProviderLogoMap: Record<string, string> = {
-  google: "https://artificialanalysis.ai/img/logos/google_small.svg",
-  microsoft: "https://upload.wikimedia.org/wikipedia/commons/a/a8/Microsoft_Azure_Logo.svg",
-  okta: "https://www.okta.com/sites/default/files/Okta_Logo_BrightBlue_Medium.png",
-  generic: "",
-};
 
 // Define the SSO provider configuration type
 interface SSOProviderConfig {
@@ -340,17 +335,14 @@ const SSOModals: React.FC<SSOModalsProps> = ({
                   <Select.Option key={value} value={value}>
                     <div style={{ display: "flex", alignItems: "center", padding: "4px 0" }}>
                       {logo && (
-                        <img
+                        <Logo
                           src={logo}
-                          alt={value}
-                          style={{ height: 24, width: 24, marginRight: 12, objectFit: "contain" }}
+                          label={ssoProviderDisplayNames[value] || value}
+                          className="h-6 w-6 mr-3 object-contain"
                         />
                       )}
                       <span>
-                        {value.toLowerCase() === "okta"
-                          ? "Okta / Auth0"
-                          : value.charAt(0).toUpperCase() + value.slice(1)}{" "}
-                        SSO
+                        {ssoProviderDisplayNames[value] || value.charAt(0).toUpperCase() + value.slice(1) + " SSO"}
                       </span>
                     </div>
                   </Select.Option>

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/Modals/BaseSSOSettingsForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/Modals/BaseSSOSettingsForm.test.tsx
@@ -293,4 +293,40 @@ describe("renderProviderFields", () => {
     expect(result).not.toBeNull();
     expect(result?.length).toBe(5);
   });
+
+  it("renders provider logos in the dropdown and falls back to a letter avatar on load error", async () => {
+    const TestWrapper = () => {
+      const [form] = Form.useForm();
+      return <BaseSSOSettingsForm form={form} onFormSubmit={vi.fn()} />;
+    };
+
+    renderWithProviders(<TestWrapper />);
+
+    await act(async () => {
+      fireEvent.mouseDown(screen.getByLabelText("SSO Provider"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByAltText("Google SSO logo").length).toBeGreaterThan(0);
+    });
+
+    expect(screen.getAllByAltText("Google SSO logo")[0]).toHaveAttribute("src", expect.stringContaining("google.svg"));
+    expect(screen.getAllByAltText("Microsoft SSO logo")[0]).toHaveAttribute(
+      "src",
+      expect.stringContaining("microsoft_azure.svg"),
+    );
+    expect(screen.queryByAltText("Generic SSO logo")).not.toBeInTheDocument();
+
+    const oktaLogo = screen.getAllByAltText("Okta / Auth0 SSO logo")[0];
+    expect(oktaLogo).toHaveAttribute("src", expect.stringContaining("https://www.okta.com/"));
+
+    await act(async () => {
+      fireEvent.error(oktaLogo);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByAltText("Okta / Auth0 SSO logo")).not.toBeInTheDocument();
+      expect(screen.getByText("O")).toBeInTheDocument();
+    });
+  });
 });

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/Modals/BaseSSOSettingsForm.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/Modals/BaseSSOSettingsForm.tsx
@@ -4,6 +4,7 @@ import { TextInput } from "@tremor/react";
 import { Checkbox, Form, Input, Select } from "antd";
 import React from "react";
 import { ssoProviderLogoMap, ssoProviderDisplayNames } from "../constants";
+import { Logo } from "@/components/molecules/logo/Logo";
 
 export interface BaseSSOSettingsFormProps {
   form: any; // Replace with proper Form type if available
@@ -117,10 +118,10 @@ const BaseSSOSettingsForm: React.FC<BaseSSOSettingsFormProps> = ({ form, onFormS
               <Select.Option key={value} value={value}>
                 <div style={{ display: "flex", alignItems: "center", padding: "4px 0" }}>
                   {logo && (
-                    <img
+                    <Logo
                       src={logo}
-                      alt={value}
-                      style={{ height: 24, width: 24, marginRight: 12, objectFit: "contain" }}
+                      label={ssoProviderDisplayNames[value] || value}
+                      className="h-6 w-6 mr-3 object-contain"
                     />
                   )}
                   <span>

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/SSOSettings.test.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/SSOSettings.test.tsx
@@ -1,14 +1,13 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import SSOSettings from "./SSOSettings";
+
+const mockUseSSOSettings = vi.fn();
 
 // Mock the useSSOSettings hook
 vi.mock("@/app/(dashboard)/hooks/sso/useSSOSettings", () => ({
-  useSSOSettings: () => ({
-    data: null,
-    refetch: vi.fn(),
-  }),
+  useSSOSettings: () => mockUseSSOSettings(),
 }));
 
 const createQueryClient = () =>
@@ -21,17 +20,61 @@ const createQueryClient = () =>
     },
   });
 
-describe("SSOSettings", () => {
-  it("should render", () => {
-    const queryClient = createQueryClient();
+const renderSSOSettings = () => {
+  const queryClient = createQueryClient();
 
-    render(
-      <QueryClientProvider client={queryClient}>
-        <SSOSettings />
-      </QueryClientProvider>,
-    );
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SSOSettings />
+    </QueryClientProvider>,
+  );
+};
+
+const googleConfiguredValues = {
+  google_client_id: "google-client-id",
+  google_client_secret: "google-client-secret",
+  microsoft_client_id: null,
+  microsoft_client_secret: null,
+  microsoft_tenant: null,
+  generic_client_id: null,
+  generic_client_secret: null,
+  generic_authorization_endpoint: null,
+  generic_token_endpoint: null,
+  generic_userinfo_endpoint: null,
+  proxy_base_url: null,
+  user_email: null,
+  ui_access_mode: null,
+  role_mappings: null,
+  team_mappings: null,
+};
+
+describe("SSOSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSSOSettings.mockReturnValue({
+      data: null,
+      isLoading: false,
+      refetch: vi.fn(),
+    });
+  });
+
+  it("should render", () => {
+    renderSSOSettings();
 
     expect(screen.getByText("SSO Configuration")).toBeInTheDocument();
     expect(screen.getByText("Manage Single Sign-On authentication settings")).toBeInTheDocument();
+  });
+
+  it("shows the local google logo asset for a google-configured settings payload", () => {
+    mockUseSSOSettings.mockReturnValue({
+      data: { values: googleConfiguredValues },
+      isLoading: false,
+      refetch: vi.fn(),
+    });
+
+    renderSSOSettings();
+
+    const logo = screen.getByAltText("Google SSO logo");
+    expect(logo).toHaveAttribute("src", expect.stringContaining("google.svg"));
   });
 });

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/SSOSettings.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/SSOSettings.tsx
@@ -4,6 +4,7 @@ import { useSSOSettings, type SSOSettingsValues } from "@/app/(dashboard)/hooks/
 import { Button, Card, Descriptions, Space, Tag, Typography } from "antd";
 import { Edit, Shield, Trash2 } from "lucide-react";
 import { useState } from "react";
+import { Logo } from "@/components/molecules/logo/Logo";
 import { ssoProviderDisplayNames, ssoProviderLogoMap } from "./constants";
 import AddSSOSettingsModal from "./Modals/AddSSOSettingsModal";
 import DeleteSSOSettingsModal from "./Modals/DeleteSSOSettingsModal";
@@ -166,10 +167,10 @@ export default function SSOSettings() {
         <Descriptions.Item label="Provider">
           <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
             {ssoProviderLogoMap[selectedProvider] && (
-              <img
+              <Logo
                 src={ssoProviderLogoMap[selectedProvider]}
-                alt={selectedProvider}
-                style={{ height: 24, width: 24, objectFit: "contain" }}
+                label={ssoProviderDisplayNames[selectedProvider] || selectedProvider}
+                className="h-6 w-6 object-contain"
               />
             )}
             <span>{config.providerText}</span>

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/constants.ts
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/SSOSettings/constants.ts
@@ -1,7 +1,10 @@
+import googleLogo from "../../../../../public/assets/logos/google.svg";
+import microsoftAzureLogo from "../../../../../public/assets/logos/microsoft_azure.svg";
+
 // SSO Provider logos
 export const ssoProviderLogoMap: Record<string, string> = {
-  google: "https://artificialanalysis.ai/img/logos/google_small.svg",
-  microsoft: "https://upload.wikimedia.org/wikipedia/commons/a/a8/Microsoft_Azure_Logo.svg",
+  google: googleLogo.src,
+  microsoft: microsoftAzureLogo.src,
   okta: "https://www.okta.com/sites/default/files/Okta_Logo_BrightBlue_Medium.png",
   generic: "",
 };

--- a/ui/litellm-dashboard/src/components/callback_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/callback_info_helpers.tsx
@@ -1,19 +1,28 @@
+import arizeLogo from "../../public/assets/logos/arize.png";
+import awsLogo from "../../public/assets/logos/aws.svg";
+import braintrustLogo from "../../public/assets/logos/braintrust.png";
+import datadogLogo from "../../public/assets/logos/datadog.png";
+import galileoLogo from "../../public/assets/logos/galileo.ico";
+import lagoLogo from "../../public/assets/logos/lago.svg";
+import langfuseLogo from "../../public/assets/logos/langfuse.png";
+import langsmithLogo from "../../public/assets/logos/langsmith.png";
+import openmeterLogo from "../../public/assets/logos/openmeter.png";
+import otelLogo from "../../public/assets/logos/otel.png";
+
 interface CallbackConfig {
   id: string;
   displayName: string;
-  logo: string;
+  logo?: string;
   supports_key_team_logging: boolean;
   dynamic_params: Record<string, "text" | "password" | "select" | "upload" | "number">;
   description: string;
 }
 
-const asset_logos_folder = "/ui/assets/logos/";
-
 export const CALLBACK_CONFIGS: CallbackConfig[] = [
   {
     id: "arize",
     displayName: "Arize",
-    logo: `${asset_logos_folder}arize.png`,
+    logo: arizeLogo.src,
     supports_key_team_logging: true,
     dynamic_params: {
       arize_api_key: "password",
@@ -24,7 +33,7 @@ export const CALLBACK_CONFIGS: CallbackConfig[] = [
   {
     id: "braintrust",
     displayName: "Braintrust",
-    logo: `${asset_logos_folder}braintrust.png`,
+    logo: braintrustLogo.src,
     supports_key_team_logging: false,
     dynamic_params: {
       braintrust_api_key: "password",
@@ -35,7 +44,6 @@ export const CALLBACK_CONFIGS: CallbackConfig[] = [
   {
     id: "custom_callback_api",
     displayName: "Custom Callback API",
-    logo: `${asset_logos_folder}custom.svg`,
     supports_key_team_logging: true,
     dynamic_params: {
       custom_callback_api_url: "text",
@@ -46,7 +54,7 @@ export const CALLBACK_CONFIGS: CallbackConfig[] = [
   {
     id: "galileo",
     displayName: "Galileo",
-    logo: `${asset_logos_folder}galileo.ico`,
+    logo: galileoLogo.src,
     supports_key_team_logging: false,
     dynamic_params: {
       GALILEO_API_KEY: "password",
@@ -61,7 +69,7 @@ export const CALLBACK_CONFIGS: CallbackConfig[] = [
   {
     id: "datadog",
     displayName: "Datadog",
-    logo: `${asset_logos_folder}datadog.png`,
+    logo: datadogLogo.src,
     supports_key_team_logging: false,
     dynamic_params: {
       dd_api_key: "password",
@@ -72,7 +80,7 @@ export const CALLBACK_CONFIGS: CallbackConfig[] = [
   {
     id: "lago",
     displayName: "Lago",
-    logo: `${asset_logos_folder}lago.svg`,
+    logo: lagoLogo.src,
     supports_key_team_logging: false,
     dynamic_params: {
       lago_api_url: "text",
@@ -83,7 +91,7 @@ export const CALLBACK_CONFIGS: CallbackConfig[] = [
   {
     id: "langfuse",
     displayName: "Langfuse",
-    logo: `${asset_logos_folder}langfuse.png`,
+    logo: langfuseLogo.src,
     supports_key_team_logging: true,
     dynamic_params: {
       langfuse_public_key: "text",
@@ -95,7 +103,7 @@ export const CALLBACK_CONFIGS: CallbackConfig[] = [
   {
     id: "langfuse_otel",
     displayName: "Langfuse OTEL",
-    logo: `${asset_logos_folder}langfuse.png`,
+    logo: langfuseLogo.src,
     supports_key_team_logging: true,
     dynamic_params: {
       langfuse_public_key: "text",
@@ -107,7 +115,7 @@ export const CALLBACK_CONFIGS: CallbackConfig[] = [
   {
     id: "langsmith",
     displayName: "LangSmith",
-    logo: `${asset_logos_folder}langsmith.png`,
+    logo: langsmithLogo.src,
     supports_key_team_logging: true,
     dynamic_params: {
       langsmith_api_key: "password",
@@ -120,7 +128,7 @@ export const CALLBACK_CONFIGS: CallbackConfig[] = [
   {
     id: "openmeter",
     displayName: "OpenMeter",
-    logo: `${asset_logos_folder}openmeter.png`,
+    logo: openmeterLogo.src,
     supports_key_team_logging: false,
     dynamic_params: {
       openmeter_api_key: "password",
@@ -131,7 +139,7 @@ export const CALLBACK_CONFIGS: CallbackConfig[] = [
   {
     id: "otel",
     displayName: "Open Telemetry",
-    logo: `${asset_logos_folder}otel.png`,
+    logo: otelLogo.src,
     supports_key_team_logging: false,
     dynamic_params: {
       otel_endpoint: "text",
@@ -142,7 +150,7 @@ export const CALLBACK_CONFIGS: CallbackConfig[] = [
   {
     id: "s3",
     displayName: "S3",
-    logo: `${asset_logos_folder}aws.svg`,
+    logo: awsLogo.src,
     supports_key_team_logging: false,
     dynamic_params: {
       s3_bucket_name: "text",
@@ -155,7 +163,7 @@ export const CALLBACK_CONFIGS: CallbackConfig[] = [
   {
     id: "SQS",
     displayName: "SQS",
-    logo: `${asset_logos_folder}aws.svg`,
+    logo: awsLogo.src,
     supports_key_team_logging: false,
     dynamic_params: {
       sqs_queue_url: "text",

--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.test.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import MCPAppsPanel from "./MCPAppsPanel";
+import { fetchMCPServers, listMCPTools } from "../networking";
+import type { MCPServer } from "../mcp_tools/types";
+import { setServerRootPath } from "@/lib/serverRootPath";
+
+vi.mock("../networking", () => ({
+  fetchMCPServers: vi.fn(),
+  getMCPOAuthUserCredentialStatus: vi.fn(),
+  listMCPTools: vi.fn(),
+  deleteMCPOAuthUserCredential: vi.fn(),
+}));
+
+vi.mock("@/hooks/useUserMcpOAuthFlow", () => ({
+  useUserMcpOAuthFlow: () => ({ startOAuthFlow: vi.fn(), status: "idle" }),
+}));
+
+const servers = [
+  {
+    server_id: "s-ext",
+    server_name: "external_logo",
+    auth_type: "none",
+    mcp_info: { server_name: "external_logo", logo_url: "https://cdn.example.com/ext.png" },
+  },
+  {
+    server_id: "s-local",
+    server_name: "local_logo",
+    auth_type: "none",
+    mcp_info: { server_name: "local_logo", logo_url: "/ui/assets/logos/github.svg" },
+  },
+  {
+    server_id: "s-none",
+    server_name: "no_logo",
+    auth_type: "none",
+  },
+] as MCPServer[];
+
+const renderPanel = () =>
+  render(
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <MCPAppsPanel accessToken="tok" selectedServers={[]} onChange={vi.fn()} />
+    </QueryClientProvider>,
+  );
+
+describe("MCPAppsPanel logos", () => {
+  afterEach(() => {
+    setServerRootPath("/");
+  });
+
+  it("resolves backend logo_url values in the server grid", async () => {
+    setServerRootPath("/litellm");
+    vi.mocked(fetchMCPServers).mockResolvedValue(servers);
+    vi.mocked(listMCPTools).mockResolvedValue({ tools: [] });
+
+    renderPanel();
+
+    expect(await screen.findByText("external_logo")).toBeInTheDocument();
+    expect(screen.getByAltText("external_logo logo").getAttribute("src")).toBe("https://cdn.example.com/ext.png");
+    expect(screen.getByAltText("local_logo logo").getAttribute("src")).toBe("/litellm/ui/assets/logos/github.svg");
+  });
+
+  it("renders a colored letter avatar for servers without logo_url", async () => {
+    vi.mocked(fetchMCPServers).mockResolvedValue(servers);
+    vi.mocked(listMCPTools).mockResolvedValue({ tools: [] });
+
+    renderPanel();
+
+    expect(await screen.findByText("no_logo")).toBeInTheDocument();
+    expect(screen.queryByAltText("no_logo logo")).not.toBeInTheDocument();
+    expect(screen.getByText("N")).toBeInTheDocument();
+  });
+
+  it("resolves the logo_url in the detail header", async () => {
+    setServerRootPath("/litellm");
+    vi.mocked(fetchMCPServers).mockResolvedValue(servers);
+    vi.mocked(listMCPTools).mockResolvedValue({ tools: [] });
+
+    renderPanel();
+
+    fireEvent.click(await screen.findByText("local_logo"));
+
+    expect(await screen.findByRole("heading", { name: "local_logo" })).toBeInTheDocument();
+    expect(screen.getByAltText("local_logo logo").getAttribute("src")).toBe("/litellm/ui/assets/logos/github.svg");
+  });
+});

--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
@@ -14,6 +14,7 @@ import {
   listMCPTools,
 } from "../networking";
 import { AUTH_TYPE, MCPServer, MCPTool, handleTransport } from "../mcp_tools/types";
+import { Logo } from "@/components/molecules/logo/Logo";
 import MessageManager from "@/components/molecules/message_manager";
 import { useUserMcpOAuthFlow } from "@/hooks/useUserMcpOAuthFlow";
 
@@ -270,26 +271,19 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
 
         <div className="flex items-start gap-5 mb-7">
           {detailServer.mcp_info?.logo_url ? (
-            <img
+            <Logo
               src={detailServer.mcp_info.logo_url}
-              alt={`${name} logo`}
+              label={name}
               className="w-16 h-16 rounded-2xl object-contain shrink-0 bg-muted/50"
-              onError={(e) => {
-                const el = e.target as HTMLImageElement;
-                el.style.display = "none";
-                if (el.nextElementSibling) (el.nextElementSibling as HTMLElement).style.display = "flex";
-              }}
             />
-          ) : null}
-          <div
-            className="w-16 h-16 rounded-2xl flex items-center justify-center text-white font-bold text-[28px] shrink-0"
-            style={{
-              background: color,
-              display: detailServer.mcp_info?.logo_url ? "none" : "flex",
-            }}
-          >
-            {name.charAt(0).toUpperCase()}
-          </div>
+          ) : (
+            <div
+              className="w-16 h-16 rounded-2xl flex items-center justify-center text-white font-bold text-[28px] shrink-0"
+              style={{ background: color }}
+            >
+              {name.charAt(0).toUpperCase()}
+            </div>
+          )}
           <div className="flex-1">
             <h2 className="m-0 mb-1 text-[22px] font-bold text-foreground">{name}</h2>
             <p className="m-0 text-sm text-muted-foreground">{detailServer.description ?? "MCP server"}</p>
@@ -478,26 +472,19 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange 
                 } ${Math.floor(idx / 2) < Math.floor((filtered.length - 1) / 2) ? "border-b" : ""}`}
               >
                 {server.mcp_info?.logo_url ? (
-                  <img
+                  <Logo
                     src={server.mcp_info.logo_url}
-                    alt={`${name} logo`}
+                    label={name}
                     className="w-[38px] h-[38px] rounded-xl object-contain shrink-0 bg-muted/50"
-                    onError={(e) => {
-                      const el = e.target as HTMLImageElement;
-                      el.style.display = "none";
-                      if (el.nextElementSibling) (el.nextElementSibling as HTMLElement).style.display = "flex";
-                    }}
                   />
-                ) : null}
-                <div
-                  className="w-[38px] h-[38px] rounded-xl flex items-center justify-center text-white font-bold text-base shrink-0"
-                  style={{
-                    background: color,
-                    display: server.mcp_info?.logo_url ? "none" : "flex",
-                  }}
-                >
-                  {name.charAt(0).toUpperCase()}
-                </div>
+                ) : (
+                  <div
+                    className="w-[38px] h-[38px] rounded-xl flex items-center justify-center text-white font-bold text-base shrink-0"
+                    style={{ background: color }}
+                  >
+                    {name.charAt(0).toUpperCase()}
+                  </div>
+                )}
                 <div className="flex-1 min-w-0">
                   <div className="text-sm font-medium text-foreground truncate">{name}</div>
                   <div className="text-xs text-muted-foreground mt-0.5 flex items-center gap-1.5">

--- a/ui/litellm-dashboard/src/components/chat/MCPConnectPicker.test.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPConnectPicker.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import MCPConnectPicker from "./MCPConnectPicker";
+import { fetchMCPServers } from "../networking";
+import type { MCPServer } from "../mcp_tools/types";
+import { setServerRootPath } from "@/lib/serverRootPath";
+
+vi.mock("../networking", () => ({
+  fetchMCPServers: vi.fn(),
+  listMCPTools: vi.fn(),
+}));
+
+const servers = [
+  {
+    server_id: "s-ext",
+    server_name: "external_logo",
+    mcp_info: { server_name: "external_logo", logo_url: "https://cdn.example.com/ext.png" },
+  },
+  {
+    server_id: "s-local",
+    server_name: "local_logo",
+    mcp_info: { server_name: "local_logo", logo_url: "/ui/assets/logos/github.svg" },
+  },
+  {
+    server_id: "s-none",
+    server_name: "no_logo",
+  },
+] as MCPServer[];
+
+describe("MCPConnectPicker logos", () => {
+  afterEach(() => {
+    setServerRootPath("/");
+  });
+
+  it("resolves backend logo_url values through the Logo component", async () => {
+    setServerRootPath("/litellm");
+    vi.mocked(fetchMCPServers).mockResolvedValue(servers);
+
+    render(<MCPConnectPicker accessToken="tok" selectedServers={[]} onChange={vi.fn()} />);
+
+    expect(await screen.findByText("external_logo")).toBeInTheDocument();
+    expect(screen.getByAltText("external_logo logo").getAttribute("src")).toBe("https://cdn.example.com/ext.png");
+    expect(screen.getByAltText("local_logo logo").getAttribute("src")).toBe("/litellm/ui/assets/logos/github.svg");
+  });
+
+  it("renders no logo at all for servers without logo_url", async () => {
+    vi.mocked(fetchMCPServers).mockResolvedValue(servers);
+
+    render(<MCPConnectPicker accessToken="tok" selectedServers={[]} onChange={vi.fn()} />);
+
+    expect(await screen.findByText("no_logo")).toBeInTheDocument();
+    expect(screen.queryByAltText("no_logo logo")).not.toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/chat/MCPConnectPicker.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPConnectPicker.tsx
@@ -3,6 +3,7 @@ import { Loader2 } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
 import { Skeleton } from "@/components/ui/skeleton";
 import MessageManager from "@/components/molecules/message_manager";
+import { Logo } from "@/components/molecules/logo/Logo";
 import { fetchMCPServers, listMCPTools } from "../networking";
 import { MCPServer } from "../mcp_tools/types";
 
@@ -98,13 +99,10 @@ const MCPConnectPicker: React.FC<Props> = ({ accessToken, selectedServers, onCha
           return (
             <div key={server.server_id} className="flex items-start justify-between px-3 py-2 gap-3">
               {server.mcp_info?.logo_url && (
-                <img
+                <Logo
                   src={server.mcp_info.logo_url}
-                  alt={`${name} logo`}
+                  label={name}
                   className="w-6 h-6 rounded-md object-contain shrink-0 mt-0.5"
-                  onError={(e) => {
-                    (e.target as HTMLImageElement).style.display = "none";
-                  }}
                 />
               )}
               <div className="flex-1 min-w-0">

--- a/ui/litellm-dashboard/src/components/logging_settings_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/logging_settings_view.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { LoggingSettingsView } from "./logging_settings_view";
+
+describe("LoggingSettingsView logos", () => {
+  it("renders the bundled logo for a known logging integration", () => {
+    render(
+      <LoggingSettingsView
+        loggingConfigs={[{ callback_name: "langfuse", callback_type: "success", callback_vars: {} }]}
+      />,
+    );
+
+    expect(screen.getByAltText("Langfuse logo")).toHaveAttribute("src", "/_next/static/media/langfuse.png");
+  });
+
+  it("renders the bundled logo for a disabled callback given by internal slug", () => {
+    render(<LoggingSettingsView disabledCallbacks={["datadog"]} />);
+
+    expect(screen.getByAltText("Datadog logo")).toHaveAttribute("src", "/_next/static/media/datadog.png");
+  });
+
+  it("renders a letter avatar for an unknown callback name", () => {
+    render(
+      <LoggingSettingsView
+        loggingConfigs={[{ callback_name: "mystery_callback", callback_type: "success", callback_vars: {} }]}
+      />,
+    );
+
+    expect(document.querySelector("img")).toBeNull();
+    expect(screen.getByText("m")).toBeInTheDocument();
+    expect(screen.getByText("mystery_callback")).toBeInTheDocument();
+  });
+
+  it("renders a letter avatar for the custom callback API, which has no bundled logo", () => {
+    render(<LoggingSettingsView disabledCallbacks={["custom_callback_api"]} />);
+
+    expect(screen.queryByAltText("Custom Callback API logo")).toBeNull();
+    expect(screen.getByText("C")).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/logging_settings_view.tsx
+++ b/ui/litellm-dashboard/src/components/logging_settings_view.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Tag } from "antd";
 import { CogIcon, BanIcon } from "@heroicons/react/outline";
 import { callbackInfo, callback_map, reverse_callback_map } from "./callback_info_helpers";
-import { resolveLogoSrc } from "@/lib/assetPaths";
+import { Logo } from "@/components/molecules/logo/Logo";
 
 interface LoggingConfig {
   callback_name: string;
@@ -69,7 +69,6 @@ export function LoggingSettingsView({
           <div className="space-y-3">
             {loggingConfigs.map((config, index) => {
               const displayName = getLoggingDisplayName(config.callback_name);
-              const logoUrl = resolveLogoSrc(callbackInfo[displayName]?.logo);
 
               return (
                 <div
@@ -77,11 +76,11 @@ export function LoggingSettingsView({
                   className="flex items-center justify-between p-3 rounded-lg bg-blue-50 border border-blue-200"
                 >
                   <div className="flex items-center gap-3">
-                    {logoUrl ? (
-                      <img src={logoUrl} alt={displayName} className="w-5 h-5 object-contain" />
-                    ) : (
-                      <CogIcon className="h-5 w-5 text-gray-400" />
-                    )}
+                    <Logo
+                      src={callbackInfo[displayName]?.logo}
+                      label={displayName}
+                      className="w-5 h-5 object-contain"
+                    />
                     <div>
                       <span className="block font-medium text-blue-800">{displayName}</span>
                       <span className="block text-xs text-blue-600">
@@ -115,7 +114,6 @@ export function LoggingSettingsView({
             {disabledCallbacks.map((callbackName, index) => {
               // Handle both display names and internal values
               const displayName = reverse_callback_map[callbackName] || callbackName;
-              const logoUrl = resolveLogoSrc(callbackInfo[displayName]?.logo);
 
               return (
                 <div
@@ -123,11 +121,11 @@ export function LoggingSettingsView({
                   className="flex items-center justify-between p-3 rounded-lg bg-red-50 border border-red-200"
                 >
                   <div className="flex items-center gap-3">
-                    {logoUrl ? (
-                      <img src={logoUrl} alt={displayName} className="w-5 h-5 object-contain" />
-                    ) : (
-                      <BanIcon className="h-5 w-5 text-gray-400" />
-                    )}
+                    <Logo
+                      src={callbackInfo[displayName]?.logo}
+                      label={displayName}
+                      className="w-5 h-5 object-contain"
+                    />
                     <div>
                       <span className="block font-medium text-red-800">{displayName}</span>
                       <span className="block text-xs text-red-600">Disabled for this key</span>

--- a/ui/litellm-dashboard/src/components/model_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.test.tsx
@@ -916,4 +916,37 @@ describe("ModelInfoView", () => {
       expect(screen.getByText(/Created By/)).toBeInTheDocument();
     });
   });
+
+  it("renders the provider card logo from the bundled provider map", async () => {
+    render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
+
+    const logo = await screen.findByAltText("openai logo");
+    expect(logo.getAttribute("src")).toContain("openai_small");
+  });
+
+  it("renders a letter avatar instead of an img for an unknown provider slug", async () => {
+    mockUseModelsInfo.mockReturnValue({
+      data: {
+        data: [
+          {
+            ...defaultModelData,
+            litellm_params: {
+              ...defaultModelData.litellm_params,
+              custom_llm_provider: "zzz-internal",
+            },
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ModelInfoView {...DEFAULT_ADMIN_PROPS} />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("zzz-internal").length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByAltText("zzz-internal logo")).not.toBeInTheDocument();
+    expect(screen.getByText("z")).toBeInTheDocument();
+  });
 });

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -43,7 +43,7 @@ import {
   tagListCall,
   testConnectionRequest,
 } from "./networking";
-import { getProviderLogoAndName } from "./provider_info_helpers";
+import { Logo } from "@/components/molecules/logo/Logo";
 import UpdateModelCredentialsModal from "./update_model_credentials_modal";
 import NumericalInput from "./shared/numerical_input";
 import { Tag } from "./tag_management/types";
@@ -660,30 +660,7 @@ export default function ModelInfoView({
               <Card>
                 <Text>Provider</Text>
                 <div className="mt-2 flex items-center space-x-2">
-                  {modelData.provider && (
-                    <img
-                      src={getProviderLogoAndName(modelData.provider).logo}
-                      alt={`${modelData.provider} logo`}
-                      className="w-4 h-4"
-                      onError={(e) => {
-                        const target = e.currentTarget as HTMLImageElement;
-                        const parent = target.parentElement;
-                        if (!parent || !parent.contains(target)) {
-                          return;
-                        }
-
-                        try {
-                          const fallbackDiv = document.createElement("div");
-                          fallbackDiv.className =
-                            "w-4 h-4 rounded-full bg-gray-200 flex items-center justify-center text-xs";
-                          fallbackDiv.textContent = modelData.provider?.charAt(0) || "-";
-                          parent.replaceChild(fallbackDiv, target);
-                        } catch (error) {
-                          console.error("Failed to replace provider logo fallback:", error);
-                        }
-                      }}
-                    />
-                  )}
+                  {modelData.provider && <Logo provider={modelData.provider} className="w-4 h-4" />}
                   <Title>{modelData.provider || "Not Set"}</Title>
                 </div>
               </Card>

--- a/ui/litellm-dashboard/src/components/settings.test.tsx
+++ b/ui/litellm-dashboard/src/components/settings.test.tsx
@@ -1,8 +1,9 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { Form } from "antd";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { alertingSettingsCall, getCallbackConfigsCall, getCallbacksCall } from "./networking";
-import Settings from "./settings";
+import Settings, { backendCallbackLogoSrc, CallbackSelector } from "./settings";
 
 vi.mock("./networking", () => ({
   getCallbacksCall: vi.fn(),
@@ -230,5 +231,46 @@ describe("Settings", () => {
     });
 
     expect(getByText("CloudZero Cost Tracking")).toBeInTheDocument();
+  });
+});
+
+describe("backendCallbackLogoSrc", () => {
+  it("prefixes bare filenames with the assets logo folder", () => {
+    expect(backendCallbackLogoSrc("datadog.png")).toBe("/ui/assets/logos/datadog.png");
+  });
+
+  it("passes through urls, data uris, and paths untouched", () => {
+    expect(backendCallbackLogoSrc("https://logos.example.com/x.png")).toBe("https://logos.example.com/x.png");
+    expect(backendCallbackLogoSrc("data:image/png;base64,abc")).toBe("data:image/png;base64,abc");
+    expect(backendCallbackLogoSrc("/custom/path.png")).toBe("/custom/path.png");
+  });
+
+  it("returns undefined when the backend provides no logo", () => {
+    expect(backendCallbackLogoSrc(undefined)).toBeUndefined();
+    expect(backendCallbackLogoSrc(null)).toBeUndefined();
+    expect(backendCallbackLogoSrc("")).toBeUndefined();
+  });
+});
+
+describe("CallbackSelector logos", () => {
+  it("resolves backend logos per entry: bare filename, external url, and missing logo", async () => {
+    const callbackConfigs = [
+      { id: "langfuse", displayName: "Langfuse", logo: "langfuse.png" },
+      { id: "hosted", displayName: "Hosted", logo: "https://logos.example.com/hosted.png" },
+      { id: "nologo", displayName: "NoLogo" },
+    ];
+
+    render(
+      <Form>
+        <CallbackSelector callbackConfigs={callbackConfigs} selectedCallback={null} onCallbackChange={vi.fn()} />
+      </Form>,
+    );
+
+    fireEvent.mouseDown(screen.getByRole("combobox"));
+
+    expect(await screen.findByAltText("Langfuse logo")).toHaveAttribute("src", "/ui/assets/logos/langfuse.png");
+    expect(screen.getByAltText("Hosted logo")).toHaveAttribute("src", "https://logos.example.com/hosted.png");
+    expect(screen.queryByAltText("NoLogo logo")).toBeNull();
+    expect(screen.getByText("N")).toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/components/settings.tsx
+++ b/ui/litellm-dashboard/src/components/settings.tsx
@@ -22,7 +22,7 @@ import React, { useEffect, useState } from "react";
 
 import { Button as Button2, Form, Input, Modal, Select, Typography } from "antd";
 import EmailSettings from "./email_settings";
-import { resolveLogoSrc } from "@/lib/assetPaths";
+import { Logo } from "@/components/molecules/logo/Logo";
 import NotificationsManager from "./molecules/notifications_manager";
 
 const { Title, Paragraph } = Typography;
@@ -55,6 +55,12 @@ interface genericCallbackParams {
 }
 
 const assetsLogoFolder = "/ui/assets/logos/";
+
+export const backendCallbackLogoSrc = (logo: string | null | undefined): string | undefined => {
+  if (!logo) return undefined;
+  if (logo.includes("/") || logo.startsWith("data:") || logo.startsWith("http")) return logo;
+  return `${assetsLogoFolder}${logo}`;
+};
 
 interface DynamicParamsFieldsProps {
   params: string[];
@@ -131,7 +137,7 @@ interface CallbackSelectorProps {
   disabled?: boolean;
 }
 
-const CallbackSelector: React.FC<CallbackSelectorProps> = ({
+export const CallbackSelector: React.FC<CallbackSelectorProps> = ({
   callbackConfigs,
   selectedCallback,
   onCallbackChange,
@@ -156,25 +162,14 @@ const CallbackSelector: React.FC<CallbackSelectorProps> = ({
         onChange={onCallbackChange}
       >
         {callbackConfigs.map((callbackConfig) => {
-          const logo = callbackConfig.logo;
-          const logoSrc = resolveLogoSrc(
-            logo && (logo.includes("/") || logo.startsWith("data:") || logo.startsWith("http"))
-              ? logo
-              : `${assetsLogoFolder}${logo}`,
-          );
-
           return (
             <SelectItem key={callbackConfig.id} value={callbackConfig.id}>
               <div className="flex items-center space-x-3 py-1">
                 <div className="w-6 h-6 flex items-center justify-center">
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={logoSrc}
-                    alt={`${callbackConfig.displayName} logo`}
+                  <Logo
+                    src={backendCallbackLogoSrc(callbackConfig.logo)}
+                    label={callbackConfig.displayName}
                     className="w-6 h-6 rounded-sm object-contain"
-                    onError={(e) => {
-                      e.currentTarget.style.display = "none";
-                    }}
                   />
                 </div>
                 <span className="font-medium text-gray-900">{callbackConfig.displayName}</span>

--- a/ui/litellm-dashboard/src/components/team/LoggingSettings.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/LoggingSettings.test.tsx
@@ -111,6 +111,36 @@ describe("LoggingSettings", () => {
     expect(updatedConfig[0].callback_vars.langsmith_sampling_rate).toBe("0.3"); // Preserves initial value
   });
 
+  it("shows the bundled logo in the integration card header", () => {
+    const initialValue = [
+      {
+        callback_name: "langsmith",
+        callback_type: "success",
+        callback_vars: {},
+      },
+    ];
+
+    renderWithProviders(<LoggingSettings value={initialValue} onChange={vi.fn()} />);
+
+    expect(screen.getByAltText("LangSmith logo")).toHaveAttribute("src", "/_next/static/media/langsmith.png");
+  });
+
+  it("shows a letter avatar in the card header for a callback without a bundled logo", () => {
+    const initialValue = [
+      {
+        callback_name: "custom_callback_api",
+        callback_type: "success",
+        callback_vars: {},
+      },
+    ];
+
+    renderWithProviders(<LoggingSettings value={initialValue} onChange={vi.fn()} />);
+
+    expect(screen.getByText("Custom Callback API Configuration")).toBeInTheDocument();
+    expect(screen.queryByAltText("Custom Callback API logo")).toBeNull();
+    expect(screen.getByText("C")).toBeInTheDocument();
+  });
+
   it("correctly handles numerical input with decimal values", () => {
     const mockOnChange = vi.fn();
 

--- a/ui/litellm-dashboard/src/components/team/LoggingSettings.tsx
+++ b/ui/litellm-dashboard/src/components/team/LoggingSettings.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @next/next/no-img-element */
 /* eslint-disable react/no-unescaped-entities */
 import React from "react";
 import { Select, Tooltip, Divider } from "antd";
@@ -6,7 +5,7 @@ import { InfoCircleOutlined } from "@ant-design/icons";
 import { Button, Card, TextInput } from "@tremor/react";
 import { PlusIcon, TrashIcon, CogIcon, BanIcon } from "@heroicons/react/outline";
 import { callbackInfo, callback_map, mapDisplayToInternalNames } from "../callback_info_helpers";
-import { resolveLogoSrc } from "@/lib/assetPaths";
+import { Logo } from "@/components/molecules/logo/Logo";
 import NumericalInput from "../shared/numerical_input";
 
 const { Option } = Select;
@@ -179,31 +178,16 @@ const LoggingSettings: React.FC<LoggingSettingsProps> = ({
             optionLabelProp="label"
           >
             {allCallbacks.map((callbackName) => {
-              const logo = resolveLogoSrc(callbackInfo[callbackName]?.logo);
               const description = callbackInfo[callbackName]?.description;
               return (
                 <Option key={callbackName} value={callbackName} label={callbackName}>
                   <Tooltip title={description} placement="right">
                     <div className="flex items-center space-x-2">
-                      {logo && (
-                        <img
-                          src={logo}
-                          alt={callbackName}
-                          className="w-4 h-4 object-contain"
-                          onError={(e) => {
-                            // Create a div with callback initial as fallback
-                            const target = e.target as HTMLImageElement;
-                            const parent = target.parentElement;
-                            if (parent) {
-                              const fallbackDiv = document.createElement("div");
-                              fallbackDiv.className =
-                                "w-4 h-4 rounded-full bg-gray-200 flex items-center justify-center text-xs";
-                              fallbackDiv.textContent = callbackName.charAt(0);
-                              parent.replaceChild(fallbackDiv, target);
-                            }
-                          }}
-                        />
-                      )}
+                      <Logo
+                        src={callbackInfo[callbackName]?.logo}
+                        label={callbackName}
+                        className="w-4 h-4 object-contain"
+                      />
                       <span>{callbackName}</span>
                     </div>
                   </Tooltip>
@@ -245,7 +229,6 @@ const LoggingSettings: React.FC<LoggingSettingsProps> = ({
           const callbackDisplayName = config.callback_name
             ? Object.entries(callback_map).find(([_, value]) => value === config.callback_name)?.[0]
             : undefined;
-          const logoUrl = callbackDisplayName ? resolveLogoSrc(callbackInfo[callbackDisplayName]?.logo) : null;
 
           return (
             <Card
@@ -256,7 +239,13 @@ const LoggingSettings: React.FC<LoggingSettingsProps> = ({
             >
               <div className="flex justify-between items-start mb-4">
                 <div className="flex items-center space-x-2">
-                  {logoUrl && <img src={logoUrl} alt={callbackDisplayName} className="w-5 h-5 object-contain" />}
+                  {callbackDisplayName && (
+                    <Logo
+                      src={callbackInfo[callbackDisplayName]?.logo}
+                      label={callbackDisplayName}
+                      className="w-5 h-5 object-contain"
+                    />
+                  )}
                   <span className="text-sm font-medium">{callbackDisplayName || "New Integration"} Configuration</span>
                 </div>
                 <Button
@@ -283,31 +272,16 @@ const LoggingSettings: React.FC<LoggingSettingsProps> = ({
                       optionLabelProp="label"
                     >
                       {supportedCallbacks.map((callbackName) => {
-                        const logo = resolveLogoSrc(callbackInfo[callbackName]?.logo);
                         const description = callbackInfo[callbackName]?.description;
                         return (
                           <Option key={callbackName} value={callbackName} label={callbackName}>
                             <Tooltip title={description} placement="right">
                               <div className="flex items-center space-x-2">
-                                {logo && (
-                                  <img
-                                    src={logo}
-                                    alt={callbackName}
-                                    className="w-4 h-4 object-contain"
-                                    onError={(e) => {
-                                      // Create a div with callback initial as fallback
-                                      const target = e.target as HTMLImageElement;
-                                      const parent = target.parentElement;
-                                      if (parent) {
-                                        const fallbackDiv = document.createElement("div");
-                                        fallbackDiv.className =
-                                          "w-4 h-4 rounded-full bg-gray-200 flex items-center justify-center text-xs";
-                                        fallbackDiv.textContent = callbackName.charAt(0);
-                                        parent.replaceChild(fallbackDiv, target);
-                                      }
-                                    }}
-                                  />
-                                )}
+                                <Logo
+                                  src={callbackInfo[callbackName]?.logo}
+                                  label={callbackName}
+                                  className="w-4 h-4 object-contain"
+                                />
                                 <span>{callbackName}</span>
                               </div>
                             </Tooltip>

--- a/ui/litellm-dashboard/src/lib/assetPaths.test.ts
+++ b/ui/litellm-dashboard/src/lib/assetPaths.test.ts
@@ -67,4 +67,15 @@ describe("resolveLogoSrc", () => {
     const { resolveLogoSrc } = await importWithRoot("/");
     expect(resolveLogoSrc("/ui/assets/logos/github.svg")).toBe("/ui/assets/logos/github.svg");
   });
+
+  it("does not double-prefix a stored value that already carries the server root path", async () => {
+    const { resolveLogoSrc } = await importWithRoot("/litellm");
+    expect(resolveLogoSrc("/litellm/ui/assets/logos/custom.svg")).toBe("/litellm/ui/assets/logos/custom.svg");
+    expect(resolveLogoSrc("/litellm")).toBe("/litellm");
+  });
+
+  it("still prefixes a path whose first segment merely starts with the root path text", async () => {
+    const { resolveLogoSrc } = await importWithRoot("/litellm");
+    expect(resolveLogoSrc("/litellm-docs/logo.png")).toBe("/litellm/litellm-docs/logo.png");
+  });
 });

--- a/ui/litellm-dashboard/src/lib/assetPaths.ts
+++ b/ui/litellm-dashboard/src/lib/assetPaths.ts
@@ -24,5 +24,7 @@ export const resolveLogoSrc = (value: string | null | undefined, root: string = 
   if (!value) return undefined;
   if (EXTERNAL_SRC.test(value)) return value;
   if (value.includes("/_next/")) return value;
+  const prefix = normalizeRootPath(root);
+  if (prefix && (value === prefix || value.startsWith(`${prefix}/`))) return value;
   return withServerRoot(value, root);
 };


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Follows #34125 and #34141 (both merged; this branch is rebased onto litellm_internal_staging as e6ebfaa17d). Gates at f6061d2300 pre-rebase, re-verified post-rebase: `npm run build` passes, 20 test files / 180 tests pass (including 6 new suites), prettier and eslint clean on changed files, knip reports no new unused exports. After the build, chunks contain no `assets/logos` strings from the migrated maps; the survivors are runtime backend values that never appear in chunks

UI verification (screenshots to follow): MCP servers page (well-known logo grid, server cards, chat apps panel and connect picker), Logging settings (proxy and team level callback selectors), Guardrails garden and info views, SSO settings modal and detail view, Search Tools create form, Usage entity breakdown, and the model info view

## Type

🧹 Refactoring

## Changes

Third step of the logo consolidation (#34125 introduced `Logo` and bundled the provider map; #34141 migrated the inline provider-map lookups). This PR migrates every remaining rogue pattern from the audit onto `Logo`, so after it no dashboard code renders a logo through a bare `img`

MCP: the `WELL_KNOWN_LOGOS` grid entries become static imports for rendering while `MCPLogoSelector` continues to store stable `/ui/assets/logos/...` strings, so existing database rows keep matching the well-known map. The backend `mcp_info.logo_url` sites in `MCPServerCard`, `MCPAppsPanel`, and `MCPConnectPicker` previously fed bare `img`s without `resolveLogoSrc`, which broke under any non-root `server_root_path`; they now resolve through `Logo` src mode, with regression tests pinning the non-root prefix behavior. Review then caught a backwards-compat gap: stored values from sub-path deployments could already carry the deployment root (the old bare sites did no resolution, so admins stored prefixed paths), and resolving them again double-prefixed; `resolveLogoSrc` is now idempotent, returning values that already start with the current normalized root segment untouched while still prefixing first segments that merely begin with the root text

Callbacks: the `callbackInfo` map holds static imports (`custom_callback_api` gets no logo field since its file never existed on disk; it falls back to the letter avatar). The backend-provided variant in `settings.tsx` keeps its own domain logic in an exported `backendCallbackLogoSrc` helper (bare filenames get the assets prefix, URLs pass through) rather than being routed through the wrong resolver. `team/LoggingSettings` loses both copies of its `document.createElement` fallback surgery

Guardrails: `guardrail_garden_data` no longer duplicates logo knowledge; every partner card derives its logo from `guardrailLogoMap`, and a test asserts the derivation per card rather than by set membership. `promptguard.svg` drops a mismatched intrinsic dimension attribute that Turbopack's import-time image parser rejects (same fix as soniox/ai21 in #34125)

SSO: the logo map existed verbatim in two files; it is now single-sourced in `SSOSettings/constants.ts`, with local static imports for google and microsoft and okta remaining an external hotlink rendered through `Logo` (error now degrades to the letter avatar instead of a broken image icon); vendoring a local okta asset is a follow-up. Search tools: the `${name}.png` filename guessing is replaced with an explicit six-entry static-import map; the eleven providers with no asset on disk get the letter avatar instead of a blank hidden image. The two straggler sites (`EntityUsage`, `model_info_view`) that fed `getProviderLogoAndName(x).logo` into hand-rolled `img`s now use `Logo provider` mode

Standardized behavior changes to be aware of: image load errors now show the gray letter avatar everywhere (previously a mix of hide-the-element, colored sibling circles, and broken image icons), unknown callbacks in the logging settings list show the avatar instead of Cog and Ban icons, and alt text derives from display names. One known site is deliberately left for a follow-up because it sits outside all six areas here: `view_logs/columns.tsx` renders `mcp_server_logo_url` through a bare `img` with the same non-root-mount bug

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
