### PR TITLE
fix(streaming): emit '{}' tool arguments for zero-argument Claude tool calls

### DIFF
--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -584,9 +584,14 @@ class ModelResponseIterator:
         Check if the tool call block so far has been an empty string
         """
         args = ""
-        # if text content block -> skip
         if len(self.content_blocks) == 0:
-            return False
+            # Zero-argument tool call: Anthropic emits content_block_start
+            # followed directly by content_block_stop, with no
+            # input_json_delta events in between. The only caller guards on
+            # current_content_block_type in ("tool_use", "server_tool_use"),
+            # so an empty delta list here means the tool's arguments are
+            # empty and the "{}" repair chunk must be emitted.
+            return True
 
         if (
             self.content_blocks[0]["delta"]["type"] == "text_delta"

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -1464,10 +1464,20 @@ class AWSEventStreamDecoder:
         # the empty-args tool chunk and reset tracking state
         if self.json_mode is True and self._current_tool_name == RESPONSE_FORMAT_TOOL_NAME:
             self._current_tool_name = None
+            self.content_blocks = []
             return tool_use
 
+        # Bedrock streams no contentBlockDelta events for a tool called with
+        # zero arguments, so content_blocks stays empty and
+        # check_empty_tool_call_args() alone cannot detect the empty tool call.
+        is_tool_block_without_deltas = self._current_tool_name is not None and len(self.content_blocks) == 0
         self._current_tool_name = None
-        is_empty = self.check_empty_tool_call_args()
+        is_empty = is_tool_block_without_deltas or self.check_empty_tool_call_args()
+        # Reset delta state at every block boundary: text blocks arrive without
+        # a contentBlockStart event (content_blocks is otherwise only reset on
+        # start events), so stale toolUse deltas would be re-checked at the next
+        # block's stop and emit a duplicate "{}" chunk.
+        self.content_blocks = []
         if is_empty:
             tool_use = {
                 "id": None,

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
@@ -2045,3 +2045,127 @@ def test_non_bash_tool_result_skipped():
     assert (
         len(code_results) == 0
     ), f"Expected 0 code_interpreter_results for text_editor result, got {len(code_results)}"
+
+
+def _accumulate_tool_call_args(iterator, chunks):
+    """Feed raw Anthropic SSE event dicts through chunk_parser, accumulate tool args per tool index."""
+    accumulated_args = {}
+    for chunk in chunks:
+        parsed = iterator.chunk_parser(chunk)
+        if not parsed.choices:
+            continue
+        for tool_call in parsed.choices[0].delta.tool_calls or []:
+            tool_call = (
+                tool_call if isinstance(tool_call, dict) else tool_call.model_dump()
+            )
+            index = tool_call["index"]
+            accumulated_args.setdefault(index, "")
+            accumulated_args[index] += tool_call["function"]["arguments"] or ""
+    return accumulated_args
+
+
+def test_tool_call_with_no_input_json_deltas_emits_empty_args_chunk():
+    """
+    A zero-argument tool call streams content_block_start(tool_use) followed
+    directly by content_block_stop - no input_json_delta events in between.
+    The iterator must still emit the arguments="{}" repair chunk at
+    content_block_stop, otherwise clients accumulate arguments == "" and
+    json.loads("") fails with "Expecting value".
+
+    See: https://github.com/BerriAI/litellm/issues/19858
+    """
+    chunks = [
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+                "type": "tool_use",
+                "id": "toolu_noargs",
+                "name": "list_files",
+                "input": {},
+            },
+        },
+        {"type": "content_block_stop", "index": 0},
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "tool_use", "stop_sequence": None},
+            "usage": {"output_tokens": 5},
+        },
+    ]
+    iterator = ModelResponseIterator(streaming_response=None, sync_stream=True)
+
+    accumulated_args = _accumulate_tool_call_args(iterator, chunks)
+    assert accumulated_args == {0: "{}"}
+    json.loads(accumulated_args[0])  # must be valid JSON
+
+
+def test_zero_arg_tool_call_followed_by_tool_with_args():
+    """A zero-argument tool must not corrupt a following tool call's index or args."""
+    chunks = [
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "list_files",
+                "input": {},
+            },
+        },
+        {"type": "content_block_stop", "index": 0},
+        {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {
+                "type": "tool_use",
+                "id": "toolu_2",
+                "name": "read_file",
+                "input": {},
+            },
+        },
+        {
+            "type": "content_block_delta",
+            "index": 1,
+            "delta": {"type": "input_json_delta", "partial_json": '{"path": "a.py"}'},
+        },
+        {"type": "content_block_stop", "index": 1},
+    ]
+    iterator = ModelResponseIterator(streaming_response=None, sync_stream=True)
+
+    accumulated_args = _accumulate_tool_call_args(iterator, chunks)
+    assert accumulated_args == {0: "{}", 1: '{"path": "a.py"}'}
+
+
+def test_text_block_stop_emits_no_tool_call_chunk():
+    """content_block_stop after a text block must not emit a "{}" tool chunk."""
+    chunks = [
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "Hello"},
+        },
+        {"type": "content_block_stop", "index": 0},
+    ]
+    iterator = ModelResponseIterator(streaming_response=None, sync_stream=True)
+
+    assert _accumulate_tool_call_args(iterator, chunks) == {}
+
+
+def test_thinking_block_stop_emits_no_tool_call_chunk():
+    """content_block_stop after a start-only thinking block must not emit a "{}" tool chunk."""
+    chunks = [
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "redacted_thinking", "data": "redacted"},
+        },
+        {"type": "content_block_stop", "index": 0},
+    ]
+    iterator = ModelResponseIterator(streaming_response=None, sync_stream=True)
+
+    assert _accumulate_tool_call_args(iterator, chunks) == {}

