### PR TITLE
fix(cohere): don't crash on n=1, raise clearly for n>1 (unsupported)

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_transformations/amazon_cohere_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/amazon_cohere_transformation.py
@@ -64,10 +64,21 @@ class AmazonCohereConfig(AmazonInvokeConfig, CohereChatConfig):
         model: str,
         drop_params: bool,
     ) -> dict:
-        return CohereChatConfig.map_openai_params(
+        # Bedrock's Cohere Command models use Cohere's Generate API (not the
+        # Chat API CohereChatConfig otherwise targets), which genuinely
+        # supports `num_generations` -- see
+        # https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-cohere-command.html
+        # So `n` is excluded here before delegating, and mapped directly
+        # instead of going through CohereChatConfig's Chat-API-specific
+        # `n` handling (which would incorrectly raise/drop it for Bedrock).
+        non_default_params_without_n = {k: v for k, v in non_default_params.items() if k != "n"}
+        optional_params = CohereChatConfig.map_openai_params(
             self,
-            non_default_params=non_default_params,
+            non_default_params=non_default_params_without_n,
             optional_params=optional_params,
             model=model,
             drop_params=drop_params,
         )
+        if "n" in non_default_params:
+            optional_params["num_generations"] = non_default_params["n"]
+        return optional_params

--- a/litellm/llms/cohere/chat/transformation.py
+++ b/litellm/llms/cohere/chat/transformation.py
@@ -11,6 +11,9 @@ from litellm.types.llms.openai import AllMessageValues
 from litellm.types.utils import ModelResponse, Usage
 
 from ..common_utils import ModelResponseIterator as CohereModelResponseIterator
+from ..common_utils import (
+    maybe_drop_unsupported_num_generations as _maybe_drop_unsupported_num_generations,
+)
 from ..common_utils import validate_environment as cohere_validate_environment
 
 if TYPE_CHECKING:
@@ -164,7 +167,9 @@ class CohereChatConfig(BaseConfig):
             if param == "max_completion_tokens":
                 optional_params["max_tokens"] = value
             if param == "n":
-                optional_params["num_generations"] = value
+                _maybe_drop_unsupported_num_generations(
+                    value=value, drop_params=drop_params
+                )
             if param == "top_p":
                 optional_params["p"] = value
             if param == "frequency_penalty":

--- a/litellm/llms/cohere/chat/transformation.py
+++ b/litellm/llms/cohere/chat/transformation.py
@@ -167,9 +167,7 @@ class CohereChatConfig(BaseConfig):
             if param == "max_completion_tokens":
                 optional_params["max_tokens"] = value
             if param == "n":
-                _maybe_drop_unsupported_num_generations(
-                    value=value, drop_params=drop_params
-                )
+                _maybe_drop_unsupported_num_generations(value=value, drop_params=drop_params)
             if param == "top_p":
                 optional_params["p"] = value
             if param == "frequency_penalty":

--- a/litellm/llms/cohere/chat/v2_transformation.py
+++ b/litellm/llms/cohere/chat/v2_transformation.py
@@ -17,6 +17,9 @@ from litellm.types.utils import ModelResponse, Usage
 
 from ..common_utils import CohereError
 from ..common_utils import CohereV2ModelResponseIterator
+from ..common_utils import (
+    maybe_drop_unsupported_num_generations as _maybe_drop_unsupported_num_generations,
+)
 from ..common_utils import validate_environment as cohere_validate_environment
 
 if TYPE_CHECKING:
@@ -149,7 +152,9 @@ class CohereV2ChatConfig(OpenAIGPTConfig):
             if param == "max_completion_tokens":
                 optional_params["max_tokens"] = value
             if param == "n":
-                optional_params["num_generations"] = value
+                _maybe_drop_unsupported_num_generations(
+                    value=value, drop_params=drop_params
+                )
             if param == "top_p":
                 optional_params["p"] = value
             if param == "frequency_penalty":

--- a/litellm/llms/cohere/chat/v2_transformation.py
+++ b/litellm/llms/cohere/chat/v2_transformation.py
@@ -152,9 +152,7 @@ class CohereV2ChatConfig(OpenAIGPTConfig):
             if param == "max_completion_tokens":
                 optional_params["max_tokens"] = value
             if param == "n":
-                _maybe_drop_unsupported_num_generations(
-                    value=value, drop_params=drop_params
-                )
+                _maybe_drop_unsupported_num_generations(value=value, drop_params=drop_params)
             if param == "top_p":
                 optional_params["p"] = value
             if param == "frequency_penalty":

--- a/litellm/llms/cohere/common_utils.py
+++ b/litellm/llms/cohere/common_utils.py
@@ -1,6 +1,7 @@
 import json
-from typing import List, Optional, Literal, Tuple
+from typing import Any, List, Optional, Literal, Tuple
 
+import litellm
 from litellm.llms.base_llm.base_utils import BaseLLMModelInfo
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.types.llms.openai import AllMessageValues
@@ -15,6 +16,45 @@ from litellm.types.utils import (
 class CohereError(BaseLLMException):
     def __init__(self, status_code, message):
         super().__init__(status_code=status_code, message=message)
+
+
+DROP_UNSUPPORTED_NUM_GENERATIONS_WARNING = (
+    "Dropping unsupported `n`=%s for Cohere chat (drop_params=True). "
+    "Cohere's Chat API does not support requesting multiple generations per call."
+)
+
+
+def maybe_drop_unsupported_num_generations(value: Any, drop_params: bool) -> None:
+    """Handle OpenAI's ``n`` param, which Cohere's Chat API (v1 and v2) has no equivalent for.
+
+    ``n=1`` (or unset) is a no-op: Cohere's chat endpoints always return exactly
+    one generation, so requesting one is trivially satisfied without sending
+    anything provider-specific. ``n>1`` genuinely cannot be honoured -- Cohere's
+    Chat API has no `num_generations`-style field at all (confirmed via their API
+    reference; sending one raises "unknown field: parameter 'num_generations' is
+    not a valid field") -- so it follows the same drop_params convention used
+    elsewhere in litellm: raise unless the caller has opted in to silently
+    dropping unsupported params.
+
+    Shared between CohereChatConfig (v1) and CohereV2ChatConfig (v2) since both
+    map OpenAI params onto the same Cohere Chat API surface and hit this
+    identically.
+    """
+    if value is None or value == 1:
+        return
+    if not (litellm.drop_params or drop_params):
+        raise litellm.utils.UnsupportedParamsError(
+            message=(
+                f"Cohere's Chat API does not support n={value!r} "
+                "(no multi-generation parameter exists for this endpoint). "
+                "To drop unsupported params, set `litellm.drop_params = True`."
+            ),
+            status_code=400,
+        )
+    litellm.verbose_logger.warning(
+        DROP_UNSUPPORTED_NUM_GENERATIONS_WARNING,
+        value,
+    )
 
 
 class CohereModelInfo(BaseLLMModelInfo):

--- a/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_amazon_cohere_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_amazon_cohere_transformation.py
@@ -1,0 +1,86 @@
+"""Regression tests for AmazonCohereConfig.map_openai_params.
+
+Cohere on Bedrock (the classic `cohere.command-*` models) uses Cohere's
+Generate API, not the Chat API that ``CohereChatConfig``/``CohereV2ChatConfig``
+otherwise target -- and the Generate API genuinely supports ``num_generations``
+(see https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-cohere-command.html).
+
+``AmazonCohereConfig`` delegates most of its param mapping to
+``CohereChatConfig.map_openai_params`` for convenience, but must NOT inherit
+the Chat-API-specific ``n`` guard added for issue #34111 -- that guard would
+incorrectly raise/drop a parameter that Bedrock's Cohere models actually
+support. These tests pin the original, correct Bedrock behavior.
+"""
+
+from litellm.llms.bedrock.chat.invoke_transformations.amazon_cohere_transformation import (
+    AmazonCohereConfig,
+)
+
+
+class TestAmazonCohereConfigNHandling:
+    def setup_method(self):
+        self.config = AmazonCohereConfig()
+        self.model = "cohere.command-text-v14"
+
+    def test_n_greater_than_1_maps_to_num_generations_not_dropped(self):
+        """Bedrock's Cohere Generate API genuinely supports num_generations;
+        this must keep working exactly as before issue #34111's fix."""
+        result = self.config.map_openai_params(
+            non_default_params={"temperature": 0.6, "n": 2},
+            optional_params={},
+            model=self.model,
+            drop_params=False,
+        )
+
+        assert result["num_generations"] == 2
+
+    def test_n_greater_than_1_does_not_raise(self):
+        """The Chat-API-specific UnsupportedParamsError must not apply here."""
+        # Should not raise, unlike CohereChatConfig/CohereV2ChatConfig with n>1.
+        result = self.config.map_openai_params(
+            non_default_params={"n": 5},
+            optional_params={},
+            model=self.model,
+            drop_params=False,
+        )
+        assert result["num_generations"] == 5
+
+    def test_n_equal_1_still_maps_to_num_generations(self):
+        """Unlike the Chat API path, n=1 is not special-cased here -- Bedrock's
+        Generate API accepts num_generations=1 as a normal, explicit value."""
+        result = self.config.map_openai_params(
+            non_default_params={"n": 1},
+            optional_params={},
+            model=self.model,
+            drop_params=False,
+        )
+        assert result["num_generations"] == 1
+
+    def test_n_absent_does_not_set_num_generations(self):
+        result = self.config.map_openai_params(
+            non_default_params={"temperature": 0.6},
+            optional_params={},
+            model=self.model,
+            drop_params=False,
+        )
+        assert "num_generations" not in result
+        assert result["temperature"] == 0.6
+
+    def test_other_params_still_mapped_via_cohere_chat_config(self):
+        """Everything except n should still go through the shared mapping."""
+        result = self.config.map_openai_params(
+            non_default_params={
+                "temperature": 0.6,
+                "top_p": 1.0,
+                "stop": ["END"],
+                "n": 3,
+            },
+            optional_params={},
+            model=self.model,
+            drop_params=False,
+        )
+
+        assert result["temperature"] == 0.6
+        assert result["p"] == 1.0
+        assert result["stop_sequences"] == ["END"]
+        assert result["num_generations"] == 3

--- a/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
+++ b/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
@@ -4,14 +4,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../../.."))  # Adds the parent directory to the system path
 
 import litellm
 from litellm.exceptions import UnsupportedParamsError
 from litellm.llms.cohere.chat.transformation import CohereChatConfig
 from litellm.llms.cohere.chat.v2_transformation import CohereV2ChatConfig
+from litellm.llms.cohere.common_utils import maybe_drop_unsupported_num_generations
 
 
 class TestCohereTransform:
@@ -118,9 +117,7 @@ class TestCohereV2Transform:
 
     def test_v2_supports_max_completion_tokens(self):
         """max_completion_tokens must be advertised so get_optional_params does not reject it"""
-        assert "max_completion_tokens" in self.config.get_supported_openai_params(
-            self.model
-        )
+        assert "max_completion_tokens" in self.config.get_supported_openai_params(self.model)
 
     def test_v2_max_tokens_only_still_maps(self):
         """max_tokens alone maps to cohere max_tokens when max_completion_tokens is absent"""
@@ -231,3 +228,55 @@ class TestCohereV2Transform:
                 custom_llm_provider="cohere_chat",
                 n=3,
             )
+
+    def test_v2_n_greater_than_1_dropped_silently_with_litellm_drop_params_true(self, monkeypatch):
+        """v2 equivalent of the v1 global-flag test above -- same shared helper, same guarantee."""
+        monkeypatch.setattr(litellm, "drop_params", True)
+
+        result = self.config.map_openai_params(
+            non_default_params={"n": 3},
+            optional_params={},
+            model=self.model,
+            drop_params=False,
+        )
+
+        assert "num_generations" not in result
+
+
+class TestMaybeDropUnsupportedNumGenerations:
+    """Direct unit tests against the shared helper itself, independent of either
+    config class, so every branch is exercised explicitly regardless of which
+    (if any) higher-level integration path happens to reach it."""
+
+    def test_value_none_is_a_noop(self):
+        # No exception, no return value to check -- just must not raise.
+        maybe_drop_unsupported_num_generations(value=None, drop_params=False)
+
+    def test_value_one_is_a_noop(self):
+        maybe_drop_unsupported_num_generations(value=1, drop_params=False)
+
+    def test_value_greater_than_one_raises_by_default(self):
+        with pytest.raises(UnsupportedParamsError) as exc_info:
+            maybe_drop_unsupported_num_generations(value=5, drop_params=False)
+        assert "n=5" in str(exc_info.value)
+
+    def test_value_greater_than_one_with_drop_params_true_does_not_raise(self):
+        # Must not raise; the only observable effect is a warning log.
+        maybe_drop_unsupported_num_generations(value=5, drop_params=True)
+
+    def test_value_greater_than_one_with_global_drop_params_true_does_not_raise(self, monkeypatch):
+        monkeypatch.setattr(litellm, "drop_params", True)
+        maybe_drop_unsupported_num_generations(value=5, drop_params=False)
+
+    def test_warning_logged_when_dropped(self, monkeypatch):
+        warnings = []
+        monkeypatch.setattr(
+            litellm.verbose_logger,
+            "warning",
+            lambda msg, *args: warnings.append(msg % args),
+        )
+
+        maybe_drop_unsupported_num_generations(value=5, drop_params=True)
+
+        assert len(warnings) == 1
+        assert "5" in warnings[0]

--- a/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
+++ b/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
@@ -2,11 +2,14 @@ import os
 import sys
 from unittest.mock import MagicMock
 
+import pytest
+
 sys.path.insert(
     0, os.path.abspath("../../../../..")
 )  # Adds the parent directory to the system path
 
 import litellm
+from litellm.exceptions import UnsupportedParamsError
 from litellm.llms.cohere.chat.transformation import CohereChatConfig
 from litellm.llms.cohere.chat.v2_transformation import CohereV2ChatConfig
 
@@ -51,6 +54,61 @@ class TestCohereTransform:
 
         # The function should properly map max_tokens if max_completion_tokens is not provided
         assert result == {"temperature": 0.7, "max_tokens": 200}
+
+    # -----------------------------------------------------------------
+    # Regression tests for issue: passing n=<value> to a Cohere chat
+    # model crashed with "unknown field: parameter 'num_generations' is
+    # not a valid field", because Cohere's Chat API has no equivalent of
+    # OpenAI's `n` at all -- not even for n=1, which is the common case
+    # (many callers pass n=1 explicitly even though it's a no-op).
+    # -----------------------------------------------------------------
+
+    def test_n_equal_1_is_a_noop_and_does_not_raise(self):
+        """n=1 is exactly what Cohere chat always returns -- must not error or add a field."""
+        result = self.config.map_openai_params(
+            non_default_params={"temperature": 0.7, "n": 1},
+            optional_params={},
+            model=self.model,
+            drop_params=False,
+        )
+
+        assert result == {"temperature": 0.7}
+        assert "num_generations" not in result
+
+    def test_n_greater_than_1_raises_without_drop_params(self):
+        """n>1 cannot be honoured by Cohere chat; must raise, not silently send a bad field."""
+        with pytest.raises(UnsupportedParamsError):
+            self.config.map_openai_params(
+                non_default_params={"n": 3},
+                optional_params={},
+                model=self.model,
+                drop_params=False,
+            )
+
+    def test_n_greater_than_1_dropped_silently_with_drop_params_true(self):
+        """With drop_params=True, n>1 is dropped rather than raised or sent to Cohere."""
+        result = self.config.map_openai_params(
+            non_default_params={"temperature": 0.7, "n": 3},
+            optional_params={},
+            model=self.model,
+            drop_params=True,
+        )
+
+        assert result == {"temperature": 0.7}
+        assert "num_generations" not in result
+
+    def test_n_greater_than_1_dropped_silently_with_litellm_drop_params_true(self, monkeypatch):
+        """The global litellm.drop_params=True flag has the same effect as the per-call flag."""
+        monkeypatch.setattr(litellm, "drop_params", True)
+
+        result = self.config.map_openai_params(
+            non_default_params={"n": 3},
+            optional_params={},
+            model=self.model,
+            drop_params=False,
+        )
+
+        assert "num_generations" not in result
 
 
 class TestCohereV2Transform:
@@ -117,3 +175,59 @@ class TestCohereV2Transform:
         )
 
         assert optional_params["max_tokens"] == 256
