### PR TITLE
fix(responses): preserve websocket api key

### DIFF
--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -2031,6 +2031,7 @@ async def _aresponses_websocket(
     resolved_api_base = dynamic_api_base or litellm_params.api_base or litellm.api_base or None
     resolved_api_key = (
         dynamic_api_key
+        or api_key
         or litellm_params.api_key
         or litellm.api_key
         or litellm.openai_key

--- a/tests/test_litellm/responses/test_responses_websocket_all_providers.py
+++ b/tests/test_litellm/responses/test_responses_websocket_all_providers.py
@@ -102,6 +102,32 @@ class TestResponsesAPIWebSocketSupport:
     def test_openai_model_in_websocket_url_default(self):
         assert OpenAIResponsesAPIConfig().model_in_websocket_url() is True
 
+    @pytest.mark.asyncio
+    async def test_openai_websocket_forwards_explicit_api_key(self, monkeypatch):
+        from unittest.mock import AsyncMock
+
+        import litellm
+        from litellm.responses import main as responses_main
+
+        websocket_handler = AsyncMock()
+        monkeypatch.setattr(litellm, "api_key", None)
+        monkeypatch.setattr(litellm, "openai_key", None)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr(
+            responses_main.base_llm_http_handler,
+            "async_responses_websocket",
+            websocket_handler,
+        )
+
+        await responses_main._aresponses_websocket.__wrapped__(
+            model="gpt-4o",
+            websocket=MagicMock(),
+            api_key="explicit-api-key",
+            litellm_logging_obj=MagicMock(),
+        )
+
+        assert websocket_handler.await_args.kwargs["api_key"] == "explicit-api-key"
+
     def test_xai_uses_managed_websocket(self):
         """XAI should use managed websocket handler"""
         config = XAIResponsesAPIConfig()


### PR DESCRIPTION
## TLDR

Problem this solves:

- Explicit Responses WebSocket API keys were discarded
- WebSocket handlers could receive no upstream credential

How it solves it:

- Preserve the explicit key during WebSocket key resolution
- Add regression coverage for handler key forwarding

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Pending live proxy verification on this draft

## Type

🐛 Bug Fix

## Changes

`_aresponses_websocket` now includes its explicit `api_key` argument in the existing key resolution order before process-level fallbacks

A focused mocked regression test verifies the resolved key reaches `async_responses_websocket`; the complete WebSocket provider unit test file passes with 107 tests

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
