### PR TITLE
test(ui): fix key and credential e2e specs after the overflow menu migrations

### DIFF
--- a/ui/litellm-dashboard/e2e_tests/tests/modelsPage/credentials.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/modelsPage/credentials.spec.ts
@@ -38,7 +38,8 @@ test.describe("Edit LLM credential", () => {
 
     const row = page.locator("tr", { hasText: credentialName });
     await expect(row).toBeVisible({ timeout: 15_000 });
-    await row.getByRole("button").first().click();
+    await row.getByTestId(`credential-actions-${credentialName}`).click();
+    await page.getByTestId("credential-action-edit").click();
 
     const modal = page.locator(".ant-modal-content").filter({ hasText: "Edit Credential" });
     await expect(modal).toBeVisible({ timeout: 10_000 });

--- a/ui/litellm-dashboard/e2e_tests/tests/proxy-admin/keys.spec.ts
+++ b/ui/litellm-dashboard/e2e_tests/tests/proxy-admin/keys.spec.ts
@@ -103,7 +103,8 @@ test.describe("Proxy Admin - Keys", () => {
 
     await expect(page.getByText("Back to Keys")).toBeVisible({ timeout: 10_000 });
 
-    await page.getByRole("button", { name: "Delete Key" }).click();
+    await page.getByRole("button", { name: "More key actions" }).click();
+    await page.getByRole("menuitem", { name: "Delete Key" }).click();
 
     const modal = page.locator(".ant-modal:visible");
     await expect(modal).toBeVisible({ timeout: 5_000 });

--- a/ui/litellm-dashboard/src/components/model_add/CredentialsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/CredentialsPanel.test.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { UploadProps } from "antd/es/upload";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { CredentialItem, credentialCreateCall } from "@/components/networking";
+import { CredentialItem, credentialCreateCall, credentialUpdateCall } from "@/components/networking";
 import NotificationsManager from "@/components/molecules/notifications_manager";
 
 import CredentialsPanel from "./CredentialsPanel";
@@ -51,11 +51,17 @@ vi.mock("./CredentialModal", () => ({
     if (!open) {
       return null;
     }
+    const values =
+      mode === "edit"
+        ? {
+            credential_name: "openai-key",
+            custom_llm_provider: "openai",
+            api_key: "sk-1****2345",
+            api_base: "https://proxy.e2e.example.com/v1",
+          }
+        : { credential_name: "new-cred", custom_llm_provider: "openai" };
     return (
-      <button
-        data-testid={`credential-modal-${mode}-submit`}
-        onClick={() => onSubmit({ credential_name: "new-cred", custom_llm_provider: "openai" })}
-      >
+      <button data-testid={`credential-modal-${mode}-submit`} onClick={() => onSubmit(values)}>
         submit {mode}
       </button>
     );
@@ -177,6 +183,26 @@ describe("CredentialsPanel", () => {
     // The modal stays open so the user can retry, and no success toast fired.
     expect(screen.getByTestId("credential-modal-add-submit")).toBeInTheDocument();
     expect(NotificationsManager.success).not.toHaveBeenCalled();
+  });
+
+  it("drops the masked api key from the update payload while keeping the edited api base", async () => {
+    const user = userEvent.setup();
+    mockUseAuthorized.mockReturnValue({ accessToken: "test-token", userRole: "Admin" });
+    mockUseCredentials.mockReturnValue({ data: { credentials }, isLoading: false, refetch: vi.fn() });
+    vi.mocked(credentialUpdateCall).mockResolvedValueOnce(undefined as never);
+
+    renderPanel();
+
+    await user.click(screen.getByTestId("credential-actions-openai-key"));
+    await user.click(await screen.findByTestId("credential-action-edit"));
+    await user.click(screen.getByTestId("credential-modal-edit-submit"));
+
+    await waitFor(() => {
+      expect(credentialUpdateCall).toHaveBeenCalled();
+    });
+    const [, updatedName, payload] = vi.mocked(credentialUpdateCall).mock.calls[0];
+    expect(updatedName).toBe("openai-key");
+    expect(payload.credential_values).toEqual({ api_base: "https://proxy.e2e.example.com/v1" });
   });
 
   describe("Admin Viewer write-action gating", () => {


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both specs run against a live proxy (freshly built UI, real Postgres, seeded DB) at 105586d780, via the suite's own runner:

```bash
CI=true DATABASE_URL="postgresql://<user>:<pass>@127.0.0.1:55432/litellm_e2e" \
  ./e2e_tests/run_e2e.sh --reporter=list \
  e2e_tests/tests/modelsPage/credentials.spec.ts e2e_tests/tests/proxy-admin/keys.spec.ts
```

```
✓  1 credentials.spec.ts:34:7 › Edit LLM credential › changing only the api base does not overwrite the stored api key with its masked value (1.3s)
✓  2 keys.spec.ts:16:7 › Proxy Admin - Keys › Create a key in a team (1.8s)
✘  3 keys.spec.ts:52:7 › Proxy Admin - Keys › Regenerate key (15.9s)
✓  6 keys.spec.ts:75:7 › Proxy Admin - Keys › Update key TPM and RPM limits (1.2s)
✓  7 keys.spec.ts:96:7 › Proxy Admin - Keys › Delete key (1.4s)
✓  8 keys.spec.ts:120:7 › Proxy Admin - Keys › See internal user keys in team (812ms)
✓  9 keys.spec.ts:127:7 › Proxy Admin - Keys › Create a key with All Proxy Models (no team) (2.2s)
✓ 10 keys.spec.ts:155:7 › Proxy Admin - Keys › Create a key with a specific proxy model (no team) (1.5s)
```

The two specs this PR touches both pass. "Regenerate key" fails only because that run had no `LITELLM_LICENSE`, so the proxy was not premium and `regenerateDisabled={!premiumUser}` kept the button disabled ("element is not enabled"). Unrelated to this PR, and re-running that one spec with a license confirms it:

```
✓  1 keys.spec.ts:52:7 › Proxy Admin - Keys › Regenerate key (2.0s)
   1 passed (4.6s)
```

Unit side, the new guard is mutation-checked rather than just green. With `stripMaskedSecrets` dropped from the update path in `CredentialsPanel`:

```
× CredentialsPanel > drops the masked api key from the update payload while keeping the edited api base
  → expected { api_key: 'sk-1****2345', …(1) } to deeply equal { Object (api_base) }
```

and with it restored, all 10 tests in the file pass

## Type

✅ Test

## Changes

Two dashboard Playwright specs went red after recent UI work, and both were stale selectors rather than broken product behavior

`proxy-admin/keys.spec.ts` "Delete key" clicked a top-level `Delete Key` button on the key info page. #34116 moved Reset Spend and Delete Key into an overflow dropdown next to Regenerate Key, so `Delete Key` is now a menu item behind the `More key actions` trigger. The spec now opens that menu first. Everything downstream is unchanged: the confirm modal still requires typing the key alias and still reports "Key deleted successfully"

`modelsPage/credentials.spec.ts` clicked the first button in the credential's row to open the edit modal. The credentials table has since moved onto the shared DataTable, where the row's only button is the `⋯` actions trigger and Edit is a menu item inside it, so the click opened a dropdown and the spec timed out waiting for the modal. It now goes through the actions menu

The behavior that second spec guards, the edit form never sending the backend's masked api key back on save, is still correct in the code; `stripMaskedSecrets` survived the table migration and is still applied in `CredentialsPanel`. That guard had no unit coverage though, so while the e2e was red nothing at all was pinning it. This PR adds a `CredentialsPanel` test that drives an edit submit carrying a masked `api_key` plus an edited `api_base` and asserts the outgoing `credential_values` contains only the api base. Removing the `stripMaskedSecrets` call makes that test fail, so it is a real guard and not coverage padding

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
