### PR TITLE
fix(rust): ship the Rust extension where the gateway actually imports litellm from

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -59,6 +59,23 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         --extra semantic-router \
         --python python3
 
+# The runtime sets PYTHONPATH=/app, so `import litellm` resolves to the source
+# tree copied above, not the wheel uv installed into /app/.venv. The Rust
+# extension only exists as a compiled artifact of that wheel build, so the
+# shadowing source tree wins at import time and `litellm.rust_bridge` degrades
+# to the Python implementation without raising. Place the extension alongside
+# the source it is imported from, and fail the build when it is missing rather
+# than shipping an image that silently never runs Rust.
+RUN set -eu; \
+    so="$(find /app/.venv -path '*/litellm/rust_bridge/_native*.so' | head -n 1)"; \
+    if [ -z "$so" ]; then \
+      echo "litellm.rust_bridge native extension not found under /app/.venv" >&2; \
+      exit 1; \
+    fi; \
+    cp "$so" /app/litellm/rust_bridge/; \
+    cd /app && python3 -c "import litellm.rust_bridge as rb, sys; sys.exit(0 if rb.get_native_bridge() is not None else 1)" \
+      || { echo "litellm.rust_bridge resolved without its native extension" >&2; exit 1; }
+
 RUN mkdir -p /home/nonroot && \
     HOME=/home/nonroot prisma generate --schema=./schema.prisma && \
     chown -R nonroot:nonroot /home/nonroot/.cache

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -59,22 +59,15 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         --extra semantic-router \
         --python python3
 
-# The runtime sets PYTHONPATH=/app, so `import litellm` resolves to the source
-# tree copied above, not the wheel uv installed into /app/.venv. The Rust
-# extension only exists as a compiled artifact of that wheel build, so the
-# shadowing source tree wins at import time and `litellm.rust_bridge` degrades
-# to the Python implementation without raising. Place the extension alongside
-# the source it is imported from, and fail the build when it is missing rather
-# than shipping an image that silently never runs Rust.
-RUN set -eu; \
-    so="$(find /app/.venv -path '*/litellm/rust_bridge/_native*.so' | head -n 1)"; \
-    if [ -z "$so" ]; then \
-      echo "litellm.rust_bridge native extension not found under /app/.venv" >&2; \
-      exit 1; \
-    fi; \
-    cp "$so" /app/litellm/rust_bridge/; \
-    cd /app && python3 -c "import litellm.rust_bridge as rb, sys; sys.exit(0 if rb.get_native_bridge() is not None else 1)" \
-      || { echo "litellm.rust_bridge resolved without its native extension" >&2; exit 1; }
+# `COPY . .` leaves a second copy of the litellm package at /app/litellm, and
+# the runtime puts /app ahead of site-packages on sys.path, so that copy shadows
+# the wheel uv just installed. The wheel is the complete package and the only
+# copy carrying the compiled Rust extension, so the shadow silently downgrades
+# `litellm.rust_bridge` to its Python implementation. Drop the redundant copy:
+# `import litellm` then resolves to the wheel, while /app stays importable for
+# `gateway`. The assertion fails the build if the extension was never built.
+RUN rm -rf /app/litellm && \
+    python3 -c "import litellm.rust_bridge as rb; assert rb.get_native_bridge() is not None"
 
 RUN mkdir -p /home/nonroot && \
     HOME=/home/nonroot prisma generate --schema=./schema.prisma && \


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The image ships two copies of the litellm package: the source tree that `COPY . .` puts at `/app/litellm`, and the wheel `uv sync` installs into `/app/.venv`. The runtime sets `PYTHONPATH=/app`, so the source copy shadows the wheel. maturin compiles the Rust extension as an artifact of the wheel build, so it exists only in the copy that loses, and `litellm/rust_bridge/loader.py` deliberately swallows the resulting `ImportError` and returns `None`. The gateway then serves every request through Python and reports nothing

**Before, on the Rust gateway running in the stage cluster** (image `litellm-rust/gateway:branch-litellm-rust-2b2ae4ca`)

