### PR TITLE
fix(scim): sync team roster and dedup teams for existing-user email upsert

### DIFF
--- a/litellm/proxy/management_endpoints/scim/scim_v2.py
+++ b/litellm/proxy/management_endpoints/scim/scim_v2.py
@@ -98,14 +98,26 @@ class UserProvisionerHelpers:
         if not existing_user:
             return None
 
-        # Update the user
+        new_teams = list(dict.fromkeys(new_user_request.teams or []))
+
+        if new_user_request.user_id != existing_user.user_id:
+            await UserRepository(prisma_client).table.update(
+                where={"user_id": existing_user.user_id},
+                data={"user_id": new_user_request.user_id},
+            )
+
+        await _handle_team_membership_changes(
+            user_id=new_user_request.user_id,
+            existing_teams=existing_user.teams or [],
+            new_teams=new_teams,
+        )
+
         updated_user = await UserRepository(prisma_client).table.update(
-            where={"user_id": existing_user.user_id},
+            where={"user_id": new_user_request.user_id},
             data={
-                "user_id": new_user_request.user_id,
                 "user_email": new_user_request.user_email,
                 "user_alias": new_user_request.user_alias,
-                "teams": new_user_request.teams,
+                "teams": new_teams,
                 "metadata": safe_dumps(new_user_request.metadata),
                 **({"user_role": new_user_request.user_role} if admin_group is not None else {}),
             },

--- a/litellm/proxy/management_endpoints/scim/scim_v2.py
+++ b/litellm/proxy/management_endpoints/scim/scim_v2.py
@@ -110,6 +110,7 @@ class UserProvisionerHelpers:
             user_id=new_user_request.user_id,
             existing_teams=existing_user.teams or [],
             new_teams=new_teams,
+            raise_on_error=True,
         )
 
         updated_user = await UserRepository(prisma_client).table.update(
@@ -452,7 +453,12 @@ async def _get_team_members_display(member_ids: List[str]) -> List[SCIMMember]:
     return members
 
 
-async def _handle_team_membership_changes(user_id: str, existing_teams: List[str], new_teams: List[str]) -> None:
+async def _handle_team_membership_changes(
+    user_id: str,
+    existing_teams: List[str],
+    new_teams: List[str],
+    raise_on_error: bool = False,
+) -> None:
     """Handle adding/removing user from teams based on changes."""
     existing_teams_set = set(existing_teams)
     new_teams_set = set(new_teams)
@@ -465,6 +471,7 @@ async def _handle_team_membership_changes(user_id: str, existing_teams: List[str
             user_id=user_id,
             teams_ids_to_add_user_to=list(teams_to_add),
             teams_ids_to_remove_user_from=list(teams_to_remove),
+            raise_on_error=raise_on_error,
         )
 
 
@@ -1513,12 +1520,17 @@ async def patch_team_membership(
     user_id: str,
     teams_ids_to_add_user_to: List[str],
     teams_ids_to_remove_user_from: List[str],
+    raise_on_error: bool = False,
 ) -> bool:
     """
     Add or remove user from teams
 
     Handles duplicate membership gracefully (idempotent operation).
     If a user is already in a team, that's fine - we don't treat it as an error.
+
+    When ``raise_on_error`` is True a genuine add failure (anything other than
+    the user already being in the team) propagates instead of being swallowed,
+    so a caller can avoid persisting a teams array the roster never received.
     """
     for _team_id in teams_ids_to_add_user_to:
         try:
@@ -1533,9 +1545,13 @@ async def patch_team_membership(
             # Handle duplicate membership gracefully - this is idempotent
             if e.type == ProxyErrorTypes.team_member_already_in_team:
                 verbose_proxy_logger.debug(f"User {user_id} is already in team {_team_id}, skipping add")
+            elif raise_on_error:
+                raise
             else:
                 verbose_proxy_logger.exception(f"Error adding user to team {_team_id}: {e}")
         except Exception as e:
+            if raise_on_error:
+                raise
             verbose_proxy_logger.exception(f"Error adding user to team {_team_id}: {e}")
 
     for _team_id in teams_ids_to_remove_user_from:

--- a/litellm/proxy/management_endpoints/scim/scim_v2.py
+++ b/litellm/proxy/management_endpoints/scim/scim_v2.py
@@ -1516,6 +1516,13 @@ def _apply_patch_ops(
     return update_data, final_team_set
 
 
+def _is_user_not_in_team_error(exc: HTTPException) -> bool:
+    """True when team_member_delete reports the user was already absent from the
+    team, which is the idempotent no-op case for a removal."""
+    detail = exc.detail
+    return isinstance(detail, dict) and detail.get("error") == "User not found in team"
+
+
 async def patch_team_membership(
     user_id: str,
     teams_ids_to_add_user_to: List[str],
@@ -1526,10 +1533,11 @@ async def patch_team_membership(
     Add or remove user from teams
 
     Handles duplicate membership gracefully (idempotent operation).
-    If a user is already in a team, that's fine - we don't treat it as an error.
+    A user already being in a team (on add) or already absent from it (on
+    remove) is treated as a no-op, not an error.
 
-    When ``raise_on_error`` is True a genuine add failure (anything other than
-    the user already being in the team) propagates instead of being swallowed,
+    When ``raise_on_error`` is True a genuine add or remove failure (anything
+    other than those idempotent no-ops) propagates instead of being swallowed,
     so a caller can avoid persisting a teams array the roster never received.
     """
     for _team_id in teams_ids_to_add_user_to:
@@ -1560,7 +1568,16 @@ async def patch_team_membership(
                 data=TeamMemberDeleteRequest(team_id=_team_id, user_id=user_id),
                 user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
             )
+        except HTTPException as e:
+            if _is_user_not_in_team_error(e):
+                verbose_proxy_logger.debug(f"User {user_id} is not in team {_team_id}, skipping remove")
+            elif raise_on_error:
+                raise
+            else:
+                verbose_proxy_logger.exception(f"Error removing user from team {_team_id}: {e}")
         except Exception as e:
+            if raise_on_error:
+                raise
             verbose_proxy_logger.exception(f"Error removing user from team {_team_id}: {e}")
 
     return True

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
@@ -8,6 +8,7 @@ from litellm.proxy._types import (
     LitellmUserRoles,
     NewUserRequest,
     NewUserResponse,
+    ProxyErrorTypes,
     ProxyException,
 )
 from litellm.proxy.management_endpoints.scim.scim_v2 import (
@@ -612,6 +613,7 @@ async def test_handle_existing_user_by_email_existing_user_updated(mocker):
         user_id="new-user-id",
         existing_teams=["old-team"],
         new_teams=["new-team"],
+        raise_on_error=True,
     )
 
     mock_transform.assert_called_once_with(updated_user)
@@ -666,12 +668,110 @@ async def test_handle_existing_user_by_email_syncs_roster_and_dedups_teams(mocke
         user_id="same-id",
         existing_teams=[],
         new_teams=["team-a", "team-b"],
+        raise_on_error=True,
     )
 
     update_calls = mock_prisma_client.db.litellm_usertable.update.call_args_list
     assert len(update_calls) == 1
     assert update_calls[0].kwargs["where"] == {"user_id": "same-id"}
     assert update_calls[0].kwargs["data"]["teams"] == ["team-a", "team-b"]
+
+
+@pytest.mark.asyncio
+async def test_handle_existing_user_by_email_roster_add_failure_blocks_teams_write(mocker):
+    """A genuine roster add failure must propagate and must not persist the teams array.
+
+    Regression: the roster sync went through patch_team_membership which swallowed
+    real team_member_add failures, so the endpoint reported success and wrote a
+    teams array listing a team the roster never received. The strict path now
+    surfaces the failure so user.teams and members_with_roles cannot diverge.
+    """
+    existing_user = mocker.MagicMock()
+    existing_user.user_id = "uid"
+    existing_user.user_email = "member@example.com"
+    existing_user.user_alias = "Member"
+    existing_user.teams = []
+    existing_user.metadata = {}
+
+    mock_prisma_client = mocker.MagicMock()
+    mock_prisma_client.db = mocker.MagicMock()
+    mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(return_value=existing_user)
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value={})
+
+    mock_team_member_add = mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2.team_member_add",
+        AsyncMock(side_effect=HTTPException(status_code=404, detail={"error": "Team not found"})),
+    )
+
+    new_user_request = NewUserRequest(
+        user_id="uid",
+        user_email="member@example.com",
+        user_alias="Member",
+        teams=["missing-team"],
+        metadata={},
+        auto_create_key=False,
+    )
+
+    with pytest.raises(HTTPException):
+        await UserProvisionerHelpers.handle_existing_user_by_email(
+            prisma_client=mock_prisma_client, new_user_request=new_user_request
+        )
+
+    mock_team_member_add.assert_awaited_once()
+    assert mock_prisma_client.db.litellm_usertable.update.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_handle_existing_user_by_email_roster_add_already_member_is_noop(mocker):
+    """Being already in the team is benign even under the strict path: the upsert
+    succeeds and the deduped teams array is still persisted."""
+    existing_user = mocker.MagicMock()
+    existing_user.user_id = "uid"
+    existing_user.user_email = "member@example.com"
+    existing_user.user_alias = "Member"
+    existing_user.teams = []
+    existing_user.metadata = {}
+
+    mock_prisma_client = mocker.MagicMock()
+    mock_prisma_client.db = mocker.MagicMock()
+    mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(return_value=existing_user)
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value={})
+
+    mock_team_member_add = mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2.team_member_add",
+        AsyncMock(
+            side_effect=ProxyException(
+                message="already in team",
+                type=ProxyErrorTypes.team_member_already_in_team.value,
+                param=None,
+                code=400,
+            )
+        ),
+    )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
+        AsyncMock(return_value=None),
+    )
+
+    new_user_request = NewUserRequest(
+        user_id="uid",
+        user_email="member@example.com",
+        user_alias="Member",
+        teams=["team-x"],
+        metadata={},
+        auto_create_key=False,
+    )
+
+    await UserProvisionerHelpers.handle_existing_user_by_email(
+        prisma_client=mock_prisma_client, new_user_request=new_user_request
+    )
+
+    mock_team_member_add.assert_awaited_once()
+    update_calls = mock_prisma_client.db.litellm_usertable.update.call_args_list
+    assert len(update_calls) == 1
+    assert update_calls[0].kwargs["data"]["teams"] == ["team-x"]
 
 
 @pytest.mark.asyncio
@@ -2436,6 +2536,10 @@ async def test_handle_existing_user_by_email_applies_role_when_admin_group_set(m
         "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
         AsyncMock(return_value=mocker.MagicMock()),
     )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2._handle_team_membership_changes",
+        AsyncMock(),
+    )
 
     new_user_request = NewUserRequest(
         user_id="new-user-id",
@@ -2471,6 +2575,10 @@ async def test_handle_existing_user_by_email_leaves_role_when_admin_group_unset(
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
         AsyncMock(return_value=mocker.MagicMock()),
+    )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2._handle_team_membership_changes",
+        AsyncMock(),
     )
 
     new_user_request = NewUserRequest(
@@ -2532,6 +2640,10 @@ async def test_create_user_existing_email_upsert_demotes_when_admin_group_set(mo
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
         AsyncMock(return_value=scim_user),
+    )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2._handle_team_membership_changes",
+        AsyncMock(),
     )
 
     await create_user(user=scim_user)

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
@@ -55,9 +55,7 @@ async def test_create_user_existing_user_conflict(mocker):
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value={"user_id": "existing-user"}
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value={"user_id": "existing-user"})
 
     # Mock the _get_prisma_client_or_raise_exception to return our mock
     mocker.patch(
@@ -231,9 +229,7 @@ async def test_create_user_ingests_entitlements_and_roles(mocker, monkeypatch):
         },
         {"value": "bare-entitlement"},
     ]
-    assert created_metadata["scim_roles"] == [
-        {"value": "engineering-admin", "type": "role"}
-    ]
+    assert created_metadata["scim_roles"] == [{"value": "engineering-admin", "type": "role"}]
 
 
 @pytest.mark.asyncio
@@ -257,9 +253,7 @@ async def test_create_user_uses_default_internal_user_params_role(mocker, monkey
     default_params = {
         "user_role": LitellmUserRoles.PROXY_ADMIN,
     }
-    monkeypatch.setattr(
-        "litellm.default_internal_user_params", default_params, raising=False
-    )
+    monkeypatch.setattr("litellm.default_internal_user_params", default_params, raising=False)
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -339,10 +333,7 @@ async def test_scim_create_user_respects_default_role_set_via_ui(mocker, monkeyp
         "BUG: _update_litellm_setting did not update litellm.default_internal_user_params in memory. "
         "The local variable reassignment (in_memory_var = ...) doesn't propagate back."
     )
-    assert (
-        litellm.default_internal_user_params.get("user_role")
-        == LitellmUserRoles.INTERNAL_USER
-    )
+    assert litellm.default_internal_user_params.get("user_role") == LitellmUserRoles.INTERNAL_USER
 
     # Step 3: Create a user via SCIM
     scim_user = SCIMUser(
@@ -438,9 +429,7 @@ async def test_get_users_filters_username_by_exposed_scim_username_for_okta(mock
         take=10,
         order={"created_at": "desc"},
     )
-    mock_prisma_client.db.litellm_usertable.count.assert_awaited_once_with(
-        where=expected_where
-    )
+    mock_prisma_client.db.litellm_usertable.count.assert_awaited_once_with(where=expected_where)
     assert response.totalResults == 1
     assert response.Resources[0].id == "internal-user-id"
 
@@ -494,9 +483,7 @@ async def test_get_users_filters_email_value_by_user_email(mocker):
         take=10,
         order={"created_at": "desc"},
     )
-    mock_prisma_client.db.litellm_usertable.count.assert_awaited_once_with(
-        where=expected_where
-    )
+    mock_prisma_client.db.litellm_usertable.count.assert_awaited_once_with(where=expected_where)
     assert response.totalResults == 1
     assert response.Resources[0].id == "internal-user-id"
 
@@ -544,15 +531,12 @@ async def test_handle_existing_user_by_email_no_existing_user(mocker):
     )
 
     assert result is None
-    mock_prisma_client.db.litellm_usertable.find_first.assert_called_once_with(
-        where={"user_email": "test@example.com"}
-    )
+    mock_prisma_client.db.litellm_usertable.find_first.assert_called_once_with(where={"user_email": "test@example.com"})
 
 
 @pytest.mark.asyncio
 async def test_handle_existing_user_by_email_existing_user_updated(mocker):
-    """Should update existing user and return SCIMUser when user with email exists"""
-    # Mock existing user - create a proper mock object with attributes
+    """Should rename the existing user, sync team roster, and return SCIMUser"""
     existing_user = mocker.MagicMock()
     existing_user.user_id = "old-user-id"
     existing_user.user_email = "test@example.com"
@@ -560,7 +544,6 @@ async def test_handle_existing_user_by_email_existing_user_updated(mocker):
     existing_user.teams = ["old-team"]
     existing_user.metadata = {"old": "data"}
 
-    # Mock updated user
     updated_user = {
         "user_id": "new-user-id",
         "user_email": "test@example.com",
@@ -569,7 +552,6 @@ async def test_handle_existing_user_by_email_existing_user_updated(mocker):
         "metadata": '{"new": "data"}',
     }
 
-    # Mock SCIM user to be returned
     mock_scim_user = SCIMUser(
         schemas=["urn:ietf:params:scim:schemas:core:2.0:User"],
         id="new-user-id",
@@ -581,17 +563,16 @@ async def test_handle_existing_user_by_email_existing_user_updated(mocker):
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(
-        return_value=existing_user
-    )
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value=updated_user
-    )
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(return_value=existing_user)
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value=updated_user)
 
-    # Mock the transformation function
     mock_transform = mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
         AsyncMock(return_value=mock_scim_user),
+    )
+    mock_membership = mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2._handle_team_membership_changes",
+        AsyncMock(),
     )
 
     new_user_request = NewUserRequest(
@@ -607,27 +588,90 @@ async def test_handle_existing_user_by_email_existing_user_updated(mocker):
         prisma_client=mock_prisma_client, new_user_request=new_user_request
     )
 
-    # Verify the result
     assert result == mock_scim_user
 
-    # Verify database operations
-    mock_prisma_client.db.litellm_usertable.find_first.assert_called_once_with(
-        where={"user_email": "test@example.com"}
-    )
+    mock_prisma_client.db.litellm_usertable.find_first.assert_called_once_with(where={"user_email": "test@example.com"})
 
-    mock_prisma_client.db.litellm_usertable.update.assert_called_once_with(
-        where={"user_id": "old-user-id"},
-        data={
-            "user_id": "new-user-id",
+    update_calls = mock_prisma_client.db.litellm_usertable.update.call_args_list
+    assert len(update_calls) == 2
+    assert update_calls[0].kwargs == {
+        "where": {"user_id": "old-user-id"},
+        "data": {"user_id": "new-user-id"},
+    }
+    assert update_calls[1].kwargs == {
+        "where": {"user_id": "new-user-id"},
+        "data": {
             "user_email": "test@example.com",
             "user_alias": "New Name",
             "teams": ["new-team"],
             "metadata": '{"new": "data"}',
         },
+    }
+
+    mock_membership.assert_awaited_once_with(
+        user_id="new-user-id",
+        existing_teams=["old-team"],
+        new_teams=["new-team"],
     )
 
-    # Verify transformation was called
     mock_transform.assert_called_once_with(updated_user)
+
+
+@pytest.mark.asyncio
+async def test_handle_existing_user_by_email_syncs_roster_and_dedups_teams(mocker):
+    """Existing-email upsert must add the user to the team roster via the shared
+    team_member_add path and dedup the teams built from repeated SCIM groups.
+
+    Regression: previously the user's ``teams`` array was raw-written (with
+    duplicates) and the team roster (members_with_roles / LiteLLM_TeamMembership)
+    was never touched, so the user appeared in the group on their profile but was
+    absent from the team directly.
+    """
+    existing_user = mocker.MagicMock()
+    existing_user.user_id = "same-id"
+    existing_user.user_email = "member@example.com"
+    existing_user.user_alias = "Member"
+    existing_user.teams = []
+    existing_user.metadata = {}
+
+    mock_prisma_client = mocker.MagicMock()
+    mock_prisma_client.db = mocker.MagicMock()
+    mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(return_value=existing_user)
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value={})
+
+    mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
+        AsyncMock(return_value=None),
+    )
+    mock_membership = mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2._handle_team_membership_changes",
+        AsyncMock(),
+    )
+
+    new_user_request = NewUserRequest(
+        user_id="same-id",
+        user_email="member@example.com",
+        user_alias="Member",
+        teams=["team-a", "team-a", "team-b"],
+        metadata={},
+        auto_create_key=False,
+    )
+
+    await UserProvisionerHelpers.handle_existing_user_by_email(
+        prisma_client=mock_prisma_client, new_user_request=new_user_request
+    )
+
+    mock_membership.assert_awaited_once_with(
+        user_id="same-id",
+        existing_teams=[],
+        new_teams=["team-a", "team-b"],
+    )
+
+    update_calls = mock_prisma_client.db.litellm_usertable.update.call_args_list
+    assert len(update_calls) == 1
+    assert update_calls[0].kwargs["where"] == {"user_id": "same-id"}
+    assert update_calls[0].kwargs["data"]["teams"] == ["team-a", "team-b"]
 
 
 @pytest.mark.asyncio
@@ -762,9 +806,7 @@ async def test_update_user_success(mocker):
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value=updated_user
-    )
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value=updated_user)
 
     # Mock dependencies
     mocker.patch(
@@ -815,11 +857,7 @@ async def test_update_user_not_found(mocker):
     )
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._check_user_exists",
-        AsyncMock(
-            side_effect=HTTPException(
-                status_code=404, detail={"error": "User not found"}
-            )
-        ),
+        AsyncMock(side_effect=HTTPException(status_code=404, detail={"error": "User not found"})),
     )
 
     # Should raise ProxyException (which wraps the HTTPException)
@@ -864,9 +902,7 @@ async def test_patch_user_success(mocker):
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value=updated_user
-    )
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value=updated_user)
 
     # Mock dependencies
     mocker.patch(
@@ -903,9 +939,7 @@ async def test_patch_user_not_found(mocker):
     """Should raise 404 when user doesn't exist for patch"""
     patch_ops = SCIMPatchOp(
         schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-        Operations=[
-            SCIMPatchOperation(op="replace", path="displayName", value="New Name")
-        ],
+        Operations=[SCIMPatchOperation(op="replace", path="displayName", value="New Name")],
     )
 
     # Mock dependencies to raise HTTPException for user not found
@@ -915,11 +949,7 @@ async def test_patch_user_not_found(mocker):
     )
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._check_user_exists",
-        AsyncMock(
-            side_effect=HTTPException(
-                status_code=404, detail={"error": "User not found"}
-            )
-        ),
+        AsyncMock(side_effect=HTTPException(status_code=404, detail={"error": "User not found"})),
     )
 
     # Should raise ProxyException (which wraps the HTTPException)
@@ -939,9 +969,7 @@ async def test_get_service_provider_config(mocker):
 
     # Verify it returns the correct response
     assert isinstance(result, SCIMServiceProviderConfig)
-    assert result.schemas == [
-        "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"
-    ]
+    assert result.schemas == ["urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"]
     assert result.patch.supported is True
     assert result.bulk.supported is False
     assert result.meta is not None
@@ -993,21 +1021,15 @@ async def test_update_group_metadata_serialization_issue(mocker):
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
 
     # Mock team operations
-    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=mock_existing_team
-    )
-    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(
-        return_value=mock_updated_team
-    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_existing_team)
+    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(return_value=mock_updated_team)
 
     # Mock user operations
     mock_user = mocker.MagicMock()
     mock_user.user_id = "user1"
     mock_user.user_email = "user1@example.com"  # Add proper string value for user_email
     mock_user.teams = [group_id]
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=mock_user
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mock_user)
     mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value=mock_user)
 
     # Mock the _get_prisma_client_or_raise_exception to return our mock
