### PR TITLE
fix(scim): apply group PATCH membership as deltas so concurrent adds are not clobbered

### DIFF
--- a/litellm/proxy/management_endpoints/scim/scim_v2.py
+++ b/litellm/proxy/management_endpoints/scim/scim_v2.py
@@ -1654,8 +1654,11 @@ async def get_groups(
         # Convert to SCIM format
         scim_groups = []
         for team in teams:
-            # Get team members with display names
-            members = await _get_team_members_display(team.members or [])
+            # Get team members with display names. members_with_roles is the
+            # source of truth; the legacy `members` column is not populated by
+            # team creation, so reading it here would report an empty member
+            # list to the IdP and trigger repeated re-provisioning.
+            members = await _get_team_members_display(await _get_team_member_user_ids_from_team(team))
             verbose_proxy_logger.debug(f"SCIM GET GROUPS members: {members}")
             team_alias = getattr(team, "team_alias", team.team_id)
             team_created_at = team.created_at.isoformat() if team.created_at else None
@@ -1885,8 +1888,12 @@ async def _process_group_patch_operations(
     existing_metadata = existing_team.metadata or {}
     metadata = dict(existing_metadata) if existing_metadata else {}
 
-    # Track member changes
-    current_members = set(existing_team.members or [])
+    # Track member changes. members_with_roles is the source of truth for team
+    # membership; the legacy `members` column is not populated by team creation
+    # or the real team endpoints, so seeding from it would make an `add`/`remove`
+    # operation recompute the member set from an empty base and silently drop
+    # everyone already in the team.
+    current_members = set(await _get_team_member_user_ids_from_team(existing_team))
     final_members = current_members.copy()
 
     # Process each patch operation

--- a/litellm/proxy/management_endpoints/scim/scim_v2.py
+++ b/litellm/proxy/management_endpoints/scim/scim_v2.py
@@ -1970,24 +1970,24 @@ async def _process_group_patch_operations(
     return update_data, final_members
 
 
-async def _apply_group_patch_updates(
-    group_id: str, update_data: Dict[str, Any], final_members: Set[str], prisma_client
-):
-    """Apply patch updates to the group in the database."""
-    # Serialize metadata if present
+async def _apply_group_patch_updates(group_id: str, update_data: Dict[str, Any], prisma_client):
+    """Apply the group's metadata/displayName patch updates to the database.
+
+    Membership itself is not written here; it is reconciled onto the source of
+    truth (members_with_roles and each member's user.teams) by
+    _handle_group_membership_changes via team_member_add/team_member_delete.
+    Writing the legacy `members` column here too would create a second, unread
+    copy of membership that could drift from the source of truth.
+    """
     if "metadata" in update_data and isinstance(update_data["metadata"], dict):
         update_data["metadata"] = safe_dumps(update_data["metadata"])
 
-    # Update members list
-    update_data["members"] = list(final_members)
-
-    # Update team in database
-    updated_team = await TeamRepository(prisma_client).table.update(
-        where={"team_id": group_id},
-        data=update_data,
-    )
-
-    return updated_team
+    if update_data:
+        return await TeamRepository(prisma_client).table.update(
+            where={"team_id": group_id},
+            data=update_data,
+        )
+    return await TeamRepository(prisma_client).table.find_unique(where={"team_id": group_id})
 
 
 async def _handle_group_membership_changes(group_id: str, current_members: Set[str], final_members: Set[str]):
@@ -2043,8 +2043,8 @@ async def patch_group(
         # Track current members BEFORE update for comparison
         current_members = set(await _get_team_member_user_ids_from_team(existing_team))
 
-        # Apply updates to the database
-        updated_team = await _apply_group_patch_updates(group_id, update_data, final_members, prisma_client)
+        # Apply the metadata/displayName updates to the database
+        updated_team = await _apply_group_patch_updates(group_id, update_data, prisma_client)
 
         # Refresh team data from database to get the latest state after concurrent updates
         # This prevents race conditions when multiple PATCH requests come in simultaneously

--- a/litellm/proxy/management_endpoints/scim/scim_v2.py
+++ b/litellm/proxy/management_endpoints/scim/scim_v2.py
@@ -1880,8 +1880,16 @@ async def delete_group(
 
 async def _process_group_patch_operations(
     patch_ops: SCIMPatchOp, existing_team, prisma_client
-) -> Tuple[Dict[str, Any], Set[str]]:
-    """Process patch operations for a group and return update data and final members."""
+) -> Tuple[Dict[str, Any], Set[str], Set[str] | None]:
+    """Process patch operations for a group and return update data, final members
+    and, when the request contained a member ``replace`` op, the absolute target
+    roster it declared (``None`` otherwise).
+
+    ``add``/``remove`` are deltas relative to the current roster, but ``replace``
+    is absolute: it declares the roster is exactly this set, so the caller must
+    reconcile against it as a set-to-target rather than rebasing it onto a
+    concurrently-mutated roster.
+    """
     update_data: Dict[str, Any] = {}
 
     # Create a fresh copy of existing metadata to avoid Prisma issues
@@ -1967,7 +1975,12 @@ async def _process_group_patch_operations(
     if metadata:
         update_data["metadata"] = metadata
 
-    return update_data, final_members
+    member_replace_present = any(
+        op.op == "replace" and (op.path or "").lower().startswith("members") for op in patch_ops.Operations
+    )
+    replace_target = set(final_members) if member_replace_present else None
+
+    return update_data, final_members, replace_target
 
 
 async def _apply_group_patch_updates(group_id: str, update_data: Dict[str, Any], prisma_client):
@@ -2038,7 +2051,9 @@ async def patch_group(
         existing_team = await _check_team_exists(group_id)
 
         # Process patch operations
-        update_data, final_members = await _process_group_patch_operations(patch_ops, existing_team, prisma_client)
+        update_data, final_members, replace_target = await _process_group_patch_operations(
+            patch_ops, existing_team, prisma_client
+        )
 
         snapshot_members = set(await _get_team_member_user_ids_from_team(existing_team))
         intended_add = final_members - snapshot_members
@@ -2053,7 +2068,9 @@ async def patch_group(
             else snapshot_members
         )
 
-        effective_final = (refreshed_current | intended_add) - intended_remove
+        effective_final = (
+            replace_target if replace_target is not None else (refreshed_current | intended_add) - intended_remove
+        )
 
         await _handle_group_membership_changes(group_id, refreshed_current, effective_final)
 

--- a/litellm/proxy/management_endpoints/scim/scim_v2.py
+++ b/litellm/proxy/management_endpoints/scim/scim_v2.py
@@ -2040,25 +2040,22 @@ async def patch_group(
         # Process patch operations
         update_data, final_members = await _process_group_patch_operations(patch_ops, existing_team, prisma_client)
 
-        # Track current members BEFORE update for comparison
-        current_members = set(await _get_team_member_user_ids_from_team(existing_team))
+        snapshot_members = set(await _get_team_member_user_ids_from_team(existing_team))
+        intended_add = final_members - snapshot_members
+        intended_remove = snapshot_members - final_members
 
-        # Apply the metadata/displayName updates to the database
         updated_team = await _apply_group_patch_updates(group_id, update_data, prisma_client)
 
-        # Refresh team data from database to get the latest state after concurrent updates
-        # This prevents race conditions when multiple PATCH requests come in simultaneously
         refreshed_team = await TeamRepository(prisma_client).table.find_unique(where={"team_id": group_id})
-        if refreshed_team:
-            # Re-read current members from refreshed team to account for concurrent updates
-            refreshed_current_members = set(
-                await _get_team_member_user_ids_from_team(LiteLLM_TeamTable(**refreshed_team.model_dump()))
-            )
-            # Use the refreshed members for comparison
-            current_members = refreshed_current_members
+        refreshed_current = (
+            set(await _get_team_member_user_ids_from_team(LiteLLM_TeamTable(**refreshed_team.model_dump())))
+            if refreshed_team
+            else snapshot_members
+        )
 
-        # Handle user-team relationship changes
-        await _handle_group_membership_changes(group_id, current_members, final_members)
+        effective_final = (refreshed_current | intended_add) - intended_remove
+
+        await _handle_group_membership_changes(group_id, refreshed_current, effective_final)
 
         # A rename can flip whether this group matches scim_admin_group by display
         # name, so retained members must be re-resolved too, not just the ones whose
@@ -2067,7 +2064,7 @@ async def patch_group(
         alias_changed = new_alias != existing_team.team_alias
         await _recompute_scim_member_roles(
             prisma_client,
-            (current_members | final_members if alias_changed else current_members ^ final_members),
+            (refreshed_current | effective_final if alias_changed else refreshed_current ^ effective_final),
         )
 
         # Refresh team one more time to get final state after membership changes

--- a/litellm/proxy/management_helpers/utils.py
+++ b/litellm/proxy/management_helpers/utils.py
@@ -252,6 +252,25 @@ async def _resolve_member_budget_id(
     return response.budget_id
 
 
+async def _append_team_id_to_user(prisma_client: PrismaClient, user_id: str, team_id: str) -> LiteLLM_UserTable | None:
+    """Append team_id to an existing user's teams array, only if not already present.
+
+    The filtered update makes the append a no-op once the team is present, so
+    repeated or concurrent adds of the same team cannot accumulate duplicate
+    team ids in user.teams (which would also break auth logic that keys off the
+    number of teams a user belongs to). Teams added concurrently for a different
+    team id are unaffected, since each update filters on its own team id.
+    """
+    await UserRepository(prisma_client).table.update_many(
+        where={"user_id": user_id, "NOT": {"teams": {"has": team_id}}},
+        data={"teams": {"push": [team_id]}},
+    )
+    updated_user = await UserRepository(prisma_client).table.find_unique(where={"user_id": user_id})
+    if updated_user is None:
+        return None
+    return LiteLLM_UserTable(**updated_user.model_dump())
+
+
 async def add_new_member(
     new_member: Member,
     max_budget_in_team: Optional[float],
@@ -275,16 +294,18 @@ async def add_new_member(
     returned_team_membership: Optional[LiteLLM_TeamMembership] = None
     ## ADD TEAM ID, to USER TABLE IF NEW ##
     if new_member.user_id is not None:
-        new_user_defaults = get_new_internal_user_defaults(user_id=new_member.user_id)
-        _returned_user = await UserRepository(prisma_client).table.upsert(
-            where={"user_id": new_member.user_id},
-            data={
-                "update": {"teams": {"push": [team_id]}},
-                "create": {"teams": [team_id], **new_user_defaults},  # type: ignore
-            },
-        )
-        if _returned_user is not None:
-            returned_user = LiteLLM_UserTable(**_returned_user.model_dump())
+        existing_user = await UserRepository(prisma_client).table.find_unique(where={"user_id": new_member.user_id})
+        if existing_user is None:
+            new_user_defaults = get_new_internal_user_defaults(user_id=new_member.user_id)
+            _created_user = await UserRepository(prisma_client).table.create(
+                data={"teams": [team_id], **new_user_defaults},
+            )
+            if _created_user is not None:
+                returned_user = LiteLLM_UserTable(**_created_user.model_dump())
+        else:
+            returned_user = await _append_team_id_to_user(
+                prisma_client=prisma_client, user_id=new_member.user_id, team_id=team_id
+            )
     elif new_member.user_email is not None:
         new_user_defaults = get_new_internal_user_defaults(user_id=str(uuid.uuid4()), user_email=new_member.user_email)
         ## user email is not unique acc. to prisma schema -> future improvement
@@ -302,12 +323,9 @@ async def add_new_member(
                 returned_user = LiteLLM_UserTable(**_returned_user.model_dump())
         elif len(existing_user_row) == 1:
             user_info = existing_user_row[0]
-            _returned_user = await UserRepository(prisma_client).table.update(
-                where={"user_id": user_info.user_id},  # type: ignore
-                data={"teams": {"push": [team_id]}},
+            returned_user = await _append_team_id_to_user(
+                prisma_client=prisma_client, user_id=user_info.user_id, team_id=team_id
             )
-            if _returned_user is not None:
-                returned_user = LiteLLM_UserTable(**_returned_user.model_dump())
         elif len(existing_user_row) > 1:
             raise HTTPException(
                 status_code=400,

--- a/litellm/proxy/management_helpers/utils.py
+++ b/litellm/proxy/management_helpers/utils.py
@@ -252,12 +252,12 @@ async def _resolve_member_budget_id(
     return response.budget_id
 
 
-async def _append_team_id_to_user(prisma_client: PrismaClient, user_id: str, team_id: str) -> LiteLLM_UserTable | None:
-    """Append team_id to an existing user's teams array, only if not already present.
+async def _append_team_id_if_absent(prisma_client: PrismaClient, user_id: str, team_id: str) -> None:
+    """Append team_id to a user's teams array, only if it is not already present.
 
-    The filtered update makes the append a no-op once the team is present, so
+    The row-level filter makes the append a no-op once the team is present, so
     repeated or concurrent adds of the same team cannot accumulate duplicate
-    team ids in user.teams (which would also break auth logic that keys off the
+    team ids in user.teams (a duplicate also breaks auth logic that keys off the
     number of teams a user belongs to). Teams added concurrently for a different
     team id are unaffected, since each update filters on its own team id.
     """
@@ -265,10 +265,6 @@ async def _append_team_id_to_user(prisma_client: PrismaClient, user_id: str, tea
         where={"user_id": user_id, "NOT": {"teams": {"has": team_id}}},
         data={"teams": {"push": [team_id]}},
     )
-    updated_user = await UserRepository(prisma_client).table.find_unique(where={"user_id": user_id})
-    if updated_user is None:
-        return None
-    return LiteLLM_UserTable(**updated_user.model_dump())
 
 
 async def add_new_member(
@@ -294,18 +290,19 @@ async def add_new_member(
     returned_team_membership: Optional[LiteLLM_TeamMembership] = None
     ## ADD TEAM ID, to USER TABLE IF NEW ##
     if new_member.user_id is not None:
-        existing_user = await UserRepository(prisma_client).table.find_unique(where={"user_id": new_member.user_id})
-        if existing_user is None:
-            new_user_defaults = get_new_internal_user_defaults(user_id=new_member.user_id)
-            _created_user = await UserRepository(prisma_client).table.create(
-                data={"teams": [team_id], **new_user_defaults},
-            )
-            if _created_user is not None:
-                returned_user = LiteLLM_UserTable(**_created_user.model_dump())
-        else:
-            returned_user = await _append_team_id_to_user(
-                prisma_client=prisma_client, user_id=new_member.user_id, team_id=team_id
-            )
+        new_user_defaults = get_new_internal_user_defaults(user_id=new_member.user_id)
+        # Upsert ensures the user row exists atomically (no create race when the
+        # same new user is provisioned concurrently), seeding teams on create.
+        # The teams append lives in the filtered update below rather than the
+        # upsert's update branch so an already-existing user does not get a
+        # duplicate team id.
+        _returned_user = await UserRepository(prisma_client).table.upsert(
+            where={"user_id": new_member.user_id},
+            data={"create": {"teams": [team_id], **new_user_defaults}, "update": {}},
+        )
+        await _append_team_id_if_absent(prisma_client, new_member.user_id, team_id)
+        if _returned_user is not None:
+            returned_user = LiteLLM_UserTable(**_returned_user.model_dump())
     elif new_member.user_email is not None:
         new_user_defaults = get_new_internal_user_defaults(user_id=str(uuid.uuid4()), user_email=new_member.user_email)
         ## user email is not unique acc. to prisma schema -> future improvement
@@ -323,9 +320,8 @@ async def add_new_member(
                 returned_user = LiteLLM_UserTable(**_returned_user.model_dump())
         elif len(existing_user_row) == 1:
             user_info = existing_user_row[0]
-            returned_user = await _append_team_id_to_user(
-                prisma_client=prisma_client, user_id=user_info.user_id, team_id=team_id
-            )
+            await _append_team_id_if_absent(prisma_client, user_info.user_id, team_id)
+            returned_user = LiteLLM_UserTable(**user_info.model_dump())
         elif len(existing_user_row) > 1:
             raise HTTPException(
                 status_code=400,

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
@@ -1658,7 +1658,7 @@ async def test_process_group_patch_operations_with_flag_true_creates_users(mocke
     )
 
     # Execute the function
-    update_data, final_members = await _process_group_patch_operations(
+    update_data, final_members, _ = await _process_group_patch_operations(
         patch_ops=patch_ops,
         existing_team=mock_existing_team,
         prisma_client=mock_prisma_client,
@@ -2679,13 +2679,14 @@ async def test_process_group_patch_operations_add_retains_existing_members(mocke
     # new-user already exists in the DB
     mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mocker.MagicMock(user_id="new-user"))
 
-    _, final_members = await _process_group_patch_operations(
+    _, final_members, replace_target = await _process_group_patch_operations(
         patch_ops=patch_ops,
         existing_team=existing_team,
         prisma_client=mock_prisma_client,
     )
 
     assert final_members == {"existing-user", "new-user"}
+    assert replace_target is None
 
 
 @pytest.mark.asyncio
@@ -2719,13 +2720,14 @@ async def test_process_group_patch_operations_remove_uses_members_with_roles(moc
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mocker.MagicMock(user_id="drop-user"))
 
-    _, final_members = await _process_group_patch_operations(
+    _, final_members, replace_target = await _process_group_patch_operations(
         patch_ops=patch_ops,
         existing_team=existing_team,
         prisma_client=mock_prisma_client,
     )
 
     assert final_members == {"keep-user"}
+    assert replace_target is None
 
 
 @pytest.mark.asyncio
@@ -2884,3 +2886,96 @@ async def test_patch_group_add_applies_delta_and_keeps_concurrent_add(mocker):
         call.kwargs["user_id"] for call in calls if call.kwargs.get("teams_ids_to_add_user_to") == [group_id]
     }
     assert added_user_ids == {"bob"}
+
+
+@pytest.mark.asyncio
+async def test_patch_group_replace_stays_absolute_against_concurrent_roster(mocker):
+    """A group PATCH ``replace`` op declares the roster is exactly the given set,
+    so it must reconcile as a set-to-target, not as a delta.
+
+    Unlike ``add``/``remove``, ``replace`` is absolute. A member that another
+    request added concurrently is present in the refreshed roster but not in the
+    replace target, and ``replace`` must drop it. Rebasing the replace onto the
+    refreshed roster (the delta behavior correct only for add/remove) would
+    wrongly retain that concurrently-added member.
+    """
+    from litellm.proxy.management_endpoints.scim.scim_transformations import (
+        ScimTransformations,
+    )
+
+    group_id = "team-replace-concurrent"
+
+    snapshot_team = LiteLLM_TeamTable(
+        team_id=group_id,
+        team_alias="Group",
+        members_with_roles=[Member(user_id="zed", role="user")],
+        metadata={"externalId": "grp-ext"},
+    )
+    refreshed_team = LiteLLM_TeamTable(
+        team_id=group_id,
+        team_alias="Group",
+        members_with_roles=[
+            Member(user_id="alice", role="user"),
+            Member(user_id="bob", role="user"),
+        ],
+        metadata={"externalId": "grp-ext"},
+    )
+    final_team = LiteLLM_TeamTable(
+        team_id=group_id,
+        team_alias="Group",
+        members_with_roles=[Member(user_id="alice", role="user")],
+        metadata={"externalId": "grp-ext"},
+    )
+
+    patch_ops = SCIMPatchOp(
+        schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        Operations=[SCIMPatchOperation(op="replace", path="members", value=[{"value": "alice"}])],
+    )
+
+    mock_prisma_client = mocker.MagicMock()
+    mock_prisma_client.db = mocker.MagicMock()
+    mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
+        side_effect=[snapshot_team, refreshed_team, final_team]
+    )
+    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(return_value=final_team)
+    mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mocker.MagicMock())
+
+    mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
+        AsyncMock(return_value=mock_prisma_client),
+    )
+    patch_membership_mock = mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2.patch_team_membership",
+        AsyncMock(),
+    )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2._recompute_scim_member_roles",
+        AsyncMock(),
+    )
+    mocker.patch.object(
+        ScimTransformations,
+        "transform_litellm_team_to_scim_group",
+        AsyncMock(
+            return_value=SCIMGroup(
+                schemas=["urn:ietf:params:scim:schemas:core:2.0:Group"],
+                id=group_id,
+                displayName="Group",
+            )
+        ),
+    )
+
+    await patch_group(group_id=group_id, patch_ops=patch_ops)
+
+    calls = patch_membership_mock.call_args_list
+
+    removed_user_ids = {
+        call.kwargs["user_id"] for call in calls if call.kwargs.get("teams_ids_to_remove_user_from") == [group_id]
+    }
+    assert removed_user_ids == {"bob"}
+
+    added_user_ids = {
+        call.kwargs["user_id"] for call in calls if call.kwargs.get("teams_ids_to_add_user_to") == [group_id]
+    }
+    assert added_user_ids == set()

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
@@ -59,9 +59,7 @@ async def test_create_user_existing_user_conflict(mocker):
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value={"user_id": "existing-user"}
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value={"user_id": "existing-user"})
 
     # Mock the _get_prisma_client_or_raise_exception to return our mock
     mocker.patch(
@@ -235,9 +233,7 @@ async def test_create_user_ingests_entitlements_and_roles(mocker, monkeypatch):
         },
         {"value": "bare-entitlement"},
     ]
-    assert created_metadata["scim_roles"] == [
-        {"value": "engineering-admin", "type": "role"}
-    ]
+    assert created_metadata["scim_roles"] == [{"value": "engineering-admin", "type": "role"}]
 
 
 @pytest.mark.asyncio
@@ -261,9 +257,7 @@ async def test_create_user_uses_default_internal_user_params_role(mocker, monkey
     default_params = {
         "user_role": LitellmUserRoles.PROXY_ADMIN,
     }
-    monkeypatch.setattr(
-        "litellm.default_internal_user_params", default_params, raising=False
-    )
+    monkeypatch.setattr("litellm.default_internal_user_params", default_params, raising=False)
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -343,10 +337,7 @@ async def test_scim_create_user_respects_default_role_set_via_ui(mocker, monkeyp
         "BUG: _update_litellm_setting did not update litellm.default_internal_user_params in memory. "
         "The local variable reassignment (in_memory_var = ...) doesn't propagate back."
     )
-    assert (
-        litellm.default_internal_user_params.get("user_role")
-        == LitellmUserRoles.INTERNAL_USER
-    )
+    assert litellm.default_internal_user_params.get("user_role") == LitellmUserRoles.INTERNAL_USER
 
     # Step 3: Create a user via SCIM
     scim_user = SCIMUser(
@@ -442,9 +433,7 @@ async def test_get_users_filters_username_by_exposed_scim_username_for_okta(mock
         take=10,
         order={"created_at": "desc"},
     )
-    mock_prisma_client.db.litellm_usertable.count.assert_awaited_once_with(
-        where=expected_where
-    )
+    mock_prisma_client.db.litellm_usertable.count.assert_awaited_once_with(where=expected_where)
     assert response.totalResults == 1
     assert response.Resources[0].id == "internal-user-id"
 
@@ -498,9 +487,7 @@ async def test_get_users_filters_email_value_by_user_email(mocker):
         take=10,
         order={"created_at": "desc"},
     )
-    mock_prisma_client.db.litellm_usertable.count.assert_awaited_once_with(
-        where=expected_where
-    )
+    mock_prisma_client.db.litellm_usertable.count.assert_awaited_once_with(where=expected_where)
     assert response.totalResults == 1
     assert response.Resources[0].id == "internal-user-id"
 
@@ -548,9 +535,7 @@ async def test_handle_existing_user_by_email_no_existing_user(mocker):
     )
 
     assert result is None
-    mock_prisma_client.db.litellm_usertable.find_first.assert_called_once_with(
-        where={"user_email": "test@example.com"}
-    )
+    mock_prisma_client.db.litellm_usertable.find_first.assert_called_once_with(where={"user_email": "test@example.com"})
 
 
 @pytest.mark.asyncio
@@ -585,12 +570,8 @@ async def test_handle_existing_user_by_email_existing_user_updated(mocker):
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(
-        return_value=existing_user
-    )
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value=updated_user
-    )
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(return_value=existing_user)
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value=updated_user)
 
     # Mock the transformation function
     mock_transform = mocker.patch(
@@ -615,9 +596,7 @@ async def test_handle_existing_user_by_email_existing_user_updated(mocker):
     assert result == mock_scim_user
 
     # Verify database operations
-    mock_prisma_client.db.litellm_usertable.find_first.assert_called_once_with(
-        where={"user_email": "test@example.com"}
-    )
+    mock_prisma_client.db.litellm_usertable.find_first.assert_called_once_with(where={"user_email": "test@example.com"})
 
     mock_prisma_client.db.litellm_usertable.update.assert_called_once_with(
         where={"user_id": "old-user-id"},
@@ -766,9 +745,7 @@ async def test_update_user_success(mocker):
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value=updated_user
-    )
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value=updated_user)
 
     # Mock dependencies
     mocker.patch(
@@ -819,11 +796,7 @@ async def test_update_user_not_found(mocker):
     )
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._check_user_exists",
-        AsyncMock(
-            side_effect=HTTPException(
-                status_code=404, detail={"error": "User not found"}
-            )
-        ),
+        AsyncMock(side_effect=HTTPException(status_code=404, detail={"error": "User not found"})),
     )
 
     # Should raise ProxyException (which wraps the HTTPException)
@@ -868,9 +841,7 @@ async def test_patch_user_success(mocker):
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value=updated_user
-    )
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value=updated_user)
 
     # Mock dependencies
     mocker.patch(
@@ -907,9 +878,7 @@ async def test_patch_user_not_found(mocker):
     """Should raise 404 when user doesn't exist for patch"""
     patch_ops = SCIMPatchOp(
         schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-        Operations=[
-            SCIMPatchOperation(op="replace", path="displayName", value="New Name")
-        ],
+        Operations=[SCIMPatchOperation(op="replace", path="displayName", value="New Name")],
     )
 
     # Mock dependencies to raise HTTPException for user not found
@@ -919,11 +888,7 @@ async def test_patch_user_not_found(mocker):
     )
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._check_user_exists",
-        AsyncMock(
-            side_effect=HTTPException(
-                status_code=404, detail={"error": "User not found"}
-            )
-        ),
+        AsyncMock(side_effect=HTTPException(status_code=404, detail={"error": "User not found"})),
     )
 
     # Should raise ProxyException (which wraps the HTTPException)
@@ -943,9 +908,7 @@ async def test_get_service_provider_config(mocker):
 
     # Verify it returns the correct response
     assert isinstance(result, SCIMServiceProviderConfig)
-    assert result.schemas == [
-        "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"
-    ]
+    assert result.schemas == ["urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"]
     assert result.patch.supported is True
     assert result.bulk.supported is False
     assert result.meta is not None
@@ -997,21 +960,15 @@ async def test_update_group_metadata_serialization_issue(mocker):
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
 
     # Mock team operations
-    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=mock_existing_team
-    )
-    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(
-        return_value=mock_updated_team
-    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_existing_team)
+    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(return_value=mock_updated_team)
 
     # Mock user operations
     mock_user = mocker.MagicMock()
     mock_user.user_id = "user1"
     mock_user.user_email = "user1@example.com"  # Add proper string value for user_email
     mock_user.teams = [group_id]
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=mock_user
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mock_user)
     mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value=mock_user)
 
     # Mock the _get_prisma_client_or_raise_exception to return our mock
@@ -1048,9 +1005,7 @@ async def test_update_group_metadata_serialization_issue(mocker):
     metadata = update_data["metadata"]
 
     # The fix should ensure metadata is serialized as a JSON string
-    assert isinstance(
-        metadata, str
-    ), f"metadata should be a JSON string, but got {type(metadata)}"
+    assert isinstance(metadata, str), f"metadata should be a JSON string, but got {type(metadata)}"
 
     # Verify we can parse it back to verify it contains the expected data
     import json
@@ -1107,9 +1062,7 @@ async def test_team_membership_management(mocker):
 
     # Check calls for adding members
     add_calls = [
-        call
-        for call in mock_patch_team_membership.call_args_list
-        if call[1]["teams_ids_to_add_user_to"] == [group_id]
+        call for call in mock_patch_team_membership.call_args_list if call[1]["teams_ids_to_add_user_to"] == [group_id]
     ]
     assert len(add_calls) == 2  # user3 and user4
 
@@ -1135,9 +1088,7 @@ async def test_team_membership_management(mocker):
         # Each call should either add OR remove, not both
         add_teams = call[1]["teams_ids_to_add_user_to"]
         remove_teams = call[1]["teams_ids_to_remove_user_from"]
-        assert (len(add_teams) > 0) != (
-            len(remove_teams) > 0
-        )  # XOR - one should be empty
+        assert (len(add_teams) > 0) != (len(remove_teams) > 0)  # XOR - one should be empty
 
 
 @pytest.mark.asyncio
@@ -1188,9 +1139,7 @@ async def test_update_group_e2e(mocker):
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
 
     # Mock database operations
-    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=existing_team
-    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=existing_team)
 
     # Mock the updated team that gets returned from database
     updated_team = LiteLLM_TeamTable(
@@ -1207,16 +1156,12 @@ async def test_update_group_e2e(mocker):
             "scim_data": scim_group_update.model_dump(),
         },
     )
-    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(
-        return_value=updated_team
-    )
+    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(return_value=updated_team)
 
     # Mock user validation (all users exist)
     mock_user = mocker.MagicMock()
     mock_user.user_id = "test-user"
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=mock_user
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mock_user)
 
     # Mock dependencies
     mocker.patch(
@@ -1269,29 +1214,19 @@ async def test_update_group_e2e(mocker):
     assert metadata["scim_data"]["displayName"] == "Updated Team Name"
 
     # Verify team membership changes were handled correctly
-    assert (
-        mock_patch_team_membership.call_count == 3
-    )  # Remove user1, add user3, add user4
+    assert mock_patch_team_membership.call_count == 3  # Remove user1, add user3, add user4
 
     # Check membership changes
     call_args_list = mock_patch_team_membership.call_args_list
 
     # Find remove operation (user1)
-    remove_calls = [
-        call
-        for call in call_args_list
-        if call[1]["teams_ids_to_remove_user_from"] == [group_id]
-    ]
+    remove_calls = [call for call in call_args_list if call[1]["teams_ids_to_remove_user_from"] == [group_id]]
     assert len(remove_calls) == 1
     assert remove_calls[0][1]["user_id"] == "user1"
     assert remove_calls[0][1]["teams_ids_to_add_user_to"] == []
 
     # Find add operations (user3, user4)
-    add_calls = [
-        call
-        for call in call_args_list
-        if call[1]["teams_ids_to_add_user_to"] == [group_id]
-    ]
+    add_calls = [call for call in call_args_list if call[1]["teams_ids_to_add_user_to"] == [group_id]]
     assert len(add_calls) == 2
     add_user_ids = {call[1]["user_id"] for call in add_calls}
     assert add_user_ids == {"user3", "user4"}
@@ -1306,9 +1241,7 @@ async def test_update_group_e2e(mocker):
     assert len(result.members) == 3
 
     # Verify SCIM transformation was called with updated team
-    ScimTransformations.transform_litellm_team_to_scim_group.assert_called_once_with(
-        updated_team
-    )
+    ScimTransformations.transform_litellm_team_to_scim_group.assert_called_once_with(updated_team)
 
 
 @pytest.mark.asyncio
@@ -1334,15 +1267,9 @@ async def test_create_group_with_nonexistent_users_rejects(mocker, monkeypatch):
         id=group_id,
         displayName="Test Group",
         members=[
-            SCIMMember(
-                value="existing-user", display="Existing User"
-            ),  # This user exists
-            SCIMMember(
-                value="new-user-1", display="New User 1"
-            ),  # This user doesn't exist
-            SCIMMember(
-                value="new-user-2", display="New User 2"
-            ),  # This user doesn't exist
+            SCIMMember(value="existing-user", display="Existing User"),  # This user exists
+            SCIMMember(value="new-user-1", display="New User 1"),  # This user doesn't exist
+            SCIMMember(value="new-user-2", display="New User 2"),  # This user doesn't exist
         ],
     )
 
@@ -1368,9 +1295,7 @@ async def test_create_group_with_nonexistent_users_rejects(mocker, monkeypatch):
             return mock_user
         return None  # new-user-1 and new-user-2 don't exist
 
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        side_effect=mock_user_lookup
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(side_effect=mock_user_lookup)
 
     # Mock dependencies
     mocker.patch(
@@ -1385,9 +1310,7 @@ async def test_create_group_with_nonexistent_users_rejects(mocker, monkeypatch):
     # Verify it's a 400 Bad Request
     assert int(exc_info.value.code) == 400
     assert "does not exist" in str(exc_info.value.message)
-    assert "new-user-1" in str(exc_info.value.message) or "new-user-2" in str(
-        exc_info.value.message
-    )
+    assert "new-user-1" in str(exc_info.value.message) or "new-user-2" in str(exc_info.value.message)
 
 
 @pytest.mark.asyncio
@@ -1422,15 +1345,9 @@ async def test_update_group_with_nonexistent_users_rejects(mocker, monkeypatch):
         id=group_id,
         displayName="Updated Group Name",
         members=[
-            SCIMMember(
-                value="existing-user", display="Existing User"
-            ),  # This user exists
-            SCIMMember(
-                value="new-user-3", display="New User 3"
-            ),  # This user doesn't exist
-            SCIMMember(
-                value="new-user-4", display="New User 4"
-            ),  # This user doesn't exist
+            SCIMMember(value="existing-user", display="Existing User"),  # This user exists
+            SCIMMember(value="new-user-3", display="New User 3"),  # This user doesn't exist
+            SCIMMember(value="new-user-4", display="New User 4"),  # This user doesn't exist
         ],
     )
 
@@ -1441,18 +1358,14 @@ async def test_update_group_with_nonexistent_users_rejects(mocker, monkeypatch):
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
 
     # Mock team operations
-    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=mock_existing_team
-    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_existing_team)
 
     # Mock updated team response
     mock_updated_team = mocker.MagicMock()
     mock_updated_team.team_id = group_id
     mock_updated_team.team_alias = "Updated Group Name"
     mock_updated_team.members = ["existing-user", "new-user-3", "new-user-4"]
-    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(
-        return_value=mock_updated_team
-    )
+    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(return_value=mock_updated_team)
 
     # Mock user lookup - only existing-user exists
     def mock_user_lookup(where):
@@ -1463,9 +1376,7 @@ async def test_update_group_with_nonexistent_users_rejects(mocker, monkeypatch):
             return mock_user
         return None  # new-user-3 and new-user-4 don't exist
 
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        side_effect=mock_user_lookup
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(side_effect=mock_user_lookup)
 
     # Mock dependencies
     mocker.patch(
@@ -1485,15 +1396,11 @@ async def test_update_group_with_nonexistent_users_rejects(mocker, monkeypatch):
     # Verify it's a 400 Bad Request
     assert int(exc_info.value.code) == 400
     assert "does not exist" in str(exc_info.value.message)
-    assert "new-user-3" in str(exc_info.value.message) or "new-user-4" in str(
-        exc_info.value.message
-    )
+    assert "new-user-3" in str(exc_info.value.message) or "new-user-4" in str(exc_info.value.message)
 
 
 @pytest.mark.asyncio
-async def test_create_group_with_nonexistent_users_creates_when_flag_true(
-    mocker, monkeypatch
-):
+async def test_create_group_with_nonexistent_users_creates_when_flag_true(mocker, monkeypatch):
     """
     Test that creating a group with non-existent users creates them when scim_upsert_user is True.
     This preserves backward compatible behavior.
@@ -1514,15 +1421,9 @@ async def test_create_group_with_nonexistent_users_creates_when_flag_true(
         id=group_id,
         displayName="Test Group",
         members=[
-            SCIMMember(
-                value="existing-user", display="Existing User"
-            ),  # This user exists
-            SCIMMember(
-                value="new-user-1", display="New User 1"
-            ),  # This user doesn't exist - should be created
-            SCIMMember(
-                value="new-user-2", display="New User 2"
-            ),  # This user doesn't exist - should be created
+            SCIMMember(value="existing-user", display="Existing User"),  # This user exists
+            SCIMMember(value="new-user-1", display="New User 1"),  # This user doesn't exist - should be created
+            SCIMMember(value="new-user-2", display="New User 2"),  # This user doesn't exist - should be created
         ],
     )
 
@@ -1544,9 +1445,7 @@ async def test_create_group_with_nonexistent_users_creates_when_flag_true(
             return mock_user
         return None  # new-user-1 and new-user-2 don't exist
 
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        side_effect=mock_user_lookup
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(side_effect=mock_user_lookup)
 
     # Mock user creation
     created_user_1 = NewUserResponse(user_id="new-user-1", key="test-key-1")
@@ -1595,9 +1494,7 @@ async def test_create_group_with_nonexistent_users_creates_when_flag_true(
 
 
 @pytest.mark.asyncio
-async def test_extract_group_member_ids_with_flag_true_creates_users(
-    mocker, monkeypatch
-):
+async def test_extract_group_member_ids_with_flag_true_creates_users(mocker, monkeypatch):
     """
     Test that _extract_group_member_ids creates users when scim_upsert_user is True.
     """
@@ -1616,12 +1513,8 @@ async def test_extract_group_member_ids_with_flag_true_creates_users(
         id="test-group",
         displayName="Test Group",
         members=[
-            SCIMMember(
-                value="existing-user", display="Existing User"
-            ),  # This user exists
-            SCIMMember(
-                value="new-user-1", display="New User 1"
-            ),  # This user doesn't exist - should be created
+            SCIMMember(value="existing-user", display="Existing User"),  # This user exists
+            SCIMMember(value="new-user-1", display="New User 1"),  # This user doesn't exist - should be created
         ],
     )
 
@@ -1639,9 +1532,7 @@ async def test_extract_group_member_ids_with_flag_true_creates_users(
             return mock_user
         return None  # new-user-1 doesn't exist
 
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        side_effect=mock_user_lookup
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(side_effect=mock_user_lookup)
 
     # Mock user creation
     created_user = NewUserResponse(user_id="new-user-1", key="test-key-1")
@@ -1666,9 +1557,7 @@ async def test_extract_group_member_ids_with_flag_true_creates_users(
     assert len(result.created_users) == 1
 
     # Verify user was created
-    mock_create_user.assert_called_once_with(
-        user_id="new-user-1", created_via="scim_group_membership"
-    )
+    mock_create_user.assert_called_once_with(user_id="new-user-1", created_via="scim_group_membership")
 
 
 @pytest.mark.asyncio
@@ -1691,12 +1580,8 @@ async def test_extract_group_member_ids_with_flag_false_rejects(mocker, monkeypa
         id="test-group",
         displayName="Test Group",
         members=[
-            SCIMMember(
-                value="existing-user", display="Existing User"
-            ),  # This user exists
-            SCIMMember(
-                value="new-user-1", display="New User 1"
-            ),  # This user doesn't exist - should be rejected
+            SCIMMember(value="existing-user", display="Existing User"),  # This user exists
+            SCIMMember(value="new-user-1", display="New User 1"),  # This user doesn't exist - should be rejected
         ],
     )
 
@@ -1714,9 +1599,7 @@ async def test_extract_group_member_ids_with_flag_false_rejects(mocker, monkeypa
             return mock_user
         return None  # new-user-1 doesn't exist
 
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        side_effect=mock_user_lookup
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(side_effect=mock_user_lookup)
 
     # Mock dependencies
     mocker.patch(
@@ -1735,9 +1618,7 @@ async def test_extract_group_member_ids_with_flag_false_rejects(mocker, monkeypa
 
 
 @pytest.mark.asyncio
-async def test_process_group_patch_operations_with_flag_true_creates_users(
-    mocker, monkeypatch
-):
+async def test_process_group_patch_operations_with_flag_true_creates_users(mocker, monkeypatch):
     """
     Test that _process_group_patch_operations creates users when scim_upsert_user is True.
     """
@@ -1753,11 +1634,7 @@ async def test_process_group_patch_operations_with_flag_true_creates_users(
     # Test data
     patch_ops = SCIMPatchOp(
         schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-        Operations=[
-            SCIMPatchOperation(
-                op="add", path="members", value=[{"value": "new-user-1"}]
-            )
-        ],
+        Operations=[SCIMPatchOperation(op="add", path="members", value=[{"value": "new-user-1"}])],
     )
 
     # Mock existing team
@@ -1791,15 +1668,11 @@ async def test_process_group_patch_operations_with_flag_true_creates_users(
     assert "new-user-1" in final_members
 
     # Verify user was created
-    mock_create_user.assert_called_once_with(
-        user_id="new-user-1", created_via="scim_group_patch"
-    )
+    mock_create_user.assert_called_once_with(user_id="new-user-1", created_via="scim_group_patch")
 
 
 @pytest.mark.asyncio
-async def test_process_group_patch_operations_with_flag_false_rejects(
-    mocker, monkeypatch
-):
+async def test_process_group_patch_operations_with_flag_false_rejects(mocker, monkeypatch):
     """
     Test that _process_group_patch_operations rejects non-existent users when scim_upsert_user is False.
     """
@@ -1815,11 +1688,7 @@ async def test_process_group_patch_operations_with_flag_false_rejects(
     # Test data
     patch_ops = SCIMPatchOp(
         schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-        Operations=[
-            SCIMPatchOperation(
-                op="add", path="members", value=[{"value": "new-user-1"}]
-            )
-        ],
+        Operations=[SCIMPatchOperation(op="add", path="members", value=[{"value": "new-user-1"}])],
     )
 
     # Mock existing team
@@ -1894,9 +1763,7 @@ async def test_create_user_grants_admin_when_in_scim_admin_group(mocker, monkeyp
 
 
 @pytest.mark.asyncio
-async def test_create_user_keeps_default_when_not_in_scim_admin_group(
-    mocker, monkeypatch
-):
+async def test_create_user_keeps_default_when_not_in_scim_admin_group(mocker, monkeypatch):
     """When scim_admin_group is configured but the user's groups don't include it,
     the user keeps the non-admin default role."""
     from litellm.proxy.proxy_server import proxy_config
@@ -1940,9 +1807,7 @@ async def test_create_user_keeps_default_when_not_in_scim_admin_group(
 
 
 @pytest.mark.asyncio
-async def test_update_user_demotes_admin_when_removed_from_scim_admin_group(
-    mocker, monkeypatch
-):
+async def test_update_user_demotes_admin_when_removed_from_scim_admin_group(mocker, monkeypatch):
     """Core demotion test: a PUT whose new groups no longer include the configured
     admin group must re-evaluate the role and write the non-admin default, so an
     admin removed from the IdP group is demoted without re-login."""
@@ -1976,9 +1841,7 @@ async def test_update_user_demotes_admin_when_removed_from_scim_admin_group(
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value=updated_user
-    )
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value=updated_user)
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -2004,9 +1867,7 @@ async def test_update_user_demotes_admin_when_removed_from_scim_admin_group(
 
 
 @pytest.mark.asyncio
-async def test_update_user_does_not_force_role_when_scim_admin_group_unset(
-    mocker, monkeypatch
-):
+async def test_update_user_does_not_force_role_when_scim_admin_group_unset(mocker, monkeypatch):
     """When scim_admin_group is unset, PUT must not touch user_role (current
     behavior preserved)."""
     from litellm.proxy.proxy_server import proxy_config
@@ -2039,9 +1900,7 @@ async def test_update_user_does_not_force_role_when_scim_admin_group_unset(
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value=updated_user
-    )
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value=updated_user)
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -2067,9 +1926,7 @@ async def test_update_user_does_not_force_role_when_scim_admin_group_unset(
 
 
 @pytest.mark.asyncio
-async def test_update_user_demotes_when_default_params_lack_user_role(
-    mocker, monkeypatch
-):
+async def test_update_user_demotes_when_default_params_lack_user_role(mocker, monkeypatch):
     """Regression: default_internal_user_params set without a user_role key must
     still resolve to the non-admin default on demotion, not silently skip and
     leave the user PROXY_ADMIN."""
@@ -2079,9 +1936,7 @@ async def test_update_user_demotes_when_default_params_lack_user_role(
         return {"litellm_settings": {"scim_admin_group": "litellm-admins"}}
 
     monkeypatch.setattr(proxy_config, "get_config", mock_get_config)
-    monkeypatch.setattr(
-        "litellm.default_internal_user_params", {"max_budget": 10}, raising=False
-    )
+    monkeypatch.setattr("litellm.default_internal_user_params", {"max_budget": 10}, raising=False)
 
     existing_user = mocker.MagicMock()
     existing_user.teams = ["litellm-admins"]
@@ -2105,9 +1960,7 @@ async def test_update_user_demotes_when_default_params_lack_user_role(
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value=updated_user
-    )
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value=updated_user)
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -2133,9 +1986,7 @@ async def test_update_user_demotes_when_default_params_lack_user_role(
 
 
 @pytest.mark.asyncio
-async def test_patch_user_demotes_admin_when_removed_from_scim_admin_group(
-    mocker, monkeypatch
-):
+async def test_patch_user_demotes_admin_when_removed_from_scim_admin_group(mocker, monkeypatch):
     """PATCH that drops the admin team from the resulting team set must write the
     non-admin default, mirroring the PUT demotion path."""
     from litellm.proxy.proxy_server import proxy_config
@@ -2152,11 +2003,7 @@ async def test_patch_user_demotes_admin_when_removed_from_scim_admin_group(
 
     patch_ops = SCIMPatchOp(
         schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-        Operations=[
-            SCIMPatchOperation(
-                op="replace", path="groups", value=[{"value": "engineering"}]
-            )
-        ],
+        Operations=[SCIMPatchOperation(op="replace", path="groups", value=[{"value": "engineering"}])],
     )
 
     updated_user = {
@@ -2172,13 +2019,9 @@ async def test_patch_user_demotes_admin_when_removed_from_scim_admin_group(
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value=updated_user
-    )
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value=updated_user)
     mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=engineering_team
-    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=engineering_team)
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -2227,11 +2070,7 @@ async def test_patch_user_grants_admin_by_team_display_name(mocker, monkeypatch)
 
     patch_ops = SCIMPatchOp(
         schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-        Operations=[
-            SCIMPatchOperation(
-                op="replace", path="groups", value=[{"value": "team-abc-123"}]
-            )
-        ],
+        Operations=[SCIMPatchOperation(op="replace", path="groups", value=[{"value": "team-abc-123"}])],
     )
 
     updated_user = {
@@ -2247,13 +2086,9 @@ async def test_patch_user_grants_admin_by_team_display_name(mocker, monkeypatch)
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value=updated_user
-    )
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value=updated_user)
     mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=admin_team
-    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=admin_team)
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -2306,9 +2141,7 @@ def _scim_admin_prisma(mocker, *, user_teams):
 
 
 @pytest.mark.asyncio
-async def test_recompute_scim_member_roles_demotes_when_not_in_admin_group(
-    mocker, monkeypatch
-):
+async def test_recompute_scim_member_roles_demotes_when_not_in_admin_group(mocker, monkeypatch):
     """The shared recompute helper writes the non-admin default for a member whose
     resulting teams no longer include the configured admin group."""
     from litellm.proxy.proxy_server import proxy_config
@@ -2328,9 +2161,7 @@ async def test_recompute_scim_member_roles_demotes_when_not_in_admin_group(
 
 
 @pytest.mark.asyncio
-async def test_recompute_scim_member_roles_grants_when_in_admin_group(
-    mocker, monkeypatch
-):
+async def test_recompute_scim_member_roles_grants_when_in_admin_group(mocker, monkeypatch):
     """The shared recompute helper grants PROXY_ADMIN when a member's resulting
     teams include the configured admin group."""
     from litellm.proxy.proxy_server import proxy_config
@@ -2350,9 +2181,7 @@ async def test_recompute_scim_member_roles_grants_when_in_admin_group(
 
 
 @pytest.mark.asyncio
-async def test_recompute_scim_member_roles_noop_when_admin_group_unset(
-    mocker, monkeypatch
-):
+async def test_recompute_scim_member_roles_noop_when_admin_group_unset(mocker, monkeypatch):
     """With scim_admin_group unset the recompute helper must not touch any role,
     preserving current behavior for SCIM group writes."""
     from litellm.proxy.proxy_server import proxy_config
@@ -2399,16 +2228,10 @@ async def test_update_group_recomputes_roles_for_changed_members(mocker):
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=existing_team
-    )
-    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(
-        return_value=existing_team
-    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=existing_team)
+    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(return_value=existing_team)
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=mocker.MagicMock()
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mocker.MagicMock())
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -2456,24 +2279,16 @@ async def test_patch_group_recomputes_roles_for_changed_members(mocker):
     )
     patch_ops = SCIMPatchOp(
         schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-        Operations=[
-            SCIMPatchOperation(op="remove", path="members", value=[{"value": "user1"}])
-        ],
+        Operations=[SCIMPatchOperation(op="remove", path="members", value=[{"value": "user1"}])],
     )
 
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=existing_team
-    )
-    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(
-        return_value=existing_team
-    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=existing_team)
+    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(return_value=existing_team)
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=mocker.MagicMock()
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mocker.MagicMock())
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -2523,9 +2338,7 @@ async def test_delete_group_recomputes_roles_for_members(mocker):
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=existing_team
-    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=existing_team)
     mock_prisma_client.db.litellm_teamtable.delete = AsyncMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=member)
@@ -2556,12 +2369,8 @@ async def test_handle_existing_user_by_email_applies_role_when_admin_group_set(m
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(
-        return_value=existing_user
-    )
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value={"user_id": "new-user-id"}
-    )
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(return_value=existing_user)
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value={"user_id": "new-user-id"})
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
         AsyncMock(return_value=mocker.MagicMock()),
@@ -2596,12 +2405,8 @@ async def test_handle_existing_user_by_email_leaves_role_when_admin_group_unset(
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(
-        return_value=existing_user
-    )
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value={"user_id": "new-user-id"}
-    )
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(return_value=existing_user)
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value={"user_id": "new-user-id"})
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
         AsyncMock(return_value=mocker.MagicMock()),
@@ -2626,9 +2431,7 @@ async def test_handle_existing_user_by_email_leaves_role_when_admin_group_unset(
 
 
 @pytest.mark.asyncio
-async def test_create_user_existing_email_upsert_demotes_when_admin_group_set(
-    mocker, monkeypatch
-):
+async def test_create_user_existing_email_upsert_demotes_when_admin_group_set(mocker, monkeypatch):
     """End-to-end create wiring: a SCIM POST that upserts an existing email while
     the user is not in the admin group must write the non-admin default, not leave
     a stale PROXY_ADMIN."""
@@ -2654,12 +2457,8 @@ async def test_create_user_existing_email_upsert_demotes_when_admin_group_set(
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
-    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(
-        return_value=existing_user
-    )
-    mock_prisma_client.db.litellm_usertable.update = AsyncMock(
-        return_value={"user_id": "returning-user"}
-    )
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(return_value=existing_user)
+    mock_prisma_client.db.litellm_usertable.update = AsyncMock(return_value={"user_id": "returning-user"})
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -2702,9 +2501,7 @@ async def test_create_group_recomputes_roles_for_members(mocker):
     mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
     mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=None)
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=mocker.MagicMock()
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mocker.MagicMock())
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -2758,16 +2555,10 @@ async def test_update_group_rename_recomputes_retained_members(mocker):
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=existing_team
-    )
-    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(
-        return_value=existing_team
-    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=existing_team)
+    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(return_value=existing_team)
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=mocker.MagicMock()
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mocker.MagicMock())
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -2812,24 +2603,16 @@ async def test_patch_group_rename_recomputes_retained_members(mocker):
     )
     patch_ops = SCIMPatchOp(
         schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-        Operations=[
-            SCIMPatchOperation(op="replace", path="displayName", value="Engineering")
-        ],
+        Operations=[SCIMPatchOperation(op="replace", path="displayName", value="Engineering")],
     )
 
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
-        return_value=existing_team
-    )
-    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(
-        return_value=existing_team
-    )
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=existing_team)
+    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(return_value=existing_team)
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=mocker.MagicMock()
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mocker.MagicMock())
 
     mocker.patch(
         "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
@@ -2862,9 +2645,7 @@ async def test_patch_group_rename_recomputes_retained_members(mocker):
 
 
 @pytest.mark.asyncio
-async def test_process_group_patch_operations_add_retains_existing_members(
-    mocker, monkeypatch
-):
+async def test_process_group_patch_operations_add_retains_existing_members(mocker, monkeypatch):
     """A SCIM group ``add`` operation must not drop members already in the team.
 
     Team membership lives in members_with_roles; team creation leaves the legacy
@@ -2889,18 +2670,14 @@ async def test_process_group_patch_operations_add_retains_existing_members(
     )
     patch_ops = SCIMPatchOp(
         schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-        Operations=[
-            SCIMPatchOperation(op="add", path="members", value=[{"value": "new-user"}])
-        ],
+        Operations=[SCIMPatchOperation(op="add", path="members", value=[{"value": "new-user"}])],
     )
 
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
     # new-user already exists in the DB
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=mocker.MagicMock(user_id="new-user")
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mocker.MagicMock(user_id="new-user"))
 
     _, final_members = await _process_group_patch_operations(
         patch_ops=patch_ops,
@@ -2912,9 +2689,7 @@ async def test_process_group_patch_operations_add_retains_existing_members(
 
 
 @pytest.mark.asyncio
-async def test_process_group_patch_operations_remove_uses_members_with_roles(
-    mocker, monkeypatch
-):
+async def test_process_group_patch_operations_remove_uses_members_with_roles(mocker, monkeypatch):
     """A ``remove`` op must diff against members_with_roles, so removing one
     member leaves the rest of the team intact rather than emptying it."""
 
@@ -2936,19 +2711,13 @@ async def test_process_group_patch_operations_remove_uses_members_with_roles(
     )
     patch_ops = SCIMPatchOp(
         schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
-        Operations=[
-            SCIMPatchOperation(
-                op="remove", path="members", value=[{"value": "drop-user"}]
-            )
-        ],
+        Operations=[SCIMPatchOperation(op="remove", path="members", value=[{"value": "drop-user"}])],
     )
 
     mock_prisma_client = mocker.MagicMock()
     mock_prisma_client.db = mocker.MagicMock()
     mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        return_value=mocker.MagicMock(user_id="drop-user")
-    )
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mocker.MagicMock(user_id="drop-user"))
 
     _, final_members = await _process_group_patch_operations(
         patch_ops=patch_ops,
@@ -3017,3 +2786,101 @@ async def test_apply_group_patch_updates_does_not_write_legacy_members(mocker):
     written = mock_prisma_client.db.litellm_teamtable.update.call_args.kwargs["data"]
     assert "members" not in written
     assert written["team_alias"] == "Renamed"
+
+
+@pytest.mark.asyncio
+async def test_patch_group_add_applies_delta_and_keeps_concurrent_add(mocker):
+    """A group PATCH op:add must be applied as a delta against the live roster,
+    not as a snapshot-based absolute target.
+
+    When a concurrent PATCH has already added a member between this request's
+    initial read and its post-write refresh, that member shows up in the
+    refreshed roster but not in this request's snapshot-derived target. Diffing
+    the refreshed roster against the snapshot target would issue a spurious
+    team_member_delete for the concurrently-added member. Applying only this
+    request's intended delta on top of the refreshed roster must retain them.
+    """
+    from litellm.proxy.management_endpoints.scim.scim_transformations import (
+        ScimTransformations,
+    )
+
+    group_id = "team-concurrent"
+
+    snapshot_team = LiteLLM_TeamTable(
+        team_id=group_id,
+        team_alias="Group",
+        members_with_roles=[Member(user_id="zed", role="user")],
+        metadata={"externalId": "grp-ext"},
+    )
+    refreshed_team = LiteLLM_TeamTable(
+        team_id=group_id,
+        team_alias="Group",
+        members_with_roles=[
+            Member(user_id="zed", role="user"),
+            Member(user_id="alice", role="user"),
+        ],
+        metadata={"externalId": "grp-ext"},
+    )
+    final_team = LiteLLM_TeamTable(
+        team_id=group_id,
+        team_alias="Group",
+        members_with_roles=[
+            Member(user_id="zed", role="user"),
+            Member(user_id="alice", role="user"),
+            Member(user_id="bob", role="user"),
+        ],
+        metadata={"externalId": "grp-ext"},
+    )
+
+    patch_ops = SCIMPatchOp(
+        schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        Operations=[SCIMPatchOperation(op="add", path="members", value=[{"value": "bob"}])],
+    )
+
+    mock_prisma_client = mocker.MagicMock()
+    mock_prisma_client.db = mocker.MagicMock()
+    mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
+        side_effect=[snapshot_team, refreshed_team, final_team]
+    )
+    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(return_value=final_team)
+    mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=mocker.MagicMock())
+
+    mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
+        AsyncMock(return_value=mock_prisma_client),
+    )
+    patch_membership_mock = mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2.patch_team_membership",
+        AsyncMock(),
+    )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2._recompute_scim_member_roles",
+        AsyncMock(),
+    )
+    mocker.patch.object(
+        ScimTransformations,
+        "transform_litellm_team_to_scim_group",
+        AsyncMock(
+            return_value=SCIMGroup(
+                schemas=["urn:ietf:params:scim:schemas:core:2.0:Group"],
+                id=group_id,
+                displayName="Group",
+            )
+        ),
+    )
+
+    await patch_group(group_id=group_id, patch_ops=patch_ops)
+
+    calls = patch_membership_mock.call_args_list
+
+    removed_user_ids = {
+        call.kwargs["user_id"] for call in calls if call.kwargs.get("teams_ids_to_remove_user_from") == [group_id]
+    }
+    assert removed_user_ids == set()
+
+    added_user_ids = {
+        call.kwargs["user_id"] for call in calls if call.kwargs.get("teams_ids_to_add_user_to") == [group_id]
+    }
+    assert added_user_ids == {"bob"}

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
@@ -4,8 +4,10 @@ import pytest
 from fastapi import HTTPException
 
 from litellm.proxy._types import (
+    LiteLLM_TeamTable,
     LiteLLM_UserTable,
     LitellmUserRoles,
+    Member,
     NewUserRequest,
     NewUserResponse,
     ProxyException,
@@ -19,6 +21,7 @@ from litellm.proxy.management_endpoints.scim.scim_v2 import (
     create_group,
     create_user,
     delete_group,
+    get_groups,
     get_users,
     get_service_provider_config,
     patch_group,
@@ -2855,3 +2858,133 @@ async def test_patch_group_rename_recomputes_retained_members(mocker):
 
     recompute_mock.assert_awaited_once()
     assert set(recompute_mock.call_args[0][1]) == {"user1"}
+
+
+@pytest.mark.asyncio
+async def test_process_group_patch_operations_add_retains_existing_members(
+    mocker, monkeypatch
+):
+    """A SCIM group ``add`` operation must not drop members already in the team.
+
+    Team membership lives in members_with_roles; team creation leaves the legacy
+    ``members`` column empty. Seeding the patch result from that empty column
+    made an ``add`` recompute the member set from scratch and remove everyone
+    already in the team. The result set must be seeded from members_with_roles so
+    existing members survive an add of a new one.
+    """
+
+    async def mock_get_config():
+        return {"litellm_settings": {"scim_upsert_user": True}}
+
+    from litellm.proxy.proxy_server import proxy_config
+
+    monkeypatch.setattr(proxy_config, "get_config", mock_get_config)
+
+    existing_team = LiteLLM_TeamTable(
+        team_id="team-1",
+        team_alias="Team One",
+        members=[],  # legacy column intentionally empty, as real teams leave it
+        members_with_roles=[Member(user_id="existing-user", role="user")],
+    )
+    patch_ops = SCIMPatchOp(
+        schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        Operations=[
+            SCIMPatchOperation(op="add", path="members", value=[{"value": "new-user"}])
+        ],
+    )
+
+    mock_prisma_client = mocker.MagicMock()
+    mock_prisma_client.db = mocker.MagicMock()
+    mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
+    # new-user already exists in the DB
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
+        return_value=mocker.MagicMock(user_id="new-user")
+    )
+
+    _, final_members = await _process_group_patch_operations(
+        patch_ops=patch_ops,
+        existing_team=existing_team,
+        prisma_client=mock_prisma_client,
+    )
+
+    assert final_members == {"existing-user", "new-user"}
+
+
+@pytest.mark.asyncio
+async def test_process_group_patch_operations_remove_uses_members_with_roles(
+    mocker, monkeypatch
+):
+    """A ``remove`` op must diff against members_with_roles, so removing one
+    member leaves the rest of the team intact rather than emptying it."""
+
+    async def mock_get_config():
+        return {"litellm_settings": {"scim_upsert_user": True}}
+
+    from litellm.proxy.proxy_server import proxy_config
+
+    monkeypatch.setattr(proxy_config, "get_config", mock_get_config)
+
+    existing_team = LiteLLM_TeamTable(
+        team_id="team-1",
+        team_alias="Team One",
+        members=[],
+        members_with_roles=[
+            Member(user_id="keep-user", role="user"),
+            Member(user_id="drop-user", role="user"),
+        ],
+    )
+    patch_ops = SCIMPatchOp(
+        schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        Operations=[
+            SCIMPatchOperation(
+                op="remove", path="members", value=[{"value": "drop-user"}]
+            )
+        ],
+    )
+
+    mock_prisma_client = mocker.MagicMock()
+    mock_prisma_client.db = mocker.MagicMock()
+    mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
+        return_value=mocker.MagicMock(user_id="drop-user")
+    )
+
+    _, final_members = await _process_group_patch_operations(
+        patch_ops=patch_ops,
+        existing_team=existing_team,
+        prisma_client=mock_prisma_client,
+    )
+
+    assert final_members == {"keep-user"}
+
+
+@pytest.mark.asyncio
+async def test_get_groups_reports_members_from_members_with_roles(mocker):
+    """GET /Groups must report members from members_with_roles (the source of
+    truth), not the legacy ``members`` column that team creation leaves empty.
+    Reporting an empty member list makes the IdP repeatedly re-provision."""
+    team = LiteLLM_TeamTable(
+        team_id="team-1",
+        team_alias="Team One",
+        members=[],  # legacy column empty
+        members_with_roles=[Member(user_id="member-1", role="user")],
+    )
+
+    mock_prisma_client = mocker.MagicMock()
+    mock_prisma_client.db = mocker.MagicMock()
+    mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
+    mock_prisma_client.db.litellm_teamtable.find_many = AsyncMock(return_value=[team])
+    mock_prisma_client.db.litellm_teamtable.count = AsyncMock(return_value=1)
+    mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
+        return_value=mocker.MagicMock(user_id="member-1", user_email="member-1@example.com")
+    )
+
+    mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
+        AsyncMock(return_value=mock_prisma_client),
+    )
+
+    response = await get_groups(startIndex=1, count=10, filter=None)
+
+    assert [m.value for m in response.Resources[0].members] == ["member-1"]

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
@@ -14,6 +14,7 @@ from litellm.proxy._types import (
 )
 from litellm.proxy.management_endpoints.scim.scim_v2 import (
     UserProvisionerHelpers,
+    _apply_group_patch_updates,
     _extract_group_member_ids,
     _handle_team_membership_changes,
     _process_group_patch_operations,
@@ -2988,3 +2989,31 @@ async def test_get_groups_reports_members_from_members_with_roles(mocker):
     response = await get_groups(startIndex=1, count=10, filter=None)
 
     assert [m.value for m in response.Resources[0].members] == ["member-1"]
+
+
+@pytest.mark.asyncio
+async def test_apply_group_patch_updates_does_not_write_legacy_members(mocker):
+    """The group PATCH apply must not write the legacy ``members`` column.
+
+    Membership is reconciled onto the source of truth (members_with_roles and
+    each member's user.teams) separately; writing the legacy column here too
+    would create a second, unread copy of membership that can drift from the
+    source of truth, which is the inconsistency this PR removes.
+    """
+    mock_prisma_client = mocker.MagicMock()
+    mock_prisma_client.db = mocker.MagicMock()
+    mock_prisma_client.db.litellm_teamtable = mocker.MagicMock()
+    updated = mocker.MagicMock()
+    mock_prisma_client.db.litellm_teamtable.update = AsyncMock(return_value=updated)
+
+    result = await _apply_group_patch_updates(
+        group_id="team-1",
+        update_data={"team_alias": "Renamed"},
+        prisma_client=mock_prisma_client,
+    )
+
+    assert result is updated
+    mock_prisma_client.db.litellm_teamtable.update.assert_awaited_once()
+    written = mock_prisma_client.db.litellm_teamtable.update.call_args.kwargs["data"]
+    assert "members" not in written
+    assert written["team_alias"] == "Renamed"

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -4105,8 +4105,9 @@ async def test_new_team_max_budget_within_user_limit():
             "teams": ["team-within-budget-789"],
         }
         mock_prisma.db.litellm_usertable = MagicMock()
-        mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
-        mock_prisma.db.litellm_usertable.create = AsyncMock(return_value=mock_user)
+        mock_prisma.db.litellm_usertable.upsert = AsyncMock(return_value=mock_user)
+        mock_prisma.db.litellm_usertable.update_many = AsyncMock()
+        mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=mock_user)
         mock_prisma.db.litellm_usertable.update = AsyncMock(return_value=mock_user)
 
         # Mock team membership table
