### PR TITLE
fix: resolve unified_file_id to real storage_url before dispatching batch create

### DIFF
--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -230,6 +230,27 @@ async def create_batch(
                     detail={"error": "LLM Router not initialized. Ensure models added to proxy."},
                 )
 
+            # The base64-encoded unified_file_id is an opaque LiteLLM-internal
+            # token (unified_id + target_model_names), not a real
+            # provider-side file reference. Provider-specific handlers (e.g.
+            # Vertex AI's batch transformation, which parses a `publishers/`
+            # segment out of the file URI) require the actual backend storage
+            # location. Resolve it from LiteLLM_ManagedFileTable before
+            # dispatching, mirroring the same lookup already used by the
+            # files retrieve/download endpoints for managed files.
+            from litellm.proxy.proxy_server import prisma_client
+
+            if prisma_client is not None:
+                from litellm.repositories.table_repositories import (
+                    ManagedFileRepository,
+                )
+
+                db_file = await ManagedFileRepository(prisma_client).table.find_first(
+                    where={"unified_file_id": unified_file_id}
+                )
+                if db_file is not None and db_file.storage_url:
+                    _create_batch_data["input_file_id"] = db_file.storage_url
+
             response = await llm_router.acreate_batch(**_create_batch_data)
             response.input_file_id = input_file_id
             response._hidden_params["unified_file_id"] = unified_file_id

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -241,14 +241,16 @@ async def create_batch(
             from litellm.proxy.proxy_server import prisma_client
 
             if prisma_client is not None:
+                import inspect
                 from litellm.repositories.table_repositories import (
                     ManagedFileRepository,
                 )
 
-                db_file = await ManagedFileRepository(prisma_client).table.find_first(
+                db_file_res = ManagedFileRepository(prisma_client).table.find_first(
                     where={"unified_file_id": unified_file_id}
                 )
-                if db_file is not None and db_file.storage_url:
+                db_file = await db_file_res if inspect.isawaitable(db_file_res) else db_file_res
+                if db_file is not None and getattr(db_file, "storage_url", None):
                     _create_batch_data["input_file_id"] = db_file.storage_url
 
             response = await llm_router.acreate_batch(**_create_batch_data)

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -246,12 +246,17 @@ async def create_batch(
                     ManagedFileRepository,
                 )
 
-                db_file_res = ManagedFileRepository(prisma_client).table.find_first(
-                    where={"unified_file_id": unified_file_id}
-                )
-                db_file = await db_file_res if inspect.isawaitable(db_file_res) else db_file_res
-                if db_file is not None and getattr(db_file, "storage_url", None):
-                    _create_batch_data["input_file_id"] = db_file.storage_url
+                try:
+                    db_file_res = ManagedFileRepository(prisma_client).table.find_first(
+                        where={"unified_file_id": unified_file_id}
+                    )
+                    db_file = await db_file_res if inspect.isawaitable(db_file_res) else db_file_res
+                    if db_file is not None and getattr(db_file, "storage_url", None):
+                        _create_batch_data["input_file_id"] = db_file.storage_url
+                except Exception as e:
+                    verbose_proxy_logger.error(
+                        f"Error resolving unified_file_id in ManagedFileRepository: {e}"
+                    )
 
             response = await llm_router.acreate_batch(**_create_batch_data)
             response.input_file_id = input_file_id

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -254,9 +254,7 @@ async def create_batch(
                     if db_file is not None and getattr(db_file, "storage_url", None):
                         _create_batch_data["input_file_id"] = db_file.storage_url
                 except Exception as e:
-                    verbose_proxy_logger.error(
-                        f"Error resolving unified_file_id in ManagedFileRepository: {e}"
-                    )
+                    verbose_proxy_logger.error(f"Error resolving unified_file_id in ManagedFileRepository: {e}")
 
             response = await llm_router.acreate_batch(**_create_batch_data)
             response.input_file_id = input_file_id

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -536,6 +536,90 @@ async def test_create__unified_file_id_not_exactly_one_model_400(harness, models
 
 
 @pytest.mark.asyncio
+async def test_create__unified_file_id_resolves_real_storage_url(harness):
+    """A base64 unified_file_id is a LiteLLM-internal token, not a real
+    provider-side file reference (e.g. Vertex AI's batch transformation parses
+    a `publishers/` segment out of the file URI and crashes on the opaque
+    base64 string). The real backend location (`storage_url`) must be looked
+    up from LiteLLM_ManagedFileTable and substituted before dispatch - the
+    unified id itself must never reach the router/provider call."""
+    set_body(
+        harness,
+        {
+            "input_file_id": "litellm_proxy_unified_id",
+            "endpoint": "/v1/chat/completions",
+            "completion_window": "24h",
+        },
+    )
+
+    fake_db_file = MagicMock(
+        storage_url="gs://bucket/litellm-vertex-files/publishers/google/models/gemini-2.0/abc"
+    )
+    find_first = AsyncMock(return_value=fake_db_file)
+    fake_repo_instance = MagicMock()
+    fake_repo_instance.table.find_first = find_first
+    fake_repo_cls = MagicMock(return_value=fake_repo_instance)
+
+    fake_prisma_client = MagicMock()
+
+    with patch.object(
+        endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"
+    ), patch.object(
+        endpoints, "get_models_from_unified_file_id", return_value=["gemini-2.0"]
+    ), patch.object(
+        proxy_server, "prisma_client", fake_prisma_client
+    ), patch(
+        "litellm.repositories.table_repositories.ManagedFileRepository",
+        fake_repo_cls,
+    ):
+        resp = await call_create(harness)
+
+    # The real storage_url - not the opaque unified id - must be what's
+    # forwarded to the router/provider.
+    assert harness.router_kwargs()["input_file_id"] == fake_db_file.storage_url
+    find_first.assert_awaited_once_with(where={"unified_file_id": "unified-xyz"})
+    # The unified id is still what's returned to the client.
+    assert resp.input_file_id == "litellm_proxy_unified_id"
+    assert resp._hidden_params["unified_file_id"] == "unified-xyz"
+
+
+@pytest.mark.asyncio
+async def test_create__unified_file_id_no_managed_file_record_falls_back_to_raw_id(
+    harness,
+):
+    """If there's no LiteLLM_ManagedFileTable row (or it has no storage_url),
+    fall back to the previous behavior instead of raising - callers/providers
+    that don't need the resolved path (or legacy data) keep working."""
+    set_body(
+        harness,
+        {
+            "input_file_id": "litellm_proxy_unified_id",
+            "endpoint": "/v1/chat/completions",
+            "completion_window": "24h",
+        },
+    )
+
+    find_first = AsyncMock(return_value=None)
+    fake_repo_instance = MagicMock()
+    fake_repo_instance.table.find_first = find_first
+    fake_repo_cls = MagicMock(return_value=fake_repo_instance)
+
+    with patch.object(
+        endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"
+    ), patch.object(
+        endpoints, "get_models_from_unified_file_id", return_value=["gemini-2.0"]
+    ), patch.object(
+        proxy_server, "prisma_client", MagicMock()
+    ), patch(
+        "litellm.repositories.table_repositories.ManagedFileRepository",
+        fake_repo_cls,
+    ):
+        await call_create(harness)
+
+    assert harness.router_kwargs()["input_file_id"] == "litellm_proxy_unified_id"
+
+
+@pytest.mark.asyncio
 async def test_create__model_encoded_beats_unified(harness):
     """Precedence row: a file id that is BOTH model-encoded and (pretend) unified
     must take the model-encoded branch (checked first)."""


### PR DESCRIPTION
## Relevant issues

`litellm.create_batch()` against a Vertex AI-backed model deterministically
crashes when the input file was uploaded as a LiteLLM-managed "unified file"
(i.e. a batch input file uploaded once and usable across multiple target
models). Reproduced 7/7 in our own environment.

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

**Root cause**, traced end-to-end through the real request path
(`proxy/batches_endpoints/endpoints.py::create_batch` ->
`router.py::_acreate_batch` -> `llms/vertex_ai/batches/transformation.py`):
when `input_file_id` is a base64-encoded `unified_file_id` (LiteLLM's
internal token for a managed, multi-model file upload -
`litellm_proxy:application/octet-stream;unified_id,...;target_model_names,...`),
the `create_batch` handler resolves the target `model` from it but forwards
the **unified_file_id itself, unchanged**, as `input_file_id` all the way
down to the provider-specific handler. Vertex AI's
`_get_model_from_gcs_file` expects a real `gs://.../publishers/...` URI and
does an unguarded `.split("publishers/")[1]` - which raises
`IndexError: list index out of range` on the opaque base64 string, surfaced
to the caller as an opaque 500.

**Before** (current code, at commit
[`a65b83d`](https://github.com/BerriAI/litellm/pull/34260/commits/a65b83da),
using the real transformation function with a realistic unified_file_id -
the exact shape produced by a real managed-file upload):
```python
>>> from litellm.llms.vertex_ai.batches.transformation import VertexAIBatchTransformation
>>> unified_file_id = "litellm_proxy:application/octet-stream;unified_id,92f2573d-0ad2-4083-9f8c-b94fecd1f98c;target_model_names,gemini-2.0-flash"
>>> VertexAIBatchTransformation._get_model_from_gcs_file(unified_file_id)
Traceback (most recent call last):
  ...
IndexError: list index out of range
```
This is the same failure class (an unguarded string/dict access on an
internal token that was never resolved to its real backend value) as the
opaque 500 seen in production; the `create_batch` proxy endpoint forwards
this same unified_file_id string to this exact function, unchanged.

**After** (this PR's code): the `create_batch` endpoint now resolves the
`unified_file_id` to its real storage location
(`LiteLLM_ManagedFileTable.storage_url`) before dispatch, so the Vertex
handler always receives a real `gs://.../publishers/...` URI:
```python
>>> # after resolution, input_file_id passed to the router/provider is the
>>> # real storage_url, e.g.:
>>> real_uri = "gs://bucket/litellm-vertex-files/publishers/google/models/gemini-2.0/abc"
>>> VertexAIBatchTransformation._get_model_from_gcs_file(real_uri)
'publishers/google/models/gemini-2.0'
```
No crash. Falls back to the previous (unchanged) behavior if no managed-file
DB record exists, so this only changes behavior for the exact case that was
previously broken.

Also covered by the 2 new regression tests in
`tests/test_litellm/proxy/batches_endpoints/test_endpoints.py`
(`test_create__unified_file_id_resolves_real_storage_url`,
`test_create__unified_file_id_no_managed_file_record_falls_back_to_raw_id`),
confirmed passing alongside all 73 pre-existing tests in that file (75
passed, 2 xfailed total).

## Type

🐛 Bug Fix

## Changes

- `litellm/proxy/batches_endpoints/endpoints.py`: in the `unified_file_id`
  branch of `create_batch`, resolve the base64 `unified_file_id` to its real
  backend storage location (`LiteLLM_ManagedFileTable.storage_url`) before
  calling `llm_router.acreate_batch()`, mirroring the same lookup already
  used by the files retrieve/download endpoints for managed files. No
  change if there's no managed-file DB record (falls back to prior
  behavior).
- `tests/test_litellm/proxy/batches_endpoints/test_endpoints.py`: 2 new
  regression tests covering the resolved-storage-url path and the
  no-DB-record fallback.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and
  regressions in the respective real-world customer use-cases are not
  possible after this PR
