### PR TITLE
fix(bedrock): preserve real tools in fake streams

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -1735,10 +1735,38 @@ class MockResponseIterator:  # for returning ai21 streaming responses
         """
         tool_use: Optional[ChatCompletionToolCallChunk] = None
         if self.json_mode is True and tool_calls is not None:
-            message = litellm.AnthropicConfig()._convert_tool_response_to_message(tool_calls=tool_calls)
-            if message is not None:
-                text = message.content or ""
-                tool_use = None
+            # ``json_mode`` is also set when response_format is emulated with the
+            # internal ``json_tool_call``. A fake stream can still contain a real
+            # user tool call, so converting the first tool unconditionally loses
+            # the protocol signal needed by streaming SDK clients to execute it.
+            json_mode_tool_calls = [
+                tool_call
+                for tool_call in tool_calls
+                if tool_call["function"].get("name") == RESPONSE_FORMAT_TOOL_NAME
+            ]
+            regular_tool_calls = [
+                tool_call
+                for tool_call in tool_calls
+                if tool_call["function"].get("name") != RESPONSE_FORMAT_TOOL_NAME
+            ]
+
+            if json_mode_tool_calls:
+                message = litellm.AnthropicConfig()._convert_tool_response_to_message(
+                    tool_calls=json_mode_tool_calls
+                )
+                if message is not None:
+                    text = message.content or ""
+            if regular_tool_calls:
+                regular_tool_call = regular_tool_calls[0]
+                tool_use = ChatCompletionToolCallChunk(
+                    id=regular_tool_call.id,
+                    type="function",
+                    function=ChatCompletionToolCallFunctionChunk(
+                        name=regular_tool_call.function.name,
+                        arguments=regular_tool_call.function.arguments,
+                    ),
+                    index=0,
+                )
         elif tool_calls is not None and len(tool_calls) > 0:
             tool_use = tool_calls[0]
         return text, tool_use

--- a/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
@@ -12,10 +12,18 @@ import litellm
 from litellm.llms.bedrock.chat.invoke_handler import (
     AWSEventStreamDecoder,
     BedrockLLM,
+    MockResponseIterator,
     make_call,
     make_sync_call,
 )
 from litellm.llms.custom_httpx.http_handler import HTTPHandler
+from litellm.types.utils import (
+    ChatCompletionMessageToolCall,
+    Choices,
+    Function,
+    Message,
+    Usage,
+)
 
 
 def test_transform_thinking_blocks_with_redacted_content():
@@ -25,6 +33,85 @@ def test_transform_thinking_blocks_with_redacted_content():
     assert len(transformed_thinking_blocks) == 1
     assert transformed_thinking_blocks[0]["type"] == "redacted_thinking"
     assert transformed_thinking_blocks[0]["data"] == "This is a redacted content"
+
+
+def test_fake_stream_json_mode_preserves_regular_tool_use():
+    """A fake stream must not turn a user tool call into JSON text."""
+    response = litellm.ModelResponse(
+        id="chatcmpl-test",
+        created=0,
+        model="test",
+        object="chat.completion",
+        choices=[
+            Choices(
+                finish_reason="tool_calls",
+                index=0,
+                message=Message(
+                    content=None,
+                    role="assistant",
+                    tool_calls=[
+                        ChatCompletionMessageToolCall(
+                            function=Function(
+                                arguments='{"prefix":"service.request"}',
+                                name="get_metrics_by_prefix",
+                            ),
+                            id="call_metrics",
+                            type="function",
+                        )
+                    ],
+                    function_call=None,
+                ),
+            )
+        ],
+        usage=Usage(completion_tokens=1, prompt_tokens=1, total_tokens=2),
+    )
+
+    response_chunk = MockResponseIterator(
+        model_response=response, json_mode=True
+    )._chunk_parser(chunk_data=response)
+
+    assert response_chunk["text"] == ""
+    assert response_chunk["tool_use"] is not None
+    assert response_chunk["tool_use"]["function"]["name"] == "get_metrics_by_prefix"
+
+
+def test_fake_stream_json_mode_converts_only_response_format_tool():
+    """The internal response-format tool remains regular JSON text."""
+    response = litellm.ModelResponse(
+        id="chatcmpl-test",
+        created=0,
+        model="test",
+        object="chat.completion",
+        choices=[
+            Choices(
+                finish_reason="tool_calls",
+                index=0,
+                message=Message(
+                    content=None,
+                    role="assistant",
+                    tool_calls=[
+                        ChatCompletionMessageToolCall(
+                            function=Function(
+                                arguments='{"values":{"result":"ok"}}',
+                                name="json_tool_call",
+                            ),
+                            id="call_response_format",
+                            type="function",
+                        )
+                    ],
+                    function_call=None,
+                ),
+            )
+        ],
+        usage=Usage(completion_tokens=1, prompt_tokens=1, total_tokens=2),
+    )
+
+    response_chunk = MockResponseIterator(
+        model_response=response, json_mode=True
+    )._chunk_parser(chunk_data=response)
+
+    assert response_chunk["text"] == '{"result": "ok"}'
+    assert response_chunk["tool_use"] is None
 
 
 def test_transform_tool_calls_index():


### PR DESCRIPTION
## Summary

Preserve real user tool calls when Bedrock Converse uses LiteLLM's fake-stream response-format fallback.

## Root cause

When `json_mode=True`, `MockResponseIterator` previously converted the first returned tool call into message text without checking its name. This is correct only for LiteLLM's internal `json_tool_call` response-format tool. A real user tool call was therefore emitted as text instead of an OpenAI-compatible tool call, so streaming agent SDKs could not execute it.

## Changes

- Separate the internal `json_tool_call` from regular tool calls in the fake-stream iterator.
- Convert only the internal response-format tool to JSON text.
- Preserve the first regular tool call as `tool_use`.
- Add regression coverage for both cases.

## Validation

`python -m pytest tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py -k 'fake_stream_json_mode' -q`

Both tests pass.
