### PR TITLE
feat(spend-tracking): add disable_entity_spend_updates flag

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2230,6 +2230,15 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
             "borrowing the `cache_params` Redis and over the REDIS_* env fallback"
         ),
     )
+    disable_entity_spend_updates: Optional[bool] = Field(
+        None,
+        description=(
+            "If true, skip entity spend counter UPDATEs (key/user/team/org/agent/tag "
+            "and daily dimension spend tables) while still writing LiteLLM_SpendLogs. "
+            "Opposite of disable_spend_logs. Disables per-entity budget enforcement. "
+            "See https://github.com/BerriAI/litellm/issues/31866"
+        ),
+    )
     allow_cli_sso_verification_uri_complete: bool | None = Field(
         None,
         description="opt-in to RFC 8628 verification_uri_complete for the CLI SSO device flow, pre-filling the user_code in the browser. Off by default; intended for same-host clients where the device that starts the flow and the browser run on the same machine",

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2230,13 +2230,25 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
             "borrowing the `cache_params` Redis and over the REDIS_* env fallback"
         ),
     )
-    disable_entity_spend_updates: Optional[bool] = Field(
+    disable_entity_spend_updates: Optional[Union[bool, List[str]]] = Field(
         None,
         description=(
-            "If true, skip entity spend counter UPDATEs (key/user/team/org/agent/tag "
-            "and daily dimension spend tables) while still writing LiteLLM_SpendLogs. "
-            "Opposite of disable_spend_logs. Disables per-entity budget enforcement. "
+            "Skip rolling entity spend counter UPDATEs while still writing "
+            "LiteLLM_SpendLogs. `true` disables all of user/key/team/org/tag/agent; "
+            "a list disables only those types (e.g. `[user]` for the hot UserTable row). "
+            "Daily tables are controlled separately by disable_daily_spend_updates. "
+            "Disables per-entity budget enforcement for skipped entities. "
             "See https://github.com/BerriAI/litellm/issues/31866"
+        ),
+    )
+    disable_daily_spend_updates: Optional[Union[bool, List[str]]] = Field(
+        None,
+        description=(
+            "Skip daily dimension spend table UPDATEs (DailyUserSpend, "
+            "DailyTagSpend, etc.). `true` disables all of "
+            "user/end_user/team/org/agent/tag; a list disables only those. "
+            "Keep `tag` enabled (or leave this false) when warehouse CDC reads "
+            "LiteLLM_DailyTagSpend. Independent of disable_entity_spend_updates."
         ),
     )
     allow_cli_sso_verification_uri_complete: bool | None = Field(

--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -187,12 +187,10 @@ class DBSpendUpdateWriter:
                     "disable_spend_logs=True. Skipping writing spend logs to db. Other spend updates - Key/User/Team table will still occur."
                 )
 
-            # Entity counter UPDATEs (key/user/team/org/agent/tag + daily
-            # dimension tables) are the high-contention path. Operators that
-            # only need raw SpendLogs for billing/audit can skip them via
-            # general_settings.disable_entity_spend_updates.
-            # See: https://github.com/BerriAI/litellm/issues/31866
-            if not ProxyUpdateSpend.disable_entity_spend_updates():
+            # Entity counters and daily tables are independently configurable via
+            # disable_entity_spend_updates / disable_daily_spend_updates
+            # (bool or list of types). See BerriAI/litellm#31866.
+            if ProxyUpdateSpend.should_run_batch_database_updates():
                 # Single task replaces 11 create_task() calls
                 asyncio.create_task(
                     self._batch_database_updates(
@@ -209,9 +207,8 @@ class DBSpendUpdateWriter:
                 )
             else:
                 verbose_proxy_logger.debug(
-                    "disable_entity_spend_updates=True. Skipping entity spend "
-                    "counter updates (key/user/team/org/agent/tag + daily "
-                    "spend tables). Raw spend logs are still written."
+                    "Skipping _batch_database_updates: all entity spend counters "
+                    "and daily spend tables are disabled. Raw spend logs still written."
                 )
 
             self._enqueue_tool_registry_upsert(
@@ -343,157 +340,174 @@ class DBSpendUpdateWriter:
         payload: SpendLogsPayload,
     ):
         """
-        Runs all 11 spend-update helpers sequentially inside a single asyncio task.
+        Runs spend-update helpers sequentially inside a single asyncio task.
 
         Each helper is wrapped in try/except so one failure doesn't prevent the others.
+        Individual helpers are skipped when disabled via
+        ``disable_entity_spend_updates`` / ``disable_daily_spend_updates``.
 
         The deepcopy runs here, off the awaited request path, so the daily spend
         helpers get a payload isolated from the spend-log queue entry and the caller.
         """
+        from litellm.proxy.utils import ProxyUpdateSpend
+
         payload_copy = copy.deepcopy(payload)
         request_tags = payload_copy.get("request_tags")
-        try:
-            await self._update_user_db(
-                response_cost=response_cost,
-                user_id=user_id,
-                prisma_client=prisma_client,
-                litellm_proxy_budget_name=litellm_proxy_budget_name,
-                end_user_id=end_user_id,
-            )
-        except Exception:
-            verbose_proxy_logger.debug(
-                "_batch_database_updates: _update_user_db failed: %s",
-                traceback.format_exc(),
-            )
 
-        try:
-            await self._update_key_db(
-                response_cost=response_cost,
-                hashed_token=hashed_token,
-                prisma_client=prisma_client,
-            )
-        except Exception:
-            verbose_proxy_logger.debug(
-                "_batch_database_updates: _update_key_db failed: %s",
-                traceback.format_exc(),
-            )
+        if not ProxyUpdateSpend.is_entity_spend_update_disabled("user"):
+            try:
+                await self._update_user_db(
+                    response_cost=response_cost,
+                    user_id=user_id,
+                    prisma_client=prisma_client,
+                    litellm_proxy_budget_name=litellm_proxy_budget_name,
+                    end_user_id=end_user_id,
+                )
+            except Exception:
+                verbose_proxy_logger.debug(
+                    "_batch_database_updates: _update_user_db failed: %s",
+                    traceback.format_exc(),
+                )
 
-        try:
-            await self._update_team_db(
-                response_cost=response_cost,
-                team_id=team_id,
-                user_id=user_id,
-                prisma_client=prisma_client,
-            )
-        except Exception:
-            verbose_proxy_logger.debug(
-                "_batch_database_updates: _update_team_db failed: %s",
-                traceback.format_exc(),
-            )
+        if not ProxyUpdateSpend.is_entity_spend_update_disabled("key"):
+            try:
+                await self._update_key_db(
+                    response_cost=response_cost,
+                    hashed_token=hashed_token,
+                    prisma_client=prisma_client,
+                )
+            except Exception:
+                verbose_proxy_logger.debug(
+                    "_batch_database_updates: _update_key_db failed: %s",
+                    traceback.format_exc(),
+                )
 
-        try:
-            await self._update_org_db(
-                response_cost=response_cost,
-                org_id=org_id,
-                prisma_client=prisma_client,
-            )
-        except Exception:
-            verbose_proxy_logger.debug(
-                "_batch_database_updates: _update_org_db failed: %s",
-                traceback.format_exc(),
-            )
+        if not ProxyUpdateSpend.is_entity_spend_update_disabled("team"):
+            try:
+                await self._update_team_db(
+                    response_cost=response_cost,
+                    team_id=team_id,
+                    user_id=user_id,
+                    prisma_client=prisma_client,
+                )
+            except Exception:
+                verbose_proxy_logger.debug(
+                    "_batch_database_updates: _update_team_db failed: %s",
+                    traceback.format_exc(),
+                )
 
-        try:
-            await self._update_tag_db(
-                response_cost=response_cost,
-                request_tags=request_tags,
-                prisma_client=prisma_client,
-            )
-        except Exception:
-            verbose_proxy_logger.debug(
-                "_batch_database_updates: _update_tag_db failed: %s",
-                traceback.format_exc(),
-            )
+        if not ProxyUpdateSpend.is_entity_spend_update_disabled("org"):
+            try:
+                await self._update_org_db(
+                    response_cost=response_cost,
+                    org_id=org_id,
+                    prisma_client=prisma_client,
+                )
+            except Exception:
+                verbose_proxy_logger.debug(
+                    "_batch_database_updates: _update_org_db failed: %s",
+                    traceback.format_exc(),
+                )
+
+        if not ProxyUpdateSpend.is_entity_spend_update_disabled("tag"):
+            try:
+                await self._update_tag_db(
+                    response_cost=response_cost,
+                    request_tags=request_tags,
+                    prisma_client=prisma_client,
+                )
+            except Exception:
+                verbose_proxy_logger.debug(
+                    "_batch_database_updates: _update_tag_db failed: %s",
+                    traceback.format_exc(),
+                )
 
         _agent_id_for_spend = payload_copy.get("agent_id")
-        try:
-            await self._update_agent_db(
-                response_cost=response_cost,
-                agent_id=_agent_id_for_spend,
-                prisma_client=prisma_client,
-            )
-        except Exception:
-            verbose_proxy_logger.debug(
-                "_batch_database_updates: _update_agent_db failed: %s",
-                traceback.format_exc(),
-            )
+        if not ProxyUpdateSpend.is_entity_spend_update_disabled("agent"):
+            try:
+                await self._update_agent_db(
+                    response_cost=response_cost,
+                    agent_id=_agent_id_for_spend,
+                    prisma_client=prisma_client,
+                )
+            except Exception:
+                verbose_proxy_logger.debug(
+                    "_batch_database_updates: _update_agent_db failed: %s",
+                    traceback.format_exc(),
+                )
 
-        try:
-            await self.add_spend_log_transaction_to_daily_user_transaction(
-                payload=payload_copy,
-                prisma_client=prisma_client,
-            )
-        except Exception:
-            verbose_proxy_logger.debug(
-                "_batch_database_updates: add_spend_log_transaction_to_daily_user_transaction failed: %s",
-                traceback.format_exc(),
-            )
+        if not ProxyUpdateSpend.is_daily_spend_update_disabled("user"):
+            try:
+                await self.add_spend_log_transaction_to_daily_user_transaction(
+                    payload=payload_copy,
+                    prisma_client=prisma_client,
+                )
+            except Exception:
+                verbose_proxy_logger.debug(
+                    "_batch_database_updates: add_spend_log_transaction_to_daily_user_transaction failed: %s",
+                    traceback.format_exc(),
+                )
 
-        try:
-            await self.add_spend_log_transaction_to_daily_end_user_transaction(
-                payload=payload_copy,
-                prisma_client=prisma_client,
-            )
-        except Exception:
-            verbose_proxy_logger.debug(
-                "_batch_database_updates: add_spend_log_transaction_to_daily_end_user_transaction failed: %s",
-                traceback.format_exc(),
-            )
+        if not ProxyUpdateSpend.is_daily_spend_update_disabled("end_user"):
+            try:
+                await self.add_spend_log_transaction_to_daily_end_user_transaction(
+                    payload=payload_copy,
+                    prisma_client=prisma_client,
+                )
+            except Exception:
+                verbose_proxy_logger.debug(
+                    "_batch_database_updates: add_spend_log_transaction_to_daily_end_user_transaction failed: %s",
+                    traceback.format_exc(),
+                )
 
-        try:
-            await self.add_spend_log_transaction_to_daily_agent_transaction(
-                payload=payload_copy,
-                prisma_client=prisma_client,
-            )
-        except Exception:
-            verbose_proxy_logger.debug(
-                "_batch_database_updates: add_spend_log_transaction_to_daily_agent_transaction failed: %s",
-                traceback.format_exc(),
-            )
+        if not ProxyUpdateSpend.is_daily_spend_update_disabled("agent"):
+            try:
+                await self.add_spend_log_transaction_to_daily_agent_transaction(
+                    payload=payload_copy,
+                    prisma_client=prisma_client,
+                )
+            except Exception:
+                verbose_proxy_logger.debug(
+                    "_batch_database_updates: add_spend_log_transaction_to_daily_agent_transaction failed: %s",
+                    traceback.format_exc(),
+                )
 
-        try:
-            await self.add_spend_log_transaction_to_daily_team_transaction(
-                payload=payload_copy,
-                prisma_client=prisma_client,
-            )
-        except Exception:
-            verbose_proxy_logger.debug(
-                "_batch_database_updates: add_spend_log_transaction_to_daily_team_transaction failed: %s",
-                traceback.format_exc(),
-            )
+        if not ProxyUpdateSpend.is_daily_spend_update_disabled("team"):
+            try:
+                await self.add_spend_log_transaction_to_daily_team_transaction(
+                    payload=payload_copy,
+                    prisma_client=prisma_client,
+                )
+            except Exception:
+                verbose_proxy_logger.debug(
+                    "_batch_database_updates: add_spend_log_transaction_to_daily_team_transaction failed: %s",
+                    traceback.format_exc(),
+                )
 
-        try:
-            await self.add_spend_log_transaction_to_daily_org_transaction(
-                payload=payload_copy,
-                org_id=org_id,
-                prisma_client=prisma_client,
-            )
-        except Exception:
-            verbose_proxy_logger.debug(
-                "_batch_database_updates: add_spend_log_transaction_to_daily_org_transaction failed: %s",
-                traceback.format_exc(),
-            )
+        if not ProxyUpdateSpend.is_daily_spend_update_disabled("org"):
+            try:
+                await self.add_spend_log_transaction_to_daily_org_transaction(
+                    payload=payload_copy,
+                    org_id=org_id,
+                    prisma_client=prisma_client,
+                )
+            except Exception:
+                verbose_proxy_logger.debug(
+                    "_batch_database_updates: add_spend_log_transaction_to_daily_org_transaction failed: %s",
+                    traceback.format_exc(),
+                )
 
-        try:
-            await self.add_spend_log_transaction_to_daily_tag_transaction(
-                payload=payload_copy,
-                prisma_client=prisma_client,
-            )
-        except Exception:
-            verbose_proxy_logger.debug(
-                "_batch_database_updates: add_spend_log_transaction_to_daily_tag_transaction failed: %s",
-                traceback.format_exc(),
-            )
+        if not ProxyUpdateSpend.is_daily_spend_update_disabled("tag"):
+            try:
+                await self.add_spend_log_transaction_to_daily_tag_transaction(
+                    payload=payload_copy,
+                    prisma_client=prisma_client,
+                )
+            except Exception:
+                verbose_proxy_logger.debug(
+                    "_batch_database_updates: add_spend_log_transaction_to_daily_tag_transaction failed: %s",
+                    traceback.format_exc(),
+                )
 
     async def _update_key_db(
         self,

--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -187,20 +187,32 @@ class DBSpendUpdateWriter:
                     "disable_spend_logs=True. Skipping writing spend logs to db. Other spend updates - Key/User/Team table will still occur."
                 )
 
-            # Single task replaces 11 create_task() calls
-            asyncio.create_task(
-                self._batch_database_updates(
-                    response_cost=response_cost,
-                    user_id=user_id,
-                    hashed_token=hashed_token,
-                    team_id=team_id,
-                    org_id=org_id,
-                    end_user_id=end_user_id,
-                    prisma_client=prisma_client,
-                    litellm_proxy_budget_name=litellm_proxy_budget_name,
-                    payload=payload,
+            # Entity counter UPDATEs (key/user/team/org/agent/tag + daily
+            # dimension tables) are the high-contention path. Operators that
+            # only need raw SpendLogs for billing/audit can skip them via
+            # general_settings.disable_entity_spend_updates.
+            # See: https://github.com/BerriAI/litellm/issues/31866
+            if not ProxyUpdateSpend.disable_entity_spend_updates():
+                # Single task replaces 11 create_task() calls
+                asyncio.create_task(
+                    self._batch_database_updates(
+                        response_cost=response_cost,
+                        user_id=user_id,
+                        hashed_token=hashed_token,
+                        team_id=team_id,
+                        org_id=org_id,
+                        end_user_id=end_user_id,
+                        prisma_client=prisma_client,
+                        litellm_proxy_budget_name=litellm_proxy_budget_name,
+                        payload=payload,
+                    )
                 )
-            )
+            else:
+                verbose_proxy_logger.debug(
+                    "disable_entity_spend_updates=True. Skipping entity spend "
+                    "counter updates (key/user/team/org/agent/tag + daily "
+                    "spend tables). Raw spend logs are still written."
+                )
 
             self._enqueue_tool_registry_upsert(
                 kwargs=kwargs,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5301,30 +5301,127 @@ class ProxyUpdateSpend:
             return True
         return False
 
+    # Rolling spend counters on key/user/team/org/agent/tag tables.
+    ENTITY_SPEND_UPDATE_TYPES = frozenset(
+        {"user", "key", "team", "org", "tag", "agent"}
+    )
+    # Daily dimension aggregation tables (DailyUserSpend, DailyTagSpend, …).
+    DAILY_SPEND_UPDATE_TYPES = frozenset(
+        {"user", "end_user", "team", "org", "agent", "tag"}
+    )
+
+    @staticmethod
+    def _disabled_spend_update_types(
+        setting_key: str,
+        valid_types: frozenset,
+    ) -> frozenset:
+        """
+        Parse a spend-update disable setting from ``general_settings``.
+
+        Accepted values:
+          - ``true`` / ``True`` → disable **all** ``valid_types``
+          - ``false`` / absent / ``None`` → disable none
+          - list/tuple/set of type names → disable only those (unknown names ignored)
+
+        This lets operators keep warehouse-facing tables (e.g. DailyTagSpend)
+        while dropping hot-row counters (e.g. UserTable), or the reverse.
+        """
+        from litellm.proxy.proxy_server import general_settings
+        from litellm.secret_managers.main import str_to_bool
+
+        raw = general_settings.get(setting_key, False)
+        if isinstance(raw, str):
+            parsed = str_to_bool(raw)
+            if parsed is not None:
+                raw = parsed
+        if raw is True:
+            return frozenset(valid_types)
+        if raw is False or raw is None:
+            return frozenset()
+        if isinstance(raw, (list, tuple, set, frozenset)):
+            return frozenset(
+                str(item).strip().lower()
+                for item in raw
+                if str(item).strip().lower() in valid_types
+            )
+        return frozenset()
+
+    @staticmethod
+    def disabled_entity_spend_update_types() -> frozenset:
+        """Entity counter types disabled by ``disable_entity_spend_updates``."""
+        return ProxyUpdateSpend._disabled_spend_update_types(
+            "disable_entity_spend_updates",
+            ProxyUpdateSpend.ENTITY_SPEND_UPDATE_TYPES,
+        )
+
+    @staticmethod
+    def disabled_daily_spend_update_types() -> frozenset:
+        """Daily spend table types disabled by ``disable_daily_spend_updates``."""
+        return ProxyUpdateSpend._disabled_spend_update_types(
+            "disable_daily_spend_updates",
+            ProxyUpdateSpend.DAILY_SPEND_UPDATE_TYPES,
+        )
+
+    @staticmethod
+    def is_entity_spend_update_disabled(entity_type: str) -> bool:
+        return entity_type in ProxyUpdateSpend.disabled_entity_spend_update_types()
+
+    @staticmethod
+    def is_daily_spend_update_disabled(daily_type: str) -> bool:
+        return daily_type in ProxyUpdateSpend.disabled_daily_spend_update_types()
+
     @staticmethod
     def disable_entity_spend_updates() -> bool:
         """
-        Returns True if entity-level spend counter UPDATEs should be skipped.
+        Returns True if **all** entity-level spend counter UPDATEs are disabled.
 
-        When True, raw spend log rows are still written to LiteLLM_SpendLogs via
-        `_insert_spend_log_to_db`, but the batch UPDATEs to the key, user,
-        end_user, team, team_member, org, agent, and tag spend counters — and
-        the daily dimension spend tables driven by `_batch_database_updates` —
-        are suppressed.
+        Prefer ``is_entity_spend_update_disabled(entity_type)`` for fine-grained
+        checks. ``disable_entity_spend_updates`` may be ``true`` or a list of
+        entity types: ``user`` | ``key`` | ``team`` | ``org`` | ``tag`` | ``agent``.
 
-        WARNING: Enabling this flag disables per-entity budget enforcement.
-        Per-key, per-user, and per-team budget limits will not be enforced while
-        this flag is active.
+        Raw SpendLogs and daily tables are controlled separately
+        (``disable_spend_logs``, ``disable_daily_spend_updates``).
 
-        Set in config.yaml:
-          general_settings:
-            disable_entity_spend_updates: true
+        WARNING: Disabling entity counters disables per-entity budget enforcement
+        for those entities.
+
+        Examples::
+
+            general_settings:
+              # drop all hot-row counters; keep DailyTagSpend for warehouse ETL
+              disable_entity_spend_updates: true
+              disable_daily_spend_updates: false
+
+              # or only drop the contended user counter
+              disable_entity_spend_updates: [user]
         """
-        from litellm.proxy.proxy_server import general_settings
+        disabled = ProxyUpdateSpend.disabled_entity_spend_update_types()
+        return disabled == ProxyUpdateSpend.ENTITY_SPEND_UPDATE_TYPES
 
-        if general_settings.get("disable_entity_spend_updates") is True:
-            return True
-        return False
+    @staticmethod
+    def disable_daily_spend_updates() -> bool:
+        """
+        Returns True if **all** daily spend dimension UPDATEs are disabled.
+
+        Prefer ``is_daily_spend_update_disabled(daily_type)`` for fine-grained
+        checks. ``disable_daily_spend_updates`` may be ``true`` or a list of
+        types: ``user`` | ``end_user`` | ``team`` | ``org`` | ``agent`` | ``tag``.
+
+        Keep ``tag`` enabled (or leave this flag false) when a warehouse CDC
+        pipeline reads ``LiteLLM_DailyTagSpend``.
+        """
+        disabled = ProxyUpdateSpend.disabled_daily_spend_update_types()
+        return disabled == ProxyUpdateSpend.DAILY_SPEND_UPDATE_TYPES
+
+    @staticmethod
+    def should_run_batch_database_updates() -> bool:
+        """True unless every entity counter and every daily update is disabled."""
+        return (
+            ProxyUpdateSpend.disabled_entity_spend_update_types()
+            != ProxyUpdateSpend.ENTITY_SPEND_UPDATE_TYPES
+            or ProxyUpdateSpend.disabled_daily_spend_update_types()
+            != ProxyUpdateSpend.DAILY_SPEND_UPDATE_TYPES
+        )
 
 
 async def update_spend(

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5301,6 +5301,31 @@ class ProxyUpdateSpend:
             return True
         return False
 
+    @staticmethod
+    def disable_entity_spend_updates() -> bool:
+        """
+        Returns True if entity-level spend counter UPDATEs should be skipped.
+
+        When True, raw spend log rows are still written to LiteLLM_SpendLogs via
+        `_insert_spend_log_to_db`, but the batch UPDATEs to the key, user,
+        end_user, team, team_member, org, agent, and tag spend counters — and
+        the daily dimension spend tables driven by `_batch_database_updates` —
+        are suppressed.
+
+        WARNING: Enabling this flag disables per-entity budget enforcement.
+        Per-key, per-user, and per-team budget limits will not be enforced while
+        this flag is active.
+
+        Set in config.yaml:
+          general_settings:
+            disable_entity_spend_updates: true
+        """
+        from litellm.proxy.proxy_server import general_settings
+
+        if general_settings.get("disable_entity_spend_updates") is True:
+            return True
+        return False
+
 
 async def update_spend(
     prisma_client: PrismaClient,

--- a/tests/proxy_unit_tests/test_unit_test_proxy_hooks.py
+++ b/tests/proxy_unit_tests/test_unit_test_proxy_hooks.py
@@ -47,3 +47,135 @@ async def test_disable_spend_logs():
         )
         # Verify no spend logs were added
         assert len(mock_prisma_client.spend_log_transactions) == 0
+
+
+@pytest.mark.asyncio
+async def test_disable_entity_spend_updates():
+    """
+    Test that _batch_database_updates is NOT scheduled when
+    disable_entity_spend_updates=True in general_settings.
+    """
+    mock_prisma_client = Mock()
+    mock_prisma_client.spend_log_transactions = []
+    mock_prisma_client._spend_log_transactions_lock = asyncio.Lock()
+
+    with (
+        patch("litellm.proxy.proxy_server.disable_spend_logs", False),
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+        patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {"disable_entity_spend_updates": True},
+        ),
+        patch(
+            "litellm.proxy.db.db_spend_update_writer.DBSpendUpdateWriter._batch_database_updates",
+            new_callable=AsyncMock,
+        ) as mock_batch,
+    ):
+        from litellm.proxy.db.db_spend_update_writer import DBSpendUpdateWriter
+
+        db_spend_update_writer = DBSpendUpdateWriter()
+
+        await db_spend_update_writer.update_database(
+            token="sk-test",
+            response_cost=0.1,
+            user_id="user123",
+            completion_response=None,
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            end_user_id="end_user_id",
+            team_id="team_id",
+            org_id="org_id",
+            kwargs={},
+        )
+        await asyncio.sleep(0.1)
+        assert not mock_batch.called, (
+            "_batch_database_updates should not have been called"
+        )
+
+
+@pytest.mark.asyncio
+async def test_disable_entity_spend_updates_preserves_spend_logs():
+    """
+    Test that raw spend logs are still written when
+    disable_entity_spend_updates=True.
+    """
+    mock_prisma_client = Mock()
+    mock_prisma_client.spend_log_transactions = []
+    mock_prisma_client._spend_log_transactions_lock = asyncio.Lock()
+
+    with (
+        patch("litellm.proxy.proxy_server.disable_spend_logs", False),
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+        patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {"disable_entity_spend_updates": True},
+        ),
+        patch(
+            "litellm.proxy.db.db_spend_update_writer.DBSpendUpdateWriter._batch_database_updates",
+            new_callable=AsyncMock,
+        ),
+    ):
+        from litellm.proxy.db.db_spend_update_writer import DBSpendUpdateWriter
+
+        db_spend_update_writer = DBSpendUpdateWriter()
+
+        await db_spend_update_writer.update_database(
+            token="sk-test",
+            response_cost=0.1,
+            user_id="user123",
+            completion_response=None,
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            end_user_id="end_user_id",
+            team_id="team_id",
+            org_id="org_id",
+            kwargs={},
+        )
+        assert len(mock_prisma_client.spend_log_transactions) == 1, (
+            "Raw spend log should still be written when "
+            "disable_entity_spend_updates=True"
+        )
+
+
+@pytest.mark.asyncio
+async def test_disable_entity_spend_updates_false_still_runs_batch():
+    """
+    Test that _batch_database_updates IS scheduled when
+    disable_entity_spend_updates is absent (default) or False.
+    """
+    mock_prisma_client = Mock()
+    mock_prisma_client.spend_log_transactions = []
+    mock_prisma_client._spend_log_transactions_lock = asyncio.Lock()
+
+    with (
+        patch("litellm.proxy.proxy_server.disable_spend_logs", False),
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+        patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {},  # flag absent — default behavior
+        ),
+        patch(
+            "litellm.proxy.db.db_spend_update_writer.DBSpendUpdateWriter._batch_database_updates",
+            new_callable=AsyncMock,
+        ) as mock_batch,
+    ):
+        from litellm.proxy.db.db_spend_update_writer import DBSpendUpdateWriter
+
+        db_spend_update_writer = DBSpendUpdateWriter()
+
+        await db_spend_update_writer.update_database(
+            token="sk-test",
+            response_cost=0.1,
+            user_id="user123",
+            completion_response=None,
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            end_user_id="end_user_id",
+            team_id="team_id",
+            org_id="org_id",
+            kwargs={},
+        )
+        await asyncio.sleep(0.1)
+        assert mock_batch.called, (
+            "_batch_database_updates should have been called by default"
+        )

--- a/tests/proxy_unit_tests/test_unit_test_proxy_hooks.py
+++ b/tests/proxy_unit_tests/test_unit_test_proxy_hooks.py
@@ -50,10 +50,56 @@ async def test_disable_spend_logs():
 
 
 @pytest.mark.asyncio
-async def test_disable_entity_spend_updates():
+async def test_disable_entity_and_daily_skips_batch_task():
     """
-    Test that _batch_database_updates is NOT scheduled when
-    disable_entity_spend_updates=True in general_settings.
+    When both entity and daily spend updates are fully disabled, the batch
+    task is not scheduled (SpendLogs still written).
+    """
+    mock_prisma_client = Mock()
+    mock_prisma_client.spend_log_transactions = []
+    mock_prisma_client._spend_log_transactions_lock = asyncio.Lock()
+
+    with (
+        patch("litellm.proxy.proxy_server.disable_spend_logs", False),
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+        patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {
+                "disable_entity_spend_updates": True,
+                "disable_daily_spend_updates": True,
+            },
+        ),
+        patch(
+            "litellm.proxy.db.db_spend_update_writer.DBSpendUpdateWriter._batch_database_updates",
+            new_callable=AsyncMock,
+        ) as mock_batch,
+    ):
+        from litellm.proxy.db.db_spend_update_writer import DBSpendUpdateWriter
+
+        db_spend_update_writer = DBSpendUpdateWriter()
+
+        await db_spend_update_writer.update_database(
+            token="sk-test",
+            response_cost=0.1,
+            user_id="user123",
+            completion_response=None,
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+            end_user_id="end_user_id",
+            team_id="team_id",
+            org_id="org_id",
+            kwargs={},
+        )
+        await asyncio.sleep(0.1)
+        assert not mock_batch.called
+        assert len(mock_prisma_client.spend_log_transactions) == 1
+
+
+@pytest.mark.asyncio
+async def test_disable_entity_keeps_daily_batch_scheduled():
+    """
+    disable_entity_spend_updates alone still schedules the batch so daily
+    tables (e.g. DailyTagSpend for warehouse CDC) keep updating.
     """
     mock_prisma_client = Mock()
     mock_prisma_client.spend_log_transactions = []
@@ -88,60 +134,112 @@ async def test_disable_entity_spend_updates():
             kwargs={},
         )
         await asyncio.sleep(0.1)
