### PR TITLE
fix(alerting): read key/team alias from top-level metadata for hanging request alerts

### DIFF
--- a/litellm/integrations/SlackAlerting/hanging_request_check.py
+++ b/litellm/integrations/SlackAlerting/hanging_request_check.py
@@ -58,6 +58,14 @@ class AlertingHangingRequestCheck:
             return
 
         request_metadata = get_litellm_metadata_from_kwargs(kwargs=request_data)
+        # At pre-call time, request_data["litellm_params"]["metadata"] doesn't
+        # exist yet (it's populated later inside the SDK completion call), so
+        # get_litellm_metadata_from_kwargs returns {} and both aliases resolve
+        # to "". The key/team alias set by the proxy actually lives at the
+        # top-level request_data["metadata"] at this point.
+        # See: https://github.com/BerriAI/litellm/issues/34271
+        if not request_metadata.get("user_api_key_alias"):
+            request_metadata = request_data.get("metadata", {}) or {}
         model = request_data.get("model", "")
         api_base: Optional[str] = None
 

--- a/tests/test_litellm/integrations/SlackAlerting/test_hanging_request_check.py
+++ b/tests/test_litellm/integrations/SlackAlerting/test_hanging_request_check.py
@@ -83,6 +83,41 @@ class TestAlertingHangingRequestCheck:
         assert cached_data.api_base == "https://api.openai.com/v1"
 
     @pytest.mark.asyncio
+    async def test_add_request_to_hanging_request_check_reads_top_level_metadata_aliases(
+        self, hanging_request_checker
+    ):
+        """
+        Regression test for: https://github.com/BerriAI/litellm/issues/34271
+
+        At pre-call time, request_data["litellm_params"]["metadata"] doesn't
+        exist yet -- the key/team alias set by the proxy lives at the
+        top-level request_data["metadata"]. key_alias/team_alias must resolve
+        from there instead of silently falling back to "".
+        """
+        request_data = {
+            "litellm_call_id": "test_request_456",
+            "model": "gpt-4",
+            "metadata": {
+                "user_api_key_alias": "my-app-key",
+                "user_api_key_team_alias": "my-team",
+            },
+        }
+
+        await hanging_request_checker.add_request_to_hanging_request_check(
+            request_data
+        )
+
+        cached_data = (
+            await hanging_request_checker.hanging_request_cache.async_get_cache(
+                key="test_request_456"
+            )
+        )
+
+        assert cached_data is not None
+        assert cached_data.key_alias == "my-app-key"
+        assert cached_data.team_alias == "my-team"
+
+    @pytest.mark.asyncio
     async def test_add_request_to_hanging_request_check_none_request_data(
         self, hanging_request_checker
     ):


### PR DESCRIPTION
Fixes #34271

## Problem
`add_request_to_hanging_request_check` read metadata via `get_litellm_metadata_from_kwargs()`, which only checks `request_data["litellm_params"]["metadata"]`. That key doesn't exist yet at pre-call time — it's populated later inside the SDK completion call. The key/team alias set by the proxy actually lives at the top-level `request_data["metadata"]` at this point, so `key_alias`/`team_alias` in the hanging-request Slack alert were always empty.

## Fix
Added a fallback to the top-level metadata location when the alias isn't found via the existing helper, mirroring the fix suggested directly in the issue.

## Tests
Added a regression test asserting both `key_alias` and `team_alias` resolve correctly from top-level metadata. Full existing test file (12 tests) still passes.