@@ -4247,8 +4248,9 @@ async def test_new_team_org_scoped_budget_bypasses_user_limit():
             "teams": ["team-org-scoped-789"],
         }
         mock_prisma.db.litellm_usertable = MagicMock()
-        mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
-        mock_prisma.db.litellm_usertable.create = AsyncMock(return_value=mock_user)
+        mock_prisma.db.litellm_usertable.upsert = AsyncMock(return_value=mock_user)
+        mock_prisma.db.litellm_usertable.update_many = AsyncMock()
+        mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=mock_user)
         mock_prisma.db.litellm_usertable.update = AsyncMock(return_value=mock_user)
 
         # Mock team membership table
@@ -4394,8 +4396,9 @@ async def test_new_team_org_scoped_models_bypasses_user_limit():
             "teams": ["team-org-scoped-models-789"],
         }
         mock_prisma.db.litellm_usertable = MagicMock()
-        mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
-        mock_prisma.db.litellm_usertable.create = AsyncMock(return_value=mock_user)
+        mock_prisma.db.litellm_usertable.upsert = AsyncMock(return_value=mock_user)
+        mock_prisma.db.litellm_usertable.update_many = AsyncMock()
+        mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=mock_user)
         mock_prisma.db.litellm_usertable.update = AsyncMock(return_value=mock_user)
 
         # Mock team membership table
