### PR TITLE
feat(proxy): add allowed_tool_types litellm_param to drop tool types strict providers reject

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -175,6 +175,7 @@ from litellm.utils import (
     token_counter,
     validate_and_fix_openai_messages,
     validate_and_fix_openai_tools,
+    filter_tools_by_allowed_types,
     validate_and_fix_thinking_param,
     validate_chat_completion_tool_choice,
     validate_openai_optional_params,
@@ -4912,6 +4913,16 @@ def completion(  # type: ignore
     # validate messages
     messages = validate_and_fix_openai_messages(messages=messages)
     tools = validate_and_fix_openai_tools(tools=tools)
+    # Per-deployment opt-in (litellm_param allowed_tool_types): drop tool types
+    # a strict OpenAI-compatible provider would reject with a 400 (e.g. the
+    # Codex-private namespace/custom/local_shell tools on Moonshot/Zhipu/
+    # DeepSeek). Runs here so it covers the direct /chat/completions path and
+    # the /responses -> chat bridge alike.
+    allowed_tool_types = kwargs.get("allowed_tool_types")
+    if allowed_tool_types is not None and tools is not None:
+        tools = filter_tools_by_allowed_types(
+            tools=tools, allowed_tool_types=allowed_tool_types
+        )
     # validate tool_choice
     tool_choice = validate_chat_completion_tool_choice(tool_choice=tool_choice)
     # validate optional params

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -176,6 +176,7 @@ from litellm.utils import (
     validate_and_fix_openai_messages,
     validate_and_fix_openai_tools,
     filter_tools_by_allowed_types,
+    reconcile_tool_choice_after_tool_filtering,
     validate_and_fix_thinking_param,
     validate_chat_completion_tool_choice,
     validate_openai_optional_params,
@@ -4922,6 +4923,9 @@ def completion(  # type: ignore
     if allowed_tool_types is not None and tools is not None:
         tools = filter_tools_by_allowed_types(
             tools=tools, allowed_tool_types=allowed_tool_types
+        )
+        tool_choice = reconcile_tool_choice_after_tool_filtering(
+            tool_choice=tool_choice, tools=tools
         )
     # validate tool_choice
     tool_choice = validate_chat_completion_tool_choice(tool_choice=tool_choice)

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -61,6 +61,9 @@ from litellm.types.router import GenericLiteLLMParams
 from litellm.utils import (
     ProviderConfigManager,
     client,
+    filter_tools_by_allowed_types,
+    reconcile_tool_choice_after_tool_filtering,
+    relocate_input_additional_tools,
 )
 
 if TYPE_CHECKING:
@@ -918,6 +921,27 @@ def responses(
         if text is not None:
             # Update local_vars to include the converted text parameter
             local_vars["text"] = text
+
+        # Per-deployment opt-in tool-type filtering (litellm_param
+        # allowed_tool_types). Must run here and not only in completion():
+        # providers with NATIVE /responses support never go through the
+        # responses -> chat bridge, so the completion() hook cannot protect
+        # them (e.g. an upstream that 400s on a Codex-private tool type would
+        # fail every request despite the flag). local_vars is re-synced
+        # because downstream helpers read request params from it.
+        _allowed_tool_types = kwargs.get("allowed_tool_types")
+        if _allowed_tool_types is not None:
+            input, tools = relocate_input_additional_tools(input=input, tools=tools)
+            local_vars["input"] = input
+            if tools is not None:
+                tools = filter_tools_by_allowed_types(
+                    tools=list(tools), allowed_tool_types=_allowed_tool_types
+                )
+                tool_choice = reconcile_tool_choice_after_tool_filtering(
+                    tool_choice=tool_choice, tools=tools
+                )
+            local_vars["tools"] = tools
+            local_vars["tool_choice"] = tool_choice
 
         # get llm provider logic
         litellm_params = GenericLiteLLMParams(**kwargs)

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3234,6 +3234,7 @@ all_litellm_params = (
         "litellm_session_id",
         "use_litellm_proxy",
         "use_chat_completions_api",
+        "allowed_tool_types",
         "prompt_label",
         "shared_session",
         "search_tool_name",

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7461,6 +7461,75 @@ def filter_tools_by_allowed_types(
     return filtered or None
 
 
+def relocate_input_additional_tools(
+    input, tools: List[dict] | None
+):
+    """
+    Move tools delivered via ``input`` items of type ``additional_tools`` into
+    the regular ``tools`` param.
+
+    Codex Desktop (0.145 alpha) sends its tools as an input item
+    ``{"type": "additional_tools", "role": "developer", "tools": [...]}`` with
+    an EMPTY ``tools`` param. Strict Responses-API providers reject the whole
+    request on the unknown input variant (e.g. "invalid request body: Invalid
+    'input': value did not match any expected variant") — while accepting the
+    very same tools when they arrive in the ``tools`` param. Relocating keeps
+    the request valid AND lets filter_tools_by_allowed_types apply the
+    deployment's allowlist to the merged list.
+
+    Returns ``(input, tools)``; both unchanged when there is nothing to move.
+    """
+    if not isinstance(input, list):
+        return input, tools
+    relocated: List[dict] = []
+    kept_items = []
+    for item in input:
+        if isinstance(item, dict) and item.get("type") == "additional_tools":
+            relocated.extend(item.get("tools") or [])
+        else:
+            kept_items.append(item)
+    if not relocated:
+        return input, tools
+    merged = list(tools) if tools is not None else []
+    merged.extend(relocated)
+    return kept_items, merged
+
+
+def reconcile_tool_choice_after_tool_filtering(
+    tool_choice, tools: List[dict] | None
+):
+    """
+    Reset ``tool_choice`` when filter_tools_by_allowed_types dropped the tool
+    it referenced — otherwise the provider 400s on a tool_choice pointing at a
+    tool that is no longer in the request.
+
+    Handles both the Chat Completions shape ({"type": "function", "function":
+    {"name": ...}}) and the Responses shape ({"type": "function", "name": ...}).
+    Returns None when no tools survived (a bare tool_choice without tools is
+    itself invalid), "auto" when the named function was dropped, and the
+    original value otherwise.
+    """
+    if not isinstance(tool_choice, dict):
+        return tool_choice
+    if tools is None:
+        return None
+    _fn = tool_choice.get("function")
+    name = (_fn or {}).get("name") if isinstance(_fn, dict) else tool_choice.get("name")
+    if not name:
+        return tool_choice
+    surviving_names = set()
+    for t in tools:
+        if not isinstance(t, dict):
+            continue
+        t_fn = t.get("function")
+        t_name = (t_fn or {}).get("name") if isinstance(t_fn, dict) else t.get("name")
+        if t_name:
+            surviving_names.add(t_name)
+    if name in surviving_names:
+        return tool_choice
+    return "auto"
+
+
 def validate_and_fix_thinking_param(
     thinking: Optional["AnthropicThinkingParam"],
 ) -> Optional["AnthropicThinkingParam"]:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7447,11 +7447,12 @@ def filter_tools_by_allowed_types(
           allowed_tool_types: ["function"]
 
     A tool without a ``type`` key is treated as ``function`` (matching OpenAI
-    defaults). Returns None when no tools survive so an empty ``tools: []``
-    array is not sent upstream (some providers reject that too).
+    defaults). Returns None when no tools survive — including when the incoming
+    list is already empty — so an empty ``tools: []`` array is never sent
+    upstream (some providers reject that too).
     """
     if not tools:
-        return tools
+        return None
     filtered = [
         t
         for t in tools

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7426,6 +7426,41 @@ def validate_and_fix_openai_tools(tools: Optional[List]) -> Optional[List[dict]]
     return new_tools
 
 
+def filter_tools_by_allowed_types(
+    tools: List[dict] | None, allowed_tool_types: List[str]
+) -> List[dict] | None:
+    """
+    Keep only tools whose ``type`` is in ``allowed_tool_types``; drop the rest.
+
+    Some OpenAI-compatible providers validate tool types strictly and reject
+    the whole request with a 400 when they see a tool type they do not know:
+    Moonshot ("unknown tool type: namespace, currently only function and plugin
+    are supported"), Zhipu ("tools[N].type:type is illegal") and DeepSeek all
+    reject the Codex-private ``namespace``/``custom``/``local_shell`` tool
+    types. Dropping the unsupported tool definitions keeps the request usable
+    instead of failing it outright.
+
+    Enabled per-deployment via the ``allowed_tool_types`` litellm_param::
+
+        litellm_params:
+          model: openai/kimi-k3
+          allowed_tool_types: ["function"]
+
+    A tool without a ``type`` key is treated as ``function`` (matching OpenAI
+    defaults). Returns None when no tools survive so an empty ``tools: []``
+    array is not sent upstream (some providers reject that too).
+    """
+    if not tools:
+        return tools
+    filtered = [
+        t
+        for t in tools
+        if not isinstance(t, dict)
+        or (t.get("type") or "function") in allowed_tool_types
+    ]
+    return filtered or None
+
+
 def validate_and_fix_thinking_param(
     thinking: Optional["AnthropicThinkingParam"],
 ) -> Optional["AnthropicThinkingParam"]:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7478,19 +7478,30 @@ def relocate_input_additional_tools(
     the request valid AND lets filter_tools_by_allowed_types apply the
     deployment's allowlist to the merged list.
 
-    Returns ``(input, tools)``; both unchanged when there is nothing to move.
+    Follow-up Codex turns re-send the item with an EMPTY tools list (tools
+    were established earlier in the thread); the empty item is still a
+    non-standard variant strict providers reject, so it is dropped even when
+    it carries nothing to merge (Codex >= 26.707 "Responses Lite"
+    serialization; see Codex issue #32086).
+
+    Returns ``(input, tools)``; both unchanged when no additional_tools item
+    is present.
     """
     if not isinstance(input, list):
         return input, tools
+    found = False
     relocated: List[dict] = []
     kept_items = []
     for item in input:
         if isinstance(item, dict) and item.get("type") == "additional_tools":
+            found = True
             relocated.extend(item.get("tools") or [])
         else:
             kept_items.append(item)
-    if not relocated:
+    if not found:
         return input, tools
+    if not relocated:
+        return kept_items, tools
     merged = list(tools) if tools is not None else []
     merged.extend(relocated)
     return kept_items, merged

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4976,3 +4976,14 @@ def test_relocate_input_additional_tools() -> None:
     # string input passes through
     s_input, s_tools = relocate_input_additional_tools(input="hello", tools=None)
     assert s_input == "hello" and s_tools is None
+
+    # follow-up Codex turns re-send the item with an EMPTY tools list — the
+    # non-standard item must STILL be dropped (strict providers reject it),
+    # with the tools param left untouched
+    turn2_input = [
+        {"role": "developer", "type": "additional_tools", "tools": []},
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "next"}]},
+    ]
+    t2_input, t2_tools = relocate_input_additional_tools(input=turn2_input, tools=None)
+    assert [i.get("type") for i in t2_input] == ["message"]
+    assert t2_tools is None

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4863,3 +4863,49 @@ def test_is_prompt_caching_valid_prompt_explicit_min_token_count_overrides_model
         is_prompt_caching_valid_prompt(model="claude-opus-4-8", messages=PROMPT_CACHE_MESSAGES, min_token_count=8192)
         is False
     )
+
+
+def test_filter_tools_by_allowed_types_drops_unknown_types() -> None:
+    """Providers like Moonshot/Zhipu/DeepSeek 400 on Codex-private tool types
+    (namespace/custom/local_shell); with allowed_tool_types=["function"] only
+    function tools survive. A tool without a type key counts as function."""
+    from litellm.utils import filter_tools_by_allowed_types
+
+    tools = [
+        {"type": "namespace", "name": "codex_ns", "description": "ns"},
+        {"type": "custom", "name": "freeform", "description": "ff"},
+        {"type": "local_shell"},
+        {"type": "function", "function": {"name": "get_weather"}},
+        {"name": "untyped_tool"},
+    ]
+    out = filter_tools_by_allowed_types(tools=tools, allowed_tool_types=["function"])
+    assert out == [
+        {"type": "function", "function": {"name": "get_weather"}},
+        {"name": "untyped_tool"},
+    ]
+
+
+def test_filter_tools_by_allowed_types_wider_allowlist_and_empty_result() -> None:
+    """A wider allowlist keeps the listed types (Bedrock's OpenAI-compatible
+    endpoint accepts namespace/custom but rejects local_shell). When nothing
+    survives, None is returned so no empty tools array reaches the provider."""
+    from litellm.utils import filter_tools_by_allowed_types
+
+    tools = [
+        {"type": "namespace", "name": "ns", "description": "d", "tools": []},
+        {"type": "local_shell"},
+    ]
+    out = filter_tools_by_allowed_types(
+        tools=tools, allowed_tool_types=["function", "custom", "namespace"]
+    )
+    assert out == [{"type": "namespace", "name": "ns", "description": "d", "tools": []}]
+
+    assert (
+        filter_tools_by_allowed_types(
+            tools=[{"type": "local_shell"}], allowed_tool_types=["function"]
+        )
+        is None
+    )
+
+    assert filter_tools_by_allowed_types(tools=None, allowed_tool_types=["function"]) is None
+    assert filter_tools_by_allowed_types(tools=[], allowed_tool_types=["function"]) == []

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4909,3 +4909,69 @@ def test_filter_tools_by_allowed_types_wider_allowlist_and_empty_result() -> Non
 
     assert filter_tools_by_allowed_types(tools=None, allowed_tool_types=["function"]) is None
     assert filter_tools_by_allowed_types(tools=[], allowed_tool_types=["function"]) == []
+
+
+def test_reconcile_tool_choice_after_tool_filtering() -> None:
+    """tool_choice pointing at a dropped tool must not reach the provider (it
+    400s on an unknown tool reference). Dropped -> "auto"; kept -> unchanged;
+    no surviving tools -> None; string/None tool_choice passes through."""
+    from litellm.utils import reconcile_tool_choice_after_tool_filtering
+
+    surviving = [{"type": "function", "function": {"name": "kept_fn"}}]
+
+    # chat-completions shape, referenced tool was dropped
+    assert (
+        reconcile_tool_choice_after_tool_filtering(
+            tool_choice={"type": "function", "function": {"name": "dropped_fn"}},
+            tools=surviving,
+        )
+        == "auto"
+    )
+    # responses shape, referenced tool survived
+    kept = {"type": "function", "name": "kept_fn"}
+    assert (
+        reconcile_tool_choice_after_tool_filtering(tool_choice=kept, tools=surviving)
+        == kept
+    )
+    # nothing survived -> tool_choice must go away entirely
+    assert (
+        reconcile_tool_choice_after_tool_filtering(
+            tool_choice={"type": "function", "function": {"name": "x"}}, tools=None
+        )
+        is None
+    )
+    # non-dict values pass through untouched
+    assert reconcile_tool_choice_after_tool_filtering(tool_choice="auto", tools=surviving) == "auto"
+    assert reconcile_tool_choice_after_tool_filtering(tool_choice=None, tools=surviving) is None
+
+
+def test_relocate_input_additional_tools() -> None:
+    """Codex Desktop delivers tools via an input item {type: "additional_tools",
+    tools: [...]} with an empty tools param; strict providers 400 on the unknown
+    input variant but accept the same tools in the tools param. Relocation must
+    move them over (merging with any existing tools) and leave other input
+    items untouched; non-list input and tool-free input pass through."""
+    from litellm.utils import relocate_input_additional_tools
+
+    codex_input = [
+        {
+            "role": "developer",
+            "type": "additional_tools",
+            "tools": [{"name": "exec", "type": "custom", "format": {"type": "grammar"}}],
+        },
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+    ]
+    new_input, new_tools = relocate_input_additional_tools(
+        input=list(codex_input), tools=[{"type": "function", "name": "f"}]
+    )
+    assert [i.get("type") for i in new_input] == ["message"]
+    assert [t.get("name") or t.get("type") for t in new_tools] == ["f", "exec"]
+
+    # nothing to move -> both returned unchanged
+    plain_input = [{"type": "message", "role": "user", "content": []}]
+    same_input, same_tools = relocate_input_additional_tools(input=plain_input, tools=None)
+    assert same_input == plain_input and same_tools is None
+
+    # string input passes through
+    s_input, s_tools = relocate_input_additional_tools(input="hello", tools=None)
+    assert s_input == "hello" and s_tools is None

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4908,7 +4908,8 @@ def test_filter_tools_by_allowed_types_wider_allowlist_and_empty_result() -> Non
     )
 
     assert filter_tools_by_allowed_types(tools=None, allowed_tool_types=["function"]) is None
-    assert filter_tools_by_allowed_types(tools=[], allowed_tool_types=["function"]) == []
+    # an already-empty list is normalized to None too — some providers reject tools: []
+    assert filter_tools_by_allowed_types(tools=[], allowed_tool_types=["function"]) is None
 
 
 def test_reconcile_tool_choice_after_tool_filtering() -> None:


### PR DESCRIPTION
## Relevant issues

N/A

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

**Problem (real traffic, no mocks).** OpenAI Codex sends its private tool types (`namespace`, `custom`, `local_shell`) on every request. Strict OpenAI-compatible providers reject the whole request:

Moonshot `api.moonshot.cn` (proxy log, production, 2026-07-21):
```
litellm.BadRequestError: OpenAIException - Invalid request: unknown tool type: namespace, currently only function and plugin are supported
litellm.BadRequestError: OpenAIException - Invalid request: unknown tool type: custom, currently only function and plugin are supported
```

Zhipu `open.bigmodel.cn` (same day):
```
litellm.BadRequestError: OpenAIException - tools[6].type:type is illegal
```

Bedrock OpenAI-compatible endpoint (direct curl, HTTP 400):
```
{"error":{"code":"validation_error","message":"Tool type 'local_shell' is not supported. Supported tool types are: function, mcp, custom, namespace, tool_search."}}
```

**After (equivalent filter running in production).** With the filter enabled on the Moonshot/Zhipu/DeepSeek deployments, the same Codex `/v1/responses` traffic succeeds end-to-end — real calls, real spend:

```
2026-07-21T16:16:04Z | openai/glm-5.2           | aresponses | success | 10,411 tokens
2026-07-21T16:16:25Z | openai/kimi-k3           | aresponses | success | 16,302 tokens
2026-07-21T16:16:55Z | openai/deepseek-v4-flash | aresponses | success | 23,064 tokens
```

Manual reproduction through the proxy (before-fix image `tokenweave-1.91.x-f30735b`, after-fix `tokenweave-1.91.x-d21951e` — our fork of this change):

```bash
curl https://<proxy>/v1/responses -H "Authorization: Bearer $KEY" -d '{
  "model": "kimi-k3", "input": "Reply with the single word: ok",
  "tools": [{"type":"namespace","name":"codex_ns"},{"type":"custom","name":"ff","description":"t"},
            {"type":"local_shell"},
            {"type":"function","name":"get_weather","parameters":{"type":"object","properties":{}}}]}'
# before: 400 unknown tool type  ->  after: 200, model answers normally
```

## Usage

```yaml
model_list:
  - model_name: kimi-k3
    litellm_params:
      model: openai/kimi-k3
      api_base: https://api.moonshot.cn/v1
      allowed_tool_types: ["function"]   # drop everything else
```

A wider allowlist works for providers that accept more types but not all (e.g. `["function", "custom", "namespace", "mcp", "tool_search"]` for Bedrock's OpenAI-compatible endpoint, which rejects only `local_shell`).

Design notes:
- Runs in `completion()` immediately after `validate_and_fix_openai_tools`, so it covers both the direct `/chat/completions` path and the `/responses`→chat bridge (the bridge forwards unknown tool types verbatim and passes litellm_params into completion kwargs).
- A tool without a `type` key is treated as `function`, matching OpenAI defaults.
- If the filter empties the list, `None` is sent instead of an empty `tools: []` array (some providers reject that too).
- Registered in `all_litellm_params` so the param itself is never forwarded upstream.

## Type

🆕 New Feature

## Changes

- `litellm/utils.py`: new `filter_tools_by_allowed_types()` helper
- `litellm/main.py`: apply the filter in `completion()` when the `allowed_tool_types` litellm_param is set
- `litellm/types/utils.py`: register `allowed_tool_types` in `all_litellm_params`
- `tests/test_litellm/test_utils.py`: unit tests (drop unknown types, wider allowlist, empty-result → None, untyped tool kept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update (second commit)

Production usage surfaced three gaps in the first cut; all three are now included and battle-tested behind a proxy serving live Codex traffic:

1. **Native `/responses` path**: the filter now also runs in `responses()`. Providers with native Responses support never pass through `completion()`, so the original hook could not protect them — Bedrock's OpenAI-compatible endpoint 400s with `Tool type 'local_shell' is not supported` and every request silently fell to the configured fallback.
2. **`tool_choice` reconciliation** (addresses the Greptile note): if `tool_choice` references a dropped tool it resets to `"auto"`; if no tools survive it is dropped with them. Both Chat (`{"function": {"name": ...}}`) and Responses (`{"name": ...}`) shapes handled.
3. **`additional_tools` input items**: Codex Desktop (0.145-alpha) delivers all its tools via an input item `{"type": "additional_tools", "role": "developer", "tools": [...]}` with an **empty** `tools` param. Strict providers reject the unknown input variant (`invalid request body: Invalid 'input': value did not match any expected variant`) while accepting the identical tools in the `tools` param — so the hook relocates them there before filtering (verified live: the relocated `custom`+grammar tool is accepted and functional).

New helpers (`reconcile_tool_choice_after_tool_filtering`, `relocate_input_additional_tools`) ship with offline unit tests alongside the existing ones.

## Ecosystem references

The `additional_tools` input variant is an ecosystem-wide breakage, not one proxy's quirk:

- openai/codex#32086 (open): Codex >= 0.144 with `use_responses_lite` serializes tools (even `tool_search`) into `AdditionalTools` — the format is not going away soon.
- router-for-me/CLIProxyAPI#4434 (fixed): the same item 422s against xAI's Responses endpoint (`data did not match any variant of untagged enum ModelInput`) — third independent strict-upstream confirmation alongside Bedrock's OpenAI-compatible endpoint and Moonshot/Zhipu.
- Soju06/codex-lb#1157 (fixed): dropping the item instead of relocating its tools loses the model's shell/filesystem access — why this PR relocates rather than drops.
