### PR TITLE
fix(router): apply order fallback before deployment affinity

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -10587,6 +10587,14 @@ class Router:
 
         healthy_deployments = self._filter_blocked_deployments(healthy_deployments)
 
+        # An explicit order fallback is a hard retry constraint. Apply it before
+        # affinity so a stale pin cannot send the retry back to an earlier order.
+        _target_order = (request_kwargs or {}).pop("_target_order", None)
+        if _target_order is not None:
+            healthy_deployments = litellm.utils._get_order_filtered_deployments(
+                cast(List[Dict], healthy_deployments), target_order=_target_order
+            )
+
         healthy_deployments = await self.async_callback_filter_deployments(
             model=model,
             healthy_deployments=healthy_deployments,
@@ -10619,7 +10627,6 @@ class Router:
         )
 
         ## ORDER FILTERING ## -> if user set 'order' in deployments, return deployments with lowest order (e.g. order=1 > order=2)
-        _target_order = (request_kwargs or {}).pop("_target_order", None)
         healthy_deployments = litellm.utils._get_order_filtered_deployments(
             cast(List[Dict], healthy_deployments), target_order=_target_order
         )

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -10628,9 +10628,7 @@ class Router:
 
         ## DEFAULT ORDER FILTERING ## -> without a fallback target, return deployments with the lowest configured order
         if _target_order is None:
-            healthy_deployments = litellm.utils._get_order_filtered_deployments(
-                cast(list[dict], healthy_deployments)
-            )
+            healthy_deployments = litellm.utils._get_order_filtered_deployments(cast(list[dict], healthy_deployments))
 
         ## WEIGHTED FAILOVER EXCLUSION ## -> drop deployments already tried in
         ## this request via weighted-failover. Always honored, regardless of the

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -10592,7 +10592,7 @@ class Router:
         _target_order = (request_kwargs or {}).pop("_target_order", None)
         if _target_order is not None:
             healthy_deployments = litellm.utils._get_order_filtered_deployments(
-                cast(List[Dict], healthy_deployments), target_order=_target_order
+                cast(list[dict], healthy_deployments), target_order=_target_order
             )
 
         healthy_deployments = await self.async_callback_filter_deployments(
@@ -10626,10 +10626,11 @@ class Router:
             request_kwargs=request_kwargs,
         )
 
