### PR TITLE
fix(proxy): enforce model access checks on Bedrock passthrough routes

### DIFF
--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -1638,6 +1638,17 @@ def get_model_from_request(
         if vertex_match:
             model = vertex_match.group(1)
 
+    if model is None and route.lower().startswith("/bedrock"):
+        from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+            _extract_model_from_bedrock_endpoint,
+        )
+
+        bedrock_endpoint = re.sub(r"^/bedrock/", "", route, flags=re.IGNORECASE)
+        try:
+            model = _extract_model_from_bedrock_endpoint(bedrock_endpoint)
+        except ValueError:
+            model = None
+
     return model
 
 

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -1638,16 +1638,20 @@ def get_model_from_request(
         if vertex_match:
             model = vertex_match.group(1)
 
-    if model is None and route.lower().startswith("/bedrock"):
-        from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
-            _extract_model_from_bedrock_endpoint,
-        )
-
+    if route.lower().startswith("/bedrock"):
         bedrock_endpoint = re.sub(r"^/bedrock/", "", route, flags=re.IGNORECASE)
-        try:
-            model = _extract_model_from_bedrock_endpoint(bedrock_endpoint)
-        except ValueError:
-            model = None
+        is_bedrock_count_tokens_route = (
+            "count_tokens" in bedrock_endpoint.lower() or "count-tokens" in bedrock_endpoint.lower()
+        )
+        if not is_bedrock_count_tokens_route:
+            from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+                _extract_model_from_bedrock_endpoint,
+            )
+
+            try:
+                model = _extract_model_from_bedrock_endpoint(bedrock_endpoint)
+            except ValueError:
+                pass
 
     return model
 

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -428,6 +428,56 @@ def test_get_model_from_request_openai_deployment_route_still_works():
     )
 
 
