### PR TITLE
chore(ui): add filename, size, JSX-handler, prefer-const, and antd lint rules

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -4,20 +4,61 @@
       "count": 1
     }
   },
-  "src/app/(dashboard)/admin-panel/_components/AdminPanel.tsx": {
+  "src/app/(dashboard)/access-groups/_components/AccessGroupsDetailsPage.tsx": {
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "src/app/(dashboard)/access-groups/_components/AccessGroupsModal/AccessGroupBaseForm.tsx": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/access-groups/_components/AccessGroupsModal/AccessGroupCreateModal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/access-groups/_components/AccessGroupsModal/AccessGroupEditModal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/access-groups/_components/AccessGroupsPage.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/admin-panel/_components/AdminPanel.tsx": {
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
+  "src/app/(dashboard)/agents/_components/AgentsPanel.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/agents/_components/AgentsTable.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/app/(dashboard)/agents/_components/add_agent_form.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "max-lines": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 3
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 2
@@ -27,6 +68,12 @@
     }
   },
   "src/app/(dashboard)/agents/_components/agent_card_discovery.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/refs": {
       "count": 3
     },
@@ -35,39 +82,77 @@
     }
   },
   "src/app/(dashboard)/agents/_components/agent_cost_view.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     }
   },
   "src/app/(dashboard)/agents/_components/agent_form_fields.tsx": {
-    "no-nested-ternary": {
+    "local/filename-pascal-case": {
       "count": 1
-    }
-  },
-  "src/app/(dashboard)/agents/_components/agent_info.tsx": {
+    },
     "no-nested-ternary": {
       "count": 1
     },
     "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/agents/_components/agent_info.tsx": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
+    "no-nested-ternary": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/immutability": {
       "count": 1
     }
   },
   "src/app/(dashboard)/agents/_components/agent_virtual_keys.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-nested-ternary": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/agents/_components/cost_config_fields.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/(dashboard)/agents/_components/dynamic_agent_form_fields.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 2
+    },
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "src/app/(dashboard)/budgets/_components/budget_modal.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     }
   },
   "src/app/(dashboard)/budgets/_components/budget_panel.test.tsx": {
@@ -76,18 +161,30 @@
     }
   },
   "src/app/(dashboard)/budgets/_components/budget_panel.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/(dashboard)/budgets/_components/edit_budget_modal.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     }
   },
   "src/app/(dashboard)/caching/_components/cache_dashboard.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
+    },
+    "prefer-const": {
+      "count": 3
     },
     "react-hooks/purity": {
       "count": 1
@@ -97,6 +194,14 @@
     }
   },
   "src/app/(dashboard)/caching/_components/cache_health.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/caching/_components/cache_settings/CacheFormField.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -106,33 +211,109 @@
       "count": 1
     }
   },
-  "src/app/(dashboard)/caching/_components/cache_settings/index.tsx": {
+  "src/app/(dashboard)/caching/_components/cache_settings/cacheSettingsFields.ts": {
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "src/app/(dashboard)/caching/_components/cache_settings/index.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
-  "src/app/(dashboard)/cost-tracking/_components/add_margin_form.tsx": {
+  "src/app/(dashboard)/caching/_components/coordination_redis_settings/CoordinationRedisFormField.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
   },
-  "src/app/(dashboard)/cost-tracking/_components/add_provider_form.tsx": {
+  "src/app/(dashboard)/caching/_components/coordination_redis_settings/CoordinationRedisTypeSelector.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
   },
-  "src/app/(dashboard)/cost-tracking/_components/cost_tracking_settings.tsx": {
-    "no-nested-ternary": {
-      "count": 2
+  "src/app/(dashboard)/caching/_components/coordination_redis_settings/coordinationRedisFields.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/caching/_components/coordination_redis_settings/index.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
     },
     "no-restricted-imports": {
       "count": 1
     }
   },
+  "src/app/(dashboard)/caching/_components/response_time_indicator.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/cost-optimization/_components/AutorouterTab.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/cost-optimization/_components/PromptCompressionTab.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/cost-optimization/_components/UsageTab.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/cost-tracking/_components/add_margin_form.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/cost-tracking/_components/add_provider_form.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/cost-tracking/_components/cost_tracking_settings.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-nested-ternary": {
+      "count": 2
+    },
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
   "src/app/(dashboard)/cost-tracking/_components/how_it_works.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/cost-tracking/_components/pricing_calculator/index.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     }
@@ -143,8 +324,11 @@
     }
   },
   "src/app/(dashboard)/cost-tracking/_components/pricing_calculator/multi_cost_results.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     }
   },
   "src/app/(dashboard)/cost-tracking/_components/pricing_calculator/multi_export_dropdown.test.tsx": {
@@ -153,6 +337,9 @@
     }
   },
   "src/app/(dashboard)/cost-tracking/_components/pricing_calculator/multi_export_dropdown.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     }
@@ -168,11 +355,17 @@
     }
   },
   "src/app/(dashboard)/cost-tracking/_components/provider_discount_table.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/(dashboard)/cost-tracking/_components/provider_margin_table.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     }
@@ -188,13 +381,24 @@
     }
   },
   "src/app/(dashboard)/guardrails-monitor/_components/EvaluationSettingsModal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/guardrails-monitor/_components/GuardrailConfig.tsx": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/(dashboard)/guardrails-monitor/_components/GuardrailDetail.tsx": {
     "no-nested-ternary": {
       "count": 3
+    },
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "src/app/(dashboard)/guardrails-monitor/_components/GuardrailsMonitorView.tsx": {
@@ -205,37 +409,64 @@
   "src/app/(dashboard)/guardrails-monitor/_components/GuardrailsOverview.tsx": {
     "no-nested-ternary": {
       "count": 8
+    },
+    "no-restricted-imports": {
+      "count": 2
     }
   },
   "src/app/(dashboard)/guardrails/_components/GuardrailTestPanel.tsx": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/(dashboard)/guardrails/_components/GuardrailTestPlayground.tsx": {
     "no-nested-ternary": {
       "count": 1
-    }
-  },
-  "src/app/(dashboard)/guardrails/_components/GuardrailTestResults.tsx": {
+    },
     "no-restricted-imports": {
       "count": 1
     }
   },
+  "src/app/(dashboard)/guardrails/_components/GuardrailTestResults.tsx": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
   "src/app/(dashboard)/guardrails/_components/GuardrailsPanel.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
   "src/app/(dashboard)/guardrails/_components/TeamGuardrailsTab.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
+    "max-lines": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 2
+    },
+    "no-restricted-imports": {
+      "count": 1
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
   "src/app/(dashboard)/guardrails/_components/add_guardrail_form.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "max-lines": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/set-state-in-effect": {
       "count": 1
     },
@@ -243,8 +474,16 @@
       "count": 2
     }
   },
+  "src/app/(dashboard)/guardrails/_components/content_filter/CategoryTable.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/app/(dashboard)/guardrails/_components/content_filter/CompetitorIntentConfiguration.tsx": {
     "no-nested-ternary": {
+      "count": 1
+    },
+    "no-restricted-imports": {
       "count": 1
     },
     "react-hooks/set-state-in-effect": {
@@ -252,10 +491,24 @@
     }
   },
   "src/app/(dashboard)/guardrails/_components/content_filter/ContentCategoryConfiguration.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 3
     },
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/guardrails/_components/content_filter/ContentFilterConfiguration.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 3
+    },
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -268,7 +521,38 @@
     "max-params": {
       "count": 2
     },
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/guardrails/_components/content_filter/CustomPatternModal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/guardrails/_components/content_filter/KeywordModal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/guardrails/_components/content_filter/KeywordTable.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/guardrails/_components/content_filter/PatternModal.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/guardrails/_components/content_filter/PatternTable.tsx": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -277,42 +561,117 @@
       "count": 6
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
-  "src/app/(dashboard)/guardrails/_components/guardrail_info.tsx": {
-    "max-params": {
+  "src/app/(dashboard)/guardrails/_components/guardrailTableColumns.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/guardrails/_components/guardrail_garden.tsx": {
+    "local/filename-pascal-case": {
       "count": 1
     },
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "src/app/(dashboard)/guardrails/_components/guardrail_garden_card.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/guardrails/_components/guardrail_garden_detail.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/guardrails/_components/guardrail_info.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
+    "max-params": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 3
     }
   },
+  "src/app/(dashboard)/guardrails/_components/guardrail_info_helpers.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
   "src/app/(dashboard)/guardrails/_components/guardrail_optional_params.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 5
+    },
+    "no-restricted-imports": {
+      "count": 1
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
   "src/app/(dashboard)/guardrails/_components/guardrail_provider_fields.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 5
+    },
+    "no-restricted-imports": {
+      "count": 1
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
-  "src/app/(dashboard)/guardrails/_components/tool_permission/ToolPermissionRulesEditor.tsx": {
+  "src/app/(dashboard)/guardrails/_components/guardrail_table.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/guardrails/_components/llm_judge/LLMJudgeFields.tsx": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/guardrails/_components/pii_components.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "src/app/(dashboard)/guardrails/_components/pii_configuration.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/guardrails/_components/tool_permission/ToolPermissionRulesEditor.tsx": {
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/purity": {
       "count": 1
@@ -478,13 +837,51 @@
       "count": 2
     }
   },
+  "src/app/(dashboard)/hooks/useTeams.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/DcrBridgeToggle.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/EnvVarsSection.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/app/(dashboard)/mcp-servers/_components/MCPLogoSelector.test.tsx": {
     "unused-imports/no-unused-imports": {
       "count": 1
     }
   },
+  "src/app/(dashboard)/mcp-servers/_components/MCPLogoSelector.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/app/(dashboard)/mcp-servers/_components/MCPNetworkSettings.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/immutability": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/MCPPermissionManagement.test.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/MCPPermissionManagement.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/MCPServerCard.tsx": {
+    "no-restricted-imports": {
       "count": 2
     }
   },
