### PR TITLE
fix(bedrock): preserve tools in Converse streams

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -9,9 +9,7 @@ from functools import partial
 from typing import (
     AsyncIterator,
     Callable,
-    Dict,
     Iterator,
-    List,
     Optional,
     Tuple,
     cast,
@@ -1288,8 +1286,8 @@ class AWSEventStreamDecoder:
         # Bedrock can stream multiple content blocks concurrently. Keep the
         # state keyed by contentBlockIndex so a later block start cannot change
         # how an earlier block's delta is interpreted.
-        self._content_blocks_by_content_block_index: Dict[int, List[ContentBlockDeltaEvent]] = {}
-        self._tool_names_by_content_block_index: Dict[int, str] = {}
+        self._content_blocks_by_content_block_index: dict[int, list[ContentBlockDeltaEvent]] = {}
+        self._tool_names_by_content_block_index: dict[int, str] = {}
         self.tool_calls_index: Optional[int] = None
         self.response_id: Optional[str] = None
         self.json_mode = json_mode

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -1753,10 +1753,38 @@ class MockResponseIterator:  # for returning ai21 streaming responses
         """
         tool_use: Optional[ChatCompletionToolCallChunk] = None
         if self.json_mode is True and tool_calls is not None:
-            message = litellm.AnthropicConfig()._convert_tool_response_to_message(tool_calls=tool_calls)
-            if message is not None:
-                text = message.content or ""
-                tool_use = None
+            # ``json_mode`` is also set when response_format is emulated with the
+            # internal ``json_tool_call``. A fake stream can still contain a real
+            # user tool call, so converting the first tool unconditionally loses
+            # the protocol signal needed by streaming SDK clients to execute it.
+            json_mode_tool_calls = [
+                tool_call
+                for tool_call in tool_calls
+                if tool_call["function"].get("name") == RESPONSE_FORMAT_TOOL_NAME
+            ]
+            regular_tool_calls = [
+                tool_call
+                for tool_call in tool_calls
+                if tool_call["function"].get("name") != RESPONSE_FORMAT_TOOL_NAME
+            ]
+
+            if json_mode_tool_calls:
+                message = litellm.AnthropicConfig()._convert_tool_response_to_message(
+                    tool_calls=json_mode_tool_calls
+                )
+                if message is not None:
+                    text = message.content or ""
+            if regular_tool_calls:
+                regular_tool_call = regular_tool_calls[0]
+                tool_use = ChatCompletionToolCallChunk(
+                    id=regular_tool_call.id,
+                    type="function",
+                    function=ChatCompletionToolCallFunctionChunk(
+                        name=regular_tool_call.function.name,
+                        arguments=regular_tool_call.function.arguments,
+                    ),
+                    index=0,
+                )
         elif tool_calls is not None and len(tool_calls) > 0:
             tool_use = tool_calls[0]
         return text, tool_use

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -9,7 +9,9 @@ from functools import partial
 from typing import (
     AsyncIterator,
     Callable,
+    Dict,
     Iterator,
+    List,
     Optional,
     Tuple,
     cast,
@@ -1283,27 +1285,35 @@ class AWSEventStreamDecoder:
 
         self.model = model
         self.parser = EventStreamJSONParser()
-        self.content_blocks: List[ContentBlockDeltaEvent] = []
+        # Bedrock can stream multiple content blocks concurrently. Keep the
+        # state keyed by contentBlockIndex so a later block start cannot change
+        # how an earlier block's delta is interpreted.
+        self._content_blocks_by_content_block_index: Dict[
+            int, List[ContentBlockDeltaEvent]
+        ] = {}
+        self._tool_names_by_content_block_index: Dict[int, str] = {}
         self.tool_calls_index: Optional[int] = None
         self.response_id: Optional[str] = None
         self.json_mode = json_mode
-        self._current_tool_name: Optional[str] = None
 
-    def check_empty_tool_call_args(self) -> bool:
+    def check_empty_tool_call_args(self, content_block_index: int) -> bool:
         """
         Check if the tool call block so far has been an empty string
         """
         args = ""
         # if text content block -> skip
-        if len(self.content_blocks) == 0:
+        content_blocks = self._content_blocks_by_content_block_index.get(
+            content_block_index, []
+        )
+        if len(content_blocks) == 0:
             return False
 
         if (
-            "toolUse" not in self.content_blocks[0]
+            "toolUse" not in content_blocks[0]
         ):  # be explicit - only do this if tool use block, as this is to prevent json decoding errors
             return False
 
-        for block in self.content_blocks:
+        for block in content_blocks:
             if "toolUse" in block:
                 args += block["toolUse"]["input"]
 
@@ -1357,6 +1367,7 @@ class AWSEventStreamDecoder:
     def _handle_converse_start_event(
         self,
         start_obj: ContentBlockStartEvent,
+        content_block_index: int = 0,
     ) -> Tuple[
         Optional[ChatCompletionToolCallChunk],
         dict,
@@ -1367,13 +1378,15 @@ class AWSEventStreamDecoder:
         provider_specific_fields: dict = {}
         thinking_blocks: Optional[List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]]] = None
 
-        self.content_blocks = []  # reset
+        self._content_blocks_by_content_block_index[content_block_index] = []
         if start_obj is not None:
             if "toolUse" in start_obj and start_obj["toolUse"] is not None:
                 ## check tool name was formatted by litellm
                 _response_tool_name = start_obj["toolUse"]["name"]
                 response_tool_name = get_bedrock_tool_name(response_tool_name=_response_tool_name)
-                self._current_tool_name = response_tool_name
+                self._tool_names_by_content_block_index[content_block_index] = (
+                    response_tool_name
+                )
 
                 # When json_mode is True, suppress the internal json_tool_call
                 # and convert its content to text in delta events instead
@@ -1417,13 +1430,17 @@ class AWSEventStreamDecoder:
         reasoning_content: Optional[str] = None
         thinking_blocks: Optional[List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]]] = None
 
-        self.content_blocks.append(delta_obj)
+        self._content_blocks_by_content_block_index.setdefault(index, []).append(delta_obj)
         if "text" in delta_obj:
             text = delta_obj["text"]
         elif "toolUse" in delta_obj:
             # When json_mode is True and this is the internal json_tool_call,
             # convert tool input to text content instead of tool call arguments
-            if self.json_mode is True and self._current_tool_name == RESPONSE_FORMAT_TOOL_NAME:
+            if (
+                self.json_mode is True
+                and self._tool_names_by_content_block_index.get(index)
+                == RESPONSE_FORMAT_TOOL_NAME
+            ):
                 text = delta_obj["toolUse"]["input"]
             else:
                 tool_use = {
@@ -1460,14 +1477,15 @@ class AWSEventStreamDecoder:
         """Handle stop/contentBlockIndex event in converse chunk parsing."""
         tool_use: Optional[ChatCompletionToolCallChunk] = None
 
+        tool_name = self._tool_names_by_content_block_index.pop(index, None)
         # If the ending block was the internal json_tool_call, skip emitting
-        # the empty-args tool chunk and reset tracking state
-        if self.json_mode is True and self._current_tool_name == RESPONSE_FORMAT_TOOL_NAME:
-            self._current_tool_name = None
+        # the empty-args tool chunk.
+        if self.json_mode is True and tool_name == RESPONSE_FORMAT_TOOL_NAME:
+            self._content_blocks_by_content_block_index.pop(index, None)
             return tool_use
 
-        self._current_tool_name = None
-        is_empty = self.check_empty_tool_call_args()
+        is_empty = self.check_empty_tool_call_args(index)
+        self._content_blocks_by_content_block_index.pop(index, None)
         if is_empty:
             tool_use = {
                 "id": None,
@@ -1504,7 +1522,7 @@ class AWSEventStreamDecoder:
                     tool_use,
                     provider_specific_fields,
                     thinking_blocks,
-                ) = self._handle_converse_start_event(start_obj)
+                ) = self._handle_converse_start_event(start_obj, content_block_index)
             elif "delta" in chunk_data:
                 delta_obj = ContentBlockDeltaEvent(**chunk_data["delta"])
                 (

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -1283,9 +1283,7 @@ class AWSEventStreamDecoder:
 
         self.model = model
         self.parser = EventStreamJSONParser()
-        # Bedrock can stream multiple content blocks concurrently. Keep the
-        # state keyed by contentBlockIndex so a later block start cannot change
-        # how an earlier block's delta is interpreted.
+        # Bedrock associates streamed deltas with content blocks by this index.
         self._content_blocks_by_content_block_index: dict[int, list[ContentBlockDeltaEvent]] = {}
         self._tool_names_by_content_block_index: dict[int, str] = {}
         self.tool_calls_index: Optional[int] = None
@@ -1380,8 +1378,7 @@ class AWSEventStreamDecoder:
                 response_tool_name = get_bedrock_tool_name(response_tool_name=_response_tool_name)
                 self._tool_names_by_content_block_index[content_block_index] = response_tool_name
 
-                # When json_mode is True, suppress the internal json_tool_call
-                # and convert its content to text in delta events instead
+                # response_format is represented by an internal tool call.
                 if self.json_mode is True and response_tool_name == RESPONSE_FORMAT_TOOL_NAME:
                     return tool_use, provider_specific_fields, thinking_blocks
 
@@ -1426,8 +1423,6 @@ class AWSEventStreamDecoder:
         if "text" in delta_obj:
             text = delta_obj["text"]
         elif "toolUse" in delta_obj:
-            # When json_mode is True and this is the internal json_tool_call,
-            # convert tool input to text content instead of tool call arguments
             if (
                 self.json_mode is True
                 and self._tool_names_by_content_block_index.get(index) == RESPONSE_FORMAT_TOOL_NAME
@@ -1469,8 +1464,6 @@ class AWSEventStreamDecoder:
         tool_use: Optional[ChatCompletionToolCallChunk] = None
 
         tool_name = self._tool_names_by_content_block_index.pop(index, None)
-        # If the ending block was the internal json_tool_call, skip emitting
-        # the empty-args tool chunk.
         if self.json_mode is True and tool_name == RESPONSE_FORMAT_TOOL_NAME:
             self._content_blocks_by_content_block_index.pop(index, None)
             return tool_use
@@ -1744,10 +1737,7 @@ class MockResponseIterator:  # for returning ai21 streaming responses
         """
         tool_use: Optional[ChatCompletionToolCallChunk] = None
         if self.json_mode is True and tool_calls is not None:
-            # ``json_mode`` is also set when response_format is emulated with the
-            # internal ``json_tool_call``. A fake stream can still contain a real
-            # user tool call, so converting the first tool unconditionally loses
-            # the protocol signal needed by streaming SDK clients to execute it.
+            # Bedrock represents response_format as an internal json_tool_call.
             json_mode_tool_calls = [
                 tool_call for tool_call in tool_calls if tool_call["function"].get("name") == RESPONSE_FORMAT_TOOL_NAME
             ]

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -1288,9 +1288,7 @@ class AWSEventStreamDecoder:
         # Bedrock can stream multiple content blocks concurrently. Keep the
         # state keyed by contentBlockIndex so a later block start cannot change
         # how an earlier block's delta is interpreted.
-        self._content_blocks_by_content_block_index: Dict[
-            int, List[ContentBlockDeltaEvent]
-        ] = {}
+        self._content_blocks_by_content_block_index: Dict[int, List[ContentBlockDeltaEvent]] = {}
         self._tool_names_by_content_block_index: Dict[int, str] = {}
         self.tool_calls_index: Optional[int] = None
         self.response_id: Optional[str] = None
@@ -1302,9 +1300,7 @@ class AWSEventStreamDecoder:
         """
         args = ""
         # if text content block -> skip
-        content_blocks = self._content_blocks_by_content_block_index.get(
-            content_block_index, []
-        )
+        content_blocks = self._content_blocks_by_content_block_index.get(content_block_index, [])
         if len(content_blocks) == 0:
             return False
 
@@ -1384,9 +1380,7 @@ class AWSEventStreamDecoder:
                 ## check tool name was formatted by litellm
                 _response_tool_name = start_obj["toolUse"]["name"]
                 response_tool_name = get_bedrock_tool_name(response_tool_name=_response_tool_name)
-                self._tool_names_by_content_block_index[content_block_index] = (
-                    response_tool_name
-                )
+                self._tool_names_by_content_block_index[content_block_index] = response_tool_name
 
                 # When json_mode is True, suppress the internal json_tool_call
                 # and convert its content to text in delta events instead
@@ -1438,8 +1432,7 @@ class AWSEventStreamDecoder:
             # convert tool input to text content instead of tool call arguments
             if (
                 self.json_mode is True
-                and self._tool_names_by_content_block_index.get(index)
-                == RESPONSE_FORMAT_TOOL_NAME
+                and self._tool_names_by_content_block_index.get(index) == RESPONSE_FORMAT_TOOL_NAME
             ):
                 text = delta_obj["toolUse"]["input"]
             else:
@@ -1758,20 +1751,14 @@ class MockResponseIterator:  # for returning ai21 streaming responses
             # user tool call, so converting the first tool unconditionally loses
             # the protocol signal needed by streaming SDK clients to execute it.
             json_mode_tool_calls = [
-                tool_call
-                for tool_call in tool_calls
-                if tool_call["function"].get("name") == RESPONSE_FORMAT_TOOL_NAME
+                tool_call for tool_call in tool_calls if tool_call["function"].get("name") == RESPONSE_FORMAT_TOOL_NAME
             ]
             regular_tool_calls = [
-                tool_call
-                for tool_call in tool_calls
-                if tool_call["function"].get("name") != RESPONSE_FORMAT_TOOL_NAME
+                tool_call for tool_call in tool_calls if tool_call["function"].get("name") != RESPONSE_FORMAT_TOOL_NAME
             ]
 
             if json_mode_tool_calls:
-                message = litellm.AnthropicConfig()._convert_tool_response_to_message(
-                    tool_calls=json_mode_tool_calls
-                )
+                message = litellm.AnthropicConfig()._convert_tool_response_to_message(tool_calls=json_mode_tool_calls)
                 if message is not None:
                     text = message.content or ""
             if regular_tool_calls:

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -426,8 +426,7 @@ class AWSEventStreamDecoder:
                     response_tool_name
                 )
 
-                # When json_mode is True, suppress the internal json_tool_call
-                # and convert its content to text in delta events instead
+                # response_format is represented by an internal tool call.
                 if self.json_mode is True and response_tool_name == RESPONSE_FORMAT_TOOL_NAME:
                     return tool_use, provider_specific_fields, thinking_blocks
 
@@ -472,8 +471,6 @@ class AWSEventStreamDecoder:
         if "text" in delta_obj:
             text = delta_obj["text"]
         elif "toolUse" in delta_obj:
-            # When json_mode is True and this is the internal json_tool_call,
-            # convert tool input to text content instead of tool call arguments
             if (
                 self.json_mode is True
                 and self._tool_names_by_content_block_index.get(index) == RESPONSE_FORMAT_TOOL_NAME
@@ -515,8 +512,6 @@ class AWSEventStreamDecoder:
         tool_use: ChatCompletionToolCallChunk | None = None
 
         tool_name = self._tool_names_by_content_block_index.pop(index, None)
-        # If the ending block was the internal json_tool_call, skip emitting
-        # the empty-args tool chunk.
         if self.json_mode is True and tool_name == RESPONSE_FORMAT_TOOL_NAME:
             self._content_blocks_by_content_block_index.pop(index, None)
             return tool_use
@@ -786,10 +781,7 @@ class MockResponseIterator:  # for returning ai21 streaming responses
         """
         tool_use: ChatCompletionToolCallChunk | None = None
         if self.json_mode is True and tool_calls is not None:
-            # ``json_mode`` is also set when response_format is emulated with the
-            # internal ``json_tool_call``. A fake stream can still contain a real
-            # user tool call, so converting the first tool unconditionally loses
-            # the protocol signal needed by streaming SDK clients to execute it.
+            # Bedrock represents response_format as an internal json_tool_call.
             json_mode_tool_calls = [
                 tool_call for tool_call in tool_calls if tool_call["function"].get("name") == RESPONSE_FORMAT_TOOL_NAME
             ]

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -328,9 +328,7 @@ class AWSEventStreamDecoder:
         # Bedrock can stream multiple content blocks concurrently. Keep the
         # state keyed by contentBlockIndex so a later block start cannot change
         # how an earlier block's delta is interpreted.
-        self._content_blocks_by_content_block_index: dict[
-            int, list[ContentBlockDeltaEvent]
-        ] = {}
+        self._content_blocks_by_content_block_index: dict[int, list[ContentBlockDeltaEvent]] = {}
         self._tool_names_by_content_block_index: dict[int, str] = {}
         self.tool_calls_index: int | None = None
         self.response_id: str | None = None
@@ -422,9 +420,7 @@ class AWSEventStreamDecoder:
                 ## check tool name was formatted by litellm
                 _response_tool_name: Final = start_obj["toolUse"]["name"]
                 response_tool_name: Final = get_bedrock_tool_name(response_tool_name=_response_tool_name)
-                self._tool_names_by_content_block_index[content_block_index] = (
-                    response_tool_name
-                )
+                self._tool_names_by_content_block_index[content_block_index] = response_tool_name
 
                 # response_format is represented by an internal tool call.
                 if self.json_mode is True and response_tool_name == RESPONSE_FORMAT_TOOL_NAME:

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -325,27 +325,35 @@ class AWSEventStreamDecoder:
 
         self.model = model
         self.parser = EventStreamJSONParser()
-        self.content_blocks: list[ContentBlockDeltaEvent] = []
+        # Bedrock can stream multiple content blocks concurrently. Keep the
+        # state keyed by contentBlockIndex so a later block start cannot change
+        # how an earlier block's delta is interpreted.
+        self._content_blocks_by_content_block_index: dict[
+            int, list[ContentBlockDeltaEvent]
+        ] = {}
+        self._tool_names_by_content_block_index: dict[int, str] = {}
         self.tool_calls_index: int | None = None
         self.response_id: str | None = None
         self.json_mode = json_mode
-        self._current_tool_name: str | None = None
 
-    def check_empty_tool_call_args(self) -> bool:
+    def check_empty_tool_call_args(self, content_block_index: int) -> bool:
         """
         Check if the tool call block so far has been an empty string
         """
         args = ""
         # if text content block -> skip
-        if len(self.content_blocks) == 0:
+        content_blocks = self._content_blocks_by_content_block_index.get(
+            content_block_index, []
+        )
+        if len(content_blocks) == 0:
             return False
 
         if (
-            "toolUse" not in self.content_blocks[0]
+            "toolUse" not in content_blocks[0]
         ):  # be explicit - only do this if tool use block, as this is to prevent json decoding errors
             return False
 
-        for block in self.content_blocks:
+        for block in content_blocks:
             if "toolUse" in block:
                 args += block["toolUse"]["input"]
 
@@ -399,6 +407,7 @@ class AWSEventStreamDecoder:
     def _handle_converse_start_event(
         self,
         start_obj: ContentBlockStartEvent,
+        content_block_index: int = 0,
     ) -> tuple[
         ChatCompletionToolCallChunk | None,
         dict,
@@ -409,13 +418,15 @@ class AWSEventStreamDecoder:
         provider_specific_fields: dict = {}
         thinking_blocks: list[ChatCompletionThinkingBlock | ChatCompletionRedactedThinkingBlock] | None = None
 
-        self.content_blocks = []  # reset
+        self._content_blocks_by_content_block_index[content_block_index] = []
         if start_obj is not None:
             if "toolUse" in start_obj and start_obj["toolUse"] is not None:
                 ## check tool name was formatted by litellm
                 _response_tool_name: Final = start_obj["toolUse"]["name"]
                 response_tool_name: Final = get_bedrock_tool_name(response_tool_name=_response_tool_name)
-                self._current_tool_name = response_tool_name
+                self._tool_names_by_content_block_index[content_block_index] = (
+                    response_tool_name
+                )
 
                 # When json_mode is True, suppress the internal json_tool_call
                 # and convert its content to text in delta events instead
@@ -459,13 +470,17 @@ class AWSEventStreamDecoder:
         reasoning_content: str | None = None
         thinking_blocks: list[ChatCompletionThinkingBlock | ChatCompletionRedactedThinkingBlock] | None = None
 
-        self.content_blocks.append(delta_obj)
+        self._content_blocks_by_content_block_index.setdefault(index, []).append(delta_obj)
         if "text" in delta_obj:
             text = delta_obj["text"]
         elif "toolUse" in delta_obj:
             # When json_mode is True and this is the internal json_tool_call,
             # convert tool input to text content instead of tool call arguments
-            if self.json_mode is True and self._current_tool_name == RESPONSE_FORMAT_TOOL_NAME:
+            if (
+                self.json_mode is True
+                and self._tool_names_by_content_block_index.get(index)
+                == RESPONSE_FORMAT_TOOL_NAME
+            ):
                 text = delta_obj["toolUse"]["input"]
             else:
                 tool_use = {
@@ -502,14 +517,15 @@ class AWSEventStreamDecoder:
         """Handle stop/contentBlockIndex event in converse chunk parsing."""
         tool_use: ChatCompletionToolCallChunk | None = None
 
+        tool_name = self._tool_names_by_content_block_index.pop(index, None)
         # If the ending block was the internal json_tool_call, skip emitting
-        # the empty-args tool chunk and reset tracking state
-        if self.json_mode is True and self._current_tool_name == RESPONSE_FORMAT_TOOL_NAME:
-            self._current_tool_name = None
+        # the empty-args tool chunk.
+        if self.json_mode is True and tool_name == RESPONSE_FORMAT_TOOL_NAME:
+            self._content_blocks_by_content_block_index.pop(index, None)
             return tool_use
 
-        self._current_tool_name = None
-        is_empty: Final = self.check_empty_tool_call_args()
+        is_empty: Final = self.check_empty_tool_call_args(index)
+        self._content_blocks_by_content_block_index.pop(index, None)
         if is_empty:
             tool_use = {
                 "id": None,
@@ -544,7 +560,7 @@ class AWSEventStreamDecoder:
                     tool_use,
                     provider_specific_fields,
                     thinking_blocks,
-                ) = self._handle_converse_start_event(start_obj)
+                ) = self._handle_converse_start_event(start_obj, content_block_index)
             elif "delta" in chunk_data:
                 delta_obj: Final = ContentBlockDeltaEvent(**chunk_data["delta"])
                 (

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -789,10 +789,38 @@ class MockResponseIterator:  # for returning ai21 streaming responses
         """
         tool_use: ChatCompletionToolCallChunk | None = None
         if self.json_mode is True and tool_calls is not None:
-            message: Final = litellm.AnthropicConfig()._convert_tool_response_to_message(tool_calls=tool_calls)
-            if message is not None:
-                text = message.content or ""
-                tool_use = None
+            # ``json_mode`` is also set when response_format is emulated with the
+            # internal ``json_tool_call``. A fake stream can still contain a real
+            # user tool call, so converting the first tool unconditionally loses
+            # the protocol signal needed by streaming SDK clients to execute it.
+            json_mode_tool_calls = [
+                tool_call
+                for tool_call in tool_calls
+                if tool_call["function"].get("name") == RESPONSE_FORMAT_TOOL_NAME
+            ]
+            regular_tool_calls = [
+                tool_call
+                for tool_call in tool_calls
+                if tool_call["function"].get("name") != RESPONSE_FORMAT_TOOL_NAME
+            ]
+
+            if json_mode_tool_calls:
+                message = litellm.AnthropicConfig()._convert_tool_response_to_message(
+                    tool_calls=json_mode_tool_calls
+                )
+                if message is not None:
+                    text = message.content or ""
+            if regular_tool_calls:
+                regular_tool_call = regular_tool_calls[0]
+                tool_use = ChatCompletionToolCallChunk(
+                    id=regular_tool_call.id,
+                    type="function",
+                    function=ChatCompletionToolCallFunctionChunk(
+                        name=regular_tool_call.function.name,
+                        arguments=regular_tool_call.function.arguments,
+                    ),
+                    index=0,
+                )
         elif tool_calls is not None and len(tool_calls) > 0:
             tool_use = tool_calls[0]
         return text, tool_use

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -342,9 +342,7 @@ class AWSEventStreamDecoder:
         """
         args = ""
         # if text content block -> skip
-        content_blocks = self._content_blocks_by_content_block_index.get(
-            content_block_index, []
-        )
+        content_blocks = self._content_blocks_by_content_block_index.get(content_block_index, [])
         if len(content_blocks) == 0:
             return False
 
@@ -478,8 +476,7 @@ class AWSEventStreamDecoder:
             # convert tool input to text content instead of tool call arguments
             if (
                 self.json_mode is True
-                and self._tool_names_by_content_block_index.get(index)
-                == RESPONSE_FORMAT_TOOL_NAME
+                and self._tool_names_by_content_block_index.get(index) == RESPONSE_FORMAT_TOOL_NAME
             ):
                 text = delta_obj["toolUse"]["input"]
             else:
@@ -794,20 +791,14 @@ class MockResponseIterator:  # for returning ai21 streaming responses
             # user tool call, so converting the first tool unconditionally loses
             # the protocol signal needed by streaming SDK clients to execute it.
             json_mode_tool_calls = [
-                tool_call
-                for tool_call in tool_calls
-                if tool_call["function"].get("name") == RESPONSE_FORMAT_TOOL_NAME
+                tool_call for tool_call in tool_calls if tool_call["function"].get("name") == RESPONSE_FORMAT_TOOL_NAME
             ]
             regular_tool_calls = [
-                tool_call
-                for tool_call in tool_calls
-                if tool_call["function"].get("name") != RESPONSE_FORMAT_TOOL_NAME
+                tool_call for tool_call in tool_calls if tool_call["function"].get("name") != RESPONSE_FORMAT_TOOL_NAME
             ]
 
             if json_mode_tool_calls:
-                message = litellm.AnthropicConfig()._convert_tool_response_to_message(
-                    tool_calls=json_mode_tool_calls
-                )
+                message = litellm.AnthropicConfig()._convert_tool_response_to_message(tool_calls=json_mode_tool_calls)
                 if message is not None:
                     text = message.content or ""
             if regular_tool_calls:

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -4517,7 +4517,7 @@ def test_streaming_filters_json_tool_call_with_real_tools():
 
 
 def test_streaming_interleaved_json_tool_call_does_not_hide_real_tool_delta():
-    """Keep each Bedrock content block's tool state separate while streaming."""
+    """Preserve a real tool delta when an internal JSON block starts later."""
     from litellm.llms.bedrock.chat.invoke_handler import AWSEventStreamDecoder
 
     decoder = AWSEventStreamDecoder(model="test-model", json_mode=True)

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -4475,7 +4475,7 @@ def test_streaming_filters_json_tool_call_with_real_tools():
             "name": "json_tool_call",
         }
     )
-    tool_use_1, _, _ = decoder._handle_converse_start_event(json_start)
+    tool_use_1, _, _ = decoder._handle_converse_start_event(json_start, 0)
     # json_tool_call start should be suppressed (return None tool_use)
     assert tool_use_1 is None
     # tool_calls_index should NOT have been incremented
@@ -4492,8 +4492,7 @@ def test_streaming_filters_json_tool_call_with_real_tools():
     # Chunk 3: json_tool_call stop
     stop_tool = decoder._handle_converse_stop_event(index=0)
     assert stop_tool is None
-    # _current_tool_name should be reset
-    assert decoder._current_tool_name is None
+    assert decoder._tool_names_by_content_block_index == {}
 
     # Chunk 4: real tool start
     real_start = ContentBlockStartEvent(
@@ -4502,7 +4501,7 @@ def test_streaming_filters_json_tool_call_with_real_tools():
             "name": "get_weather",
         }
     )