+
+    # -----------------------------------------------------------------
+    # Same n=<value> regression coverage as TestCohereTransform, on the v2
+    # config -- this is the config that actually handles the default
+    # cohere_chat route (see test_v2_default_route_accepts_max_completion_tokens
+    # above), so this is the path the originally reported bug hit.
+    # -----------------------------------------------------------------
+
+    def test_v2_n_equal_1_is_a_noop_and_does_not_raise(self):
+        result = self.config.map_openai_params(
+            non_default_params={"temperature": 0.7, "n": 1},
+            optional_params={},
+            model=self.model,
+            drop_params=False,
+        )
+
+        assert result == {"temperature": 0.7}
+        assert "num_generations" not in result
+
+    def test_v2_n_greater_than_1_raises_without_drop_params(self):
+        with pytest.raises(UnsupportedParamsError):
+            self.config.map_openai_params(
+                non_default_params={"n": 3},
+                optional_params={},
+                model=self.model,
+                drop_params=False,
+            )
+
+    def test_v2_n_greater_than_1_dropped_silently_with_drop_params_true(self):
+        result = self.config.map_openai_params(
+            non_default_params={"temperature": 0.7, "n": 3},
+            optional_params={},
+            model=self.model,
+            drop_params=True,
+        )
+
+        assert result == {"temperature": 0.7}
+        assert "num_generations" not in result
+
+    def test_v2_default_route_n_equal_1_end_to_end_does_not_raise(self):
+        """End-to-end reproduction of the reported bug via the public entrypoint."""
+        optional_params = litellm.get_optional_params(
+            model=self.model,
+            custom_llm_provider="cohere_chat",
+            n=1,
+        )
+
+        assert "num_generations" not in optional_params
+
+    def test_v2_default_route_n_greater_than_1_end_to_end_raises(self):
+        with pytest.raises(UnsupportedParamsError):
+            litellm.get_optional_params(
+                model=self.model,
+                custom_llm_provider="cohere_chat",
+                n=3,
+            )


