### PR TITLE
fix(ui): abort policy enrichment streams when their modals close or unmount

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/ai_suggestion_modal.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/ai_suggestion_modal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Modal, Spin, Checkbox, Select, Input, Typography, Tooltip } from "antd";
 import { Button, Card } from "@tremor/react";
 import {
@@ -92,6 +92,14 @@ const AiSuggestionModal: React.FC<AiSuggestionModalProps> = ({
       loadModels();
     }
   }, [visible]);
+
+  const enrichAbortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (!visible) enrichAbortRef.current?.abort();
+  }, [visible]);
+
+  useEffect(() => () => enrichAbortRef.current?.abort(), []);
 
   const loadModels = async () => {
     if (!accessToken) return;
@@ -287,6 +295,9 @@ const AiSuggestionModal: React.FC<AiSuggestionModalProps> = ({
 
     setIsEnriching(true);
     setEnrichStatusMessage("");
+    enrichAbortRef.current?.abort();
+    const controller = new AbortController();
+    enrichAbortRef.current = controller;
     try {
       for (const template of templatesToEnrich) {
         const paramName = template.llm_enrichment.parameter;
@@ -343,7 +354,7 @@ const AiSuggestionModal: React.FC<AiSuggestionModalProps> = ({
             (error) => {
               finish(() => reject(new Error(error)));
             },
-            undefined,
+            { signal: controller.signal },
             (status) => setEnrichStatusMessage(status),
           ).catch((error) => {
             finish(() => reject(error));
@@ -351,7 +362,9 @@ const AiSuggestionModal: React.FC<AiSuggestionModalProps> = ({
         });
       }
     } catch (e) {
-      console.error("Failed to enrich templates:", e);
+      if (!controller.signal.aborted) {
+        console.error("Failed to enrich templates:", e);
+      }
     } finally {
       setIsEnriching(false);
       setEnrichStatusMessage("");

--- a/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/template_parameter_modal.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/template_parameter_modal.test.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "@/../tests/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import TemplateParameterModal from "./template_parameter_modal";
+import * as networking from "@/components/networking";
+
+vi.mock("@/components/networking", () => ({
+  modelHubCall: vi.fn(),
+  enrichPolicyTemplateStream: vi.fn(),
+}));
+
+const template = {
+  id: "competitor-blocking",
+  title: "Competitor Blocking",
+  parameters: [
+    {
+      name: "brand_name",
+      label: "Brand Name",
+      type: "string",
+      required: true,
+      placeholder: "e.g. Acme Airlines",
+    },
+  ],
+  llm_enrichment: { parameter: "brand_name" },
+};
+
+const defaultProps = {
+  visible: true,
+  template,
+  onConfirm: vi.fn(),
+  onCancel: vi.fn(),
+  accessToken: "test-token",
+};
+
+type UserEvent = ReturnType<typeof userEvent.setup>;
+
+const startEnrichment = async (user: UserEvent) => {
+  await user.type(screen.getByPlaceholderText("e.g. Acme Airlines"), "Acme Airlines");
+
+  const modelSection = screen.getByText("Select Model").closest("div") as HTMLElement;
+  const combobox = within(modelSection).getByRole("combobox");
+  await user.click(combobox);
+  await user.click(await screen.findByTitle("gpt-4o"));
+
+  await user.click(screen.getByRole("button", { name: /generate competitor names/i }));
+
+  await waitFor(() => {
+    expect(networking.enrichPolicyTemplateStream).toHaveBeenCalledTimes(1);
+  });
+
+  const options = vi.mocked(networking.enrichPolicyTemplateStream).mock.calls[0][7];
+  expect(options?.signal).toBeInstanceOf(AbortSignal);
+  return options!.signal!;
+};
+
+describe("TemplateParameterModal enrichment stream cancellation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(networking.modelHubCall).mockResolvedValue({
+      data: [{ model_group: "gpt-4o" }],
+    } as any);
+    vi.mocked(networking.enrichPolicyTemplateStream).mockReturnValue(new Promise(() => {}));
+  });
+
+  it("aborts an in-flight enrichment stream when the modal unmounts", async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderWithProviders(<TemplateParameterModal {...defaultProps} />);
+
+    const signal = await startEnrichment(user);
+    expect(signal.aborted).toBe(false);
+
+    unmount();
+
+    expect(signal.aborted).toBe(true);
+  });
+
+  it("aborts an in-flight enrichment stream when the modal is closed", async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderWithProviders(<TemplateParameterModal {...defaultProps} />);
+
+    const signal = await startEnrichment(user);
+    expect(signal.aborted).toBe(false);
+
+    rerender(<TemplateParameterModal {...defaultProps} visible={false} />);
+
+    await waitFor(() => {
+      expect(signal.aborted).toBe(true);
+    });
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/template_parameter_modal.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/template_parameter_modal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { Modal, Spin, Radio, Select } from "antd";
 import { Button, TextInput } from "@tremor/react";
 import { modelHubCall, enrichPolicyTemplateStream } from "@/components/networking";
@@ -75,6 +75,14 @@ const TemplateParameterModal: React.FC<TemplateParameterModalProps> = ({
     }
   }, [visible, hasEnrichment, competitorMode]);
 
+  const enrichAbortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (!visible) enrichAbortRef.current?.abort();
+  }, [visible]);
+
+  useEffect(() => () => enrichAbortRef.current?.abort(), []);
+
   const loadModels = async () => {
     if (!accessToken) return;
     setIsLoadingModels(true);
@@ -100,6 +108,9 @@ const TemplateParameterModal: React.FC<TemplateParameterModalProps> = ({
     setCompetitorTags([]);
     setVariationsMap({});
     setStatusMessage("");
+    enrichAbortRef.current?.abort();
+    const controller = new AbortController();
+    enrichAbortRef.current = controller;
     try {
       await enrichPolicyTemplateStream(
         accessToken,
@@ -121,11 +132,13 @@ const TemplateParameterModal: React.FC<TemplateParameterModalProps> = ({
           setIsGenerating(false);
           setStatusMessage("");
         },
-        undefined,
+        { signal: controller.signal },
         (status) => setStatusMessage(status),
       );
     } catch (error) {
-      console.error("Error generating competitor names:", error);
+      if (!controller.signal.aborted) {
+        console.error("Error generating competitor names:", error);
+      }
       setIsGenerating(false);
     }
   };
@@ -135,6 +148,9 @@ const TemplateParameterModal: React.FC<TemplateParameterModalProps> = ({
 
     setIsRefining(true);
     setStatusMessage("");
+    enrichAbortRef.current?.abort();
+    const controller = new AbortController();
+    enrichAbortRef.current = controller;
     try {
       await enrichPolicyTemplateStream(
         accessToken,
@@ -162,11 +178,14 @@ const TemplateParameterModal: React.FC<TemplateParameterModalProps> = ({
         {
           instruction: refinementInput.trim(),
           existingCompetitors: competitorTags,
+          signal: controller.signal,
         },
         (status) => setStatusMessage(status),
       );
     } catch (error) {
-      console.error("Error refining competitor names:", error);
+      if (!controller.signal.aborted) {
+        console.error("Error refining competitor names:", error);
+      }
       setIsRefining(false);
     }
   };

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -4109,7 +4109,7 @@ export const enrichPolicyTemplateStream = async (
     guardrailDefinitions: any[];
   }) => void,
   onError?: (error: string) => void,
-  options?: { instruction?: string; existingCompetitors?: string[] },
+  options?: { instruction?: string; existingCompetitors?: string[]; signal?: AbortSignal },
   onStatus?: (message: string) => void,
 ) => {
   const url = proxyBaseUrl ? `${proxyBaseUrl}/policy/templates/enrich/stream` : `/policy/templates/enrich/stream`;
@@ -4124,6 +4124,7 @@ export const enrichPolicyTemplateStream = async (
       "Content-Type": "application/json",
     },
     body: JSON.stringify(body),
+    signal: options?.signal,
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Manual repro against a live proxy plus dashboard, screenshots to follow:

1. Go to http://localhost:3000/?login=success&page=policies, open "Use Template" on a competitor blocking template so the parameter modal appears
2. Fill in a brand name, pick a model, open the DevTools Network tab, and click "Generate Competitor Names" so the `/policy/templates/enrich/stream` request starts streaming
3. Close the modal (or navigate to another page) while the stream is still running
4. Before this fix (capture at the parent of this branch), the Network tab shows the enrich request still pending and draining until the server ends it on its own. After this fix (capture at the head commit), the request flips to "(canceled)" the moment the modal closes

The two new regression tests fail on the parent commit (`expected undefined to be an instance of AbortSignal`, since no signal was ever passed to the stream helper) and pass on this branch:

```
$ npx vitest run "src/app/(dashboard)/policies/_components/template_parameter_modal.test.tsx"
Tests  2 passed (2)
```

## Type

🐛 Bug Fix

## Changes

`enrichPolicyTemplateStream` in `networking.tsx` opened a fetch and consumed `response.body.getReader()` in a `while (true)` loop with no `AbortSignal` parameter, so callers had no way to cancel it. Both callers, the policies AI suggestion modal and the template parameter modal, kicked the stream off from a button and never tore it down: closing the modal mid-stream left the SSE connection open and draining until the server finished, with the reader, the response body, and the component closures all held alive, and every `onCompetitor`/`onStatus`/`onDone` callback still calling `setState` on the closed modal

This PR adds an optional `signal` to the helper's existing `options` argument and passes it to `fetch`, which makes an abort reject the in-flight `reader.read()` and release the connection. Both modals now keep an `AbortController` in a ref, abort it when the modal becomes hidden or unmounts, and also abort any previous run before starting a new one so rapid re-generates cannot stack concurrent streams. Aborts are not logged as errors

Regression tests cover the two teardown paths on the template parameter modal: unmounting mid-stream and closing the modal mid-stream both flip the signal that was handed to the stream helper to aborted

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