-    tool_use_4, _, _ = decoder._handle_converse_start_event(real_start)
+    tool_use_4, _, _ = decoder._handle_converse_start_event(real_start, 1)
     assert tool_use_4 is not None
     assert tool_use_4["function"]["name"] == "get_weather"
     assert decoder.tool_calls_index == 0
@@ -4515,6 +4514,51 @@ def test_streaming_filters_json_tool_call_with_real_tools():
     assert text_5 == ""
     assert tool_use_5 is not None
     assert tool_use_5["function"]["arguments"] == '{"location": "SF"}'
+
+
+def test_streaming_interleaved_json_tool_call_does_not_hide_real_tool_delta():
+    """Keep each Bedrock content block's tool state separate while streaming."""
+    from litellm.llms.bedrock.chat.invoke_handler import AWSEventStreamDecoder
+
+    decoder = AWSEventStreamDecoder(model="test-model", json_mode=True)
+
+    real_start = decoder.converse_chunk_parser(
+        {
+            "contentBlockIndex": 0,
+            "start": {
+                "toolUse": {
+                    "toolUseId": "tooluse_metrics_001",
+                    "name": "query_metrics",
+                }
+            },
+        }
+    )
+    assert (
+        real_start.choices[0].delta.tool_calls[0]["function"]["name"]
+        == "query_metrics"
+    )
+
+    decoder.converse_chunk_parser(
+        {
+            "contentBlockIndex": 1,
+            "start": {
+                "toolUse": {
+                    "toolUseId": "tooluse_json_001",
+                    "name": "json_tool_call",
+                }
+            },
+        }
+    )
+
+    real_delta = decoder.converse_chunk_parser(
+        {
+            "contentBlockIndex": 0,
+            "delta": {"toolUse": {"input": '{"prefix":"trace.grpc.server"}'}},
+        }
+    )
+    delta = real_delta.choices[0].delta
+    assert delta.content == ""
+    assert delta.tool_calls[0]["function"]["arguments"] == '{"prefix":"trace.grpc.server"}'
 
 
 def test_streaming_without_json_mode_passes_all_tools():

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -4683,7 +4683,7 @@ def test_streaming_filters_json_tool_call_with_real_tools():
 
 
 def test_streaming_interleaved_json_tool_call_does_not_hide_real_tool_delta():
