### PR TITLE
fix(langfuse): honor request tracing environment

### DIFF
--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -110,6 +110,7 @@ class LangFuseLogger:
         langfuse_public_key=None,
         langfuse_secret=None,
         langfuse_host=None,
+        langfuse_environment=None,
         flush_interval=1,
         allow_env_credentials: bool = True,
     ):
@@ -129,6 +130,7 @@ class LangFuseLogger:
         if not (self.langfuse_host.startswith("http://") or self.langfuse_host.startswith("https://")):
             # add http:// if unset, assume communicating over private network - e.g. render
             self.langfuse_host = "http://" + self.langfuse_host
+        self.langfuse_environment = langfuse_environment
         self.langfuse_release = os.getenv("LANGFUSE_RELEASE")
         self.langfuse_debug = os.getenv("LANGFUSE_DEBUG")
         self.langfuse_flush_interval = LangFuseLogger._get_langfuse_flush_interval(flush_interval)
@@ -145,6 +147,7 @@ class LangFuseLogger:
             "public_key": self.public_key,
             "secret_key": self.secret_key,
             "host": self.langfuse_host,
+            "environment": langfuse_environment,
             "release": self.langfuse_release,
             "debug": self.langfuse_debug,
             "flush_interval": self.langfuse_flush_interval,  # flush interval in seconds

--- a/litellm/integrations/langfuse/langfuse_handler.py
+++ b/litellm/integrations/langfuse/langfuse_handler.py
@@ -108,6 +108,7 @@ class LangFuseHandler:
             langfuse_public_key=credentials.get("langfuse_public_key"),
             langfuse_secret=credentials.get("langfuse_secret") or credentials.get("langfuse_secret_key"),
             langfuse_host=credentials.get("langfuse_host"),
+            langfuse_environment=credentials.get("langfuse_environment"),
             allow_env_credentials=credentials.get("langfuse_host") is None,
         )
         in_memory_dynamic_logger_cache.set_cache(
@@ -135,6 +136,7 @@ class LangFuseHandler:
             or standard_callback_dynamic_params.get("langfuse_secret_key"),
             langfuse_public_key=standard_callback_dynamic_params.get("langfuse_public_key"),
             langfuse_host=standard_callback_dynamic_params.get("langfuse_host"),
+            langfuse_environment=standard_callback_dynamic_params.get("langfuse_environment"),
         )
 
     @staticmethod
@@ -153,6 +155,7 @@ class LangFuseHandler:
             or standard_callback_dynamic_params.get("langfuse_public_key") is not None
             or standard_callback_dynamic_params.get("langfuse_secret") is not None
             or standard_callback_dynamic_params.get("langfuse_secret_key") is not None
+            or standard_callback_dynamic_params.get("langfuse_environment") is not None
         ):
             return True
         return False

--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -223,7 +223,12 @@ class LangfuseOtelLogger(OpenTelemetry):
         from litellm.integrations.arize._utils import safe_set_attribute
         from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 
-        langfuse_environment = os.environ.get("LANGFUSE_TRACING_ENVIRONMENT")
+        metadata = LangfuseOtelLogger._extract_langfuse_metadata(kwargs)
+        langfuse_environment = (
+            metadata.get("trace_environment")
+            or metadata.get("environment")
+            or os.environ.get("LANGFUSE_TRACING_ENVIRONMENT")
+        )
         if langfuse_environment:
             safe_set_attribute(
                 span,
@@ -231,7 +236,6 @@ class LangfuseOtelLogger(OpenTelemetry):
                 langfuse_environment,
             )
 
-        metadata = LangfuseOtelLogger._extract_langfuse_metadata(kwargs)
         LangfuseOtelLogger._set_metadata_attributes(span=span, metadata=metadata)
 
         messages = kwargs.get("messages")

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1624,13 +1624,9 @@ class Logging(LiteLLMLoggingBaseClass):
         )
         if not isinstance(environment, str) or not environment:
             return self.standard_callback_dynamic_params
-        return cast(
-            StandardCallbackDynamicParams,
-            {
-                **self.standard_callback_dynamic_params,
-                "langfuse_environment": environment,
-            },
-        )
+        dynamic_params = self.standard_callback_dynamic_params.copy()
+        dynamic_params["langfuse_environment"] = environment
+        return dynamic_params
 
     def should_run_logging(
         self,

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1612,6 +1612,26 @@ class Logging(LiteLLMLoggingBaseClass):
             **kwargs,
         )
 
+    def _get_langfuse_dynamic_params(self) -> StandardCallbackDynamicParams:
+        litellm_params = self.model_call_details.get("litellm_params", {}) or {}
+        metadata = litellm_params.get("metadata", {}) or {}
+        requester_metadata = metadata.get("requester_metadata", {}) or {}
+        environment = (
+            metadata.get("trace_environment")
+            or metadata.get("environment")
+            or requester_metadata.get("trace_environment")
+            or requester_metadata.get("environment")
+        )
+        if not isinstance(environment, str) or not environment:
+            return self.standard_callback_dynamic_params
+        return cast(
+            StandardCallbackDynamicParams,
+            {
+                **self.standard_callback_dynamic_params,
+                "langfuse_environment": environment,
+            },
+        )
+
     def should_run_logging(
         self,
         event_type: Literal["async_success", "sync_success", "async_failure", "sync_failure"],
@@ -2196,7 +2216,7 @@ class Logging(LiteLLMLoggingBaseClass):
 
                         langfuse_logger_to_use = LangFuseHandler.get_langfuse_logger_for_request(
                             globalLangfuseLogger=langFuseLogger,
-                            standard_callback_dynamic_params=self.standard_callback_dynamic_params,
+                            standard_callback_dynamic_params=self._get_langfuse_dynamic_params(),
                             in_memory_dynamic_logger_cache=in_memory_dynamic_logger_cache,
                         )
                         if langfuse_logger_to_use is not None:
@@ -2869,7 +2889,7 @@ class Logging(LiteLLMLoggingBaseClass):
                         # this only logs streaming once, complete_streaming_response exists i.e when stream ends
                         langfuse_logger_to_use = LangFuseHandler.get_langfuse_logger_for_request(
                             globalLangfuseLogger=langFuseLogger,
-                            standard_callback_dynamic_params=self.standard_callback_dynamic_params,
+                            standard_callback_dynamic_params=self._get_langfuse_dynamic_params(),
                             in_memory_dynamic_logger_cache=in_memory_dynamic_logger_cache,
                         )
                         _response = langfuse_logger_to_use.log_event_on_langfuse(
@@ -3015,26 +3035,28 @@ class Logging(LiteLLMLoggingBaseClass):
         global langFuseLogger
 
         if service_name == "langfuse":
+            langfuse_dynamic_params = self._get_langfuse_dynamic_params()
             if langFuseLogger is None or (
                 (
-                    self.standard_callback_dynamic_params.get("langfuse_public_key") is not None
-                    and self.standard_callback_dynamic_params.get("langfuse_public_key") != langFuseLogger.public_key
+                    langfuse_dynamic_params.get("langfuse_public_key") is not None
+                    and langfuse_dynamic_params.get("langfuse_public_key") != langFuseLogger.public_key
                 )
                 or (
-                    self.standard_callback_dynamic_params.get("langfuse_public_key") is not None
-                    and self.standard_callback_dynamic_params.get("langfuse_public_key") != langFuseLogger.public_key
+                    langfuse_dynamic_params.get("langfuse_host") is not None
+                    and langfuse_dynamic_params.get("langfuse_host") != langFuseLogger.langfuse_host
                 )
                 or (
-                    self.standard_callback_dynamic_params.get("langfuse_host") is not None
-                    and self.standard_callback_dynamic_params.get("langfuse_host") != langFuseLogger.langfuse_host
+                    langfuse_dynamic_params.get("langfuse_environment") is not None
+                    and langfuse_dynamic_params.get("langfuse_environment") != langFuseLogger.langfuse_environment
                 )
             ):
                 return LangFuseLogger(
-                    langfuse_public_key=self.standard_callback_dynamic_params.get("langfuse_public_key"),
-                    langfuse_secret=self.standard_callback_dynamic_params.get("langfuse_secret")
-                    or self.standard_callback_dynamic_params.get("langfuse_secret_key"),
-                    langfuse_host=self.standard_callback_dynamic_params.get("langfuse_host"),
-                    allow_env_credentials=self.standard_callback_dynamic_params.get("langfuse_host") is None,
+                    langfuse_public_key=langfuse_dynamic_params.get("langfuse_public_key"),
+                    langfuse_secret=langfuse_dynamic_params.get("langfuse_secret")
+                    or langfuse_dynamic_params.get("langfuse_secret_key"),
+                    langfuse_host=langfuse_dynamic_params.get("langfuse_host"),
+                    langfuse_environment=langfuse_dynamic_params.get("langfuse_environment"),
+                    allow_env_credentials=langfuse_dynamic_params.get("langfuse_host") is None,
                 )
             return langFuseLogger
 

--- a/litellm/types/integrations/langfuse.py
+++ b/litellm/types/integrations/langfuse.py
@@ -7,6 +7,7 @@ class LangfuseLoggingConfig(TypedDict):
     langfuse_secret: Optional[str]
     langfuse_public_key: Optional[str]
     langfuse_host: Optional[str]
+    langfuse_environment: Optional[str]
 
 
 class LangfuseUsageDetails(TypedDict):

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3015,6 +3015,7 @@ class StandardCallbackDynamicParams(TypedDict, total=False):
     langfuse_secret: Optional[str]
     langfuse_secret_key: Optional[str]
     langfuse_host: Optional[str]
+    langfuse_environment: Optional[str]
 
     # Langfuse prompt version
     langfuse_prompt_version: Optional[int]

--- a/tests/logging_callback_tests/test_langfuse_dynamic_credentials.py
+++ b/tests/logging_callback_tests/test_langfuse_dynamic_credentials.py
@@ -78,8 +78,10 @@ def test_upstream_langfuse_debug_env_is_passed(monkeypatch):
         langfuse_public_key="public",
         langfuse_secret="secret",
         langfuse_host="https://langfuse.example",
+        langfuse_environment="staging",
     )
 
+    assert FakeLangfuse.instances[0].kwargs["environment"] == "staging"
     assert logger.upstream_langfuse_debug == "true"
     assert FakeLangfuse.instances[-1].kwargs["debug"] is True
 
@@ -94,11 +96,13 @@ def test_langfuse_handler_accepts_secret_key_alias(monkeypatch):
             langfuse_public_key=None,
             langfuse_secret=None,
             langfuse_host=None,
+            langfuse_environment=None,
             allow_env_credentials=True,
         ):
             captured["langfuse_public_key"] = langfuse_public_key
             captured["langfuse_secret"] = langfuse_secret
             captured["langfuse_host"] = langfuse_host
