### PR TITLE
fix(tests): remove importlib.reload of http_handler that breaks client injection in later tests

### DIFF
--- a/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py
@@ -70,25 +70,33 @@ class TestAgentCoreAcceptHeader:
         """
         End-to-end test: verify Accept header appears in the final HTTP request
         when using JWT auth through litellm.completion().
+
+        No exception swallowing: if completion() raises (for example because the
+        injected client was silently ignored and a real network call was made),
+        the test must fail with that error, not a misleading mock assertion.
         """
         from litellm.llms.custom_httpx.http_handler import HTTPHandler
 
         client = HTTPHandler()
-        with patch.object(client, "post", return_value=MagicMock()) as mock_post:
-            try:
-                litellm.completion(
-                    model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/test_runtime",
-                    messages=[{"role": "user", "content": "test"}],
-                    api_key="test-jwt-token",
-                    client=client,
-                )
-            except Exception:
-                pass
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.json.return_value = {
+            "result": {"role": "assistant", "content": [{"text": "agent reply"}]}
+        }
 
-            mock_post.assert_called_once()
-            headers = mock_post.call_args.kwargs["headers"]
-            assert "Accept" in headers
-            assert headers["Accept"] == "application/json, text/event-stream"
+        with patch.object(client, "post", return_value=mock_response) as mock_post:
+            response = litellm.completion(
+                model="bedrock/agentcore/arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/test_runtime",
+                messages=[{"role": "user", "content": "test"}],
+                api_key="test-jwt-token",
+                client=client,
+            )
+
+        mock_post.assert_called_once()
+        headers = mock_post.call_args.kwargs["headers"]
+        assert headers["Accept"] == "application/json, text/event-stream"
+        assert response.choices[0].message.content == "agent reply"
 
 
 class TestAgentCoreJsonResponseParsing:

--- a/tests/test_litellm/llms/huggingface/embedding/test_huggingface_embedding_handler.py
+++ b/tests/test_litellm/llms/huggingface/embedding/test_huggingface_embedding_handler.py
@@ -1,4 +1,3 @@
-import importlib
 import json
 import os
 import sys
@@ -16,22 +15,7 @@ MOCK_EMBEDDING_RESPONSE = [[0.1, 0.2, 0.3, 0.4, 0.5]]
 
 
 @pytest.fixture
-def reload_huggingface_modules():
-    """
-    Reload modules to ensure fresh references after conftest reloads litellm.
-    This ensures the HTTPHandler class being patched is the same one used by
-    the embedding handler during parallel test execution.
-    """
-    import litellm.llms.custom_httpx.http_handler as http_handler_module
-    import litellm.llms.huggingface.embedding.handler as hf_embedding_handler_module
-
-    importlib.reload(http_handler_module)
-    importlib.reload(hf_embedding_handler_module)
-    yield
-
-
-@pytest.fixture
-def mock_embedding_http_handler(reload_huggingface_modules):
+def mock_embedding_http_handler():
     """Fixture to mock the HTTP handler for embedding tests"""
     with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post") as mock_post:
         mock_response = MagicMock()
@@ -43,7 +27,7 @@ def mock_embedding_http_handler(reload_huggingface_modules):
 
 
 @pytest.fixture