@@ -498,9 +895,14 @@
       "count": 1
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/OAuthFormFields.test.tsx": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -509,11 +911,47 @@
       "count": 1
     },
     "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/OpenAPIFormSection.tsx": {
+    "local/no-complex-jsx-arrow": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     }
   },
   "src/app/(dashboard)/mcp-servers/_components/OpenAPIQuickPicker.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/PassthroughAuthorizeSection.test.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/PassthroughAuthorizeSection.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/StdioConfiguration.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/TokenEndpointAuthMethodField.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/TokenExchangeFormFields.tsx": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -522,65 +960,111 @@
       "count": 3
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/TruePassthroughWarning.tsx": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/(dashboard)/mcp-servers/_components/UserEnvVarsModal.tsx": {
     "no-nested-ternary": {
       "count": 2
+    },
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "src/app/(dashboard)/mcp-servers/_components/create_mcp_server.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "max-lines": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 1
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 4
     }
   },
-  "src/app/(dashboard)/mcp-servers/_components/mcp_connect.tsx": {
-    "no-restricted-imports": {
+  "src/app/(dashboard)/mcp-servers/_components/index.tsx": {
+    "local/filename-pascal-case": {
       "count": 1
+    }
+  },
+  "src/app/(dashboard)/mcp-servers/_components/mcp_connect.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/static-components": {
       "count": 4
     }
   },
   "src/app/(dashboard)/mcp-servers/_components/mcp_connection_status.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 3
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/(dashboard)/mcp-servers/_components/mcp_discovery.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/set-state-in-effect": {
       "count": 2
     }
   },
   "src/app/(dashboard)/mcp-servers/_components/mcp_server_cost_config.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     }
   },
   "src/app/(dashboard)/mcp-servers/_components/mcp_server_cost_display.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "max-lines": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 1
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/immutability": {
       "count": 1
@@ -590,40 +1074,78 @@
     }
   },
   "src/app/(dashboard)/mcp-servers/_components/mcp_server_view.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     }
   },
   "src/app/(dashboard)/mcp-servers/_components/mcp_servers.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "local/no-complex-jsx-arrow": {
+      "count": 3
+    },
     "no-nested-ternary": {
       "count": 1
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 2
     }
   },
   "src/app/(dashboard)/mcp-servers/_components/mcp_tool_configuration.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     }
   },
   "src/app/(dashboard)/mcp-servers/_components/mcp_tools.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 1
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 2
     }
   },
-  "src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.tsx": {
+  "src/app/(dashboard)/mcp-servers/_components/utils.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/memory/_components/MemoryDetailDrawer.tsx": {
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "src/app/(dashboard)/memory/_components/MemoryEditModal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/memory/_components/MemoryView.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.tsx": {
+    "no-restricted-imports": {
+      "count": 3
     },
     "react-hooks/preserve-manual-memoization": {
       "count": 4
@@ -638,8 +1160,11 @@
     }
   },
   "src/app/(dashboard)/models-and-endpoints/components/AllModelsTab.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 2
+    },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 3
@@ -655,7 +1180,7 @@
       "count": 1
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/(dashboard)/models-and-endpoints/components/PriceDataManagementTab.tsx": {
@@ -663,7 +1188,21 @@
       "count": 1
     }
   },
+  "src/app/(dashboard)/models-and-endpoints/utils/modelDataTransformer.ts": {
+    "prefer-const": {
+      "count": 6
+    }
+  },
   "src/app/(dashboard)/old-usage/_components/usage.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "max-lines": {
+      "count": 1
+    },
+    "prefer-const": {
+      "count": 6
+    },
     "react-hooks/immutability": {
       "count": 1
     },
@@ -671,9 +1210,19 @@
       "count": 1
     }
   },
-  "src/app/(dashboard)/playground/components/chat_ui/AdditionalModelSettings.tsx": {
+  "src/app/(dashboard)/organizations/_components/OrganizationsPanel.tsx": {
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "src/app/(dashboard)/playground/components/chat_ui/A2AMetrics.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/playground/components/chat_ui/AdditionalModelSettings.tsx": {
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 2
@@ -683,8 +1232,16 @@
     "no-nested-ternary": {
       "count": 2
     },
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/set-state-in-effect": {
       "count": 5
+    }
+  },
+  "src/app/(dashboard)/playground/components/chat_ui/ChatImageUpload.tsx": {
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "src/app/(dashboard)/playground/components/chat_ui/ChatImageUtils.test.tsx": {
@@ -698,10 +1255,19 @@
     }
   },
   "src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 2
+    },
+    "max-lines": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 7
     },
     "no-restricted-imports": {
+      "count": 2
+    },
+    "prefer-const": {
       "count": 1
     },
     "react-hooks/set-state-in-effect": {
@@ -715,11 +1281,19 @@
     "no-nested-ternary": {
       "count": 1
     },
+    "no-restricted-imports": {
+      "count": 1
+    },
     "no-restricted-syntax": {
       "count": 2
     }
   },
   "src/app/(dashboard)/playground/components/chat_ui/CodeInterpreterTool.tsx": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/playground/components/chat_ui/EndpointSelector.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -728,6 +1302,9 @@
     "no-nested-ternary": {
       "count": 2
     },
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/immutability": {
       "count": 2
     },
@@ -735,11 +1312,40 @@
       "count": 1
     }
   },
+  "src/app/(dashboard)/playground/components/chat_ui/ResponsesImageUpload.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/playground/components/chat_ui/SearchResultsDisplay.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/playground/components/chat_ui/SessionManagement.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/app/(dashboard)/playground/components/compareUI/CompareUI.tsx": {
+    "max-lines": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 4
     },
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/playground/components/compareUI/components/ComparisonPanel.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 2
+    },
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -748,12 +1354,28 @@
       "count": 1
     }
   },
+  "src/app/(dashboard)/playground/components/compareUI/components/MessageInput.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/app/(dashboard)/playground/components/compareUI/components/ModelSelector.tsx": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/playground/components/compareUI/components/UnifiedSelector.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/(dashboard)/playground/components/complianceUI/ComplianceUI.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 2
+    },
+    "max-lines": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 8
     },
@@ -762,6 +1384,9 @@
     }
   },
   "src/app/(dashboard)/playground/llm_calls/a2a_send_message.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "max-params": {
       "count": 2
     },
@@ -770,21 +1395,33 @@
     }
   },
   "src/app/(dashboard)/playground/llm_calls/anthropic_messages.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "max-params": {
       "count": 1
     }
   },
   "src/app/(dashboard)/playground/llm_calls/audio_speech.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "max-params": {
       "count": 1
     }
   },
   "src/app/(dashboard)/playground/llm_calls/audio_transcriptions.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "max-params": {
       "count": 1
     }
   },
   "src/app/(dashboard)/playground/llm_calls/embeddings_api.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "max-params": {
       "count": 1
     },
@@ -793,21 +1430,33 @@
     }
   },
   "src/app/(dashboard)/playground/llm_calls/fetch_agents.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-syntax": {
       "count": 1
     }
   },
   "src/app/(dashboard)/playground/llm_calls/image_edits.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "max-params": {
       "count": 1
     }
   },
   "src/app/(dashboard)/playground/llm_calls/image_generation.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "max-params": {
       "count": 1
     }
   },
   "src/app/(dashboard)/playground/llm_calls/interactions_api.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "max-params": {
       "count": 1
     },
@@ -821,16 +1470,25 @@
     }
   },
   "src/app/(dashboard)/policies/_components/add_attachment_form.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/immutability": {
       "count": 1
     }
   },
   "src/app/(dashboard)/policies/_components/add_policy_form.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
+    },
+    "prefer-const": {
+      "count": 2
     },
     "react-hooks/immutability": {
       "count": 2
@@ -840,18 +1498,33 @@
     }
   },
   "src/app/(dashboard)/policies/_components/ai_suggestion_modal.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "local/no-complex-jsx-arrow": {