@@ -7247,8 +7250,9 @@ async def test_new_team_soft_budget_validation(
             "teams": ["test-team-123"],
         }
         mock_prisma.db.litellm_usertable = MagicMock()
-        mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
-        mock_prisma.db.litellm_usertable.create = AsyncMock(return_value=mock_user)
+        mock_prisma.db.litellm_usertable.upsert = AsyncMock(return_value=mock_user)
+        mock_prisma.db.litellm_usertable.update_many = AsyncMock()
+        mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=mock_user)
         mock_prisma.db.litellm_usertable.update = AsyncMock(return_value=mock_user)
 
         # Mock team membership table

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -4105,7 +4105,8 @@ async def test_new_team_max_budget_within_user_limit():
             "teams": ["team-within-budget-789"],
         }
         mock_prisma.db.litellm_usertable = MagicMock()
-        mock_prisma.db.litellm_usertable.upsert = AsyncMock(return_value=mock_user)
+        mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+        mock_prisma.db.litellm_usertable.create = AsyncMock(return_value=mock_user)
         mock_prisma.db.litellm_usertable.update = AsyncMock(return_value=mock_user)
 
         # Mock team membership table
@@ -4246,7 +4247,8 @@ async def test_new_team_org_scoped_budget_bypasses_user_limit():
             "teams": ["team-org-scoped-789"],
         }
         mock_prisma.db.litellm_usertable = MagicMock()