-    """Keep each Bedrock content block's tool state separate while streaming."""
+    """Preserve a real tool delta when an internal JSON block starts later."""
     from litellm.llms.bedrock.chat.invoke_handler import AWSEventStreamDecoder
 
     decoder = AWSEventStreamDecoder(model="test-model", json_mode=True)

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -4641,7 +4641,7 @@ def test_streaming_filters_json_tool_call_with_real_tools():
             "name": "json_tool_call",
         }
     )
-    tool_use_1, _, _ = decoder._handle_converse_start_event(json_start)
+    tool_use_1, _, _ = decoder._handle_converse_start_event(json_start, 0)
     # json_tool_call start should be suppressed (return None tool_use)
     assert tool_use_1 is None
     # tool_calls_index should NOT have been incremented
@@ -4658,8 +4658,7 @@ def test_streaming_filters_json_tool_call_with_real_tools():
     # Chunk 3: json_tool_call stop
     stop_tool = decoder._handle_converse_stop_event(index=0)
     assert stop_tool is None
-    # _current_tool_name should be reset
-    assert decoder._current_tool_name is None
+    assert decoder._tool_names_by_content_block_index == {}
 
     # Chunk 4: real tool start
     real_start = ContentBlockStartEvent(
@@ -4668,7 +4667,7 @@ def test_streaming_filters_json_tool_call_with_real_tools():
             "name": "get_weather",
         }
     )