+      "count": 3
+    },
+    "max-lines": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 10
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/immutability": {
       "count": 1
     }
   },
   "src/app/(dashboard)/policies/_components/guardrail_selection_modal.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-nested-ternary": {
+      "count": 1
+    },
+    "no-restricted-imports": {
       "count": 1
     },
     "react-hooks/set-state-in-effect": {
@@ -864,7 +1537,18 @@
     }
   },
   "src/app/(dashboard)/policies/_components/impact_popover.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-nested-ternary": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/policies/_components/impact_preview_alert.tsx": {
+    "local/filename-pascal-case": {
       "count": 1
     },
     "no-restricted-imports": {
@@ -877,43 +1561,72 @@
     }
   },
   "src/app/(dashboard)/policies/_components/index.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
   "src/app/(dashboard)/policies/_components/pipeline_flow_builder.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "max-lines": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 1
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 2
     }
   },
   "src/app/(dashboard)/policies/_components/policy_info.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
-  "src/app/(dashboard)/policies/_components/policy_test_panel.tsx": {
+  "src/app/(dashboard)/policies/_components/policy_templates.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "src/app/(dashboard)/policies/_components/policy_test_panel.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/immutability": {
       "count": 1
     }
   },
   "src/app/(dashboard)/policies/_components/template_parameter_modal.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/immutability": {
       "count": 1
@@ -925,28 +1638,71 @@
   "src/app/(dashboard)/projects/_components/ProjectDetailsPage.tsx": {
     "no-nested-ternary": {
       "count": 3
-    }
-  },
-  "src/app/(dashboard)/projects/_components/ProjectKeysSection.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/projects/_components/ProjectModals/ProjectBaseForm.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 2
-    }
-  },
-  "src/app/(dashboard)/prompts/_components/add_prompt_form.tsx": {
+    },
     "no-restricted-imports": {
       "count": 1
     }
   },
+  "src/app/(dashboard)/projects/_components/ProjectKeysSection.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/projects/_components/ProjectModals/CreateProjectModal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/projects/_components/ProjectModals/EditProjectModal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/projects/_components/ProjectModals/ProjectBaseForm.test.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/projects/_components/ProjectModals/ProjectBaseForm.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/projects/_components/ProjectsPage.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/prompts/_components/add_prompt_form.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 3
+    }
+  },
   "src/app/(dashboard)/prompts/_components/index.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 1
     },
     "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/prompts/_components/prompt_editor_view.tsx": {
+    "local/filename-pascal-case": {
       "count": 1
     }
   },
@@ -957,7 +1713,7 @@
   },
   "src/app/(dashboard)/prompts/_components/prompt_editor_view/ModelConfigCard.tsx": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptCodeSnippets.tsx": {
@@ -965,7 +1721,7 @@
       "count": 1
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
@@ -973,17 +1729,17 @@
   },
   "src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptEditorHeader.tsx": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/(dashboard)/prompts/_components/prompt_editor_view/PromptMessagesCard.tsx": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/(dashboard)/prompts/_components/prompt_editor_view/PublishModal.tsx": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/(dashboard)/prompts/_components/prompt_editor_view/ToolsCard.tsx": {
@@ -997,7 +1753,13 @@
     }
   },
   "src/app/(dashboard)/prompts/_components/prompt_editor_view/VersionHistorySidePanel.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
     "no-nested-ternary": {
+      "count": 1
+    },
+    "no-restricted-imports": {
       "count": 1
     },
     "react-hooks/immutability": {
@@ -1006,10 +1768,23 @@
   },
   "src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageInput.tsx": {
     "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/MessageList.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/VariableInput.tsx": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
   "src/app/(dashboard)/prompts/_components/prompt_editor_view/conversation_panel/index.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     }
@@ -1019,70 +1794,132 @@
       "count": 1
     }
   },
+  "src/app/(dashboard)/prompts/_components/prompt_editor_view/index.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
   "src/app/(dashboard)/prompts/_components/prompt_info.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 3
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 2
     }
   },
+  "src/app/(dashboard)/prompts/_components/prompt_utils.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/prompts/_components/tool_modal.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/prompts/_components/variable_textarea.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/app/(dashboard)/router-settings/_components/general_settings.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 1
     },
     "no-restricted-imports": {
+      "count": 3
+    },
+    "prefer-const": {
       "count": 2
     }
   },
   "src/app/(dashboard)/search-tools/_components/CreateSearchTools.tsx": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
-  "src/app/(dashboard)/search-tools/_components/SearchToolTester.tsx": {
+  "src/app/(dashboard)/search-tools/_components/SearchConnectionTest.tsx": {
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "src/app/(dashboard)/search-tools/_components/SearchToolTester.tsx": {
+    "no-restricted-imports": {
+      "count": 2
     }
   },
   "src/app/(dashboard)/search-tools/_components/SearchToolView.tsx": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/(dashboard)/search-tools/_components/SearchTools.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 2
+    },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/static-components": {
       "count": 1
     }
   },
+  "src/app/(dashboard)/search-tools/_components/index.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/search-tools/_components/types.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
   "src/app/(dashboard)/skills/_components/ClaudeCodePluginsPanel.tsx": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
   "src/app/(dashboard)/skills/_components/add_plugin_form.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     }
   },
   "src/app/(dashboard)/tag-management/_components/components/CreateTagModal.tsx": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/(dashboard)/tag-management/_components/index.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     },
@@ -1090,9 +1927,17 @@
       "count": 1
     }
   },
-  "src/app/(dashboard)/tag-management/_components/tag_info.tsx": {
-    "no-restricted-imports": {
+  "src/app/(dashboard)/tag-management/_components/tagTableColumns.tsx": {
+    "local/filename-pascal-case": {
       "count": 1
+    }
+  },
+  "src/app/(dashboard)/tag-management/_components/tag_info.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 3
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
@@ -1112,14 +1957,25 @@
   "src/app/(dashboard)/usage/_components/components/EndpointUsage/components/EndpointUsageTable.tsx": {
     "no-nested-ternary": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     }
   },
   "src/app/(dashboard)/usage/_components/components/EntityUsage/EntityUsage.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 2
+    },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/app/(dashboard)/usage/_components/components/EntityUsage/SpendByProvider.tsx": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/usage/_components/components/EntityUsage/TopModelView.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -1128,22 +1984,39 @@
     "no-nested-ternary": {
       "count": 1
     },
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/immutability": {
       "count": 1
     }
   },
   "src/app/(dashboard)/usage/_components/components/UsagePageView.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 2
+    },
+    "max-lines": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 1
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/purity": {
       "count": 1
     },
     "react-hooks/set-state-in-effect": {
       "count": 3
+    }
+  },
+  "src/app/(dashboard)/usage/_components/components/UsageViewSelect/UsageViewSelect.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 2
+    },
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "src/app/(dashboard)/usage/_components/hooks/usePaginatedDailyActivity.ts": {
@@ -1154,13 +2027,29 @@
       "count": 1
     }
   },
-  "src/app/(dashboard)/users/_components/DefaultUserSettings.tsx": {
+  "src/app/(dashboard)/users/_components/BulkEditUsers.tsx": {
     "no-restricted-imports": {
+      "count": 1
+    },
+    "prefer-const": {
       "count": 1
     }
   },
-  "src/app/(dashboard)/users/_components/edit_user.tsx": {
+  "src/app/(dashboard)/users/_components/DefaultUserSettings.tsx": {
     "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/users/_components/edit_user.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/users/_components/index.tsx": {
+    "local/filename-pascal-case": {
       "count": 1
     }
   },
@@ -1173,15 +2062,24 @@
     }
   },
   "src/app/(dashboard)/users/_components/user_edit_view.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
   "src/app/(dashboard)/users/_components/view_users.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
+      "count": 3
+    },
+    "prefer-const": {
       "count": 1
     },
     "react-hooks/set-state-in-effect": {
@@ -1189,14 +2087,30 @@
     }
   },
   "src/app/(dashboard)/users/_components/view_users/user_info_view.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
   "src/app/(dashboard)/vector-stores/_components/CreateVectorStore.tsx": {
+    "no-restricted-imports": {
+      "count": 3
+    }
+  },
+  "src/app/(dashboard)/vector-stores/_components/S3VectorsConfig.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/vector-stores/_components/TestVectorStoreTab.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -1206,13 +2120,21 @@
       "count": 2
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react/no-unescaped-entities": {
       "count": 1
     }
   },
+  "src/app/(dashboard)/vector-stores/_components/VectorStoreTester.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/app/(dashboard)/vector-stores/_components/index.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     },
@@ -1221,8 +2143,11 @@
     }
   },
   "src/app/(dashboard)/vector-stores/_components/vector_store_info.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
@@ -1230,6 +2155,9 @@
   },
   "src/app/(dashboard)/workflows/WorkflowRuns.tsx": {
     "no-nested-ternary": {
+      "count": 1
+    },
+    "no-restricted-imports": {
       "count": 1
     },
     "no-restricted-syntax": {
@@ -1245,6 +2173,12 @@
     }
   },
   "src/app/login/LoginPage.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/set-state-in-effect": {
       "count": 2
     }