@@ -1044,9 +1066,7 @@ async def test_update_group_metadata_serialization_issue(mocker):
     metadata = update_data["metadata"]
 
     # The fix should ensure metadata is serialized as a JSON string
-    assert isinstance(
-        metadata, str
-    ), f"metadata should be a JSON string, but got {type(metadata)}"
+    assert isinstance(metadata, str), f"metadata should be a JSON string, but got {type(metadata)}"
 
     # Verify we can parse it back to verify it contains the expected data
     import json
@@ -1103,9 +1123,7 @@ async def test_team_membership_management(mocker):
 
     # Check calls for adding members
     add_calls = [
-        call
-        for call in mock_patch_team_membership.call_args_list
-        if call[1]["teams_ids_to_add_user_to"] == [group_id]
+        call for call in mock_patch_team_membership.call_args_list if call[1]["teams_ids_to_add_user_to"] == [group_id]
     ]
     assert len(add_calls) == 2  # user3 and user4
 
@@ -1131,9 +1149,7 @@ async def test_team_membership_management(mocker):
         # Each call should either add OR remove, not both
         add_teams = call[1]["teams_ids_to_add_user_to"]
         remove_teams = call[1]["teams_ids_to_remove_user_from"]
-        assert (len(add_teams) > 0) != (
-            len(remove_teams) > 0
-        )  # XOR - one should be empty
+        assert (len(add_teams) > 0) != (len(remove_teams) > 0)  # XOR - one should be empty
 
 
 @pytest.mark.asyncio
