### PR TITLE
test(e2e): fail the run when a Rust gateway silently serves /messages through Python

### DIFF
--- a/tests/e2e/e2e_config.py
+++ b/tests/e2e/e2e_config.py
@@ -72,6 +72,8 @@ POLL_TIMEOUT = float(os.environ.get("E2E_POLL_TIMEOUT", "120"))
 POLL_INTERVAL = float(os.environ.get("E2E_POLL_INTERVAL", "5"))
 REQUEST_TIMEOUT = float(os.environ.get("E2E_REQUEST_TIMEOUT", "60"))
 
+EXPECT_RUST = os.environ.get("E2E_EXPECT_RUST", "").strip().lower() in ("1", "true", "yes")
+
 LOAD_USERS = int(os.environ.get("E2E_LOAD_USERS", "750"))
 LOAD_SPAWN_RATE = float(os.environ.get("E2E_LOAD_SPAWN_RATE", "50"))
 LOAD_DURATION_SECONDS = float(os.environ.get("E2E_LOAD_DURATION_SECONDS", "60"))

--- a/tests/e2e/llm_translation/test_messages_azure_foundry_e2e.py
+++ b/tests/e2e/llm_translation/test_messages_azure_foundry_e2e.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import pytest
 
-from e2e_config import unique_marker
+from e2e_config import EXPECT_RUST, unique_marker
 from e2e_http import StreamingResponse, require_successful_call, unwrap
 from endpoints_client import EndpointsClient
 from lifecycle import ResourceManager
@@ -50,6 +50,13 @@ def _assert_streamed_ok(result: StreamingResponse) -> None:
     assert any("message_stop" in event for event in result.stream_events), (
         "stream never reached message_stop"
     )
+    if EXPECT_RUST:
+        assert result.headers.get("x-litellm-rust") == "true", (
+            "E2E_EXPECT_RUST is set, so this gateway must serve /v1/messages through the "
+            "Rust path, but the response carried no x-litellm-rust marker. The request "
+            "still succeeded, which is exactly the failure mode: a gateway whose native "
+            f"extension is unavailable falls back to Python silently. headers={result.headers}"
+        )
 
 
 class TestAzureFoundryMessages:


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

A gateway whose Rust extension is unavailable serves `/v1/messages` through Python and returns a completely normal response; the only difference on the wire is the absent `x-litellm-rust` header. Nothing in the suite looked at that header, so a Rust deployment that had silently stopped running Rust would produce a fully green e2e run

Both gateways below are the SAME image, same config, answering real Azure AI Foundry Claude calls (real spend). The only difference is that one has the native extension deleted from the import path, reproducing exactly what a broken Rust image does

```
$ docker run -d --name rustgw-after  -p 4030:4000 ... litellm-rust-gw-test
$ docker run -d --name rustgw-before -p 4031:4000 ... --entrypoint sh litellm-rust-gw-test \
    -c 'rm -f /app/litellm/rust_bridge/_native*.so; exec uvicorn gateway.main:app --host 0.0.0.0 --port 4000'
```

Driving a real streamed `/v1/messages` call against each and feeding the response into the changed helper, with `E2E_EXPECT_RUST=1` (captured at `3b4d3d4`):

```
BEFORE  python-fallback gateway: ASSERTION FAILED (marker=<absent>)
   -> E2E_EXPECT_RUST is set, so this gateway must serve /v1/messages through the Rust path,
      but the response carried no x-litellm-rust marker. The request still succeeded, which is
      exactly the failure mode: a gateway whose native extension is unavailable falls back to
      Python silently.
AFTER   rust gateway           : assertion PASSED (marker=true)
```

Confirming the marker is genuinely present on the wire for a streamed response, not just in `_hidden_params`:

```
$ curl -s -D - -o /dev/null http://127.0.0.1:4030/v1/messages -H "Authorization: Bearer sk-1234" \
    -d '{"model":"azure-foundry-claude","max_tokens":32,"stream":true,"messages":[...]}'
HTTP/1.1 200 OK
content-type: text/event-stream; charset=utf-8
x-litellm-rust: true
```

With `E2E_EXPECT_RUST` unset (every existing run, including the standard staging instance) both gateways pass exactly as before, so this is inert for non-Rust deployments

`make lint-e2e-basedpyright` reports `0 errors, 0 warnings, 0 notes`

## Type

✅ Test

## Changes

Adds `EXPECT_RUST` to `tests/e2e/e2e_config.py`, read from `E2E_EXPECT_RUST` in the same module-level style as the suite's other env-derived settings, and asserts the `x-litellm-rust` response marker inside `_assert_streamed_ok` in the Azure Foundry Messages e2e test when it is set

The assertion is opt-in because the same suite image runs against both the standard gateway (which has no Rust path and must keep passing) and the Rust gateway (which must fail if it is not actually running Rust). The two deployments are already separate ArgoCD Applications, so this is one value on the Rust instance rather than any branching inside the tests

Scoped to the streamed assertions because `StreamingResponse` already carries response headers, so no harness change is needed. The non-streaming path returns `Result[AnthropicMessagesResponse]`, which does not surface headers; plumbing that through would be a larger change for the same signal, since a missing extension takes out streaming and non-streaming alike

## QA runbook

- tests/e2e/llm_translation/test_messages_azure_foundry_e2e.py::TestAzureFoundryMessages::test_basic_stream - a streamed Messages call against a gateway declared to be running Rust must carry the Rust marker, and the run must fail if the gateway quietly fell back to Python
  - [ ] Point the suite at a gateway built with the Rust extension and export `E2E_EXPECT_RUST=1`
  - [ ] Send a streamed `/v1/messages` request for an `azure_ai/<claude>` deployment and confirm HTTP 200 with `content-type: text/event-stream` and an `x-litellm-rust: true` response header
  - [ ] Repeat against a gateway with the native extension removed from the import path: the response is still HTTP 200 with correct content, and the test must FAIL naming the absent `x-litellm-rust` marker
  - [ ] Unset `E2E_EXPECT_RUST` and re-run against that same fallback gateway: the test must PASS again, proving the assertion is inert for non-Rust deployments
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_messages_azure_foundry_e2e.py::TestAzureFoundryMessages::test_tool_use_stream - the same guarantee holds for the streamed tool-use path, which shares the helper
  - [ ] With `E2E_EXPECT_RUST=1`, send a streamed `/v1/messages` request carrying the `get_weather` tool and confirm the stream reaches `message_stop` and carries `x-litellm-rust: true`
  - [ ] Confirm the same request against an extension-less gateway fails on the marker rather than on tool-use behavior
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
