### PR TITLE
fix(scim): prune deleted user from teams' members_with_roles

### DIFF
--- a/litellm/proxy/management_endpoints/scim/scim_v2.py
+++ b/litellm/proxy/management_endpoints/scim/scim_v2.py
@@ -1317,6 +1317,13 @@ async def delete_user(
                     where={"team_id": team.team_id}, data={"members": new_members}
                 )
 
+            team_row = LiteLLM_TeamTable(**team.model_dump())
+            if any(member.user_id == user_id for member in team_row.members_with_roles or []):
+                await team_member_delete(
+                    data=TeamMemberDeleteRequest(team_id=team_row.team_id, user_id=user_id),
+                    user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
+                )
+
         await _set_user_keys_blocked(user_id=user_id, blocked=True)
 
         await _delete_rows_referencing_user(prisma_client, user_id=user_id)

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
@@ -23,6 +23,7 @@ from litellm.proxy.management_endpoints.scim.scim_v2 import (
     create_group,
     create_user,
     delete_group,
+    delete_user,
     get_groups,
     get_users,
     get_service_provider_config,
@@ -3062,3 +3063,126 @@ async def test_apply_group_patch_updates_does_not_write_legacy_members(mocker):
     written = mock_prisma_client.db.litellm_teamtable.update.call_args.kwargs["data"]
     assert "members" not in written
     assert written["team_alias"] == "Renamed"
+
+
+def _mock_prisma_for_delete_user(mocker, team):
+    mock_prisma_client = mocker.MagicMock()
+    mock_prisma_client.db = mocker.MagicMock()
+    mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=team)
+    mock_prisma_client.db.litellm_teamtable.update = AsyncMock()
+    mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
+    mock_prisma_client.db.litellm_usertable.delete = AsyncMock()
+    return mock_prisma_client
+
+
+def _patch_delete_user_dependencies(mocker, mock_prisma_client, existing_user):
+    mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
+        AsyncMock(return_value=mock_prisma_client),
+    )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2._check_user_exists",
+        AsyncMock(return_value=existing_user),
+    )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2._set_user_keys_blocked",
+        AsyncMock(),
+    )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2._delete_rows_referencing_user",
+        AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_user_prunes_members_with_roles(mocker):
+    """Deleting a SCIM user must remove them from every team they belong to via
+    team_member_delete, which prunes members_with_roles (the source of truth for
+    SCIM group membership) so GET /Groups no longer returns a dangling reference
+    to the now-deleted user."""
+    user_id = "scim-del-user"
+
+    existing_user = mocker.MagicMock()
+    existing_user.teams = ["team-1"]
+
+    team = LiteLLM_TeamTable(
+        team_id="team-1",
+        members=[user_id, "other-user"],
+        members_with_roles=[Member(user_id=user_id, role="user"), Member(user_id="other-user", role="admin")],
+    )
+
+    mock_prisma_client = _mock_prisma_for_delete_user(mocker, team)
+    _patch_delete_user_dependencies(mocker, mock_prisma_client, existing_user)
+    team_member_delete_mock = mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2.team_member_delete",
+        AsyncMock(),
+    )
+
+    await delete_user(user_id=user_id)
+
+    team_member_delete_mock.assert_awaited_once()
+    call = team_member_delete_mock.call_args
+    assert call.kwargs["data"].team_id == "team-1"
+    assert call.kwargs["data"].user_id == user_id
+    assert call.kwargs["user_api_key_dict"].user_role == LitellmUserRoles.PROXY_ADMIN
+    mock_prisma_client.db.litellm_usertable.delete.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_user_surfaces_prune_failure_and_keeps_user(mocker):
+    """A genuine failure while pruning members_with_roles must surface: the
+    endpoint fails loudly and the user row is NOT deleted, so we never report a
+    successful delete while leaving a dangling member (SCIM DELETE is idempotent,
+    so the IdP retries)."""
+    user_id = "scim-del-user"
+
+    existing_user = mocker.MagicMock()
+    existing_user.teams = ["team-1"]
+
+    team = LiteLLM_TeamTable(
+        team_id="team-1",
+        members=[user_id],
+        members_with_roles=[Member(user_id=user_id, role="user")],
+    )
+
+    mock_prisma_client = _mock_prisma_for_delete_user(mocker, team)
+    _patch_delete_user_dependencies(mocker, mock_prisma_client, existing_user)
+    mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2.team_member_delete",
+        AsyncMock(side_effect=Exception("database connection lost")),
+    )
+
+    with pytest.raises(Exception):
+        await delete_user(user_id=user_id)
+
+    mock_prisma_client.db.litellm_usertable.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_user_skips_teams_where_not_a_member(mocker):
+    """If the user is not in a team's members_with_roles, deletion must treat that
+    team as a no-op (no team_member_delete call, no error) and still delete the
+    user, so a stale legacy membership can't block the delete."""
+    user_id = "scim-del-user"
+
+    existing_user = mocker.MagicMock()
+    existing_user.teams = ["team-1"]
+
+    team = LiteLLM_TeamTable(
+        team_id="team-1",
+        members=[user_id],
+        members_with_roles=[Member(user_id="someone-else", role="admin")],
+    )
+
+    mock_prisma_client = _mock_prisma_for_delete_user(mocker, team)
+    _patch_delete_user_dependencies(mocker, mock_prisma_client, existing_user)
+    team_member_delete_mock = mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2.team_member_delete",
+        AsyncMock(),
+    )
+
+    await delete_user(user_id=user_id)
+
+    team_member_delete_mock.assert_not_awaited()
+    mock_prisma_client.db.litellm_usertable.delete.assert_awaited_once()