@@ -1184,9 +1200,7 @@ async def test_update_group_e2e(mocker):
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
 
     # Mock database operations
-    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=existing_team
-    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=existing_team)
 
     # Mock the updated team that gets returned from database
     updated_team = LiteLLM_TeamTable(
@@ -1203,16 +1217,12 @@ async def test_update_group_e2e(mocker):
             "scim_data": scim_group_update.model_dump(),
         },
     )
-    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(
-        return_value=updated_team
-    )
+    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(return_value=updated_team)
 
     # Mock user validation (all users exist)
     mock_user = mocker.MagicMock()
     mock_user.user_id = "test-user"
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=mock_user
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mock_user)
 
     # Mock dependencies
     mocker.patch(
@@ -1265,29 +1275,19 @@ async def test_update_group_e2e(mocker):
     assert metadata["scim_data"]["displayName"] == "Updated Team Name"
 
     # Verify team membership changes were handled correctly
-    assert (
-        mock_patch_team_membership.call_count == 3
-    )  # Remove user1, add user3, add user4
+    assert mock_patch_team_membership.call_count == 3  # Remove user1, add user3, add user4
 
     # Check membership changes
     call_args_list = mock_patch_team_membership.call_args_list
 
     # Find remove operation (user1)
-    remove_calls = [
-        call
-        for call in call_args_list
-        if call[1]["teams_ids_to_remove_user_from"] == [group_id]
-    ]
+    remove_calls = [call for call in call_args_list if call[1]["teams_ids_to_remove_user_from"] == [group_id]]
     assert len(remove_calls) == 1
     assert remove_calls[0][1]["user_id"] == "user1"
     assert remove_calls[0][1]["teams_ids_to_add_user_to"] == []
 
     # Find add operations (user3, user4)
-    add_calls = [
-        call
-        for call in call_args_list
-        if call[1]["teams_ids_to_add_user_to"] == [group_id]
-    ]
+    add_calls = [call for call in call_args_list if call[1]["teams_ids_to_add_user_to"] == [group_id]]
     assert len(add_calls) == 2
     add_user_ids = {call[1]["user_id"] for call in add_calls}
     assert add_user_ids == {"user3", "user4"}
@@ -1302,9 +1302,7 @@ async def test_update_group_e2e(mocker):
     assert len(result.members) == 3
 
     # Verify SCIM transformation was called with updated team
-    ScimTransformations.transform_litellm_team_to_scim_group.assert_called_once_with(
-        updated_team
-    )
+    ScimTransformations.transform_litellm_team_to_scim_group.assert_called_once_with(updated_team)
 
 
 @pytest.mark.asyncio
@@ -1330,15 +1328,9 @@ async def test_create_group_with_nonexistent_users_rejects(mocker, monkeypatch):
         id=group_id,
         displayName="Test Group",
         members=[
-            SCIMMember(
-                value="existing-user", display="Existing User"
-            ),  # This user exists
-            SCIMMember(
-                value="new-user-1", display="New User 1"
-            ),  # This user doesn't exist
-            SCIMMember(
-                value="new-user-2", display="New User 2"
-            ),  # This user doesn't exist
+            SCIMMember(value="existing-user", display="Existing User"),  # This user exists
+            SCIMMember(value="new-user-1", display="New User 1"),  # This user doesn't exist
+            SCIMMember(value="new-user-2", display="New User 2"),  # This user doesn't exist
         ],
     )
 