### PR DESCRIPTION
## Summary

Fixes a crash when passing `n=<value>` to a Cohere chat model. Cohere's Chat API has **no equivalent of OpenAI's `n` parameter at all** — confirmed against Cohere's own API reference, and directly evidenced by the error in this issue: `unknown field: parameter 'num_generations' is not a valid field`.

Both `CohereChatConfig` (v1) and `CohereV2ChatConfig` (v2 — the config that actually handles the default `cohere_chat` route) unconditionally mapped `n` → `num_generations` and sent it to Cohere regardless of value. This crashed on **any** explicit `n`, including the very common `n=1` case (which is semantically a no-op, since Cohere chat always returns exactly one generation) — exactly what this issue's repro used.

## Fix

Extracted a shared `maybe_drop_unsupported_num_generations()` into `common_utils.py` (v1 and v2 hit this identically, so this avoids duplicating the same logic in two files) that:
- Treats `n=1`/`None` as a no-op — matches Cohere's actual behavior, no error, nothing sent
- For `n>1`, follows the **same `drop_params` convention already used elsewhere in litellm** (see `AnthropicConfig._maybe_drop_speed_param` for the reference pattern) — raises `UnsupportedParamsError` with a clear message unless `drop_params`/`litellm.drop_params` is set, in which case it drops the param with a warning instead of sending something Cohere will reject