--- a/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 from unittest.mock import AsyncMock, MagicMock
@@ -326,3 +327,121 @@ def test_legacy_bedrock_llm_streaming_does_not_rechunk_by_default():
     )
 
     mock_response.iter_bytes.assert_called_once_with(chunk_size=None)
+
+
+def _collect_tool_call_args(parsed_chunks):
+    """Accumulate tool_call argument deltas across parsed chunks, keyed by tool index."""
+    accumulated_args = {}
+    for parsed_chunk in parsed_chunks:
+        chunk_dict = (
+            parsed_chunk.model_dump()
+            if hasattr(parsed_chunk, "model_dump")
+            else parsed_chunk
+        )
+        choices = chunk_dict.get("choices") or []
+        if not choices:
+            continue
+        for tool_call in choices[0].get("delta", {}).get("tool_calls") or []:
+            index = tool_call["index"]
+            accumulated_args.setdefault(index, "")
+            accumulated_args[index] += tool_call["function"]["arguments"] or ""
+    return accumulated_args
+
+
+def test_tool_call_with_no_input_deltas_emits_empty_args_chunk():
+    """
+    A tool called with zero arguments streams contentBlockStart(toolUse)
+    followed directly by contentBlockStop - no contentBlockDelta events.
+    The decoder must still emit the arguments="{}" repair chunk, otherwise
+    clients accumulate arguments == "" and json.loads("") fails.
+
+    See: https://github.com/BerriAI/litellm/issues/19858
+    """
+    chunks = [
+        {"messageStart": {"role": "assistant"}},
+        {
+            "start": {"toolUse": {"toolUseId": "tooluse_noargs", "name": "get_time"}},
+            "contentBlockIndex": 0,
+        },
+        {"contentBlockIndex": 0},  # stop event, no deltas were streamed
+        {"stopReason": "tool_use"},
+    ]
+    decoder = AWSEventStreamDecoder(model="test")
+    parsed_chunks = [decoder._chunk_parser(chunk) for chunk in chunks]
+
+    accumulated_args = _collect_tool_call_args(parsed_chunks)
+    assert accumulated_args == {0: "{}"}
+    json.loads(accumulated_args[0])  # must be valid JSON
+
+
+def test_tool_call_with_no_input_deltas_followed_by_second_tool():
+    """A zero-argument tool must not corrupt a following tool call's index or args."""
+    chunks = [
+        {"messageStart": {"role": "assistant"}},
+        {
+            "start": {"toolUse": {"toolUseId": "tooluse_1", "name": "get_time"}},
+            "contentBlockIndex": 0,
+        },
+        {"contentBlockIndex": 0},
+        {
+            "start": {"toolUse": {"toolUseId": "tooluse_2", "name": "search_drugs"}},
+            "contentBlockIndex": 1,
+        },
+        {
+            "delta": {"toolUse": {"input": '{"query": "amlodipine"}'}},
+            "contentBlockIndex": 1,
+        },
+        {"contentBlockIndex": 1},
+        {"stopReason": "tool_use"},
+    ]
+    decoder = AWSEventStreamDecoder(model="test")
+    parsed_chunks = [decoder._chunk_parser(chunk) for chunk in chunks]
+
+    accumulated_args = _collect_tool_call_args(parsed_chunks)
+    assert accumulated_args == {0: "{}", 1: '{"query": "amlodipine"}'}
+
+
+def test_empty_args_tool_then_startless_text_block_no_duplicate_empty_args_chunk():
+    """
+    Text blocks stream without a contentBlockStart event, so delta state must
+    be reset at contentBlockStop. Otherwise the text block's stop event
+    re-checks the stale toolUse deltas and emits a second "{}" chunk, and the
+    accumulated arguments "{}{}" fail json.loads with "Extra data".
+
+    See: https://github.com/BerriAI/litellm/issues/19858
+    """
+    chunks = [
+        {"messageStart": {"role": "assistant"}},
+        {
+            "start": {"toolUse": {"toolUseId": "tooluse_G", "name": "get_time"}},
+            "contentBlockIndex": 0,
+        },
+        {"delta": {"toolUse": {"input": ""}}, "contentBlockIndex": 0},
+        {"contentBlockIndex": 0},  # tool stop -> emits the "{}" repair chunk
+        {
+            "delta": {"text": "Fetching the time."},
+            "contentBlockIndex": 1,
+        },  # no start event
+        {"contentBlockIndex": 1},  # text stop -> must NOT emit another "{}"
+        {"stopReason": "tool_use"},
+    ]
+    decoder = AWSEventStreamDecoder(model="test")
+    parsed_chunks = [decoder._chunk_parser(chunk) for chunk in chunks]
+
+    accumulated_args = _collect_tool_call_args(parsed_chunks)
+    assert accumulated_args == {0: "{}"}
+    json.loads(accumulated_args[0])  # "{}{}" would raise "Extra data"
+
+
+def test_text_only_block_stop_emits_no_tool_call_chunk():
+    """A stream with only text blocks must never emit tool_call chunks at stop events."""
+    chunks = [
+        {"messageStart": {"role": "assistant"}},
+        {"delta": {"text": "Hello"}, "contentBlockIndex": 0},
+        {"contentBlockIndex": 0},
+        {"stopReason": "end_turn"},
+    ]
+    decoder = AWSEventStreamDecoder(model="test")
+    parsed_chunks = [decoder._chunk_parser(chunk) for chunk in chunks]
+
+    assert _collect_tool_call_args(parsed_chunks) == {}