-        mock_prisma.db.litellm_usertable.upsert = AsyncMock(return_value=mock_user)
+        mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+        mock_prisma.db.litellm_usertable.create = AsyncMock(return_value=mock_user)
         mock_prisma.db.litellm_usertable.update = AsyncMock(return_value=mock_user)
 
         # Mock team membership table
@@ -4392,7 +4394,8 @@ async def test_new_team_org_scoped_models_bypasses_user_limit():
             "teams": ["team-org-scoped-models-789"],
         }
         mock_prisma.db.litellm_usertable = MagicMock()
-        mock_prisma.db.litellm_usertable.upsert = AsyncMock(return_value=mock_user)
+        mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+        mock_prisma.db.litellm_usertable.create = AsyncMock(return_value=mock_user)
         mock_prisma.db.litellm_usertable.update = AsyncMock(return_value=mock_user)
 
         # Mock team membership table
@@ -7244,7 +7247,8 @@ async def test_new_team_soft_budget_validation(
             "teams": ["test-team-123"],
         }
         mock_prisma.db.litellm_usertable = MagicMock()
-        mock_prisma.db.litellm_usertable.upsert = AsyncMock(return_value=mock_user)
+        mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+        mock_prisma.db.litellm_usertable.create = AsyncMock(return_value=mock_user)
         mock_prisma.db.litellm_usertable.update = AsyncMock(return_value=mock_user)
 
         # Mock team membership table

