### PR TITLE
feat(ui): standalone /connect route for MCP OAuth, decoupled from Chat UI flag

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useKeys.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useKeys.ts
@@ -101,13 +101,14 @@ export const useKeys = (
   page: number,
   pageSize: number,
   options: KeyListCallOptions = {},
+  enabled: boolean = true,
 ): UseQueryResult<KeysResponse> => {
   const { accessToken } = useAuthorized();
 
   return useQuery<KeysResponse>({
     queryKey: keyKeys.list({ page, limit: pageSize, ...options }),
     queryFn: async () => await keyListCall(accessToken!, page, pageSize, options),
-    enabled: Boolean(accessToken),
+    enabled: Boolean(accessToken) && enabled,
     staleTime: 30000, // 30 seconds
     placeholderData: keepPreviousData,
   });

--- a/ui/litellm-dashboard/src/app/(dashboard)/page.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/page.test.tsx
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import CreateKeyPage from "./page";
+
+interface KeyRow {
+  token: string;
+}
+
+const { mockReplace, mockUseKeys, mockMigratedHref, state } = vi.hoisted(() => {
+  const state = {
+    login: "success" as string | null,
+    userRole: "Internal User",
+    keys: [] as KeyRow[],
+    keysLoading: false,
+    returnUrl: null as string | null,
+  };
+  return {
+    state,
+    mockReplace: vi.fn(),
+    mockMigratedHref: vi.fn((segment: string) => `/mocked-ui/${segment}`),
+    mockUseKeys: vi.fn((_page: number, _size: number, _opts: unknown, _enabled: boolean) => ({
+      data: state.keysLoading ? undefined : { keys: state.keys, total_count: state.keys.length },
+      isLoading: state.keysLoading,
+    })),
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  useSearchParams: () => ({ get: (key: string) => (key === "login" ? state.login : null) }),
+}));
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    authLoading: false,
+    token: "tok",
+    userRole: state.userRole,
+    userID: "user-1",
+  }),
+}));
+vi.mock("@/app/(dashboard)/hooks/keys/useKeys", () => ({ useKeys: mockUseKeys }));
+vi.mock("@/app/(dashboard)/api-keys/ApiKeysDashboard", () => ({
+  default: () => <div data-testid="api-keys-dashboard" />,
+}));
+vi.mock("@/components/common_components/LoadingScreen", () => ({
+  default: () => <div data-testid="loading-screen" />,
+}));
+vi.mock("@/components/networking", () => ({ proxyBaseUrl: "" }));
+vi.mock("@/utils/migratedPages", () => ({ MIGRATED_PAGES: {}, migratedHref: mockMigratedHref }));
+vi.mock("@/utils/returnUrlUtils", () => ({
+  buildLoginUrlWithReturn: (u: string) => u,
+  consumeReturnUrl: () => state.returnUrl,
+  getLoginUrl: () => "/login",
+  isValidReturnUrl: () => true,
+  normalizeUrlForCompare: (u: string) => u,
+  storeReturnUrl: () => undefined,
+}));
+
+describe("dashboard landing keyless redirect", () => {
+  afterEach(() => {
+    state.login = "success";
+    state.userRole = "Internal User";
+    state.keys = [];
+    state.keysLoading = false;
+    state.returnUrl = null;
+    mockReplace.mockClear();
+    mockUseKeys.mockClear();
+    mockMigratedHref.mockClear();
+  });
+
+  it("sends a keyless non-admin to the connect page after login", () => {
+    render(<CreateKeyPage />);
+    expect(mockReplace).toHaveBeenCalledWith("/mocked-ui/connect");
+    expect(screen.queryByTestId("api-keys-dashboard")).not.toBeInTheDocument();
+  });
+
+  it("leaves an admin with no keys on the dashboard", () => {
+    state.userRole = "Admin";
+    render(<CreateKeyPage />);
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(screen.getByTestId("api-keys-dashboard")).toBeInTheDocument();
+  });
+
+  it("leaves a user who already has a key on the dashboard", () => {
+    state.keys = [{ token: "sk-abc" }];
+    render(<CreateKeyPage />);
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(screen.getByTestId("api-keys-dashboard")).toBeInTheDocument();
+  });
+
+  it("does not redirect outside the post-login landing, and skips the key lookup entirely", () => {
+    state.login = null;
+    render(<CreateKeyPage />);
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(screen.getByTestId("api-keys-dashboard")).toBeInTheDocument();
+    expect(mockUseKeys.mock.calls[0][3]).toBe(false);
+  });
+
+  it("holds the loading screen while the key lookup is in flight", () => {
+    state.keysLoading = true;
+    render(<CreateKeyPage />);
+    expect(screen.getByTestId("loading-screen")).toBeInTheDocument();
+    expect(screen.queryByTestId("api-keys-dashboard")).not.toBeInTheDocument();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("yields to an explicit return URL instead of the connect redirect", () => {
+    state.returnUrl = "/ui/models-and-endpoints";
+    render(<CreateKeyPage />);
+    expect(mockReplace).not.toHaveBeenCalledWith("/mocked-ui/connect");
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/page.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/page.test.tsx
@@ -67,14 +67,15 @@ describe("dashboard landing keyless redirect", () => {
     mockMigratedHref.mockClear();
   });
 
-  it("sends a keyless non-admin to the connect page after login", () => {
+  it.each(["Internal User", "Internal Viewer"])("sends a keyless %s to the connect page after login", (role) => {
+    state.userRole = role;
     render(<CreateKeyPage />);
     expect(mockReplace).toHaveBeenCalledWith("/mocked-ui/connect");
     expect(screen.queryByTestId("api-keys-dashboard")).not.toBeInTheDocument();
   });
 
-  it("leaves an admin with no keys on the dashboard", () => {
-    state.userRole = "Admin";
+  it.each(["Admin", "Admin Viewer", "Org Admin"])("leaves a keyless %s on the dashboard", (role) => {
+    state.userRole = role;
     render(<CreateKeyPage />);
     expect(mockReplace).not.toHaveBeenCalled();
     expect(screen.getByTestId("api-keys-dashboard")).toBeInTheDocument();

--- a/ui/litellm-dashboard/src/app/(dashboard)/page.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/page.test.tsx
@@ -96,6 +96,21 @@ describe("dashboard landing keyless redirect", () => {
     expect(mockUseKeys.mock.calls[0][3]).toBe(false);
   });
 
+  it("holds the loading screen on the landing until the role hydrates, instead of flashing the dashboard", () => {
+    state.userRole = "";
+    render(<CreateKeyPage />);
+    expect(screen.getByTestId("loading-screen")).toBeInTheDocument();
+    expect(screen.queryByTestId("api-keys-dashboard")).not.toBeInTheDocument();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("does not hold the dashboard for an unhydrated role outside the post-login landing", () => {
+    state.login = null;
+    state.userRole = "";
+    render(<CreateKeyPage />);
+    expect(screen.getByTestId("api-keys-dashboard")).toBeInTheDocument();
+  });
+
   it("holds the loading screen while the key lookup is in flight", () => {
     state.keysLoading = true;
     render(<CreateKeyPage />);

--- a/ui/litellm-dashboard/src/app/(dashboard)/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/page.tsx
@@ -3,6 +3,8 @@
 import ApiKeysDashboard from "@/app/(dashboard)/api-keys/ApiKeysDashboard";
 import LoadingScreen from "@/components/common_components/LoadingScreen";
 import { proxyBaseUrl } from "@/components/networking";
+import { useKeys } from "@/app/(dashboard)/hooks/keys/useKeys";
+import { isAdminRole } from "@/utils/roles";
 import { useAuth } from "@/contexts/AuthContext";
 import {
   buildLoginUrlWithReturn,
@@ -17,7 +19,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useRef } from "react";
 
 function CreateKeyPageContent() {
-  const { authLoading, token } = useAuth();
+  const { authLoading, token, userRole, userID } = useAuth();
 
   const router = useRouter();
   const searchParams = useSearchParams()!;
@@ -26,6 +28,7 @@ function CreateKeyPageContent() {
 
   // Track if we've already attempted a return URL redirect to prevent race conditions
   const hasAttemptedReturnRedirectRef = useRef(false);
+  const didReturnRedirectRef = useRef(false);
 
   const redirectToLogin = authLoading === false && token === null;
 
@@ -75,6 +78,7 @@ function CreateKeyPageContent() {
       // Only redirect if the return URL is different from the current URL
       // This prevents infinite redirect loops
       if (normalizedReturnUrl !== normalizedCurrentUrl) {
+        didReturnRedirectRef.current = true;
         window.location.replace(safeUrl.href);
       }
     }
@@ -83,10 +87,26 @@ function CreateKeyPageContent() {
   useEffect(() => {
     if (!token) {
       hasAttemptedReturnRedirectRef.current = false;
+      didReturnRedirectRef.current = false;
     }
   }, [token]);
 
-  if (authLoading || redirectToLogin || isLegacyRedirect) {
+  const isPostLoginLanding = searchParams.get("login") === "success";
+  const isSignedIn = !authLoading && Boolean(token);
+  const shouldCheckForKeys = isPostLoginLanding && isSignedIn && !isAdminRole(userRole);
+  const { data: keysData, isLoading: keysLoading } = useKeys(1, 1, { userID }, shouldCheckForKeys);
+  const isKeylessLanding = shouldCheckForKeys && !keysLoading && keysData?.keys?.length === 0;
+  const isResolvingKeylessLanding = (shouldCheckForKeys && keysLoading) || isKeylessLanding;
+
+  useEffect(() => {
+    if (isKeylessLanding && !didReturnRedirectRef.current) {
+      router.replace(migratedHref("connect"));
+    }
+  }, [isKeylessLanding, router]);
+
+  const isRedirecting = redirectToLogin || isLegacyRedirect || isResolvingKeylessLanding;
+
+  if (authLoading || isRedirecting) {
     return <LoadingScreen />;
   }
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/page.tsx
@@ -4,7 +4,7 @@ import ApiKeysDashboard from "@/app/(dashboard)/api-keys/ApiKeysDashboard";
 import LoadingScreen from "@/components/common_components/LoadingScreen";
 import { proxyBaseUrl } from "@/components/networking";
 import { useKeys } from "@/app/(dashboard)/hooks/keys/useKeys";
-import { isAdminRole } from "@/utils/roles";
+import { internalUserRoles } from "@/utils/roles";
 import { useAuth } from "@/contexts/AuthContext";
 import {
   buildLoginUrlWithReturn,
@@ -93,7 +93,7 @@ function CreateKeyPageContent() {
 
   const isPostLoginLanding = searchParams.get("login") === "success";
   const isSignedIn = !authLoading && Boolean(token);
-  const shouldCheckForKeys = isPostLoginLanding && isSignedIn && !isAdminRole(userRole);
+  const shouldCheckForKeys = isPostLoginLanding && isSignedIn && internalUserRoles.includes(userRole);
   const { data: keysData, isLoading: keysLoading } = useKeys(1, 1, { userID }, shouldCheckForKeys);
   const isKeylessLanding = shouldCheckForKeys && !keysLoading && keysData?.keys?.length === 0;
   const isResolvingKeylessLanding = (shouldCheckForKeys && keysLoading) || isKeylessLanding;

--- a/ui/litellm-dashboard/src/app/(dashboard)/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/page.tsx
@@ -93,10 +93,12 @@ function CreateKeyPageContent() {
 
   const isPostLoginLanding = searchParams.get("login") === "success";
   const isSignedIn = !authLoading && Boolean(token);
+  const isAwaitingRole = isPostLoginLanding && isSignedIn && userRole === "";
   const shouldCheckForKeys = isPostLoginLanding && isSignedIn && internalUserRoles.includes(userRole);
   const { data: keysData, isLoading: keysLoading } = useKeys(1, 1, { userID }, shouldCheckForKeys);
   const isKeylessLanding = shouldCheckForKeys && !keysLoading && keysData?.keys?.length === 0;
   const isResolvingKeylessLanding = (shouldCheckForKeys && keysLoading) || isKeylessLanding;
+  const isResolvingLanding = isAwaitingRole || isResolvingKeylessLanding;
 
   useEffect(() => {
     if (isKeylessLanding && !didReturnRedirectRef.current) {
@@ -104,7 +106,7 @@ function CreateKeyPageContent() {
     }
   }, [isKeylessLanding, router]);
 
-  const isRedirecting = redirectToLogin || isLegacyRedirect || isResolvingKeylessLanding;
+  const isRedirecting = redirectToLogin || isLegacyRedirect || isResolvingLanding;
 
   if (authLoading || isRedirecting) {
     return <LoadingScreen />;

--- a/ui/litellm-dashboard/src/app/connect/layout.test.tsx
+++ b/ui/litellm-dashboard/src/app/connect/layout.test.tsx
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ConnectLayout from "./layout";
+
+const { mockUseAuthorized, state } = vi.hoisted(() => {
+  const state = {
+    accessToken: "token-123" as string | null,
+    isAuthorized: true,
+    isLoading: false,
+  };
+  return {
+    state,
+    mockUseAuthorized: vi.fn(() => ({
+      accessToken: state.accessToken,
+      isAuthorized: state.isAuthorized,
+      isLoading: state.isLoading,
+    })),
+  };
+});
+
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({ default: mockUseAuthorized }));
+vi.mock("@/components/navbar", () => ({ default: () => <div data-testid="navbar" /> }));
+vi.mock("@/contexts/ThemeContext", () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe("ConnectLayout", () => {
+  afterEach(() => {
+    state.accessToken = "token-123";
+    state.isAuthorized = true;
+    state.isLoading = false;
+  });
+
+  it("renders the connect surface for an authorized user without any chat-ui flag", () => {
+    render(
+      <ConnectLayout>
+        <div data-testid="page-content" />
+      </ConnectLayout>,
+    );
+    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("page-content")).toBeInTheDocument();
+  });
+
+  it("renders nothing when the user is not authorized", () => {
+    state.isAuthorized = false;
+    render(
+      <ConnectLayout>
+        <div data-testid="page-content" />
+      </ConnectLayout>,
+    );
+    expect(screen.queryByTestId("page-content")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("navbar")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing while authorization is still loading", () => {
+    state.isLoading = true;
+    render(
+      <ConnectLayout>
+        <div data-testid="page-content" />
+      </ConnectLayout>,
+    );
+    expect(screen.queryByTestId("page-content")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("navbar")).not.toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/app/connect/layout.tsx
+++ b/ui/litellm-dashboard/src/app/connect/layout.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import Navbar from "@/components/navbar";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+
+export default function ConnectLayout({ children }: { children: React.ReactNode }) {
+  const { accessToken, isAuthorized, isLoading } = useAuthorized();
+
+  if (isLoading || !isAuthorized) return null;
+
+  return (
+    <ThemeProvider accessToken={accessToken}>
+      <div className="flex h-screen flex-col">
+        <Navbar accessToken={accessToken} isPublicPage={false} />
+        <div className="min-h-0 flex-1 overflow-auto">{children}</div>
+      </div>
+    </ThemeProvider>
+  );
+}

--- a/ui/litellm-dashboard/src/app/connect/page.test.tsx
+++ b/ui/litellm-dashboard/src/app/connect/page.test.tsx
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ConnectPage from "./page";
+
+interface PanelProps {
+  accessToken: string;
+  selectedServers: string[];
+  onChange: (servers: string[]) => void;
+}
+
+const { mockReplace, mockPanel, state } = vi.hoisted(() => {
+  const state = {
+    oauthReturn: null as string | null,
+  };
+  return {
+    state,
+    mockReplace: vi.fn(),
+    mockPanel: vi.fn((_props: PanelProps) => <div data-testid="mcp-apps-panel" />),
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  useSearchParams: () => ({ get: (key: string) => (key === "mcpOauthReturn" ? state.oauthReturn : null) }),
+}));
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
+  default: () => ({ accessToken: "token-123" }),
+}));
+vi.mock("@/components/chat/MCPAppsPanel", () => ({ default: mockPanel }));
+
+describe("ConnectPage", () => {
+  afterEach(() => {
+    state.oauthReturn = null;
+    mockReplace.mockClear();
+    mockPanel.mockClear();
+  });
+
+  it("renders the MCP connect panel with the user's access token", () => {
+    render(<ConnectPage />);
+    expect(screen.getByTestId("mcp-apps-panel")).toBeInTheDocument();
+    expect(mockPanel.mock.calls[0][0]).toMatchObject({ accessToken: "token-123", selectedServers: [] });
+  });
+
+  it("strips the mcpOauthReturn param from the URL after an OAuth return", () => {
+    state.oauthReturn = "apps";
+    window.history.replaceState({}, "", "/connect?mcpOauthReturn=apps");
+    render(<ConnectPage />);
+    expect(mockReplace).toHaveBeenCalledWith("/connect");
+  });
+
+  it("does not rewrite the URL when there is no OAuth return param", () => {
+    render(<ConnectPage />);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+});

--- a/ui/litellm-dashboard/src/app/connect/page.tsx
+++ b/ui/litellm-dashboard/src/app/connect/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import MCPAppsPanel from "@/components/chat/MCPAppsPanel";
+
+function ConnectPageContent() {
+  const { accessToken } = useAuthorized();
+  const [selectedServers, setSelectedServers] = useState<string[]>([]);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const oauthReturn = searchParams.get("mcpOauthReturn");
+
+  useEffect(() => {
+    if (oauthReturn) {
+      const url = new URL(window.location.href);
+      url.searchParams.delete("mcpOauthReturn");
+      router.replace(url.pathname + url.search);
+    }
+  }, [oauthReturn, router]);
+
+  return (
+    <div className="mx-auto w-full max-w-5xl px-8 py-8">
+      <MCPAppsPanel accessToken={accessToken ?? ""} selectedServers={selectedServers} onChange={setSelectedServers} />
+    </div>
+  );
+}
+
+export default function ConnectPage() {
+  return (
+    <Suspense>
+      <ConnectPageContent />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Keyless SSO users cannot reach the MCP connect surface unless an admin enables Chat UI
- After login they land on an empty API-keys dashboard with no path to connect

How it solves it:

- Adds a standalone `/ui/connect` route with no `enable_chat_ui` gate
- Sends keyless internal users there on login instead of the empty dashboard

## Relevant issues

- Adds `/ui/connect` so keyless SSO users can connect their own MCP servers over OAuth without an admin turning on Chat UI first
- Redirects keyless internal users to it on login, so the surface is actually reachable rather than just un-gated
- Leaves the chat playground, its in-chat Integrations tab, and the `enable_chat_ui` gate exactly as they are

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

UI change, so the proof is a manual walk-through. Run the proxy with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver` and the dashboard with `npm run dev` in `ui/litellm-dashboard`, with SSO configured and at least one OAuth-backed MCP server under Tools -> MCP Servers

1. Confirm Chat UI is off at http://localhost:4000/ui/?page=admin-panel -> UI Settings ("Enable Chat UI" unchecked)
2. Visit http://localhost:4000/ui/chat and confirm you are still bounced to the dashboard (unchanged behavior)
3. Log in via SSO as an internal user that has no keys; expect to land on `/ui/connect` showing the MCP servers panel, not the empty API-keys dashboard
4. Click Connect on an OAuth server, finish the provider consent screen, and confirm you return to `/ui/connect` with the server connected and no `mcpOauthReturn` left in the address bar
5. Navigate back to http://localhost:4000/ui and confirm you can still reach the dashboard (the redirect only fires on the post-login landing)
6. Log in as a proxy admin, as an org admin, and separately as an internal user who does have a key; all three should land on the dashboard as before

Please capture screenshots of steps 3, 4, and 5

## Type

🆕 New Feature

## Changes

- New `app/connect/` route group: an auth-only layout that never reads `enable_chat_ui` and does not mount the chat shell, rendering the existing `MCPAppsPanel`
- The dashboard landing redirects to `/ui/connect` when the URL carries `?login=success`, the user holds an internal-user role, and their key list comes back empty
- `useKeys` takes an optional `enabled` flag so that key lookup only runs on the post-login landing rather than on every dashboard visit
- No backend changes: the MCP OAuth flow already captures its return URL from `window.location.href` at flow start and the shared callback replays it, so a flow begun at `/ui/connect` returns there

What does not change: the chat playground, the in-chat Integrations tab, and the `enable_chat_ui` gate are untouched, and admins and users who already have keys land on the dashboard exactly as before

### Things a reviewer will ask about

The redirect lives in the dashboard landing rather than the SSO callback. Putting it in `ui_sso.py` would add a database round trip to the authentication path and would have to reason about the cross-origin `return_to` branch; the landing already knows the user's role and keys. Because `?login=success` is also set by the username and password login flows, the role gate is what keeps this scoped to the users the flow targets. It gates positively on `internalUserRoles` rather than negatively on `isAdminRole`, because `all_admin_roles` mixes raw and formatted role strings (it holds raw `org_admin` but not the `"Org Admin"` that `formatUserRole` emits, which is the form `AuthContext` stores), so a negative check would read a keyless org admin as a non-admin and redirect them. `internalUserRoles` carries both representations, so any role that is not unambiguously an internal user is simply left on the dashboard. Completing the shared admin list instead would change org-admin access across every `isAdminRole` caller, which is a roles-policy decision of its own

It fires only on the post-login landing, never on an ordinary dashboard visit, so a keyless user can still navigate to the dashboard afterwards instead of being trapped on the connect page. An explicit stored return URL also outranks it, so a deep link that survived login is not swallowed

If the key lookup fails, no redirect happens and the dashboard renders, so a transient error cannot strand anyone on the connect page

`AuthContext` hydrates in two phases: one effect sets the token and clears `authLoading`, then a token-keyed effect derives `userRole`, so there is a render where the user is signed in but the role is still empty. On the landing that interim state holds the loading screen rather than painting the dashboard, so the positive role check cannot flash the api-keys view before the role arrives. Every `login=success` token carries a required `user_role` claim, so the role always hydrates and the hold cannot become permanent, and the hold is scoped to the landing so ordinary dashboard visits are untouched

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only routing and conditional redirects with role/key guards; no auth or backend changes.
> 
> **Overview**
> Adds a **standalone `/connect` route** that renders `MCPAppsPanel` behind an auth-only layout (no `enable_chat_ui` gate), so keyless SSO users can complete MCP OAuth without Chat UI enabled.
> 
> On the **dashboard post-login landing** (`?login=success`), internal users with **no API keys** are redirected to connect instead of an empty API-keys view. Admins, users who already have keys, and non-landing visits are unchanged. `useKeys` gains an optional **`enabled`** flag so the key lookup runs only on that landing path.
> 
> The landing shows a **loading screen** while role hydrates or keys load, and defers to an explicit stored return URL over the connect redirect. The connect page strips **`mcpOauthReturn`** from the URL after OAuth. Unit tests cover redirect rules, layout auth gating, and connect page behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 531854db4eb8ad04e50330ef5c6bdc5389aea9d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