### PR DESCRIPTION
## Relevant issues

https://github.com/BerriAI/litellm/pull/34162

## Linear ticket

Part of LIT-4676

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Independent e2e (Devin): after DELETE /Users the deleted user is pruned from the team's members_with_roles and no longer returned by GET /Groups (parent left the stale member).

![proof](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/lit-4676/34180_proof.png)

SCIM `delete_user` used to remove the user from the legacy `team.members` String[] column and delete their `LiteLLM_TeamMembership` rows, but it never pruned `members_with_roles`, which is the source of truth `ScimTransformations.transform_litellm_team_to_scim_group` reads for `GET /Groups/{id}`. So a deleted user kept showing up as a dangling member reference on every team they belonged to. The prune now runs before the user row is deleted, through `team_member_delete`, and a genuine prune failure surfaces instead of being swallowed, so we never report a successful delete while leaving a stale member (SCIM DELETE is idempotent, so the IdP retries). This bug lives entirely in the SCIM management path with no LLM inference, so the faithful end-user reproduction is curl against a live proxy plus a direct look at the `members_with_roles` column in Postgres

Live proxy on `127.0.0.1:4292`, backed by a local Postgres, master-key auth

Before (bug), captured at commit `2b2ae4ca491278ed9e88227bb166a5c8c3c29279`

```
# create user + group with the user as a member, then:
$ docker exec pg psql -U litellm -d litellm -t -c \
    "SELECT members_with_roles FROM \"LiteLLM_TeamTable\" WHERE team_id='team-1';"
 [{"role": "user", "user_id": "user-1", "user_email": null}]

$ curl -s -o /dev/null -w "delete http=%{http_code}\n" -X DELETE \
    127.0.0.1:4292/scim/v2/Users/user-1 -H "Authorization: Bearer $KEY"
delete http=204

$ docker exec pg psql -U litellm -d litellm -t -c \
    "SELECT members_with_roles FROM \"LiteLLM_TeamTable\" WHERE team_id='team-1';"
 [{"role": "user", "user_id": "user-1", "user_email": null}]   # BUG: user still present

$ curl -s 127.0.0.1:4292/scim/v2/Groups/team-1 -H "Authorization: Bearer $KEY"
members: [{'value': 'user-1', 'display': 'user-1'}]            # BUG: dangling member

$ curl ... /scim/v2/Users/user-1   ->  GET user http=404       # the user really is gone
```

After (fixed), captured at commit `0358d8739fe6e47de2d7030dfafa2b1e260bb10e`

Scenario A, normal delete leaves no dangling member

```
$ docker exec pg psql ... "SELECT members_with_roles ... team_id='teamA';"
 [{"role": "user", "user_id": "userA", "user_email": null}]

$ curl -X DELETE .../scim/v2/Users/userA        ->  delete http=204

$ docker exec pg psql ... "SELECT members_with_roles ... team_id='teamA';"
 []                                              # fixed: pruned from source of truth

$ curl .../scim/v2/Groups/teamA                 ->  members: []
$ curl .../scim/v2/Users/userA                  ->  GET user http=404
```

Scenario B, a prune-path failure surfaces and the user is kept (fault injected by corrupting the team's `members_with_roles` so the prune cannot complete)

```
$ docker exec pg psql ... "SELECT members_with_roles ... team_id='teamB';"
 [{"role": "user", "user_id": "userB", "user_email": null}]

$ docker exec pg psql -c "UPDATE \"LiteLLM_TeamTable\" SET members_with_roles='[42]'::jsonb WHERE team_id='teamB';"

$ curl -X DELETE .../scim/v2/Users/userB
delete http=500
{"error":{"message":"1 validation error for LiteLLM_TeamTable ... members_with_roles.0 ...","type":"internal_server_error", ...}}

$ curl .../scim/v2/Users/userB                  ->  GET user http=200   # user kept, not silently dropped with a dangling member
```

## Type

🐛 Bug Fix

## Changes

`delete_user` now prunes each of the user's teams before deleting the user row. For every team the user belongs to whose `members_with_roles` actually contains them, it calls `team_member_delete` (with a `PROXY_ADMIN` `UserAPIKeyAuth`, the same pattern the sibling SCIM group code uses), which keeps `members_with_roles`, `user.teams`, and `LiteLLM_TeamMembership` consistent, so the source of truth `GET /Groups/{id}` reads no longer references a deleted user. Teams the user is not a member of are skipped, so a stale legacy `team.members` entry can't turn the delete into an error. The legacy `team.members` cleanup stays because that column is still queried elsewhere (`list_team_v2`)

The prune runs directly rather than through `patch_team_membership`, which logs and suppresses every `team_member_delete` error. Under that helper a genuine DB failure mid-prune left a dangling member while the endpoint still returned 204. Routing directly lets a real failure propagate through the endpoint's exception handler so it fails loudly and the user row is not deleted; SCIM DELETE is idempotent, so the IdP retries. `patch_team_membership` is unchanged for its other callers

Three regression tests cover it: `test_delete_user_prunes_members_with_roles` (a member is removed via `team_member_delete` and the user is deleted), `test_delete_user_surfaces_prune_failure_and_keeps_user` (a raised prune error surfaces and the user row is not deleted), and `test_delete_user_skips_teams_where_not_a_member` (a user absent from `members_with_roles` is a no-op and the delete still succeeds). All three fail on the pre-fix behavior and pass with the fix

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

