### PR TITLE
docs: add TLDR section to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,17 @@
 ## TLDR
 
-<!-- In a few plain-language sentences, state 1) the problem being solved and 2) how this PR solves it
-     This section must be extremely human parsable, comprehensible, and readable: its target audience is humans, not AI agents, so skip jargon and implementation minutiae and write it so a reviewer understands the PR from this section alone -->
+<!-- Fill in the bullets below and keep each one short and concrete
+     This section must be extremely human parsable, comprehensible, and readable: its target audience is humans, not AI agents -->
+
+Problem this solves:
+
+- <blah>
+- ...
+
+How it solves it:
+
+- <blah>
+- ...
 
 ## Relevant issues
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## TLDR
 
-<!-- Fill in the bullets below and keep each one short and concrete
+<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max
      This section must be extremely human parsable, comprehensible, and readable: its target audience is humans, not AI agents -->
 
 Problem this solves:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,8 @@
+## TLDR
+
+<!-- In a few plain-language sentences, state 1) the problem being solved and 2) how this PR solves it
+     This section must be extremely human parsable, comprehensible, and readable: its target audience is humans, not AI agents, so skip jargon and implementation minutiae and write it so a reviewer understands the PR from this section alone -->
+
 ## Relevant issues
 
 <!-- e.g., "Fixes #000" -->


### PR DESCRIPTION
## TLDR

Problem this solves:

- Reviewers must dig through diffs to learn what a PR does

How it solves it:

- PR template now opens with problem/solution TLDR bullets
- A comment caps bullets at one short human-readable line each

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR only edits the PR template markdown, so the end-to-end proof is the template itself in use: this PR's own description leads with the new TLDR section filled out as the scaffold prescribes (captured at 4c1f071add). After merge, opening https://github.com/BerriAI/litellm/compare and starting a new PR prefills the description with the TLDR section at the top

## Type

📖 Documentation

## Changes

Adds a TLDR section at the top of .github/pull_request_template.md with prefilled "Problem this solves:" and "How it solves it:" bullet scaffolding. Its comment caps bullets at one line of roughly 10 words and stresses that the section must be extremely human parsable, comprehensible, and readable because its target audience is humans, not AI agents

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR