### PR TITLE
fix(responses): preserve usage on incomplete chat stream bridge

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -1302,22 +1302,28 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                         )
                     ]
                 )
-        elif event_type == "response.completed":
-            # Response is fully complete - now we can signal is_finished=True
-            # This ensures we don't prematurely end the stream before tool_calls arrive
-
-            # Check if response contains function_call items in output
-            # to determine correct finish_reason
-            response_data = parsed_chunk.get("response", {})
+        elif event_type in (
+            "response.completed",
+            "response.incomplete",
+            "response.failed",
+        ):
+            # Preserve upstream usage on terminal events so chat streaming does
+            # not fall back to local token_counter (e.g. max_output_tokens).
+            response_data = parsed_chunk.get("response", {}) or {}
             output_items = response_data.get("output", []) if response_data else []
 
             has_function_calls = any(
                 item.get("type") == "function_call" for item in output_items if isinstance(item, dict)
             )
 
-            finish_reason = "tool_calls" if has_function_calls else "stop"
+            status = response_data.get("status")
+            if event_type == "response.incomplete" or status == "incomplete":
+                finish_reason = "length"
+            elif event_type == "response.completed" and has_function_calls:
+                finish_reason = "tool_calls"
+            else:
+                finish_reason = "stop"
 
-            # Extract reasoning items with encrypted_content for round-tripping
             completed_reasoning_items: Optional[List[Dict[str, Any]]] = None
             for item in output_items:
                 if not isinstance(item, dict) or item.get("type") != "reasoning":

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -1072,9 +1072,9 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
 
     @staticmethod
     def _finish_reason_for_incomplete_response(
-        incomplete_details: Optional[object],
+        incomplete_details: object | None,
     ) -> str:
-        reason: Optional[str] = None
+        reason: str | None = None
         if isinstance(incomplete_details, dict):
             raw_reason = incomplete_details.get("reason")
             if isinstance(raw_reason, str):

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -1070,6 +1070,23 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
 
         return status_mapping.get(status, "stop")
 
+    @staticmethod
+    def _finish_reason_for_incomplete_response(
+        incomplete_details: Optional[object],
+    ) -> str:
+        reason: Optional[str] = None
+        if isinstance(incomplete_details, dict):
+            raw_reason = incomplete_details.get("reason")
+            if isinstance(raw_reason, str):
+                reason = raw_reason
+        elif incomplete_details is not None:
+            raw_reason = getattr(incomplete_details, "reason", None)
+            if isinstance(raw_reason, str):
+                reason = raw_reason
+        if reason == "content_filter":
+            return "content_filter"
+        return "length"
+
 
 class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
     def __init__(self, streaming_response, sync_stream: bool, json_mode: Optional[bool] = False):
@@ -1318,7 +1335,9 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
 
             status = response_data.get("status")
             if event_type == "response.incomplete" or status == "incomplete":
-                finish_reason = "length"
+                finish_reason = LiteLLMResponsesTransformationHandler._finish_reason_for_incomplete_response(
+                    response_data.get("incomplete_details")
+                )
             elif event_type == "response.completed" and has_function_calls:
                 finish_reason = "tool_calls"
             else:

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -1237,6 +1237,57 @@ def test_response_incomplete_preserves_usage_and_length_finish_reason():
     assert result.choices[0].finish_reason == "length"
 
 