@@ -1364,9 +1356,7 @@ async def test_create_group_with_nonexistent_users_rejects(mocker, monkeypatch):
             return mock_user
         return None  # new-user-1 and new-user-2 don't exist
 
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        side_effect=mock_user_lookup
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(side_effect=mock_user_lookup)
 
     # Mock dependencies
     mocker.patch(
@@ -1381,9 +1371,7 @@ async def test_create_group_with_nonexistent_users_rejects(mocker, monkeypatch):
     # Verify it's a 400 Bad Request
     assert int(exc_info.value.code) == 400
     assert "does not exist" in str(exc_info.value.message)
-    assert "new-user-1" in str(exc_info.value.message) or "new-user-2" in str(
-        exc_info.value.message
-    )
+    assert "new-user-1" in str(exc_info.value.message) or "new-user-2" in str(exc_info.value.message)
 
 
 @pytest.mark.asyncio
@@ -1418,15 +1406,9 @@ async def test_update_group_with_nonexistent_users_rejects(mocker, monkeypatch):
         id=group_id,
         displayName="Updated Group Name",
         members=[
-            SCIMMember(
-                value="existing-user", display="Existing User"
-            ),  # This user exists
-            SCIMMember(
-                value="new-user-3", display="New User 3"
-            ),  # This user doesn't exist
-            SCIMMember(
-                value="new-user-4", display="New User 4"
-            ),  # This user doesn't exist
+            SCIMMember(value="existing-user", display="Existing User"),  # This user exists
+            SCIMMember(value="new-user-3", display="New User 3"),  # This user doesn't exist
+            SCIMMember(value="new-user-4", display="New User 4"),  # This user doesn't exist
         ],
     )
 
@@ -1437,18 +1419,14 @@ async def test_update_group_with_nonexistent_users_rejects(mocker, monkeypatch):
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
 
     # Mock team operations
-    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=mock_existing_team
-    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_existing_team)
 
     # Mock updated team response
     mock_updated_team = mocker.MagicMock()
     mock_updated_team.team_id = group_id
     mock_updated_team.team_alias = "Updated Group Name"
     mock_updated_team.members = ["existing-user", "new-user-3", "new-user-4"]
-    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(
-        return_value=mock_updated_team
-    )
+    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(return_value=mock_updated_team)
 
     # Mock user lookup - only existing-user exists
     def mock_user_lookup(where):
@@ -1459,9 +1437,7 @@ async def test_update_group_with_nonexistent_users_rejects(mocker, monkeypatch):
             return mock_user
         return None  # new-user-3 and new-user-4 don't exist
 
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        side_effect=mock_user_lookup
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(side_effect=mock_user_lookup)
 
     # Mock dependencies
     mocker.patch(
@@ -1481,15 +1457,11 @@ async def test_update_group_with_nonexistent_users_rejects(mocker, monkeypatch):
     # Verify it's a 400 Bad Request
     assert int(exc_info.value.code) == 400
     assert "does not exist" in str(exc_info.value.message)
-    assert "new-user-3" in str(exc_info.value.message) or "new-user-4" in str(
-        exc_info.value.message
-    )
+    assert "new-user-3" in str(exc_info.value.message) or "new-user-4" in str(exc_info.value.message)
 
 
 @pytest.mark.asyncio
-async def test_create_group_with_nonexistent_users_creates_when_flag_true(
-    mocker, monkeypatch
-):
+async def test_create_group_with_nonexistent_users_creates_when_flag_true(mocker, monkeypatch):
     """
     Test that creating a group with non-existent users creates them when scim_upsert_user is True.
     This preserves backward compatible behavior.
@@ -1510,15 +1482,9 @@ async def test_create_group_with_nonexistent_users_creates_when_flag_true(
         id=group_id,
         displayName="Test Group",
         members=[
-            SCIMMember(
-                value="existing-user", display="Existing User"
-            ),  # This user exists
-            SCIMMember(
-                value="new-user-1", display="New User 1"
-            ),  # This user doesn't exist - should be created
-            SCIMMember(
-                value="new-user-2", display="New User 2"
-            ),  # This user doesn't exist - should be created
+            SCIMMember(value="existing-user", display="Existing User"),  # This user exists
+            SCIMMember(value="new-user-1", display="New User 1"),  # This user doesn't exist - should be created
+            SCIMMember(value="new-user-2", display="New User 2"),  # This user doesn't exist - should be created
         ],
     )
 
@@ -1540,9 +1506,7 @@ async def test_create_group_with_nonexistent_users_creates_when_flag_true(
             return mock_user
         return None  # new-user-1 and new-user-2 don't exist
 
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        side_effect=mock_user_lookup
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(side_effect=mock_user_lookup)
 
     # Mock user creation
     created_user_1 = NewUserResponse(user_id="new-user-1", key="test-key-1")
@@ -1591,9 +1555,7 @@ async def test_create_group_with_nonexistent_users_creates_when_flag_true(
 
 
 @pytest.mark.asyncio
-async def test_extract_group_member_ids_with_flag_true_creates_users(
-    mocker, monkeypatch
-):
+async def test_extract_group_member_ids_with_flag_true_creates_users(mocker, monkeypatch):
     """
     Test that _extract_group_member_ids creates users when scim_upsert_user is True.
     """
@@ -1612,12 +1574,8 @@ async def test_extract_group_member_ids_with_flag_true_creates_users(
         id="test-group",
         displayName="Test Group",
         members=[
-            SCIMMember(
-                value="existing-user", display="Existing User"
-            ),  # This user exists
-            SCIMMember(
-                value="new-user-1", display="New User 1"
-            ),  # This user doesn't exist - should be created
+            SCIMMember(value="existing-user", display="Existing User"),  # This user exists
+            SCIMMember(value="new-user-1", display="New User 1"),  # This user doesn't exist - should be created
         ],
     )
 
@@ -1635,9 +1593,7 @@ async def test_extract_group_member_ids_with_flag_true_creates_users(
             return mock_user
         return None  # new-user-1 doesn't exist
 
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        side_effect=mock_user_lookup
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(side_effect=mock_user_lookup)
 
     # Mock user creation
     created_user = NewUserResponse(user_id="new-user-1", key="test-key-1")
@@ -1662,9 +1618,7 @@ async def test_extract_group_member_ids_with_flag_true_creates_users(
     assert len(result.created_users) == 1
 
     # Verify user was created
-    mock_create_user.assert_called_once_with(
-        user_id="new-user-1", created_via="scim_group_membership"
-    )
+    mock_create_user.assert_called_once_with(user_id="new-user-1", created_via="scim_group_membership")
 
 
 @pytest.mark.asyncio
@@ -1687,12 +1641,8 @@ async def test_extract_group_member_ids_with_flag_false_rejects(mocker, monkeypa
         id="test-group",
         displayName="Test Group",
         members=[
-            SCIMMember(
-                value="existing-user", display="Existing User"
-            ),  # This user exists
-            SCIMMember(
-                value="new-user-1", display="New User 1"
-            ),  # This user doesn't exist - should be rejected
+            SCIMMember(value="existing-user", display="Existing User"),  # This user exists
+            SCIMMember(value="new-user-1", display="New User 1"),  # This user doesn't exist - should be rejected
         ],
     )
 
@@ -1710,9 +1660,7 @@ async def test_extract_group_member_ids_with_flag_false_rejects(mocker, monkeypa
             return mock_user
         return None  # new-user-1 doesn't exist
 
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        side_effect=mock_user_lookup
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(side_effect=mock_user_lookup)
 
     # Mock dependencies
     mocker.patch(
@@ -1731,9 +1679,7 @@ async def test_extract_group_member_ids_with_flag_false_rejects(mocker, monkeypa
 
 
 @pytest.mark.asyncio
-async def test_process_group_patch_operations_with_flag_true_creates_users(
-    mocker, monkeypatch
-):
+async def test_process_group_patch_operations_with_flag_true_creates_users(mocker, monkeypatch):
     """
     Test that _process_group_patch_operations creates users when scim_upsert_user is True.
     """
@@ -1749,11 +1695,7 @@ async def test_process_group_patch_operations_with_flag_true_creates_users(
     # Test data
     patch_ops = SCIMPatchOp(
         schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-        Operations=[
-            SCIMPatchOperation(
-                op="add", path="members", value=[{"value": "new-user-1"}]
-            )
-        ],
+        Operations=[SCIMPatchOperation(op="add", path="members", value=[{"value": "new-user-1"}])],
     )
 
     # Mock existing team
@@ -1787,15 +1729,11 @@ async def test_process_group_patch_operations_with_flag_true_creates_users(
     assert "new-user-1" in final_members
 
     # Verify user was created
-    mock_create_user.assert_called_once_with(
-        user_id="new-user-1", created_via="scim_group_patch"
-    )
+    mock_create_user.assert_called_once_with(user_id="new-user-1", created_via="scim_group_patch")
 
 
 @pytest.mark.asyncio
-async def test_process_group_patch_operations_with_flag_false_rejects(
-    mocker, monkeypatch
-):
+async def test_process_group_patch_operations_with_flag_false_rejects(mocker, monkeypatch):
     """
     Test that _process_group_patch_operations rejects non-existent users when scim_upsert_user is False.
     """
@@ -1811,11 +1749,7 @@ async def test_process_group_patch_operations_with_flag_false_rejects(
     # Test data
     patch_ops = SCIMPatchOp(
         schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-        Operations=[
-            SCIMPatchOperation(
-                op="add", path="members", value=[{"value": "new-user-1"}]
-            )
-        ],
+        Operations=[SCIMPatchOperation(op="add", path="members", value=[{"value": "new-user-1"}])],
     )
 
     # Mock existing team
@@ -1890,9 +1824,7 @@ async def test_create_user_grants_admin_when_in_scim_admin_group(mocker, monkeyp
 
 
 @pytest.mark.asyncio
-async def test_create_user_keeps_default_when_not_in_scim_admin_group(
-    mocker, monkeypatch
-):
+async def test_create_user_keeps_default_when_not_in_scim_admin_group(mocker, monkeypatch):
     """When scim_admin_group is configured but the user's groups don't include it,
     the user keeps the non-admin default role."""
     from litellm.proxy.proxy_server import proxy_config
@@ -1936,9 +1868,7 @@ async def test_create_user_keeps_default_when_not_in_scim_admin_group(
 
 
 @pytest.mark.asyncio
-async def test_update_user_demotes_admin_when_removed_from_scim_admin_group(
-    mocker, monkeypatch
-):
+async def test_update_user_demotes_admin_when_removed_from_scim_admin_group(mocker, monkeypatch):
     """Core demotion test: a PUT whose new groups no longer include the configured
     admin group must re-evaluate the role and write the non-admin default, so an
     admin removed from the IdP group is demoted without re-login."""
@@ -1972,9 +1902,7 @@ async def test_update_user_demotes_admin_when_removed_from_scim_admin_group(
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value=updated_user
-    )
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value=updated_user)
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -2000,9 +1928,7 @@ async def test_update_user_demotes_admin_when_removed_from_scim_admin_group(
 
 
 @pytest.mark.asyncio
-async def test_update_user_does_not_force_role_when_scim_admin_group_unset(
-    mocker, monkeypatch
-):
+async def test_update_user_does_not_force_role_when_scim_admin_group_unset(mocker, monkeypatch):
     """When scim_admin_group is unset, PUT must not touch user_role (current
     behavior preserved)."""
     from litellm.proxy.proxy_server import proxy_config
@@ -2035,9 +1961,7 @@ async def test_update_user_does_not_force_role_when_scim_admin_group_unset(
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value=updated_user
-    )
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value=updated_user)
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -2063,9 +1987,7 @@ async def test_update_user_does_not_force_role_when_scim_admin_group_unset(
 
 
 @pytest.mark.asyncio
-async def test_update_user_demotes_when_default_params_lack_user_role(
-    mocker, monkeypatch
-):
+async def test_update_user_demotes_when_default_params_lack_user_role(mocker, monkeypatch):
     """Regression: default_internal_user_params set without a user_role key must
     still resolve to the non-admin default on demotion, not silently skip and
     leave the user PROXY_ADMIN."""
@@ -2075,9 +1997,7 @@ async def test_update_user_demotes_when_default_params_lack_user_role(
         return {"litellm_settings": {"scim_admin_group": "litellm-admins"}}
 
     monkeypatch.setattr(proxy_config, "get_config", mock_get_config)
-    monkeypatch.setattr(
-        "litellm.default_internal_user_params", {"max_budget": 10}, raising=False
-    )
+    monkeypatch.setattr("litellm.default_internal_user_params", {"max_budget": 10}, raising=False)
 
     existing_user = mocker.MagicMock()
     existing_user.teams = ["litellm-admins"]
@@ -2101,9 +2021,7 @@ async def test_update_user_demotes_when_default_params_lack_user_role(
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value=updated_user
-    )
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value=updated_user)
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -2129,9 +2047,7 @@ async def test_update_user_demotes_when_default_params_lack_user_role(
 
 
 @pytest.mark.asyncio
-async def test_patch_user_demotes_admin_when_removed_from_scim_admin_group(
-    mocker, monkeypatch
-):
+async def test_patch_user_demotes_admin_when_removed_from_scim_admin_group(mocker, monkeypatch):
     """PATCH that drops the admin team from the resulting team set must write the
     non-admin default, mirroring the PUT demotion path."""
     from litellm.proxy.proxy_server import proxy_config
@@ -2148,11 +2064,7 @@ async def test_patch_user_demotes_admin_when_removed_from_scim_admin_group(
 
     patch_ops = SCIMPatchOp(
         schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-        Operations=[
-            SCIMPatchOperation(
-                op="replace", path="groups", value=[{"value": "engineering"}]
-            )
-        ],
+        Operations=[SCIMPatchOperation(op="replace", path="groups", value=[{"value": "engineering"}])],
     )
 
     updated_user = {
@@ -2168,13 +2080,9 @@ async def test_patch_user_demotes_admin_when_removed_from_scim_admin_group(
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value=updated_user
-    )
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value=updated_user)
     mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=engineering_team
-    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=engineering_team)
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -2223,11 +2131,7 @@ async def test_patch_user_grants_admin_by_team_display_name(mocker, monkeypatch)
 
     patch_ops = SCIMPatchOp(
         schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-        Operations=[
-            SCIMPatchOperation(
-                op="replace", path="groups", value=[{"value": "team-abc-123"}]
-            )
-        ],
+        Operations=[SCIMPatchOperation(op="replace", path="groups", value=[{"value": "team-abc-123"}])],
     )
 
     updated_user = {
@@ -2243,13 +2147,9 @@ async def test_patch_user_grants_admin_by_team_display_name(mocker, monkeypatch)
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value=updated_user
-    )
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value=updated_user)
     mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=admin_team
-    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=admin_team)
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -2302,9 +2202,7 @@ def _scim_admin_prisma(mocker, *, user_teams):
 
 
 @pytest.mark.asyncio
-async def test_recompute_scim_member_roles_demotes_when_not_in_admin_group(
-    mocker, monkeypatch
-):
+async def test_recompute_scim_member_roles_demotes_when_not_in_admin_group(mocker, monkeypatch):
     """The shared recompute helper writes the non-admin default for a member whose
     resulting teams no longer include the configured admin group."""
     from litellm.proxy.proxy_server import proxy_config
@@ -2324,9 +2222,7 @@ async def test_recompute_scim_member_roles_demotes_when_not_in_admin_group(
 
 
 @pytest.mark.asyncio
-async def test_recompute_scim_member_roles_grants_when_in_admin_group(
-    mocker, monkeypatch
-):
+async def test_recompute_scim_member_roles_grants_when_in_admin_group(mocker, monkeypatch):
     """The shared recompute helper grants PROXY_ADMIN when a member's resulting
     teams include the configured admin group."""
     from litellm.proxy.proxy_server import proxy_config
@@ -2346,9 +2242,7 @@ async def test_recompute_scim_member_roles_grants_when_in_admin_group(
 
 
 @pytest.mark.asyncio
-async def test_recompute_scim_member_roles_noop_when_admin_group_unset(
-    mocker, monkeypatch
-):
+async def test_recompute_scim_member_roles_noop_when_admin_group_unset(mocker, monkeypatch):
     """With scim_admin_group unset the recompute helper must not touch any role,
     preserving current behavior for SCIM group writes."""
     from litellm.proxy.proxy_server import proxy_config
@@ -2395,16 +2289,10 @@ async def test_update_group_recomputes_roles_for_changed_members(mocker):
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=existing_team
-    )
-    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(
-        return_value=existing_team
-    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=existing_team)
+    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(return_value=existing_team)
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=mocker.MagicMock()
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mocker.MagicMock())
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -2452,24 +2340,16 @@ async def test_patch_group_recomputes_roles_for_changed_members(mocker):
     )
     patch_ops = SCIMPatchOp(
         schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-        Operations=[
-            SCIMPatchOperation(op="remove", path="members", value=[{"value": "user1"}])
-        ],
+        Operations=[SCIMPatchOperation(op="remove", path="members", value=[{"value": "user1"}])],
     )
 
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=existing_team
-    )
-    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(
-        return_value=existing_team
-    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=existing_team)
+    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(return_value=existing_team)
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=mocker.MagicMock()
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mocker.MagicMock())
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -2519,9 +2399,7 @@ async def test_delete_group_recomputes_roles_for_members(mocker):
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=existing_team
-    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=existing_team)
     mock_prisma_client.db.litellm_teamtable.delete = AsyncMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=member)
@@ -2552,12 +2430,8 @@ async def test_handle_existing_user_by_email_applies_role_when_admin_group_set(m
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(
-        return_value=existing_user
-    )
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value={"user_id": "new-user-id"}
-    )
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(return_value=existing_user)
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value={"user_id": "new-user-id"})
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
         AsyncMock(return_value=mocker.MagicMock()),
@@ -2592,12 +2466,8 @@ async def test_handle_existing_user_by_email_leaves_role_when_admin_group_unset(
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(
-        return_value=existing_user
-    )
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value={"user_id": "new-user-id"}
-    )
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(return_value=existing_user)
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value={"user_id": "new-user-id"})
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
         AsyncMock(return_value=mocker.MagicMock()),
@@ -2622,9 +2492,7 @@ async def test_handle_existing_user_by_email_leaves_role_when_admin_group_unset(
 
 
 @pytest.mark.asyncio
-async def test_create_user_existing_email_upsert_demotes_when_admin_group_set(
-    mocker, monkeypatch
-):
+async def test_create_user_existing_email_upsert_demotes_when_admin_group_set(mocker, monkeypatch):
     """End-to-end create wiring: a SCIM POST that upserts an existing email while
     the user is not in the admin group must write the non-admin default, not leave
     a stale PROXY_ADMIN."""
@@ -2650,12 +2518,8 @@ async def test_create_user_existing_email_upsert_demotes_when_admin_group_set(
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
-    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(
-        return_value=existing_user
-    )
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value={"user_id": "returning-user"}
-    )
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(return_value=existing_user)
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value={"user_id": "returning-user"})
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -2698,9 +2562,7 @@ async def test_create_group_recomputes_roles_for_members(mocker):
     mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
     mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=None)
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=mocker.MagicMock()
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mocker.MagicMock())
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -2754,16 +2616,10 @@ async def test_update_group_rename_recomputes_retained_members(mocker):
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=existing_team
-    )
-    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(
-        return_value=existing_team
-    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=existing_team)
+    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(return_value=existing_team)
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=mocker.MagicMock()
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mocker.MagicMock())
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -2808,24 +2664,16 @@ async def test_patch_group_rename_recomputes_retained_members(mocker):
     )
     patch_ops = SCIMPatchOp(
         schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-        Operations=[
-            SCIMPatchOperation(op="replace", path="displayName", value="Engineering")
-        ],
+        Operations=[SCIMPatchOperation(op="replace", path="displayName", value="Engineering")],
     )
 
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=existing_team
-    )
-    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(
-        return_value=existing_team
-    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=existing_team)
+    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(return_value=existing_team)
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=mocker.MagicMock()
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mocker.MagicMock())
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
@@ -775,6 +775,91 @@ async def test_handle_existing_user_by_email_roster_add_already_member_is_noop(m
 
 
 @pytest.mark.asyncio
+async def test_handle_existing_user_by_email_roster_remove_failure_blocks_teams_write(mocker):
+    """A genuine roster removal failure must propagate and must not persist the teams array,
+    symmetrically with add failures, so user.teams cannot drop a team the roster still holds."""
+    existing_user = mocker.MagicMock()
+    existing_user.user_id = "uid"
+    existing_user.user_email = "member@example.com"
+    existing_user.user_alias = "Member"
+    existing_user.teams = ["old-team"]
+    existing_user.metadata = {}
+
+    mock_prisma_client = mocker.MagicMock()
+    mock_prisma_client.db = mocker.MagicMock()
+    mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(return_value=existing_user)
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value={})
+
+    mock_team_member_delete = mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2.team_member_delete",
+        AsyncMock(side_effect=HTTPException(status_code=500, detail={"error": "No db connected"})),
+    )
+
+    new_user_request = NewUserRequest(
+        user_id="uid",
+        user_email="member@example.com",
+        user_alias="Member",
+        teams=[],
+        metadata={},
+        auto_create_key=False,
+    )
+
+    with pytest.raises(HTTPException):
+        await UserProvisionerHelpers.handle_existing_user_by_email(
+            prisma_client=mock_prisma_client, new_user_request=new_user_request
+        )
+
+    mock_team_member_delete.assert_awaited_once()
+    assert mock_prisma_client.db.litellm_usertable.update.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_handle_existing_user_by_email_roster_remove_already_absent_is_noop(mocker):
+    """A user already absent from the team is the idempotent removal no-op even under the
+    strict path: the upsert succeeds and the deduped teams array is still persisted."""
+    existing_user = mocker.MagicMock()
+    existing_user.user_id = "uid"
+    existing_user.user_email = "member@example.com"
+    existing_user.user_alias = "Member"
+    existing_user.teams = ["old-team"]
+    existing_user.metadata = {}
+
+    mock_prisma_client = mocker.MagicMock()
+    mock_prisma_client.db = mocker.MagicMock()
+    mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(return_value=existing_user)
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value={})
+
+    mock_team_member_delete = mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2.team_member_delete",
+        AsyncMock(side_effect=HTTPException(status_code=400, detail={"error": "User not found in team"})),
+    )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
+        AsyncMock(return_value=None),
+    )
+
+    new_user_request = NewUserRequest(
+        user_id="uid",
+        user_email="member@example.com",
+        user_alias="Member",
+        teams=[],
+        metadata={},
+        auto_create_key=False,
+    )
+
+    await UserProvisionerHelpers.handle_existing_user_by_email(
+        prisma_client=mock_prisma_client, new_user_request=new_user_request
+    )
+
+    mock_team_member_delete.assert_awaited_once()
+    update_calls = mock_prisma_client.db.litellm_usertable.update.call_args_list
+    assert len(update_calls) == 1
+    assert update_calls[0].kwargs["data"]["teams"] == []
+
+
+@pytest.mark.asyncio
 async def test_handle_team_membership_changes_no_changes(mocker):
     """Should not call patch_team_membership when existing teams equal new teams"""
     mock_patch_team_membership = mocker.patch(


### PR DESCRIPTION
## Relevant issues

Follow-up to https://github.com/BerriAI/litellm/pull/34162

## Linear ticket

Part of LIT-4676

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Independent e2e (Devin): existing-user-by-email POST with duplicated groups dedups user.teams and syncs the roster (members_with_roles populated).

![proof](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/lit-4676/34183_proof_api.png)

Admin UI user detail Teams panel: the team is listed once (parent listed it twice, with an empty roster).

![proof](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/lit-4676/34183_proof_ui.png)

SCIM management endpoints, no LLM call needed. Live proxy on localhost:4290 backed by a real Postgres 16, `litellm_settings.scim_upsert_user: true`

Repro: create user `ua` (email `e@t.com`), create team `T` via POST /scim/v2/Groups with an empty roster, then POST /scim/v2/Users with a different userName but the same email and `groups=[{value: T}]`. The user then lists T on their profile but is absent from T's roster

### Before (unfixed, commit `2b2ae4ca49`)

```
$ curl -s -X POST $BASE/scim/v2/Users ... userName=ua-eu  email=e-eu@t.com
id= ua-eu groups= []
$ curl -s -X POST $BASE/scim/v2/Groups ... id=T-eu members=[]
id= T-eu members= []
$ curl -s -X POST $BASE/scim/v2/Users ... userName=ua2-eu  email=e-eu@t.com  groups=[{value:T-eu}]
id= ua2-eu userName= e-eu@t.com groups= [{'value': 'T-eu', 'display': 'Team EU', 'type': 'direct'}]
```

Database and SCIM API afterward show the user in the group but not in the roster:

```
LiteLLM_UserTable  : ua2-eu | {T-eu}
LiteLLM_TeamTable  : T-eu   | []          <-- members_with_roles empty
LiteLLM_TeamMembership for T-eu : (none)

GET /scim/v2/Groups/T-eu -> members= []   <-- roster empty
```

### After (fixed, commit `e5f9d1e10c`)

Same flow, plus a deliberately duplicated group in the POST to exercise dedup (`groups=[{value:T-fix},{value:T-fix}]`):

```
$ curl -s -X POST $BASE/scim/v2/Users ... userName=ua-fix  email=e-fix@t.com
id= ua-fix groups= []
$ curl -s -X POST $BASE/scim/v2/Groups ... id=T-fix members=[]
id= T-fix members= []
$ curl -s -X POST $BASE/scim/v2/Users ... userName=ua2-fix email=e-fix@t.com groups=[{value:T-fix},{value:T-fix}]
id= ua2-fix userName= e-fix@t.com groups= [{'value': 'T-fix', 'display': 'Team Fix', 'type': 'direct'}]
```

Database and SCIM API afterward show the user in the roster, teams deduped, and the old primary key renamed away:

```
LiteLLM_UserTable  : ua2-fix | {T-fix}                                   <-- single entry, deduped
LiteLLM_TeamTable  : T-fix   | [{"role":"user","user_id":"ua2-fix","user_email":"e-fix@t.com"}]
count(user_id='ua-fix') : 0                                              <-- rename preserved

GET /scim/v2/Groups/T-fix -> members= [{'value': 'e-fix@t.com', 'display': 'e-fix@t.com'}]
```

A `LiteLLM_TeamMembership` row is only written when a team budget applies, which matches the existing PUT `update_user` behavior this change now reuses; `members_with_roles` is the roster source of truth and is now correct.

### Roster-sync failure now surfaces (fixed, commit `d498cf07de`)

The roster sync used to swallow genuine `team_member_add` failures, so a failed add still reported success and persisted a teams array the roster never received. The upsert now runs the sync strictly and only persists the deduped teams once it succeeds. A POST whose group points at a team that does not exist returns an error instead of a false 201, and the user's teams array is left untouched so it cannot diverge from the roster; the IdP retries and converges:

```
$ curl ... -X POST $BASE/scim/v2/Users ... userName=ua-s2 email=s2@t.com               # existing user
$ curl -w '%{http_code}' -X POST $BASE/scim/v2/Users ... userName=ua2-s2 email=s2@t.com groups=[{value:NO-SUCH-TEAM}]
POST status=404
{"detail":{"error":"Team doesn't exist in db. Team=NO-SUCH-TEAM. Create team via `/team/new` call."}}

LiteLLM_UserTable : ua2-s2 | {}          <-- teams NOT set to a team the roster never received
```

The happy path (a group pointing at a real team) still returns 201 and adds the user to `members_with_roles`, verified on the same head. The benign "already a member" case stays a no-op

## Type

🐛 Bug Fix

## Changes

`UserProvisionerHelpers.handle_existing_user_by_email` now routes the existing-user team assignment through the same `_handle_team_membership_changes` helper the PUT `update_user` handler already uses, so `members_with_roles`, `LiteLLM_TeamMembership`, and the user's `teams` array stay in sync instead of the roster being silently skipped. The teams derived from `user.groups` are deduped before they are written or diffed

The roster sync runs strictly for this path via a new opt-in `raise_on_error` flag on `patch_team_membership` and `_handle_team_membership_changes`: a genuine add or remove failure propagates so the deduped teams array is only persisted once the roster actually received the change. Adds and removes are treated symmetrically; the idempotent no-ops (the user is already in the team on add, or already absent on remove) stay no-ops even under the strict path. The flag defaults to False, so the PUT `update_user`, PATCH `patch_user`, and group callers keep their existing best-effort behavior

The user_id rewrite to the new userName is left intact so this stays a single isolated fix; it is sequenced as its own update before the roster sync so the roster keys off the final primary key, and the authoritative field write runs last so the returned SCIM user and the persisted `teams` array reflect the deduped set. On a mid-flight failure the endpoint returns an error and the IdP retries; because the second attempt finds the already-renamed user by email, the rename is idempotent and the teams array and roster converge without diverging. Making the primary-key rename plus its foreign-key cascade a single atomic transaction is a broader concern that predates this change (the prior code renamed the same way) and belongs with the transactional-write work, so it is intentionally out of scope here

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

