### PR TITLE
fix(cost): try exactly priced model names before capability-rule matches in completion_cost

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -799,6 +799,36 @@ def _select_model_name_for_cost_calc(
     return return_model
 
 
+def _prices_only_via_capability_rule(model: str | None, custom_llm_provider: str | None) -> bool:
+    """Return True when ``model`` has no exact cost-map entry under any of its
+    name variants and resolves only through a capability generalization rule.
+
+    Rule-derived entries describe capabilities but carry no pricing, so
+    ``get_model_info`` synthesizes them with input/output cost 0. If the cost
+    ladder accepted such a candidate as a successful pricing lookup, the
+    request would be billed $0 even though a later candidate (e.g. the
+    deployment's real model name, when the response carries a router
+    model-group alias stamped on streaming chunks) has exact pricing. The
+    ladder therefore tries exactly-priced candidates first and rule-derived
+    ones last.
+    """
+    if model is None:
+        return False
+    from litellm.utils import (
+        _get_model_info_from_generalization,
+        _get_potential_model_names,
+    )
+
+    return (
+        _get_model_info_from_generalization(
+            model=model,
+            potential_model_names=_get_potential_model_names(model=model, custom_llm_provider=custom_llm_provider),
+            custom_llm_provider=custom_llm_provider,
+        )
+        is not None
+    )
+
+
 @lru_cache(maxsize=DEFAULT_MAX_LRU_CACHE_SIZE)
 def _model_contains_known_llm_provider(model: str) -> bool:
     """
@@ -1218,12 +1248,16 @@ def completion_cost(
             router_model_id=router_model_id,
         )
 
-        potential_model_names = [
+        _candidate_model_names = (
             selected_model,
             _get_response_model(completion_response),
-        ]
-        if model is not None:
-            potential_model_names.append(model)
+        ) + ((model,) if model is not None else ())
+        potential_model_names = sorted(
+            _candidate_model_names,
+            key=lambda candidate: _prices_only_via_capability_rule(
+                model=candidate, custom_llm_provider=custom_llm_provider
+            ),
+        )
 
         for idx, model in enumerate(potential_model_names):
             try:

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -3479,3 +3479,60 @@ def test_batch_cost_calculator_cache_creation_falls_back_to_input_rate():
     )
 
     assert prompt_cost == pytest.approx((1000 * 3e-6 + 8000 * 3e-7 + 2000 * 3e-6) / 2)
+
+
+def test_streaming_alias_response_model_loses_to_exactly_priced_candidate(monkeypatch):
+    """A router model-group alias (e.g. ``anthropic/claude-sonnet-4-6-defaultcaching``)
+    is stamped onto streaming chunks by the proxy, so the reassembled response
+    carries the alias as its model name. The alias has no cost-map entry but
+    prefix-matches a Claude capability generalization rule, whose synthesized
+    entry prices at $0. The cost ladder must prefer the exactly priced
+    deployment model over the rule-derived alias instead of billing $0.
+    Regression test for streaming requests on Claude-named alias groups being
+    logged with zero spend since the fallback-generalizations feature.
+    """
+    from litellm.litellm_core_utils.fallback_generalizations import (
+        match_capability_generalizations,
+    )
+
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+
+    alias = "anthropic/claude-sonnet-4-6-defaultcaching"
+    assert alias not in litellm.model_cost
+    assert match_capability_generalizations("claude-sonnet-4-6-defaultcaching") is not None
+
+    usage = Usage(prompt_tokens=100, completion_tokens=10)
+    alias_cost = completion_cost(
+        completion_response=ModelResponse(usage=usage, model=alias),
+        model="anthropic/claude-sonnet-4-6",
+        custom_llm_provider="anthropic",
+    )
+    real_cost = completion_cost(
+        completion_response=ModelResponse(usage=usage, model="claude-sonnet-4-6"),
+        model="anthropic/claude-sonnet-4-6",
+        custom_llm_provider="anthropic",
+    )
+
+    assert real_cost > 0
+    assert alias_cost == real_cost
+
+
+def test_capability_rule_still_prices_model_with_no_exactly_priced_candidate(monkeypatch):
+    """When every ladder candidate is unmapped and only a capability rule
+    matches, the rule-derived entry must still resolve (at its synthesized $0)
+    rather than raising, preserving the fallback-generalizations behavior for
+    genuinely unknown models.
+    """
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+
+    alias = "anthropic/claude-sonnet-4-6-defaultcaching"
+    usage = Usage(prompt_tokens=100, completion_tokens=10)
+    cost = completion_cost(
+        completion_response=ModelResponse(usage=usage, model="claude-sonnet-4-6-defaultcaching"),
+        model=alias,
+        custom_llm_provider="anthropic",
+    )
+
+    assert cost == 0.0


### PR DESCRIPTION
## Relevant issues

No existing issue found. We hit this in production after upgrading the proxy from 1.89.1 to 1.93.0: every streaming request on a model group named `anthropic/claude-sonnet-4-6-defaultcaching` (an alias deployment for `anthropic/claude-sonnet-4-6` that injects cache_control) was written to spend logs with spend 0, while the same requests non-streaming, and all requests on the plain `anthropic/claude-sonnet-4-6` group, kept billing correctly

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The bug was found on a production proxy making real Anthropic calls: after the 1.93.0 upgrade, 65+ real streaming requests (roughly $2.80 of real Anthropic spend) were logged with `spend = 0` while their `metadata.usage_object` carried full token usage and `metadata.model_map_information` showed the correct per-token prices, with `cost_breakdown` all zeros. The cutover in the spend logs matches the deployment timestamp of 1.93.0 to the minute

For the repro below the Anthropic API is stood in by a local stub that replays Anthropic's exact wire format (`message_start`/`message_delta` SSE events with `cache_creation_input_tokens: 13927, input_tokens: 3, output_tokens: 22`), because this environment has no Anthropic key; the fix is entirely in cost accounting after the response is received, so the bytes on the wire are identical to a real call. Config used (same on both runs):

```yaml
model_list:
  - model_name: anthropic/claude-sonnet-4-6-defaultcaching
    litellm_params:
      model: anthropic/claude-sonnet-4-6
      api_base: http://127.0.0.1:41931
      api_key: sk-fake
      cache_control_injection_points:
        - location: message
          index: -1
  - model_name: anthropic/claude-sonnet-4-6
    litellm_params:
      model: anthropic/claude-sonnet-4-6
      api_base: http://127.0.0.1:41931
      api_key: sk-fake
```

Request (identical on both runs), with a one-line CustomLogger that appends the spend-tracked cost of each request to a file:

```bash
curl -s http://127.0.0.1:41930/v1/chat/completions \
  -H "Authorization: Bearer sk-repro-1234" -H "Content-Type: application/json" \
  -d '{"model": "anthropic/claude-sonnet-4-6-defaultcaching", "stream": true, "messages": [{"role": "user", "content": "Say hi"}]}'
```

Before, at 5d4c4d0fce45 (litellm_oss_daily_2026_07_20 base): the request streams fine but is billed $0

```json
{"model_group": "anthropic/claude-sonnet-4-6-defaultcaching", "stream": true, "response_obj_model": "anthropic/claude-sonnet-4-6-defaultcaching", "kwargs_response_cost": 0.0, "slp_response_cost": 0.0, "map_key": "anthropic/claude-sonnet-4-6"}
```

After, at fbac372651: the same request is billed the correct 3 * 3e-6 + 13927 * 3.75e-6 + 22 * 1.5e-5 = $0.05256525

```json
{"model_group": "anthropic/claude-sonnet-4-6-defaultcaching", "stream": true, "response_obj_model": "anthropic/claude-sonnet-4-6-defaultcaching", "kwargs_response_cost": 0.05256525, "slp_response_cost": 0.05256525, "map_key": "anthropic/claude-sonnet-4-6"}
```

Non-streaming requests on the alias and all requests on the plain group bill $0.05256525 on both commits, confirming the regression is specific to the streaming + alias combination

## Type

🐛 Bug Fix

## Changes

Root cause is an interaction of three existing behaviors. The proxy restamps every streaming chunk's `model` field to the client-requested model group name (`_restamp_streaming_chunk_model` in `proxy_server.py`), and the logging pipeline reassembles the complete streaming response from those same chunk objects, so `completion_response.model` carries the alias by the time `completion_cost` runs. `_select_model_name_for_cost_calc` prefers the response's model name, so the alias becomes the first candidate in the cost ladder. Before the fallback generalizations feature, looking up an unmapped alias raised "This model isn't mapped yet" and the ladder fell through to the deployment's real model name, which priced correctly. Since that feature, an alias that matches a capability rule (any `claude-sonnet-4-6*` name once the provider prefix is stripped) resolves to a rule-derived entry whose synthesized pricing is `input_cost_per_token: 0, output_cost_per_token: 0`, so the ladder stops at the first candidate and bills the request $0

`_get_model_info_from_generalization` already enforces "rules lose to exact entries" among the name variants of a single lookup, and its docstring explicitly worries about callers whose fallback ladder still had a priced exact name to try. This PR extends that same invariant across the `completion_cost` candidate ladder: candidates are now ordered so that names which resolve only through a capability rule are tried after names with exact cost-map pricing. A new helper `_prices_only_via_capability_rule` reuses `_get_potential_model_names` and `_get_model_info_from_generalization`, so the detection logic stays in one place

Behavior for genuinely unknown models is unchanged: when every candidate is unmapped and only a capability rule matches, the rule-derived entry still resolves as before. Both directions are covered by the two added tests in `tests/test_litellm/test_cost_calculator.py`; the regression test fails on the base commit and passes with the fix

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