-    tool_use_4, _, _ = decoder._handle_converse_start_event(real_start)
+    tool_use_4, _, _ = decoder._handle_converse_start_event(real_start, 1)
     assert tool_use_4 is not None
     assert tool_use_4["function"]["name"] == "get_weather"
     assert decoder.tool_calls_index == 0
@@ -4681,6 +4680,51 @@ def test_streaming_filters_json_tool_call_with_real_tools():
     assert text_5 == ""
     assert tool_use_5 is not None
     assert tool_use_5["function"]["arguments"] == '{"location": "SF"}'
+
+
+def test_streaming_interleaved_json_tool_call_does_not_hide_real_tool_delta():
+    """Keep each Bedrock content block's tool state separate while streaming."""
+    from litellm.llms.bedrock.chat.invoke_handler import AWSEventStreamDecoder
+
+    decoder = AWSEventStreamDecoder(model="test-model", json_mode=True)
+
+    real_start = decoder.converse_chunk_parser(
+        {
+            "contentBlockIndex": 0,
+            "start": {
+                "toolUse": {
+                    "toolUseId": "tooluse_metrics_001",
+                    "name": "query_metrics",
+                }
+            },
+        }
+    )
+    assert (
+        real_start.choices[0].delta.tool_calls[0]["function"]["name"]
+        == "query_metrics"
+    )
+
+    decoder.converse_chunk_parser(
+        {
+            "contentBlockIndex": 1,
+            "start": {
+                "toolUse": {
+                    "toolUseId": "tooluse_json_001",
+                    "name": "json_tool_call",
+                }
+            },
+        }
+    )
+
+    real_delta = decoder.converse_chunk_parser(
+        {
+            "contentBlockIndex": 0,
+            "delta": {"toolUse": {"input": '{"prefix":"trace.grpc.server"}'}},
+        }
+    )
+    delta = real_delta.choices[0].delta
+    assert delta.content == ""
+    assert delta.tool_calls[0]["function"]["arguments"] == '{"prefix":"trace.grpc.server"}'
 
 
 def test_streaming_without_json_mode_passes_all_tools():