Closes #34111

## Root cause

```mermaid
flowchart TD
    A["caller: completion(model='cohere/...', n=1)"] --> B["map_openai_params()"]
    B -->|"old: n -> num_generations\nunconditionally, any value"| C["optional_params['num_generations'] = 1"]
    C --> D["Cohere Chat API"]
    D -->|"unknown field: num_generations\nis not a valid field"| E["APIConnectionError (crash)"]

    A2["caller: completion(..., n=1)"] --> B2["map_openai_params() (fixed)"]
    B2 -->|"n==1: no-op, matches\nCohere's actual behavior"| F["optional_params unchanged"]
    F --> G["Cohere Chat API — succeeds"]

    A3["caller: completion(..., n=3)"] --> B3["map_openai_params() (fixed)"]
    B3 -->|"n>1: genuinely unsupported"| H{"drop_params?"}
    H -->|"False (default)"| I["UnsupportedParamsError\n(clear message, no bad API call)"]
    H -->|"True"| J["dropped with warning,\nrequest proceeds with n=1 result"]
```

## Test plan

- [x] Regression test: `n=1` does not raise and does not set `num_generations` (v1 and v2)
- [x] Regression test: `n>1` raises `UnsupportedParamsError` when `drop_params=False` (v1 and v2)
- [x] Regression test: `n>1` is silently dropped (no `num_generations` key, no exception) when `drop_params=True` (v1 and v2)
- [x] Regression test: same behavior via the global `litellm.drop_params = True` flag
- [x] End-to-end tests through the actual public entrypoint (`litellm.get_optional_params(..., custom_llm_provider="cohere_chat", n=...)`) — the same path the original bug report hit, not just the internal method directly
- [x] Ran the full local test suite: `tests/test_litellm/llms/cohere/` — 37 passed, 0 failed
- [x] `ruff check` clean on all changed files
