### PR TITLE
fix: add supports_native_structured_output for claude-sonnet-5 / claude-fable-5 / claude-haiku-4-5 (anthropic)

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -11211,6 +11211,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_native_structured_output": true,
         "supports_tool_choice": true,
         "supports_vision": true,
         "prompt_cache_min_tokens": 4096
@@ -11233,6 +11234,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_native_structured_output": true,
         "supports_tool_choice": true,
         "supports_vision": true,
         "prompt_cache_min_tokens": 4096
@@ -11450,6 +11452,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_native_structured_output": true,
         "supports_sampling_params": false,
         "supports_tool_choice": true,
         "supports_vision": true,
@@ -11835,6 +11838,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_native_structured_output": true,
         "supports_sampling_params": false,
         "supports_tool_choice": true,
         "supports_vision": true,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -11211,6 +11211,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_native_structured_output": true,
         "supports_tool_choice": true,
         "supports_vision": true,
         "prompt_cache_min_tokens": 4096
@@ -11233,6 +11234,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_native_structured_output": true,
         "supports_tool_choice": true,
         "supports_vision": true,
         "prompt_cache_min_tokens": 4096
@@ -11450,6 +11452,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_native_structured_output": true,
         "supports_sampling_params": false,
         "supports_tool_choice": true,
         "supports_vision": true,
@@ -11835,6 +11838,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_native_structured_output": true,
         "supports_sampling_params": false,
         "supports_tool_choice": true,
         "supports_vision": true,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Anthropic `claude-sonnet-5`, `claude-fable-5`, and `claude-haiku-4-5` are missing `supports_native_structured_output` in the cost map
- So `response_format: json_schema` falls back to the `json_tool_call` tool emulation instead of Anthropic native `output_format`
- The emulation path can leak the tool invocation as literal text content (observed in production: `{"$FUNCTION_NAME": "json_tool_call", "tool_parameters": {...}}`), breaking downstream JSON parsing

How it solves it:

- Adds `"supports_native_structured_output": true` to the four anthropic-provider entries (`claude-sonnet-5`, `claude-fable-5`, `claude-haiku-4-5`, `claude-haiku-4-5-20251001`)
- Mirrors the existing `claude-sonnet-4-6` and `claude-opus-4-8` entries, which already carry the flag
- Anthropic's structured outputs docs list all four models as supported (https://platform.claude.com/docs/en/build-with-claude/structured-outputs), and the bedrock_converse variants of the same models already have the flag in the cost map

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Cost-map-only change (8 inserted lines across the two JSON files, no code). Current state on main:

```
claude-sonnet-4-6 -> supports_native_structured_output: True   (has the flag)
claude-opus-4-8   -> supports_native_structured_output: True   (has the flag)
claude-sonnet-5   -> supports_native_structured_output: None   (missing)
claude-fable-5    -> supports_native_structured_output: None   (missing)
claude-haiku-4-5  -> supports_native_structured_output: None   (missing)
```

Observed impact of the missing flag with a litellm proxy in front of Anthropic: `response_format: json_schema` requests served by `anthropic/claude-sonnet-5` went through the `json_tool_call` emulation, and one response arrived as literal text `{"$FUNCTION_NAME": "json_tool_call", "tool_parameters": {...actual payload...}}` instead of the schema payload, failing downstream validation. With the flag set, `AnthropicConfig.map_openai_params` routes these models to native `output_format`, which constrains decoding server-side and makes that failure mode impossible.

Both `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json` are updated in sync; JSON validity and flag placement verified programmatically.