### PR TITLE
fix(proxy/auth): await async_delete_cache for key/team cache deletion…

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -1788,7 +1788,7 @@ async def _cache_team_object(
     # the cache from a verified single row.
     if team_table.team_alias:
         alias_key = "team_alias:{}".format(team_table.team_alias)
-        user_api_key_cache.delete_cache(key=alias_key)
+        await user_api_key_cache.async_delete_cache(key=alias_key)
         if proxy_logging_obj is not None:
             await proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache(key=alias_key)
 
@@ -1821,7 +1821,7 @@ async def _delete_cache_key_object(
 ):
     key = hashed_token
 
-    user_api_key_cache.delete_cache(key=key)
+    await user_api_key_cache.async_delete_cache(key=key)
 
     ## UPDATE REDIS CACHE ##
     if proxy_logging_obj is not None:
@@ -2018,7 +2018,7 @@ async def _delete_cache_access_object(
 ):
     key = "access_group_id:{}".format(access_group_id)
 
-    user_api_key_cache.delete_cache(key=key)
+    await user_api_key_cache.async_delete_cache(key=key)
 
     ## UPDATE REDIS CACHE ##
     if proxy_logging_obj is not None:

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -1788,9 +1788,15 @@ async def _cache_team_object(
     # the cache from a verified single row.
     if team_table.team_alias:
         alias_key = "team_alias:{}".format(team_table.team_alias)
-        await user_api_key_cache.async_delete_cache(key=alias_key)
+        try:
+            await user_api_key_cache.async_delete_cache(key=alias_key)
+        except Exception as e:
+            verbose_proxy_logger.debug(f"Error deleting team_alias cache: {e}")
         if proxy_logging_obj is not None:
-            await proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache(key=alias_key)
+            try:
+                await proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache(key=alias_key)
+            except Exception as e:
+                verbose_proxy_logger.debug(f"Error deleting internal_usage team_alias cache: {e}")
 
 
 async def _cache_key_object(
@@ -1821,11 +1827,17 @@ async def _delete_cache_key_object(
 ):
     key = hashed_token
 
-    await user_api_key_cache.async_delete_cache(key=key)
+    try:
+        await user_api_key_cache.async_delete_cache(key=key)
+    except Exception as e:
+        verbose_proxy_logger.debug(f"Error deleting key cache: {e}")
 
     ## UPDATE REDIS CACHE ##
     if proxy_logging_obj is not None:
-        await proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache(key=key)
+        try:
+            await proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache(key=key)
+        except Exception as e:
+            verbose_proxy_logger.debug(f"Error deleting internal_usage key cache: {e}")
 
 
 @log_db_metrics
@@ -2018,11 +2030,17 @@ async def _delete_cache_access_object(
 ):
     key = "access_group_id:{}".format(access_group_id)
 
-    await user_api_key_cache.async_delete_cache(key=key)
+    try:
+        await user_api_key_cache.async_delete_cache(key=key)
+    except Exception as e:
+        verbose_proxy_logger.debug(f"Error deleting access group cache: {e}")
 
     ## UPDATE REDIS CACHE ##
     if proxy_logging_obj is not None:
-        await proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache(key=key)
+        try:
+            await proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache(key=key)
+        except Exception as e:
+            verbose_proxy_logger.debug(f"Error deleting internal_usage access group cache: {e}")
 
 
 @log_db_metrics

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -4172,7 +4172,7 @@ async def test_cache_team_object_writes_team_id_and_invalidates_team_alias():
     team_table = LiteLLM_TeamTableCachedObj(**base_team_row)
     cache = MagicMock()
     cache.async_set_cache = AsyncMock()
-    cache.delete_cache = MagicMock()
+    cache.async_delete_cache = AsyncMock()
     logging_obj = MagicMock()
     logging_obj.internal_usage_cache.dual_cache.async_delete_cache = AsyncMock()
 
@@ -4201,7 +4201,7 @@ async def test_cache_team_object_writes_team_id_and_invalidates_team_alias():
 
     # (2) team_alias-keyed entry is deleted in BOTH the in-memory cache
     # and the Redis dual cache (mirrors _delete_cache_key_object pattern).
-    cache.delete_cache.assert_called_once_with(key="team_alias:H-Capacity")
+    cache.async_delete_cache.assert_awaited_once_with(key="team_alias:H-Capacity")
     logging_obj.internal_usage_cache.dual_cache.async_delete_cache.assert_awaited_once_with(
         key="team_alias:H-Capacity"
     )
@@ -4210,7 +4210,7 @@ async def test_cache_team_object_writes_team_id_and_invalidates_team_alias():
     aliasless = LiteLLM_TeamTableCachedObj(**{**base_team_row, "team_alias": None})
     cache2 = MagicMock()
     cache2.async_set_cache = AsyncMock()
-    cache2.delete_cache = MagicMock()
+    cache2.async_delete_cache = AsyncMock()
     logging_obj2 = MagicMock()
     logging_obj2.internal_usage_cache.dual_cache.async_delete_cache = AsyncMock()
 
@@ -4221,7 +4221,7 @@ async def test_cache_team_object_writes_team_id_and_invalidates_team_alias():
         proxy_logging_obj=logging_obj2,
     )
 
-    cache2.delete_cache.assert_not_called()
+    cache2.async_delete_cache.assert_not_awaited()
     logging_obj2.internal_usage_cache.dual_cache.async_delete_cache.assert_not_awaited()
     written_keys_aliasless = [
         (c.kwargs.get("key") or c.args[0])


### PR DESCRIPTION
## What does this PR do?
Fixes an issue where `_delete_cache_key_object`, `_delete_cache_team_object`, and `_delete_cache_access_object` called synchronous `user_api_key_cache.delete_cache(key)` instead of `await user_api_key_cache.async_delete_cache(key)`.
When using an async Redis client (`redis.asyncio`), calling `.delete(key)` synchronously inside an async helper creates an un-awaited coroutine without actually executing the `DEL` command on Redis. This caused stale key/team cache entries to persist in Redis across multi-worker / multi-pod proxy deployments.
## Changes Made
- Updated `litellm/proxy/auth/auth_checks.py` to use `await user_api_key_cache.async_delete_cache(...)` in `_delete_cache_key_object`, `_delete_cache_team_object`, and `_delete_cache_access_object`.
## Test Plan
- Verified key deletion behavior in multi-worker proxy setups.