### PR TITLE
fix(responses): preserve custom tools through guardrails

### DIFF
--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -34,9 +34,6 @@ from openai.types.responses.response_function_tool_call import ResponseFunctionT
 from pydantic import BaseModel
 
 from litellm._logging import verbose_proxy_logger
-from litellm.completion_extras.litellm_responses_transformation.transformation import (
-    OpenAiResponsesToChatCompletionStreamIterator,
-)
 from litellm.llms.base_llm.guardrail_translation.base_translation import BaseTranslation
 from litellm.responses.litellm_completion_transformation.transformation import (
     LiteLLMCompletionResponsesConfig,
@@ -48,6 +45,7 @@ from litellm.types.llms.openai import (
     ResponsesAPIStreamEvents,
 )
 from litellm.types.responses.main import (
+    CustomToolCallOutputItem,
     GenericResponseOutputItem,
     OutputFunctionToolCall,
     OutputText,
@@ -252,21 +250,45 @@ class OpenAIResponsesHandler(BaseTranslation):
         """
         if not original_tools:
             return remapped
+        remaining_custom_tools = [
+            tool for tool in original_tools if isinstance(tool, dict) and tool.get("type") == "custom"
+        ]
         result: List[Dict[str, Any]] = []
-        j = 0
-        for tool in original_tools:
-            if isinstance(tool, dict) and tool.get("type") in (
-                "web_search",
-                "web_search_preview",
-            ):
-                result.append(tool)
-            else:
-                if j < len(remapped):
-                    result.append(remapped[j])
-                    j += 1
-        # Keep guardrail-appended tools that matched no original slot above.
-        result.extend(remapped[j:])
+        for remapped_tool in remapped:
+            restored_tool = remapped_tool
+            for custom_index, original_tool in enumerate(remaining_custom_tools):
+                candidate = self._restore_unchanged_custom_tool(
+                    original_tool=original_tool,
+                    remapped_tool=remapped_tool,
+                )
+                if candidate is original_tool:
+                    restored_tool = candidate
+                    remaining_custom_tools.pop(custom_index)
+                    break
+            result.append(restored_tool)
+
+        for original_index, original_tool in enumerate(original_tools):
+            if original_tool.get("type") in ("web_search", "web_search_preview"):
+                result.insert(min(original_index, len(result)), original_tool)
         return result
+
+    def _restore_unchanged_custom_tool(
+        self,
+        original_tool: dict[str, Any],
+        remapped_tool: dict[str, Any],
+    ) -> dict[str, Any]:
+        if original_tool.get("type") != "custom":
+            return remapped_tool
+
+        transformed, _ = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            [original_tool]
+        )
+        expected = LiteLLMCompletionResponsesConfig.transform_chat_completion_tool_params_to_responses_api_tools(
+            transformed
+        )
+        if expected == [remapped_tool]:
+            return original_tool
+        return remapped_tool
 
     def _apply_guardrailed_tools_to_data(
         self,
@@ -550,15 +572,22 @@ class OpenAIResponsesHandler(BaseTranslation):
         # Case 2: response.output_item.done — extract tool calls only.        #
         # ------------------------------------------------------------------ #
         if final_chunk.get("type") == "response.output_item.done":
-            model_response_stream = (
-                OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(final_chunk)
-            )
-            tool_calls = model_response_stream.choices[0].delta.tool_calls
+            tool_calls: list[ChatCompletionToolCallChunk] = []
+            output_item = final_chunk.get("item")
+            if output_item is not None:
+                self._extract_output_text_and_images(
+                    output_item=output_item,
+                    output_idx=final_chunk.get("output_index", 0),
+                    texts_to_check=[],
+                    images_to_check=[],
+                    task_mappings=[],
+                    tool_calls_to_check=tool_calls,
+                )
             if tool_calls:
-                inputs = GenericGuardrailAPIInputs()
-                inputs["tool_calls"] = cast(List[ChatCompletionToolCallChunk], tool_calls)
-                if hasattr(model_response_stream, "model") and model_response_stream.model:
-                    inputs["model"] = model_response_stream.model
+                inputs = GenericGuardrailAPIInputs(tool_calls=cast(list[ChatCompletionToolCallChunk], tool_calls))
+                response_model = final_chunk.get("model")
+                if response_model:
+                    inputs["model"] = response_model
                 await guardrail_to_apply.apply_guardrail(
                     inputs=inputs,
                     request_data=request_data if request_data is not None else {},
@@ -656,8 +685,7 @@ class OpenAIResponsesHandler(BaseTranslation):
         Override this method to customize text/image/tool extraction logic.
         """
 
-        # Check if this is a tool call (OutputFunctionToolCall)
-        if isinstance(output_item, OutputFunctionToolCall):
+        if isinstance(output_item, (OutputFunctionToolCall, CustomToolCallOutputItem)):
             if tool_calls_to_check is not None:
                 tool_call_dict = (
                     LiteLLMCompletionResponsesConfig.convert_response_function_tool_call_to_chat_completion_tool_call(
@@ -670,7 +698,7 @@ class OpenAIResponsesHandler(BaseTranslation):
         elif (
             isinstance(output_item, BaseModel)
             and hasattr(output_item, "type")
-            and getattr(output_item, "type") == "function_call"
+            and getattr(output_item, "type") in ("function_call", "custom_tool_call")
         ):
             if tool_calls_to_check is not None:
                 tool_call_dict = (
@@ -681,12 +709,17 @@ class OpenAIResponsesHandler(BaseTranslation):
                 )
                 tool_calls_to_check.append(cast(ChatCompletionToolCallChunk, tool_call_dict))
             return
-        elif isinstance(output_item, dict) and output_item.get("type") == "function_call":
-            # Handle dict representation of tool call
+        elif isinstance(output_item, dict) and output_item.get("type") in (
+            "function_call",
+            "custom_tool_call",
+        ):
             if tool_calls_to_check is not None:
-                # Convert dict to ResponseFunctionToolCall for processing
                 try:
-                    tool_call_obj = ResponseFunctionToolCall(**output_item)
+                    tool_call_obj = (
+                        CustomToolCallOutputItem(**output_item)
+                        if output_item.get("type") == "custom_tool_call"
+                        else ResponseFunctionToolCall(**output_item)
+                    )
                     tool_call_dict = LiteLLMCompletionResponsesConfig.convert_response_function_tool_call_to_chat_completion_tool_call(
                         tool_call_item=tool_call_obj,
                         index=output_idx,

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -157,7 +157,7 @@ class LiteLLMCompletionResponsesConfig:
                 # "tool" without a specific function name means "use any tool"
                 # which is equivalent to "required" in OpenAI format
                 return "required"
-            elif tool_choice_type == "function":
+            elif tool_choice_type in ("function", "custom"):
                 function_name = tool_choice.get("name")
                 if function_name:
                     return {"type": "function", "function": {"name": function_name}}
@@ -1530,7 +1530,11 @@ class LiteLLMCompletionResponsesConfig:
 
         function_dict: dict[str, Any] = {
             "name": tool_call_item.name,
-            "arguments": tool_call_item.arguments,
+            "arguments": (
+                json.dumps({"content": tool_call_item.input})
+                if getattr(tool_call_item, "type", None) == "custom_tool_call"
+                else tool_call_item.arguments
+            ),
         }
 
         if provider_specific_fields:
@@ -1543,7 +1547,7 @@ class LiteLLMCompletionResponsesConfig:
             ),
             "function": function_dict,
             "type": "function",
-            "index": 0,
+            "index": index,
         }
 
         if provider_specific_fields:

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_guardrail_handler.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_guardrail_handler.py
@@ -5,8 +5,10 @@ Tests the handler's ability to process input/output for the Responses API
 with guardrail transformations.
 """
 
+import json
 import os
 import sys
+from copy import deepcopy
 from typing import Any, List, Literal, Optional, Tuple
 from unittest.mock import AsyncMock, MagicMock
 
@@ -24,8 +26,18 @@ from litellm.llms import get_guardrail_translation_mapping
 from litellm.llms.openai.responses.guardrail_translation.handler import (
     OpenAIResponsesHandler,
 )
-from litellm.types.llms.openai import ResponsesAPIResponse
-from litellm.types.responses.main import GenericResponseOutputItem, OutputText
+from litellm.responses.litellm_completion_transformation.transformation import (
+    LiteLLMCompletionResponsesConfig,
+)
+from litellm.types.llms.openai import (
+    ChatCompletionToolCallChunk,
+    ResponsesAPIResponse,
+)
+from litellm.types.responses.main import (
+    CustomToolCallOutputItem,
+    GenericResponseOutputItem,
+    OutputText,
+)
 from litellm.types.utils import CallTypes, GenericGuardrailAPIInputs
 
 
@@ -181,6 +193,69 @@ class TestOpenAIResponsesHandlerInputProcessing:
         assert result["input"][0]["content"] is None
         # Empty string should be processed
         assert result["input"][1]["content"] == " [GUARDRAILED]"
+
+    @pytest.mark.asyncio
+    async def test_process_input_preserves_unchanged_custom_tool(self) -> None:
+        handler = OpenAIResponsesHandler()
+        guardrail = MockGuardrail(guardrail_name="test")
+        original_tools = [
+            {
+                "type": "custom",
+                "name": "exec",
+                "description": "Execute JavaScript",
+                "format": {
+                    "type": "grammar",
+                    "syntax": "lark",
+                    "definition": "start: /[\\s\\S]+/",
+                },
+            },
+            {
+                "type": "function",
+                "name": "get_weather",
+                "description": "Get the weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+            {"type": "web_search"},
+        ]
+        data = {
+            "input": "Use a tool",
+            "model": "gpt-4",
+            "tools": deepcopy(original_tools),
+        }
+
+        result = await handler.process_input_messages(data, guardrail)
+
+        assert result["tools"][0] == original_tools[0]
+        assert result["tools"][1]["type"] == "function"
+        assert result["tools"][1]["name"] == "get_weather"
+        assert result["tools"][2] == {"type": "web_search"}
+
+    def test_modified_custom_tool_is_not_restored(self) -> None:
+        handler = OpenAIResponsesHandler()
+        original_tool = {
+            "type": "custom",
+            "name": "exec",
+            "description": "Execute JavaScript",
+            "format": {"type": "text"},
+        }
+        transformed, _ = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            [original_tool]
+        )
+        remapped = LiteLLMCompletionResponsesConfig.transform_chat_completion_tool_params_to_responses_api_tools(
+            transformed
+        )[0]
+        remapped["description"] = "Redacted by guardrail"
+
+        result = handler._restore_unchanged_custom_tool(
+            original_tool=original_tool,
+            remapped_tool=remapped,
+        )
+
+        assert result == remapped
 
 
 class TestOpenAIResponsesHandlerOutputProcessing:
@@ -626,6 +701,53 @@ class TestOpenAIResponsesHandlerToolCallExtraction:
             == '{"location":"Boston, MA","unit":"celsius"}'
         )
 
+    @pytest.mark.parametrize(
+        "output_item",
+        [
+            CustomToolCallOutputItem(
+                call_id="call_exec",
+                id="fc_exec",
+                input='text("OK")',
+                name="exec",
+                status="completed",
+                type="custom_tool_call",
+            ),
+            {
+                "call_id": "call_exec",
+                "id": "fc_exec",
+                "input": 'text("OK")',
+                "name": "exec",
+                "status": "completed",
+                "type": "custom_tool_call",
+            },
+        ],
+    )
+    def test_extract_custom_tool_call(
+        self,
+        output_item: CustomToolCallOutputItem | dict[str, str],
+    ) -> None:
+        handler = OpenAIResponsesHandler()
+        tool_calls_to_check: List[ChatCompletionToolCallChunk] = []
+
+        handler._extract_output_text_and_images(
+            output_item=output_item,
+            output_idx=3,
+            texts_to_check=[],
+            images_to_check=[],
+            task_mappings=[],
+            tool_calls_to_check=tool_calls_to_check,
+        )
+
+        assert len(tool_calls_to_check) == 1
+        tool_call = tool_calls_to_check[0]
+        assert tool_call["id"] == "call_exec"
+        assert tool_call["type"] == "function"
+        assert tool_call["function"]["name"] == "exec"
+        assert tool_call["index"] == 3
+        assert json.loads(tool_call["function"]["arguments"]) == {
+            "content": 'text("OK")'
+        }
+
     @pytest.mark.asyncio
     async def test_process_output_response_with_tool_calls(self):
         """Test processing output response containing function tool calls"""
@@ -657,6 +779,33 @@ class TestOpenAIResponsesHandlerToolCallExtraction:
 
         assert exc_info.value.status_code == 400
         assert "Response blocked by guardrail" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_process_output_response_with_custom_tool_call(self) -> None:
+        handler = OpenAIResponsesHandler()
+        guardrail = MockGuardrail(guardrail_name="test")
+        response = ResponsesAPIResponse(
+            id="resp_custom",
+            created_at=1234567890,
+            model="glm",
+            object="response",
+            status="completed",
+            output=[
+                CustomToolCallOutputItem(
+                    call_id="call_exec",
+                    id="fc_exec",
+                    input='text("OK")',
+                    name="exec",
+                    status="completed",
+                    type="custom_tool_call",
+                )
+            ],
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await handler.process_output_response(response, guardrail)
+
+        assert exc_info.value.status_code == 400
 
     def test_extract_mixed_content_with_text_and_tool_calls(self):
         """Test extracting both text and tool calls from response"""
@@ -835,6 +984,66 @@ class MockPassThroughGuardrail(CustomGuardrail):
 
 class TestOpenAIResponsesHandlerStreamingOutputProcessing:
     """Test streaming output processing functionality"""
+
+    @pytest.mark.asyncio
+    async def test_completed_stream_custom_tool_call_runs_guardrail(self) -> None:
+        handler = OpenAIResponsesHandler()
+        guardrail = MockGuardrail(guardrail_name="test")
+        responses_so_far = [
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_custom",
+                    "model": "glm",
+                    "output": [
+                        {
+                            "call_id": "call_exec",
+                            "id": "fc_exec",
+                            "input": 'text("OK")',
+                            "name": "exec",
+                            "status": "completed",
+                            "type": "custom_tool_call",
+                        }
+                    ],
+                    "status": "completed",
+                },
+            }
+        ]
+
+        with pytest.raises(HTTPException) as exc_info:
+            await handler.process_output_streaming_response(
+                responses_so_far=responses_so_far,
+                guardrail_to_apply=guardrail,
+            )
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_output_item_done_custom_tool_call_runs_guardrail(self) -> None:
+        handler = OpenAIResponsesHandler()
+        guardrail = MockGuardrail(guardrail_name="test")
+        responses_so_far = [
+            {
+                "type": "response.output_item.done",
+                "output_index": 2,
+                "item": {
+                    "call_id": "call_exec",
+                    "id": "fc_exec",
+                    "input": 'text("OK")',
+                    "name": "exec",
+                    "status": "completed",
+                    "type": "custom_tool_call",
+                },
+            }
+        ]
+
+        with pytest.raises(HTTPException) as exc_info:
+            await handler.process_output_streaming_response(
+                responses_so_far=responses_so_far,
+                guardrail_to_apply=guardrail,
+            )
+
+        assert exc_info.value.status_code == 400
 
     @pytest.mark.asyncio
     async def test_process_output_streaming_response_empty_output(self):
@@ -1209,6 +1418,59 @@ class TestOpenAIResponsesHandlerToolInjection:
         ]
         merged = handler._merge_tools_after_guardrail(original, remapped)
         assert [t["name"] for t in merged] == ["a", "b"]
+
+    def test_merge_restores_custom_tool_after_preceding_tool_removed(self) -> None:
+        handler = OpenAIResponsesHandler()
+        custom_tool = {
+            "type": "custom",
+            "name": "exec",
+            "description": "Execute JavaScript",
+            "format": {"type": "text"},
+        }
+        transformed, _ = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            [custom_tool]
+        )
+        synthetic_tool = LiteLLMCompletionResponsesConfig.transform_chat_completion_tool_params_to_responses_api_tools(
+            transformed
+        )[0]
+        original = [
+            {"type": "function", "name": "removed_tool"},
+            custom_tool,
+        ]
+
+        merged = handler._merge_tools_after_guardrail(original, [synthetic_tool])
+
+        assert merged == [custom_tool]
+
+    def test_merge_restores_reordered_custom_tool_after_prepended_tool(self) -> None:
+        handler = OpenAIResponsesHandler()
+        custom_tool = {
+            "type": "custom",
+            "name": "exec",
+            "description": "Execute JavaScript",
+            "format": {"type": "text"},
+        }
+        transformed, _ = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            [custom_tool]
+        )
+        synthetic_tool = LiteLLMCompletionResponsesConfig.transform_chat_completion_tool_params_to_responses_api_tools(
+            transformed
+        )[0]
+        original_function = {
+            "type": "function",
+            "name": "get_weather",
+        }
+        prepended_function = {
+            "type": "function",
+            "name": "injected_tool",
+        }
+
+        merged = handler._merge_tools_after_guardrail(
+            [original_function, custom_tool],
+            [prepended_function, synthetic_tool, original_function],
+        )
+
+        assert merged == [prepended_function, custom_tool, original_function]
 
     @pytest.mark.asyncio
     async def test_injected_tool_survives_when_request_already_has_tools(self):

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -959,6 +959,12 @@ class TestToolChoiceTransformation:
         )
         assert result == {"type": "function", "function": {"name": "get_weather"}}
 
+    def test_transform_tool_choice_responses_custom_name(self) -> None:
+        result = LiteLLMCompletionResponsesConfig._transform_tool_choice(
+            {"type": "custom", "name": "exec"}
+        )
+        assert result == {"type": "function", "function": {"name": "exec"}}
+
     def test_transform_tool_choice_function_without_name_falls_back_to_required(self):
         """A function-type dict with no name still falls back to required"""
         result = LiteLLMCompletionResponsesConfig._transform_tool_choice(


### PR DESCRIPTION
## TLDR

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max
     This section must be extremely human parsable, comprehensible, and readable: its target audience is humans, not AI agents -->

Problem this solves:

- Custom tools lose their Responses shape after guardrails
- Custom outputs can skip guardrail inspection

How it solves it:

- Restore only unchanged custom tools after guardrails
- Inspect custom calls across all response paths

## Relevant issues

<!-- e.g., "Fixes #000" -->

Follow-up to #32258

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

The proxy used a live provider-backed model with a pass-through request and response guardrail

Request used for both runs:

```json
{
  "model": "glm-local",
  "input": "Call exec with exactly text(\"OK\"). Do not answer in prose.",
  "tools": [
    {
      "type": "custom",
      "name": "exec",
      "description": "Execute JavaScript and return its output",
      "format": {
        "type": "grammar",
        "syntax": "lark",
        "definition": "start: /[\\s\\S]+/"
      }
    }
  ],
  "tool_choice": {
    "type": "custom",
    "name": "exec"
  },
  "max_output_tokens": 100
}
```

Before (`baf85d7`):

```text
HTTP 500
Invalid tool choice, tool_choice={'type': 'custom', 'name': 'exec'}
```

After (`4fbe675`):

```text
HTTP 200
x-litellm-applied-guardrails: live-pass-through
LIVE_GUARDRAIL {"input_type":"request","tool_count":1,"tool_names":["exec"]}
LIVE_GUARDRAIL {"input_type":"response","tool_count":1,"tool_names":["exec"]}
```

```json
{
  "status": "completed",
  "output": [
    {
      "type": "custom_tool_call",
      "name": "exec",
      "input": "text(\"OK\")",
      "arguments": null
    }
  ]
}
```

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

The Responses bridge added in #32258 projects custom tools into functions for Chat Completions providers. Responses guardrail processing kept that projected function after inspection, so downstream clients received a `function_call` instead of the original `custom_tool_call`. Response guardrails also omitted custom calls from completed responses and `response.output_item.done` streaming events

This change restores an original custom tool only when the guardrail output exactly matches its function projection. Guardrail removals, reordering, modifications, and injected tools remain intact. Forced custom tool choices are translated for the provider, raw custom inputs are wrapped for guardrail inspection, and tool-call output indexes are preserved

Regression tests cover unchanged and modified custom tools, removed and reordered tools, injected tools, forced custom choices, Pydantic and dictionary outputs, completed and streaming responses, guardrail blocking, and output index preservation

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
