### PR TITLE
fix(interactions): add queued to Interaction status enum (OSS daily)

### DIFF
--- a/litellm/types/interactions/generated.py
+++ b/litellm/types/interactions/generated.py
@@ -173,6 +173,7 @@ class Status1(Enum):
     cancelled = "cancelled"
     incomplete = "incomplete"
     budget_exceeded = "budget_exceeded"
+    queued = "queued"
 
 
 class InteractionStatusUpdate(BaseModel):
@@ -341,6 +342,7 @@ class Status3(Enum):
     CANCELLED = "cancelled"
     INCOMPLETE = "incomplete"
     BUDGET_EXCEEDED = "budget_exceeded"
+    QUEUED = "queued"
 
 
 class ModelOption(RootModel[str]):

--- a/tests/test_litellm/interactions/test_openapi_compliance.py
+++ b/tests/test_litellm/interactions/test_openapi_compliance.py
@@ -194,6 +194,7 @@ class TestResponseCompliance:
             "cancelled",
             "incomplete",
             "budget_exceeded",
+            "queued",
         ]
         assert status_prop["enum"] == expected_statuses
         print(f"✓ Status enum values: {expected_statuses}")


### PR DESCRIPTION
## Summary

- Add `queued` to Interaction status enums (`Status1` / `Status3`) and the OpenAPI compliance golden.
- Backports the already-merged staging/main fix (#34135) onto the current OSS daily base so fork PRs stop failing `test_status_enum_values`.

## Motivation

Google's live Interactions OpenAPI added `queued` to `Interaction.status`. The compliance canary intentionally exact-matches the live enum, so every PR against `litellm_oss_daily_2026_07_20` reds on:

`Left contains one more item: 'queued'`

#34135 already landed this on staging/main; the OSS daily cut predates that merge. Same minimal delta here unblocks the daily OSS queue (including validate_environment/pricing work).

AI-assisted; human-reviewed. Prior art condensed from #34135 by @yuneng-berri.

## Verification

- Diff matches #34135 intent on three symbols only
- `osv-scan` lockfile noise out of scope

## Base branch

Targets `litellm_oss_daily_2026_07_20` (OSS daily — never `main`).

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
