### PR TITLE
feat: add TrustedRouter as a JSON-configured OpenAI-compatible provider

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -726,6 +726,7 @@ openai_compatible_endpoints: List = [
     "https://api.inference.wandb.ai/v1",
     "https://api.clarifai.com/v2/ext/openai/v1",
     "https://api.libertai.io/v1",
+    "https://api.trustedrouter.com/v1",
     "https://pinstripes.io/v1",
     "https://api.meta.ai/v1",
 ]
@@ -773,6 +774,7 @@ openai_compatible_providers: List = [
     "chutes",  # Chutes - JSON-configured provider
     "parasail",  # Parasail - JSON-configured provider
     "libertai",  # LibertAI - JSON-configured provider
+    "trustedrouter",  # TrustedRouter - JSON-configured provider
     "featherless_ai",
     "nscale",
     "nebius",

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -788,6 +788,7 @@ openai_compatible_endpoints: Final[list] = [
     "https://api.inference.wandb.ai/v1",
     "https://api.clarifai.com/v2/ext/openai/v1",
     "https://api.libertai.io/v1",
+    "https://api.trustedrouter.com/v1",
     "https://pinstripes.io/v1",
     "https://api.meta.ai/v1",
     "https://api.cognition.ai/v1",
@@ -837,6 +838,7 @@ openai_compatible_providers: Final[list] = [
     "chutes",  # Chutes - JSON-configured provider
     "parasail",  # Parasail - JSON-configured provider
     "libertai",  # LibertAI - JSON-configured provider
+    "trustedrouter",  # TrustedRouter - JSON-configured provider
     "featherless_ai",
     "nscale",
     "nebius",

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -343,6 +343,9 @@ def get_llm_provider(
                     elif endpoint == "https://api.inference.wandb.ai/v1":
                         custom_llm_provider = "wandb"
                         dynamic_api_key = get_secret_str("WANDB_API_KEY")
+                    elif endpoint == "https://api.trustedrouter.com/v1":
+                        custom_llm_provider = "trustedrouter"
+                        dynamic_api_key = get_secret_str("TRUSTEDROUTER_API_KEY")
                     elif endpoint == "https://pinstripes.io/v1":
                         custom_llm_provider = "pinstripes"
                         dynamic_api_key = get_secret_str("PINSTRIPES_API_KEY")

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -183,5 +183,11 @@
       "max_completion_tokens": "max_tokens"
     },
     "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/embeddings"]
+  },
+  "trustedrouter": {
+    "base_url": "https://api.trustedrouter.com/v1",
+    "api_key_env": "TRUSTEDROUTER_API_KEY",
+    "api_base_env": "TRUSTEDROUTER_API_BASE",
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
   }
 }

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -200,5 +200,11 @@
       "temperature_max": 1.99
     },
     "supported_endpoints": ["/v1/chat/completions"]
+  },
+  "trustedrouter": {
+    "base_url": "https://api.trustedrouter.com/v1",
+    "api_key_env": "TRUSTEDROUTER_API_KEY",
+    "api_base_env": "TRUSTEDROUTER_API_BASE",
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
   }
 }

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3507,6 +3507,7 @@ class LlmProviders(str, Enum):
     XIAOMI_MIMO = "xiaomi_mimo"
     TENSORMESH = "tensormesh"
     LIBERTAI = "libertai"
+    TRUSTEDROUTER = "trustedrouter"
     PINSTRIPES = "pinstripes"
     DARKBLOOM = "darkbloom"
     META = "meta"

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3831,6 +3831,7 @@ class LlmProviders(str, Enum):
     XIAOMI_MIMO = "xiaomi_mimo"
     TENSORMESH = "tensormesh"
     LIBERTAI = "libertai"
+    TRUSTEDROUTER = "trustedrouter"
     PINSTRIPES = "pinstripes"
     COGNITION = "cognition"
     SCX_AI = "scx-ai"

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -2441,6 +2441,24 @@
         "interactions": true
       }
     },
