### PR TITLE
fix(ui): revoke abandoned upload preview object URLs when the playground unmounts

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
@@ -413,4 +413,47 @@ describe("ChatUI", () => {
       }
     }
   });
+
+  it("revokes pending upload preview object URLs on unmount", async () => {
+    const createSpy = vi.fn(() => "blob:preview-1");
+    const revokeSpy = vi.fn();
+    const originalCreate = URL.createObjectURL;
+    const originalRevoke = URL.revokeObjectURL;
+    URL.createObjectURL = createSpy;
+    URL.revokeObjectURL = revokeSpy;
+
+    try {
+      const { container, unmount } = render(
+        <ChatUI
+          accessToken="1234567890"
+          token="1234567890"
+          userRole="user"
+          userID="1234567890"
+          disabledPersonalKeyCreation={false}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(container.querySelector('input[type="file"]')).toBeInTheDocument();
+      });
+
+      const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+      const file = new File(["image data"], "photo.png", { type: "image/png" });
+      await act(async () => {
+        fireEvent.change(fileInput, { target: { files: [file] } });
+      });
+
+      await waitFor(() => {
+        expect(createSpy).toHaveBeenCalledWith(file);
+      });
+      expect(revokeSpy).not.toHaveBeenCalledWith("blob:preview-1");
+
+      unmount();
+
+      expect(revokeSpy).toHaveBeenCalledWith("blob:preview-1");
+    } finally {
+      URL.createObjectURL = originalCreate;
+      URL.revokeObjectURL = originalRevoke;
+    }
+  });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -254,6 +254,16 @@ const ChatUI: React.FC<ChatUIProps> = ({
   const [chatUploadedImage, setChatUploadedImage] = useState<File | null>(null);
   const [chatImagePreviewUrl, setChatImagePreviewUrl] = useState<string | null>(null);
   const [uploadedAudio, setUploadedAudio] = useState<File | null>(null);
+  const pendingPreviewUrlsRef = useRef<string[]>([]);
+
+  useEffect(() => {
+    pendingPreviewUrlsRef.current = [...imagePreviewUrls, responsesImagePreviewUrl, chatImagePreviewUrl].filter(
+      (url): url is string => !!url,
+    );
+  }, [imagePreviewUrls, responsesImagePreviewUrl, chatImagePreviewUrl]);
+
+  useEffect(() => () => pendingPreviewUrlsRef.current.forEach((url) => URL.revokeObjectURL(url)), []);
+
   const [isGetCodeModalVisible, setIsGetCodeModalVisible] = useState(false);
   const [generatedCode, setGeneratedCode] = useState("");
   const [selectedSdk, setSelectedSdk] = useState<"openai" | "azure">("openai");


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Manual repro against a live proxy plus dashboard, screenshots to follow:

1. Open http://localhost:3000/?login=success&page=llm-playground on a chat completions endpoint and attach an image with the paperclip button, but do not send
2. In DevTools grab the preview's blob URL: `copy(document.querySelector('img[src^="blob:"]').src)`
3. Navigate to another dashboard page so the playground unmounts, then run `await fetch("<paste the blob url>")` in the console
4. Before this fix (capture at the parent of this branch), the fetch resolves with the image bytes; the blob stays pinned until full page unload. After this fix (capture at the head commit), the fetch rejects because the URL was revoked on unmount

The new regression test fails on the parent commit (revoke never called for the created preview URL) and passes on this branch:

```
$ npx vitest run "src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx"
Tests  10 passed (10)
```

## Type

🐛 Bug Fix

## Changes

The playground creates object URLs for image and PDF upload previews (`imagePreviewUrls` for image edits, `responsesImagePreviewUrl` and `chatImagePreviewUrl` for the responses and chat endpoints). Sending a message or removing the file already revokes them, but navigating away with a pending upload dropped the component state without revoking anything, so the file blobs stayed pinned in memory until full page unload

The fix mirrors the current preview URLs into a ref whenever they change and revokes whatever is still pending in an unmount cleanup. Previews that were already revoked by the send or remove paths are cleared from state at that point, so they are not in the ref by unmount and cannot be double revoked into someone else's URL

The regression test uploads a file through the real file input, confirms the preview URL was created and not yet revoked, unmounts, and asserts the URL was revoked

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