@@ -1259,15 +2193,41 @@
       "count": 1
     }
   },
+  "src/app/onboarding/OnboardingErrorView.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/onboarding/OnboardingFormBody.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/onboarding/OnboardingLoadingView.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/components/AIHub/ModelHubTable.test.tsx": {
     "max-params": {
       "count": 1
     }
   },
   "src/components/AIHub/ModelHubTable.tsx": {
+    "max-lines": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 1
     },
+    "no-restricted-imports": {
+      "count": 2
+    },
+    "prefer-const": {
+      "count": 4
+    }
+  },
+  "src/components/AIHub/SkillHubDashboard.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -1282,7 +2242,7 @@
   },
   "src/components/AIHub/forms/MakeAgentPublicForm.tsx": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
@@ -1298,7 +2258,7 @@
       "count": 2
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
@@ -1306,17 +2266,77 @@
   },
   "src/components/AIHub/forms/MakeModelPublicForm.tsx": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
-  "src/components/CreateUserButton.tsx": {
+  "src/components/BetaBadge.tsx": {
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "src/components/CloudZeroCostTracking/CloudZeroCostTracking.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/CloudZeroCostTracking/CloudZeroCreateModal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/CloudZeroCostTracking/CloudZeroEmptyPlaceholder.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/CloudZeroCostTracking/CloudZeroIntegrationSettings.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/CloudZeroCostTracking/CloudZeroUpdateModal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/CreateUserButton.tsx": {
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/components/DebugWarningBanner.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/DeletedKeysPage/DeletedKeysPage.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/DeletedTeamsPage/DeletedTeamsPage.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/DeprecationBanner.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/EntityUsageExport/EntityUsageExportModal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/EntityUsageExport/ExportFormatSelector.tsx": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -1325,9 +2345,14 @@
       "count": 1
     }
   },
+  "src/components/EntityUsageExport/ExportTypeSelector.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/components/EntityUsageExport/UsageExportHeader.tsx": {
     "no-restricted-imports": {
-      "count": 2
+      "count": 3
     }
   },
   "src/components/EntityUsageExport/types.ts": {
@@ -1351,10 +2376,16 @@
   "src/components/GuardrailSettingsView.tsx": {
     "no-nested-ternary": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "src/components/GuardrailsMonitor/LogViewer.tsx": {
     "no-nested-ternary": {
+      "count": 1
+    },
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -1363,8 +2394,26 @@
       "count": 1
     }
   },
+  "src/components/KeyAliasSelect/PaginatedKeyAliasSelect/PaginatedKeyAliasSelect.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/LicenseExpiryBanner.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/ModelSelect/ModelSelect.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/components/ModelSelect/PaginatedModelSelect/PaginatedModelSelect.tsx": {
     "no-nested-ternary": {
+      "count": 1
+    },
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -1373,20 +2422,58 @@
       "count": 12
     }
   },
-  "src/components/Navbar/UserDropdown/UserDropdown.tsx": {
-    "react-hooks/set-state-in-effect": {
+  "src/components/Navbar/BlogDropdown/BlogDropdown.tsx": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/components/Navbar/CommunityEngagementButtons/CommunityEngagementButtons.tsx": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
-  "src/components/SCIM.tsx": {
+  "src/components/Navbar/NotificationsBell/NotificationsBell.tsx": {
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "src/components/Navbar/UserDropdown/UserDropdown.tsx": {
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
+  "src/components/Navbar/ViewSwitcher.tsx": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/components/Navbar/WorkerDropdown/WorkerDropdown.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/SCIM.tsx": {
+    "no-restricted-imports": {
+      "count": 2
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/components/SSOModals.test.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/components/SSOModals.tsx": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/components/Settings/AdminSettings/HashicorpVault/EditHashicorpVaultModal.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -1394,19 +2481,55 @@
   "src/components/Settings/AdminSettings/HashicorpVault/HashicorpVault.tsx": {
     "no-nested-ternary": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/Settings/AdminSettings/HashicorpVault/HashicorpVaultEmptyPlaceholder.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/Settings/AdminSettings/LoggingSettings/LoggingSettings.tsx": {
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "src/components/Settings/AdminSettings/MCPSemanticFilterSettings/MCPSemanticFilterSettings.tsx": {
     "no-nested-ternary": {
       "count": 1
     },
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/components/Settings/AdminSettings/MCPSemanticFilterSettings/MCPSemanticFilterTestPanel.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/Settings/AdminSettings/PluginSettings/PluginSettings.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/Settings/AdminSettings/SSOSettings/Modals/AddSSOSettingsModal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/Settings/AdminSettings/SSOSettings/Modals/BaseSSOSettingsForm.test.tsx": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
   "src/components/Settings/AdminSettings/SSOSettings/Modals/BaseSSOSettingsForm.tsx": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/components/Settings/AdminSettings/SSOSettings/Modals/EditSSOSettingsModal.test.tsx": {
@@ -1414,8 +2537,31 @@
       "count": 1
     }
   },
+  "src/components/Settings/AdminSettings/SSOSettings/Modals/EditSSOSettingsModal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/components/Settings/AdminSettings/SSOSettings/RedactableField.tsx": {
     "no-nested-ternary": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/Settings/AdminSettings/SSOSettings/RoleMappings.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/Settings/AdminSettings/SSOSettings/SSOSettings.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/Settings/AdminSettings/SSOSettings/SSOSettingsEmptyPlaceholder.tsx": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -1424,7 +2570,15 @@
       "count": 4
     }
   },
+  "src/components/Settings/AdminSettings/SSOSettings/SSOSettingsLoadingSkeleton.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/components/Settings/AdminSettings/UISettings/PageVisibilitySettings.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/set-state-in-render": {
       "count": 2
     }
@@ -1432,19 +2586,40 @@
   "src/components/Settings/AdminSettings/UISettings/UISettings.tsx": {
     "no-nested-ternary": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "src/components/Settings/RouterSettings/Fallbacks/AddFallbacks.tsx": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
-  "src/components/Settings/RouterSettings/Fallbacks/FallbackSelectionForm.tsx": {
+  "src/components/Settings/RouterSettings/Fallbacks/AddFallbacksModal.tsx": {
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "src/components/Settings/RouterSettings/Fallbacks/EditFallbacks.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/Settings/RouterSettings/Fallbacks/FallbackGroupConfig.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/Settings/RouterSettings/Fallbacks/FallbackSelectionForm.tsx": {
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
@@ -1452,7 +2627,10 @@
   },
   "src/components/Settings/RouterSettings/Fallbacks/Fallbacks.tsx": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
+    },
+    "prefer-const": {
+      "count": 2
     }
   },
   "src/components/TeamSSOSettings.test.tsx": {
@@ -1460,49 +2638,146 @@
       "count": 1
     }
   },
+  "src/components/TeamSSOSettings.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/components/Teams.test.tsx": {
     "max-nested-callbacks": {
       "count": 4
+    },
+    "prefer-const": {
+      "count": 6
     }
   },
   "src/components/Teams.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 4
+    },
+    "max-lines": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 2
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
+    },
+    "prefer-const": {
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 3
     }
   },
+  "src/components/TeamsPage/teamTableColumns.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
   "src/components/ToolDetail.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
     "unused-imports/no-unused-imports": {
       "count": 2
     }
   },
+  "src/components/ToolPolicies/PolicySelect.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/ToolPolicies/ToolPoliciesTableColumns.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/components/UIAccessControlForm.tsx": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/components/UsagePage/components/EntityUsage/TopKeyView.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/UsagePage/components/KeyModelUsageView.tsx": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/components/UsagePage/utils/value_formatters.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/VirtualKeysPage/keyTableColumns.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/components/activity_metrics.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 1
     },
     "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/components/add_model/AdaptiveRoutingConfig.tsx": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
+  "src/components/add_model/AddModelForm.test.tsx": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
   "src/components/add_model/AddModelForm.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 1
     },
+    "no-restricted-imports": {
+      "count": 4
+    }
+  },
+  "src/components/add_model/ClassificationMethodConfig.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/add_model/ComplexityRouterConfig.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/add_model/EscalationKeywords.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/add_model/KeywordTierRules.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/components/add_model/RouterConfigBuilder.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/purity": {
       "count": 1
     },
@@ -1510,56 +2785,153 @@
       "count": 1
     }
   },
-  "src/components/add_model/add_auto_router_tab.tsx": {
+  "src/components/add_model/SemanticKeywordMatching.tsx": {
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "src/components/add_model/add_auto_router_tab.test.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/add_model/add_auto_router_tab.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 3
+    }
+  },
+  "src/components/add_model/add_model_modes.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/add_model/add_model_tab.test.tsx": {
+    "no-restricted-imports": {
+      "count": 2
     }
   },
   "src/components/add_model/add_model_tab.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 4
+    }
+  },
+  "src/components/add_model/advanced_settings.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 4
+    },
+    "prefer-const": {
+      "count": 2
+    }
+  },
+  "src/components/add_model/auto_router_connection_test.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     }
   },
-  "src/components/add_model/advanced_settings.tsx": {
+  "src/components/add_model/cache_control_settings.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "prefer-const": {
+      "count": 1
+    }
+  },
+  "src/components/add_model/conditional_public_model_name.test.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/components/add_model/conditional_public_model_name.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 2
     }
   },
+  "src/components/add_model/handle_add_auto_router_submit.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/add_model/handle_add_model_submit.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/add_model/litellm_model_name.test.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/components/add_model/litellm_model_name.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 3
+    }
+  },
+  "src/components/add_model/model_connection_test.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-nested-ternary": {
+      "count": 2
     },
     "no-restricted-imports": {
       "count": 1
     }
   },
-  "src/components/add_model/model_connection_test.tsx": {
-    "no-nested-ternary": {
-      "count": 2
+  "src/components/add_model/provider_specific_fields.test.tsx": {
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "src/components/add_model/provider_specific_fields.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 5
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/immutability": {
       "count": 3
     }
   },
   "src/components/add_pass_through.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
-      "count": 2
+      "count": 3
     }
   },
   "src/components/agent_management/AgentSelector.test.tsx": {
@@ -1570,19 +2942,46 @@
       "count": 1
     }
   },
+  "src/components/agent_management/AgentSelector.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "prefer-const": {
+      "count": 1
+    }
+  },
+  "src/components/alerting/alerting_settings.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "prefer-const": {
+      "count": 1
+    }
+  },
   "src/components/alerting/dynamic_form.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 4
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/components/bulk_create_users_button.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
     },
+    "no-restricted-imports": {
+      "count": 2
+    },
     "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/components/callback_info_helpers.tsx": {
+    "local/filename-pascal-case": {
       "count": 1
     }
   },
@@ -1592,6 +2991,9 @@
     }
   },
   "src/components/chat/MCPAppsPanel.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 7
     }
@@ -1611,17 +3013,45 @@
       "count": 2
     }
   },
-  "src/components/claude_code_plugins/MakeSkillPublicForm.tsx": {
+  "src/components/chat_ui/MCPEventsDisplay.tsx": {
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "src/components/chat_ui/ReasoningContent.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/chat_ui/ResponseMetrics.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/chat_ui/mode_endpoint_mapping.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/claude_code_plugins/MakeSkillPublicForm.tsx": {
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
-  "src/components/cloudzero_export_modal.tsx": {
-    "no-restricted-imports": {
+  "src/components/claude_code_plugins/skill_detail.tsx": {
+    "local/filename-pascal-case": {
       "count": 1
+    }
+  },
+  "src/components/cloudzero_export_modal.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     },
     "no-restricted-syntax": {
       "count": 3
@@ -1632,7 +3062,7 @@
   },
   "src/components/common_components/AccessGroupSelector.tsx": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/components/common_components/AutoRotationView.tsx": {
@@ -1640,13 +3070,39 @@
       "count": 1
     }
   },
+  "src/components/common_components/DefaultProxyAdminTag.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/components/common_components/DeleteResourceModal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
+  "src/components/common_components/DurationSelect.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/components/common_components/Filters/FilterInput.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/components/common_components/Filters/FiltersButton.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/common_components/Filters/ResetFiltersButton.tsx": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
@@ -1655,9 +3111,27 @@
       "count": 1
     }
   },
-  "src/components/common_components/KeyLifecycleSettings.tsx": {
+  "src/components/common_components/IconActionButton/TableIconActionButtons/TableIconActionButton.tsx": {
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "src/components/common_components/KeyLifecycleSettings.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/components/common_components/LabeledField.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/common_components/MemberTable.tsx": {
+    "no-restricted-imports": {
+      "count": 2
     }
   },
   "src/components/common_components/ModelAliasManager.tsx": {
@@ -1670,23 +3144,41 @@
   },
   "src/components/common_components/ModelSelector.tsx": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/components/common_components/NewBadge.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/common_components/OrganizationDropdown.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
+    "no-restricted-imports": {
       "count": 1
     }
   },
   "src/components/common_components/PassThroughGuardrailsSection.tsx": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
-  "src/components/common_components/PassThroughSecuritySection.tsx": {
+  "src/components/common_components/PassThroughRoutesSelector.tsx": {
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "src/components/common_components/PassThroughSecuritySection.tsx": {
+    "no-restricted-imports": {
+      "count": 2
     }
   },
   "src/components/common_components/PremiumLoggingSettings.tsx": {
@@ -1694,7 +3186,38 @@
       "count": 1
     }
   },
+  "src/components/common_components/ProjectDropdown.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/common_components/RateLimitTypeFormItem.test.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/common_components/RateLimitTypeFormItem.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/components/common_components/RouterSettingsAccordion.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/common_components/TableHeaderSortDropdown/TableHeaderSortDropdown.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/common_components/budget_duration_dropdown.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     }
@@ -1705,6 +3228,9 @@
     }
   },
   "src/components/common_components/chartUtils.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 1
     },
@@ -1713,17 +3239,50 @@
     }
   },
   "src/components/common_components/check_openapi_schema.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 3
     }
   },
   "src/components/common_components/fetch_teams.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "max-params": {
       "count": 1
     }
   },
   "src/components/common_components/simple_table.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-nested-ternary": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/common_components/team_dropdown.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/common_components/team_multi_select.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/common_components/user_search_modal.tsx": {
+    "local/filename-pascal-case": {
       "count": 1
     },
     "no-restricted-imports": {
@@ -1731,55 +3290,157 @@
     }
   },
   "src/components/constants.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
   "src/components/edit_auto_router/edit_auto_router_modal.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/immutability": {
       "count": 1
     }
   },
   "src/components/email_events/email_event_settings.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     },
     "react-hooks/immutability": {
       "count": 1
     }
   },
   "src/components/email_settings.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
+      "count": 2
+    },
+    "prefer-const": {
+      "count": 1
+    }
+  },
+  "src/components/guardrails/GuardrailSelector.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/key_info_utils.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/key_team_helpers/BudgetFallbacksEditor.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/key_team_helpers/BudgetWindowsEditor.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/key_team_helpers/TagRateLimitEditor.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/key_team_helpers/fetch_available_models_team_key.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "prefer-const": {
       "count": 1
     }
   },
   "src/components/key_team_helpers/key_list.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
+  "src/components/key_team_helpers/transform_key_info.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
   "src/components/key_value_input.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/components/leftnav.tsx": {
+    "local/filename-pascal-case": {
       "count": 1
     }
   },
   "src/components/llm_calls/chat_completion.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "max-params": {
       "count": 1
     },
     "no-nested-ternary": {
       "count": 1
+    },
+    "prefer-const": {
+      "count": 1
+    }
+  },
+  "src/components/llm_calls/fetch_models.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
     }
   },
   "src/components/llm_calls/responses_api.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "max-params": {
       "count": 1
     }
   },
+  "src/components/logging_settings_view.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/mcp_server_management/MCPServerSelector.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/components/mcp_server_management/MCPToolPermissions.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/components/mcp_tools/ByokCredentialModal.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -1787,6 +3448,9 @@
   "src/components/mcp_tools/MCPToolArgumentsForm.tsx": {
     "no-nested-ternary": {
       "count": 5
+    },
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "src/components/mcp_tools/McpCrudPermissionPanel.tsx": {
@@ -1794,20 +3458,61 @@
       "count": 3
     },
     "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/components/mcp_tools/types.tsx": {
+    "local/filename-pascal-case": {
       "count": 1
     }
   },
   "src/components/model_add/CredentialModal.tsx": {
     "no-restricted-imports": {
+      "count": 3
+    }
+  },
+  "src/components/model_add/CredentialsPanel.test.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/model_add/CredentialsPanel.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/model_add/credential_form_helpers.test.ts": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/model_add/credential_form_helpers.ts": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
   "src/components/model_add/reuse_credentials.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/components/model_dashboard/HealthCheckComponent.tsx": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/components/model_dashboard/ModelSettingsModal/ModelSettingsModal.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/components/model_dashboard/all_models_table.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 1
     },
@@ -1816,11 +3521,17 @@
     }
   },
   "src/components/model_filters.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/components/model_group_alias_settings.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     },
@@ -1829,18 +3540,49 @@
     }
   },
   "src/components/model_info_view.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
+    "max-lines": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 14
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
+    },
+    "prefer-const": {
+      "count": 5
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
+  "src/components/molecules/cost_optimization_feedback_banner.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
   "src/components/molecules/filter.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-nested-ternary": {
+      "count": 2
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/molecules/message_manager.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
       "count": 2
     }
   },
@@ -1853,6 +3595,9 @@
     }
   },
   "src/components/molecules/models/columns.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "max-params": {
       "count": 1
     },
@@ -1860,15 +3605,45 @@
       "count": 2
     },
     "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/components/molecules/notifications_manager.test.tsx": {
+    "no-restricted-imports": {
       "count": 1
     }
   },
+  "src/components/molecules/notifications_manager.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 3
+    }
+  },
   "src/components/navbar.test.tsx": {
+    "prefer-const": {
+      "count": 1
+    },
     "unused-imports/no-unused-imports": {
       "count": 1
     }
   },
+  "src/components/navbar.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/components/networking.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "max-lines": {
+      "count": 1
+    },
     "max-params": {
       "count": 23
     },
@@ -1877,14 +3652,28 @@
     },
     "no-restricted-syntax": {
       "count": 154
+    },
+    "prefer-const": {
+      "count": 33
     }
   },
   "src/components/object_permissions_view.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/components/onboarding_link.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/components/organisms/RegenerateKeyModal.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -1898,16 +3687,31 @@
     }
   },
   "src/components/organisms/create_key_button.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "local/no-complex-jsx-arrow": {
+      "count": 2
+    },
+    "max-lines": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
+    },
+    "prefer-const": {
+      "count": 4
     },
     "react-hooks/set-state-in-effect": {
       "count": 4
     }
   },
   "src/components/organization/organization_view.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 3
     },
     "unused-imports/no-unused-imports": {
       "count": 1
@@ -1919,11 +3723,17 @@
     }
   },
   "src/components/pass_through_info.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     }
   },
   "src/components/per_user_usage.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     },
@@ -1933,7 +3743,7 @@
   },
   "src/components/permissions/AgentPermissions.tsx": {
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/components/permissions/MCPServerPermissions.tsx": {
@@ -1941,7 +3751,7 @@
       "count": 3
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/components/permissions/VectorStorePermissions.tsx": {
@@ -1952,19 +3762,58 @@
   "src/components/policies/PolicySelector.tsx": {
     "no-nested-ternary": {
       "count": 1
-    }
-  },
-  "src/components/price_data_reload.tsx": {
-    "react-hooks/immutability": {
-      "count": 2
-    }
-  },
-  "src/components/public_model_hub.tsx": {
+    },
     "no-restricted-imports": {
       "count": 1
     }
   },
+  "src/components/price_data_reload.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "react-hooks/immutability": {
+      "count": 2
+    }
+  },
+  "src/components/provider_info_helpers.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "prefer-const": {
+      "count": 3
+    }
+  },
+  "src/components/public_model_hub.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "max-lines": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
   "src/components/query_param_input.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/components/route_preview.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/router_settings/LatencyBasedConfiguration.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -1972,9 +3821,49 @@
   "src/components/router_settings/ReliabilityRetriesSection.tsx": {
     "no-nested-ternary": {
       "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/router_settings/RoutingStrategySelector.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/router_settings/TagFilteringToggle.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/router_settings/index.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "prefer-const": {
+      "count": 2
+    }
+  },
+  "src/components/routing_groups/RoutingGroupModal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/routing_groups/RoutingGroupsTable.tsx": {
+    "no-restricted-imports": {
+      "count": 2
     }
   },
   "src/components/routing_groups/index.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/preserve-manual-memoization": {
       "count": 1
     }
@@ -1982,17 +3871,42 @@
   "src/components/search_tools/SearchToolSelector.tsx": {
     "no-nested-ternary": {
       "count": 1
-    }
-  },
-  "src/components/settings.tsx": {
-    "no-nested-ternary": {
-      "count": 2
     },
     "no-restricted-imports": {
       "count": 1
     }
   },
+  "src/components/settings.test.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/settings.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "local/no-complex-jsx-arrow": {
+      "count": 4
+    },
+    "no-nested-ternary": {
+      "count": 2
+    },
+    "no-restricted-imports": {
+      "count": 3
+    },
+    "prefer-const": {
+      "count": 7
+    }
+  },
+  "src/components/shared/CreatedKeyDisplay.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/components/shared/advanced_date_picker.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     },
@@ -2000,13 +3914,119 @@
       "count": 3
     }
   },
+  "src/components/shared/chart_loader.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/shared/charts/area_chart.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/shared/charts/bar_chart.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/shared/charts/chart_legend.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/shared/charts/chart_tooltip.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/shared/charts/donut_chart.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/shared/charts/line_chart.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/shared/errorUtils.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/shared/form/FormField.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    }
+  },
+  "src/components/shared/form/field.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
   "src/components/shared/numerical_input.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     }
   },
+  "src/components/shared/table_cells/cell_tooltip.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/shared/table_cells/date_cell.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/shared/table_cells/id_cell.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/shared/table_cells/identity_cell.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/shared/table_cells/models_cell.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/shared/table_cells/money_cell.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/shared/table_cells/spend_budget_cell.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/shared/table_cells/status_badge.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
   "src/components/shared/usage_date_picker.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/tag_management/TagSelector.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/tag_management/types.tsx": {
+    "local/filename-pascal-case": {
       "count": 1
     }
   },
@@ -2015,23 +4035,39 @@
       "count": 1
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/components/team/LoggingSettings.tsx": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "src/components/team/MyUserTab.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
   },
   "src/components/team/TeamInfo.tsx": {
+    "max-lines": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 3
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
+    }
+  },
+  "src/components/team/TeamMemberTab.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 2
     }
   },
   "src/components/team/TeamVirtualKeysTable.tsx": {
@@ -2039,14 +4075,22 @@
       "count": 1
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/components/team/member_permissions.tsx": {
-    "no-restricted-imports": {
+    "local/filename-pascal-case": {
       "count": 1
     },
+    "no-restricted-imports": {
+      "count": 2
+    },
     "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/components/team/permission_definitions.tsx": {
+    "local/filename-pascal-case": {
       "count": 1
     }
   },
@@ -2055,12 +4099,23 @@
       "count": 1
     }
   },
+  "src/components/templates/KeyInfoHeader.tsx": {
+    "no-restricted-imports": {
+      "count": 2
+    }
+  },
   "src/components/templates/key_edit_view.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "local/no-complex-jsx-arrow": {
+      "count": 2
+    },
     "no-nested-ternary": {
       "count": 2
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     }
   },
   "src/components/templates/key_info_view.test.tsx": {
@@ -2069,40 +4124,252 @@
     }
   },
   "src/components/templates/key_info_view.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "max-lines": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 1
     },
     "no-restricted-imports": {
-      "count": 1
+      "count": 2
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
-  "src/components/user_agent_activity.tsx": {
+  "src/components/ui/AntDLoadingSpinner.tsx": {
     "no-restricted-imports": {
-      "count": 2
+      "count": 1
+    }
+  },
+  "src/components/ui/alert-dialog.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/avatar.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/badge.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/breadcrumb.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/button.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/card.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/chart.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/checkbox.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/collapsible.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/combobox.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/dialog.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/dropdown-menu.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/input-group.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/input.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/label.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/meter.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/popover.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/scroll-area.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/select.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/separator.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/sheet.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/sidebar.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/skeleton.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/switch.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/table.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/tabs.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/textarea.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/tooltip.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/ui/ui-loading-spinner.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/update_model_credentials_modal.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/user_agent_activity.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 3
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
   "src/components/user_dashboard.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
+      "count": 1
+    },
+    "prefer-const": {
       "count": 1
     },
     "react-hooks/set-state-in-effect": {
       "count": 2
     }
   },