-        ## ORDER FILTERING ## -> if user set 'order' in deployments, return deployments with lowest order (e.g. order=1 > order=2)
-        healthy_deployments = litellm.utils._get_order_filtered_deployments(
-            cast(List[Dict], healthy_deployments), target_order=_target_order
-        )
+        ## DEFAULT ORDER FILTERING ## -> without a fallback target, return deployments with the lowest configured order
+        if _target_order is None:
+            healthy_deployments = litellm.utils._get_order_filtered_deployments(
+                cast(List[Dict], healthy_deployments)
+            )
 
         ## WEIGHTED FAILOVER EXCLUSION ## -> drop deployments already tried in
         ## this request via weighted-failover. Always honored, regardless of the

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -10592,7 +10592,7 @@ class Router:
         _target_order = (request_kwargs or {}).pop("_target_order", None)
         if _target_order is not None:
             healthy_deployments = litellm.utils._get_order_filtered_deployments(
-                cast(list[dict], healthy_deployments), target_order=_target_order
+                healthy_deployments, target_order=_target_order
             )
 
         healthy_deployments = await self.async_callback_filter_deployments(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -10629,7 +10629,7 @@ class Router:
         ## DEFAULT ORDER FILTERING ## -> without a fallback target, return deployments with the lowest configured order
         if _target_order is None:
             healthy_deployments = litellm.utils._get_order_filtered_deployments(
-                cast(List[Dict], healthy_deployments)
+                cast(list[dict], healthy_deployments)
             )
 
         ## WEIGHTED FAILOVER EXCLUSION ## -> drop deployments already tried in

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -11057,7 +11057,7 @@ class Router:
         _target_order: Final = (request_kwargs or {}).pop("_target_order", None)
         if _target_order is not None:
             healthy_deployments = litellm.utils._get_order_filtered_deployments(
-                cast(list[dict], healthy_deployments), target_order=_target_order
+                healthy_deployments, target_order=_target_order
             )
 
         healthy_deployments = await self.async_callback_filter_deployments(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -11056,7 +11056,7 @@ class Router:
         # affinity so a stale pin cannot send the retry back to an earlier order.
         _target_order: Final = (request_kwargs or {}).pop("_target_order", None)
         if _target_order is not None:
-            healthy_deployments = litellm.utils._get_order_filtered_deployments(  # pyright: ignore[reportPrivateUsage]
+            healthy_deployments = litellm.utils._get_order_filtered_deployments(  # pyright: ignore[reportPrivateUsage]  # Router's internal order helper
                 healthy_deployments, target_order=_target_order
             )
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -11093,9 +11093,7 @@ class Router:
 
         # Without a fallback target, return deployments with the lowest configured order.
         if _target_order is None:
-            healthy_deployments = litellm.utils._get_order_filtered_deployments(
-                cast(list[dict], healthy_deployments)
-            )
+            healthy_deployments = litellm.utils._get_order_filtered_deployments(cast(list[dict], healthy_deployments))
 
         ## WEIGHTED FAILOVER EXCLUSION ## -> drop deployments already tried in
         ## this request via weighted-failover. Always honored, regardless of the

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -11052,6 +11052,14 @@ class Router:
 
         healthy_deployments = self._filter_blocked_deployments(healthy_deployments)
 
+        # An explicit order fallback is a hard retry constraint. Apply it before
+        # affinity so a stale pin cannot send the retry back to an earlier order.
+        _target_order: Final = (request_kwargs or {}).pop("_target_order", None)
+        if _target_order is not None:
+            healthy_deployments = litellm.utils._get_order_filtered_deployments(
+                cast(list[dict], healthy_deployments), target_order=_target_order
+            )
+
         healthy_deployments = await self.async_callback_filter_deployments(
             model=model,
             healthy_deployments=healthy_deployments,
@@ -11083,11 +11091,11 @@ class Router:
             request_kwargs=request_kwargs,
         )
 
-        ## ORDER FILTERING ## -> if user set 'order' in deployments, return deployments with lowest order (e.g. order=1 > order=2)
-        _target_order: Final = (request_kwargs or {}).pop("_target_order", None)
-        healthy_deployments = litellm.utils._get_order_filtered_deployments(
-            cast(list[dict], healthy_deployments), target_order=_target_order
-        )
+        # Without a fallback target, return deployments with the lowest configured order.
+        if _target_order is None:
+            healthy_deployments = litellm.utils._get_order_filtered_deployments(
+                cast(list[dict], healthy_deployments)
+            )
 
         ## WEIGHTED FAILOVER EXCLUSION ## -> drop deployments already tried in
         ## this request via weighted-failover. Always honored, regardless of the

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -11056,7 +11056,7 @@ class Router:
         # affinity so a stale pin cannot send the retry back to an earlier order.
         _target_order: Final = (request_kwargs or {}).pop("_target_order", None)
         if _target_order is not None:
-            healthy_deployments = litellm.utils._get_order_filtered_deployments(
+            healthy_deployments = litellm.utils._get_order_filtered_deployments(  # pyright: ignore[reportPrivateUsage]
                 healthy_deployments, target_order=_target_order
             )
 

--- a/tests/test_litellm/test_router_order_fallback.py
+++ b/tests/test_litellm/test_router_order_fallback.py
@@ -11,6 +11,9 @@ from typing import Optional
 import pytest
 
 from litellm import Router
+from litellm.router_utils.pre_call_checks.deployment_affinity_check import (
+    DeploymentAffinityCheck,
+)
 from litellm.utils import _get_order_filtered_deployments
 
 # ---------------------------------------------------------------------------
@@ -190,6 +193,56 @@ async def test_router_order_fallback_on_failure():
         messages=[{"role": "user", "content": "hi"}],
     )
     assert response._hidden_params["model_id"] == "2"
+
+
+@pytest.mark.asyncio
+async def test_order_fallback_overrides_session_affinity():
+    """An order fallback must not reuse a deployment pinned at an earlier order."""
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "gpt-4o", "api_key": "key", "order": 1},
+                "model_info": {"id": "1"},
+            },
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "gpt-4o", "api_key": "key", "order": 2},
+                "model_info": {"id": "2"},
+            },
+        ],
+        optional_pre_call_checks=["session_affinity"],
+    )
+    callback = next(
+        callback
+        for callback in router.optional_callbacks
+        if isinstance(callback, DeploymentAffinityCheck)
+    )
+    session_id = "test-session"
+    await callback.cache.async_set_cache(
+        key=DeploymentAffinityCheck.get_session_affinity_cache_key(
+            "test-model", session_id
+        ),
+        value={"model_id": "1"},
+    )
+
+    try:
+        pinned = await router.async_get_healthy_deployments(
+            model="test-model",
+            request_kwargs={"metadata": {"session_id": session_id}},
+        )
+        fallback = await router.async_get_healthy_deployments(
+            model="test-model",
+            request_kwargs={
+                "_target_order": 2,
+                "metadata": {"session_id": session_id},
+            },
+        )
+
+        assert [deployment["model_info"]["id"] for deployment in pinned] == ["1"]
+        assert [deployment["model_info"]["id"] for deployment in fallback] == ["2"]
+    finally:
+        router.discard()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/test_router_order_fallback.py
+++ b/tests/test_litellm/test_router_order_fallback.py
@@ -221,7 +221,7 @@ async def test_order_fallback_overrides_session_affinity():
     session_id = "test-session"
     await callback.cache.async_set_cache(
         key=DeploymentAffinityCheck.get_session_affinity_cache_key(
-            "test-model", session_id
+            "test-model", session_id, None
         ),
         value={"model_id": "1"},
     )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Session affinity can repin explicit order fallbacks.
- Retries can select an earlier deployment order again.

How it solves it:

- Prefilter explicit target orders before affinity callbacks.
- Add regression coverage for pinned order-one sessions.

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in PR merge, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This bug is in the in-process deployment-selection pipeline and requires no provider request. On base commit `abf18f8`, affinity narrows the candidates to the cached order-1 deployment before `_target_order=2` is applied. Because no order-2 candidate remains, the order helper returns the pinned deployment unchanged. On fix commit `39a58ba`, the explicit target order narrows candidates first, so the stale order-1 pin cannot match.

```console
$ pytest tests/test_litellm/test_router_order_fallback.py -q
...............                                                          [100%]
15 passed
```

## Type

🐛 Bug Fix

## Changes

`async_get_healthy_deployments` now consumes and applies an explicit `_target_order` immediately after health, cooldown, and blocked-deployment filtering. This makes the fallback order a hard retry constraint before `DeploymentAffinityCheck` runs. The existing final order filter remains in place for normal selection, preserving routing-plugin and default-order behavior.

The regression test primes session affinity to order 1, verifies an ordinary selection remains pinned there, then verifies an order-2 fallback selects the order-2 deployment.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR