### PR TITLE
fix(image-generation): preserve requested output format

### DIFF
--- a/litellm/llms/openai/image_generation/gpt_transformation.py
+++ b/litellm/llms/openai/image_generation/gpt_transformation.py
@@ -83,6 +83,6 @@ class GPTImageGenerationConfig(BaseImageGenerationConfig):
         # set optional params
         image_response.size = optional_params.get("size", "1024x1024")  # default is always 1024x1024
         image_response.quality = optional_params.get("quality", "high")  # always hd for dall-e-3
-        image_response.output_format = optional_params.get("response_format", "png")  # always png for dall-e-3
+        image_response.output_format = optional_params.get("output_format", "png")  # always png for dall-e-3
 
         return image_response

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2982,6 +2982,7 @@ def get_optional_params_image_gen(
         "n": None,
         "quality": None,
         "response_format": None,
+        "output_format": None,
         "size": None,
         "style": None,
         "user": None,

--- a/tests/test_litellm/llms/openai/image_generation/test_gpt_image_generation_transformation.py
+++ b/tests/test_litellm/llms/openai/image_generation/test_gpt_image_generation_transformation.py
@@ -1,0 +1,29 @@
+from unittest.mock import MagicMock
+
+import httpx
+
+from litellm.llms.openai.image_generation.gpt_transformation import (
+    GPTImageGenerationConfig,
+)
+from litellm.types.utils import ImageResponse
+
+
+def test_transform_image_generation_response_preserves_output_format():
+    config = GPTImageGenerationConfig()
+    raw_response = httpx.Response(
+        status_code=200,
+        json={"created": 1, "data": [{"b64_json": "image-data"}]},
+    )
+
+    result = config.transform_image_generation_response(
+        model="gpt-image-2",
+        raw_response=raw_response,
+        model_response=ImageResponse(),
+        logging_obj=MagicMock(),
+        request_data={"prompt": "A white cat"},
+        optional_params={"output_format": "webp"},
+        litellm_params={},
+        encoding=None,
+    )
+
+    assert result.output_format == "webp"

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -171,6 +171,7 @@ def test_get_optional_params_image_gen():
     optional_params = get_optional_params_image_gen(
         model="gpt-image-1",
         response_format="b64_json",
+        output_format="webp",
         n=3,
         custom_llm_provider="azure",
         drop_params=True,
@@ -179,6 +180,7 @@ def test_get_optional_params_image_gen():
     assert optional_params is not None
     assert "response_format" not in optional_params
     assert optional_params["n"] == 3
+    assert optional_params["output_format"] == "webp"
 
 
 def test_get_optional_params_image_gen_vertex_ai_size():


### PR DESCRIPTION
## TLDR

Problem this solves:

- GPT Image requests silently drop `output_format`.
- Responses read the wrong parameter and report PNG.

How it solves it:

- Preserve `output_format` during optional parameter mapping.
- Read the requested format in GPT Image responses.

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both runs used the same local LiteLLM proxy configuration, live OpenAI-compatible GPT Image endpoint, and request:

```bash
curl --fail-with-body --silent http://127.0.0.1:4000/v1/images/generations \
  -H "Authorization: Bearer example-master-key" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "proof-gpt-image",
    "prompt": "A small white circle centered on a plain black background",
    "n": 1,
    "size": "1024x1024",
    "quality": "low",
    "output_format": "jpeg"
  }' > response.json

jq '{output_format, size, quality, usage}' response.json
jq -r '.data[0].b64_json' response.json | base64 --decode > output.jpeg
file output.jpeg
sha256sum output.jpeg
```

Before, commit `f1f0a0bacd5ce681d404264db2bcd27801d9d8ac`:

```text
{
  "output_format": "png",
  "size": "1024x1024",
  "quality": "low",
  "usage": {
    "total_tokens": 288,
    "input_tokens": 16,
    "output_tokens": 272
  }
}
output.jpeg: PNG image data, 1024 x 1024, 8-bit/color RGB, non-interlaced
9e01cec4e201b83c36f4ebdf45646b72869fffcdc52e67dcddf5f695b58f5ad6  output.jpeg
```

After, commit `9a58f1ac7d702ae7e7e7de4ebcc89a37cc19bff9`:

```text
{
  "output_format": "jpeg",
  "size": "1024x1024",
  "quality": "low",
  "usage": {
    "total_tokens": 288,
    "input_tokens": 16,
    "output_tokens": 272
  }
}
output.jpeg: JPEG image data, baseline, precision 8, 1024x1024, components 3
ba1e488198cbf63e6723c4cd00a4f60732da35881cdde3fc100ec106c7048217  output.jpeg
```

The PR was later rebased onto staging commit `3bba3633c7c826891929bb0d5536b818d7dc4179` without changing the patch. The current head is `7510f88cd5eb335217354c547ec7ead9a7ce63a6`

## Type

🐛 Bug Fix

## Changes

`get_optional_params_image_gen` filtered out `output_format` because it was missing from its default parameter map. The GPT Image response transformation also looked up `response_format` instead of `output_format`.

- Add `output_format` to image generation optional parameter handling.
- Read `output_format` when building GPT Image responses.
- Cover request mapping and response metadata with regression tests.

Validation:

- Related OpenAI and Azure image tests: `21 passed`.
- Targeted Ruff format and lint checks passed.
- Live before and after proxy proof passed.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