+  "src/components/vector_store_management/VectorStoreSelector.test.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/vector_store_management/VectorStoreSelector.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/vector_store_management/types.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/vector_store_providers.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/view_logs/AuditLogDrawer/AuditLogDrawer.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/view_logs/CostBreakdownViewer.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/components/view_logs/EvalViewer/EvalViewer.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
     "no-nested-ternary": {
+      "count": 1
+    },
+    "no-restricted-imports": {
       "count": 1
     }
   },
   "src/components/view_logs/GuardrailViewer/CompliancePanel.tsx": {
     "no-nested-ternary": {
       "count": 2
+    },
+    "no-restricted-imports": {
+      "count": 1
     },
     "react-hooks/set-state-in-effect": {
       "count": 1
@@ -2116,24 +4383,88 @@
   "src/components/view_logs/GuardrailViewer/GuardrailViewer.tsx": {
     "no-nested-ternary": {
       "count": 4
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/view_logs/LogDetailsDrawer/CollapsibleMessage.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/view_logs/LogDetailsDrawer/DrawerHeader.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/view_logs/LogDetailsDrawer/HistoryTree.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/view_logs/LogDetailsDrawer/JsonViewer.tsx": {
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "src/components/view_logs/LogDetailsDrawer/LogDetailContent.tsx": {
     "no-nested-ternary": {
       "count": 3
+    },
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx": {
     "no-nested-ternary": {
       "count": 3
     },
+    "no-restricted-imports": {
+      "count": 1
+    },
     "react-hooks/set-state-in-effect": {
       "count": 2
+    }
+  },
+  "src/components/view_logs/LogDetailsDrawer/OutputCard.tsx": {
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "src/components/view_logs/LogDetailsDrawer/RealtimePrettyView.test.tsx": {
     "unused-imports/no-unused-imports": {
       "count": 2
+    }
+  },
+  "src/components/view_logs/LogDetailsDrawer/RealtimePrettyView.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/view_logs/LogDetailsDrawer/SectionHeader.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/view_logs/LogDetailsDrawer/SimpleMessageBlock.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/view_logs/LogDetailsDrawer/SimpleToolCallBlock.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/view_logs/LogDetailsDrawer/TokenFlow.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/view_logs/LogDetailsDrawer/TruncatedValue.tsx": {
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "src/components/view_logs/LogDetailsDrawer/prettyMessagesUtils.ts": {
@@ -2147,11 +4478,53 @@
     }
   },
   "src/components/view_logs/LogsTableToolbar.tsx": {
+    "local/no-complex-jsx-arrow": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 4
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/view_logs/ToolsSection/FormattedToolView.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/view_logs/ToolsSection/ToolExpandedContent.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/view_logs/ToolsSection/ToolItem.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/view_logs/ToolsSection/ToolsSection.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/view_logs/VectorStoreViewer.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/view_logs/columns.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "src/components/view_logs/index.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     },
@@ -2159,14 +4532,43 @@
       "count": 1
     }
   },
+  "src/components/view_logs/log_filter_logic.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
+  "src/components/view_logs/logs_utils.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
   "src/components/view_logs/table.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 2
     }
   },
+  "src/components/view_model/model_name_display.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    }
+  },
   "src/components/view_user_spend.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
+    "prefer-const": {
+      "count": 3
+    },
     "react-hooks/set-state-in-effect": {
       "count": 2
+    }
+  },
+  "src/contexts/AntdGlobalProvider.tsx": {
+    "no-restricted-imports": {
+      "count": 1
     }
   },
   "src/contexts/AuthContext.tsx": {
@@ -2195,11 +4597,17 @@
     }
   },
   "src/hooks/useMcpOAuthFlow.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
   "src/hooks/useTestMCPConnection.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "no-nested-ternary": {
       "count": 1
     },
@@ -2208,6 +4616,9 @@
     }
   },
   "src/hooks/useToolsOAuthFlow.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "react-hooks/refs": {
       "count": 1
     },
@@ -2216,6 +4627,9 @@
     }
   },
   "src/hooks/useUserMcpOAuthFlow.tsx": {
+    "local/filename-pascal-case": {
+      "count": 1
+    },
     "react-hooks/set-state-in-effect": {
       "count": 1
     }

--- a/ui/litellm-dashboard/eslint.config.mjs
+++ b/ui/litellm-dashboard/eslint.config.mjs
@@ -19,12 +19,13 @@ const eslintConfig = [
       "unused-imports/no-unused-imports": "error",
       "local/no-large-inline-object-arg": "warn",
       "local/no-long-condition-chain": "warn",
+      "local/no-complex-jsx-arrow": ["error", { maxStatements: 2 }],
       "@typescript-eslint/no-explicit-any": "warn",
       "no-console": ["warn", { allow: ["warn", "error"] }],
       "@typescript-eslint/no-unused-vars": "off",
       "@typescript-eslint/no-unused-expressions": "off",
       "@typescript-eslint/ban-ts-comment": "off",
-      "prefer-const": "off",
+      "prefer-const": "error",
       "no-empty": "off",
       "no-prototype-builtins": "off",
       "no-useless-catch": "off",
@@ -51,11 +52,30 @@ const eslintConfig = [
           patterns: [
             {
               group: ["@tremor/react", "@tremor/react/*"],
-              message: "@tremor/react is being phased out; build new UI with antd instead of adding tremor imports.",
+              message:
+                "@tremor/react is being phased out; build new UI with shadcn/ui primitives instead of adding tremor imports.",
+            },
+            {
+              group: ["antd", "antd/*"],
+              message:
+                "antd is being phased out; build new UI with shadcn/ui primitives instead of adding antd imports.",
             },
           ],
         },
       ],
+    },
+  },
+  {
+    files: ["src/**/*.tsx"],
+    rules: {
+      "local/filename-pascal-case": "error",
+    },
+  },
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    ignores: ["src/**/*.test.{ts,tsx}", "src/**/*.spec.{ts,tsx}", "src/data/**"],
+    rules: {
+      "max-lines": ["error", { max: 800, skipBlankLines: true, skipComments: true }],
     },
   },
   {

--- a/ui/litellm-dashboard/scripts/eslint-rules/filename-pascal-case.mjs
+++ b/ui/litellm-dashboard/scripts/eslint-rules/filename-pascal-case.mjs
@@ -42,11 +42,12 @@ const rule = {
     if (rest.includes("test") || rest.includes("spec")) return {};
     if (NEXT_RESERVED.has(head)) return {};
     if (PASCAL_CASE.test(head)) return {};
-    const suggestion = head
+    const pascalHead = head
       .split(/[-_]/)
       .filter(Boolean)
       .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
       .join("");
+    const suggestion = [pascalHead, ...rest].join(".");
     return {
       Program(node) {
         context.report({ node, messageId: "notPascalCase", data: { name: `${stem}.tsx`, suggestion } });

--- a/ui/litellm-dashboard/scripts/eslint-rules/filename-pascal-case.mjs
+++ b/ui/litellm-dashboard/scripts/eslint-rules/filename-pascal-case.mjs
@@ -1,0 +1,58 @@
+import { basename } from "path";
+
+const NEXT_RESERVED = new Set([
+  "page",
+  "layout",
+  "route",
+  "template",
+  "default",
+  "loading",
+  "error",
+  "global-error",
+  "not-found",
+  "middleware",
+  "instrumentation",
+  "sitemap",
+  "robots",
+  "manifest",
+  "icon",
+  "apple-icon",
+  "favicon",
+  "opengraph-image",
+  "twitter-image",
+]);
+
+const PASCAL_CASE = /^[A-Z][A-Za-z0-9]*$/;
+
+const rule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Require PascalCase filenames for .tsx modules; exempt Next.js reserved files and test/spec files.",
+    },
+    schema: [],
+    messages: {
+      notPascalCase: "Filename '{{name}}' should be PascalCase (e.g. '{{suggestion}}.tsx').",
+    },
+  },
+  create(context) {
+    const filename = context.filename;
+    const stem = basename(filename).replace(/\.tsx$/, "");
+    const [head, ...rest] = stem.split(".");
+    if (rest.includes("test") || rest.includes("spec")) return {};
+    if (NEXT_RESERVED.has(head)) return {};
+    if (PASCAL_CASE.test(head)) return {};
+    const suggestion = head
+      .split(/[-_]/)
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join("");
+    return {
+      Program(node) {
+        context.report({ node, messageId: "notPascalCase", data: { name: `${stem}.tsx`, suggestion } });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/ui/litellm-dashboard/scripts/eslint-rules/index.mjs
+++ b/ui/litellm-dashboard/scripts/eslint-rules/index.mjs
@@ -1,10 +1,14 @@
 import noLargeInlineObjectArg from "./no-large-inline-object-arg.mjs";
 import noLongConditionChain from "./no-long-condition-chain.mjs";
+import noComplexJsxArrow from "./no-complex-jsx-arrow.mjs";
+import filenamePascalCase from "./filename-pascal-case.mjs";
 
 const plugin = {
   rules: {
     "no-large-inline-object-arg": noLargeInlineObjectArg,
     "no-long-condition-chain": noLongConditionChain,
+    "no-complex-jsx-arrow": noComplexJsxArrow,
+    "filename-pascal-case": filenamePascalCase,
   },
 };
 

--- a/ui/litellm-dashboard/scripts/eslint-rules/no-complex-jsx-arrow.mjs
+++ b/ui/litellm-dashboard/scripts/eslint-rules/no-complex-jsx-arrow.mjs
@@ -1,0 +1,41 @@
+const DEFAULT_MAX_STATEMENTS = 2;
+
+const isJsxAttributeValue = (node) => {
+  const parent = node.parent;
+  if (parent == null) return false;
+  return parent.type === "JSXExpressionContainer" && parent.parent?.type === "JSXAttribute";
+};
+
+const rule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Disallow arrow functions with block bodies over a few statements passed inline as JSX attributes; extract them into a named handler.",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: { maxStatements: { type: "integer", minimum: 1 } },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      tooComplex: "Inline JSX arrow handler has {{count}} statements; extract it into a named function (max {{max}}).",
+    },
+  },
+  create(context) {
+    const maxStatements = context.options[0]?.maxStatements ?? DEFAULT_MAX_STATEMENTS;
+    return {
+      ArrowFunctionExpression(node) {
+        if (node.body.type !== "BlockStatement") return;
+        if (!isJsxAttributeValue(node)) return;
+        const count = node.body.body.length;
+        if (count <= maxStatements) return;
+        context.report({ node, messageId: "tooComplex", data: { count, max: maxStatements } });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/ui/litellm-dashboard/tests/eslint-rules/filename-pascal-case.test.ts
+++ b/ui/litellm-dashboard/tests/eslint-rules/filename-pascal-case.test.ts
@@ -12,6 +12,10 @@ ruleTester.run("filename-pascal-case", rule as never, {
     { code: "export const x = 1;", filename: "src/app/teams/page.tsx" },
     { code: "export const x = 1;", filename: "src/app/teams/layout.tsx" },
     { code: "export const x = 1;", filename: "src/app/teams/not-found.tsx" },
+    { code: "export const x = 1;", filename: "src/app/global-error.tsx" },
+    { code: "export const x = 1;", filename: "src/app/apple-icon.tsx" },
+    { code: "export const x = 1;", filename: "src/app/opengraph-image.tsx" },
+    { code: "export const x = 1;", filename: "src/app/twitter-image.tsx" },
     { code: "export const x = 1;", filename: "src/components/TeamInfo.test.tsx" },
     { code: "export const x = 1;", filename: "src/components/view_users.test.tsx" },
     { code: "export const x = 1;", filename: "src/components/TeamInfo.spec.tsx" },
@@ -31,6 +35,13 @@ ruleTester.run("filename-pascal-case", rule as never, {
       code: "export const x = 1;",
       filename: "src/components/teamInfo.tsx",
       errors: [{ messageId: "notPascalCase", data: { name: "teamInfo.tsx", suggestion: "TeamInfo" } }],
+    },
+    {
+      code: "export const x = 1;",
+      filename: "src/components/my-component.utils.tsx",
+      errors: [
+        { messageId: "notPascalCase", data: { name: "my-component.utils.tsx", suggestion: "MyComponent.utils" } },
+      ],
     },
   ],
 });

--- a/ui/litellm-dashboard/tests/eslint-rules/filename-pascal-case.test.ts
+++ b/ui/litellm-dashboard/tests/eslint-rules/filename-pascal-case.test.ts
@@ -1,0 +1,36 @@
+import { RuleTester } from "eslint";
+import rule from "../../scripts/eslint-rules/filename-pascal-case.mjs";
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: "latest", sourceType: "module", parserOptions: { ecmaFeatures: { jsx: true } } },
+});
+
+ruleTester.run("filename-pascal-case", rule as never, {
+  valid: [
+    { code: "export const x = 1;", filename: "src/components/TeamInfo.tsx" },
+    { code: "export const x = 1;", filename: "src/components/Button.tsx" },
+    { code: "export const x = 1;", filename: "src/app/teams/page.tsx" },
+    { code: "export const x = 1;", filename: "src/app/teams/layout.tsx" },
+    { code: "export const x = 1;", filename: "src/app/teams/not-found.tsx" },
+    { code: "export const x = 1;", filename: "src/components/TeamInfo.test.tsx" },
+    { code: "export const x = 1;", filename: "src/components/view_users.test.tsx" },
+    { code: "export const x = 1;", filename: "src/components/TeamInfo.spec.tsx" },
+  ],
+  invalid: [
+    {
+      code: "export const x = 1;",
+      filename: "src/components/user_info_view.tsx",
+      errors: [{ messageId: "notPascalCase", data: { name: "user_info_view.tsx", suggestion: "UserInfoView" } }],
+    },
+    {
+      code: "export const x = 1;",
+      filename: "src/components/team-info.tsx",
+      errors: [{ messageId: "notPascalCase", data: { name: "team-info.tsx", suggestion: "TeamInfo" } }],
+    },
+    {
+      code: "export const x = 1;",
+      filename: "src/components/teamInfo.tsx",
+      errors: [{ messageId: "notPascalCase", data: { name: "teamInfo.tsx", suggestion: "TeamInfo" } }],
+    },
+  ],
+});

--- a/ui/litellm-dashboard/tests/eslint-rules/no-complex-jsx-arrow.test.ts
+++ b/ui/litellm-dashboard/tests/eslint-rules/no-complex-jsx-arrow.test.ts
@@ -1,0 +1,34 @@
+import { RuleTester } from "eslint";
+import rule from "../../scripts/eslint-rules/no-complex-jsx-arrow.mjs";
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: "latest", sourceType: "module", parserOptions: { ecmaFeatures: { jsx: true } } },
+});
+
+ruleTester.run("no-complex-jsx-arrow", rule as never, {
+  valid: [
+    "const x = <button onClick={() => doThing()} />;",
+    "const x = <button onClick={() => { a(); }} />;",
+    "const x = <button onClick={() => { a(); b(); }} />;",
+    "const handler = () => { a(); b(); c(); }; const x = <button onClick={handler} />;",
+    "const run = () => { a(); b(); c(); };",
+    "foo(() => { a(); b(); c(); });",
+    "const x = <List renderItem={(i) => i.name} />;",
+    { code: "const x = <button onClick={() => { a(); b(); c(); }} />;", options: [{ maxStatements: 3 }] },
+  ],
+  invalid: [
+    {
+      code: "const x = <button onClick={() => { a(); b(); c(); }} />;",
+      errors: [{ messageId: "tooComplex", data: { count: 3, max: 2 } }],
+    },
+    {
+      code: "const x = <form onSubmit={() => { a(); b(); c(); d(); }} />;",
+      errors: [{ messageId: "tooComplex", data: { count: 4, max: 2 } }],
+    },
+    {
+      code: "const x = <button onClick={() => { a(); b(); }} />;",
+      options: [{ maxStatements: 1 }],
+      errors: [{ messageId: "tooComplex", data: { count: 2, max: 1 } }],
+    },
+  ],
+});