### PR DESCRIPTION
# Relevant issues

Fixes #19858
Related: RooCodeInc/Roo-Code#10725 (same symptom via a LiteLLM gateway)

# Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

# Type

🐛 Bug Fix

# Changes

## Problem

When Claude calls a tool with **zero arguments**, both the Anthropic and Bedrock Converse streams emit the tool-use block `start` event followed directly by the block `stop` event — there are **no argument delta events in between** (`input_json_delta` for Anthropic, `contentBlockDelta.toolUse` for Bedrock).

Both stream decoders only emit the `arguments="{}"` repair chunk at block stop when at least one argument delta was seen: `check_empty_tool_call_args()` starts with `if len(self.content_blocks) == 0: return False`, and `content_blocks` is populated **only** by delta events. So for a zero-argument tool call, the client receives an initial tool-call chunk with `arguments: ""` and then nothing — the accumulated arguments string is `""`, and `json.loads("")` fails:

```
json.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

Clients like Kilo Code / Roo Code then reject the tool call ("tried to use write_to_file without value for required parameter"), and OpenAI-compatible orchestrators that proxy LiteLLM fail the whole request. We (Amazon Pharmacy) hit this in production behind an ElevenLabs conversational-AI orchestrator: the JSONDecodeError caused "Brain failed → cascade to backup LLM" on live phone calls.

The Bedrock decoder has a second, related defect: `content_blocks` is only reset on `contentBlockStart` events, but **text blocks stream without a start event** (see existing fixtures in `test_invoke_handler.py`). After an empty-args tool call, the following text block's stop event re-runs `check_empty_tool_call_args()` against the stale toolUse delta state and emits a **duplicate** `"{}"` chunk at the same tool index — accumulated arguments become `"{}{}"`:

```
json.JSONDecodeError: Extra data: line 1 column 3 (char 2)
```

## Root cause

- `litellm/llms/anthropic/chat/handler.py` — `check_empty_tool_call_args()` returns `False` when `content_blocks` is empty, so `content_block_stop` never emits the `"{}"` repair chunk for zero-argument tools. The only caller already guards on `current_content_block_type in ("tool_use", "server_tool_use")`, so returning `True` there is safe for text/thinking blocks.
- `litellm/llms/bedrock/chat/invoke_handler.py` — same empty-`content_blocks` early return, plus `content_blocks` is never reset at `contentBlockStop`, corrupting the next start-less block's stop handling.

## Fix (18 lines across the two decoders)

1. **Anthropic**: `check_empty_tool_call_args()` returns `True` when `content_blocks` is empty (a closing tool block with zero deltas *is* an empty tool call; the caller's block-type guard keeps text/thinking blocks unaffected).
2. **Bedrock**: detect a tool block closing with zero deltas via `self._current_tool_name is not None and len(self.content_blocks) == 0`, and reset `content_blocks` at every `contentBlockStop` so stale toolUse deltas can't leak into the next start-less block's stop event.

## Proof (before/after, raw provider events through the decoders)

```
=== BEFORE (master, 30ed840ff5) ===
=== Anthropic: zero-arg tool (content_block_start -> content_block_stop) ===
accumulated tool arguments: {0: ''}
json.loads -> JSONDecodeError: Expecting value: line 1 column 1 (char 0)