+def test_response_incomplete_content_filter_finish_reason():
+    """
+    response.incomplete with reason=content_filter must map to chat
+    finish_reason=content_filter, not length.
+    """
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        OpenAiResponsesToChatCompletionStreamIterator,
+    )
+
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(
+        streaming_response=None, sync_stream=True
+    )
+
+    chunk = {
+        "type": "response.incomplete",
+        "response": {
+            "id": "resp_filtered",
+            "status": "incomplete",
+            "incomplete_details": {"reason": "content_filter"},
+            "output": [
+                {
+                    "type": "message",
+                    "id": "msg_filtered",
+                    "role": "assistant",
+                    "status": "incomplete",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "partial",
+                            "annotations": [],
+                        }
+                    ],
+                }
+            ],
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 4,
+                "total_tokens": 14,
+                "output_tokens_details": {"reasoning_tokens": 0},
+            },
+        },
+    }
+
+    result = iterator.chunk_parser(chunk)
+
+    assert result.usage is not None
+    assert result.usage.completion_tokens == 4
+    assert len(result.choices) > 0
+    assert result.choices[0].finish_reason == "content_filter"
+
+
 def test_function_call_done_emits_is_finished():
     """
     Test that OUTPUT_ITEM_DONE for a function_call does NOT emit finish_reason.

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -1172,6 +1172,71 @@ def test_response_completed_preserves_usage_with_cached_tokens():
     ), "cached_tokens should be preserved from input_tokens_details"
 
 
+def test_response_incomplete_preserves_usage_and_length_finish_reason():
+    """
+    When chat completions are bridged to the Responses API and the model hits
+    max_output_tokens, Azure/OpenAI emits response.incomplete with the real
+    usage (including reasoning_tokens). That usage must map into the chat
+    stream chunk; otherwise stream_chunk_builder falls back to local
+    token_counter and under-reports completion_tokens / drops reasoning_tokens.
+    """
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        OpenAiResponsesToChatCompletionStreamIterator,
+    )
+
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(
+        streaming_response=None, sync_stream=True
+    )
+
+    chunk = {
+        "type": "response.incomplete",
+        "response": {
+            "id": "resp_incomplete",
+            "status": "incomplete",
+            "incomplete_details": {"reason": "max_output_tokens"},
+            "output": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "summary": [],
+                    "content": [],
+                },
+                {
+                    "type": "message",
+                    "id": "msg_incomplete",
+                    "role": "assistant",
+                    "status": "incomplete",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "truncated answer",
+                            "annotations": [],
+                        }
+                    ],
+                },
+            ],
+            "usage": {
+                "input_tokens": 1299,
+                "output_tokens": 1024,
+                "total_tokens": 2323,
+                "input_tokens_details": {"cached_tokens": 0},
+                "output_tokens_details": {"reasoning_tokens": 516},
+            },
+            "max_output_tokens": 1024,
+        },
+    }
+
+    result = iterator.chunk_parser(chunk)
+
+    assert result.usage is not None, "usage should be set on response.incomplete chunk"
+    assert result.usage.prompt_tokens == 1299
+    assert result.usage.completion_tokens == 1024
+    assert result.usage.completion_tokens_details is not None
+    assert result.usage.completion_tokens_details.reasoning_tokens == 516
+    assert len(result.choices) > 0
+    assert result.choices[0].finish_reason == "length"
+
+
 def test_function_call_done_emits_is_finished():
     """
     Test that OUTPUT_ITEM_DONE for a function_call does NOT emit finish_reason.

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -1288,6 +1288,59 @@ def test_response_incomplete_content_filter_finish_reason():
     assert result.choices[0].finish_reason == "content_filter"
 
 
+def test_finish_reason_for_incomplete_response_object_attr():
+    """Cover getattr path when incomplete_details is not a dict."""
+    from types import SimpleNamespace
+
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    finish = LiteLLMResponsesTransformationHandler._finish_reason_for_incomplete_response
+    assert (
+        finish(SimpleNamespace(reason="content_filter")) == "content_filter"
+    )
+    assert finish(SimpleNamespace(reason="max_output_tokens")) == "length"
+    assert finish(SimpleNamespace(reason=None)) == "length"
+    assert finish(SimpleNamespace()) == "length"
+    assert finish(None) == "length"
+
+
+def test_response_failed_preserves_usage():
+    """response.failed must still forward upstream usage like completed."""
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        OpenAiResponsesToChatCompletionStreamIterator,
+    )
+
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(
+        streaming_response=None, sync_stream=True
+    )
+
+    chunk = {
+        "type": "response.failed",
+        "response": {
+            "id": "resp_failed",
+            "status": "failed",
+            "output": [],
+            "usage": {
+                "input_tokens": 20,
+                "output_tokens": 3,
+                "total_tokens": 23,
+                "output_tokens_details": {"reasoning_tokens": 1},
+            },
+        },
+    }
+
+    result = iterator.chunk_parser(chunk)
+
+    assert result.usage is not None
+    assert result.usage.prompt_tokens == 20
+    assert result.usage.completion_tokens == 3
+    assert result.usage.completion_tokens_details is not None
+    assert result.usage.completion_tokens_details.reasoning_tokens == 1
+    assert result.choices[0].finish_reason == "stop"
+
+
 def test_function_call_done_emits_is_finished():
     """
     Test that OUTPUT_ITEM_DONE for a function_call does NOT emit finish_reason.


### PR DESCRIPTION
## TLDR

Problem this solves:

- Chat completions bridged to Responses drop upstream usage on `response.incomplete`
- Stream then falls back to local `token_counter`, under-reporting tokens (e.g. 607 vs 1024) and zeroing `reasoning_tokens`

How it solves it:

- Map `response.incomplete` / `response.failed` like `response.completed`, preserving usage
- Set `finish_reason=length` when status/event is incomplete

## Relevant issues

Fixes #34351

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Unit regression (before fix: incomplete chunk had no usage; after: upstream usage and `finish_reason=length` are preserved):

```bash
pytest tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py::test_response_incomplete_preserves_usage_and_length_finish_reason -q
```

Live proof against a proxy with `azure/responses/<gpt-5.x>` and a low `max_tokens` so Azure emits `response.incomplete` with `reason=max_output_tokens`:

```bash
curl -sN http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"model":"<your-azure-responses-alias>","messages":[{"role":"user","content":"write a long answer"}],"max_tokens":64,"stream":true,"stream_options":{"include_usage":true}}'
```

Expect the final usage chunk `completion_tokens` to match Azure `output_tokens` (including reasoning), not a smaller local tiktoken estimate, and `finish_reason` to be `length`.

## Type

Bug Fix
Test

## Changes

- `OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream` now treats `response.incomplete` and `response.failed` as terminal events with usage translation
- Incomplete maps to chat `finish_reason=length`
- Regression test covering max_output_tokens incomplete usage + reasoning_tokens

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR