### PR TITLE
fix(proxy): invalidate key and team cache on /team/delete (#34217)

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -67,6 +67,7 @@ from litellm.proxy._types import (
 )
 from litellm.proxy.auth.auth_checks import (
     _cache_team_object,
+    _delete_cache_key_object,
     allowed_route_check_inside_route,
     can_org_access_model,
     get_org_object,
@@ -3198,6 +3199,33 @@ async def bulk_team_member_add(
         )
 
 
+async def _invalidate_caches_after_team_key_delete(
+    keys_to_delete: List[LiteLLM_VerificationToken],
+    team_rows: List[LiteLLM_TeamTable],
+) -> None:
+    from litellm.proxy.proxy_server import proxy_logging_obj, user_api_key_cache
+
+    for key_row in keys_to_delete:
+        if key_row.token is None:
+            continue
+        await _delete_cache_key_object(
+            hashed_token=key_row.token,
+            user_api_key_cache=user_api_key_cache,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+
+    for team_row in team_rows:
+        team_cache_key = "team_id:{}".format(team_row.team_id)
+        user_api_key_cache.delete_cache(key=team_cache_key)
+        if proxy_logging_obj is not None:
+            await proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache(key=team_cache_key)
+        if team_row.team_alias:
+            alias_key = "team_alias:{}".format(team_row.team_alias)
+            user_api_key_cache.delete_cache(key=alias_key)
+            if proxy_logging_obj is not None:
+                await proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache(key=alias_key)
+
+
 @router.post("/team/delete", tags=["team management"], dependencies=[Depends(user_api_key_auth)])
 @management_endpoint_wrapper
 async def delete_team(
@@ -3325,6 +3353,11 @@ async def delete_team(
         )
 
     await prisma_client.delete_data(team_id_list=data.team_ids, table_name="key")
+
+    await _invalidate_caches_after_team_key_delete(
+        keys_to_delete=keys_to_delete,
+        team_rows=team_rows,
+    )
 
     ## DELETE ASSOCIATED BYOK MODELS
     # Runs before the team rows are deleted so a mid-flight failure never leaves

--- a/litellm/proxy/management_helpers/utils.py
+++ b/litellm/proxy/management_helpers/utils.py
@@ -378,11 +378,13 @@ def _delete_team_id_from_cache(kwargs):
     if kwargs.get("data") is not None:
         update_request = kwargs.get("data")
         if isinstance(update_request, UpdateTeamRequest):
+            user_api_key_cache.delete_cache(key="team_id:{}".format(update_request.team_id))
             user_api_key_cache.delete_cache(key=update_request.team_id)
 
         # delete team request
         if isinstance(update_request, DeleteTeamRequest):
             for team_id in update_request.team_ids:
+                user_api_key_cache.delete_cache(key="team_id:{}".format(team_id))
                 user_api_key_cache.delete_cache(key=team_id)
     pass
 

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -6947,6 +6947,141 @@ async def test_delete_team_persists_deleted_teams(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_delete_team_invalidates_cached_virtual_keys(monkeypatch):
+    from litellm.caching.dual_cache import DualCache
+    from litellm.proxy._types import DeleteTeamRequest, LiteLLM_VerificationToken
+    from litellm.proxy.utils import ProxyLogging
+
+    mock_prisma_client = AsyncMock()
+    mock_user_api_key_dict = UserAPIKeyAuth(
+        user_id="admin-user",
+        api_key="sk-admin",
+        user_role=LitellmUserRoles.PROXY_ADMIN.value,
+    )
+
+    team1 = LiteLLM_TeamTable(
+        team_id="team-1",
+        team_alias="test-team-1",
+        members_with_roles=[
+            Member(user_id="user-1", role="admin"),
+        ],
+        metadata={},
+        model_max_budget={},
+        model_spend={},
+    )
+    key1 = LiteLLM_VerificationToken(
+        token="hashed-token-team-1",
+        team_id="team-1",
+        user_id="user-1",
+    )
+
+    mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=team1)
+    mock_prisma_client.delete_data = AsyncMock(return_value={"deleted_teams": ["team-1"]})
+    mock_prisma_client.db.litellm_deletedteamtable.create_many = AsyncMock()
+    mock_prisma_client.db.litellm_deletedverificationtoken.create_many = AsyncMock()
+    mock_prisma_client.db.litellm_verificationtoken.find_many = AsyncMock(
+        return_value=[key1]
+    )
+
+    mock_tx = AsyncMock()
+    mock_tx.litellm_proxymodeltable.find_many = AsyncMock(return_value=[])
+    mock_tx_cm = MagicMock()
+    mock_tx_cm.__aenter__ = AsyncMock(return_value=mock_tx)
+    mock_tx_cm.__aexit__ = AsyncMock(return_value=False)
+    mock_prisma_client.db.tx = MagicMock(return_value=mock_tx_cm)
+
+    key_cache = DualCache()
+    await key_cache.async_set_cache(
+        key="hashed-token-team-1",
+        value=UserAPIKeyAuth(token="hashed-token-team-1", team_id="team-1"),
+    )
+    await key_cache.async_set_cache(
+        key="team_id:team-1",
+        value=LiteLLM_TeamTableCachedObj(**team1.model_dump()),
+    )
+    await key_cache.async_set_cache(key="team_alias:test-team-1", value={"team_id": "team-1"})
+
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=key_cache)
+    proxy_logging_obj.internal_usage_cache.dual_cache = DualCache()
+    await proxy_logging_obj.internal_usage_cache.dual_cache.async_set_cache(
+        key="hashed-token-team-1",
+        value={"token": "hashed-token-team-1"},
+    )
+    await proxy_logging_obj.internal_usage_cache.dual_cache.async_set_cache(
+        key="team_id:team-1",
+        value={"team_id": "team-1"},
+    )
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.create_audit_log_for_update",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.litellm_proxy_admin_name",
+        "admin",
+    )
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.team_endpoints.team_member_delete",
+        AsyncMock(return_value=team1),
+    )
+    monkeypatch.setattr("litellm.proxy.proxy_server.user_api_key_cache", key_cache)
+    monkeypatch.setattr("litellm.proxy.proxy_server.proxy_logging_obj", proxy_logging_obj)
+    monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", None)
+
+    result = await delete_team(
+        data=DeleteTeamRequest(team_ids=["team-1"]),
+        http_request=MagicMock(),
+        user_api_key_dict=mock_user_api_key_dict,
+        litellm_changed_by="admin-user",
+    )
+
+    assert result == {"deleted_teams": ["team-1"]}
+    assert key_cache.get_cache(key="hashed-token-team-1") is None
+    assert key_cache.get_cache(key="team_id:team-1") is None
+    assert key_cache.get_cache(key="team_alias:test-team-1") is None
+    assert (
+        proxy_logging_obj.internal_usage_cache.dual_cache.get_cache(
+            key="hashed-token-team-1"
+        )
+        is None
+    )
+    assert (
+        proxy_logging_obj.internal_usage_cache.dual_cache.get_cache(key="team_id:team-1")
+        is None
+    )
+
+
+def test_delete_team_id_from_cache_uses_prefixed_key(monkeypatch):
+    from litellm.proxy._types import DeleteTeamRequest, UpdateTeamRequest
+    from litellm.proxy.management_helpers.utils import _delete_team_id_from_cache
+
+    deleted_keys: list[str] = []
+
+    class _FakeCache:
+        def delete_cache(self, key):
+            deleted_keys.append(key)
+
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.user_api_key_cache",
+        _FakeCache(),
+    )
+
+    _delete_team_id_from_cache(
+        kwargs={"data": DeleteTeamRequest(team_ids=["team-abc"])}
+    )
+    assert "team_id:team-abc" in deleted_keys
+    assert "team-abc" in deleted_keys
+
+    deleted_keys.clear()
+    _delete_team_id_from_cache(
+        kwargs={"data": UpdateTeamRequest(team_id="team-xyz")}
+    )
+    assert "team_id:team-xyz" in deleted_keys
+    assert "team-xyz" in deleted_keys
+
+
+@pytest.mark.asyncio
 async def test_team_member_delete_persists_deleted_keys(monkeypatch):
     from litellm.proxy._types import TeamMemberDeleteRequest
     from litellm.proxy.management_endpoints.key_management_endpoints import (


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/team/delete` removed keys from DB but left them auth-valid in cache
- Team object cache keyed as `team_id:{id}` was never cleared on delete

How it solves it:

- Evict each deleted key via `_delete_cache_key_object` after DB delete
- Clear `team_id:{id}` and `team_alias:{alias}` in memory and Redis dual cache
- Fix `_delete_team_id_from_cache` to delete the prefixed team cache key

## Relevant issues

Fixes #34217

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Commit `427b2e2289` (tip of this branch).

Unit regression (cache eviction + prefixed team_id key):

```bash
.venv/bin/pytest tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py -k "delete_team_invalidates or delete_team_id_from_cache_uses or delete_team_persists" -q
```

```
3 passed
```

Live curl against localhost:4000 was not captured in this environment (no Docker/Postgres ready; `http://localhost:4000/health/liveliness` unreachable). Reviewer manual repro:

```bash
# 1) Create team + virtual key; call /v1/models with that key (expect 200)
# 2) Warm auth cache with a second /v1/models call
# 3) POST /team/delete for that team_id
# 4) Call /v1/models again with the same key
# Before: still 200 while TTL remains
# After: 401/403 immediately (key + team_id:{id} evicted)
```

## Type

🐛 Bug Fix

## Changes

`/key/delete` already evicts hashed tokens from `user_api_key_cache` (and the Redis dual cache). `/team/delete` deleted the same rows in Postgres but skipped that eviction, so a previously authenticated key stayed valid until TTL expiry. Separately, `_delete_team_id_from_cache` deleted the bare `team_id` string while teams are stored under `team_id:{id}`

This change:

1. After `prisma_client.delete_data(..., table_name="key")`, calls `_invalidate_caches_after_team_key_delete` to evict each key via `_delete_cache_key_object` and clear `team_id:{id}` / `team_alias:{alias}`
2. Updates `_delete_team_id_from_cache` so delete and update team paths clear the prefixed cache key (and still clear the bare id for any legacy entries)

No schema change. Keys without a cached entry are a no-op

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
