### PR TITLE
chore: bump litellm-proxy-extras 0.4.79 -> 0.4.80, litellm 1.94.0 -> 1.95.0

### DIFF
--- a/litellm-proxy-extras/pyproject.toml
+++ b/litellm-proxy-extras/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm-proxy-extras"
-version = "0.4.79"
+version = "0.4.80"
 description = "Additional files for the LiteLLM Proxy. Reduces the size of the main litellm package."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -26,7 +26,7 @@ required-version = ">=0.10.9"
 module-root = ""
 
 [tool.commitizen]
-version = "0.4.79"
+version = "0.4.80"
 version_files = [
     "pyproject.toml:^version",
     "../pyproject.toml:litellm-proxy-extras==",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm"
-version = "1.94.0"
+version = "1.95.0"
 description = "Library to easily interface with LLM API providers"
 readme = "README.md"
 requires-python = ">=3.10, <3.15"
@@ -62,7 +62,7 @@ proxy = [
     "azure-identity>=1.25.2,<2.0",
     "azure-storage-blob>=12.28.0,<13.0",
     "mcp>=1.28.1,<2.0",
-    "litellm-proxy-extras==0.4.79",
+    "litellm-proxy-extras==0.4.80",
     "litellm-enterprise==0.1.51",
     "RestrictedPython>=8.1,<9.0",
     "rich>=13.9.4,<14.0",
@@ -289,7 +289,7 @@ members = ["enterprise", "litellm-proxy-extras"]
 profile = "black"
 
 [tool.commitizen]
-version = "1.94.0"
+version = "1.95.0"
 version_files = [
     "pyproject.toml:^version",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-18T21:57:43.13625Z"
+exclude-newer = "2026-07-19T00:00:06.091071Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3966,7 +3966,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.94.0"
+version = "1.95.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -4350,7 +4350,7 @@ source = { editable = "enterprise" }
 
 [[package]]
 name = "litellm-proxy-extras"
-version = "0.4.79"
+version = "0.4.80"
 source = { editable = "litellm-proxy-extras" }
 
 [[package]]


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

Tests: not applicable; this is a version-bump-only change with no behavior to test

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

No proof of fix applies here; nothing about runtime behavior changes. The only verifiable claim is that `uv lock` re-resolves cleanly against the new versions, which it did, reporting only the two editable packages as updated

## Type

🚄 Infrastructure

## Changes

Preparing the version bumps before promoting `litellm_internal_staging` into `main`

`litellm-proxy-extras` changed since the last release and still sat at main's version, so it takes a PATCH bump from 0.4.79 to 0.4.80, along with the matching pin in the root pyproject

The root `litellm` package takes its MINOR bump from 1.94.0 to 1.95.0. The 1.94.0 line has already graduated with `v1.94.0-rc.1` and `v1.94.0-rc.2`, so this promotion opens the next line

`enterprise` is unchanged between main and staging, so it stays at 0.1.51

`uv.lock` is refreshed in the same commit. Beyond the two package versions it carries a moved `exclude-newer` timestamp, which is expected: the lock uses a rolling `exclude-newer-span = "P3D"` window. No third-party dependency version moved

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
