### PR TITLE
fix(reset_budget_job): commit end-user budget resets in bounded batches

### DIFF
--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -31,6 +31,14 @@ from litellm.repositories.verification_token_repository import (
 )
 from litellm.types.services import ServiceTypes
 
+# Max number of end-user rows written per Prisma batch during budget reset.
+# The end-user reset writes every row in a single `batch_().commit()` — one
+# request to the Prisma query engine covering all rows. On large deployments
+# that request exceeds the Prisma HTTP client read timeout and the whole reset
+# fails with httpx.ReadTimeout, so no end-user budgets are reset. Committing in
+# bounded chunks keeps each request small enough to complete.
+RESET_BUDGET_ENDUSER_BATCH_SIZE = 100
+
 
 class ResetBudgetJob:
     """
@@ -306,11 +314,20 @@ class ResetBudgetJob:
                     json.dumps(updated_endusers, indent=4, default=str),
                 )
 
-                await self.prisma_client.update_data(
-                    query_type="update_many",
-                    data_list=updated_endusers,
-                    table_name="enduser",
-                )
+                # Commit in bounded chunks. A single batch commit for all
+                # end users is one query-engine request that times out
+                # (httpx.ReadTimeout) once the set is large enough, failing
+                # the entire reset.
+                for i in range(
+                    0, len(updated_endusers), RESET_BUDGET_ENDUSER_BATCH_SIZE
+                ):
+                    await self.prisma_client.update_data(
+                        query_type="update_many",
+                        data_list=updated_endusers[
+                            i : i + RESET_BUDGET_ENDUSER_BATCH_SIZE
+                        ],
+                        table_name="enduser",
+                    )
 
             end_time = time.time()
             if len(failed_endusers) > 0:  # If any endusers failed to reset

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -151,6 +151,9 @@ class MockPrismaClient:
             "budget": [],
             "enduser": [],
         }
+        # Records every update_data invocation (one entry per call) so tests can
+        # assert on how writes are batched, not just the final overwrite above.
+        self.update_data_calls: List[Dict[str, Any]] = []
         self.db = MockDB()
 
     async def get_data(self, table_name, query_type, **kwargs):
@@ -180,6 +183,13 @@ class MockPrismaClient:
         return data
 
     async def update_data(self, query_type, data_list, table_name):
+        self.update_data_calls.append(
+            {
+                "query_type": query_type,
+                "table_name": table_name,
+                "data_list": list(data_list),
+            }
+        )
         self.updated_data[table_name] = data_list
         return data_list
 
@@ -379,6 +389,73 @@ def test_reset_budget_for_enduser(reset_budget_job, mock_prisma_client):
     updated_budget = mock_prisma_client.updated_data["budget"][0]
     assert updated_enduser.spend == 0.0
     assert updated_budget.budget_reset_at > now
+
+
+def test_reset_budget_for_endusers_commits_in_bounded_chunks(
+    reset_budget_job, mock_prisma_client
+):
+    """
+    End users must be written in bounded batches. A single batch commit for
+    every end user is one Prisma query-engine request that times out
+    (httpx.ReadTimeout) at scale, failing the whole reset. Verify writes are
+    split into chunks of at most RESET_BUDGET_ENDUSER_BATCH_SIZE, and that every
+    end user is still reset.
+    """
+    from litellm.proxy.common_utils.reset_budget_job import (
+        RESET_BUDGET_ENDUSER_BATCH_SIZE,
+    )
+
+    now = datetime.now(timezone.utc)
+    test_budget = type(
+        "LiteLLM_BudgetTable",
+        (),
+        {
+            "max_budget": 500.0,
+            "budget_duration": "1d",
+            "budget_reset_at": now,
+            "budget_id": "test-budget-1",
+        },
+    )
+
+    num_endusers = RESET_BUDGET_ENDUSER_BATCH_SIZE * 2 + 5  # spans 3 chunks
+    endusers = [
+        type(
+            "LiteLLM_EndUserTable",
+            (),
+            {
+                "spend": 20.0,
+                "litellm_budget_table": test_budget,
+                "user_id": f"test-enduser-{i}",
+            },
+        )
+        for i in range(num_endusers)
+    ]
+
+    mock_prisma_client.data["budget"] = [test_budget]
+    mock_prisma_client.data["enduser"] = endusers
+
+    asyncio.run(reset_budget_job.reset_budget_for_litellm_budget_table())
+
+    enduser_calls = [
+        c
+        for c in mock_prisma_client.update_data_calls
+        if c["table_name"] == "enduser"
+    ]
+
+    # Chunked into ceil(n / batch) calls, none larger than the batch size.
+    expected_calls = (
+        num_endusers + RESET_BUDGET_ENDUSER_BATCH_SIZE - 1
+    ) // RESET_BUDGET_ENDUSER_BATCH_SIZE
+    assert len(enduser_calls) == expected_calls
+    assert all(
+        len(c["data_list"]) <= RESET_BUDGET_ENDUSER_BATCH_SIZE for c in enduser_calls
+    )
+
+    # Every end user was written exactly once, and all had spend reset to 0.
+    written = [eu for c in enduser_calls for eu in c["data_list"]]
+    assert len(written) == num_endusers
+    assert {eu.user_id for eu in written} == {eu.user_id for eu in endusers}
+    assert all(eu.spend == 0.0 for eu in written)
 
 
 def test_reset_budget_all(reset_budget_job, mock_prisma_client):


### PR DESCRIPTION
## Summary

`ResetBudgetJob.reset_budget_for_litellm_budget_table()` resets **all** end users in a single Prisma batch — one `self.db.batch_()` with an `upsert` per end user, committed in a single `await batcher.commit()`. That commit is one HTTP request to the Prisma query engine covering every row.

On deployments with a large number of end users, that single request exceeds the Prisma HTTP client read timeout and fails with `httpx.ReadTimeout`. Because the exception propagates out of the end-user step, **no** end-user budgets are reset for that cycle, and affected end users stay over budget (surfacing as `ExceededBudget` at auth time) until a later run happens to be fast enough to succeed. The `@backoff` retry on `update_data` doesn't help — each retry re-sends the same oversized batch and times out again.

Observed stacktrace (prod, `main-v1.83.14-stable`):

```
ERROR reset_budget_job.py  Failed to reset budget for endusers:
  reset_budget_for_litellm_budget_table
    -> PrismaClient.update_data -> batcher.commit()
    -> prisma engine query -> httpx _send_single_request
httpcore.ReadTimeout -> httpx.ReadTimeout
```

## Fix

Commit the end-user resets in bounded chunks of `RESET_BUDGET_ENDUSER_BATCH_SIZE` (100) instead of one unbounded batch, so each query-engine request stays small enough to complete regardless of end-user count. Behaviour is unchanged for small deployments (a single chunk).

## Test

Adds `test_reset_budget_for_endusers_commits_in_bounded_chunks`, which resets `2 * batch_size + 5` end users and asserts the writes are split into `ceil(n / batch_size)` calls, none larger than the batch size, and that every end user is still reset (spend → 0). Existing single-end-user tests continue to pass unchanged.

## Notes

- The same one-batch pattern exists for the `budget`/`user`/`team`/`key` reset paths; those sets are typically much smaller, so this PR scopes the fix to the end-user path where the timeout was observed. Happy to extend the chunking to the other paths if maintainers prefer.
- Could expose the chunk size as a config setting if that's preferred over a module constant.