### PR TITLE
fix(ui): restore guardrail_info_helpers exports in GuardrailsPanel test mock

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/GuardrailsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/GuardrailsPanel.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import GuardrailsPanel from "./GuardrailsPanel";
-import { getGuardrailsList } from "@/components/networking";
+import { getGuardrailsList, deleteGuardrailCall } from "@/components/networking";
 
 vi.mock("@/components/networking", () => ({
   getGuardrailsList: vi.fn(),
@@ -48,7 +48,8 @@ vi.mock("@/utils/roles", () => ({
   isAdminRole: vi.fn((role: string) => role === "admin"),
 }));
 
-vi.mock("./guardrail_info_helpers", () => ({
+vi.mock("./guardrail_info_helpers", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./guardrail_info_helpers")>()),
   getGuardrailLogoAndName: vi.fn(() => ({
     logo: null,
     displayName: "Test Provider",
@@ -78,6 +79,7 @@ describe("GuardrailsPanel", () => {
   };
 
   const mockGetGuardrailsList = vi.mocked(getGuardrailsList);
+  const mockDeleteGuardrailCall = vi.mocked(deleteGuardrailCall);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -106,5 +108,36 @@ describe("GuardrailsPanel", () => {
     // Activate the Guardrails tab so its content (including the Add button) is rendered
     fireEvent.click(screen.getByText("Guardrails"));
     expect(screen.getByText("Add New Guardrail")).toBeInTheDocument();
+  });
+
+  it("should delete the clicked guardrail after confirming in the modal", async () => {
+    render(<GuardrailsPanel {...defaultProps} />);
+    fireEvent.click(screen.getByText("Guardrails"));
+
+    fireEvent.click(await screen.findByTestId("delete-button"));
+
+    const modal = within(await screen.findByRole("dialog"));
+    expect(modal.getByText("Delete Guardrail")).toBeInTheDocument();
+    expect(modal.getByText("test-guardrail-1")).toBeInTheDocument();
+    expect(modal.getByText("Test Provider")).toBeInTheDocument();
+
+    fireEvent.click(modal.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(mockDeleteGuardrailCall).toHaveBeenCalledWith("test-token", "test-guardrail-1");
+    });
+    expect(mockGetGuardrailsList).toHaveBeenCalledTimes(2);
+  });
+
+  it("should not delete anything when the modal is cancelled", async () => {
+    render(<GuardrailsPanel {...defaultProps} />);
+    fireEvent.click(screen.getByText("Guardrails"));
+
+    fireEvent.click(await screen.findByTestId("delete-button"));
+    const modal = within(await screen.findByRole("dialog"));
+
+    fireEvent.click(modal.getByRole("button", { name: "Cancel" }));
+
+    expect(mockDeleteGuardrailCall).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This change lives entirely in a vitest file, so there is no proxy route or UI surface to exercise; the failing artifact is the test run itself, and that run is the proof. Both captures are from `ui/litellm-dashboard`

Before, at `28e93e42e5` (current `litellm_internal_staging` tip):

```bash
CI=true npx vitest run --pool forks --poolOptions.forks.maxForks=4 "src/app/(dashboard)/guardrails/_components/GuardrailsPanel.test.tsx"
```

```
 FAIL  src/app/(dashboard)/guardrails/_components/GuardrailsPanel.test.tsx [ src/app/(dashboard)/guardrails/_components/GuardrailsPanel.test.tsx ]
Error: [vitest] No "guardrailLogoMap" export is defined on the "./guardrail_info_helpers" mock. Did you forget to return it from "vi.mock"?
If you need to partially mock a module, you can use "importOriginal" helper inside:

 ❯ src/app/(dashboard)/guardrails/_components/guardrail_garden_data.ts:21:34
     19| }
     20|
     21| const litellmContentFilterLogo = guardrailLogoMap["LiteLLM Content Fil…
       |                                  ^
 ❯ src/app/(dashboard)/guardrails/_components/guardrail_garden.tsx:4:1

 Test Files  1 failed (1)
      Tests  no tests
```

After, at `3db042ae70`:

```
 ✓ src/app/(dashboard)/guardrails/_components/GuardrailsPanel.test.tsx (3 tests) 507ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Full suite at `3db042ae70`, which is what a push to `litellm_internal_staging` runs:

```bash
CI=true npm run test -- --run --pool forks --poolOptions.forks.maxForks=4
```

```
 Test Files  501 passed (501)
      Tests  5086 passed (5086)
   Duration  285.78s
```

## Type

🐛 Bug Fix

✅ Test

## Changes

`GuardrailsPanel.test.tsx` mocked `./guardrail_info_helpers` with a factory that returned only `getGuardrailLogoAndName`, which replaces the whole module and leaves every other export undefined. `guardrail_info_helpers.tsx` also exports `guardrailLogoMap`, and `guardrail_garden_data.ts` indexes that map at module scope; since `guardrail_garden.tsx` pulls it in, the index threw on undefined and the file failed to collect, so the suite never ran at all. The mock now spreads the real module through `importOriginal` and overrides only the stubbed function

This became load-bearing with #34175, which added `.github/workflows/test-litellm-ui-unit.yml`. Pull requests there only run tests reachable from the diff, but a push to `litellm_internal_staging` runs the full suite, so a broken collection turns that job red. The same property means a PR that does not touch guardrails will not surface it, so this was verified with a full local run rather than `--changed`

While in the file I covered the delete flow. The mocked guardrail table already rendered a delete button that no test ever clicked, and that path is the only consumer of the stubbed `getGuardrailLogoAndName` in this component, so the stub was carrying no weight. Two tests now walk it: confirming in the modal calls `deleteGuardrailCall` with the clicked guardrail's id and refetches the list, and cancelling deletes nothing. Both were checked against mutated source (wrong id passed to the delete call, provider display name dropped from the modal, a delete fired on cancel) and each mutation fails them

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