--- a/tests/test_litellm/proxy/management_helpers/test_management_helpers_utils.py
+++ b/tests/test_litellm/proxy/management_helpers/test_management_helpers_utils.py
@@ -202,7 +202,8 @@ async def test_add_new_member_clones_default_team_budget_id():
         "teams": [test_team_id],
         "user_role": "internal_user",
     }
-    mock_prisma_client.db.litellm_usertable.upsert = AsyncMock(
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+    mock_prisma_client.db.litellm_usertable.create = AsyncMock(
         return_value=mock_user_response
     )
 
@@ -260,7 +261,7 @@ async def test_add_new_member_clones_default_team_budget_id():
     assert result_team_membership.budget_id == test_cloned_budget_id
     assert result_team_membership.budget_id != test_default_budget_id
 
-    mock_prisma_client.db.litellm_usertable.upsert.assert_called_once()
+    mock_prisma_client.db.litellm_usertable.create.assert_called_once()
     mock_prisma_client.db.litellm_teammembership.create.assert_called_once()
 
     # The clone must have happened: find_unique on the default, create for the clone.
@@ -305,7 +306,8 @@ async def test_add_new_member_budget_duration_only_clones_default_max_budget():
         "teams": ["team-dc"],
         "user_role": "internal_user",
     }
-    mock_prisma_client.db.litellm_usertable.upsert = AsyncMock(
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+    mock_prisma_client.db.litellm_usertable.create = AsyncMock(
         return_value=mock_user_response
     )
     mock_default_budget_row = MagicMock()
@@ -388,7 +390,8 @@ async def test_add_new_member_no_budget_when_no_default_and_no_max_budget():
         "teams": [test_team_id],
         "user_role": "internal_user",
     }
