### PR TITLE
fix(proxy): expand config-defined model access groups when resolving team models for /v2/model/info

### DIFF
--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -52,20 +52,20 @@ def _get_models_from_access_groups(
     model_access_groups: dict[str, list[str]],
     all_models: list[str],
     include_model_access_groups: bool | None = False,
+    proxy_model_list: list[str] | None = None,
 ) -> list[str]:
-    idx_to_remove: Final = []
-    new_models: Final = []
-    for idx, model in enumerate(all_models):
-        if model in model_access_groups:
-            if not include_model_access_groups:  # remove access group, unless requested - e.g. when creating a key
-                idx_to_remove.append(idx)
-            new_models.extend(model_access_groups[model])
-
-    for idx in sorted(idx_to_remove, reverse=True):
-        all_models.pop(idx)
-
-    all_models.extend(new_models)
-    return all_models
+    # a grant naming both a deployed model and an access group means both at runtime
+    # (_check_model_access_helper unions them), so listings must keep the literal too
+    deployed_model_names: Final = frozenset(proxy_model_list or ())
+    kept_models: Final = [
+        model
+        for model in all_models
+        if model not in model_access_groups or include_model_access_groups or model in deployed_model_names
+    ]
+    member_models: Final = [
+        member for model in all_models if model in model_access_groups for member in model_access_groups[model]
+    ]
+    return kept_models + member_models
 
 
 async def get_mcp_server_ids(
@@ -128,6 +128,7 @@ def get_key_models(
         model_access_groups=model_access_groups,
         all_models=all_models,
         include_model_access_groups=include_model_access_groups,
+        proxy_model_list=proxy_model_list,
     )
 
     # deduplicate while preserving order
@@ -169,6 +170,7 @@ def get_team_models(
         model_access_groups=model_access_groups,
         all_models=list(all_models_set),
         include_model_access_groups=include_model_access_groups,
+        proxy_model_list=proxy_model_list,
     )
 
     # deduplicate while preserving order

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -52,7 +52,7 @@ def _get_models_from_access_groups(
     model_access_groups: dict[str, list[str]],
     all_models: list[str],
     include_model_access_groups: bool | None = False,
-    proxy_model_list: list[str] | None = None,
+    proxy_model_list: Sequence[str] | None = None,
 ) -> list[str]:
     # a grant naming both a deployed model and an access group means both at runtime
     # (_check_model_access_helper unions them), so listings must keep the literal too

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -11050,6 +11050,8 @@ def _add_team_models_to_all_models(
     Add team models to all models
     """
     team_models: Dict[str, Set[str]] = {}
+    proxy_model_list = llm_router.get_model_names()
+    model_access_groups = llm_router.get_model_access_groups()
 
     for team_object in team_db_objects_typed:
         if (
@@ -11073,7 +11075,12 @@ def _add_team_models_to_all_models(
                     if can_add_model:
                         team_models.setdefault(model_id, set()).add(team_object.team_id)
         else:
-            for model_name in team_object.models:
+            resolved_model_names = get_team_models(
+                team_models=team_object.models,
+                proxy_model_list=proxy_model_list,
+                model_access_groups=model_access_groups,
+            )
+            for model_name in resolved_model_names:
                 _models = llm_router.get_model_list(model_name=model_name, team_id=team_object.team_id)
                 if _models is not None:
                     for model in _models:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -11858,6 +11858,8 @@ def _add_team_models_to_all_models(
     Add team models to all models
     """
     team_models: Final[dict[str, set[str]]] = {}
+    proxy_model_list: Final = llm_router.get_model_names()
+    model_access_groups: Final = llm_router.get_model_access_groups()
 
     for team_object in team_db_objects_typed:
         if (
@@ -11879,7 +11881,12 @@ def _add_team_models_to_all_models(
                     if can_add_model:
                         team_models.setdefault(model_id, set()).add(team_object.team_id)
         else:
-            for model_name in team_object.models:
+            resolved_model_names = get_team_models(
+                team_models=team_object.models,
+                proxy_model_list=proxy_model_list,
+                model_access_groups=model_access_groups,
+            )
+            for model_name in resolved_model_names:
                 _models = llm_router.get_model_list(model_name=model_name, team_id=team_object.team_id)
                 if _models is not None:
                     for model in _models:

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -133,6 +133,50 @@ def test_get_key_models_passes_include_model_access_groups():
     assert "model2" in result
 
 
+def test_get_key_models_keeps_literal_model_colliding_with_group_name():
+    """A name that is BOTH a deployed model and an access group grants both at
+    runtime (_check_model_access_helper unions them), so the listing must keep
+    the literal model alongside the group members instead of dropping it."""
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.auth.model_checks import get_key_models
+
+    user_api_key_dict = UserAPIKeyAuth(models=["beta-models"], api_key="test-key")
+
+    result = get_key_models(
+        user_api_key_dict=user_api_key_dict,
+        proxy_model_list=["beta-models", "member-a", "unrelated"],
+        model_access_groups={"beta-models": ["member-a"]},
+        include_model_access_groups=False,
+    )
+    assert sorted(result) == ["beta-models", "member-a"]
+
+
+def test_get_team_models_keeps_literal_model_colliding_with_group_name():
+    """Team flavor of the collision case: literal deployment survives group expansion."""
+    from litellm.proxy.auth.model_checks import get_team_models
+
+    result = get_team_models(
+        team_models=["beta-models"],
+        proxy_model_list=["beta-models", "member-a", "unrelated"],
+        model_access_groups={"beta-models": ["member-a"]},
+        include_model_access_groups=False,
+    )
+    assert sorted(result) == ["beta-models", "member-a"]
+
+
+def test_get_team_models_drops_group_name_that_is_not_a_deployed_model():
+    """No collision: a pure access-group name is still replaced by its members."""
+    from litellm.proxy.auth.model_checks import get_team_models
+
+    result = get_team_models(
+        team_models=["beta-models"],
+        proxy_model_list=["member-a", "unrelated"],
+        model_access_groups={"beta-models": ["member-a"]},
+        include_model_access_groups=False,
+    )
+    assert result == ["member-a"]
+
+
 def test_get_key_models_does_not_mutate_input():
     """
     get_key_models must not mutate user_api_key_dict.models in-place.

--- a/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
+++ b/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
@@ -539,6 +539,63 @@ async def test_populate_team_access_sets_direct_access_false_by_default(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_populate_team_access_grants_config_access_group_model():
+    """LIT-4433: a team whose only model grant is a CONFIG-defined access group
+    (model_info.access_groups) must have that group's member deployments listed in
+    access_via_team_ids. Before the fix _add_team_models_to_all_models passed the
+    access-group name straight to get_model_list, which never matched, leaving the
+    team's /v2/model/info?include_team_models=true result empty."""
+    team_id = "team-access-group-only"
+    access_group_model = {
+        "model_name": "team-allowed-model-a",
+        "litellm_params": {"model": "gpt-4"},
+        "model_info": {
+            "id": "model-a-id",
+            "access_groups": ["test-access-group"],
+            "db_model": False,
+        },
+    }
+
+    router = MagicMock()
+    router.get_model_names.return_value = ["team-allowed-model-a"]
+    router.get_model_access_groups.return_value = {"test-access-group": ["team-allowed-model-a"]}
+    router.get_model_ids.return_value = []
+
+    def get_model_list(model_name=None, team_id=None):
+        if model_name == "team-allowed-model-a":
+            return [access_group_model]
+        return None
+
+    router.get_model_list.side_effect = get_model_list
+
+    team_db_object = MagicMock()
+    team_db_object.model_dump.return_value = {
+        "team_id": team_id,
+        "models": ["test-access-group"],
+        "access_group_ids": [],
+    }
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_teamtable.find_many = AsyncMock(return_value=[team_db_object])
+
+    admin = UserAPIKeyAuth(user_id="u", user_role=LitellmUserRoles.PROXY_ADMIN, team_models=[])
+    result = await ps._populate_team_access_on_models(
+        user_api_key_dict=admin,
+        prisma_client=prisma_client,
+        llm_router=router,
+        all_models=[
+            {
+                "model_name": "team-allowed-model-a",
+                "litellm_params": {"model": "gpt-4"},
+                "model_info": {"id": "model-a-id", "access_groups": ["test-access-group"], "db_model": False},
+            }
+        ],
+    )
+
+    by_id = {m["model_info"]["id"]: m for m in result}
+    assert by_id["model-a-id"]["model_info"]["access_via_team_ids"] == [team_id]
+
+
+@pytest.mark.asyncio
 async def test_model_info_v1_team_id_without_db_fails_fast(monkeypatch):
     """`teamId` without a connected DB raises 500 before any enrichment work runs."""
     router = MagicMock()

--- a/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
+++ b/tests/test_litellm/proxy/proxy_server/test_team_model_name_translation.py
@@ -581,6 +581,63 @@ async def test_populate_team_access_gives_view_only_admin_full_admin_scope(monke
 
 
 @pytest.mark.asyncio
+async def test_populate_team_access_grants_config_access_group_model():
+    """LIT-4433: a team whose only model grant is a CONFIG-defined access group
+    (model_info.access_groups) must have that group's member deployments listed in
+    access_via_team_ids. Before the fix _add_team_models_to_all_models passed the
+    access-group name straight to get_model_list, which never matched, leaving the
+    team's /v2/model/info?include_team_models=true result empty."""
+    team_id = "team-access-group-only"
+    access_group_model = {
+        "model_name": "team-allowed-model-a",
+        "litellm_params": {"model": "gpt-4"},
+        "model_info": {
+            "id": "model-a-id",
+            "access_groups": ["test-access-group"],
+            "db_model": False,
+        },
+    }
+
+    router = MagicMock()
+    router.get_model_names.return_value = ["team-allowed-model-a"]
+    router.get_model_access_groups.return_value = {"test-access-group": ["team-allowed-model-a"]}
+    router.get_model_ids.return_value = []
+
+    def get_model_list(model_name=None, team_id=None):
+        if model_name == "team-allowed-model-a":
+            return [access_group_model]
+        return None
+
+    router.get_model_list.side_effect = get_model_list
+
+    team_db_object = MagicMock()
+    team_db_object.model_dump.return_value = {
+        "team_id": team_id,
+        "models": ["test-access-group"],
+        "access_group_ids": [],
+    }
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_teamtable.find_many = AsyncMock(return_value=[team_db_object])
+
+    admin = UserAPIKeyAuth(user_id="u", user_role=LitellmUserRoles.PROXY_ADMIN, team_models=[])
+    result = await ps._populate_team_access_on_models(
+        user_api_key_dict=admin,
+        prisma_client=prisma_client,
+        llm_router=router,
+        all_models=[
+            {
+                "model_name": "team-allowed-model-a",
+                "litellm_params": {"model": "gpt-4"},
+                "model_info": {"id": "model-a-id", "access_groups": ["test-access-group"], "db_model": False},
+            }
+        ],
+    )
+
+    by_id = {m["model_info"]["id"]: m for m in result}
+    assert by_id["model-a-id"]["model_info"]["access_via_team_ids"] == [team_id]
+
+
+@pytest.mark.asyncio
 async def test_model_info_v1_team_id_without_db_fails_fast(monkeypatch):
     """`teamId` without a connected DB raises 500 before any enrichment work runs."""
     router = MagicMock()

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -1533,6 +1533,125 @@ def test_add_team_models_to_all_models():
     assert result == {"gpt-4-model-2": {"team1"}}
 
 
+def _make_router_with_access_groups(model_names, model_access_groups, deployments):
+    llm_router = MagicMock()
+    llm_router.get_model_names.return_value = model_names
+    llm_router.get_model_access_groups.return_value = model_access_groups
+
+    def get_model_list(model_name=None, team_id=None):
+        matched = [
+            deployment
+            for deployment in deployments
+            if deployment["model_name"] == model_name
+            and (
+                team_id is None
+                or deployment.get("model_info", {}).get("team_id") is None
+                or deployment.get("model_info", {}).get("team_id") == team_id
+            )
+        ]
+        return matched or None
+
+    llm_router.get_model_list.side_effect = get_model_list
+    return llm_router
+
+
+def test_add_team_models_to_all_models_resolves_config_access_group():
+    """
+    LIT-4433: a CONFIG-defined access group (model_info.access_groups) named in
+    team.models must resolve to its member deployments' ids. The pre-fix code
+    passed the group name straight to get_model_list, which never matched, so the
+    team's /v2/model/info?include_team_models=true result was empty.
+    """
+    from litellm.proxy._types import LiteLLM_TeamTable
+    from litellm.proxy.proxy_server import _add_team_models_to_all_models
+
+    team = MagicMock(spec=LiteLLM_TeamTable)
+    team.team_id = "team-a"
+    team.models = ["test-access-group"]
+
+    llm_router = _make_router_with_access_groups(
+        model_names=["team-allowed-model-a"],
+        model_access_groups={"test-access-group": ["team-allowed-model-a"]},
+        deployments=[{"model_name": "team-allowed-model-a", "model_info": {"id": "model-a-id"}}],
+    )
+
+    result = _add_team_models_to_all_models(team_db_objects_typed=[team], llm_router=llm_router)
+    assert result == {"model-a-id": {"team-a"}}
+
+
+def test_add_team_models_to_all_models_resolves_mixed_literal_and_access_group():
+    """A team.models list mixing a literal model name and a config access-group
+    name must resolve both to their deployment ids."""
+    from litellm.proxy._types import LiteLLM_TeamTable
+    from litellm.proxy.proxy_server import _add_team_models_to_all_models
+
+    team = MagicMock(spec=LiteLLM_TeamTable)
+    team.team_id = "team-a"
+    team.models = ["team-allowed-model-b", "test-access-group"]
+
+    llm_router = _make_router_with_access_groups(
+        model_names=["team-allowed-model-a", "team-allowed-model-b"],
+        model_access_groups={"test-access-group": ["team-allowed-model-a"]},
+        deployments=[
+            {"model_name": "team-allowed-model-a", "model_info": {"id": "model-a-id"}},
+            {"model_name": "team-allowed-model-b", "model_info": {"id": "model-b-id"}},
+        ],
+    )
+
+    result = _add_team_models_to_all_models(team_db_objects_typed=[team], llm_router=llm_router)
+    assert result == {"model-a-id": {"team-a"}, "model-b-id": {"team-a"}}
+
+
+def test_add_team_models_to_all_models_excludes_other_access_group():
+    """Only the access group named in team.models is expanded; deployments that
+    belong solely to a different access group must not leak into the team map."""
+    from litellm.proxy._types import LiteLLM_TeamTable
+    from litellm.proxy.proxy_server import _add_team_models_to_all_models
+
+    team = MagicMock(spec=LiteLLM_TeamTable)
+    team.team_id = "team-a"
+    team.models = ["test-access-group"]
+
+    llm_router = _make_router_with_access_groups(
+        model_names=["team-allowed-model-a", "forbidden-model"],
+        model_access_groups={
+            "test-access-group": ["team-allowed-model-a"],
+            "other-access-group": ["forbidden-model"],
+        },
+        deployments=[
+            {"model_name": "team-allowed-model-a", "model_info": {"id": "model-a-id"}},
+            {"model_name": "forbidden-model", "model_info": {"id": "forbidden-id"}},
+        ],
+    )
+
+    result = _add_team_models_to_all_models(team_db_objects_typed=[team], llm_router=llm_router)
+    assert result == {"model-a-id": {"team-a"}}
+
+
+def test_add_team_models_to_all_models_excludes_other_teams_byok_with_shared_name():
+    """A BYOK deployment owned by a DIFFERENT team but sharing the resolved model
+    name must not be added for this team. Guards the team_id filter passed to
+    get_model_list: dropping it would leak the other team's private deployment."""
+    from litellm.proxy._types import LiteLLM_TeamTable
+    from litellm.proxy.proxy_server import _add_team_models_to_all_models
+
+    team = MagicMock(spec=LiteLLM_TeamTable)
+    team.team_id = "team-a"
+    team.models = ["test-access-group"]
+
+    llm_router = _make_router_with_access_groups(
+        model_names=["team-allowed-model-a"],
+        model_access_groups={"test-access-group": ["team-allowed-model-a"]},
+        deployments=[
+            {"model_name": "team-allowed-model-a", "model_info": {"id": "model-a-id", "team_id": "team-a"}},
+            {"model_name": "team-allowed-model-a", "model_info": {"id": "other-team-byok-id", "team_id": "team-b"}},
+        ],
+    )
+
+    result = _add_team_models_to_all_models(team_db_objects_typed=[team], llm_router=llm_router)
+    assert result == {"model-a-id": {"team-a"}}
+
+
 @pytest.mark.asyncio
 async def test_apply_search_filter_matches_team_public_model_name():
     """

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -1777,6 +1777,30 @@ def test_add_team_models_to_all_models_resolves_mixed_literal_and_access_group()
     assert result == {"model-a-id": {"team-a"}, "model-b-id": {"team-a"}}
 
 
+def test_add_team_models_to_all_models_keeps_literal_model_colliding_with_group_name():
+    """A team.models entry that names BOTH a deployed model and an access group
+    grants both at runtime, so the /v2 team map must contain the literal
+    deployment's id alongside the group members' ids."""
+    from litellm.proxy._types import LiteLLM_TeamTable
+    from litellm.proxy.proxy_server import _add_team_models_to_all_models
+
+    team = MagicMock(spec=LiteLLM_TeamTable)
+    team.team_id = "team-a"
+    team.models = ["beta-models"]
+
+    llm_router = _make_router_with_access_groups(
+        model_names=["beta-models", "member-a"],
+        model_access_groups={"beta-models": ["member-a"]},
+        deployments=[
+            {"model_name": "beta-models", "model_info": {"id": "collision-id"}},
+            {"model_name": "member-a", "model_info": {"id": "member-a-id"}},
+        ],
+    )
+
+    result = _add_team_models_to_all_models(team_db_objects_typed=[team], llm_router=llm_router)
+    assert result == {"collision-id": {"team-a"}, "member-a-id": {"team-a"}}
+
+
 def test_add_team_models_to_all_models_excludes_other_access_group():
     """Only the access group named in team.models is expanded; deployments that
     belong solely to a different access group must not leak into the team map."""

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -1708,6 +1708,125 @@ def test_add_team_models_to_all_models():
     assert result == {"gpt-4-model-2": {"team1"}}
 
 
+def _make_router_with_access_groups(model_names, model_access_groups, deployments):
+    llm_router = MagicMock()
+    llm_router.get_model_names.return_value = model_names
+    llm_router.get_model_access_groups.return_value = model_access_groups
+
+    def get_model_list(model_name=None, team_id=None):
+        matched = [
+            deployment
+            for deployment in deployments
+            if deployment["model_name"] == model_name
+            and (
+                team_id is None
+                or deployment.get("model_info", {}).get("team_id") is None
+                or deployment.get("model_info", {}).get("team_id") == team_id
+            )
+        ]
+        return matched or None
+
+    llm_router.get_model_list.side_effect = get_model_list
+    return llm_router
+
+
+def test_add_team_models_to_all_models_resolves_config_access_group():
+    """
+    LIT-4433: a CONFIG-defined access group (model_info.access_groups) named in
+    team.models must resolve to its member deployments' ids. The pre-fix code
+    passed the group name straight to get_model_list, which never matched, so the
+    team's /v2/model/info?include_team_models=true result was empty.
+    """
+    from litellm.proxy._types import LiteLLM_TeamTable
+    from litellm.proxy.proxy_server import _add_team_models_to_all_models
+
+    team = MagicMock(spec=LiteLLM_TeamTable)
+    team.team_id = "team-a"
+    team.models = ["test-access-group"]
+
+    llm_router = _make_router_with_access_groups(
+        model_names=["team-allowed-model-a"],
+        model_access_groups={"test-access-group": ["team-allowed-model-a"]},
+        deployments=[{"model_name": "team-allowed-model-a", "model_info": {"id": "model-a-id"}}],
+    )
+
+    result = _add_team_models_to_all_models(team_db_objects_typed=[team], llm_router=llm_router)
+    assert result == {"model-a-id": {"team-a"}}
+
+
+def test_add_team_models_to_all_models_resolves_mixed_literal_and_access_group():
+    """A team.models list mixing a literal model name and a config access-group
+    name must resolve both to their deployment ids."""
+    from litellm.proxy._types import LiteLLM_TeamTable
+    from litellm.proxy.proxy_server import _add_team_models_to_all_models
+
+    team = MagicMock(spec=LiteLLM_TeamTable)
+    team.team_id = "team-a"
+    team.models = ["team-allowed-model-b", "test-access-group"]
+
+    llm_router = _make_router_with_access_groups(
+        model_names=["team-allowed-model-a", "team-allowed-model-b"],
+        model_access_groups={"test-access-group": ["team-allowed-model-a"]},
+        deployments=[
+            {"model_name": "team-allowed-model-a", "model_info": {"id": "model-a-id"}},
+            {"model_name": "team-allowed-model-b", "model_info": {"id": "model-b-id"}},
+        ],
+    )
+
+    result = _add_team_models_to_all_models(team_db_objects_typed=[team], llm_router=llm_router)
+    assert result == {"model-a-id": {"team-a"}, "model-b-id": {"team-a"}}
+
+
+def test_add_team_models_to_all_models_excludes_other_access_group():
+    """Only the access group named in team.models is expanded; deployments that
+    belong solely to a different access group must not leak into the team map."""
+    from litellm.proxy._types import LiteLLM_TeamTable
+    from litellm.proxy.proxy_server import _add_team_models_to_all_models
+
+    team = MagicMock(spec=LiteLLM_TeamTable)
+    team.team_id = "team-a"
+    team.models = ["test-access-group"]
+
+    llm_router = _make_router_with_access_groups(
+        model_names=["team-allowed-model-a", "forbidden-model"],
+        model_access_groups={
+            "test-access-group": ["team-allowed-model-a"],
+            "other-access-group": ["forbidden-model"],
+        },
+        deployments=[
+            {"model_name": "team-allowed-model-a", "model_info": {"id": "model-a-id"}},
+            {"model_name": "forbidden-model", "model_info": {"id": "forbidden-id"}},
+        ],
+    )
+
+    result = _add_team_models_to_all_models(team_db_objects_typed=[team], llm_router=llm_router)
+    assert result == {"model-a-id": {"team-a"}}
+
+
+def test_add_team_models_to_all_models_excludes_other_teams_byok_with_shared_name():
+    """A BYOK deployment owned by a DIFFERENT team but sharing the resolved model
+    name must not be added for this team. Guards the team_id filter passed to
+    get_model_list: dropping it would leak the other team's private deployment."""
+    from litellm.proxy._types import LiteLLM_TeamTable
+    from litellm.proxy.proxy_server import _add_team_models_to_all_models
+
+    team = MagicMock(spec=LiteLLM_TeamTable)
+    team.team_id = "team-a"
+    team.models = ["test-access-group"]
+
+    llm_router = _make_router_with_access_groups(
+        model_names=["team-allowed-model-a"],
+        model_access_groups={"test-access-group": ["team-allowed-model-a"]},
+        deployments=[
+            {"model_name": "team-allowed-model-a", "model_info": {"id": "model-a-id", "team_id": "team-a"}},
+            {"model_name": "team-allowed-model-a", "model_info": {"id": "other-team-byok-id", "team_id": "team-b"}},
+        ],
+    )
+
+    result = _add_team_models_to_all_models(team_db_objects_typed=[team], llm_router=llm_router)
+    assert result == {"model-a-id": {"team-a"}}
+
+
 @pytest.mark.asyncio
 async def test_apply_search_filter_matches_team_public_model_name():
     """


### PR DESCRIPTION
## TLDR

Problem this solves:

- Teams granted a config model access group saw empty Models + Endpoints
- A model sharing a group's name was hidden from listings yet callable

How it solves it:

- Resolve team.models through the same resolver runtime auth uses
- Listings keep a literal model whose name collides with a group

## User Flow

Before: a team member whose team is granted a model access group sees an empty Models + Endpoints page

1. The proxy admin tags two deployments with access group `team-models-group` in the config and creates a team whose only model grant is `team-models-group`
2. A member of that team sends GET http://localhost:4000/v1/models with their team key and gets both models back
3. The same member opens http://localhost:4000/ui/?page=models and selects their team: the table is empty, and the raw call behind it, GET /v2/model/info?include_team_models=true&teamId=..., returns `{"data": [], "total_count": 0}`
4. POST /v1/chat/completions with either model returns 200, so the page contradicts what the key can actually do

After: the models page lists exactly what the team can call

1. Same config, team, and key
2. GET /v2/model/info?include_team_models=true&teamId=... returns both group members with the team's id attached, and the UI table shows them
3. A deployment that happens to share the group's name now also appears in both GET /v1/models and the models page instead of silently disappearing while still being callable

## Relevant issues

## Linear ticket

Resolves LIT-4433

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured live against a DB-backed local proxy on :44331. The config tags two deployments with the config-defined access group `lit4433-team-models`, adds a third deployment literally named `lit4433-team-models` (the collision case), and a fourth deployment in a different group. The team's only grant is the string `lit4433-team-models`

```yaml
model_list:
  - model_name: lit4433-allowed-model-a
    litellm_params: {model: openai/gpt-4o-mini, mock_response: "allowed model a"}
    model_info: {access_groups: ["lit4433-team-models"]}
  - model_name: lit4433-allowed-model-b
    litellm_params: {model: openai/gpt-4o-mini, mock_response: "allowed model b"}
    model_info: {access_groups: ["lit4433-team-models"]}
  - model_name: lit4433-team-models
    litellm_params: {model: openai/gpt-4o-mini, mock_response: "collision literal model"}
  - model_name: lit4433-outside-model
    litellm_params: {model: openai/gpt-4o-mini, mock_response: "outside model"}
    model_info: {access_groups: ["lit4433-other-models"]}
```

Setup, identical on every run

```
$ curl -s -X POST $BASE/team/new -H "Authorization: Bearer sk-1234" -d '{"team_id": "lit4433-repro-team", "models": ["lit4433-team-models"]}'
$ curl -s -X POST $BASE/user/new -d '{"user_id": "lit4433-repro-user", "user_role": "internal_user", "teams": ["lit4433-repro-team"]}'
$ curl -s -X POST $BASE/key/generate -d '{"team_id": "lit4433-repro-team", "user_id": "lit4433-repro-user", "models": []}'
```

### Main bug, before, captured at 422d925334 (latest litellm_internal_staging without this PR)

/v1/models resolves the group but the Models + Endpoints endpoint returns nothing

```
$ curl -s $BASE/v1/models -H "Authorization: Bearer $TEAM_KEY"
"id":"lit4433-allowed-model-a"
"id":"lit4433-allowed-model-b"

$ curl -s "$BASE/v2/model/info?include_team_models=true&page=1&size=50" -H "Authorization: Bearer $TEAM_KEY"
{"data":[],"total_count":0,"current_page":1,"total_pages":0,"size":50}

$ curl -s "$BASE/v2/model/info?include_team_models=true&teamId=lit4433-repro-team&page=1&size=50" -H "Authorization: Bearer $TEAM_KEY"
{"data":[],"total_count":0,"current_page":1,"total_pages":0,"size":50}
```

### Main bug, after, captured at 740f75b9a1

Both /v2 queries return the group members and runtime enforcement is unchanged

```
$ curl -s "$BASE/v2/model/info?include_team_models=true&page=1&size=50" -H "Authorization: Bearer $TEAM_KEY"
"model_name":"lit4433-allowed-model-a"
"model_name":"lit4433-allowed-model-b"
"total_count":2

$ curl -s "$BASE/v2/model/info?include_team_models=true&teamId=lit4433-repro-team&page=1&size=50" -H "Authorization: Bearer $TEAM_KEY"
"model_name":"lit4433-allowed-model-a"
"model_name":"lit4433-allowed-model-b"
"total_count":2

$ curl -s -w '%{http_code}' -X POST $BASE/v1/chat/completions -d '{"model": "lit4433-allowed-model-a", ...}'
200
$ curl -s -w '%{http_code}' -X POST $BASE/v1/chat/completions -d '{"model": "lit4433-outside-model", ...}'
403 team not allowed to access model. This team can only access models=['lit4433-team-models']. Tried to access lit4433-outside-model
```

### Collision hardening, before, captured at 740f75b9a1

The deployment named `lit4433-team-models` is callable but hidden from every listing

```
$ curl -s $BASE/v1/models -H "Authorization: Bearer $TEAM_KEY"
"id":"lit4433-allowed-model-a"
"id":"lit4433-allowed-model-b"

$ curl -s "$BASE/v2/model/info?include_team_models=true&page=1&size=50" -H "Authorization: Bearer $TEAM_KEY"
"model_name":"lit4433-allowed-model-a"
"model_name":"lit4433-allowed-model-b"
"total_count":2

$ curl -s -w '%{http_code}' -X POST $BASE/v1/chat/completions -d '{"model": "lit4433-team-models", ...}'
200
```

### Collision hardening, after, captured at c773891bf7

Listings now match runtime access exactly: the literal deployment and both group members are visible, the outside model stays denied

```
$ curl -s $BASE/v1/models -H "Authorization: Bearer $TEAM_KEY"
"id":"lit4433-team-models"
"id":"lit4433-allowed-model-a"
"id":"lit4433-allowed-model-b"

$ curl -s "$BASE/v2/model/info?include_team_models=true&page=1&size=50" -H "Authorization: Bearer $TEAM_KEY"
"model_name":"lit4433-allowed-model-a"
"model_name":"lit4433-allowed-model-b"
"model_name":"lit4433-team-models"
"total_count":3

$ curl -s "$BASE/v2/model/info?include_team_models=true&teamId=lit4433-repro-team&page=1&size=50" -H "Authorization: Bearer $TEAM_KEY"
"model_name":"lit4433-allowed-model-a"
"model_name":"lit4433-allowed-model-b"
"model_name":"lit4433-team-models"
"total_count":3

$ curl -s -w '%{http_code}' -X POST $BASE/v1/chat/completions -d '{"model": "lit4433-team-models", ...}'
200
$ curl -s -w '%{http_code}' -X POST $BASE/v1/chat/completions -d '{"model": "lit4433-outside-model", ...}'
403
```

## Type

🐛 Bug Fix

## Caveats (if any)

- /v1/models now also lists a literal model colliding with a group name; strictly additive and matches what runtime auth already allowed
- A colliding name still widens the grant to group members at runtime; pre-existing behavior, the real fix is typed group grants (follow-up)
- No validation stops an admin from reusing a model name as a group name; same follow-up

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
