### PR TITLE
fix(langfuse): detach explicit traces from external parents

### DIFF
--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -409,6 +409,12 @@ class LangfuseOtelLogger(OpenTelemetry):
             langfuse_host=langfuse_host,
         )
 
+    def _get_span_context(self, kwargs, default_span: Optional[Span] = None):
+        metadata = self._extract_langfuse_metadata(kwargs)
+        if metadata.get("trace_id") is not None:
+            return None, None
+        return super()._get_span_context(kwargs, default_span)
+
     def create_litellm_proxy_request_started_span(
         self,
         start_time: datetime,

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -137,6 +137,39 @@ class TestLangfuseOtelIntegration:
                     mock_span, "langfuse.environment", test_env
                 )
 
+    def test_explicit_trace_id_does_not_inherit_external_parent_context(self):
+        logger = object.__new__(LangfuseOtelLogger)
+        kwargs = {
+            "litellm_params": {
+                "metadata": {"trace_id": "0123456789abcdef0123456789abcdef"},
+                "proxy_server_request": {
+                    "headers": {
+                        "traceparent": "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01"
+                    }
+                },
+            }
+        }
+
+        with patch(
+            "litellm.integrations.opentelemetry.OpenTelemetry._get_span_context"
+        ) as parent_context:
+            assert logger._get_span_context(kwargs) == (None, None)
+
+        parent_context.assert_not_called()
+
+    def test_request_without_trace_id_keeps_parent_context_propagation(self):
+        logger = object.__new__(LangfuseOtelLogger)
+        kwargs = {"litellm_params": {"metadata": {}}}
+        expected = (MagicMock(), MagicMock())
+
+        with patch(
+            "litellm.integrations.opentelemetry.OpenTelemetry._get_span_context",
+            return_value=expected,
+        ) as parent_context:
+            assert logger._get_span_context(kwargs) == expected
+
+        parent_context.assert_called_once_with(kwargs, None)
+
     def test_extract_langfuse_metadata_basic(self):
         """Ensure metadata is correctly pulled from litellm_params."""
         metadata_in = {"generation_name": "my-gen", "custom": "data"}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Explicit Langfuse traces retain unrelated external parent span IDs
- Resulting parent observations do not exist in the selected trace

How it solves it:

- Start an independent OTEL context for explicit Langfuse trace IDs
- Preserve normal traceparent propagation without an explicit trace ID

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR’s scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live validation is pending an image build from this branch

Before this fix, an explicit Langfuse `trace_id` combined with an incoming `traceparent` produced a trace whose generation referenced a parent observation that could not exist in the selected trace

## Type

🐛 Bug Fix

## Changes

Langfuse OTEL now starts a root context when request metadata supplies an explicit `trace_id`

Requests without an explicit Langfuse Trace ID retain the existing OpenTelemetry parent context behavior

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