-    mock_prisma_client.db.litellm_usertable.upsert = AsyncMock(
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+    mock_prisma_client.db.litellm_usertable.create = AsyncMock(
         return_value=mock_user_response
     )
 
@@ -455,7 +458,8 @@ async def test_add_new_member_creates_new_budget_when_max_budget_provided():
         "teams": [test_team_id],
         "user_role": "internal_user",
     }
-    mock_prisma_client.db.litellm_usertable.upsert = AsyncMock(
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+    mock_prisma_client.db.litellm_usertable.create = AsyncMock(
         return_value=mock_user_response
     )
 
@@ -531,7 +535,8 @@ async def test_add_new_member_persists_budget_duration():
         "teams": ["team-dur"],
         "user_role": "internal_user",
     }
-    mock_prisma_client.db.litellm_usertable.upsert = AsyncMock(
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+    mock_prisma_client.db.litellm_usertable.create = AsyncMock(
         return_value=mock_user_response
     )
     mock_budget_response = MagicMock()
@@ -594,7 +599,8 @@ async def test_add_new_member_persists_budget_duration_without_max_budget():
         "teams": ["team-dur2"],
         "user_role": "internal_user",
     }
-    mock_prisma_client.db.litellm_usertable.upsert = AsyncMock(
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+    mock_prisma_client.db.litellm_usertable.create = AsyncMock(
         return_value=mock_user_response
     )
     mock_budget_response = MagicMock()
@@ -997,3 +1003,65 @@ async def test_attach_object_permission_to_dict_with_none_object_permission_id()
 
     # Verify no database query was made
     mock_prisma_client.db.litellm_objectpermissiontable.find_unique.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_add_new_member_appends_team_only_if_absent_for_existing_user():
+    """Adding an existing user to a team must append the team id only if it is
+    not already present.
+
+    add_new_member is the single writer of user.teams for every team add
+    (/team/member_add, /user/new, SSO, SCIM). An unconditional append let
+    repeated or concurrent adds accumulate duplicate team ids in user.teams,
+    which also breaks auth logic that keys off the number of teams a user
+    belongs to. The append must go through a filtered update that no-ops when
+    the team is already present, and it must not fall through to creating a new
+    user row for a user that already exists.
+    """
+    from litellm.proxy._types import LitellmUserRoles
+
+    new_member = Member(user_id="existing-user", role="user")
+    user_api_key_dict = UserAPIKeyAuth(
+        user_id="admin_user", user_role=LitellmUserRoles.PROXY_ADMIN
+    )
+
+    mock_prisma_client = AsyncMock()
+
+    mock_user_after = MagicMock()
+    mock_user_after.model_dump.return_value = {
+        "user_id": "existing-user",
+        "user_email": None,
+        "teams": ["team-1"],
+        "user_role": "internal_user",
+    }
+    # first find_unique: existence check (user exists); second: refetch after update_many
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
+        side_effect=[MagicMock(), mock_user_after]
+    )
+    mock_prisma_client.db.litellm_usertable.update_many = AsyncMock()
+    mock_prisma_client.db.litellm_usertable.create = AsyncMock()
+    # no team default budget and no explicit budget -> no team membership row
+    mock_prisma_client.db.litellm_budgettable.find_unique = AsyncMock(return_value=None)
+
+    result_user, _ = await add_new_member(
+        new_member=new_member,
+        max_budget_in_team=None,
+        prisma_client=mock_prisma_client,
+        team_id="team-1",
+        user_api_key_dict=user_api_key_dict,
+        litellm_proxy_admin_name="admin",
+    )
+
+    assert result_user is not None
+    assert result_user.user_id == "existing-user"
+
+    # existing user must not be recreated
+    mock_prisma_client.db.litellm_usertable.create.assert_not_called()
+
+    # the append must be a filtered, idempotent update keyed off the team id
+    mock_prisma_client.db.litellm_usertable.update_many.assert_called_once()
+    where = mock_prisma_client.db.litellm_usertable.update_many.call_args.kwargs["where"]
+    assert where["user_id"] == "existing-user"
+    assert where["NOT"] == {"teams": {"has": "team-1"}}
+    data = mock_prisma_client.db.litellm_usertable.update_many.call_args.kwargs["data"]
+    assert data == {"teams": {"push": ["team-1"]}}