--- a/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
@@ -12,10 +12,18 @@ import litellm
 from litellm.llms.bedrock.chat.invoke_handler import (
     AWSEventStreamDecoder,
     BedrockLLM,
+    MockResponseIterator,
     make_call,
     make_sync_call,
 )
 from litellm.llms.custom_httpx.http_handler import HTTPHandler
+from litellm.types.utils import (
+    ChatCompletionMessageToolCall,
+    Choices,
+    Function,
+    Message,
+    Usage,
+)
 
 
 def test_transform_thinking_blocks_with_redacted_content():
@@ -25,6 +33,85 @@ def test_transform_thinking_blocks_with_redacted_content():
     assert len(transformed_thinking_blocks) == 1
     assert transformed_thinking_blocks[0]["type"] == "redacted_thinking"
     assert transformed_thinking_blocks[0]["data"] == "This is a redacted content"
+
+
+def test_fake_stream_json_mode_preserves_regular_tool_use():
+    """A fake stream must not turn a user tool call into JSON text."""
+    response = litellm.ModelResponse(
+        id="chatcmpl-test",
+        created=0,
+        model="test",
+        object="chat.completion",
+        choices=[
+            Choices(
+                finish_reason="tool_calls",
+                index=0,
+                message=Message(
+                    content=None,
+                    role="assistant",
+                    tool_calls=[
+                        ChatCompletionMessageToolCall(
+                            function=Function(
+                                arguments='{"prefix":"service.request"}',
+                                name="get_metrics_by_prefix",
+                            ),
+                            id="call_metrics",
+                            type="function",
+                        )
+                    ],
+                    function_call=None,
+                ),
+            )
+        ],
+        usage=Usage(completion_tokens=1, prompt_tokens=1, total_tokens=2),
+    )
+
+    response_chunk = MockResponseIterator(
+        model_response=response, json_mode=True
+    )._chunk_parser(chunk_data=response)
+
+    assert response_chunk["text"] == ""
+    assert response_chunk["tool_use"] is not None
+    assert response_chunk["tool_use"]["function"]["name"] == "get_metrics_by_prefix"
+
+
+def test_fake_stream_json_mode_converts_only_response_format_tool():
+    """The internal response-format tool remains regular JSON text."""
+    response = litellm.ModelResponse(
+        id="chatcmpl-test",
+        created=0,
+        model="test",
+        object="chat.completion",
+        choices=[
+            Choices(
+                finish_reason="tool_calls",
+                index=0,
+                message=Message(
+                    content=None,
+                    role="assistant",
+                    tool_calls=[
+                        ChatCompletionMessageToolCall(
+                            function=Function(
+                                arguments='{"values":{"result":"ok"}}',
+                                name="json_tool_call",
+                            ),
+                            id="call_response_format",
+                            type="function",
+                        )
+                    ],
+                    function_call=None,
+                ),
+            )
+        ],
+        usage=Usage(completion_tokens=1, prompt_tokens=1, total_tokens=2),
+    )
+
+    response_chunk = MockResponseIterator(
+        model_response=response, json_mode=True
+    )._chunk_parser(chunk_data=response)
+
+    assert response_chunk["text"] == '{"result": "ok"}'
+    assert response_chunk["tool_use"] is None
 
 
 def test_transform_tool_calls_index():