+            captured["langfuse_environment"] = langfuse_environment
             captured["allow_env_credentials"] = allow_env_credentials
 
     class FakeDynamicLoggingCache:
@@ -117,6 +121,7 @@ def test_langfuse_handler_accepts_secret_key_alias(monkeypatch):
             "langfuse_public_key": "dynamic-public",
             "langfuse_secret_key": "dynamic-secret",
             "langfuse_host": "https://langfuse.example",
+            "langfuse_environment": "staging",
         },
         in_memory_dynamic_logger_cache=FakeDynamicLoggingCache(),
     )
@@ -124,6 +129,7 @@ def test_langfuse_handler_accepts_secret_key_alias(monkeypatch):
     assert captured["langfuse_public_key"] == "dynamic-public"
     assert captured["langfuse_secret"] == "dynamic-secret"
     assert captured["langfuse_host"] == "https://langfuse.example"
+    assert captured["langfuse_environment"] == "staging"
     assert captured["allow_env_credentials"] is False
     assert captured["cached_service_name"] == "langfuse"
     assert captured["cached_logging_obj"] is logger

--- a/tests/logging_callback_tests/test_langfuse_unit_tests.py
+++ b/tests/logging_callback_tests/test_langfuse_unit_tests.py
@@ -94,12 +94,14 @@ standard_params_1 = StandardCallbackDynamicParams(
     langfuse_public_key="test_public_key",
     langfuse_secret="test_secret",
     langfuse_host="https://test.langfuse.com",
+    langfuse_environment="staging",
 )
 
 standard_params_2 = StandardCallbackDynamicParams(
     langfuse_public_key="test_public_key",
     langfuse_secret_key="test_secret",
     langfuse_host="https://test.langfuse.com",
+    langfuse_environment="staging",
 )
 
 
@@ -126,6 +128,7 @@ def test_get_langfuse_logger_for_request_with_dynamic_params(
     assert result.public_key == "test_public_key"
     assert result.secret_key == "test_secret"
     assert result.langfuse_host == "https://test.langfuse.com"
+    assert result.langfuse_environment == "staging"
 
     # Check if the logger is cached
     cached_logger = dynamic_logging_cache.get_cache(
@@ -133,6 +136,7 @@ def test_get_langfuse_logger_for_request_with_dynamic_params(
             "langfuse_public_key": "test_public_key",
             "langfuse_secret": "test_secret",
             "langfuse_host": "https://test.langfuse.com",
+            "langfuse_environment": "staging",
         },
         service_name="langfuse",
     )
@@ -202,11 +206,13 @@ def test_get_dynamic_langfuse_logging_config():
         langfuse_public_key="dynamic_key",
         langfuse_secret="dynamic_secret",
         langfuse_host="https://dynamic.langfuse.com",
+        langfuse_environment="development",
     )
     config = LangFuseHandler.get_dynamic_langfuse_logging_config(dynamic_params)
     assert config["langfuse_public_key"] == "dynamic_key"
     assert config["langfuse_secret"] == "dynamic_secret"
     assert config["langfuse_host"] == "https://dynamic.langfuse.com"