--- a/tests/test_litellm/proxy/management_helpers/test_management_helpers_utils.py
+++ b/tests/test_litellm/proxy/management_helpers/test_management_helpers_utils.py
@@ -202,8 +202,8 @@ async def test_add_new_member_clones_default_team_budget_id():
         "teams": [test_team_id],
         "user_role": "internal_user",
     }
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
-    mock_prisma_client.db.litellm_usertable.create = AsyncMock(
+    mock_prisma_client.db.litellm_usertable.upsert = AsyncMock(return_value=mock_user_response)
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
         return_value=mock_user_response
     )
 
@@ -261,7 +261,7 @@ async def test_add_new_member_clones_default_team_budget_id():
     assert result_team_membership.budget_id == test_cloned_budget_id
     assert result_team_membership.budget_id != test_default_budget_id
 
-    mock_prisma_client.db.litellm_usertable.create.assert_called_once()
+    mock_prisma_client.db.litellm_usertable.upsert.assert_called_once()
     mock_prisma_client.db.litellm_teammembership.create.assert_called_once()
 
     # The clone must have happened: find_unique on the default, create for the clone.
@@ -306,8 +306,8 @@ async def test_add_new_member_budget_duration_only_clones_default_max_budget():
         "teams": ["team-dc"],
         "user_role": "internal_user",
     }
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
-    mock_prisma_client.db.litellm_usertable.create = AsyncMock(
+    mock_prisma_client.db.litellm_usertable.upsert = AsyncMock(return_value=mock_user_response)
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
         return_value=mock_user_response
     )
     mock_default_budget_row = MagicMock()
