### PR TITLE
fix(azure): send only max_completion_tokens when both token params are set

### DIFF
--- a/litellm/llms/azure/chat/gpt_transformation.py
+++ b/litellm/llms/azure/chat/gpt_transformation.py
@@ -169,6 +169,8 @@ class AzureOpenAIConfig(BaseConfig):
             api_version_day = None
 
         for param, value in non_default_params.items():
+            if param == "max_tokens" and "max_completion_tokens" in non_default_params:
+                continue
             if param == "tool_choice":
                 """
                 This parameter requires API version 2023-12-01-preview or later

--- a/tests/test_litellm/llms/azure/chat/test_azure_chat_gpt_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_chat_gpt_transformation.py
@@ -54,3 +54,39 @@ def test_map_openai_params_with_preview_api_version():
     assert config.map_openai_params(
         non_default_params, optional_params, model, drop_params, api_version
     )
+
+
+def test_map_openai_params_sends_only_max_completion_tokens_when_both_set():
+    config = AzureOpenAIConfig()
+    result = config.map_openai_params(
+        non_default_params={"max_tokens": 512, "max_completion_tokens": 256},
+        optional_params={},
+        model="gpt-4o",
+        drop_params=False,
+        api_version="2025-01-01-preview",
+    )
+    assert result == {"max_completion_tokens": 256}
+
+
+def test_map_openai_params_keeps_lone_max_tokens():
+    config = AzureOpenAIConfig()
+    result = config.map_openai_params(
+        non_default_params={"max_tokens": 512},
+        optional_params={},
+        model="gpt-4o",
+        drop_params=False,
+        api_version="2025-01-01-preview",
+    )
+    assert result == {"max_tokens": 512}
+
+
+def test_map_openai_params_keeps_lone_max_completion_tokens():
+    config = AzureOpenAIConfig()
+    result = config.map_openai_params(
+        non_default_params={"max_completion_tokens": 256},
+        optional_params={},
+        model="gpt-4o",
+        drop_params=False,
+        api_version="2025-01-01-preview",
+    )
+    assert result == {"max_completion_tokens": 256}


### PR DESCRIPTION
## TLDR

Problem this solves:

- config-level max_tokens plus client max_completion_tokens forwarded both to Azure
- Azure rejects the pair with a 400 BadRequestError

How it solves it:

- Azure param mapping skips max_tokens when max_completion_tokens is also set
- only the client's max_completion_tokens reaches Azure

## Relevant issues

Fixes #31614

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both phases ran a live proxy against the real Azure OpenAI API (deployment `gpt-4o` on `litellm-e2e-suite-resource`), each from its own fresh worktree and venv, using this `qa_config.yaml` with a config-level `max_tokens: 512` default while the client sends `max_completion_tokens: 256`

```yaml
model_list:
  - model_name: azure-gpt-4o
    litellm_params:
      model: azure/gpt-4o
      api_base: os.environ/AZURE_API_BASE
      api_key: os.environ/AZURE_API_KEY
      api_version: "2024-10-21"
      max_tokens: 512
general_settings:
  master_key: sk-qa-31614
```

### Before (litellm_internal_staging @ 1aba849af2)

```bash
python litellm/proxy/proxy_cli.py --config qa_config.yaml --port 48817
```

Non-streaming request

```bash
curl -sS -w '\nHTTP %{http_code}\n' http://localhost:48817/v1/chat/completions -H 'Authorization: Bearer sk-qa-31614' -H 'Content-Type: application/json' -d '{"model": "azure-gpt-4o", "messages": [{"role": "user", "content": "reply with one word"}], "max_completion_tokens": 256}'
```

```
{
    "error": {
        "message": "litellm.BadRequestError: AzureException BadRequestError - Setting 'max_tokens' and 'max_completion_tokens' at the same time is not supported.. Received Model Group=azure-gpt-4o\nAvailable Model Group Fallbacks=None",
        "type": "invalid_request_error",
        "param": "max_tokens",
        "code": "400"
    }
}
HTTP 400
```

Streaming request

```bash
curl -sS -w '\nHTTP %{http_code}\n' http://localhost:48817/v1/chat/completions -H 'Authorization: Bearer sk-qa-31614' -H 'Content-Type: application/json' -d '{"model": "azure-gpt-4o", "messages": [{"role": "user", "content": "reply with one word"}], "max_completion_tokens": 256, "stream": true}'
```

```
{
    "error": {
        "message": "litellm.BadRequestError: AzureException BadRequestError - Setting 'max_tokens' and 'max_completion_tokens' at the same time is not supported.. Received Model Group=azure-gpt-4o\nAvailable Model Group Fallbacks=None",
        "type": "invalid_request_error",
        "param": "max_tokens",
        "code": "400"
    }
}
HTTP 400
```

### After (this branch @ db30fa0f9e)

```bash
python litellm/proxy/proxy_cli.py --config qa_config.yaml --port 54824
```

Non-streaming request

```bash
curl -sS -w '\nHTTP %{http_code}\n' http://localhost:54824/v1/chat/completions -H 'Authorization: Bearer sk-qa-31614' -H 'Content-Type: application/json' -d '{"model": "azure-gpt-4o", "messages": [{"role": "user", "content": "reply with one word"}], "max_completion_tokens": 256}'
```

```
{
    "id": "chatcmpl-E4GLq07ShFLgOoDJtOh9ke33qBK31",
    "created": 1784684874,
    "model": "azure-gpt-4o",
    "object": "chat.completion",
    "system_fingerprint": "fp_6ef6b02e87",
    "choices": [
        {
            "finish_reason": "stop",
            "index": 0,
            "message": {
                "content": "Sure!",
                "role": "assistant",
                "provider_specific_fields": {
                    "refusal": null
                },
                "annotations": []
            },
            "provider_specific_fields": {
                "content_filter_results": {
                    "hate": {
                        "filtered": false,
                        "severity": "safe"
                    },
                    "protected_material_code": {
                        "detected": false,
                        "filtered": false
                    },
                    "protected_material_text": {
                        "detected": false,
                        "filtered": false
                    },
                    "self_harm": {
                        "filtered": false,
                        "severity": "safe"
                    },
                    "sexual": {
                        "filtered": false,
                        "severity": "safe"
                    },
                    "violence": {
                        "filtered": false,
                        "severity": "safe"
                    }
                }
            }
        }
    ],
    "usage": {
        "completion_tokens": 3,
        "prompt_tokens": 11,
        "total_tokens": 14,
        "completion_tokens_details": {
            "accepted_prediction_tokens": 0,
            "audio_tokens": 0,
            "reasoning_tokens": 0,
            "rejected_prediction_tokens": 0
        },
        "prompt_tokens_details": {
            "audio_tokens": 0,
            "cached_tokens": 0
        },
        "latency_checkpoint": {
            "engine_tbt_ms": 6,
            "engine_ttft_ms": 26,
            "engine_ttlt_ms": 44,
            "pre_inference_ms": 104,
            "service_tbt_ms": 7,
            "service_ttft_ms": 207,
            "service_ttlt_ms": 223,
            "total_duration_ms": 125,
            "user_visible_ttft_ms": 104
        }
    },
    "service_tier": "default",
    "prompt_filter_results": [
        {
            "prompt_index": 0,
            "content_filter_results": {
                "hate": {
                    "filtered": false,
                    "severity": "safe"
                },
                "jailbreak": {
                    "detected": false,
                    "filtered": false
                },
                "self_harm": {
                    "filtered": false,
                    "severity": "safe"
                },
                "sexual": {
                    "filtered": false,
                    "severity": "safe"
                },
                "violence": {
                    "filtered": false,
                    "severity": "safe"
                }
            }
        }
    ]
}
HTTP 200
```

Streaming request

```bash
curl -sS -w '\nHTTP %{http_code}\n' http://localhost:54824/v1/chat/completions -H 'Authorization: Bearer sk-qa-31614' -H 'Content-Type: application/json' -d '{"model": "azure-gpt-4o", "messages": [{"role": "user", "content": "reply with one word"}], "max_completion_tokens": 256, "stream": true}'
```

```
data: {"id":"chatcmpl-E4GLxKTkvCBgLSTzrOF2piUsHikRn","created":1784684881,"model":"azure-gpt-4o","object":"chat.completion.chunk","system_fingerprint":"fp_9baf9886c5","choices":[{"content_filter_results":{},"index":0,"delta":{"content":"","role":"assistant"}}],"service_tier":"default","obfuscation":"UZ0hWUc3Bwl"}

data: {"id":"chatcmpl-E4GLxKTkvCBgLSTzrOF2piUsHikRn","created":1784684881,"model":"azure-gpt-4o","object":"chat.completion.chunk","system_fingerprint":"fp_9baf9886c5","choices":[{"content_filter_results":{"protected_material_code":{"detected":false,"filtered":false}},"index":0,"delta":{"content":"Okay"}}],"service_tier":"default","obfuscation":"30HlKd1E2"}

data: {"id":"chatcmpl-E4GLxKTkvCBgLSTzrOF2piUsHikRn","created":1784684881,"model":"azure-gpt-4o","object":"chat.completion.chunk","system_fingerprint":"fp_9baf9886c5","choices":[{"content_filter_results":{"protected_material_code":{"detected":false,"filtered":false}},"index":0,"delta":{"content":"."}}],"service_tier":"default","obfuscation":"cN7pvh94jtQp"}

data: {"id":"chatcmpl-E4GLxKTkvCBgLSTzrOF2piUsHikRn","created":1784684881,"model":"azure-gpt-4o","object":"chat.completion.chunk","system_fingerprint":"fp_9baf9886c5","choices":[{"finish_reason":"stop","index":0,"delta":{}}],"service_tier":"default","obfuscation":"ZsfwhX4"}

data: [DONE]

HTTP 200
```

## Type

🐛 Bug Fix

## Changes

When a proxy deployment carries a config-level `max_tokens` default and the client request sets `max_completion_tokens`, the router merges the deployment `litellm_params` into the request kwargs, so both token params reach `get_optional_params`. `AzureOpenAIConfig.map_openai_params` listed both in its supported params and forwarded both to the wire, and Azure rejects the pair with "Setting 'max_tokens' and 'max_completion_tokens' at the same time is not supported"

This PR makes `AzureOpenAIConfig.map_openai_params` skip `max_tokens` whenever `max_completion_tokens` is also present, so only the newer param is sent; in the failing scenario that is the client's explicit choice while `max_tokens` is just the config default. Requests that set only one of the two params behave exactly as before, and streaming and non-streaming share this transformation path so both are covered. The Azure o-series and gpt-5 configs already collapse the pair via their own `max_tokens` -> `max_completion_tokens` mapping, so this only changes the default Azure chat path

Regression tests live in `tests/test_litellm/llms/azure/chat/test_azure_chat_gpt_transformation.py`: with both params present only `max_completion_tokens` survives, and a lone `max_tokens` or lone `max_completion_tokens` passes through unchanged

## QA runbook

1. Save this config as `azure_dual_token.yaml`:
   ```yaml
   model_list:
     - model_name: azure-gpt-4o
       litellm_params:
         model: azure/gpt-4o
         api_base: os.environ/AZURE_API_BASE
         api_key: os.environ/AZURE_API_KEY
         max_tokens: 512
   general_settings:
     master_key: sk-1234
   ```
2. Start the proxy: `python litellm/proxy/proxy_cli.py --config azure_dual_token.yaml --port 41614`
3. Send a chat completion that sets the other token param:
   ```bash
   curl -sS http://localhost:41614/v1/chat/completions \
     -H "Authorization: Bearer sk-1234" \
     -H "Content-Type: application/json" \
     -d '{"model": "azure-gpt-4o", "messages": [{"role": "user", "content": "reply with one word"}], "max_completion_tokens": 256}'
   ```
4. Before this fix the proxy returns a 400 with "AzureException BadRequestError - Setting 'max_tokens' and 'max_completion_tokens' at the same time is not supported"; after this fix it returns 200 with a completion

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