-        assert not mock_batch.called, (
-            "_batch_database_updates should not have been called"
-        )
+        assert mock_batch.called
+        assert len(mock_prisma_client.spend_log_transactions) == 1
 
 
 @pytest.mark.asyncio
-async def test_disable_entity_spend_updates_preserves_spend_logs():
+async def test_batch_skips_entity_helpers_keeps_daily_tag():
     """
-    Test that raw spend logs are still written when
-    disable_entity_spend_updates=True.
+    Inside the batch: entity helpers skipped, daily tag helper still runs.
     """
     mock_prisma_client = Mock()
-    mock_prisma_client.spend_log_transactions = []
-    mock_prisma_client._spend_log_transactions_lock = asyncio.Lock()
 
-    with (
-        patch("litellm.proxy.proxy_server.disable_spend_logs", False),
-        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
-        patch(
-            "litellm.proxy.proxy_server.general_settings",
-            {"disable_entity_spend_updates": True},
-        ),
-        patch(
-            "litellm.proxy.db.db_spend_update_writer.DBSpendUpdateWriter._batch_database_updates",
-            new_callable=AsyncMock,
-        ),
+    with patch(
+        "litellm.proxy.proxy_server.general_settings",
+        {"disable_entity_spend_updates": True},
     ):
         from litellm.proxy.db.db_spend_update_writer import DBSpendUpdateWriter
 
-        db_spend_update_writer = DBSpendUpdateWriter()
+        writer = DBSpendUpdateWriter()
+        writer._update_user_db = AsyncMock()
+        writer._update_key_db = AsyncMock()
+        writer._update_team_db = AsyncMock()
+        writer._update_org_db = AsyncMock()
+        writer._update_tag_db = AsyncMock()
+        writer._update_agent_db = AsyncMock()
+        writer.add_spend_log_transaction_to_daily_user_transaction = AsyncMock()
+        writer.add_spend_log_transaction_to_daily_end_user_transaction = AsyncMock()
+        writer.add_spend_log_transaction_to_daily_agent_transaction = AsyncMock()
+        writer.add_spend_log_transaction_to_daily_team_transaction = AsyncMock()
+        writer.add_spend_log_transaction_to_daily_org_transaction = AsyncMock()
+        writer.add_spend_log_transaction_to_daily_tag_transaction = AsyncMock()
 
-        await db_spend_update_writer.update_database(
-            token="sk-test",
+        await writer._batch_database_updates(
             response_cost=0.1,
             user_id="user123",
-            completion_response=None,
-            start_time=datetime.now(),
-            end_time=datetime.now(),
-            end_user_id="end_user_id",
-            team_id="team_id",
-            org_id="org_id",
-            kwargs={},
+            hashed_token="hashed",
+            team_id="team",
+            org_id="org",
+            end_user_id="end",
+            prisma_client=mock_prisma_client,
+            litellm_proxy_budget_name=None,
+            payload={"request_tags": [], "agent_id": None},
         )
-        assert len(mock_prisma_client.spend_log_transactions) == 1, (
-            "Raw spend log should still be written when "
-            "disable_entity_spend_updates=True"
+
+        writer._update_user_db.assert_not_called()
+        writer._update_key_db.assert_not_called()
+        writer._update_team_db.assert_not_called()
+        writer._update_org_db.assert_not_called()
+        writer._update_tag_db.assert_not_called()
+        writer._update_agent_db.assert_not_called()
+
+        writer.add_spend_log_transaction_to_daily_tag_transaction.assert_awaited_once()
+        writer.add_spend_log_transaction_to_daily_user_transaction.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_list_config_disables_only_named_entity_and_daily_types():
+    """List form: only named types are skipped."""
+    mock_prisma_client = Mock()
+
+    with patch(
+        "litellm.proxy.proxy_server.general_settings",
+        {
+            "disable_entity_spend_updates": ["user", "key"],
+            "disable_daily_spend_updates": ["user", "team"],
+        },
+    ):
+        from litellm.proxy.db.db_spend_update_writer import DBSpendUpdateWriter
+
+        writer = DBSpendUpdateWriter()
+        writer._update_user_db = AsyncMock()
+        writer._update_key_db = AsyncMock()
+        writer._update_team_db = AsyncMock()
+        writer._update_org_db = AsyncMock()
+        writer._update_tag_db = AsyncMock()
+        writer._update_agent_db = AsyncMock()
+        writer.add_spend_log_transaction_to_daily_user_transaction = AsyncMock()
+        writer.add_spend_log_transaction_to_daily_end_user_transaction = AsyncMock()
+        writer.add_spend_log_transaction_to_daily_agent_transaction = AsyncMock()
+        writer.add_spend_log_transaction_to_daily_team_transaction = AsyncMock()
+        writer.add_spend_log_transaction_to_daily_org_transaction = AsyncMock()
+        writer.add_spend_log_transaction_to_daily_tag_transaction = AsyncMock()
+
+        await writer._batch_database_updates(
+            response_cost=0.1,
+            user_id="user123",
+            hashed_token="hashed",
+            team_id="team",
+            org_id="org",
+            end_user_id="end",
+            prisma_client=mock_prisma_client,
+            litellm_proxy_budget_name=None,
+            payload={"request_tags": [], "agent_id": None},
         )
+
+        writer._update_user_db.assert_not_called()
+        writer._update_key_db.assert_not_called()
+        writer._update_team_db.assert_awaited_once()
+        writer.add_spend_log_transaction_to_daily_user_transaction.assert_not_called()
+        writer.add_spend_log_transaction_to_daily_team_transaction.assert_not_called()
+        writer.add_spend_log_transaction_to_daily_tag_transaction.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_disable_entity_spend_updates_false_still_runs_batch():
     """
-    Test that _batch_database_updates IS scheduled when
-    disable_entity_spend_updates is absent (default) or False.
+    Test that _batch_database_updates IS scheduled when flags are absent.
     """
     mock_prisma_client = Mock()
     mock_prisma_client.spend_log_transactions = []

--- a/tests/test_litellm/proxy/utils/prisma_and_spend/test_proxy_update_spend.py
+++ b/tests/test_litellm/proxy/utils/prisma_and_spend/test_proxy_update_spend.py
@@ -384,17 +384,18 @@ def test_disable_spend_updates_error_when_general_settings_unavailable(
 def test_disable_entity_spend_updates_reflects_general_settings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The static method delegates to ``general_settings['disable_entity_spend_updates']``."""
+    """``true`` disables all entity counter types."""
     import litellm.proxy.proxy_server as proxy_server_mod
 
     monkeypatch.setattr(
         proxy_server_mod, "general_settings", {"disable_entity_spend_updates": True}
     )
     assert ProxyUpdateSpend.disable_entity_spend_updates() is True
-    assert isinstance(ProxyUpdateSpend.disable_entity_spend_updates(), bool)
-    assert isinstance(
-        ProxyUpdateSpend.__dict__["disable_entity_spend_updates"], staticmethod
-    )
+    assert ProxyUpdateSpend.is_entity_spend_update_disabled("user") is True
+    assert ProxyUpdateSpend.is_entity_spend_update_disabled("key") is True
+    # Daily tables unaffected by entity flag alone
+    assert ProxyUpdateSpend.is_daily_spend_update_disabled("tag") is False
+    assert ProxyUpdateSpend.should_run_batch_database_updates() is True
 
 
 def test_disable_entity_spend_updates_default_false_without_flag(
@@ -404,3 +405,58 @@ def test_disable_entity_spend_updates_default_false_without_flag(
 
     monkeypatch.setattr(proxy_server_mod, "general_settings", {})
     assert ProxyUpdateSpend.disable_entity_spend_updates() is False
+    assert ProxyUpdateSpend.disable_daily_spend_updates() is False
+    assert ProxyUpdateSpend.should_run_batch_database_updates() is True
+
+
+def test_disable_entity_spend_updates_list_form(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import litellm.proxy.proxy_server as proxy_server_mod
+
+    monkeypatch.setattr(
+        proxy_server_mod,
+        "general_settings",
+        {"disable_entity_spend_updates": ["user", "KEY", "unknown"]},
+    )
+    assert ProxyUpdateSpend.disable_entity_spend_updates() is False  # not all
+    assert ProxyUpdateSpend.is_entity_spend_update_disabled("user") is True
+    assert ProxyUpdateSpend.is_entity_spend_update_disabled("key") is True
+    assert ProxyUpdateSpend.is_entity_spend_update_disabled("team") is False
+    assert ProxyUpdateSpend.disabled_entity_spend_update_types() == frozenset(
+        {"user", "key"}
+    )
+
+
+def test_disable_daily_spend_updates_list_keeps_tag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import litellm.proxy.proxy_server as proxy_server_mod
+
+    monkeypatch.setattr(
+        proxy_server_mod,
+        "general_settings",
+        {
+            "disable_entity_spend_updates": True,
+            "disable_daily_spend_updates": ["user", "team"],
+        },
+    )
+    assert ProxyUpdateSpend.is_daily_spend_update_disabled("user") is True
+    assert ProxyUpdateSpend.is_daily_spend_update_disabled("tag") is False
+    assert ProxyUpdateSpend.should_run_batch_database_updates() is True
+
+
+def test_both_flags_true_skips_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import litellm.proxy.proxy_server as proxy_server_mod
+
+    monkeypatch.setattr(
+        proxy_server_mod,
+        "general_settings",
+        {
+            "disable_entity_spend_updates": True,
+            "disable_daily_spend_updates": True,
+        },
+    )
+    assert ProxyUpdateSpend.should_run_batch_database_updates() is False

--- a/tests/test_litellm/proxy/utils/prisma_and_spend/test_proxy_update_spend.py
+++ b/tests/test_litellm/proxy/utils/prisma_and_spend/test_proxy_update_spend.py
@@ -379,3 +379,28 @@ def test_disable_spend_updates_error_when_general_settings_unavailable(
     monkeypatch.delattr(proxy_server_mod, "general_settings", raising=False)
     with pytest.raises(ImportError):
         ProxyUpdateSpend.disable_spend_updates()
+
+
+def test_disable_entity_spend_updates_reflects_general_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The static method delegates to ``general_settings['disable_entity_spend_updates']``."""
+    import litellm.proxy.proxy_server as proxy_server_mod
+
+    monkeypatch.setattr(
+        proxy_server_mod, "general_settings", {"disable_entity_spend_updates": True}
+    )
+    assert ProxyUpdateSpend.disable_entity_spend_updates() is True
+    assert isinstance(ProxyUpdateSpend.disable_entity_spend_updates(), bool)
+    assert isinstance(
+        ProxyUpdateSpend.__dict__["disable_entity_spend_updates"], staticmethod
+    )
+
+
+def test_disable_entity_spend_updates_default_false_without_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import litellm.proxy.proxy_server as proxy_server_mod
+
+    monkeypatch.setattr(proxy_server_mod, "general_settings", {})
+    assert ProxyUpdateSpend.disable_entity_spend_updates() is False


### PR DESCRIPTION
## Summary
Implements / extends [BerriAI/litellm#31866](https://github.com/BerriAI/litellm/issues/31866) with **independent** controls for entity counters vs daily tables.

### Why not gate the whole `_batch_database_updates`?
The original issue proposal skipped the entire batch task. That also drops `LiteLLM_DailyTagSpend`, which many deployments CDC into a warehouse (e.g. Snowflake). Operators usually want to kill the **UserTable / key / team hot-row UPDATEs** while **keeping** DailyTagSpend.

### Config (maximum configurability)

```yaml
general_settings:
  # Rolling counters on key/user/team/org/tag/agent tables.
  # true = all; or list a subset: [user], [user, key], …
  disable_entity_spend_updates: true

  # Daily dimension tables (DailyUserSpend, DailyTagSpend, …).
  # false/absent = keep all (warehouse-friendly default when only entity is disabled).
  # true = all; or list: [user, team] while keeping tag for CDC.
  disable_daily_spend_updates: false
```

| Setting | SpendLogs | UserTable/key/team counters | DailyTagSpend |
|---|---|---|---|
| (defaults) | ✅ | ✅ | ✅ |
| `disable_entity_spend_updates: true` | ✅ | ❌ | ✅ |
| `disable_entity_spend_updates: [user]` | ✅ | user ❌, others ✅ | ✅ |
| `disable_daily_spend_updates: true` | ✅ | ✅ | ❌ |
| both `true` | ✅ | ❌ | ❌ |
| `disable_spend_updates: true` (existing) | ❌ | ❌ | ❌ |

### Behavior notes
- Defaults absent/`false` → no behavior change
- List form is case-insensitive; unknown names ignored
- Per-entity budget enforcement is disabled only for skipped entity counter types
- If both categories are fully disabled, `_batch_database_updates` is not scheduled (SpendLogs still written)

## Test plan
- [x] Unit: entity `true` still schedules batch (daily kept)
- [x] Unit: entity+daily `true` skips batch; SpendLogs preserved
- [x] Unit: inside batch, entity helpers skipped / daily tag still called
- [x] Unit: list form disables only named types
- [ ] CI pytest for the new cases

Closes #31866