+def test_get_model_from_request_bedrock_converse_passthrough():
+    assert (
+        get_model_from_request(
+            request_data={},
+            route="/bedrock/model/us.anthropic.claude-sonnet-4-6/converse",
+        )
+        == "us.anthropic.claude-sonnet-4-6"
+    )
+
+
+def test_get_model_from_request_bedrock_invoke_passthrough():
+    assert (
+        get_model_from_request(
+            request_data={},
+            route="/bedrock/model/us.anthropic.claude-sonnet-4-6/invoke",
+        )
+        == "us.anthropic.claude-sonnet-4-6"
+    )
+
+
+def test_get_model_from_request_bedrock_v2_converse_stream_passthrough():
+    assert (
+        get_model_from_request(
+            request_data={},
+            route="/bedrock/v2/model/us.anthropic.claude-sonnet-4-6/converse-stream",
+        )
+        == "us.anthropic.claude-sonnet-4-6"
+    )
+
+
+def test_get_model_from_request_bedrock_model_id_with_slashes():
+    assert (
+        get_model_from_request(
+            request_data={},
+            route="/bedrock/model/aws/anthropic/model-name/invoke",
+        )
+        == "aws/anthropic/model-name"
+    )
+
+
+def test_get_model_from_request_bedrock_unparseable_endpoint_returns_none():
+    assert (
+        get_model_from_request(
+            request_data={},
+            route="/bedrock/agents/some-agent-route",
+        )
+        is None
+    )
+
+
 def test_get_model_from_request_includes_file_endpoint_header_model():
     assert (
         get_model_from_request(

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -478,6 +478,46 @@ def test_get_model_from_request_bedrock_unparseable_endpoint_returns_none():
     )
 
 
+def test_get_model_from_request_bedrock_url_model_overrides_body_model():
+    assert (
+        get_model_from_request(
+            request_data={"model": "us.anthropic.claude-sonnet-4-6"},
+            route="/bedrock/model/us.anthropic.claude-opus-4-6-v1/converse",
+        )
+        == "us.anthropic.claude-opus-4-6-v1"
+    )
+
+
+def test_get_model_from_request_bedrock_invoke_url_model_overrides_body_model():
+    assert (
+        get_model_from_request(
+            request_data={"model": "us.anthropic.claude-sonnet-4-6"},
+            route="/bedrock/model/us.anthropic.claude-opus-4-6-v1/invoke",
+        )
+        == "us.anthropic.claude-opus-4-6-v1"
+    )
+
+
+def test_get_model_from_request_bedrock_count_tokens_uses_body_model():
+    assert (
+        get_model_from_request(
+            request_data={"model": "us.anthropic.claude-sonnet-4-6"},
+            route="/bedrock/v1/messages/count_tokens",
+        )
+        == "us.anthropic.claude-sonnet-4-6"
+    )
+
+
+def test_get_model_from_request_bedrock_unparseable_endpoint_keeps_body_model():
+    assert (
+        get_model_from_request(
+            request_data={"model": "us.anthropic.claude-sonnet-4-6"},
+            route="/bedrock/agents/some-agent-route",
+        )
+        == "us.anthropic.claude-sonnet-4-6"
+    )
+
+
 def test_get_model_from_request_includes_file_endpoint_header_model():
     assert (
         get_model_from_request(


### PR DESCRIPTION
## TLDR

Problem this solves:

LiteLLM's centralized model-access check (`common_checks`) silently skips enforcement for Bedrock passthrough routes (`/bedrock/model/{model}/{action}`) because `get_model_from_request` has no path pattern for them, unlike the existing OpenAI-deployments, Google generateContent, and Vertex AI passthrough patterns. A key or project restricted to a specific model allowlist can call any Bedrock model via passthrough regardless of its configured allowlist, while the same model is correctly blocked on `/v1/chat/completions`. This reproduces for every Bedrock passthrough action (`invoke`, `invoke-with-response-stream`, `converse`, `converse-stream`, `count_tokens`), not just one

How it solves it:

Adds a Bedrock branch to `get_model_from_request` that reuses `_extract_model_from_bedrock_endpoint`, the same parser the Bedrock passthrough handler itself already relies on, to resolve the model from the URL path. Handles model ids containing slashes (e.g. `aws/anthropic/model-name`). The resolved model then flows into the existing `common_checks` allowlist enforcement, so behavior now matches `/v1/chat/completions` and the existing Vertex AI passthrough path

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Verified against a downstream LiteLLM proxy deployment with per-project Bedrock model allowlists. A project scoped to a specific set of models correctly gets rejected calling an out-of-allowlist Bedrock model via the passthrough route, matching the existing `/v1/chat/completions` behavior:

```
$ curl --request POST \
  --url http://localhost:4000/bedrock/model/us.anthropic.claude-opus-4-6-v1/invoke \
  --header 'authorization: Bearer $TOKEN' \
  --header 'content-type: application/json' \
  --data '{"messages": [{"role": "user", "content": [{"type": "text", "text": "..."}]}], "max_tokens": 120, "anthropic_version": "bedrock-2023-05-31"}'

{
  "error": {
    "message": "project not allowed to access model. This project can only access models=['azure/gpt-4.1-mini-2025-04-14', 'openai.gpt-oss-20b-1:0', 'us.anthropic.claude-sonnet-4-6', 'gemini-2.5-pro']. Tried to access us.anthropic.claude-opus-4-6-v1",
    "type": "project_model_access_denied",
    "param": "model",
    "code": "403"
  }
}
```

Server logs confirm the model is correctly resolved from the passthrough URL before the allowlist check runs:

```
model extracted is : None
model extracted for bedrock is : us.anthropic.claude-opus-4-6-v1
```

Before this fix, the same request returned 200 and the call went through regardless of the allowlist.

## Type

🐛 Bug Fix

## Changes

`litellm/proxy/auth/auth_utils.py`: added a Bedrock branch to `get_model_from_request`, mirroring the existing Vertex AI branch, that strips the `/bedrock/` prefix and delegates to `_extract_model_from_bedrock_endpoint` (imported lazily to avoid a circular import with `user_api_key_auth.py`)

`tests/test_litellm/proxy/auth/test_auth_utils.py`: added coverage for `converse`, `invoke`, the `v2/.../converse-stream` shape, model ids containing slashes, and an unparseable-endpoint case that falls back to `None`

## QA runbook

1. Configure a key/project with a model allowlist that excludes some Bedrock model, e.g. `us.anthropic.claude-opus-4-6-v1`
2. `POST /bedrock/model/us.anthropic.claude-opus-4-6-v1/converse` with that key: before this fix, returns 200; after, returns 403 `project_model_access_denied` / `key_model_access_denied`
3. `POST /bedrock/model/<allowed-model>/converse` with the same key: still returns 200, confirming allowed models are unaffected

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR