### PR TITLE
refactor(ui): migrate api-reference to shadcn

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -65,11 +65,6 @@
       "count": 2
     }
   },
-  "src/app/(dashboard)/api-reference/_components/APIReferenceView.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/app/(dashboard)/budgets/_components/budget_modal.tsx": {
     "no-restricted-imports": {
       "count": 1

--- a/ui/litellm-dashboard/src/app/(dashboard)/api-reference/_components/APIReferenceView.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/api-reference/_components/APIReferenceView.test.tsx
@@ -85,8 +85,8 @@ describe("APIReferenceView", () => {
 
     expect(screen.getByRole("tab", { name: tabName }).getAttribute("aria-selected")).toBe("true");
 
-    const snippet = screen.getAllByTestId(codeBlockTestId).find((block) => block.textContent?.includes(marker));
-    expect(snippet).toBeDefined();
-    expect(snippet?.textContent).toContain(proxyUrl);
+    const selectedPanel = screen.getByRole("tabpanel");
+    expect(selectedPanel.textContent).toContain(marker);
+    expect(selectedPanel.textContent).toContain(proxyUrl);
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/api-reference/_components/APIReferenceView.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/api-reference/_components/APIReferenceView.test.tsx
@@ -1,4 +1,5 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import APIReferenceView from "./APIReferenceView";
 
@@ -43,5 +44,49 @@ describe("APIReferenceView", () => {
     const renderedCode = codeBlocks[0].textContent ?? "";
     expect(renderedCode).toContain(apiDocUrl);
     expect(renderedCode).not.toContain(proxyUrl);
+  });
+
+  it("renders the page title, blurb and docs link", () => {
+    render(<APIReferenceView proxySettings={{ PROXY_BASE_URL: "https://proxy.litellm.test" }} />);
+
+    expect(screen.getByText("OpenAI Compatible Proxy: API Reference")).toBeTruthy();
+    expect(screen.getByText(/LiteLLM is OpenAI Compatible/)).toBeTruthy();
+
+    const docsLink = screen.getByRole("link", { name: /API Reference Docs/ });
+    expect(docsLink.getAttribute("href")).toBe("https://docs.litellm.ai/docs/proxy/user_keys");
+    expect(docsLink.getAttribute("target")).toBe("_blank");
+  });
+
+  it("exposes the three SDK tabs with the first selected by default", () => {
+    render(<APIReferenceView proxySettings={{ PROXY_BASE_URL: "https://proxy.litellm.test" }} />);
+
+    expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
+      "OpenAI Python SDK",
+      "LlamaIndex",
+      "Langchain Py",
+    ]);
+    expect(screen.getAllByRole("tab").map((tab) => tab.getAttribute("aria-selected"))).toEqual([
+      "true",
+      "false",
+      "false",
+    ]);
+  });
+
+  it.each([
+    ["OpenAI Python SDK", "import openai"],
+    ["LlamaIndex", "from llama_index.llms import AzureOpenAI"],
+    ["Langchain Py", "from langchain.chat_models import ChatOpenAI"],
+  ])("selecting %s shows its snippet wired to the base url", async (tabName, marker) => {
+    const proxyUrl = "https://proxy.litellm.test";
+    const user = userEvent.setup();
+    render(<APIReferenceView proxySettings={{ PROXY_BASE_URL: proxyUrl }} />);
+
+    await user.click(screen.getByRole("tab", { name: tabName }));
+
+    expect(screen.getByRole("tab", { name: tabName }).getAttribute("aria-selected")).toBe("true");
+
+    const snippet = screen.getAllByTestId(codeBlockTestId).find((block) => block.textContent?.includes(marker));
+    expect(snippet).toBeDefined();
+    expect(snippet?.textContent).toContain(proxyUrl);
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/api-reference/_components/APIReferenceView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/api-reference/_components/APIReferenceView.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React from "react";
-import { Text, Tab, TabGroup, TabList, TabPanel, TabPanels, Grid } from "@tremor/react";
 import CodeBlock from "@/components/CodeBlock";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import DocLink from "./DocLink";
 
 interface ApiRefProps {
@@ -21,33 +21,35 @@ const APIReferenceView: React.FC<ApiRefProps> = ({ proxySettings }) => {
   }
 
   return (
-    <>
-      <Grid className="gap-2 p-8 h-[80vh] w-full mt-2">
-        <div className="mb-5">
-          {/* Header row with Docs link on the right */}
-          <div className="flex items-center justify-between">
-            <p className="text-2xl text-tremor-content-strong dark:text-dark-tremor-content-strong font-semibold">
-              OpenAI Compatible Proxy: API Reference
-            </p>
-            <DocLink className="ml-3 shrink-0" href="https://docs.litellm.ai/docs/proxy/user_keys" />
-          </div>
+    <div className="grid grid-cols-1 gap-2 p-8 h-[80vh] w-full mt-2">
+      <div className="mb-5">
+        {/* Header row with Docs link on the right */}
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-semibold text-foreground">OpenAI Compatible Proxy: API Reference</h1>
+          <DocLink className="ml-3 shrink-0" href="https://docs.litellm.ai/docs/proxy/user_keys" />
+        </div>
 
-          <Text className="mt-2 mb-2">
-            LiteLLM is OpenAI Compatible. This means your API Key works with the OpenAI SDK. Just replace the base_url
-            to point to your litellm proxy. Example Below{" "}
-          </Text>
+        <p className="mt-2 mb-2 text-sm text-muted-foreground">
+          LiteLLM is OpenAI Compatible. This means your API Key works with the OpenAI SDK. Just replace the base_url to
+          point to your litellm proxy. Example Below{" "}
+        </p>
 
-          <TabGroup>
-            <TabList>
-              <Tab>OpenAI Python SDK</Tab>
-              <Tab>LlamaIndex</Tab>
-              <Tab>Langchain Py</Tab>
-            </TabList>
-            <TabPanels>
-              <TabPanel>
-                <CodeBlock
-                  language="python"
-                  code={`import openai
+        <Tabs defaultValue="openai">
+          <TabsList variant="line" className="border-b rounded-none w-full justify-start h-auto p-0">
+            <TabsTrigger value="openai" className="rounded-none px-4 py-2 flex-none">
+              OpenAI Python SDK
+            </TabsTrigger>
+            <TabsTrigger value="llamaindex" className="rounded-none px-4 py-2 flex-none">
+              LlamaIndex
+            </TabsTrigger>
+            <TabsTrigger value="langchain" className="rounded-none px-4 py-2 flex-none">
+              Langchain Py
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="openai">
+            <CodeBlock
+              language="python"
+              code={`import openai
 client = openai.OpenAI(
     api_key="your_api_key",
     base_url="${base_url}" # LiteLLM Proxy is OpenAI compatible, Read More: https://docs.litellm.ai/docs/proxy/user_keys
@@ -64,13 +66,13 @@ response = client.chat.completions.create(
 )
 
 print(response)`}
-                />
-              </TabPanel>
+            />
+          </TabsContent>
 
-              <TabPanel>
-                <CodeBlock
-                  language="python"
-                  code={`import os, dotenv
+          <TabsContent value="llamaindex">
+            <CodeBlock
+              language="python"
+              code={`import os, dotenv
 
 from llama_index.llms import AzureOpenAI
 from llama_index.embeddings import AzureOpenAIEmbedding
@@ -98,13 +100,13 @@ index = VectorStoreIndex.from_documents(documents, service_context=service_conte
 query_engine = index.as_query_engine()
 response = query_engine.query("What did the author do growing up?")
 print(response)`}
-                />
-              </TabPanel>
+            />
+          </TabsContent>
 
-              <TabPanel>
-                <CodeBlock
-                  language="python"
-                  code={`from langchain.chat_models import ChatOpenAI
+          <TabsContent value="langchain">
+            <CodeBlock
+              language="python"
+              code={`from langchain.chat_models import ChatOpenAI
 from langchain.prompts.chat import (
     ChatPromptTemplate,
     HumanMessagePromptTemplate,
@@ -129,13 +131,11 @@ messages = [
 response = chat(messages)
 
 print(response)`}
-                />
-              </TabPanel>
-            </TabPanels>
-          </TabGroup>
-        </div>
-      </Grid>
-    </>
+            />
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- API reference page still renders on Tremor primitives
- Tremor and antd are being retired from the dashboard
- Page had no test covering its tabs

How it solves it:

- Swaps Tremor Grid, Text and Tab for shadcn Tabs
- Markup only; no behaviour or data changes
- Adds a characterisation test first, then migrates under it

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before (`4ac63155fb`, Tremor) and after (`accce8d555`, shadcn), captured on the API reference page at 1280x720; screenshots attached below.

Layout is preserved: page title, "API Reference Docs" button on the right, the three SDK tabs left-aligned at content width, and the code block below. The tab underline picks up the design system's active-tab treatment instead of Tremor's blue, and the intro paragraph now wraps onto a second line; both are expected for a page moving onto the shared primitives.

Reviewer steps to confirm on a local proxy:

1. Start the proxy, then the dashboard dev server in `ui/litellm-dashboard` with `npm run dev`
2. Open the API reference page at http://localhost:3000/?page=api-reference
3. Confirm the title, the "API Reference Docs" button on the right, and the intro paragraph all render
4. Click through "OpenAI Python SDK", "LlamaIndex" and "Langchain Py"; each shows that SDK's snippet and the snippet's base_url matches the proxy's own URL
5. Confirm the page does not scroll sideways at 1280px wide

## Type

🧹 Refactoring

## Changes

`src/app/(dashboard)/api-reference/_components/APIReferenceView.tsx` moves off Tremor. `Grid` becomes a plain `div`, `Text` becomes a `p` with token classes, the page title becomes an `h1`, and `TabGroup` / `TabList` / `Tab` / `TabPanels` / `TabPanel` become the shadcn `Tabs` primitive. The Python snippets and the `base_url` resolution are untouched. Dark-mode classes are dropped since the dashboard is light-only.

The wrapper keeps an explicit `grid-cols-1`. Tremor's `Grid` defaults to `numItems=1` and emitted that class, and `grid-cols-1` resolves to `repeat(1, minmax(0, 1fr))`; without it the implicit column sizes to its widest child, so the code block pushed the page into horizontal overflow. That regression showed up in the rendered screenshot and is fixed here.

Removing the Tremor import made the file's grandfathered `no-restricted-imports` entry stale, so `eslint-suppressions.json` drops it, taking the baseline from 350 files to 349. The prune was scoped to this one file, so no other entry moved.

The first commit adds the characterisation test and changes no component; the second migrates and does not touch the test. A third commit then scopes the snippet assertion to the rendered `tabpanel` rather than searching every mounted code block, so the check holds even if the panels are ever kept mounted. The test asserts the three tabs and their accessible names, the default selection, that selecting a tab surfaces that SDK's snippet wired to the resolved base url, and the title, blurb and docs link. It was proven green against the Tremor version first, so it carries over unedited rather than being written to fit the new markup.

Scope was taken from the route's real import closure. Only the file above is owned by this route and free of forms. Left alone deliberately:

- `src/components/common_components/check_openapi_schema.tsx` contains an antd `Form`, so it is deferred until forms are unblocked
- `src/components/DeprecationBanner.tsx` (7 pages), `src/components/molecules/message_manager.tsx` (46 pages) and `src/components/molecules/notifications_manager.tsx` (46 pages) are shared, and editing one from a page PR would silently change every other page that renders it

This supersedes the API reference half of #32343, which also rewrites the shared `leftnav.tsx` and predates the move of this file into `_components/`.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