### PR DESCRIPTION
## TLDR

Problem this solves:

- Dashboard had no filename, file-size, or JSX-handler lint rules
- prefer-const was off and antd imports were unrestricted

How it solves it:

- Adds five error-level ESLint rules, grandfathering every current offender
- New code is gated; the baseline ratchets down as files get fixed

## Relevant issues

## Linear ticket



## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This is lint tooling with no runtime surface, so the proof is the gate itself: the grandfathered baseline stays clean while brand-new violations are rejected. Captured at commit `deadcecf49`

The whole repo passes with the new rules active because current offenders are suppressed in `eslint-suppressions.json`

```
$ npx eslint . ; echo "exit=$?"
exit=0
```

A brand-new file that trips four of the five rules is rejected

```
$ cat src/__lintproof__/bad_widget.tsx
import { Button } from "antd";

export const Bad = () => {
  let label = "hi";
  return <Button onClick={() => { a(); b(); c(); }}>{label}</Button>;
};

$ npx eslint src/__lintproof__/bad_widget.tsx
1:1   error  Filename 'bad_widget.tsx' should be PascalCase (e.g. 'BadWidget.tsx')      local/filename-pascal-case
1:1   error  'antd' import is restricted ... build new UI with shadcn/ui primitives     no-restricted-imports
4:7   error  'label' is never reassigned. Use 'const' instead                          prefer-const
5:27  error  Inline JSX arrow handler has 3 statements; extract it into a named function (max 2)  local/no-complex-jsx-arrow
✖ 4 problems (4 errors, 0 warnings)
```

The two new local rules ship with RuleTester coverage

```
$ npx vitest run tests/eslint-rules/
 ✓ tests/eslint-rules/filename-pascal-case.test.ts (11 tests)
 ✓ tests/eslint-rules/no-complex-jsx-arrow.test.ts (11 tests)
 ✓ tests/eslint-rules/no-large-inline-object-arg.test.ts (14 tests)
 ✓ tests/eslint-rules/no-long-condition-chain.test.ts (16 tests)
 Test Files  4 passed (4)
      Tests  52 passed (52)
```

## Type

🚄 Infrastructure

## Changes

Five error-level rules on the dashboard, each grandfathering its current offenders in `eslint-suppressions.json` so only new code is gated and the baseline ratchets down as files are fixed

| Rule | What it enforces | Why | Suppressions added |
|---|---|---|---|
| `local/filename-pascal-case` (new) | PascalCase `.tsx` filenames; Next.js reserved files (page, layout, route, and so on) and `.test` / `.spec` files exempt | Consistent, predictable component filenames | 239 |
| `max-lines` | 800-line cap over `src/**` (blank lines and comments skipped), excluding tests, `src/data`, and the generated `schema.d.ts` | Flags god files that are hard to review and maintain | 20 |
| `local/no-complex-jsx-arrow` (new) | Inline JSX arrow handlers limited to two block-body statements | Keeps render markup readable and pushes logic into named handlers; each failure is a small extract-to-named-handler refactor | 65 |
| `prefer-const` | `const` over `let` when a binding is never reassigned | Was off; surfaces immutability and prevents accidental reassignment | 103 |
| `no-restricted-imports` (+antd) | Bans new `antd` imports, joining the existing tremor ban; both messages now point at shadcn/ui primitives | antd is being phased out for shadcn/ui | 445 |

That is 872 grandfathered offenders total across 649 files

Tailwind class sorting via prettier-plugin-tailwindcss is deliberately left out; it reformats nearly every file and belongs in its own isolated PR

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