+    assert config["langfuse_environment"] == "development"
 
     # Test with no dynamic params
     empty_params = StandardCallbackDynamicParams()
@@ -214,6 +220,7 @@ def test_get_dynamic_langfuse_logging_config():
     assert config["langfuse_public_key"] is None
     assert config["langfuse_secret"] is None
     assert config["langfuse_host"] is None
+    assert config["langfuse_environment"] is None
 
 
 def test_return_global_langfuse_logger():

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -118,24 +118,43 @@ class TestLangfuseOtelIntegration:
                 "langfuse.observation.type", "generation"
             )
 
-    def test_set_langfuse_environment_attribute(self):
-        """Test that Langfuse environment is set correctly when environment variable is present."""
+    @pytest.mark.parametrize(
+        ("metadata", "process_environment", "expected_environment"),
+        [
+            (
+                {"trace_environment": "staging", "environment": "development"},
+                "production",
+                "staging",
+            ),
+            ({"environment": "development"}, "production", "development"),
+            ({}, "production", "production"),
+        ],
+    )
+    def test_set_langfuse_environment_attribute(
+        self,
+        metadata: dict[str, str],
+        process_environment: str,
+        expected_environment: str,
+    ):
         mock_span = MagicMock()
-        mock_kwargs = {"test": "kwargs"}
-        test_env = "staging"
+        kwargs = {"litellm_params": {"metadata": metadata}}
 
-        with patch.dict(os.environ, {"LANGFUSE_TRACING_ENVIRONMENT": test_env}):
+        with patch.dict(
+            os.environ,
+            {"LANGFUSE_TRACING_ENVIRONMENT": process_environment},
+        ):
             with patch(
                 "litellm.integrations.arize._utils.safe_set_attribute"
             ) as mock_safe_set_attribute:
                 LangfuseOtelLogger._set_langfuse_specific_attributes(
-                    mock_span, mock_kwargs, {}
+                    mock_span, kwargs, {}
                 )
 
-                # safe_set_attribute(span, key, value) → positional args
-                mock_safe_set_attribute.assert_called_once_with(
-                    mock_span, "langfuse.environment", test_env
-                )
+        mock_safe_set_attribute.assert_any_call(
+            mock_span,
+            "langfuse.environment",
+            expected_environment,
+        )
 
     def test_extract_langfuse_metadata_basic(self):
         """Ensure metadata is correctly pulled from litellm_params."""

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -32,6 +32,29 @@ def logging_obj():
     )
 
 
+@pytest.mark.parametrize(
+    ("metadata", "expected_environment"),
+    [
+        (
+            {"trace_environment": "staging", "environment": "development"},
+            "staging",
+        ),
+        ({"environment": "development"}, "development"),
+        ({"requester_metadata": {"trace_environment": "production"}}, "production"),
+    ],
+)
+def test_get_langfuse_dynamic_params_uses_request_environment(
+    logging_obj,
+    metadata,
+    expected_environment,
+):
+    logging_obj.model_call_details["litellm_params"]["metadata"] = metadata
+
+    params = logging_obj._get_langfuse_dynamic_params()
+
+    assert params["langfuse_environment"] == expected_environment
+
+
 def test_get_combined_callback_list_preserves_insertion_order(logging_obj):
     assert logging_obj.get_combined_callback_list(
         dynamic_success_callbacks=["prometheus", "langfuse", "datadog", "otel", "s3"],


### PR DESCRIPTION
## TLDR

Problem this solves:

- Langfuse callbacks ignore request-level trace environments
- Shared proxies write every trace to the default environment

How it solves it:

- Route Langfuse SDK clients by request environment
- Map request environments onto Langfuse OTEL spans
- Reuse cached clients for each credential and environment combination

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR’s scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live validation is pending an image build from this branch

Before this fix, requests containing `trace_environment=staging` and `environment=staging` were stored by Langfuse with `environment=default`

## Type

🐛 Bug Fix

## Changes

The standard `langfuse` callback derives request environment from top-level or requester metadata and selects a cached Langfuse client configured for that environment

The `langfuse_otel` callback prefers `trace_environment`, then `environment`, then the process-level fallback

The tests cover top-level metadata, proxy requester metadata, dynamic client caching, SDK construction, and OTEL precedence

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
