### PR TITLE
feat(ui): rebuild Organization Settings on react-hook-form + zod with a dirty-field PATCH

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -3610,9 +3610,6 @@
     },
     "no-restricted-imports": {
       "count": 3
-    },
-    "unused-imports/no-unused-imports": {
-      "count": 1
     }
   },
   "src/components/page_utils.test.ts": {

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -212,6 +212,7 @@ export interface Organization {
     object_permission_id: string;
     mcp_servers: string[];
     mcp_access_groups?: string[];
+    mcp_toolsets?: string[];
     vector_stores: string[];
   };
 }

--- a/ui/litellm-dashboard/src/components/organization/org-settings/OrgSettingsForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/organization/org-settings/OrgSettingsForm.test.tsx
@@ -1,0 +1,202 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/molecules/notifications_manager", () => ({
+  __esModule: true,
+  default: { success: vi.fn(), fromBackend: vi.fn() },
+}));
+vi.mock("@/components/ModelSelect/ModelSelect", () => ({
+  ModelSelect: ({ onChange }: { onChange: (values: string[]) => void }) => (
+    <button type="button" onClick={() => onChange([])}>
+      clear-models
+    </button>
+  ),
+}));
+vi.mock("@/components/vector_store_management/VectorStoreSelector", () => ({
+  __esModule: true,
+  default: ({ onChange }: { onChange: (values: string[]) => void }) => (
+    <button type="button" onClick={() => onChange(["vs-2"])}>
+      set-vector-stores
+    </button>
+  ),
+}));
+vi.mock("@/components/mcp_server_management/MCPServerSelector", () => ({
+  __esModule: true,
+  default: ({
+    onChange,
+  }: {
+    onChange: (values: { servers: string[]; accessGroups: string[]; toolsets: string[] }) => void;
+  }) => (
+    <button type="button" onClick={() => onChange({ servers: ["srv-2"], accessGroups: [], toolsets: [] })}>
+      set-mcp
+    </button>
+  ),
+}));
+
+import type { Organization } from "@/components/networking";
+
+import { OrgSettingsForm } from "./OrgSettingsForm";
+
+const org: Organization = {
+  organization_id: "org-1",
+  organization_alias: "acme",
+  budget_id: "budget-1",
+  metadata: {},
+  models: ["gpt-5.2"],
+  spend: 0,
+  model_spend: {},
+  created_at: "2026-01-01T00:00:00Z",
+  created_by: "admin",
+  updated_at: "2026-01-01T00:00:00Z",
+  updated_by: "admin",
+  litellm_budget_table: { max_budget: 100, budget_duration: "30d", tpm_limit: 1000, rpm_limit: 50 },
+  teams: null,
+  users: null,
+  members: null,
+  object_permission: {
+    object_permission_id: "op-1",
+    mcp_servers: ["srv-1"],
+    mcp_access_groups: [],
+    vector_stores: ["vs-1"],
+  },
+};
+
+const renderForm = (overrides?: { patchOrganization?: ReturnType<typeof vi.fn>; onSaved?: () => void }) => {
+  const patchOrganization = overrides?.patchOrganization ?? vi.fn().mockResolvedValue({});
+  const onSaved = overrides?.onSaved ?? vi.fn();
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <OrgSettingsForm
+        organizationId="org-1"
+        org={org}
+        accessToken="token"
+        onCancel={vi.fn()}
+        onSaved={onSaved}
+        patchOrganization={patchOrganization}
+      />
+    </QueryClientProvider>,
+  );
+  return { patchOrganization, onSaved };
+};
+
+describe("OrgSettingsForm", () => {
+  it("disables Save while the form is pristine", () => {
+    renderForm();
+
+    expect(screen.getByRole("button", { name: "Save Changes" })).toBeDisabled();
+  });
+
+  it("sends only the edited field", async () => {
+    const user = userEvent.setup();
+    const { patchOrganization } = renderForm();
+
+    await user.clear(screen.getByLabelText("Organization Name"));
+    await user.type(screen.getByLabelText("Organization Name"), "acme-2");
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => expect(patchOrganization).toHaveBeenCalledTimes(1));
+    expect(patchOrganization).toHaveBeenCalledWith("org-1", { organization_alias: "acme-2" });
+  });
+
+  it("sends null when a limit is cleared", async () => {
+    const user = userEvent.setup();
+    const { patchOrganization } = renderForm();
+
+    await user.clear(screen.getByLabelText("Tokens per minute Limit (TPM)"));
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => expect(patchOrganization).toHaveBeenCalledTimes(1));
+    expect(patchOrganization).toHaveBeenCalledWith("org-1", { tpm_limit: null });
+  });
+
+  it("sends models as [] when the selector is cleared", async () => {
+    const user = userEvent.setup();
+    const { patchOrganization } = renderForm();
+
+    await user.click(screen.getByRole("button", { name: "clear-models" }));
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => expect(patchOrganization).toHaveBeenCalledTimes(1));
+    expect(patchOrganization).toHaveBeenCalledWith("org-1", { models: [] });
+  });
+
+  it("wraps a vector store change in object_permission without mcp keys", async () => {
+    const user = userEvent.setup();
+    const { patchOrganization } = renderForm();
+
+    await user.click(screen.getByRole("button", { name: "set-vector-stores" }));
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => expect(patchOrganization).toHaveBeenCalledTimes(1));
+    expect(patchOrganization).toHaveBeenCalledWith("org-1", {
+      object_permission: { vector_stores: ["vs-2"] },
+    });
+  });
+
+  it("wraps an mcp change in object_permission with all three mcp keys", async () => {
+    const user = userEvent.setup();
+    const { patchOrganization } = renderForm();
+
+    await user.click(screen.getByRole("button", { name: "set-mcp" }));
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => expect(patchOrganization).toHaveBeenCalledTimes(1));
+    expect(patchOrganization).toHaveBeenCalledWith("org-1", {
+      object_permission: { mcp_servers: ["srv-2"], mcp_access_groups: [], mcp_toolsets: [] },
+    });
+  });
+
+  it("does not send a patch when an edit is reverted to the original value", async () => {
+    const user = userEvent.setup();
+    renderForm();
+
+    const alias = screen.getByLabelText("Organization Name");
+    await user.clear(alias);
+    await user.type(alias, "acme");
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save Changes" })).toBeDisabled());
+  });
+
+  it("blocks submit and shows an error for invalid metadata JSON", async () => {
+    const user = userEvent.setup();
+    const { patchOrganization } = renderForm();
+
+    await user.type(screen.getByLabelText("Metadata"), "not json");
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Metadata must be a valid JSON object");
+    expect(patchOrganization).not.toHaveBeenCalled();
+  });
+
+  it("keeps the view open when the patch fails", async () => {
+    const user = userEvent.setup();
+    const onSaved = vi.fn();
+    const { patchOrganization } = renderForm({
+      patchOrganization: vi.fn().mockRejectedValue(new Error("boom")),
+      onSaved,
+    });
+
+    await user.clear(screen.getByLabelText("Organization Name"));
+    await user.type(screen.getByLabelText("Organization Name"), "acme-2");
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => expect(patchOrganization).toHaveBeenCalledTimes(1));
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it("calls onSaved after a successful patch", async () => {
+    const user = userEvent.setup();
+    const onSaved = vi.fn();
+    renderForm({ onSaved });
+
+    await user.clear(screen.getByLabelText("Requests per minute Limit (RPM)"));
+    await user.type(screen.getByLabelText("Requests per minute Limit (RPM)"), "75");
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalledTimes(1));
+  });
+});

