### PR TITLE
fix(ci): stop auto price-update crashing when Vercel AI Gateway omits pricing fields

### DIFF
--- a/.github/workflows/auto_update_price_and_context_window_file.py
+++ b/.github/workflows/auto_update_price_and_context_window_file.py
@@ -85,11 +85,20 @@ def transform_openrouter_data(data):
 def transform_vercel_ai_gateway_data(data):
     transformed = {}
     for row in data:
+        pricing = row.get("pricing") or {}
+        # Skip rows missing required fields. Vercel's API omits input/output pricing
+        # for some models; a bare KeyError here aborts the whole run (including the
+        # already-fetched OpenRouter data), so skip the row instead of crashing.
+        if pricing.get("input") is None or pricing.get("output") is None \
+                or row.get("context_window") is None:
+            print(f"Skipping vercel_ai_gateway/{row.get('id')}: missing pricing/context_window")
+            continue
+
         obj = {
             "max_tokens": row["context_window"],
-            "input_cost_per_token": float(row["pricing"]["input"]),
-            "output_cost_per_token": float(row["pricing"]["output"]),
-            'max_output_tokens': row['max_tokens'],
+            "input_cost_per_token": float(pricing["input"]),
+            "output_cost_per_token": float(pricing["output"]),
+            'max_output_tokens': row.get('max_tokens'),
             'max_input_tokens': row["context_window"],
         }
 


### PR DESCRIPTION
## What

`transform_vercel_ai_gateway_data` in `.github/workflows/auto_update_price_and_context_window_file.py` indexes `row["pricing"]["input"]`, `row["pricing"]["output"]`, `row["context_window"]` and `row["max_tokens"]` directly. Vercel AI Gateway's `/v1/models` now returns rows that omit these fields, so the transform raises `KeyError: 'output'` and the whole script exits non-zero.

Because OpenRouter is fetched/transformed *before* Vercel in `main()`, this also throws away the already-fetched OpenRouter pricing — so the scheduled job never writes anything and never opens its PR.

## Impact

The weekly **"Updates model_prices_and_context_window.json and Create Pull Request"** workflow has failed on every scheduled run for months (each dies at the `Update JSON Data` step with this `KeyError`). As a result, new OpenRouter models stop getting into `model_prices_and_context_window.json`.

```
Traceback (most recent call last):
  File ".../auto_update_price_and_context_window_file.py", line 145, in main
    vercel_data = transform_vercel_ai_gateway_data(vercel_data)
  File ".../auto_update_price_and_context_window_file.py", line 91, in transform_vercel_ai_gateway_data
    "output_cost_per_token": float(row["pricing"]["output"]),
KeyError: 'output'
```

## Fix

Skip Vercel rows that are missing required pricing/context fields instead of crashing the run. Well-formed rows are unchanged; a malformed provider row can no longer abort the OpenRouter update.

## Test

```
kept:    ['vercel_ai_gateway/good/model']
skipped: bad/no-output, bad/no-pricing  (previously raised KeyError)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
