### PR TITLE
fix(proxy): reserve the largest explicit token cap when max_tokens and max_completion_tokens conflict

### DIFF
--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -517,7 +517,10 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
 
         estimated_input_tokens = max(1, total_chars // DEFAULT_CHARS_PER_TOKEN) if total_chars > 0 else 0
 
-        explicit_max_tokens = data.get("max_tokens") or data.get("max_completion_tokens")
+        explicit_max_tokens = max(
+            (int(v) for v in (data.get("max_tokens"), data.get("max_completion_tokens")) if v),
+            default=None,
+        )
 
         match (explicit_max_tokens, input_text):
             case (mt, _) if mt is not None:

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -1215,11 +1215,14 @@ def _estimate_output_tokens(
     if _is_input_only_route(route=route):
         return 0
 
-    requested: Optional[int] = None
-    for key in ("max_completion_tokens", "max_tokens", "max_output_tokens"):
-        requested = _to_int(request_body.get(key))
-        if requested is not None:
-            break
+    requested: Optional[int] = max(
+        (
+            value
+            for key in ("max_completion_tokens", "max_tokens", "max_output_tokens")
+            if (value := _to_int(request_body.get(key))) is not None
+        ),
+        default=None,
+    )
 
     # Clamp at min(requested-or-default, model_max-or-default). Two purposes:
     # (1) Without an explicit cap we still need a finite reservation so the

--- a/litellm/router_utils/pre_call_checks/io_token_rate_limit_check.py
+++ b/litellm/router_utils/pre_call_checks/io_token_rate_limit_check.py
@@ -135,13 +135,17 @@ def _resolve_max_tokens(request_kwargs: Optional[dict[str, Any]], deployment: di
     if request_kwargs:
         # An explicit max_tokens=0 must be honored, not treated as absent and
         # replaced by the model default.
-        explicit = request_kwargs.get("max_tokens")
-        if explicit is None:
-            explicit = request_kwargs.get("max_completion_tokens")
-        if explicit is None:
-            explicit = request_kwargs.get("max_output_tokens")
-        if explicit is not None:
-            return max(0, int(explicit))
+        explicit_caps = [
+            int(value)
+            for value in (
+                request_kwargs.get("max_tokens"),
+                request_kwargs.get("max_completion_tokens"),
+                request_kwargs.get("max_output_tokens"),
+            )
+            if value is not None
+        ]
+        if explicit_caps:
+            return max(0, max(explicit_caps))
 
     model_name = (deployment.get("litellm_params") or {}).get("model")
     if model_name:

--- a/tests/e2e/load/test_session_anomaly.py
+++ b/tests/e2e/load/test_session_anomaly.py
@@ -62,7 +62,7 @@ class TestSummarizePlannedTurns:
 
 class TestRetried:
     def test_transient_failures_then_success_returns_the_success(self) -> None:
-        outcome = Success(data=SessionMessagesResponse())
+        outcome = Success(status_code=200, data=SessionMessagesResponse())
         calls = iter(
             (NetworkError(message="overloaded"), NetworkError(message="overloaded"), outcome)
         )
@@ -88,7 +88,7 @@ class TestRetried:
             raise AssertionError("slept after a successful attempt")
 
         result = retried(
-            lambda: Success(data=SessionMessagesResponse()),
+            lambda: Success(status_code=200, data=SessionMessagesResponse()),
             attempts=3,
             sleep=sleep_means_retry,
         )

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
@@ -4652,3 +4652,28 @@ async def test_streaming_mirror_matches_non_streaming_header_shape(monkeypatch):
         f" non_streaming={_rl_only(non_stream_headers)}"
     )
     assert "x-ratelimit-model_per_key-remaining-requests" in stream_slp_headers
+
+
+def test_estimate_tokens_reserves_larger_cap_when_max_tokens_conflicts():
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(DualCache()),
+    )
+    messages = [{"role": "user", "content": "hi"}]
+
+    conflicting_small_first = handler._estimate_tokens_for_request(
+        data={"messages": messages, "max_tokens": 1, "max_completion_tokens": 5000},
+    )
+    conflicting_large_first = handler._estimate_tokens_for_request(
+        data={"messages": messages, "max_tokens": 5000, "max_completion_tokens": 1},
+    )
+    only_max_completion_tokens = handler._estimate_tokens_for_request(
+        data={"messages": messages, "max_completion_tokens": 5000},
+    )
+    only_max_tokens = handler._estimate_tokens_for_request(
+        data={"messages": messages, "max_tokens": 5000},
+    )
+
+    assert conflicting_small_first == only_max_completion_tokens
+    assert conflicting_small_first == only_max_tokens
+    assert conflicting_large_first == conflicting_small_first
+    assert conflicting_small_first > 5000

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -2484,3 +2484,33 @@ async def test_streaming_slow_path_processes_and_yields_chunk(spend_counter_stat
 
     assert received == [{"content": "hi"}]
     streaming_logging_obj.async_post_call_streaming_hook.assert_awaited_once()
+
+
+def test_estimate_output_tokens_conflicting_caps_reserve_larger():
+    from litellm.proxy.spend_tracking.budget_reservation import _estimate_output_tokens
+
+    model_info = {"max_output_tokens": 200000}
+    assert (
+        _estimate_output_tokens(
+            request_body={"max_completion_tokens": 1, "max_tokens": 5000},
+            route="/chat/completions",
+            model_info=model_info,
+        )
+        == 5000
+    )
+    assert (
+        _estimate_output_tokens(
+            request_body={"max_completion_tokens": 5000, "max_tokens": 1},
+            route="/chat/completions",
+            model_info=model_info,
+        )
+        == 5000
+    )
+    assert (
+        _estimate_output_tokens(
+            request_body={"max_completion_tokens": 7},
+            route="/chat/completions",
+            model_info=model_info,
+        )
+        == 7
+    )

--- a/tests/test_litellm/test_router/test_io_token_rate_limits.py
+++ b/tests/test_litellm/test_router/test_io_token_rate_limits.py
@@ -51,9 +51,16 @@ class TestIOTokenRateLimitHelpers:
         deployment = {"litellm_params": {"model": "openai/gpt-4o-mini"}}
         # An explicit max_tokens=0 is honored, not replaced by the model default.
         assert _resolve_max_tokens({"max_tokens": 0}, deployment) == 0
-        # max_completion_tokens is the fallback only when max_tokens is absent.
+        # Any of the explicit cap aliases is honored on its own; when several
+        # are present the reservation uses the largest one.
         assert _resolve_max_tokens({"max_completion_tokens": 12}, deployment) == 12
         assert _resolve_max_tokens({"max_output_tokens": 9}, deployment) == 9
+
+    def test_resolve_max_tokens_conflicting_caps_reserve_larger(self):
+        deployment = {"litellm_params": {"model": "openai/gpt-4o-mini"}}
+        assert _resolve_max_tokens({"max_tokens": 1, "max_completion_tokens": 5000}, deployment) == 5000
+        assert _resolve_max_tokens({"max_tokens": 5000, "max_completion_tokens": 1}, deployment) == 5000
+        assert _resolve_max_tokens({"max_tokens": 0, "max_completion_tokens": 12}, deployment) == 12
 
     def test_build_io_token_rate_limit_headers(self):
         headers = build_io_token_rate_limit_headers(


### PR DESCRIPTION
## Relevant issues

Closes the admission-side token rate-limit bypass flagged by the automated security review on PR #34214 (https://github.com/BerriAI/litellm/pull/34214#discussion_r3626840248) and complements that PR's outbound Azure fix

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All runs hit the real Azure OpenAI API (real spend, no mocks). Because this PR sits on `litellm_internal_staging`, where Azure rejects a request that carries both `max_tokens` and `max_completion_tokens` upstream, the bypass is only reachable once PR #34214's outbound Azure fix (which sends only `max_completion_tokens` when both are set) is present. The BEFORE stack is therefore PR #34214's head `db30fa0f9e` exactly (vulnerable: #34214's Azure fix without this PR's reservation fix); the AFTER stack is a local, unpushed merge `965578ecad` of `db30fa0f9e` and this PR's fix commit `c80de961a0`. Both stacks ran the identical config and identical curl commands against the same Azure deployment; the only difference is this PR's three-line reservation fix

The attack body is `max_tokens: 1` paired with `max_completion_tokens: 800`. Scenario 1 targets a deployment `otpm: 50` limit and exercises `_resolve_max_tokens`; scenario 2 targets a virtual key `tpm_limit: 60` and exercises `_estimate_tokens_for_request` in the v3 parallel request limiter. Controls in the AFTER stack send only a small `max_completion_tokens: 30` and are expected to pass, proving the fix reserves the true cap rather than blanket-blocking

| run | stack | scenario | request cap pair | result |
| --- | --- | --- | --- | --- |
| 1 | before `db30fa0f9e` | S1 deployment OTPM=50 | max_tokens=1, mct=800 | 200, completion_tokens=800 |
| 1b | before `db30fa0f9e` | S1 repeat (post-call charged) | max_tokens=1, mct=800 | 200, completion_tokens=715 |
| 2 | before `db30fa0f9e` | S2 key TPM=60 | max_tokens=1, mct=800 | 200, completion_tokens=738 |
| 3 | after `965578ecad` | S1 deployment OTPM=50 | max_tokens=1, mct=800 | 429 OTPM, 0 tokens generated |
| 4 | after `965578ecad` | S1 control | mct=30 only | 200, completion_tokens=2 |
| 5 | after `965578ecad` | S2 key TPM=60 | max_tokens=1, mct=800 | 429 TPM, 0 tokens generated |
| 6 | after `965578ecad` | S2 control fresh key | mct=30 only | 200, completion_tokens=2 |

Config used on both stacks (`mct` is `max_completion_tokens`); the v3 key TPM path needs no extra flag, the deployment OTPM path needs `optional_pre_call_checks: ["enforce_model_rate_limits"]`:

```yaml
model_list:
  - model_name: azure-gpt-4o-otpm
    litellm_params:
      model: azure/gpt-4o
      api_base: os.environ/AZURE_API_BASE
      api_key: os.environ/AZURE_API_KEY
      api_version: "2024-10-21"
      otpm: 50
  - model_name: azure-gpt-4o
    litellm_params:
      model: azure/gpt-4o
      api_base: os.environ/AZURE_API_BASE
      api_key: os.environ/AZURE_API_KEY
      api_version: "2024-10-21"
router_settings:
  optional_pre_call_checks: ["enforce_model_rate_limits"]
general_settings:
  master_key: sk-qa-34223
```

### Scenario 1, deployment OTPM=50, BEFORE (`db30fa0f9e`)

The `max_tokens: 1` cap is what the limiter reserved, so 800 output tokens sail through against a 50 OTPM limit; the bypass is the admission window

```
curl -sS -w '\nHTTP_STATUS:%{http_code}\n' http://localhost:41387/v1/chat/completions \
  -H "Authorization: Bearer sk-qa-34223" -H "Content-Type: application/json" \
  -d '{"model":"azure-gpt-4o-otpm","messages":[{"role":"user","content":"Write a 500 word essay about the history of shipping containers."}],"max_tokens":1,"max_completion_tokens":800}'

{"id": "chatcmpl-E4JDYcvpZWYkHT3AdFsT9wxLwnk63", "model": "azure-gpt-4o-otpm", "choices": [{"finish_reason": "length", "message": {"role": "assistant", "content": "**The History of Shipping Containers: Revolutionizing Global Trade** ..."}}], "usage": {"completion_tokens": 800, "prompt_tokens": 20, "total_tokens": 820, "completion_tokens_details": {"accepted_prediction_tokens": 0, "audio_tokens": 0, "reasoning_tokens": 0, "rejected_prediction_tokens": 0}, "prompt_tokens_details": {"audio_tokens": 0, "cached_tokens": 0}}
HTTP_STATUS:200
```

An immediately repeated identical request still returns 200 because post-call reconciliation only charges the actual usage after the first call completes, confirming the exposure is the admission window rather than a permanent hole:

```
HTTP_STATUS:200   completion_tokens=715
```

### Scenario 1, deployment OTPM=50, AFTER (`965578ecad`)

Reserving the true 800-token cap up front exceeds the 50 OTPM limit, so the request is refused before any tokens are generated:

```
curl -sS -w '\nHTTP_STATUS:%{http_code}\n' http://localhost:52734/v1/chat/completions \
  -H "Authorization: Bearer sk-qa-34223" -H "Content-Type: application/json" \
  -d '{"model":"azure-gpt-4o-otpm","messages":[{"role":"user","content":"Write a 500 word essay about the history of shipping containers."}],"max_tokens":1,"max_completion_tokens":800}'

{"error":{"message":"litellm.RateLimitError: Model rate limit exceeded. OTPM limit=50, current usage=800. Received Model Group=azure-gpt-4o-otpm\nAvailable Model Group Fallbacks=None","type":"throttling_error","param":null,"code":"429"}}
HTTP_STATUS:429
```

Control on the same route, small cap only, proves the fix does not over-block:

```
curl -sS -w '\nHTTP_STATUS:%{http_code}\n' http://localhost:52734/v1/chat/completions \
  -H "Authorization: Bearer sk-qa-34223" -H "Content-Type: application/json" \
  -d '{"model":"azure-gpt-4o-otpm","messages":[{"role":"user","content":"Reply with just OK."}],"max_completion_tokens":30}'

{"id": "chatcmpl-E4JIhP1zBimFKoZhInJzrnosD2aIB", "model": "azure-gpt-4o-otpm", "choices": [{"finish_reason": "stop", "message": {"role": "assistant", "content": "OK ..."}}], "usage": {"completion_tokens": 2, "prompt_tokens": 12, "total_tokens": 14, "completion_tokens_details": {"accepted_prediction_tokens": 0, "audio_tokens": 0, "reasoning_tokens": 0, "rejected_prediction_tokens": 0}, "prompt_tokens_details": {"audio_tokens": 0, "cached_tokens": 0}}
HTTP_STATUS:200
```

### Scenario 2, key TPM=60, BEFORE (`db30fa0f9e`)

Generate a limited key, then send the attack body. 738 output tokens pass against a 60 TPM key because the v3 limiter reserved off `max_tokens=1`:

```
curl -sS http://localhost:41387/key/generate -H "Authorization: Bearer sk-qa-34223" \
  -H "Content-Type: application/json" -d '{"tpm_limit": 60, "models": []}'

curl -sS -w '\nHTTP_STATUS:%{http_code}\n' http://localhost:41387/v1/chat/completions \
  -H "Authorization: Bearer <generated-key>" -H "Content-Type: application/json" \
  -d '{"model":"azure-gpt-4o","messages":[{"role":"user","content":"Write a 500 word essay about the history of shipping containers."}],"max_tokens":1,"max_completion_tokens":800}'

{"id": "chatcmpl-E4JH3OYPUpXt9mmYe8qhwoaI6MG5z", "model": "azure-gpt-4o", "choices": [{"finish_reason": "stop", "message": {"role": "assistant", "content": "### The History of Shipping Containers ..."}}], "usage": {"completion_tokens": 738, "prompt_tokens": 20, "total_tokens": 758, "completion_tokens_details": {"accepted_prediction_tokens": 0, "audio_tokens": 0, "reasoning_tokens": 0, "rejected_prediction_tokens": 0}, "prompt_tokens_details": {"audio_tokens": 0, "cached_tokens": 0}}
HTTP_STATUS:200
```

The v3 limiter reservation log line confirms the under-reservation (`max_tokens=1`):

```
TPM reservation estimate: input=16, max_tokens=1 (explicit=True), total=17
```

### Scenario 2, key TPM=60, AFTER (`965578ecad`)

Same attack body, fresh 60 TPM key; the reservation now reflects the true 800 cap and the request is refused:

```
curl -sS -w '\nHTTP_STATUS:%{http_code}\n' http://localhost:52734/v1/chat/completions \
  -H "Authorization: Bearer <generated-key>" -H "Content-Type: application/json" \
  -d '{"model":"azure-gpt-4o","messages":[{"role":"user","content":"Write a 500 word essay about the history of shipping containers."}],"max_tokens":1,"max_completion_tokens":800}'

{"error":{"message":"Rate limit exceeded for api_key: <hash>. Limit type: tokens. Current limit: 60, Remaining: 60. Limit resets at: 2026-07-21 21:58:02 UTC","type":"throttling_error","param":null,"code":"429"}}
HTTP_STATUS:429
```

The v3 limiter reservation log line now shows the corrected reservation (`max_tokens=800`):

```
TPM reservation estimate: input=16, max_tokens=800 (explicit=True), total=816
```

Control on a fresh 60 TPM key, small cap only, passes:

```
curl -sS -w '\nHTTP_STATUS:%{http_code}\n' http://localhost:52734/v1/chat/completions \
  -H "Authorization: Bearer <generated-key>" -H "Content-Type: application/json" \
  -d '{"model":"azure-gpt-4o","messages":[{"role":"user","content":"Reply with just OK."}],"max_completion_tokens":30}'

{"id": "chatcmpl-E4JJ3hsuc2oBtU112GQfM8q1m6FZN", "model": "azure-gpt-4o", "choices": [{"finish_reason": "stop", "message": {"role": "assistant", "content": "OK ..."}}], "usage": {"completion_tokens": 2, "prompt_tokens": 12, "total_tokens": 14, "completion_tokens_details": {"accepted_prediction_tokens": 0, "audio_tokens": 0, "reasoning_tokens": 0, "rejected_prediction_tokens": 0}, "prompt_tokens_details": {"audio_tokens": 0, "cached_tokens": 0}}
HTTP_STATUS:200
```

The matching control reservation line confirms the small cap is reserved as-is, so the fix reserves the true cap in both directions:

```
TPM reservation estimate: input=4, max_tokens=30 (explicit=True), total=34
```

## Type

🐛 Bug Fix

## Changes

An authenticated caller could send max_tokens=1 together with a large max_completion_tokens and have the pre-call reservation estimators reserve output budget from the smaller cap while the provider generated up to the larger one. PR #34214 made Azure honor max_completion_tokens when both caps are sent and other providers resolve the conflict differently, so any first-wins precedence in a reservation estimator can under-reserve. Post-call reconciliation charges actual usage, which limits the exposure to the concurrent admission window, but during that window a burst of tiny-cap requests could admit far more in-flight output tokens than the configured limits allow

This PR makes every pre-routing reservation estimator reserve the largest explicit cap present. _estimate_tokens_for_request in litellm/proxy/hooks/parallel_request_limiter_v3.py now takes the max over max_tokens and max_completion_tokens instead of preferring max_tokens, and _resolve_max_tokens in litellm/router_utils/pre_call_checks/io_token_rate_limit_check.py now takes the max over max_tokens, max_completion_tokens, and max_output_tokens instead of returning the first one present. A sweep for other reservation sites found _estimate_output_tokens in litellm/proxy/spend_tracking/budget_reservation.py with the mirror-image precedence (max_completion_tokens first), so it now takes the max as well

Reservation estimators run before routing and cannot know which cap the provider transformation will honor, so reserving the max is the only value that never under-reserves; over-reservation self-corrects at post-call reconciliation, while under-reservation was the bypass. Explicit-zero semantics are preserved: a request carrying only max_tokens=0 still reserves 0

One unrelated two-line touch rode along because make pre-commit is currently red on the branch tip: tests/e2e/load/test_session_anomaly.py constructs Success without its required status_code field, which fails the e2e basedpyright lint step for every PR, so the two constructions now pass status_code=200

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
