### PR TITLE
fix(ui): stop the policy template queue timer chain on unmount

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/index.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/index.test.tsx
@@ -104,7 +104,12 @@ vi.mock("./add_policy_form", () => ({
 
 vi.mock("./guardrail_selection_modal", () => ({
   __esModule: true,
-  default: () => null,
+  default: ({ visible, onConfirm }: { visible: boolean; onConfirm: (defs: unknown[]) => void }) =>
+    visible ? (
+      <button type="button" data-testid="guardrail-selection-confirm" onClick={() => onConfirm([])}>
+        confirm guardrails
+      </button>
+    ) : null,
 }));
 
 vi.mock("./template_parameter_modal", () => ({
@@ -114,7 +119,20 @@ vi.mock("./template_parameter_modal", () => ({
 
 vi.mock("./ai_suggestion_modal", () => ({
   __esModule: true,
-  default: () => null,
+  default: ({ onSelectTemplates }: { onSelectTemplates: (templates: unknown[]) => void }) => (
+    <button
+      type="button"
+      data-testid="ai-suggestion-select-two"
+      onClick={() =>
+        onSelectTemplates([
+          { id: "tmpl-1", guardrailDefinitions: [] },
+          { id: "tmpl-2", guardrailDefinitions: [] },
+        ])
+      }
+    >
+      select two templates
+    </button>
+  ),
 }));
 
 vi.mock("./policy_test_panel", () => ({
@@ -194,5 +212,32 @@ describe("PoliciesPanel attachment delete", () => {
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
+  });
+});
+
+describe("PoliciesPanel template queue", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stops processing queued templates after unmount", async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderWithProviders(<PoliciesPanel accessToken="test-token" userRole="Admin" />);
+
+    await user.click(await screen.findByTestId("ai-suggestion-select-two"));
+
+    const callsAfterFirstTemplate = networkingMocks.getGuardrailsList.mock.calls.length;
+    await user.click(await screen.findByTestId("guardrail-selection-confirm"));
+
+    await waitFor(() => {
+      expect(networkingMocks.getGuardrailsList.mock.calls.length).toBe(callsAfterFirstTemplate + 1);
+    });
+
+    const callsBeforeUnmount = networkingMocks.getGuardrailsList.mock.calls.length;
+    unmount();
+
+    await new Promise((resolve) => setTimeout(resolve, 700));
+
+    expect(networkingMocks.getGuardrailsList.mock.calls.length).toBe(callsBeforeUnmount);
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/index.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import { Button, TabGroup, TabList, Tab, TabPanels, TabPanel } from "@tremor/react";
 import { Alert } from "antd";
 
@@ -66,6 +66,13 @@ const PoliciesPanel: React.FC<PoliciesPanelProps> = ({ accessToken, userRole }) 
   const [loadedTemplates, setLoadedTemplates] = useState<any[]>([]);
   const [templateQueue, setTemplateQueue] = useState<any[]>([]);
   const [templateQueueProgress, setTemplateQueueProgress] = useState<{ current: number; total: number } | null>(null);
+  const templateQueueTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (templateQueueTimerRef.current !== null) clearTimeout(templateQueueTimerRef.current);
+    };
+  }, []);
 
   const isAdmin = userRole ? isAdminRole(userRole) : false;
 
@@ -338,7 +345,7 @@ const PoliciesPanel: React.FC<PoliciesPanelProps> = ({ accessToken, userRole }) 
         setTemplateQueue(remaining);
         setTemplateQueueProgress((prev) => (prev ? { ...prev, current: prev.current + 1 } : null));
         // Small delay so user can see the success message
-        setTimeout(() => handleUseTemplate(nextTemplate), 500);
+        templateQueueTimerRef.current = setTimeout(() => handleUseTemplate(nextTemplate), 500);
       } else {
         setTemplateQueueProgress(null);
       }


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Manual repro against a live proxy plus dashboard, screenshots to follow:

1. Go to http://localhost:3000/?login=success&page=policies, open the AI suggestion flow, and have it suggest several templates; select two or more and use them so the queue starts processing
2. Confirm the guardrail selection for the first template, then immediately navigate to another dashboard page before the next template comes up
3. Before this fix (capture at the parent of this branch), the Network tab keeps showing guardrail list fetches and guardrail create calls arriving after you left the page; the queue chain is still running. After this fix (capture at the head commit), all activity stops the moment you navigate away

The new regression test fails on the parent commit (`expected 4 to be 3`, one extra guardrail fetch fired 500ms after unmount) and passes on this branch:

```
$ npx vitest run "src/app/(dashboard)/policies/_components/index.test.tsx"
Tests  3 passed (3)
```

## Type

🐛 Bug Fix

## Changes

When multiple AI-suggested templates are applied, the policies panel processes them as a queue: after each guardrail selection is confirmed it schedules the next template with `setTimeout(() => handleUseTemplate(nextTemplate), 500)` and discards the timer id. Nothing cancels the chain, so unmounting the panel mid-queue let it keep going: fetching guardrail lists, creating guardrails through the API, and calling `setState` on the unmounted component, one template every cycle until the queue drained

The timer id now lives in a ref that an unmount cleanup clears, which breaks the chain at the next link. The regression test drives the real two-template flow through stubbed modals, unmounts after the first template completes, waits out the 500ms delay, and asserts no further guardrail fetches happen

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