=== Bedrock Converse: zero-arg tool (contentBlockStart -> contentBlockStop) ===
accumulated tool arguments: {0: ''}
json.loads -> JSONDecodeError: Expecting value: line 1 column 1 (char 0)

=== Bedrock Converse: empty-args tool then start-less text block ===
accumulated tool arguments: {0: '{}{}'}
json.loads -> JSONDecodeError: Extra data: line 1 column 3 (char 2)

=== AFTER (this PR, e7e27134de) ===
=== Anthropic: zero-arg tool ===
accumulated tool arguments: {0: '{}'}   json.loads -> OK: {}
=== Bedrock Converse: zero-arg tool ===
accumulated tool arguments: {0: '{}'}   json.loads -> OK: {}
=== Bedrock Converse: empty-args tool then start-less text block ===
accumulated tool arguments: {0: '{}'}   json.loads -> OK: {}
```

## Testing

9 new mocked tests in `tests/test_litellm/` (mirroring the source paths), all passing; the 5 bug-repro tests **fail on master without the fix**:

- `tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py`: zero-arg tool emits `{}`; zero-arg tool followed by tool-with-args keeps indices/args intact; text-block stop and thinking-block stop emit no tool chunk.
- `tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py`: zero-arg tool emits `{}`; zero-arg tool followed by second tool; empty-args tool + start-less text block emits exactly one `{}` (no `"{}{}"`); text-only stream emits no tool chunks.

Full suites: `tests/test_litellm/llms/anthropic/chat/` + `tests/test_litellm/llms/bedrock/chat/` — 50/50 passing. `ruff check` and `ruff format --check` clean on changed files.

## Why the prior attempt (#19928) stalled

#19928 buffered all argument deltas until `content_block_stop`, changing streaming behavior for every tool call. This PR instead fixes only the zero-argument edge case (and the Bedrock state-reset bug), preserving incremental argument streaming exactly as-is for tools with arguments.

Note: this does not claim to fix every report on #19858 — truncated *non-empty* arguments via OpenRouter/Vertex may have additional causes (e.g. SSE line fragmentation) that deserve a separate, isolated PR. This PR eliminates the reproducible zero-argument failure mode present in both decoders.