--- a/ui/litellm-dashboard/src/components/organization/org-settings/OrgSettingsForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/organization/org-settings/OrgSettingsForm.test.tsx
@@ -26,11 +26,18 @@ vi.mock("@/components/vector_store_management/VectorStoreSelector", () => ({
 vi.mock("@/components/mcp_server_management/MCPServerSelector", () => ({
   __esModule: true,
   default: ({
+    value,
     onChange,
   }: {
+    value?: { servers: string[]; accessGroups: string[]; toolsets?: string[] };
     onChange: (values: { servers: string[]; accessGroups: string[]; toolsets: string[] }) => void;
   }) => (
-    <button type="button" onClick={() => onChange({ servers: ["srv-2"], accessGroups: [], toolsets: [] })}>
+    <button
+      type="button"
+      onClick={() =>
+        onChange({ servers: ["srv-2"], accessGroups: value?.accessGroups ?? [], toolsets: value?.toolsets ?? [] })
+      }
+    >
       set-mcp
     </button>
   ),
@@ -64,7 +71,11 @@ const org: Organization = {
   },
 };
 
-const renderForm = (overrides?: { patchOrganization?: ReturnType<typeof vi.fn>; onSaved?: () => void }) => {
+const renderForm = (overrides?: {
+  patchOrganization?: ReturnType<typeof vi.fn>;
+  onSaved?: () => void;
+  org?: Organization;
+}) => {
   const patchOrganization = overrides?.patchOrganization ?? vi.fn().mockResolvedValue({});
   const onSaved = overrides?.onSaved ?? vi.fn();
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -72,7 +83,7 @@ const renderForm = (overrides?: { patchOrganization?: ReturnType<typeof vi.fn>; 
     <QueryClientProvider client={queryClient}>
       <OrgSettingsForm
         organizationId="org-1"
-        org={org}
+        org={overrides?.org ?? org}
         accessToken="token"
         onCancel={vi.fn()}
         onSaved={onSaved}
@@ -147,6 +158,23 @@ describe("OrgSettingsForm", () => {
     await waitFor(() => expect(patchOrganization).toHaveBeenCalledTimes(1));
     expect(patchOrganization).toHaveBeenCalledWith("org-1", {
       object_permission: { mcp_servers: ["srv-2"], mcp_access_groups: [], mcp_toolsets: [] },
+    });
+  });
+
+  it("preserves existing toolsets when only the servers change", async () => {
+    const user = userEvent.setup();
+    const orgWithToolsets: Organization = {
+      ...org,
+      object_permission: { ...org.object_permission!, mcp_toolsets: ["ts-1"] },
+    };
+    const { patchOrganization } = renderForm({ org: orgWithToolsets });
+
+    await user.click(screen.getByRole("button", { name: "set-mcp" }));
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => expect(patchOrganization).toHaveBeenCalledTimes(1));
+    expect(patchOrganization).toHaveBeenCalledWith("org-1", {
+      object_permission: { mcp_servers: ["srv-2"], mcp_access_groups: [], mcp_toolsets: ["ts-1"] },
     });
   });
 

--- a/ui/litellm-dashboard/src/components/organization/org-settings/OrgSettingsForm.tsx
+++ b/ui/litellm-dashboard/src/components/organization/org-settings/OrgSettingsForm.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import * as React from "react";
+
+import { organizationKeys } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
+import { ModelSelect } from "@/components/ModelSelect/ModelSelect";
+import MCPServerSelector from "@/components/mcp_server_management/MCPServerSelector";
+import NotificationsManager from "@/components/molecules/notifications_manager";
+import type { Organization } from "@/components/networking";
+import { FieldGroup } from "@/components/shared/form/field";
+import { FormField } from "@/components/shared/form/FormField";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import VectorStoreSelector from "@/components/vector_store_management/VectorStoreSelector";
+import { pickDirty } from "@/lib/forms/pickDirty";
+import { useZodForm } from "@/lib/forms/useZodForm";
+import { fetchClient } from "@/lib/http/api";
+
+import { buildOrgPatch, orgToForm, type OrgPatchBody } from "./mapper";
+import { orgSettingsSchema } from "./schema";
+
+const NO_RESET = "never";
+
+const BUDGET_DURATION_OPTIONS = [
+  { value: NO_RESET, label: "No reset" },
+  { value: "24h", label: "daily" },
+  { value: "7d", label: "weekly" },
+  { value: "30d", label: "monthly" },
+] as const;
+
+const defaultPatchOrganization = async (organizationId: string, body: OrgPatchBody): Promise<unknown> => {
+  const { data } = await fetchClient.PATCH("/v2/organization/{organization_id}", {
+    params: { path: { organization_id: organizationId } },
+    body,
+  });
+  return data;
+};
+
+interface OrgSettingsFormProps {
+  organizationId: string;
+  org: Organization;
+  accessToken: string;
+  onCancel: () => void;
+  onSaved: () => void;
+  patchOrganization?: (organizationId: string, body: OrgPatchBody) => Promise<unknown>;
+}
+
+export const OrgSettingsForm = ({
+  organizationId,
+  org,
+  accessToken,
+  onCancel,
+  onSaved,
+  patchOrganization = defaultPatchOrganization,
+}: OrgSettingsFormProps) => {
+  const queryClient = useQueryClient();
+  const form = useZodForm(orgSettingsSchema, { defaultValues: orgToForm(org) });
+  const { isDirty } = form.formState;
+
+  const mutation = useMutation({
+    mutationFn: (body: OrgPatchBody) => patchOrganization(organizationId, body),
+    onSuccess: () => {
+      NotificationsManager.success("Organization settings updated successfully");
+      queryClient.invalidateQueries({ queryKey: organizationKeys.all });
+      onSaved();
+    },
+    onError: (error: unknown) =>
+      NotificationsManager.fromBackend(
+        error instanceof Error ? error.message : "Failed to update organization settings",
+      ),
+  });
+
+  const onSubmit = form.handleSubmit((values) => {
+    mutation.mutate(buildOrgPatch(pickDirty(values, form.formState.dirtyFields)));
+  });
+
+  return (
+    <form onSubmit={onSubmit}>
+      <FieldGroup>
+        <FormField control={form.control} name="organization_alias" label="Organization Name">
+          {({ ref, ...field }) => <Input {...field} ref={ref} />}
+        </FormField>
+
+        <FormField control={form.control} name="models" label="Models">
+          {(field) => (
+            <ModelSelect
+              value={field.value}
+              onChange={field.onChange}
+              context="organization"
+              options={{ includeSpecialOptions: true, showAllProxyModelsOverride: true }}
+            />
+          )}
+        </FormField>
+
+        <FormField control={form.control} name="max_budget" label="Max Budget (USD)">
+          {({ ref, ...field }) => <Input {...field} ref={ref} type="number" step={0.01} min={0} />}
+        </FormField>
+
+        <FormField control={form.control} name="budget_duration" label="Reset Budget">
+          {({ id, value, onChange, "aria-invalid": ariaInvalid, "aria-describedby": ariaDescribedBy }) => (
+            <Select
+              value={value === "" ? NO_RESET : value}
+              onValueChange={(selected) => onChange(selected === NO_RESET ? "" : selected)}
+            >
+              <SelectTrigger id={id} aria-invalid={ariaInvalid} aria-describedby={ariaDescribedBy}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {BUDGET_DURATION_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </FormField>
+
+        <FormField control={form.control} name="tpm_limit" label="Tokens per minute Limit (TPM)">
+          {({ ref, ...field }) => <Input {...field} ref={ref} type="number" step={1} min={0} />}
+        </FormField>
+
+        <FormField control={form.control} name="rpm_limit" label="Requests per minute Limit (RPM)">
+          {({ ref, ...field }) => <Input {...field} ref={ref} type="number" step={1} min={0} />}
+        </FormField>
+
+        <FormField control={form.control} name="vector_stores" label="Vector Stores">
+          {(field) => (
+            <VectorStoreSelector
+              value={field.value}
+              onChange={field.onChange}
+              accessToken={accessToken}
+              placeholder="Select vector stores"
+            />
+          )}
+        </FormField>
+
+        <FormField control={form.control} name="mcp" label="MCP Servers & Access Groups">
+          {(field) => (
+            <MCPServerSelector
+              value={field.value}
+              onChange={field.onChange}
+              accessToken={accessToken}
+              placeholder="Select MCP servers and access groups"
+            />
+          )}
+        </FormField>
+
+        <FormField control={form.control} name="metadata" label="Metadata">
+          {({ ref, ...field }) => <Textarea {...field} ref={ref} rows={4} />}
+        </FormField>
+      </FieldGroup>
+
+      <div className="sticky z-10 bg-white p-4 border-t border-gray-200 -bottom-6 -inset-x-6 mt-6">
+        <div className="flex justify-end items-center gap-2">
+          <Button type="button" variant="outline" onClick={onCancel} disabled={mutation.isPending}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={!isDirty || mutation.isPending}>
+            {mutation.isPending ? "Saving..." : "Save Changes"}
+          </Button>
+        </div>
+      </div>
+    </form>
+  );
+};

--- a/ui/litellm-dashboard/src/components/organization/org-settings/mapper.test.ts
+++ b/ui/litellm-dashboard/src/components/organization/org-settings/mapper.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import type { Organization } from "@/components/networking";
+
+import { buildOrgPatch, orgToForm } from "./mapper";
+
+const org: Organization = {
+  organization_id: "org-1",
+  organization_alias: "acme",
+  budget_id: "budget-1",
+  metadata: { cost_center: "eng" },
+  models: ["gpt-5.2"],
+  spend: 0,
+  model_spend: {},
+  created_at: "2026-01-01T00:00:00Z",
+  created_by: "admin",
+  updated_at: "2026-01-01T00:00:00Z",
+  updated_by: "admin",
+  litellm_budget_table: { max_budget: 100.5, budget_duration: "30d", tpm_limit: 1000, rpm_limit: 50 },
+  teams: null,
+  users: null,
+  members: null,
+  object_permission: {
+    object_permission_id: "op-1",
+    mcp_servers: ["srv-1"],
+    mcp_access_groups: ["group-1"],
+    mcp_toolsets: ["ts-1"],
+    vector_stores: ["vs-1"],
+  },
+};
+
+describe("orgToForm", () => {
+  it("maps the server row onto widget-space strings and arrays", () => {
+    expect(orgToForm(org)).toEqual({
+      organization_alias: "acme",
+      models: ["gpt-5.2"],
+      max_budget: "100.5",
+      budget_duration: "30d",
+      tpm_limit: "1000",
+      rpm_limit: "50",
+      vector_stores: ["vs-1"],
+      mcp: { servers: ["srv-1"], accessGroups: ["group-1"], toolsets: ["ts-1"] },
+      metadata: JSON.stringify({ cost_center: "eng" }, null, 2),
+    });
+  });
+
+  it("maps missing budget values and permissions to empty widget state", () => {
+    const bare: Organization = {
+      ...org,
+      metadata: {},
+      litellm_budget_table: { max_budget: null, budget_duration: null, tpm_limit: null, rpm_limit: null },
+      object_permission: undefined,
+    };
+
+    expect(orgToForm(bare)).toEqual({
+      organization_alias: "acme",
+      models: ["gpt-5.2"],
+      max_budget: "",
+      budget_duration: "",
+      tpm_limit: "",
+      rpm_limit: "",
+      vector_stores: [],
+      mcp: { servers: [], accessGroups: [], toolsets: [] },
+      metadata: "",
+    });
+  });
+});
+
+describe("buildOrgPatch", () => {
+  it("returns an empty patch when nothing is dirty", () => {
+    expect(buildOrgPatch({})).toEqual({});
+  });
+
+  it("sends only the dirty scalar and converts it to a number", () => {
+    expect(buildOrgPatch({ tpm_limit: "2000" })).toEqual({ tpm_limit: 2000 });
+  });
+
+  it("clears scalars with null when the widget is emptied", () => {
+    expect(buildOrgPatch({ max_budget: "", tpm_limit: "", budget_duration: "" })).toEqual({
+      max_budget: null,
+      tpm_limit: null,
+      budget_duration: null,
+    });
+  });
+
+  it("keeps an empty models list as [] rather than dropping or nulling it", () => {
+    expect(buildOrgPatch({ models: [] })).toEqual({ models: [] });
+  });
+
+  it("clears metadata with null and parses non-empty metadata JSON", () => {
+    expect(buildOrgPatch({ metadata: "" })).toEqual({ metadata: null });
+    expect(buildOrgPatch({ metadata: '{"a": 1}' })).toEqual({ metadata: { a: 1 } });
+  });
+
+  it("builds object_permission from vector stores alone without touching mcp keys", () => {
+    expect(buildOrgPatch({ vector_stores: [] })).toEqual({ object_permission: { vector_stores: [] } });
+  });
+
+  it("builds object_permission from mcp alone, keeping empty arrays as clears", () => {
+    expect(buildOrgPatch({ mcp: { servers: [], accessGroups: [], toolsets: ["ts-2"] } })).toEqual({
+      object_permission: { mcp_servers: [], mcp_access_groups: [], mcp_toolsets: ["ts-2"] },
+    });
+  });
+
+  it("omits object_permission entirely when neither permission field is dirty", () => {
+    expect(buildOrgPatch({ organization_alias: "acme-2" })).toEqual({ organization_alias: "acme-2" });
+  });
+});

--- a/ui/litellm-dashboard/src/components/organization/org-settings/mapper.ts
+++ b/ui/litellm-dashboard/src/components/organization/org-settings/mapper.ts
@@ -1,0 +1,73 @@
+import { z } from "zod/v4";
+
+import type { Organization } from "@/components/networking";
+import type { components } from "@/lib/http/schema";
+
+import type { OrgSettingsFormValues } from "./schema";
+
+export type OrgPatchBody = components["schemas"]["OrganizationUpdateRequestV2"];
+
+const budgetSliceSchema = z.object({
+  max_budget: z.number().nullish(),
+  budget_duration: z.string().nullish(),
+  tpm_limit: z.number().nullish(),
+  rpm_limit: z.number().nullish(),
+});
+
+const metadataRecordSchema = z.record(z.string(), z.unknown());
+
+export const orgToForm = (org: Organization): OrgSettingsFormValues => {
+  const budget = budgetSliceSchema.parse(org.litellm_budget_table ?? {});
+  return {
+    organization_alias: org.organization_alias ?? "",
+    models: org.models ?? [],
+    max_budget: budget.max_budget?.toString() ?? "",
+    budget_duration: budget.budget_duration ?? "",
+    tpm_limit: budget.tpm_limit?.toString() ?? "",
+    rpm_limit: budget.rpm_limit?.toString() ?? "",
+    vector_stores: org.object_permission?.vector_stores ?? [],
+    mcp: {
+      servers: org.object_permission?.mcp_servers ?? [],
+      accessGroups: org.object_permission?.mcp_access_groups ?? [],
+      toolsets: org.object_permission?.mcp_toolsets ?? [],
+    },
+    metadata: org.metadata && Object.keys(org.metadata).length > 0 ? JSON.stringify(org.metadata, null, 2) : "",
+  };
+};
+
+const numberOrNull = (raw: string): number | null => (raw.trim() === "" ? null : Number(raw));
+
+const metadataOrNull = (raw: string): OrgPatchBody["metadata"] =>
+  raw.trim() === "" ? null : metadataRecordSchema.parse(JSON.parse(raw));
+
+const objectPermissionFromDirty = (
+  dirty: Partial<OrgSettingsFormValues>,
+): OrgPatchBody["object_permission"] | undefined => {
+  if (dirty.vector_stores === undefined && dirty.mcp === undefined) {
+    return undefined;
+  }
+  return {
+    ...(dirty.vector_stores !== undefined && { vector_stores: dirty.vector_stores }),
+    ...(dirty.mcp !== undefined && {
+      mcp_servers: dirty.mcp.servers,
+      mcp_access_groups: dirty.mcp.accessGroups,
+      mcp_toolsets: dirty.mcp.toolsets,
+    }),
+  };
+};
+
+export const buildOrgPatch = (dirty: Partial<OrgSettingsFormValues>): OrgPatchBody => {
+  const objectPermission = objectPermissionFromDirty(dirty);
+  return {
+    ...(dirty.organization_alias !== undefined && { organization_alias: dirty.organization_alias }),
+    ...(dirty.models !== undefined && { models: dirty.models }),
+    ...(dirty.max_budget !== undefined && { max_budget: numberOrNull(dirty.max_budget) }),
+    ...(dirty.tpm_limit !== undefined && { tpm_limit: numberOrNull(dirty.tpm_limit) }),
+    ...(dirty.rpm_limit !== undefined && { rpm_limit: numberOrNull(dirty.rpm_limit) }),
+    ...(dirty.budget_duration !== undefined && {
+      budget_duration: dirty.budget_duration === "" ? null : dirty.budget_duration,
+    }),
+    ...(dirty.metadata !== undefined && { metadata: metadataOrNull(dirty.metadata) }),
+    ...(objectPermission !== undefined && { object_permission: objectPermission }),
+  };
+};

--- a/ui/litellm-dashboard/src/components/organization/org-settings/schema.ts
+++ b/ui/litellm-dashboard/src/components/organization/org-settings/schema.ts
@@ -1,0 +1,43 @@
+import { z } from "zod/v4";
+
+const isBlank = (value: string): boolean => value.trim() === "";
+
+const isJsonObject = (value: string): boolean => {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed);
+  } catch {
+    return false;
+  }
+};
+
+const wholeNumberOrEmpty = z
+  .string()
+  .refine((value) => isBlank(value) || /^\d+$/.test(value.trim()), "Must be a non-negative whole number");
+
+const amountOrEmpty = z
+  .string()
+  .refine(
+    (value) => isBlank(value) || (Number.isFinite(Number(value)) && Number(value) >= 0),
+    "Must be a non-negative number",
+  );
+
+const orgSettingsShape = {
+  organization_alias: z.string().min(1, "Please input an organization name"),
+  models: z.array(z.string()),
+  max_budget: amountOrEmpty,
+  budget_duration: z.string(),
+  tpm_limit: wholeNumberOrEmpty,
+  rpm_limit: wholeNumberOrEmpty,
+  vector_stores: z.array(z.string()),
+  mcp: z.object({
+    servers: z.array(z.string()),
+    accessGroups: z.array(z.string()),
+    toolsets: z.array(z.string()),
+  }),
+  metadata: z.string().refine((value) => isBlank(value) || isJsonObject(value), "Metadata must be a valid JSON object"),
+};
+
+export const orgSettingsSchema = z.object(orgSettingsShape);
+
+export type OrgSettingsFormValues = z.output<typeof orgSettingsSchema>;

--- a/ui/litellm-dashboard/src/components/organization/organization_view.tsx
+++ b/ui/litellm-dashboard/src/components/organization/organization_view.tsx
@@ -5,28 +5,23 @@ import { MoneyCell } from "@/components/shared/table_cells";
 import { formatNumberWithCommas, copyToClipboard as utilCopyToClipboard } from "@/utils/dataUtils";
 import { createTeamAliasMap } from "@/utils/teamUtils";
 import { ArrowLeftIcon } from "@heroicons/react/outline";
-import { Badge, Card, Grid, Text, TextInput, Title, Button as TremorButton } from "@tremor/react";
-import { Button, Form, Input, Select, Tabs, Typography } from "antd";
+import { Badge, Card, Grid, Text, Title, Button as TremorButton } from "@tremor/react";
+import { Button, Tabs, Typography } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import React, { useMemo, useState } from "react";
 import MemberTable from "../common_components/MemberTable";
 import UserSearchModal from "../common_components/user_search_modal";
-import MCPServerSelector from "../mcp_server_management/MCPServerSelector";
-import { ModelSelect } from "../ModelSelect/ModelSelect";
 import NotificationsManager from "../molecules/notifications_manager";
 import {
   Member,
-  Organization,
   organizationMemberAddCall,
   organizationMemberDeleteCall,
   organizationMemberUpdateCall,
-  organizationUpdateCall,
 } from "../networking";
 import ObjectPermissionsView from "../object_permissions_view";
-import NumericalInput from "../shared/numerical_input";
 import MemberModal from "../team/EditMembership";
-import VectorStoreSelector from "../vector_store_management/VectorStoreSelector";
+import { OrgSettingsForm } from "./org-settings/OrgSettingsForm";
 
 interface OrganizationInfoProps {
   organizationId: string;
@@ -49,13 +44,11 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
 }) => {
   const queryClient = useQueryClient();
   const { data: orgData, isLoading: loading } = useOrganization(organizationId);
-  const [form] = Form.useForm();
   const [isEditing, setIsEditing] = useState(false);
   const [isAddMemberModalVisible, setIsAddMemberModalVisible] = useState(false);
   const [isEditMemberModalVisible, setIsEditMemberModalVisible] = useState(false);
   const [selectedEditMember, setSelectedEditMember] = useState<Member | null>(null);
   const [copiedStates, setCopiedStates] = useState<Record<string, boolean>>({});
-  const [isOrgSaving, setIsOrgSaving] = useState(false);
   const canEditOrg = is_org_admin || is_proxy_admin;
   const { data: teams } = useTeams();
 
@@ -76,7 +69,6 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
 
       NotificationsManager.success("Organization member added successfully");
       setIsAddMemberModalVisible(false);
-      form.resetFields();
       queryClient.invalidateQueries({ queryKey: organizationKeys.all });
     } catch (error) {
       NotificationsManager.fromBackend("Failed to add organization member");
@@ -97,7 +89,6 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
       const response = await organizationMemberUpdateCall(accessToken, organizationId, member);
       NotificationsManager.success("Organization member updated successfully");
       setIsEditMemberModalVisible(false);
-      form.resetFields();
       queryClient.invalidateQueries({ queryKey: organizationKeys.all });
     } catch (error) {
       NotificationsManager.fromBackend("Failed to update organization member");
@@ -112,63 +103,10 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
       await organizationMemberDeleteCall(accessToken, organizationId, values.user_id);
       NotificationsManager.success("Organization member deleted successfully");
       setIsEditMemberModalVisible(false);
-      form.resetFields();
       queryClient.invalidateQueries({ queryKey: organizationKeys.all });
     } catch (error) {
       NotificationsManager.fromBackend("Failed to delete organization member");
       console.error("Error deleting organization member:", error);
-    }
-  };
-
-  const handleOrgUpdate = async (values: any) => {
-    try {
-      if (!accessToken) return;
-      setIsOrgSaving(true);
-
-      const updateData: any = {
-        organization_id: organizationId,
-        organization_alias: values.organization_alias,
-        models: values.models,
-        litellm_budget_table: {
-          tpm_limit: values.tpm_limit,
-          rpm_limit: values.rpm_limit,
-          max_budget: values.max_budget,
-          budget_duration: values.budget_duration,
-        },
-        metadata: values.metadata ? JSON.parse(values.metadata) : null,
-      };
-
-      // Handle object_permission updates
-      if (values.vector_stores !== undefined || values.mcp_servers_and_groups !== undefined) {
-        updateData.object_permission = {
-          ...orgData?.object_permission,
-          vector_stores: values.vector_stores || [],
-        };
-
-        if (values.mcp_servers_and_groups !== undefined) {
-          const { servers, accessGroups } = values.mcp_servers_and_groups || {
-            servers: [],
-            accessGroups: [],
-          };
-          if (servers && servers.length > 0) {
-            updateData.object_permission.mcp_servers = servers;
-          }
-          if (accessGroups && accessGroups.length > 0) {
-            updateData.object_permission.mcp_access_groups = accessGroups;
-          }
-        }
-      }
-
-      const response = await organizationUpdateCall(accessToken, updateData);
-
-      NotificationsManager.success("Organization settings updated successfully");
-      setIsEditing(false);
-      queryClient.invalidateQueries({ queryKey: organizationKeys.all });
-    } catch (error) {
-      NotificationsManager.fromBackend("Failed to update organization settings");
-      console.error("Error updating organization:", error);
-    } finally {
-      setIsOrgSaving(false);
     }
   };
 
@@ -356,103 +294,13 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
                 </div>
 
                 {isEditing ? (
-                  <Form
-                    form={form}
-                    onFinish={handleOrgUpdate}
-                    initialValues={{
-                      organization_alias: orgData.organization_alias,
-                      models: orgData.models,
-                      tpm_limit: orgData.litellm_budget_table.tpm_limit,
-                      rpm_limit: orgData.litellm_budget_table.rpm_limit,
-                      max_budget: orgData.litellm_budget_table.max_budget,
-                      budget_duration: orgData.litellm_budget_table.budget_duration,
-                      metadata: orgData.metadata ? JSON.stringify(orgData.metadata, null, 2) : "",
-                      vector_stores: orgData.object_permission?.vector_stores || [],
-                      mcp_servers_and_groups: {
-                        servers: orgData.object_permission?.mcp_servers || [],
-                        accessGroups: orgData.object_permission?.mcp_access_groups || [],
-                      },
-                    }}
-                    layout="vertical"
-                  >
-                    <Form.Item
-                      label="Organization Name"
-                      name="organization_alias"
-                      rules={[
-                        {
-                          required: true,
-                          message: "Please input an organization name",
-                        },
-                      ]}
-                    >
-                      <TextInput />
-                    </Form.Item>
-
-                    <Form.Item label="Models" name="models">
-                      <ModelSelect
-                        value={form.getFieldValue("models")}
-                        onChange={(values) => form.setFieldValue("models", values)}
-                        context="organization"
-                        options={{
-                          includeSpecialOptions: true,
-                          showAllProxyModelsOverride: true,
-                        }}
-                      />
-                    </Form.Item>
-
-                    <Form.Item label="Max Budget (USD)" name="max_budget">
-                      <NumericalInput step={0.01} precision={2} style={{ width: "100%" }} />
-                    </Form.Item>
-
-                    <Form.Item label="Reset Budget" name="budget_duration">
-                      <Select placeholder="n/a">
-                        <Select.Option value="24h">daily</Select.Option>
-                        <Select.Option value="7d">weekly</Select.Option>
-                        <Select.Option value="30d">monthly</Select.Option>
-                      </Select>
-                    </Form.Item>
-
-                    <Form.Item label="Tokens per minute Limit (TPM)" name="tpm_limit">
-                      <NumericalInput step={1} style={{ width: "100%" }} />
-                    </Form.Item>
-
-                    <Form.Item label="Requests per minute Limit (RPM)" name="rpm_limit">
-                      <NumericalInput step={1} style={{ width: "100%" }} />
-                    </Form.Item>
-
-                    <Form.Item label="Vector Stores" name="vector_stores">
-                      <VectorStoreSelector
-                        onChange={(values) => form.setFieldValue("vector_stores", values)}
-                        value={form.getFieldValue("vector_stores")}
-                        accessToken={accessToken || ""}
-                        placeholder="Select vector stores"
-                      />
-                    </Form.Item>
-
-                    <Form.Item label="MCP Servers & Access Groups" name="mcp_servers_and_groups">
-                      <MCPServerSelector
-                        onChange={(values) => form.setFieldValue("mcp_servers_and_groups", values)}
-                        value={form.getFieldValue("mcp_servers_and_groups")}
-                        accessToken={accessToken || ""}
-                        placeholder="Select MCP servers and access groups"
-                      />
-                    </Form.Item>
-
-                    <Form.Item label="Metadata" name="metadata">
-                      <Input.TextArea rows={4} />
-                    </Form.Item>
-
-                    <div className="sticky z-10 bg-white p-4 border-t border-gray-200 -bottom-6 -inset-x-6">
-                      <div className="flex justify-end items-center gap-2">
-                        <TremorButton variant="secondary" onClick={() => setIsEditing(false)} disabled={isOrgSaving}>
-                          Cancel
-                        </TremorButton>
-                        <TremorButton type="submit" loading={isOrgSaving}>
-                          Save Changes
-                        </TremorButton>
-                      </div>
-                    </div>
-                  </Form>
+                  <OrgSettingsForm
+                    organizationId={organizationId}
+                    org={orgData}
+                    accessToken={accessToken || ""}
+                    onCancel={() => setIsEditing(false)}
+                    onSaved={() => setIsEditing(false)}
+                  />
                 ) : (
                   <div className="space-y-4">
                     <div>

--- a/ui/litellm-dashboard/src/components/ui/input-group.tsx
+++ b/ui/litellm-dashboard/src/components/ui/input-group.tsx
@@ -124,17 +124,21 @@ const InputGroupInput = React.forwardRef<HTMLInputElement, React.ComponentPropsW
 );
 InputGroupInput.displayName = "InputGroupInput";
 
-function InputGroupTextarea({ className, ...props }: React.ComponentProps<"textarea">) {
-  return (
-    <Textarea
-      data-slot="input-group-control"
-      className={cn(
-        "flex-1 resize-none rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent",
-        className,
-      )}
-      {...props}
-    />
-  );
-}
+const InputGroupTextarea = React.forwardRef<HTMLTextAreaElement, React.ComponentPropsWithoutRef<"textarea">>(
+  ({ className, ...props }, ref) => {
+    return (
+      <Textarea
+        ref={ref}
+        data-slot="input-group-control"
+        className={cn(
+          "flex-1 resize-none rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+InputGroupTextarea.displayName = "InputGroupTextarea";
 
 export { InputGroup, InputGroupAddon, InputGroupButton, InputGroupText, InputGroupInput, InputGroupTextarea };

--- a/ui/litellm-dashboard/src/components/ui/textarea.tsx
+++ b/ui/litellm-dashboard/src/components/ui/textarea.tsx
@@ -2,9 +2,10 @@ import * as React from "react";
 
 import { cn } from "@/lib/cva.config";
 
-function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
-  return (
+const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"textarea">>(
+  ({ className, ...props }, ref) => (
     <textarea
+      ref={ref}
       data-slot="textarea"
       className={cn(
         "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-2.5 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
@@ -12,7 +13,8 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
       )}
       {...props}
     />
-  );
-}
+  ),
+);
+Textarea.displayName = "Textarea";
 
 export { Textarea };

--- a/ui/litellm-dashboard/src/lib/forms/useZodForm.test.tsx
+++ b/ui/litellm-dashboard/src/lib/forms/useZodForm.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod/v4";
+
+import { useZodForm } from "./useZodForm";
+
+const schema = z.object({
+  alias: z.string().min(1, "Alias is required"),
+  budget: z.string().transform((value) => Number(value)),
+});
+
+const TestForm = ({ onSubmit }: { onSubmit: (values: z.output<typeof schema>) => void }) => {
+  const form = useZodForm(schema, { defaultValues: { alias: "", budget: "42" } });
+  return (
+    <form onSubmit={form.handleSubmit(onSubmit)}>
+      <input aria-label="Alias" {...form.register("alias")} />
+      <button type="submit">Save</button>
+    </form>
+  );
+};
+
+describe("useZodForm", () => {
+  it("blocks submit when the schema rejects the values", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<TestForm onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(onSubmit).not.toHaveBeenCalled());
+  });
+
+  it("hands submit the transformed output, not the raw input", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<TestForm onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText("Alias"), "acme");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0]).toEqual({ alias: "acme", budget: 42 });
+  });
+});

--- a/ui/litellm-dashboard/src/lib/forms/useZodForm.ts
+++ b/ui/litellm-dashboard/src/lib/forms/useZodForm.ts
@@ -4,6 +4,10 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm, type FieldValues, type UseFormProps, type UseFormReturn } from "react-hook-form";
 import type { $ZodType } from "zod/v4/core";
 
+// TInput is what the widgets hold (strings), TOutput is what handleSubmit receives after
+// zod runs coerce/transform; typing useForm with z.infer would collapse the two and lie
+// about defaultValues. zod's $ZodType declares them as <Output, Input>, in that order.
+// The `unknown` in the middle is RHF's context generic, which we never use.
 export const useZodForm = <TInput extends FieldValues, TOutput extends FieldValues>(
   schema: $ZodType<TOutput, TInput>,
   props?: Omit<UseFormProps<TInput, unknown, TOutput>, "resolver">,

--- a/ui/litellm-dashboard/src/lib/forms/useZodForm.ts
+++ b/ui/litellm-dashboard/src/lib/forms/useZodForm.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm, type FieldValues, type UseFormProps, type UseFormReturn } from "react-hook-form";
+import type { $ZodType } from "zod/v4/core";
+
+export const useZodForm = <TInput extends FieldValues, TOutput extends FieldValues>(
+  schema: $ZodType<TOutput, TInput>,
+  props?: Omit<UseFormProps<TInput, unknown, TOutput>, "resolver">,
+): UseFormReturn<TInput, unknown, TOutput> =>
+  useForm<TInput, unknown, TOutput>({
+    ...props,
+    resolver: zodResolver(schema),
+  });


### PR DESCRIPTION
## TLDR

Problem this solves:

- The Organization Settings edit form re-sent nearly every field on every save and could not clear anything: emptied budget/TPM/RPM widgets were dropped by v1's `exclude_none`, and `length > 0` guards silently dropped vector store / MCP clears
- Every form in the dashboard hand-rolls its own antd submit path; there was no shared, typed pattern to copy

How it solves it:

- Rebuilds the form as `OrgSettingsForm`, the first consumer of the shared react-hook-form + zod form kit (`shared/form/FormField`, `pickDirty` from #34170), stacked on the typed `PATCH /v2/organization/{organization_id}` from #32350
- Submits only the RHF dirty-field delta: untouched fields are omitted, emptied scalars send `null`, cleared lists send `[]`, and vector store / MCP edits are wrapped into a partial `object_permission` that the v2 endpoint merges
- Adds `src/lib/forms/useZodForm.ts` so every future form gets the `z.input`/`z.output` generics and `zodResolver` wiring from one helper

## Relevant issues

## Linear ticket

Resolves LIT-3664

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

UI walkthrough (screenshots to be posted below after running it):

1. Run the proxy (`python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver`) and the dashboard (`npm run dev` in `ui/litellm-dashboard`)
2. Open http://localhost:3000/?page=organizations, click into an org, open the Settings tab, click Edit Settings
3. With devtools Network open, change only the TPM limit and save: the request is a `PATCH /v2/organization/{id}` whose entire body is `{"tpm_limit": <n>}`
4. Edit again, clear the TPM limit field and save: body is `{"tpm_limit": null}` and the Overview tab now shows TPM Unlimited, which is the LIT-3664 repro that used to silently keep the old value
5. Edit again without touching anything: Save Changes stays disabled
6. Paste `not json` into Metadata: an inline "Metadata must be a valid JSON object" error blocks the save
7. Verify persistence: `curl -s http://localhost:4000/organization/info?organization_id=<id> -H "Authorization: Bearer sk-1234" | jq .litellm_budget_table.tpm_limit` returns `null` after step 4

## Type

🐛 Bug Fix
🧹 Refactoring

## Changes

`src/components/organization/org-settings/` holds the new form split the way future forms should copy: `schema.ts` (zod widget-space schema; numbers live as strings so an emptied input is a first-class clear token), `mapper.ts` (`orgToForm` seeds defaults from the server row; `buildOrgPatch` maps the dirty subset to `components["schemas"]["OrganizationUpdateRequestV2"]`, so a gen:api drift is a compile error), and `OrgSettingsForm.tsx` (shared `FormField` kit + shadcn widgets, TanStack mutation, Save gated on `isDirty`). The heavy selectors (ModelSelect, VectorStoreSelector, MCPServerSelector) are reused as-is under `Controller`

`organization_view.tsx` loses `handleOrgUpdate`, the antd `Form` block, and the shared antd form instance whose `resetFields()` the member handlers were pointlessly calling. The PATCH function is injected into `OrgSettingsForm` (defaulting to the typed `fetchClient.PATCH`), so tests assert the exact wire payload without monkeypatching

`ui/textarea.tsx` is wrapped in `React.forwardRef`; the repo's React 18 ref tripwire caught it dropping RHF's register ref. `InputGroupTextarea` is forwardRef'd to match, mirroring how `InputGroupInput` already wraps the forwardRef'd `Input`. `Organization.object_permission` gains the `mcp_toolsets` field the backend already returns, and the form always sends all three MCP keys when the MCP selector is dirty, so toolsets survive edits and empty selections actually clear

Tests: `mapper.test.ts` pins the clear-token contract (omitted vs `null` vs `[]`, `object_permission` built only from dirty permission fields), `OrgSettingsForm.test.tsx` pins the wire payloads end to end (single-field patch, `null` clears, `[]` models, partial `object_permission`, pristine and reverted forms send nothing, invalid metadata blocks submit, failed PATCH keeps the form open), and `useZodForm.test.tsx` pins that submit receives the transformed schema output

## QA runbook

Covered by the Screenshots / Proof of Fix walkthrough above; steps 3, 4, and 5 are the customer-visible behaviors this PR changes

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
