### PR TITLE
fix(anthropic): stop tool translation from mutating caller's input_schema

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -768,7 +768,9 @@ class LiteLLMAnthropicMessagesAdapter:
                 name=truncated_name,
             )
             if "input_schema" in tool:
-                function_chunk["parameters"] = tool["input_schema"]  # type: ignore
+                input_schema = tool["input_schema"]
+                if input_schema is not None:
+                    function_chunk["parameters"] = dict(input_schema)
             if "description" in tool:
                 function_chunk["description"] = tool["description"]  # type: ignore
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -3147,3 +3147,29 @@ def test_translate_anthropic_tools_to_openai_preserves_parameters_type():
     params = new_tools[0]["function"]["parameters"]
     assert params["type"] == "object"
     assert new_tools[0]["type"] == "function"
+
+
+def test_translate_anthropic_tools_to_openai_does_not_mutate_caller_input_schema():
+    """Regression for #34277: extra top-level tool keys (e.g. a computer tool's
+    display_width_px) must not leak into the caller's input_schema. The caller
+    reuses the same in-memory tool list across translations (proxy pre-call
+    hook, then the real call), so mutating input_schema in place pollutes it."""
+    import copy
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    tool = {
+        "name": "computer",
+        "type": "computer_20241022",
+        "input_schema": {"type": "object", "properties": {"action": {"type": "string"}}},
+        "display_width_px": 1024,
+        "display_height_px": 768,
+    }
+    input_schema_before = copy.deepcopy(tool["input_schema"])
+
+    new_tools, _ = adapter.translate_anthropic_tools_to_openai(tools=[tool], model="claude-3-5-sonnet")
+
+    assert tool["input_schema"] == input_schema_before
+    assert "display_width_px" not in tool["input_schema"]
+    params = new_tools[0]["function"]["parameters"]
+    assert params["display_width_px"] == 1024
+    assert params["display_height_px"] == 768


### PR DESCRIPTION
## TLDR

Problem this solves:

- `translate_anthropic_tools_to_openai` mutates the caller's `input_schema` in place
- Extra top-level tool keys (e.g. a computer tool's `display_width_px`) leak into it
- Callers reuse the same tool list across translations, so the schema stays polluted

How it solves it:

- Shallow-copy `input_schema` before assigning it to `parameters`
- The later merge only adds top-level keys, so a shallow copy fully isolates it
- Also drops the pre-existing no-op `# type: ignore` on that line

## Relevant issues

Fixes #34277

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

The bug lives entirely in pure translation logic, so it reproduces with just the `litellm` package, no provider credentials. Repro (`/tmp/repro34277.py`):

```python
import copy
from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
    LiteLLMAnthropicMessagesAdapter,
)
adapter = LiteLLMAnthropicMessagesAdapter()
tool = {
    "name": "computer",
    "type": "computer_20241022",
    "input_schema": {"type": "object", "properties": {"action": {"type": "string"}}},
    "display_width_px": 1024,
    "display_height_px": 768,
}
before = copy.deepcopy(tool["input_schema"])
adapter.translate_anthropic_tools_to_openai(tools=[tool], model="claude-3-5-sonnet")
print("caller input_schema mutated:", tool["input_schema"] != before)
print("input_schema now:", tool["input_schema"])
```

Before (commit `17a83aa8`):

```
caller input_schema mutated: True
input_schema now: {'type': 'object', 'properties': {'action': {'type': 'string'}}, 'display_width_px': 1024, 'display_height_px': 768}
```

After (commit `95b60780`):

```
caller input_schema mutated: False
input_schema now: {'type': 'object', 'properties': {'action': {'type': 'string'}}}
```

The translated OpenAI tool still carries `display_width_px` / `display_height_px` in its `parameters`; only the caller's original `input_schema` is left untouched.

## Type

🐛 Bug Fix

## Changes

In `translate_anthropic_tools_to_openai`, `function_chunk["parameters"]` was assigned `tool["input_schema"]` by reference, then the loop over remaining tool keys merged extra entries into that same dict via `.update`, so the caller's `input_schema` was mutated. The fix narrows the `None` case and assigns `dict(input_schema)`, a shallow copy; the merge only adds top-level keys, so a shallow copy is sufficient to isolate the caller's dict. Narrowing also removes the pre-existing `# type: ignore` (a no-op under this repo's `enableTypeIgnoreComments=false`) and leaves that line type-clean.

Regression test `test_translate_anthropic_tools_to_openai_does_not_mutate_caller_input_schema` asserts the caller's `input_schema` is unchanged after translation while the extra keys still land in the translated tool's `parameters`. It fails on the parent commit and passes on the fix.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