```
$ curl -s -D /tmp/h.txt http://127.0.0.1:4020/v1/messages -H "Authorization: Bearer $MK" \
    -d '{"model":"azure-foundry-claude-haiku","max_tokens":32,"messages":[{"role":"user","content":"Reply with exactly: RUST_STAGE_OK"}]}'
{"content":[{"type":"text","text":"RUST_STAGE_OK"}],"stop_reason":"end_turn", ...}

$ grep -i "x-litellm-rust" /tmp/h.txt
(no x-litellm-rust header)

$ kubectl exec -n litellm-rust "$POD" -- python3 -c \
    "import litellm, os, litellm.rust_bridge as rb; print(os.path.dirname(litellm.__file__)); print(rb.get_native_bridge() is not None)"
/app/litellm
False

$ kubectl exec -n litellm-rust "$POD" -- sh -c 'find / -name "_native*.so" -path "*rust_bridge*" 2>/dev/null'
/app/.venv/lib/python3.13/site-packages/litellm/rust_bridge/_native.cpython-313-x86_64-linux-gnu.so
```

A real Azure AI Foundry Claude call, answered correctly, costing real money, with no Rust marker. The gateway has `LITELLM_RUST=1` set and this branch has already removed the flags, so it should have been Rust

**After, on an image built from this PR**

```
$ docker build -t litellm-rust-rootfix -f gateway/Dockerfile .      # builder 8/9 runs the assertion

$ docker run --rm --entrypoint python3 litellm-rust-rootfix -c \
    "import litellm, os, litellm.rust_bridge as rb; print(os.path.dirname(litellm.__file__)); print(rb.get_native_bridge() is not None)"
/app/.venv/lib/python3.13/site-packages/litellm
True

$ curl -s -D - -o /dev/null http://127.0.0.1:4030/v1/messages -H "Authorization: Bearer sk-1234" \
    -d '{"model":"azure-foundry-claude","max_tokens":32,"messages":[{"role":"user","content":"Reply with exactly: ROOTFIX_OK"}]}'
HTTP/1.1 200 OK
x-litellm-rust: true          <-- text returned: ROOTFIX_OK

$ # streamed, same model
HTTP/1.1 200 OK
content-type: text/event-stream; charset=utf-8
x-litellm-rust: true          <-- 6 SSE events
```

**Checks that the wheel is genuinely the complete package**, since it is now the only copy:

```
$ docker exec rootfix-gw python3 -c "...litellm/proxy/_experimental/out..."
assets dir: /app/.venv/lib/python3.13/site-packages/litellm/proxy/_experimental/out
exists: True | files: 850 | index.html present: True
schema.prisma in pkg: True

$ docker exec rootfix-gw python3 -c "import gateway.main; print('ok')"
ok                                  # /app stays importable for `gateway`

/health/readiness -> 200            # against a real Postgres
/v1/models        -> 200
/ui               -> 404            # identical on the pre-fix image (see below)
```

`/ui` returning 404 is not a regression: the gateway component does not serve the dashboard (the ALB path-routes `/ui` to the `litellm-ui` Service). Verified by running the same three requests against the pre-fix image in the cluster, which returns 404 for `/ui`, `/ui/` and `/ui/index.html` exactly as this one does

## Type

🐛 Bug Fix

## Changes

Deletes the redundant source copy of the litellm package from the image so `import litellm` resolves to the installed wheel, and asserts at build time that the Rust extension is loadable

The first version of this PR copied the compiled `.so` from the wheel into the shadowing source tree. That worked, but it kept both copies and fixed only the one artifact we happened to notice; any future wheel-only artifact would have gone missing the same silent way. Removing the duplicate addresses the class of bug rather than the instance, and it is less code

The assertion earns its place because `loader.py` returns `None` rather than raising when the extension is absent. That graceful degradation is correct for pure-Python installs and CI, but it means an image that cannot run Rust looks completely healthy: requests succeed, and the only symptom is a missing response header. Build time is the one point where "this image must be able to run Rust" is knowable, so it fails there instead

Note `gateway/Dockerfile` is currently byte-identical on `litellm_internal_staging` and `litellm_rust`. The shadowing is not Rust-specific, so this arguably belongs on the trunk; it only becomes visible here because the Rust extension is the first artifact that exists in the wheel and not in the source tree

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
