### PR TITLE
fix(mcp): stop leaking upstream server credentials in tool-call 403

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2649,7 +2649,7 @@ if MCP_AVAILABLE:
             ):
                 raise HTTPException(
                     status_code=403,
-                    detail=f"User not allowed to call this tool. Allowed MCP servers: {allowed_mcp_servers}",
+                    detail="User not allowed to call this tool.",
                 )
 
         standard_logging_mcp_tool_call: StandardLoggingMCPToolCall = _get_standard_logging_mcp_tool_call(

--- a/litellm/types/mcp_server/mcp_server_manager.py
+++ b/litellm/types/mcp_server/mcp_server_manager.py
@@ -163,6 +163,15 @@ class MCPServer(BaseModel):
     allow_elicitation: bool = False
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
+    def __repr__(self) -> str:
+        return (
+            f"MCPServer(server_id={self.server_id!r}, name={self.name!r}, "
+            f"transport={self.transport!r}, auth_type={self.auth_type!r})"
+        )
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
     @property
     def has_client_credentials(self) -> bool:
         """True if this server should use the OAuth2 client_credentials (M2M) flow.

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -3356,6 +3356,121 @@ async def test_call_mcp_tool_user_unauthorized_access():
 
 
 @pytest.mark.asyncio
+async def test_call_mcp_tool_unauthorized_403_does_not_leak_server_credentials():
+    """Regression for LIT-4703 / GH #29936.
+
+    Calling a tool on a server the key is not scoped to must 403 with a bare
+    message. The prior code interpolated the caller's allowed ``List[MCPServer]``
+    config objects into the 403 detail, dumping every upstream credential
+    (authentication_token, client_secret, AWS keys, private keys, env,
+    static_headers) in cleartext to the caller.
+    """
+    from fastapi import HTTPException
+
+    from litellm.proxy._experimental.mcp_server.server import call_mcp_tool
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    mock_user_auth = UserAPIKeyAuth(
+        api_key="test-key",
+        user_id="test-user",
+        team_id="team-basic",
+        object_permission_id="key-permission-123",
+    )
+
+    secret_fields = {
+        "authentication_token": "sk-LEAK-authtok",
+        "client_id": "LEAK-clientid",
+        "client_secret": "sk-LEAK-clientsecret",
+        "aws_access_key_id": "LEAK-akid",
+        "aws_secret_access_key": "LEAK-awssecret",
+        "aws_session_token": "LEAK-awssess",
+        "client_private_key": "LEAK-privkey",
+    }
+    allowed_server_obj = MCPServer(
+        server_id="allowed_server",
+        name="allowed_server",
+        server_name="allowed_server",
+        alias="allowed_server",
+        transport="http",
+        auth_type=MCPAuth.bearer_token,
+        env={"UPSTREAM_API_KEY": "LEAK-env"},
+        static_headers={"X-Upstream-Auth": "LEAK-header"},
+        **secret_fields,
+    )
+
+    def mock_get_server_by_id(server_id):
+        if server_id == "allowed_server":
+            return allowed_server_obj
+        return None
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler.get_allowed_mcp_servers",
+            AsyncMock(return_value=["allowed_server"]),
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager.get_mcp_server_by_id",
+            side_effect=mock_get_server_by_id,
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await call_mcp_tool(
+                name="restricted_server-send_email",
+                arguments={"to": "test@example.com"},
+                user_api_key_auth=mock_user_auth,
+                mcp_auth_header="Bearer test_token",
+            )
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "User not allowed to call this tool."
+    all_secret_values = list(secret_fields.values()) + ["LEAK-env", "LEAK-header"]
+    detail_text = str(exc_info.value.detail)
+    leaked = [value for value in all_secret_values if value in detail_text]
+    assert leaked == [], f"403 body leaked upstream credentials: {leaked}"
+
+
+def test_mcpserver_repr_and_str_mask_credentials():
+    """Regression for LIT-4703 / GH #29936.
+
+    ``MCPServer.__repr__``/``__str__`` must never render credential fields, so a
+    stray f-string, log line, or list interpolation cannot leak them. Only
+    display is masked; ``model_dump`` serialization is unchanged.
+    """
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    secret_fields = {
+        "authentication_token": "sk-SENTINEL-authtok",
+        "client_id": "SENTINEL-clientid",
+        "client_secret": "sk-SENTINEL-clientsecret",
+        "aws_access_key_id": "SENTINEL-akid",
+        "aws_secret_access_key": "SENTINEL-awssecret",
+        "aws_session_token": "SENTINEL-awssess",
+        "client_private_key": "SENTINEL-privkey",
+        "client_private_key_id": "SENTINEL-privkeyid",
+    }
+    server = MCPServer(
+        server_id="srv1",
+        name="srv1",
+        transport="http",
+        auth_type=MCPAuth.bearer_token,
+        env={"UPSTREAM_API_KEY": "SENTINEL-env"},
+        static_headers={"X-Upstream-Auth": "SENTINEL-header"},
+        env_vars=[{"name": "K", "value": "SENTINEL-envvar"}],
+        **secret_fields,
+    )
+
+    all_secrets = list(secret_fields.values()) + ["SENTINEL-env", "SENTINEL-header", "SENTINEL-envvar"]
+    for text in (repr(server), str(server), repr([server]), f"{server}", f"{[server]}"):
+        leaked = [secret for secret in all_secrets if secret in text]
+        assert leaked == [], f"MCPServer rendering leaked credentials {leaked} in {text!r}"
+
+    assert "srv1" in repr(server)
+    assert server.model_dump()["authentication_token"] == "sk-SENTINEL-authtok"
+    assert server.model_dump()["client_secret"] == "sk-SENTINEL-clientsecret"
+
+
+@pytest.mark.asyncio
 async def test_list_tools_filters_by_key_team_permissions():
     """Test that list_tools filters tools based on key/team mcp_tool_permissions"""
     try:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Any authenticated caller could read the gateway's upstream MCP credentials by calling a tool on a server they are not scoped to
- The 403 for that denial interpolated the caller's allowed `List[MCPServer]` config objects into the error text, so pydantic's default repr printed every secret field in cleartext

How it solves it:

- The denial now returns the bare message its two sibling call sites already return
- `MCPServer` no longer renders credential fields in `repr`/`str`, so a future f-string or log line cannot re-leak them

## Relevant issues

- Stops a tool-call 403 from returning upstream MCP server credentials (bearer tokens, OAuth client secrets, AWS keys, signing keys, env and static header values) to the caller
- Makes `MCPServer` mask its secret fields in `repr`/`str` so any future interpolation is safe by default
- Adds two regression tests, one pinning the 403 body and one pinning the masked rendering

Fixes https://github.com/BerriAI/litellm/issues/29936

## Linear ticket

Resolves LIT-4703

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Config used, with obviously fake credentials so the leak is visible in the output. No database is needed; config-only servers plus the master key are enough

```yaml
general_settings:
  master_key: sk-1234
mcp_servers:
  allowed_server:
    url: https://example.com/mcp
    transport: http
    auth_type: bearer_token
    authentication_token: sk-LEAKED-BEARER-TOKEN-9f8e7d6c
    client_id: leaked-oauth-client-id
    client_secret: sk-LEAKED-OAUTH-SECRET-abc123
    aws_access_key_id: AKIALEAKED0000EXAMPLE
    aws_secret_access_key: leakedAWSsecretKEYexample1234567890
    static_headers:
      X-Upstream-Auth: leaked-static-header-value
```

```bash
python litellm/proxy/proxy_cli.py --config lit4703_repro_config.yaml
```

The call is a tool on a server the key is not scoped to. Note the URL is `/mcp/`, the JSON-RPC endpoint

```bash
curl -s -X POST http://localhost:4000/mcp/ \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call",
       "params":{"name":"restricted_server-some_tool","arguments":{}}}'
```

Worth knowing before you verify this yourself: the curl in the GitHub issue posts to `/mcp/tools/call`, and that path does not reproduce. Everything after `/mcp/` is parsed as a server-name scope, and server names may contain slashes, so `/mcp/tools/call` scopes to a server literally named `tools/call`, finds none, and returns the safe message from a different call site. Reproducing needs `POST /mcp/` or `POST /mcp/<an allowed server>`. Checking with the issue's own URL reads as already fixed on broken code

Before, on `litellm_internal_staging`. Every credential on the server comes back to the caller, and the HTTP status is 200 because JSON-RPC wraps the 403 as `isError`, so status-code scanners do not catch it

```
event: message
data: {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"Error: User not allowed to call this tool. Allowed MCP servers: [MCPServer(server_id='1aa39be1eb5598c990d5b47bd9a4c205', name='allowed_server', alias=None, server_name='allowed_server', url='https://example.com/mcp', transport=<MCPTransport.http: 'http'>, spec_path=None, auth_type=<MCPAuth.bearer_token: 'bearer_token'>, authentication_token='sk-LEAKED-BEARER-TOKEN-9f8e7d6c', instructions=None, mcp_info={'server_name': 'allowed_server'}, extra_headers=None, allowed_tools=None, disallowed_tools=None, tool_name_to_display_name=None, tool_name_to_description=None, allowed_params=None, static_headers={'X-Upstream-Auth': 'leaked-static-header-value'}, env_vars=None, client_id='leaked-oauth-client-id', client_secret='sk-LEAKED-OAUTH-SECRET-abc123', issuer=None, ..., aws_access_key_id='AKIALEAKED0000EXAMPLE', aws_secret_access_key='leakedAWSsecretKEYexample1234567890', ...)]"}],"isError":true}}
```

After, on this branch

```
event: message
data: {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"Error: User not allowed to call this tool."}],"isError":true}}
```

The same call against `/mcp/allowed_server` also leaked before and is clean now. As a negative control, a tool on a server the key *is* scoped to is still not denied by the permission gate; it proceeds and fails later on the tool lookup, which is the expected behavior for a server that does not really exist

```bash
curl -s -X POST http://localhost:4000/mcp/ \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call",
       "params":{"name":"allowed_server-some_tool","arguments":{}}}'
```

```
data: {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"Error: Tool 'some_tool' not found"}],"isError":true}}
```

## Type

🐛 Bug Fix

## Changes

- `server.py`: the unauthorized tool-call 403 returns `"User not allowed to call this tool."` instead of interpolating the allowed `List[MCPServer]` objects
- `mcp_server_manager.py`: `MCPServer.__repr__`/`__str__` render only `server_id`, `name`, `transport` and `auth_type`, so no credential field can reach a log line or an f-string
- `test_mcp_server.py`: a regression test asserting the 403 body carries no credential substring, and one asserting every rendering of an `MCPServer` masks its secrets while `model_dump` is unchanged

Only the error text and the debug rendering change. The permission decision itself, the serialization used for config and API responses, and every field type are untouched

## QA runbook

1. Save the config above as `lit4703_repro_config.yaml` and start the proxy with `python litellm/proxy/proxy_cli.py --config lit4703_repro_config.yaml`
2. Run the `POST /mcp/` curl above and confirm the response text is exactly `Error: User not allowed to call this tool.` with no `authentication_token`, `client_secret` or `aws_` value present
3. Repeat against `http://localhost:4000/mcp/allowed_server` and confirm the same clean response
4. Run the negative control curl and confirm it is not rejected with `User not allowed to call this tool`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This closes an information-disclosure bug in the MCP proxy auth path where upstream credentials were returned to callers; the change is narrowly scoped to error text and debug repr with tests, but it touches security-sensitive denial handling.
> 
> **Overview**
> Fixes a **credential disclosure** where denying an MCP tool call on a server the API key is not scoped to could return upstream secrets in the error body.
> 
> The unauthorized tool-call **403** in `execute_mcp_tool` no longer embeds the caller’s allowed `MCPServer` objects in `detail`; it returns the same generic message as the other denial paths (`"User not allowed to call this tool."`). Previously, default Pydantic `repr` of those configs dumped tokens, OAuth secrets, AWS keys, env, and static headers to any authenticated client who triggered the denial.
> 
> **`MCPServer`** now defines **`__repr__` / `__str__`** that only show `server_id`, `name`, `transport`, and `auth_type`, so accidental interpolation in logs or error strings cannot re-expose secrets. **`model_dump`** and normal API/config serialization are unchanged.
> 
> Regression tests pin the clean 403 body and masked rendering (LIT-4703 / GH #29936).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 050cef5f1fccfb3239104b7fd9171f620923323b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->