@@ -390,8 +390,8 @@ async def test_add_new_member_no_budget_when_no_default_and_no_max_budget():
         "teams": [test_team_id],
         "user_role": "internal_user",
     }
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
-    mock_prisma_client.db.litellm_usertable.create = AsyncMock(
+    mock_prisma_client.db.litellm_usertable.upsert = AsyncMock(return_value=mock_user_response)
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
         return_value=mock_user_response
     )
 
@@ -458,8 +458,8 @@ async def test_add_new_member_creates_new_budget_when_max_budget_provided():
         "teams": [test_team_id],
         "user_role": "internal_user",
     }
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
-    mock_prisma_client.db.litellm_usertable.create = AsyncMock(
+    mock_prisma_client.db.litellm_usertable.upsert = AsyncMock(return_value=mock_user_response)
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
         return_value=mock_user_response
     )
 
@@ -535,8 +535,8 @@ async def test_add_new_member_persists_budget_duration():
         "teams": ["team-dur"],
         "user_role": "internal_user",
     }
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
-    mock_prisma_client.db.litellm_usertable.create = AsyncMock(
+    mock_prisma_client.db.litellm_usertable.upsert = AsyncMock(return_value=mock_user_response)
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
         return_value=mock_user_response
     )
     mock_budget_response = MagicMock()
@@ -599,8 +599,8 @@ async def test_add_new_member_persists_budget_duration_without_max_budget():
         "teams": ["team-dur2"],
         "user_role": "internal_user",
     }
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
-    mock_prisma_client.db.litellm_usertable.create = AsyncMock(
+    mock_prisma_client.db.litellm_usertable.upsert = AsyncMock(return_value=mock_user_response)
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
         return_value=mock_user_response
     )
     mock_budget_response = MagicMock()
@@ -1034,12 +1034,8 @@ async def test_add_new_member_appends_team_only_if_absent_for_existing_user():
         "teams": ["team-1"],
         "user_role": "internal_user",
     }
-    # first find_unique: existence check (user exists); second: refetch after update_many
-    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
-        side_effect=[MagicMock(), mock_user_after]
-    )
+    mock_prisma_client.db.litellm_usertable.upsert = AsyncMock(return_value=mock_user_after)
     mock_prisma_client.db.litellm_usertable.update_many = AsyncMock()
-    mock_prisma_client.db.litellm_usertable.create = AsyncMock()
     # no team default budget and no explicit budget -> no team membership row
     mock_prisma_client.db.litellm_budgettable.find_unique = AsyncMock(return_value=None)
 
@@ -1055,13 +1051,68 @@ async def test_add_new_member_appends_team_only_if_absent_for_existing_user():
     assert result_user is not None
     assert result_user.user_id == "existing-user"
 
-    # existing user must not be recreated
-    mock_prisma_client.db.litellm_usertable.create.assert_not_called()
-
-    # the append must be a filtered, idempotent update keyed off the team id
+    # the append must be a filtered, idempotent update keyed off the team id, so
+    # a repeated or concurrent add of a team the user already has is a no-op
     mock_prisma_client.db.litellm_usertable.update_many.assert_called_once()
     where = mock_prisma_client.db.litellm_usertable.update_many.call_args.kwargs["where"]
     assert where["user_id"] == "existing-user"
     assert where["NOT"] == {"teams": {"has": "team-1"}}
     data = mock_prisma_client.db.litellm_usertable.update_many.call_args.kwargs["data"]
     assert data == {"teams": {"push": ["team-1"]}}
+
+    # upsert (not an unconditional teams push) is what ensures the row exists, so
+    # its update branch must not carry a teams push that would duplicate
+    mock_prisma_client.db.litellm_usertable.upsert.assert_called_once()
+    upsert_update = mock_prisma_client.db.litellm_usertable.upsert.call_args.kwargs["data"]["update"]
+    assert "teams" not in upsert_update
+
+
+@pytest.mark.asyncio
+async def test_add_new_member_creates_missing_user_atomically_via_upsert():
+    """A brand-new user added to a team must be created via an atomic upsert, not
+    a separate existence check followed by create.
+
+    Concurrent provisioning of the same new user (which SCIM group reconciles do)
+    would race a check-then-create into a duplicate-key failure. The upsert seeds
+    teams on create, and the filtered append is a no-op because the team is
+    already present on the freshly created row.
+    """
+    from litellm.proxy._types import LitellmUserRoles
+
+    new_member = Member(user_id="brand-new-user", role="user")
+    user_api_key_dict = UserAPIKeyAuth(
+        user_id="admin_user", user_role=LitellmUserRoles.PROXY_ADMIN
+    )
+
+    mock_prisma_client = AsyncMock()
+
+    mock_created = MagicMock()
+    mock_created.model_dump.return_value = {
+        "user_id": "brand-new-user",
+        "user_email": None,
+        "teams": ["team-1"],
+        "user_role": "internal_user",
+    }
+    mock_prisma_client.db.litellm_usertable.upsert = AsyncMock(return_value=mock_created)
+    mock_prisma_client.db.litellm_usertable.update_many = AsyncMock()
+    mock_prisma_client.db.litellm_usertable.create = AsyncMock()
+    mock_prisma_client.db.litellm_budgettable.find_unique = AsyncMock(return_value=None)
+
+    result_user, _ = await add_new_member(
+        new_member=new_member,
+        max_budget_in_team=None,
+        prisma_client=mock_prisma_client,
+        team_id="team-1",
+        user_api_key_dict=user_api_key_dict,
+        litellm_proxy_admin_name="admin",
+    )
+
+    assert result_user is not None
+    assert result_user.user_id == "brand-new-user"
+
+    # existence is established by an atomic upsert (create-or-update), never a
+    # non-atomic standalone create that could race under concurrent provisioning
+    mock_prisma_client.db.litellm_usertable.upsert.assert_called_once()
+    mock_prisma_client.db.litellm_usertable.create.assert_not_called()
+    create_data = mock_prisma_client.db.litellm_usertable.upsert.call_args.kwargs["data"]["create"]
+    assert create_data["teams"] == ["team-1"]


### PR DESCRIPTION
## Relevant issues

Stacked on https://github.com/BerriAI/litellm/pull/34185 (atomic team member add) and also depends on https://github.com/BerriAI/litellm/pull/34162 (members_with_roles as the group-membership source of truth). This PR must merge after both, and the delta-rebase here only takes effect together with #34185's atomic write

## Linear ticket

Part of LIT-4676 (closes the concurrent SCIM group PATCH add surface of item 4)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Namespaced live proxy (one gpt-4o-mini deployment, `scim_upsert_user: true`, master-key auth), Postgres on :5724, proxy on :4294

### add/remove concurrency (primary fix)

Two concurrent SCIM group PATCH `op:add` of different users to the same team. The team starts with member `zed`; one request adds `alice`, the other adds `bob`; the alice request is issued first and the bob request is staggered a few ms behind so its snapshot is taken before the alice add commits but its refresh reads the roster after. The assertion reads `members_with_roles` straight from Postgres and expects all of `zed`, `alice`, `bob`

BEFORE, at the integration base HEAD `72a354a0e5` (this branch with #34162 and #34185 present, without the delta-rebase in this PR). The write is already atomic, yet the reconcile still removes the concurrently-added member:

```
===== BEFORE (reverted HEAD 72a354a0e5) — focused window 9..18ms x5 =====
  [DROP] delay=10ms members=['bob', 'zed'] gid=7b73e760
  [DROP] delay=12ms members=['bob', 'zed'] gid=115d2df6
  [DROP] delay=14ms members=['bob', 'zed'] gid=5106e43d
  [DROP] delay=16ms members=['bob', 'zed'] gid=c4aa93b5
  ... (alice actively removed by the other request's stale-snapshot diff)
=== before: 25/50 trials dropped a member ===
```

AFTER, at head, identical driver and delays:

```
===== AFTER (delta-rebase fix) — SAME focused window 9..18ms x5 =====
=== after: 0/50 trials dropped a member ===
```

### replace stays absolute (regression fix from review)

The first fix rebased every member op as a delta, which is wrong for `replace`: a `replace` op declares the roster is exactly the listed set, so a member another request added concurrently must be dropped. The deterministic proof is the unit test `test_patch_group_replace_stays_absolute_against_concurrent_roster` (snapshot `[zed]`, refreshed roster `[alice, bob]`, op `replace [alice]`; asserts `bob` is removed and nothing is spuriously added). It fails on the delta-only code (bob retained) and passes after the replace-absolute fix

Live directional signal for the same scenario (team `{zed}`, one request adds `bob`, another replaces the roster with `[alice]` staggered behind). The final state of a replace racing an add is inherently order-dependent, so this is directional rather than crisp. With the delta-only code the replace kept the non-listed `bob` in 33/40 trials; with the fix the replace correctly drops `bob` in the discriminating interleavings, ending at exactly `{alice}` far more often. Sequential `replace [alice, bob]` on `{zed}` still yields exactly `{alice, bob}`, and the add/remove concurrency behavior above is unchanged (0/30 dropped)

## Type

🐛 Bug Fix

## Changes

`patch_group` computed `final_members` as an absolute target derived from a pre-request snapshot of the roster, then diffed the refreshed live roster against that snapshot-based target and issued a `team_member_delete` for everyone in the refreshed roster but absent from the target. Under two concurrent `op:add` PATCHes of different users, a member the other request had just committed is present in the refreshed roster but missing from this request's snapshot-based target, so it is actively removed even though #34185's atomic write kept it

For add/remove-only requests this change applies only the request's own delta (its adds and removes relative to its own snapshot) on top of the refreshed live roster, so a concurrently-added member is retained instead of reconciled away. A `replace` op is different: it is absolute, so `_process_group_patch_operations` now also returns the replace target set when the request contained a member replace op, and `patch_group` uses that target as the absolute `effective_final`, dropping any member not in it (including one added concurrently). The PUT `update_group` path still drives `_handle_group_membership_changes` as an absolute set-to-target, so that helper's signature is unchanged

Together with #34185, the atomic write stops the lost update on the write side and this reconcile change stops the spurious remove for add/remove while preserving absolute semantics for replace

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