--- a/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
@@ -36,7 +36,7 @@ def test_transform_thinking_blocks_with_redacted_content():
 
 
 def test_fake_stream_json_mode_preserves_regular_tool_use():
-    """A fake stream must not turn a user tool call into JSON text."""
+    """Preserve a regular tool call in a fake stream with JSON mode enabled."""
     response = litellm.ModelResponse(
         id="chatcmpl-test",
         created=0,
@@ -76,7 +76,7 @@ def test_fake_stream_json_mode_preserves_regular_tool_use():
 
 
 def test_fake_stream_json_mode_converts_only_response_format_tool():
-    """The internal response-format tool remains regular JSON text."""
+    """Convert only the response-format helper tool to JSON content."""
     response = litellm.ModelResponse(
         id="chatcmpl-test",
         created=0,

--- a/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
@@ -34,7 +34,7 @@ def test_transform_thinking_blocks_with_redacted_content():
 
 
 def test_fake_stream_json_mode_preserves_regular_tool_use():
-    """A fake stream must not turn a user tool call into JSON text."""
+    """Preserve a regular tool call in a fake stream with JSON mode enabled."""
     response = litellm.ModelResponse(
         id="chatcmpl-test",
         created=0,
@@ -74,7 +74,7 @@ def test_fake_stream_json_mode_preserves_regular_tool_use():
 
 
 def test_fake_stream_json_mode_converts_only_response_format_tool():
-    """The internal response-format tool remains regular JSON text."""
+    """Convert only the response-format helper tool to JSON content."""
     response = litellm.ModelResponse(
         id="chatcmpl-test",
         created=0,

--- a/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
@@ -8,10 +8,19 @@ sys.path.insert(
     0, os.path.abspath("../../../../..")
 )  # Adds the parent directory to the system path
 
+import litellm
 from litellm.llms.bedrock.chat.invoke_handler import (
     AWSEventStreamDecoder,
+    MockResponseIterator,
     make_call,
     make_sync_call,
+)
+from litellm.types.utils import (
+    ChatCompletionMessageToolCall,
+    Choices,
+    Function,
+    Message,
+    Usage,
 )
 
 
@@ -22,6 +31,85 @@ def test_transform_thinking_blocks_with_redacted_content():
     assert len(transformed_thinking_blocks) == 1
     assert transformed_thinking_blocks[0]["type"] == "redacted_thinking"
     assert transformed_thinking_blocks[0]["data"] == "This is a redacted content"
+
+
+def test_fake_stream_json_mode_preserves_regular_tool_use():
+    """A fake stream must not turn a user tool call into JSON text."""
+    response = litellm.ModelResponse(
+        id="chatcmpl-test",
+        created=0,
+        model="test",
+        object="chat.completion",
+        choices=[
+            Choices(
+                finish_reason="tool_calls",
+                index=0,
+                message=Message(
+                    content=None,
+                    role="assistant",
+                    tool_calls=[
+                        ChatCompletionMessageToolCall(
+                            function=Function(
+                                arguments='{"prefix":"service.request"}',
+                                name="get_metrics_by_prefix",
+                            ),
+                            id="call_metrics",
+                            type="function",
+                        )
+                    ],
+                    function_call=None,
+                ),
+            )
+        ],
+        usage=Usage(completion_tokens=1, prompt_tokens=1, total_tokens=2),
+    )
+
+    response_chunk = MockResponseIterator(
+        model_response=response, json_mode=True
+    )._chunk_parser(chunk_data=response)
+
+    assert response_chunk["text"] == ""
+    assert response_chunk["tool_use"] is not None
+    assert response_chunk["tool_use"]["function"]["name"] == "get_metrics_by_prefix"
+
+
+def test_fake_stream_json_mode_converts_only_response_format_tool():
+    """The internal response-format tool remains regular JSON text."""
+    response = litellm.ModelResponse(
+        id="chatcmpl-test",
+        created=0,
+        model="test",
+        object="chat.completion",
+        choices=[
+            Choices(
+                finish_reason="tool_calls",
+                index=0,
+                message=Message(
+                    content=None,
+                    role="assistant",
+                    tool_calls=[
+                        ChatCompletionMessageToolCall(
+                            function=Function(
+                                arguments='{"values":{"result":"ok"}}',
+                                name="json_tool_call",
+                            ),
+                            id="call_response_format",
+                            type="function",
+                        )
+                    ],
+                    function_call=None,
+                ),
+            )
+        ],
+        usage=Usage(completion_tokens=1, prompt_tokens=1, total_tokens=2),
+    )
+
+    response_chunk = MockResponseIterator(
+        model_response=response, json_mode=True
+    )._chunk_parser(chunk_data=response)
+
+    assert response_chunk["text"] == '{"result": "ok"}'
+    assert response_chunk["tool_use"] is None
 
 
 def test_transform_tool_calls_index():
@@ -292,4 +380,3 @@ def test_make_sync_call_honors_explicit_stream_chunk_size():
     )
 
     response.iter_bytes.assert_called_once_with(chunk_size=2048)
-


### PR DESCRIPTION
## What this fixes

When a Bedrock Converse request combines `response_format` with normal user tools, a real tool call can be exposed to a streaming client as ordinary JSON text instead of an OpenAI-compatible `tool_call`. Agent SDKs then treat the JSON as a final assistant message and do not run the tool.

For example, a model response intended as:

```text
tool_call: get_metrics_by_prefix({"prefix":"trace.grpc.server"})
```

could be emitted as:

```text
assistant message: {"prefix":"trace.grpc.server"}
```

## Why it happens

LiteLLM uses the internal `json_tool_call` tool to emulate `response_format` for Bedrock models that cannot use native structured output. There are two independent streaming paths where that internal tool can be confused with a real user tool:

1. **Bedrock's real stream**: content blocks can be interleaved. A single mutable "current tool name" is overwritten by a `json_tool_call` block, so a later delta belonging to a real tool is filtered as JSON output.
2. **Fake stream**: LiteLLM first receives one complete Converse response and wraps it as a stream. With `json_mode=True`, the wrapper converted the first tool call to text without checking its name.

## What changed

- Track tool names by Bedrock `contentBlockIndex`, isolating interleaved blocks in the real stream decoder.
- In fake streams, identify the internal `json_tool_call` by name.
- Convert only that internal tool to message text; keep real tools as `tool_use` so OpenAI-compatible streaming clients can execute them.

## Behaviour preserved

- A response containing only LiteLLM's internal `json_tool_call` still produces the structured JSON text expected by `response_format`.
- Requests without `json_mode` keep their existing behavior.

## Tests

- Interleaved real-tool and `json_tool_call` Bedrock stream blocks preserve the real tool's arguments.
- Fake stream with a real tool preserves `tool_use`.
- Fake stream with only `json_tool_call` still emits JSON text.

```bash
python -m pytest tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py::test_streaming_interleaved_json_tool_call_does_not_hide_real_tool_delta -q
python -m pytest tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py -k 'fake_stream_json_mode' -q
```

All three targeted tests pass.
