### PR TITLE
fix(jwt): include anthropic_routes in default team_allowed_routes

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -4220,7 +4220,7 @@ class LiteLLM_JWTAuth(LiteLLMPydanticObjectBase):
     team_id_upsert: bool = False
     team_ids_jwt_field: Optional[str] = None
     upsert_sso_user_to_team: bool = False
-    team_allowed_routes: List[str] = ["openai_routes", "info_routes", "mcp_routes"]
+    team_allowed_routes: List[str] = ["openai_routes", "anthropic_routes", "info_routes", "mcp_routes"]
     team_id_default: Optional[str] = Field(
         default=None,
         description="If no team_id given, default permissions/spend-tracking to this team.s",


### PR DESCRIPTION
Resolves: #31189

Root cause is in LiteLLM_JWTAuth.team_allowed_routes in litellm/proxy/_types.py. The default is ["openai_routes", "info_routes", "mcp_routes"]. /v1/messages belongs to anthropic_routes, which is not in that list. When find_team_with_model_access loops over JWT-extracted teams and calls allowed_routes_check, every team returns is_allowed = False for the /v1/messages route, so the function raises a 403 regardless of model access.

Adding x-litellm-team-id works because the header-supplied team takes a separate early-exit path in auth_builder that skips find_team_with_model_access entirely.

Fix is a one-line change in LiteLLM_JWTAuth.team_allowed_routes:

team_allowed_routes: List[str] = ["openai_routes", "anthropic_routes", "info_routes", "mcp_routes"]