### PR TITLE
fix(bedrock): include type in tool_choice disable_parallel_tool_use config for Converse

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -1211,7 +1211,11 @@ class AmazonConverseConfig(BaseConfig):
     def _merge_parallel_tool_use_config(additional_request_params: dict, parallel_tool_use_config: dict) -> dict:
         merged_entries = {
             key: (
-                {**value, **additional_request_params[key]}
+                {
+                    **value,
+                    **additional_request_params[key],
+                    **{k: v for k, v in value.items() if k != "type"},
+                }
                 if isinstance(additional_request_params.get(key), dict) and isinstance(value, dict)
                 else value
             )

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -895,9 +895,8 @@ class AmazonConverseConfig(BaseConfig):
                 if _tool_choice_value is not None:
                     optional_params["tool_choice"] = _tool_choice_value
             if param == "parallel_tool_calls":
-                disable_parallel = not value
                 optional_params["_parallel_tool_use_config"] = {
-                    "tool_choice": {"disable_parallel_tool_use": disable_parallel}
+                    "tool_choice": {"type": "auto", "disable_parallel_tool_use": not value}
                 }
             if param == "thinking":
                 if (
@@ -1208,6 +1207,18 @@ class AmazonConverseConfig(BaseConfig):
 
         return {}
 
+    @staticmethod
+    def _merge_parallel_tool_use_config(additional_request_params: dict, parallel_tool_use_config: dict) -> dict:
+        merged_entries = {
+            key: (
+                {**value, **additional_request_params[key]}
+                if isinstance(additional_request_params.get(key), dict) and isinstance(value, dict)
+                else value
+            )
+            for key, value in parallel_tool_use_config.items()
+        }
+        return {**additional_request_params, **merged_entries}
+
     def _prepare_request_params(
         self, optional_params: dict, model: str, drop_params: bool = False
     ) -> Tuple[dict, dict, dict, Optional[OutputConfigBlock]]:
@@ -1276,15 +1287,9 @@ class AmazonConverseConfig(BaseConfig):
         # Handle parallel_tool_calls configuration
         parallel_tool_use_config = additional_request_params.pop("_parallel_tool_use_config", None)
         if parallel_tool_use_config is not None and bedrock_converse_supports_parallel_tool_use_config(model):
-            for key, value in parallel_tool_use_config.items():
-                if (
-                    key in additional_request_params
-                    and isinstance(additional_request_params[key], dict)
-                    and isinstance(value, dict)
-                ):
-                    additional_request_params[key].update(value)
-                else:
-                    additional_request_params[key] = value
+            additional_request_params = self._merge_parallel_tool_use_config(
+                additional_request_params, parallel_tool_use_config
+            )
 
         additional_request_params.pop("parallel_tool_calls", None)
 

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -633,7 +633,8 @@ def test_parallel_tool_calls_config_kept_for_sonnet_5():
         )
 
         assert data["additionalModelRequestFields"]["tool_choice"] == {
-            "disable_parallel_tool_use": True
+            "type": "auto",
+            "disable_parallel_tool_use": True,
         }
     finally:
         litellm.model_cost = old_cost
@@ -4249,6 +4250,49 @@ def test_parallel_tool_calls_older_model_drops_disable_flag():
     additional = request_data.get("additionalModelRequestFields", {})
     assert "tool_choice" not in additional
     assert "parallel_tool_calls" not in additional
+
+
+@pytest.mark.parametrize(
+    "parallel_tool_calls, expected_disable",
+    [(True, False), (False, True)],
+)
+def test_parallel_tool_calls_emits_typed_auto_tool_choice(parallel_tool_calls, expected_disable):
+    config = AmazonConverseConfig()
+    model = "us.anthropic.claude-opus-4-8"
+    messages = [{"role": "user", "content": "What's the weather in SF and NYC?"}]
+
+    optional_params = config.map_openai_params(
+        non_default_params={"parallel_tool_calls": parallel_tool_calls, "tools": _TOOL_PARAM},
+        optional_params={},
+        model=model,
+        drop_params=False,
+    )
+
+    request_data = config.transform_request(
+        model=model,
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert request_data["additionalModelRequestFields"]["tool_choice"] == {
+        "type": "auto",
+        "disable_parallel_tool_use": expected_disable,
+    }
+
+
+def test_parallel_tool_use_merge_preserves_user_tool_choice_type():
+    merged = AmazonConverseConfig._merge_parallel_tool_use_config(
+        {"tool_choice": {"type": "tool", "name": "get_weather"}},
+        {"tool_choice": {"type": "auto", "disable_parallel_tool_use": True}},
+    )
+
+    assert merged["tool_choice"] == {
+        "type": "tool",
+        "name": "get_weather",
+        "disable_parallel_tool_use": True,
+    }
 
 
 class TestBedrockMinThinkingBudgetTokens:

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -4284,7 +4284,7 @@ def test_parallel_tool_calls_emits_typed_auto_tool_choice(parallel_tool_calls, e
 
 def test_parallel_tool_use_merge_preserves_user_tool_choice_type():
     merged = AmazonConverseConfig._merge_parallel_tool_use_config(
-        {"tool_choice": {"type": "tool", "name": "get_weather"}},
+        {"tool_choice": {"type": "tool", "name": "get_weather", "disable_parallel_tool_use": False}},
         {"tool_choice": {"type": "auto", "disable_parallel_tool_use": True}},
     )
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- parallel_tool_calls on Bedrock Converse Claude 400s with missing field `type`
- LiteLLM sent tool_choice without the required Anthropic type tag

How it solves it:

- emit tool_choice as `{"type": "auto", "disable_parallel_tool_use": <bool>}`
- preserve a user-supplied tool_choice `type` when merging the flag

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both runs below hit the real Bedrock Converse API through a live local proxy, no mocks; the same worktree venv, config, and request body were used for both runs, with only the checked-out commit changing in between, and each run got its own random free high port. The config routes the model group to `bedrock/global.anthropic.claude-opus-4-8` in us-east-1 with `drop_params: true`, since Opus 4.8 accepts only temperature=1 and the reproducing request pins `"temperature": 0.0`

qa_config.yaml:

```yaml
model_list:
  - model_name: anthropic.claude-opus-4-8
    litellm_params:
      model: bedrock/global.anthropic.claude-opus-4-8
      aws_region_name: us-east-1
      drop_params: true
```

req.json, an OpenAI-compatible request with `parallel_tool_calls: true`, tools present, and no tool_choice:

```json
{
  "model": "anthropic.claude-opus-4-8",
  "messages": [
    {"role": "system", "content": "You are the team lead. Route the query."},
    {"role": "user", "content": "Give me the NRM ASF trunk-route health report for Australia."}
  ],
  "parallel_tool_calls": true,
  "temperature": 0.0,
  "tools": [{
    "type": "function",
    "function": {
      "name": "execute_python_code",
      "description": "Execute Python code with automatic data loading and safety validation.\n\nAuto-loads Excel/CSV files into DataFrames accessible via 'filename_to_dataframe_dicts'.\nInjects boilerplate with common imports (pandas, numpy, matplotlib, seaborn) and\nruntime variables (session_id, invoke_id, logger, directory_manager).\n\nPerforms LLM-based security validation before execution in isolated thread environment.\n\nArgs:\n    code: Python code to execute. DataFrames are pre-loaded and available.\n    config: RunnableConfig with thread_id, files, and directory_manager\n    state: AgentState for conversation context\n\nReturns:\n    Formatted execution result with stdout/stderr, success status, and timing",
      "parameters": {
        "properties": {"code": {"type": "string"}},
        "required": ["code"],
        "type": "object"
      }
    }
  }],
  "stream": false
}
```

**Before, captured at base commit 0c2b86e1678069bd5d02c7d990adcc3e26c9e0ce**

```bash
.venv/bin/python litellm/proxy/proxy_cli.py --config qa_config.yaml --port 31560 --detailed_debug 2>&1 | tee before.log
curl -sS -w '\nHTTP_STATUS:%{http_code}\n' http://localhost:31560/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H 'Content-Type: application/json' \
  -d @req.json
```

```
{"error":{"message":"litellm.BadRequestError: BedrockException - {\"message\":\"The model returned the following errors: missing field `type` at line 1 column 1158\"}. Received Model Group=anthropic.claude-opus-4-8\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
HTTP_STATUS:400
```

before.log shows the outbound Converse body Bedrock rejected; tool_choice carries no `type`:

```
additionalModelRequestFields": {"tool_choice": {"disable_parallel_tool_use": false}}
```

**After, captured at head commit 75c0e12dacd245db4e6c164397b39e9cf211502a**

```bash
git checkout 75c0e12dacd245db4e6c164397b39e9cf211502a
.venv/bin/python litellm/proxy/proxy_cli.py --config qa_config.yaml --port 37548 --detailed_debug 2>&1 | tee after.log
curl -sS -w '\nHTTP_STATUS:%{http_code}\n' http://localhost:37548/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H 'Content-Type: application/json' \
  -d @req.json
```

```
{"id":"chatcmpl-8567ddf6-d67e-4781-b978-b56ebba4bdae","created":1784775271,"model":"anthropic.claude-opus-4-8","object":"chat.completion","choices":[{"finish_reason":"tool_calls","index":0,"message":{"content":"I'll help you generate the NRM ASF trunk-route health report for Australia. Let me first explore the available data files to understand what we're working with.","role":"assistant","tool_calls":[{"index":1,"function":{"arguments":"{\"code\": \"import os\\n\\n# List available dataframes loaded from files\\nprint(\\\"Available dataframes:\\\")\\nfor key in filename_to_dataframe_dicts.keys():\\n    print(f\\\"  - {key}\\\")\\n\\nprint(\\\"\\\\n\\\" + \\\"=\\\"*60)\\n# Inspect each dataframe\\nfor name, df in filename_to_dataframe_dicts.items():\\n    print(f\\\"\\\\nDataFrame: {name}\\\")\\n    print(f\\\"Shape: {df.shape}\\\")\\n    print(f\\\"Columns: {list(df.columns)}\\\")\\n    print(\\\"Sample:\\\")\\n    print(df.head(3))\\n    print(\\\"-\\\"*60)\\n\"}","name":"execute_python_code"},"id":"tooluse_v55DpDDkpeMuwpXYNFXzOv","type":"function"}]}}],"usage":{"completion_tokens":283,"prompt_tokens":657,"total_tokens":940,"completion_tokens_details":{"reasoning_tokens":0,"text_tokens":283},"prompt_tokens_details":{"cached_tokens":0,"text_tokens":657,"cache_creation_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}
HTTP_STATUS:200
```

after.log shows the outbound Converse body now carries the required `type`:

```
additionalModelRequestFields": {"tool_choice": {"type": "auto", "disable_parallel_tool_use": false}}
```

Repeating the identical request with `"parallel_tool_calls": false` at the same head also returned HTTP 200 with a tool call (id chatcmpl-c2c0d15f-48df-4ea1-914c-bf678521dc8a, finish_reason tool_calls), and after.log shows `additionalModelRequestFields": {"tool_choice": {"type": "auto", "disable_parallel_tool_use": true}}` for that run

## Type

🐛 Bug Fix

## Changes

An OpenAI-compatible /v1/chat/completions request with `parallel_tool_calls` set, tools present, and no `tool_choice` against a Bedrock Converse Claude model failed with a BedrockException saying "The model returned the following errors: missing field `type`". `map_openai_params` mapped `parallel_tool_calls` to `additionalModelRequestFields.tool_choice = {"disable_parallel_tool_use": <bool>}`, but Anthropic's tool_choice is a tagged union that requires a `type` field ("auto", "any", "tool", or "none"), so Bedrock rejected the request

The mapping now emits `{"type": "auto", "disable_parallel_tool_use": <bool>}`, matching what the direct Anthropic transformation does when no tool_choice is given. The merge into `additionalModelRequestFields` moved into `AmazonConverseConfig._merge_parallel_tool_use_config`, which builds a new dict instead of mutating in place. Precedence: an already-present tool_choice dict keeps its own `type` and any keys the derived config does not set (such as `name`), while the `parallel_tool_calls`-derived `disable_parallel_tool_use` wins over a conflicting raw user value, since the OpenAI-compatible param is the explicit request-level intent

Regression tests assert the fully typed tool_choice in the outbound request for both `parallel_tool_calls` values on a Converse model that supports the config, and that the merge preserves a user-supplied tool_choice `type` while the derived `disable_parallel_tool_use` overrides a conflicting raw value

## QA runbook

- [ ] In a worktree with its own venv and a .env containing AWS_BEARER_TOKEN_BEDROCK and LITELLM_MASTER_KEY, save the qa_config.yaml and req.json shown in the proof section
- [ ] Pick a random free high port (verify with `lsof -nP -iTCP:<port> -sTCP:LISTEN`) and start the proxy: `.venv/bin/python litellm/proxy/proxy_cli.py --config qa_config.yaml --port <port> --detailed_debug`
- [ ] Send the request: `curl -sS http://localhost:<port>/v1/chat/completions -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' -d @req.json`
- [ ] Expect HTTP 200 with finish_reason `tool_calls`; at the base commit the same request fails with a BedrockException naming missing field `type`
- [ ] Repeat with `"parallel_tool_calls": false` and expect HTTP 200 as well
- [ ] Grep the proxy log for `additionalModelRequestFields` and confirm tool_choice carries `"type": "auto"` alongside `disable_parallel_tool_use`

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
