### PR TITLE
fix(proxy): reseed spend:end_user: counter from LiteLLM_EndUserTable

### DIFF
--- a/litellm/proxy/db/spend_counter_reseed.py
+++ b/litellm/proxy/db/spend_counter_reseed.py
@@ -22,6 +22,7 @@ from litellm.constants import SPEND_COUNTER_RESEED_LOCKS_MAX_SIZE
 from litellm.litellm_core_utils.duration_parser import duration_in_seconds
 from litellm.repositories.organization_repository import OrganizationRepository
 from litellm.repositories.table_repositories import (
+    EndUserRepository,
     SpendLogsRepository,
     TeamMembershipRepository,
 )
@@ -107,7 +108,8 @@ class SpendCounterReseed:
                 user_id = counter_key[len("spend:user:") :]
                 row = await UserRepository(prisma_client).table.find_unique(where={"user_id": user_id})
             elif counter_key.startswith("spend:end_user:"):
-                return None
+                user_id = counter_key[len("spend:end_user:") :]
+                row = await EndUserRepository(prisma_client).table.find_unique(where={"user_id": user_id})
             elif counter_key.startswith("spend:tag:"):
                 return None
             elif counter_key.startswith("spend:org:"):


### PR DESCRIPTION
Fixes #34238

## Problem
SpendCounterReseed.from_db() unconditionally returns None for the spend:end_user: branch, unlike every other entity branch (key, team, user, org) which correctly reseeds from its DB table when the Redis counter expires.

## Impact
When the Redis counter for an end user's spend expires (~60s TTL), it gets recreated from a per-pod fallback_spend cache instead of the authoritative LiteLLM_EndUserTable.spend value. This stale, potentially lower value can let requests past max_budget succeed, effectively bypassing budget enforcement.

## Fix
Added the missing spend:end_user: branch using EndUserRepository, mirroring the existing spend:user: pattern exactly. LiteLLM_EndUserTable's primary key is user_id, confirmed against schema.prisma.