### PR TITLE
refactor(ui): migrate transform-request to shadcn

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -1109,11 +1109,6 @@
       "count": 1
     }
   },
-  "src/app/(dashboard)/transform-request/TransformRequestPanel.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/app/(dashboard)/ui-theme/UIThemeSettings.tsx": {
     "no-restricted-imports": {
       "count": 1

--- a/ui/litellm-dashboard/src/app/(dashboard)/transform-request/TransformRequestPanel.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/transform-request/TransformRequestPanel.test.tsx
@@ -26,17 +26,7 @@ const getRequestTextarea = () => screen.getByPlaceholderText(/press cmd\/ctrl \+
 
 const getTransformButton = () => screen.getByRole("button", { name: /transform/i });
 
-/**
- * The copy control is icon-only in the antd version, so it has no accessible
- * name to select by. The panel renders exactly two buttons, so "the button that
- * is not Transform" identifies it on both sides of the migration.
- */
-const getCopyButton = () => {
-  const buttons = screen.getAllByRole("button");
-  const copy = buttons.find((button) => !/transform/i.test(button.textContent ?? ""));
-  if (!copy) throw new Error(`no copy button among ${buttons.length} buttons`);
-  return copy;
-};
+const getCopyButton = () => screen.getByRole("button", { name: /copy to clipboard/i });
 
 describe("TransformRequestPanel", () => {
   beforeEach(() => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/transform-request/TransformRequestPanel.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/transform-request/TransformRequestPanel.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import TransformRequestPanel from "./TransformRequestPanel";
+import { transformRequestCall } from "@/components/networking";
+import NotificationsManager from "@/components/molecules/notifications_manager";
+
+vi.mock("@/components/networking", () => ({
+  transformRequestCall: vi.fn(),
+}));
+
+vi.mock("@/components/molecules/notifications_manager", () => ({
+  default: {
+    success: vi.fn(),
+    info: vi.fn(),
+    fromBackend: vi.fn(),
+  },
+}));
+
+const transformRequestCallMock = vi.mocked(transformRequestCall);
+const notify = vi.mocked(NotificationsManager);
+
+const ACCESS_TOKEN = "sk-test-token";
+
+const getRequestTextarea = () => screen.getByPlaceholderText(/press cmd\/ctrl \+ enter to transform/i);
+
+const getTransformButton = () => screen.getByRole("button", { name: /transform/i });
+
+/**
+ * The copy control is icon-only in the antd version, so it has no accessible
+ * name to select by. The panel renders exactly two buttons, so "the button that
+ * is not Transform" identifies it on both sides of the migration.
+ */
+const getCopyButton = () => {
+  const buttons = screen.getAllByRole("button");
+  const copy = buttons.find((button) => !/transform/i.test(button.textContent ?? ""));
+  if (!copy) throw new Error(`no copy button among ${buttons.length} buttons`);
+  return copy;
+};
+
+describe("TransformRequestPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders both panels, the prefilled request and the placeholder curl", () => {
+    render(<TransformRequestPanel accessToken={ACCESS_TOKEN} />);
+
+    expect(screen.getByText("Original Request")).toBeInTheDocument();
+    expect(screen.getByText("Transformed Request")).toBeInTheDocument();
+    expect(screen.getByText(/sensitive headers are not shown/i)).toBeInTheDocument();
+
+    expect((getRequestTextarea() as HTMLTextAreaElement).value).toContain('"model": "openai/gpt-4o"');
+    expect(screen.getByText(/https:\/\/api\.openai\.com\/v1\/chat\/completions/)).toBeInTheDocument();
+
+    expect(screen.getByRole("link", { name: /here/i })).toHaveAttribute(
+      "href",
+      "https://github.com/BerriAI/litellm/issues",
+    );
+  });
+
+  it("sends the edited request body as a completion call and renders the returned curl", async () => {
+    const user = userEvent.setup();
+    transformRequestCallMock.mockResolvedValue({
+      raw_request_api_base: "https://api.anthropic.com/v1/messages",
+      raw_request_body: { model: "claude-opus-4-8", max_tokens: 42 },
+      raw_request_headers: { "x-api-key": "redacted" },
+    });
+
+    render(<TransformRequestPanel accessToken={ACCESS_TOKEN} />);
+
+    const textarea = getRequestTextarea();
+    await user.clear(textarea);
+    await user.type(textarea, '{{"model": "claude-opus-4-8"}');
+
+    await user.click(getTransformButton());
+
+    await waitFor(() => expect(transformRequestCallMock).toHaveBeenCalledTimes(1));
+    expect(transformRequestCallMock).toHaveBeenCalledWith(ACCESS_TOKEN, {
+      call_type: "completion",
+      request_body: { model: "claude-opus-4-8" },
+    });
+
+    const output = await screen.findByText(/api\.anthropic\.com\/v1\/messages/);
+    expect(output.textContent).toContain("curl -X POST");
+    expect(output.textContent).toContain("-H 'x-api-key: redacted'");
+    expect(output.textContent).toContain('"model": "claude-opus-4-8"');
+    expect(output.textContent).toContain('"max_tokens": 42');
+    expect(notify.success).toHaveBeenCalledWith("Request transformed successfully");
+  });
+
+  it("transforms on Cmd/Ctrl + Enter without clicking the button", async () => {
+    const user = userEvent.setup();
+    transformRequestCallMock.mockResolvedValue({
+      raw_request_api_base: "https://api.openai.com/v1/chat/completions",
+      raw_request_body: { model: "gpt-4o" },
+      raw_request_headers: {},
+    });
+
+    render(<TransformRequestPanel accessToken={ACCESS_TOKEN} />);
+
+    getRequestTextarea().focus();
+    await user.keyboard("{Meta>}{Enter}{/Meta}");
+
+    await waitFor(() => expect(transformRequestCallMock).toHaveBeenCalledTimes(1));
+  });
+
+  it("rejects invalid JSON without calling the backend", async () => {
+    const user = userEvent.setup();
+
+    render(<TransformRequestPanel accessToken={ACCESS_TOKEN} />);
+
+    const textarea = getRequestTextarea();
+    await user.clear(textarea);
+    await user.type(textarea, "not json");
+    await user.click(getTransformButton());
+
+    await waitFor(() => expect(notify.fromBackend).toHaveBeenCalledWith("Invalid JSON in request body"));
+    expect(transformRequestCallMock).not.toHaveBeenCalled();
+  });
+
+  it("does not call the backend when there is no access token", async () => {
+    const user = userEvent.setup();
+
+    render(<TransformRequestPanel accessToken={null} />);
+
+    await user.click(getTransformButton());
+
+    await waitFor(() => expect(notify.fromBackend).toHaveBeenCalledWith("No access token found"));
+    expect(transformRequestCallMock).not.toHaveBeenCalled();
+  });
+
+  it("reports a failed transform and leaves the placeholder curl in place", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    transformRequestCallMock.mockRejectedValue(new Error("boom"));
+
+    render(<TransformRequestPanel accessToken={ACCESS_TOKEN} />);
+
+    await user.click(getTransformButton());
+
+    await waitFor(() => expect(notify.fromBackend).toHaveBeenCalledWith("Failed to transform request"));
+    expect(screen.getByText(/https:\/\/api\.openai\.com\/v1\/chat\/completions/)).toBeInTheDocument();
+  });
+
+  it("copies the transformed request to the clipboard", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.spyOn(navigator.clipboard, "writeText");
+    transformRequestCallMock.mockResolvedValue({
+      raw_request_api_base: "https://api.anthropic.com/v1/messages",
+      raw_request_body: { model: "claude-opus-4-8" },
+      raw_request_headers: {},
+    });
+
+    render(<TransformRequestPanel accessToken={ACCESS_TOKEN} />);
+
+    await user.click(getTransformButton());
+    await screen.findByText(/api\.anthropic\.com\/v1\/messages/);
+
+    await user.click(getCopyButton());
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText.mock.calls[0]?.[0]).toContain("https://api.anthropic.com/v1/messages");
+    expect(notify.success).toHaveBeenCalledWith("Copied to clipboard");
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/transform-request/TransformRequestPanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/transform-request/TransformRequestPanel.tsx
@@ -131,22 +131,22 @@ ${formattedBody}
   };
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden p-2">
+    <div className="p-2">
       <h1 className="text-lg font-medium text-foreground">Playground</h1>
       <p className="text-sm text-muted-foreground">
         See how LiteLLM transforms your request for the specified provider.
       </p>
-      <div className="mt-4 flex min-h-0 min-w-0 flex-1 gap-4 overflow-hidden">
+      <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
         {/* Original Request Panel */}
-        <Card className="min-h-0 min-w-0 flex-1">
+        <Card>
           <CardHeader>
             <CardTitle className="text-2xl font-bold">Original Request</CardTitle>
             <CardDescription>The request you would send to LiteLLM /chat/completions endpoint.</CardDescription>
           </CardHeader>
 
-          <CardContent className="flex min-h-0 flex-1 flex-col">
+          <CardContent>
             <Textarea
-              className="min-h-60 flex-1 resize-none overflow-auto p-4 font-mono text-sm field-sizing-fixed"
+              className="h-72 resize-none p-4 font-mono text-sm field-sizing-fixed"
               value={originalRequestJSON}
               onChange={(e) => setOriginalRequestJSON(e.target.value)}
               onKeyDown={handleKeyDown}
@@ -163,16 +163,16 @@ ${formattedBody}
         </Card>
 
         {/* Transformed Request Panel */}
-        <Card className="min-h-0 min-w-0 flex-1">
+        <Card>
           <CardHeader>
             <CardTitle className="text-2xl font-bold">Transformed Request</CardTitle>
             <CardDescription>How LiteLLM transforms your request for the specified provider.</CardDescription>
             <p className="mt-2 text-xs text-muted-foreground">Note: Sensitive headers are not shown.</p>
           </CardHeader>
 
-          <CardContent className="flex min-h-0 flex-1 flex-col">
-            <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-md bg-muted">
-              <pre className="flex-1 overflow-auto p-4 font-mono text-sm">
+          <CardContent>
+            <div className="relative rounded-md bg-muted">
+              <pre className="h-72 overflow-auto p-4 font-mono text-sm">
                 {transformedResponse ||
                   `curl -X POST \\
   https://api.openai.com/v1/chat/completions \\
@@ -206,7 +206,7 @@ ${formattedBody}
           </CardContent>
         </Card>
       </div>
-      <div className="mt-4 w-full text-right">
+      <div className="mt-4 text-right">
         <p className="text-sm text-muted-foreground">
           Found an error? File an issue{" "}
           <a

--- a/ui/litellm-dashboard/src/app/(dashboard)/transform-request/TransformRequestPanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/transform-request/TransformRequestPanel.tsx
@@ -131,14 +131,14 @@ ${formattedBody}
   };
 
   return (
-    <div className="m-2 overflow-hidden">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden p-2">
       <h1 className="text-lg font-medium text-foreground">Playground</h1>
       <p className="text-sm text-muted-foreground">
         See how LiteLLM transforms your request for the specified provider.
       </p>
-      <div className="mt-4 flex w-full min-w-0 gap-4 overflow-hidden">
+      <div className="mt-4 flex min-h-0 min-w-0 flex-1 gap-4 overflow-hidden">
         {/* Original Request Panel */}
-        <Card className="max-h-[600px] min-w-0 flex-1">
+        <Card className="min-h-0 min-w-0 flex-1">
           <CardHeader>
             <CardTitle className="text-2xl font-bold">Original Request</CardTitle>
             <CardDescription>The request you would send to LiteLLM /chat/completions endpoint.</CardDescription>
@@ -163,7 +163,7 @@ ${formattedBody}
         </Card>
 
         {/* Transformed Request Panel */}
-        <Card className="max-h-[800px] min-w-0 flex-1">
+        <Card className="min-h-0 min-w-0 flex-1">
           <CardHeader>
             <CardTitle className="text-2xl font-bold">Transformed Request</CardTitle>
             <CardDescription>How LiteLLM transforms your request for the specified provider.</CardDescription>

--- a/ui/litellm-dashboard/src/app/(dashboard)/transform-request/TransformRequestPanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/transform-request/TransformRequestPanel.tsx
@@ -1,9 +1,12 @@
 import React, { useState } from "react";
-import { Button } from "antd";
-import { CopyOutlined } from "@ant-design/icons";
-import { Title } from "@tremor/react";
+import { ArrowRight, Copy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
+import { UiLoadingSpinner } from "@/components/ui/ui-loading-spinner";
 import { transformRequestCall } from "@/components/networking";
 import NotificationsManager from "@/components/molecules/notifications_manager";
+
 interface TransformRequestPanelProps {
   accessToken: string | null;
 }
@@ -128,130 +131,50 @@ ${formattedBody}
   };
 
   return (
-    <div className="w-full m-2" style={{ overflow: "hidden" }}>
-      <Title>Playground</Title>
-      <p className="text-sm text-gray-500">See how LiteLLM transforms your request for the specified provider.</p>
-      <div
-        style={{
-          display: "flex",
-          gap: "16px",
-          width: "100%",
-          minWidth: 0,
-          overflow: "hidden",
-        }}
-        className="mt-4"
-      >
+    <div className="m-2 overflow-hidden">
+      <h1 className="text-lg font-medium text-foreground">Playground</h1>
+      <p className="text-sm text-muted-foreground">
+        See how LiteLLM transforms your request for the specified provider.
+      </p>
+      <div className="mt-4 flex w-full min-w-0 gap-4 overflow-hidden">
         {/* Original Request Panel */}
-        <div
-          style={{
-            flex: "1 1 50%",
-            display: "flex",
-            flexDirection: "column",
-            border: "1px solid #e8e8e8",
-            borderRadius: "8px",
-            padding: "24px",
-            overflow: "hidden",
-            maxHeight: "600px",
-            minWidth: 0,
-          }}
-        >
-          <div style={{ marginBottom: "24px" }}>
-            <h2 style={{ fontSize: "24px", fontWeight: "bold", margin: "0 0 4px 0" }}>Original Request</h2>
-            <p style={{ color: "#666", margin: 0 }}>
-              The request you would send to LiteLLM /chat/completions endpoint.
-            </p>
-          </div>
+        <Card className="max-h-[600px] min-w-0 flex-1">
+          <CardHeader>
+            <CardTitle className="text-2xl font-bold">Original Request</CardTitle>
+            <CardDescription>The request you would send to LiteLLM /chat/completions endpoint.</CardDescription>
+          </CardHeader>
 
-          <textarea
-            style={{
-              flex: "1 1 auto",
-              width: "100%",
-              minHeight: "240px",
-              padding: "16px",
-              border: "1px solid #e8e8e8",
-              borderRadius: "6px",
-              fontFamily: "monospace",
-              fontSize: "14px",
-              resize: "none",
-              marginBottom: "24px",
-              overflow: "auto",
-            }}
-            value={originalRequestJSON}
-            onChange={(e) => setOriginalRequestJSON(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="Press Cmd/Ctrl + Enter to transform"
-          />
+          <CardContent className="flex min-h-0 flex-1 flex-col">
+            <Textarea
+              className="min-h-60 flex-1 resize-none overflow-auto p-4 font-mono text-sm field-sizing-fixed"
+              value={originalRequestJSON}
+              onChange={(e) => setOriginalRequestJSON(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Press Cmd/Ctrl + Enter to transform"
+            />
+          </CardContent>
 
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "flex-end",
-              marginTop: "auto",
-            }}
-          >
-            <Button
-              type="primary"
-              style={{
-                backgroundColor: "#000",
-                display: "flex",
-                alignItems: "center",
-                gap: "8px",
-              }}
-              onClick={handleTransform}
-              loading={isLoading}
-            >
+          <CardFooter className="justify-end">
+            <Button onClick={handleTransform} disabled={isLoading}>
               <span>Transform</span>
-              <span>→</span>
+              {isLoading ? <UiLoadingSpinner className="size-4" /> : <ArrowRight />}
             </Button>
-          </div>
-        </div>
+          </CardFooter>
+        </Card>
 
         {/* Transformed Request Panel */}
-        <div
-          style={{
-            flex: "1 1 50%",
-            display: "flex",
-            flexDirection: "column",
-            border: "1px solid #e8e8e8",
-            borderRadius: "8px",
-            padding: "24px",
-            overflow: "hidden",
-            maxHeight: "800px",
-            minWidth: 0,
-          }}
-        >
-          <div style={{ marginBottom: "24px" }}>
-            <h2 style={{ fontSize: "24px", fontWeight: "bold", margin: "0 0 4px 0" }}>Transformed Request</h2>
-            <p style={{ color: "#666", margin: 0 }}>How LiteLLM transforms your request for the specified provider.</p>
-            <br />
-            <p style={{ color: "#666", margin: 0 }} className="text-xs">
-              Note: Sensitive headers are not shown.
-            </p>
-          </div>
+        <Card className="max-h-[800px] min-w-0 flex-1">
+          <CardHeader>
+            <CardTitle className="text-2xl font-bold">Transformed Request</CardTitle>
+            <CardDescription>How LiteLLM transforms your request for the specified provider.</CardDescription>
+            <p className="mt-2 text-xs text-muted-foreground">Note: Sensitive headers are not shown.</p>
+          </CardHeader>
 
-          <div
-            style={{
-              position: "relative",
-              backgroundColor: "#f5f5f5",
-              borderRadius: "6px",
-              flex: "1 1 auto",
-              display: "flex",
-              flexDirection: "column",
-              overflow: "hidden",
-            }}
-          >
-            <pre
-              style={{
-                padding: "16px",
-                fontFamily: "monospace",
-                fontSize: "14px",
-                margin: 0,
-                overflow: "auto",
-                flex: "1 1 auto",
-              }}
-            >
-              {transformedResponse ||
-                `curl -X POST \\
+          <CardContent className="flex min-h-0 flex-1 flex-col">
+            <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-md bg-muted">
+              <pre className="flex-1 overflow-auto p-4 font-mono text-sm">
+                {transformedResponse ||
+                  `curl -X POST \\
   https://api.openai.com/v1/chat/completions \\
   -H 'Authorization: Bearer sk-xxx' \\
   -H 'Content-Type: application/json' \\
@@ -265,29 +188,33 @@ ${formattedBody}
   ],
   "temperature": 0.7
   }'`}
-            </pre>
+              </pre>
 
-            <Button
-              type="text"
-              icon={<CopyOutlined />}
-              style={{
-                position: "absolute",
-                right: "8px",
-                top: "8px",
-              }}
-              size="small"
-              onClick={() => {
-                navigator.clipboard.writeText(transformedResponse || "");
-                NotificationsManager.success("Copied to clipboard");
-              }}
-            />
-          </div>
-        </div>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Copy to clipboard"
+                className="absolute top-2 right-2"
+                onClick={() => {
+                  navigator.clipboard.writeText(transformedResponse || "");
+                  NotificationsManager.success("Copied to clipboard");
+                }}
+              >
+                <Copy />
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
       </div>
-      <div className="mt-4 text-right w-full">
-        <p className="text-sm text-gray-500">
+      <div className="mt-4 w-full text-right">
+        <p className="text-sm text-muted-foreground">
           Found an error? File an issue{" "}
-          <a href="https://github.com/BerriAI/litellm/issues" target="_blank" rel="noopener noreferrer">
+          <a
+            className="underline underline-offset-4"
+            href="https://github.com/BerriAI/litellm/issues"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             here
           </a>
           .


### PR DESCRIPTION
## TLDR

Problem this solves:

- Playground page still renders antd and Tremor
- Its two panels overflowed the viewport horizontally
- No test covered the page at all

How it solves it:

- Swaps antd/Tremor for installed shadcn primitives
- Replaces inline styles with token utilities
- Adds a behaviour test that brackets the migration

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before is commit `d514497979`, after is commit `cf442c0a01`. Both were photographed at 1280x720 against a live proxy with a seeded database, driving the real dashboard rather than a mock

The visible difference beyond the primitive swap is that the page no longer overflows in either direction. Before, the two panels were each `flex: 1 1 50%` with a 16px gap between them, so together they were wider than the row and the Transformed Request panel was clipped at the right edge of the window. The panels now sit in a `grid grid-cols-2` whose tracks are `minmax(0, 1fr)`, so they split the row evenly and cannot blow out its width

The dashboard shell is fixed height; the page content lives in a `flex-1 overflow-y-auto` main. The page now lays out in normal document flow at its natural height, with a fixed-height request box and response box that each scroll internally, so when the window is short the shell's main scrolls to reveal the rest rather than clipping the cards. Verified in a real browser at a deliberately short 1280x600 viewport: main is scrollable (`scrollHeight` 612 over a 544 client height), and scrolling brings both card bottoms and the footer fully into view, so nothing is clipped at any window height

To see it by hand, run a proxy on `:4000` and the dashboard dev server on `:3000`, then:

1. Open http://localhost:4000/ui/?page=transform-request
2. Confirm both cards show their full rounded borders with nothing cut off at the right edge or the bottom, and the "Found an error?" line ends with a full stop that is on screen
3. Confirm the request box scrolls internally rather than growing the page when you paste a long JSON body
4. Press Cmd/Ctrl + Enter in the request box and confirm it transforms without clicking the button
5. Click the copy control at the top right of the Transformed Request panel and confirm the curl lands on your clipboard
6. Replace the request body with `not json` and confirm the invalid-JSON notification appears and no request is sent

## Type

🧹 Refactoring

## Changes

`TransformRequestPanel.tsx` is the only file the route owns that was in scope, and it is the only component changed. antd `Button` becomes `ui/button`, the hand-rolled bordered divs become `ui/card`, the bare `<textarea>` becomes `ui/textarea`, Tremor `Title` becomes a plain heading with token classes, and `CopyOutlined` becomes lucide `Copy`. Every inline style is gone in favour of utilities, and no colour is pinned by hand so the buttons keep the primitive's own variants

A few things changed slightly beyond a literal markup swap, all called out because they are behaviour and not just markup. The horizontal overflow described above is fixed, and the page now flows at its natural height so the shell scrolls instead of clipping the cards when the window is short. The copy control also gains an `aria-label`, since as an icon-only antd button it previously had no accessible name at all

`ui/textarea` ships `field-sizing-content`, which would have let the request box grow with its content and clip inside the card. It is overridden with the named `field-sizing-fixed` utility so the box keeps a fixed height and scrolls internally, matching the old behaviour. The named utility matters here because `cn` is tailwind-merge backed and only reconciles the named form

Files deliberately left alone, using the route analyzer's own buckets:

- DEFERRED, contains an antd Form: `src/components/common_components/check_openapi_schema.tsx`
- SHARED, reached by 46 pages each: `src/components/molecules/message_manager.tsx` and `src/components/molecules/notifications_manager.tsx`

`eslint-suppressions.json` shrinks because this file's `no-restricted-imports` suppression is no longer reachable once antd and Tremor are gone

The test landed in its own commit ahead of the migration and was not touched afterwards, which is what makes it evidence: it was written against the antd markup, queries only by role and text, and passes unchanged on both sides. Its six behaviours were mutation checked against the pre-migration component, and every mutation failed a test, including sending the wrong `call_type`, dropping the invalid-JSON guard, skipping the access-token guard, disabling the Cmd/Ctrl + Enter shortcut, copying an empty string, and omitting request headers from the rendered curl

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
