### PR TITLE
fix(ui): revoke code interpreter image object URLs on unmount

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/CodeInterpreterOutput.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/CodeInterpreterOutput.test.tsx
@@ -295,6 +295,100 @@ describe("CodeInterpreterOutput", () => {
     });
   });
 
+  it("revokes created object URLs on unmount", async () => {
+    let urlCounter = 0;
+    (URL.createObjectURL as ReturnType<typeof vi.fn>).mockImplementation(() => `blob:test-${++urlCounter}`);
+
+    const mockBlob = new Blob(["image data"], { type: "image/png" });
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      blob: vi.fn().mockResolvedValue(mockBlob),
+    });
+
+    const annotations = [
+      {
+        type: "container_file_citation" as const,
+        container_id: "container-1",
+        file_id: "file-1",
+        filename: "chart.png",
+        start_index: 0,
+        end_index: 10,
+      },
+      {
+        type: "container_file_citation" as const,
+        container_id: "container-1",
+        file_id: "file-2",
+        filename: "plot.jpg",
+        start_index: 0,
+        end_index: 10,
+      },
+    ];
+
+    const { unmount } = render(
+      <CodeInterpreterOutput
+        code="import matplotlib.pyplot as plt"
+        annotations={annotations}
+        accessToken="test-token"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(URL.createObjectURL).toHaveBeenCalledTimes(2);
+    });
+
+    unmount();
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:test-1");
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:test-2");
+  });
+
+  it("does not leak object URLs from fetches that complete after unmount", async () => {
+    let urlCounter = 0;
+    (URL.createObjectURL as ReturnType<typeof vi.fn>).mockImplementation(() => `blob:late-${++urlCounter}`);
+
+    const mockBlob = new Blob(["image data"], { type: "image/png" });
+    let resolveBlob: (value: Blob) => void;
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      blob: vi.fn().mockReturnValue(
+        new Promise<Blob>((resolve) => {
+          resolveBlob = resolve;
+        }),
+      ),
+    });
+
+    const annotations = [
+      {
+        type: "container_file_citation" as const,
+        container_id: "container-1",
+        file_id: "file-1",
+        filename: "chart.png",
+        start_index: 0,
+        end_index: 10,
+      },
+    ];
+
+    const { unmount } = render(
+      <CodeInterpreterOutput
+        code="import matplotlib.pyplot as plt"
+        annotations={annotations}
+        accessToken="test-token"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    unmount();
+    resolveBlob!(mockBlob);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const created = (URL.createObjectURL as ReturnType<typeof vi.fn>).mock.results.map((r) => r.value);
+    const revoked = (URL.revokeObjectURL as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0]);
+    expect(revoked).toEqual(expect.arrayContaining(created));
+  });
+
   it("should handle fetch errors gracefully", async () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     (global.fetch as any).mockRejectedValue(new Error("Network error"));

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/CodeInterpreterOutput.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/CodeInterpreterOutput.tsx
@@ -39,6 +39,9 @@ const CodeInterpreterOutput: React.FC<CodeInterpreterOutputProps> = ({
 
   // Fetch images from container files API
   useEffect(() => {
+    const createdUrls: string[] = [];
+    const abortController = new AbortController();
+
     const fetchImages = async () => {
       for (const annotation of annotations) {
         const isImage =
@@ -58,16 +61,21 @@ const CodeInterpreterOutput: React.FC<CodeInterpreterOutputProps> = ({
                 headers: {
                   [getGlobalLitellmHeaderName()]: `Bearer ${accessToken}`,
                 },
+                signal: abortController.signal,
               },
             );
 
             if (response.ok) {
               const blob = await response.blob();
+              if (abortController.signal.aborted) return;
               const url = URL.createObjectURL(blob);
+              createdUrls.push(url);
               setImageUrls((prev) => ({ ...prev, [annotation.file_id]: url }));
             }
           } catch (error) {
-            console.error("Error fetching image:", error);
+            if (!abortController.signal.aborted) {
+              console.error("Error fetching image:", error);
+            }
           } finally {
             setLoadingImages((prev) => ({ ...prev, [annotation.file_id]: false }));
           }
@@ -81,7 +89,8 @@ const CodeInterpreterOutput: React.FC<CodeInterpreterOutputProps> = ({
 
     // Cleanup URLs on unmount
     return () => {
-      Object.values(imageUrls).forEach((url) => URL.revokeObjectURL(url));
+      abortController.abort();
+      createdUrls.forEach((url) => URL.revokeObjectURL(url));
     };
   }, [annotations, accessToken, proxyBaseUrl]);
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Manual repro against a live proxy plus dashboard, screenshots to follow:

1. Open the playground at http://localhost:3000/?login=success&page=llm-playground, pick a model that supports code interpreter on the Responses API, and send a prompt like "use the code interpreter to plot y = x^2 and show me the chart"
2. Once the chart image renders, open DevTools and grab its blob URL: `copy(document.querySelector('img[src^="blob:"]').src)`
3. Navigate to any other dashboard page so the playground unmounts, then in the console run `await fetch("<paste the blob url>")`
4. Before this fix (capture at the parent of this branch), the fetch resolves with the image bytes because the object URL was never revoked and the blob stays pinned until full page unload. After this fix (capture at the head commit), the fetch rejects with a network error because the URL was revoked on unmount

The two new regression tests fail on the parent commit and pass on this branch:

```
$ npx vitest run "src/app/(dashboard)/playground/components/chat_ui/CodeInterpreterOutput.test.tsx"
Tests  11 passed (11)
```

## Type

🐛 Bug Fix

## Changes

The image fetch effect in `CodeInterpreterOutput.tsx` returned a cleanup that did `Object.values(imageUrls).forEach(URL.revokeObjectURL)`, but the effect's dependency array is `[annotations, accessToken, proxyBaseUrl]`, so the cleanup closure captures the `imageUrls` state value from the render the effect ran in. That value is always the initial empty object; the URLs are created later inside the async fetch via `setImageUrls`. The revoke loop therefore always iterated an empty object and every code interpreter chart blob stayed alive until full page unload

The fix tracks created object URLs in an effect-local array that the cleanup revokes, and wires an `AbortController` into the image fetches so unmount also cancels in-flight requests. A blob that resolves after unmount can no longer create an object URL because creation is gated on the abort signal. Abort rejections are not logged as fetch errors

Two regression tests cover both windows: URLs created before unmount get revoked, and fetches that complete after unmount do not leak URLs. Both fail on the previous implementation

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