+    "trustedrouter": {
+      "display_name": "TrustedRouter (`trustedrouter`)",
+      "url": "https://docs.litellm.ai/docs/providers/trustedrouter",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": true,
+        "responses": true,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false,
+        "interactions": false
+      }
+    },
     "v0": {
       "display_name": "V0 (`v0`)",
       "url": "https://docs.litellm.ai/docs/providers/v0",

--- a/tests/test_litellm/llms/trustedrouter/test_trustedrouter.py
+++ b/tests/test_litellm/llms/trustedrouter/test_trustedrouter.py
@@ -1,0 +1,59 @@
+import os
+from unittest.mock import patch
+
+TRUSTEDROUTER_API_BASE = "https://api.trustedrouter.com/v1"
+
+
+def test_trustedrouter_json_registry():
+    import litellm
+    from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+    assert litellm.LlmProviders.TRUSTEDROUTER.value == "trustedrouter"
+    assert litellm.LlmProviders("trustedrouter") == litellm.LlmProviders.TRUSTEDROUTER
+    assert JSONProviderRegistry.exists("trustedrouter")
+    config = JSONProviderRegistry.get("trustedrouter")
+    assert config is not None
+    assert config.base_url == TRUSTEDROUTER_API_BASE
+    assert config.api_key_env == "TRUSTEDROUTER_API_KEY"
+    assert config.api_base_env == "TRUSTEDROUTER_API_BASE"
+    assert "/v1/chat/completions" in config.supported_endpoints
+    assert "/v1/responses" in config.supported_endpoints
+
+
+def test_trustedrouter_listed_in_openai_compatible_providers():
+    from litellm.constants import (
+        openai_compatible_endpoints,
+        openai_compatible_providers,
+    )
+
+    assert "trustedrouter" in openai_compatible_providers
+    assert TRUSTEDROUTER_API_BASE in openai_compatible_endpoints
+
+
+def test_trustedrouter_dynamic_config_env_vars():
+    from litellm.llms.openai_like.dynamic_config import create_config_class
+    from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+    config = create_config_class(JSONProviderRegistry.get("trustedrouter"))()
+
+    with patch.dict(
+        os.environ,
+        {
+            "TRUSTEDROUTER_API_KEY": "test-key",
+            "TRUSTEDROUTER_API_BASE": "https://example.com/v1",
+        },
+    ):
+        api_base, api_key = config._get_openai_compatible_provider_info(None, None)
+
+    assert api_base == "https://example.com/v1"
+    assert api_key == "test-key"
+
+
+def test_trustedrouter_provider_detection_by_prefix():
+    from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+    model, provider, _, api_base = get_llm_provider("trustedrouter/zdr")
+
+    assert model == "zdr"
+    assert provider == "trustedrouter"
+    assert api_base == TRUSTEDROUTER_API_BASE

--- a/tests/test_litellm/llms/trustedrouter/test_trustedrouter.py
+++ b/tests/test_litellm/llms/trustedrouter/test_trustedrouter.py
@@ -1,0 +1,71 @@
+import os
+from unittest.mock import patch
+
+TRUSTEDROUTER_API_BASE = "https://api.trustedrouter.com/v1"
+
+
+def test_trustedrouter_json_registry():
+    import litellm
+    from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+    assert litellm.LlmProviders.TRUSTEDROUTER.value == "trustedrouter"
+    assert litellm.LlmProviders("trustedrouter") == litellm.LlmProviders.TRUSTEDROUTER
+    assert JSONProviderRegistry.exists("trustedrouter")
+    config = JSONProviderRegistry.get("trustedrouter")
+    assert config is not None
+    assert config.base_url == TRUSTEDROUTER_API_BASE
+    assert config.api_key_env == "TRUSTEDROUTER_API_KEY"
+    assert config.api_base_env == "TRUSTEDROUTER_API_BASE"
+    assert "/v1/chat/completions" in config.supported_endpoints
+    assert "/v1/responses" in config.supported_endpoints
+
+
+def test_trustedrouter_listed_in_openai_compatible_providers():
+    from litellm.constants import (
+        openai_compatible_endpoints,
+        openai_compatible_providers,
+    )
+
+    assert "trustedrouter" in openai_compatible_providers
+    assert TRUSTEDROUTER_API_BASE in openai_compatible_endpoints
+
+
+def test_trustedrouter_dynamic_config_env_vars():
+    from litellm.llms.openai_like.dynamic_config import create_config_class
+    from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+    config = create_config_class(JSONProviderRegistry.get("trustedrouter"))()
+
+    with patch.dict(
+        os.environ,
+        {
+            "TRUSTEDROUTER_API_KEY": "test-key",
+            "TRUSTEDROUTER_API_BASE": "https://example.com/v1",
+        },
+    ):
+        api_base, api_key = config._get_openai_compatible_provider_info(None, None)
+
+    assert api_base == "https://example.com/v1"
+    assert api_key == "test-key"
+
+
+def test_trustedrouter_provider_detection_by_prefix():
+    from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+    model, provider, _, api_base = get_llm_provider("trustedrouter/zdr")
+
+    assert model == "zdr"
+    assert provider == "trustedrouter"
+    assert api_base == TRUSTEDROUTER_API_BASE
+
+
+def test_trustedrouter_provider_detection_by_api_base():
+    from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+    with patch.dict(os.environ, {"TRUSTEDROUTER_API_KEY": "test-key"}):
+        model, provider, dynamic_api_key, api_base = get_llm_provider("auto", api_base=TRUSTEDROUTER_API_BASE)
+
+    assert model == "auto"
+    assert provider == "trustedrouter"
+    assert api_base == TRUSTEDROUTER_API_BASE
+    assert dynamic_api_key == "test-key"

--- a/ui/litellm-dashboard/public/assets/logos/trustedrouter.svg
+++ b/ui/litellm-dashboard/public/assets/logos/trustedrouter.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+  <path d="M1.4 7.5 H6.5 L11 12" stroke="#1f2328"/>
+  <path d="M1.4 16.5 H4 L8.5 12" stroke="#1f2328"/>
+  <path d="M1.4 12 H15.5" stroke="#1f2328"/>
+  <path d="M17.4 12 H22.6" stroke="#0F9D58"/>
+  <circle cx="15.5" cy="12" r="1.9" fill="#0F9D58"/>
+</svg>

--- a/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
@@ -54,6 +54,7 @@ import snowflakeLogo from "../../public/assets/logos/snowflake.svg";
 import sonioxLogo from "../../public/assets/logos/soniox.svg";
 import togetheraiLogo from "../../public/assets/logos/togetherai.svg";
 import topazLogo from "../../public/assets/logos/topaz.svg";
+import trustedrouterLogo from "../../public/assets/logos/trustedrouter.svg";
 import v0Logo from "../../public/assets/logos/v0.svg";
 import vercelLogo from "../../public/assets/logos/vercel.svg";
 import vllmLogo from "../../public/assets/logos/vllm.png";
@@ -157,6 +158,7 @@ export enum Providers {
   TogetherAI = "TogetherAI",
   TOPAZ = "Topaz",
   Triton = "Triton",
+  Trustedrouter = "Trustedrouter",
   V0 = "V0",
   VERCEL_AI_GATEWAY = "Vercel Ai Gateway",
   Vertex_AI = "Vertex AI (Anthropic, Gemini, etc.)",
@@ -266,6 +268,7 @@ export const provider_map: Record<string, string> = {
   TogetherAI: "together_ai",
   TOPAZ: "topaz",
   Triton: "triton",
+  Trustedrouter: "trustedrouter",
   V0: "v0",
   VERCEL_AI_GATEWAY: "vercel_ai_gateway",
   Vertex_AI: "vertex_ai",
@@ -357,6 +360,7 @@ export const providerLogoMap: Partial<Record<Providers, string>> = {
   [Providers.TogetherAI]: togetheraiLogo.src,
   [Providers.TOPAZ]: topazLogo.src,
   [Providers.Triton]: nvidiaTritonLogo.src,
+  [Providers.Trustedrouter]: trustedrouterLogo.src,
   [Providers.V0]: v0Logo.src,
   [Providers.VERCEL_AI_GATEWAY]: vercelLogo.src,
   [Providers.Vertex_AI]: googleLogo.src,

--- a/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
@@ -42,6 +42,7 @@ import nvidiaTritonLogo from "../../public/assets/logos/nvidia_triton.png";
 import ollamaLogo from "../../public/assets/logos/ollama.svg";
 import openaiSmallLogo from "../../public/assets/logos/openai_small.svg";
 import openrouterLogo from "../../public/assets/logos/openrouter.svg";
+import trustedrouterLogo from "../../public/assets/logos/trustedrouter.svg";
 import oracleLogo from "../../public/assets/logos/oracle.svg";
 import perplexityAiLogo from "../../public/assets/logos/perplexity-ai.svg";
 import qwenLogo from "../../public/assets/logos/qwen.png";
@@ -161,6 +162,7 @@ export enum Providers {
   TogetherAI = "TogetherAI",
   TOPAZ = "Topaz",
   Triton = "Triton",
+  Trustedrouter = "Trustedrouter",
   V0 = "V0",
   VERCEL_AI_GATEWAY = "Vercel Ai Gateway",
   Vertex_AI = "Vertex AI (Anthropic, Gemini, etc.)",
@@ -273,6 +275,7 @@ export const provider_map: Record<string, string> = {
   TogetherAI: "together_ai",
   TOPAZ: "topaz",
   Triton: "triton",
+  Trustedrouter: "trustedrouter",
   V0: "v0",
   VERCEL_AI_GATEWAY: "vercel_ai_gateway",
   Vertex_AI: "vertex_ai",
@@ -366,6 +369,7 @@ export const providerLogoMap: Partial<Record<Providers, string>> = {
   [Providers.TogetherAI]: togetheraiLogo.src,
   [Providers.TOPAZ]: topazLogo.src,
   [Providers.Triton]: nvidiaTritonLogo.src,
+  [Providers.Trustedrouter]: trustedrouterLogo.src,
   [Providers.V0]: v0Logo.src,
   [Providers.VERCEL_AI_GATEWAY]: vercelLogo.src,
   [Providers.Vertex_AI]: googleLogo.src,


### PR DESCRIPTION
## Relevant issues

Companion docs PR: BerriAI/litellm-docs#426

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live completion through the registered provider against the real TrustedRouter endpoint, no mocks. TrustedRouter uses namespaced model ids, so the model after the `trustedrouter/` prefix is the full TrustedRouter id (a vendor model, or a `trustedrouter/<alias>` router alias)

Vendor model:

```
$ export TRUSTEDROUTER_API_KEY=<key>
$ python -c "import litellm; r=litellm.completion(model='trustedrouter/google/gemini-2.5-flash-lite', messages=[{'role':'user','content':'Reply with exactly: hello from trustedrouter'}], max_tokens=30); print(r.model, '|', r.choices[0].message.content, '|', r.usage.total_tokens)"
trustedrouter/google/gemini-2.5-flash-lite | hello from trustedrouter | 12
```

Router alias (the alias keeps its own `trustedrouter/` namespace, so it follows the provider prefix):

```
$ python -c "import litellm; r=litellm.completion(model='trustedrouter/trustedrouter/auto', messages=[{'role':'user','content':'Reply with exactly: hello from trustedrouter'}], max_tokens=30); print(r.model, '|', r.choices[0].message.content)"
trustedrouter/anthropic/claude-opus-4.7 | hello from trustedrouter
```

## Type

New Feature

## Changes

Adds TrustedRouter (https://trustedrouter.com), an OpenAI-compatible LLM router, via the JSON provider registry following the parasail/libertai pattern. One entry in `litellm/llms/openai_like/providers.json` (base url, `TRUSTEDROUTER_API_KEY`, `TRUSTEDROUTER_API_BASE`, chat completions and responses endpoints), list membership in `openai_compatible_providers` and `openai_compatible_endpoints`, the `LlmProviders.TRUSTEDROUTER` enum member, and unit tests in `tests/test_litellm/llms/trustedrouter/test_trustedrouter.py` covering the registry entry, constants membership, env-var dynamic config, and `trustedrouter/` prefix routing

Like libertai, resolution is by the `trustedrouter/` model prefix. TrustedRouter model ids are namespaced (`openai/...`, `google/...`, or the `trustedrouter/...` router aliases), and the segment after the provider prefix is forwarded verbatim, so `trustedrouter/google/gemini-2.5-flash-lite` sends `google/gemini-2.5-flash-lite` and `trustedrouter/trustedrouter/auto` sends `trustedrouter/auto`

## QA runbook

Add a model to `litellm/proxy/dev_config.yaml`:

```yaml
model_list:
  - model_name: tr-gemini-flash-lite
    litellm_params:
      model: trustedrouter/google/gemini-2.5-flash-lite
      api_key: os.environ/TRUSTEDROUTER_API_KEY
```

1. `export TRUSTEDROUTER_API_KEY=<key>` (keys at https://trustedrouter.com)
2. Start the proxy: `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug`
3. `curl http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model": "tr-gemini-flash-lite", "messages": [{"role": "user", "content": "Say hi"}]}'`
4. Expect a completion routed through api.trustedrouter.com with usage reported

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