-def mock_embedding_async_http_handler(reload_huggingface_modules):
+def mock_embedding_async_http_handler():
     """Fixture to mock the async HTTP handler for embedding tests"""
     with patch(
         "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",

--- a/tests/test_litellm/llms/vertex_ai/rerank/test_vertex_ai_rerank_integration.py
+++ b/tests/test_litellm/llms/vertex_ai/rerank/test_vertex_ai_rerank_integration.py
@@ -3,26 +3,16 @@ Integration tests for Vertex AI rerank functionality.
 These tests demonstrate end-to-end usage of the Vertex AI rerank feature.
 """
 
-import importlib
 from unittest.mock import MagicMock
 
 import httpx
 
+from litellm.llms.vertex_ai.rerank.transformation import VertexAIRerankConfig
+
 
 class TestVertexAIRerankIntegration:
     def setup_method(self):
-        # Reload modules to ensure fresh references after conftest reloads litellm.
-        # This ensures the class being patched is the same one used by the tests.
-        import litellm.llms.vertex_ai.rerank.transformation as rerank_transformation_module
-
-        importlib.reload(rerank_transformation_module)
-
-        # Re-import after reload to get the fresh class
-        from litellm.llms.vertex_ai.rerank.transformation import (
-            VertexAIRerankConfig as FreshConfig,
-        )
-
-        self.config = FreshConfig()
+        self.config = VertexAIRerankConfig()
         self.model = "semantic-ranker-default@latest"
 
     def test_end_to_end_rerank_flow(self):


### PR DESCRIPTION
## Relevant issues

Fixes the required "Unit Tests: LLM Provider Transformations / All Other Providers" shard failure blocking #34319

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a deterministic test-order bug, not a product bug, so the proof is a deterministic replay of the exact CI execution order instead of a live-proxy curl

On PR #34319 the required shard failed twice identically (initial run and rerun, job 89078720683) on `test_accept_header_in_completion_request_jwt`, while the file passes in isolation, which pointed to cross-test pollution. Replaying CI worker gw1's exact test order in a single process reproduces it locally

Before, captured at the CI merge ref `3a79b0cd71` (PR #34319 head `2ec2a92da2` merged into staging `c2c12d70b5`), no fix:

```
$ PYTEST_XDIST_WORKER=gw1 pytest -q -p no:cacheprovider -p replay_order_plugin $(cat gw1_ci_order.txt)
...
FAILED tests/test_litellm/llms/bedrock/chat/agentcore/test_agentcore_transformation.py::TestAgentCoreAcceptHeader::test_accept_header_in_completion_request_jwt
=========== 1 failed, 3101 passed, 59 skipped, 63 warnings in 15.20s ===========
```

The underlying error, previously swallowed by a bare `except`, shows the injected mock client was discarded and a real network call to AWS was made from a unit test:

```
litellm.llms.custom_httpx.http_handler.MaskedHTTPStatusError: Client error '404 Not Found' for url 'https://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/arn%3Aaws%3Abedrock-agentcore%3Aus-west-2%3A888602223428%3Aruntime%2Ftest_runtime/invocations'
litellm.exceptions.NotFoundError: litellm.NotFoundError: BedrockException - {"message":"No endpoint or agent found with qualifier 'DEFAULT' for agent 'arn:aws:bedrock-agentcore:us-west-2:888602223428:runtime/test_runtime'"}
```

After, same merge ref with this PR's diff applied (commit `61ff87a535`), identical replay:

```
3102 passed, 59 skipped, 63 warnings in 15.92s
```

`replay_order_plugin` is a 6 line plugin that pins collection to the recorded CI worker order (needed because `tests/test_litellm/conftest.py` re-sorts explicitly passed node ids), and `PYTEST_XDIST_WORKER=gw1` makes the conftest take the same code path it takes inside a real xdist worker

## Type

✅ Test

## Changes

`tests/test_litellm/llms/huggingface/embedding/test_huggingface_embedding_handler.py` had a `reload_huggingface_modules` fixture that ran `importlib.reload(litellm.llms.custom_httpx.http_handler)` before every test in the class. Reloading creates a brand new `HTTPHandler` class object, but `litellm/llms/custom_httpx/llm_http_handler.py` holds the class it captured at import time. Any test that runs later in the same worker process and passes `client=HTTPHandler()` into `litellm.completion()` then fails the `isinstance(client, HTTPHandler)` check in `BaseLLMHTTPHandler.completion`, the injected mock client is silently discarded, and a real client is built that makes a real network call

The victim was `test_accept_header_in_completion_request_jwt` in the bedrock agentcore tests: the real AWS call raised `NotFoundError`, a bare `except Exception: pass` swallowed it, and the test failed with the misleading "Expected 'post' to have been called once. Called 0 times". Under `--dist=loadscope` whether the huggingface class and the agentcore class share a worker depends on the global test population, so any PR that adds or removes tests elsewhere (here #34319 adding 3 anthropic tests) can flip the distribution and turn the latent pollution into a hard failure that survives `--reruns 2`, since pytest-rerunfailures reruns in the same polluted process

These reloads were already removed once in `a6df01caec` (Feb 2026) and were resurrected by a merge conflict resolution in March 2026. This PR re-applies both halves and hardens the victim test:

- remove the `reload_huggingface_modules` fixture from the huggingface embedding tests; the fixtures patch by string path so they never needed the reload
- remove the `importlib.reload` of the rerank transformation module from `test_vertex_ai_rerank_integration.py` setup
- harden `test_accept_header_in_completion_request_jwt`: drop the exception swallowing and assert on the completion response, so a discarded injected client now fails loudly with the real error instead of a misleading mock assertion

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
