### PR TITLE
fix(openrouter): preserve shared session when streaming

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -535,6 +535,7 @@ class BaseLLMHTTPHandler:
                     json_mode=json_mode,
                     optional_params=optional_params,
                     signed_json_body=signed_json_body,
+                    shared_session=shared_session,
                 )
 
             else:
@@ -726,6 +727,7 @@ class BaseLLMHTTPHandler:
         client: Optional[AsyncHTTPHandler] = None,
         json_mode: Optional[bool] = None,
         signed_json_body: Optional[bytes] = None,
+        shared_session: Optional["ClientSession"] = None,
     ):
         if provider_config.has_custom_stream_wrapper is True:
             return await provider_config.get_async_custom_stream_wrapper(
@@ -757,6 +759,7 @@ class BaseLLMHTTPHandler:
             optional_params=optional_params,
             json_mode=json_mode,
             signed_json_body=signed_json_body,
+            shared_session=shared_session,
         )
         streamwrapper = CustomStreamWrapper(
             completion_stream=completion_stream,
@@ -783,6 +786,7 @@ class BaseLLMHTTPHandler:
         client: Optional[AsyncHTTPHandler] = None,
         json_mode: Optional[bool] = None,
         signed_json_body: Optional[bytes] = None,
+        shared_session: Optional["ClientSession"] = None,
     ) -> Tuple[Any, httpx.Headers]:
         """
         Helper function for making an async call with stream.
@@ -793,6 +797,7 @@ class BaseLLMHTTPHandler:
             async_httpx_client = get_async_httpx_client(
                 llm_provider=litellm.LlmProviders(custom_llm_provider),
                 params={"ssl_verify": litellm_params.get("ssl_verify", None)},
+                shared_session=shared_session,
             )
         else:
             async_httpx_client = client

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -543,6 +543,7 @@ class BaseLLMHTTPHandler:
                     json_mode=json_mode,
                     optional_params=optional_params,
                     signed_json_body=signed_json_body,
+                    shared_session=shared_session,
                 )
 
             else:
@@ -734,6 +735,7 @@ class BaseLLMHTTPHandler:
         client: AsyncHTTPHandler | None = None,
         json_mode: bool | None = None,
         signed_json_body: bytes | None = None,
+        shared_session: Optional["ClientSession"] = None,
     ):
         if provider_config.has_custom_stream_wrapper is True:
             return await provider_config.get_async_custom_stream_wrapper(
@@ -765,6 +767,7 @@ class BaseLLMHTTPHandler:
             optional_params=optional_params,
             json_mode=json_mode,
             signed_json_body=signed_json_body,
+            shared_session=shared_session,
         )
         streamwrapper: Final = CustomStreamWrapper(
             completion_stream=completion_stream,
@@ -791,6 +794,7 @@ class BaseLLMHTTPHandler:
         client: AsyncHTTPHandler | None = None,
         json_mode: bool | None = None,
         signed_json_body: bytes | None = None,
+        shared_session: Optional["ClientSession"] = None,
     ) -> tuple[object, httpx.Headers]:
         """
         Helper function for making an async call with stream.
@@ -801,6 +805,7 @@ class BaseLLMHTTPHandler:
             async_httpx_client = get_async_httpx_client(
                 llm_provider=litellm.LlmProviders(custom_llm_provider),
                 params={"ssl_verify": litellm_params.get("ssl_verify", None)},
+                shared_session=shared_session,
             )
         else:
             async_httpx_client = client

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -31,6 +31,53 @@ _ACTIVE_KEY = "_code_interpreter_interception_active"
 _SANDBOX_KEY = "_code_interpreter_interception_sandbox_key"
 
 
+@pytest.mark.asyncio
+async def test_async_streaming_completion_uses_shared_session():
+    handler = BaseLLMHTTPHandler()
+    provider_config = Mock()
+    provider_config.should_fake_stream.return_value = False
+    provider_config.validate_environment.return_value = {}
+    provider_config.get_complete_url.return_value = "https://openrouter.ai/api/v1/chat/completions"
+    provider_config.transform_request.return_value = {"model": "openai/gpt-4o", "messages": []}
+    provider_config.sign_request.return_value = ({}, None)
+    provider_config.supports_stream_param_in_request_body = True
+    provider_config.has_custom_stream_wrapper = False
+    provider_config.max_retry_on_unprocessable_entity_error = 0
+    provider_config.get_model_response_iterator.return_value = Mock()
+    logging_obj = Mock()
+    logging_obj.model_call_details = {}
+    shared_session = Mock()
+    async_client = Mock()
+    async_client.post = AsyncMock(return_value=httpx.Response(200))
+
+    with patch(
+        "litellm.llms.custom_httpx.llm_http_handler.get_async_httpx_client",
+        return_value=async_client,
+    ) as get_async_httpx_client:
+        await handler.completion(
+            model="openai/gpt-4o",
+            messages=[],
+            api_base=None,
+            custom_llm_provider="openrouter",
+            model_response=litellm.ModelResponse(),
+            encoding=None,
+            logging_obj=logging_obj,
+            optional_params={},
+            timeout=60.0,
+            litellm_params={},
+            acompletion=True,
+            stream=True,
+            provider_config=provider_config,
+            shared_session=shared_session,
+        )
+
+    get_async_httpx_client.assert_called_once_with(
+        llm_provider=litellm.LlmProviders.OPENROUTER,
+        params={"ssl_verify": None},
+        shared_session=shared_session,
+    )
+
+
 def test_prepare_fake_stream_request():
     # Initialize the BaseLLMHTTPHandler
     handler = BaseLLMHTTPHandler()


### PR DESCRIPTION
## TLDR

Problem this solves:

- Native OpenRouter async streams discard supplied shared HTTP sessions

How it solves it:

- Propagates `shared_session` through the streaming HTTP handler chain

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

With `OPENROUTER_API_KEY` set, I ran the same live OpenRouter streaming request at each commit with an `aiohttp` trace attached to the caller-supplied session

```bash
uv run python - <<'PY'
import asyncio
import subprocess

import aiohttp
import litellm


async def main() -> None:
    requests = 0

    async def count_request(*args: object) -> None:
        nonlocal requests
        requests += 1

    trace = aiohttp.TraceConfig()
    trace.on_request_start.append(count_request)
    async with aiohttp.ClientSession(trace_configs=[trace]) as session:
        response = await litellm.acompletion(
            model="openrouter/openai/gpt-5.2",
            messages=[{"role": "user", "content": "Reply only OK"}],
            max_tokens=4,
            stream=True,
            shared_session=session,
        )
        chunks = sum([1 async for _ in response])

    commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
    print(f"commit={commit}")
    print(f"shared_session_requests={requests}")
    print(f"stream_chunks={chunks}")


asyncio.run(main())
PY
```

Before:

```text
commit=9ab3847c0b2132221aecf858a3ac5c62697359a9
shared_session_requests=0
stream_chunks=3
```

After:

```text
commit=42934718bb5f7566e22d766d4d967e156a69d3bc
shared_session_requests=1
stream_chunks=3
```

## Type

🐛 Bug Fix

## Changes

`shared_session` now reaches the async streaming HTTP client factory, matching the existing non-streaming path

The mapped handler test covers the native OpenRouter streaming path and fails if session propagation regresses

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

