### PR TITLE
fix(router): handle missing failure metadata

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7068,10 +7068,11 @@ class Router:
         """
         Update RPM usage for a deployment
         """
-        deployment_name = kwargs["litellm_params"]["metadata"].get(
+        metadata = kwargs["litellm_params"].get("metadata") or {}
+        deployment_name = metadata.get(
             "deployment", None
         )  # handles wildcard routes - by giving the original name sent to `litellm.completion`
-        model_group = kwargs["litellm_params"]["metadata"].get("model_group", None)
+        model_group = metadata.get("model_group", None)
         model_info = kwargs["litellm_params"].get("model_info", {}) or {}
         id = model_info.get("id", None)
         if model_group is None or id is None:

--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -608,6 +608,28 @@ async def test_deployment_callback_on_failure(model_list):
     )
 
 
+@pytest.mark.asyncio
+async def test_async_deployment_callback_on_failure_with_none_metadata(model_list):
+    import time
+
+    router = Router(model_list=model_list)
+    kwargs = {
+        "litellm_params": {
+            "metadata": None,
+            "model_info": {"id": 100},
+        },
+    }
+
+    result = await router.async_deployment_callback_on_failure(
+        kwargs=kwargs,
+        completion_response=None,
+        start_time=time.time(),
+        end_time=time.time(),
+    )
+
+    assert result is None
+
+
 def test_deployment_callback_respects_cooldown_time(model_list):
     """Ensure per-model cooldown_time is honored even when exception headers are present."""
     import httpx


### PR DESCRIPTION
## TLDR

Problem this solves:

- Offline health checks emit a secondary router callback error

How it solves it:

- Treat absent failure metadata as empty before reading routing fields

## Relevant issues

Fixes #34281

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

I ran a local proxy with one `ollama_chat/qwen3` deployment pointed at an intentionally offline address, then called the same health endpoint on both commits

```bash
curl -H 'Authorization: Bearer sk-local-test' \
  'http://127.0.0.1:4011/health?model=offline-ollama'
```

Before, at `0fcaadf11c`, the expected unhealthy result was accompanied by this secondary callback failure

```text
Custom Logger Error
File "litellm/router.py", line 7071, in async_deployment_callback_on_failure
  deployment_name = kwargs["litellm_params"]["metadata"].get(
AttributeError: 'NoneType' object has no attribute 'get'
```

After, at `e43d14b7ac`, the same request returns the intended unhealthy endpoint result and the router callback completes without a `Custom Logger Error`

```json
{"healthy_count":0,"unhealthy_count":1}
```

## Type

🐛 Bug Fix

## Changes

- Normalize missing failure metadata before reading router fields
- Cover the `metadata: None` callback path with a regression test

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR