### PR TITLE
fix(proxy): read local config.yaml as utf-8 regardless of OS locale

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3804,7 +3804,7 @@ class ProxyConfig:
         Load and parse a YAML file
         """
         try:
-            with open(file_path, "r") as file:
+            with open(file_path, "r", encoding="utf-8") as file:
                 return yaml.safe_load(file) or {}
         except Exception as e:
             raise Exception(f"Error loading yaml file {file_path}: {str(e)}")
@@ -3825,7 +3825,7 @@ class ProxyConfig:
         # Load existing config
         ## Yaml
         if os.path.exists(f"{file_path}"):
-            with open(f"{file_path}", "r") as config_file:
+            with open(f"{file_path}", "r", encoding="utf-8") as config_file:
                 config = yaml.safe_load(config_file)
         elif file_path is not None:
             raise Exception(f"Config file not found: {file_path}")

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -8,6 +8,7 @@ Pins covered:
 
 from __future__ import annotations
 
+import builtins
 import json
 import os
 from types import SimpleNamespace
@@ -325,6 +326,24 @@ def test_ProxyConfig__load_yaml_file_raises_on_missing_file():
         pc._load_yaml_file("/no/such/file.yaml")
 
 
+def _open_with_ascii_default(real_open):
+    def opener(file, mode="r", *args, encoding=None, **kwargs):
+        if "b" not in mode and encoding is None:
+            encoding = "ascii"
+        return real_open(file, mode, *args, encoding=encoding, **kwargs)
+
+    return opener
+
+
+def test_ProxyConfig__load_yaml_file_reads_utf8_under_non_utf8_locale(tmp_path, monkeypatch):
+    f = tmp_path / "c.yaml"
+    f.write_text('general_settings:\n  alerting_args:\n    daily_report_note: "Pākīhi – café"\n', encoding="utf-8")
+    monkeypatch.setattr(builtins, "open", _open_with_ascii_default(open))
+    pc = ProxyConfig()
+    result = pc._load_yaml_file(str(f))
+    assert result == {"general_settings": {"alerting_args": {"daily_report_note": "Pākīhi – café"}}}
+
+
 # ---------------------------------------------------------------------------
 # ProxyConfig._get_config_from_file
 # ---------------------------------------------------------------------------
@@ -348,6 +367,19 @@ async def test_ProxyConfig__get_config_from_file_missing_path_raises():
     pc = ProxyConfig()
     with pytest.raises(Exception):
         await pc._get_config_from_file(config_file_path="/no/such/file.yaml")
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig__get_config_from_file_reads_utf8_under_non_utf8_locale(tmp_path, monkeypatch):
+    f = tmp_path / "c.yaml"
+    f.write_text(
+        'model_list:\n  - model_name: "summariser – bāsic"\n    litellm_params:\n      model: gpt-4o\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(builtins, "open", _open_with_ascii_default(open))
+    pc = ProxyConfig()
+    result = await pc._get_config_from_file(config_file_path=str(f))
+    assert result == {"model_list": [{"model_name": "summariser – bāsic", "litellm_params": {"model": "gpt-4o"}}]}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## TLDR

Problem this solves:

- Proxy on Windows crashes loading a UTF-8 config.yaml with non-ASCII characters
- Other non-ASCII characters silently corrupt model names instead of crashing

How it solves it:

- Open the local config.yaml with explicit utf-8 encoding
- Matches what the S3 and GCS config loaders already do

## Relevant issues

Same bug class as #10272, #10340, #10503 and #10570, which were all fixed by adding explicit utf-8 encoding to packaged JSON reads. The local proxy config loader was not covered by those fixes

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

`ProxyConfig._load_yaml_file` and `ProxyConfig._get_config_from_file` open the user's config.yaml without an encoding argument, so Python falls back to the OS locale encoding. On Linux and macOS that is UTF-8 and everything works. On Windows it is a legacy code page (cp1252 on Western installs), which breaks a UTF-8 config in two ways: characters whose UTF-8 bytes include 0x81, 0x8D, 0x8F, 0x90 or 0x9D (for example the macron in "tāhua") crash the proxy at startup with UnicodeDecodeError, and most other non-ASCII characters decode to the wrong text with no error at all, so a model_name like "haiku café tier" silently becomes "haiku cafÃ© tier" and requests for the configured name return 404

The S3 and GCS config paths already decode the file as UTF-8 explicitly (litellm/proxy/common_utils/load_config_utils.py), so the same config behaves differently depending on where it is loaded from. Config includes are covered by this fix too because _process_includes loads each included file through _load_yaml_file

Config used for both runs (saved as UTF-8, which is what every modern editor writes):

```yaml
model_list:
  - model_name: "haiku – tāhua tier"
    litellm_params:
      model: anthropic/claude-haiku-4-5-20251001
      api_key: os.environ/ANTHROPIC_API_KEY
  - model_name: "haiku café tier"
    litellm_params:
      model: anthropic/claude-haiku-4-5-20251001
      api_key: os.environ/ANTHROPIC_API_KEY

general_settings:
  master_key: sk-proof-1234
```

Before (commit f1f0a0bacd, Windows 11, Python 3.13.12, cp1252 locale), the proxy cannot start:

```
> litellm --config config.yaml --port 4000
...
  File "...\litellm\proxy\proxy_server.py", line 3828, in _get_config_from_file
    config = yaml.safe_load(config_file)
  File "...\yaml\reader.py", line 178, in update_raw
    data = self.stream.read(size)
  File "...\Python313\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 41: character maps to <undefined>
```

After (commit 770b0da0b6), same config and machine, the proxy starts and serves a real Anthropic completion through the accented alias:

```
> litellm --config config.yaml --port 4000
...
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:4000 (Press CTRL+C to quit)

> curl -s -X POST http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer sk-proof-1234" -H "Content-Type: application/json" \
    -d '{"model": "haiku café tier", "messages": [{"role": "user", "content": "Say hello in te reo Māori, five words max"}], "max_tokens": 60}'
{"id":"chatcmpl-6e4dbbd9-4b31-4226-9cc6-fe00a9351f5c","created":1784716410,"model":"haiku café tier",
 "object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":
 "Kia ora! Tēnā koe!\n\n(Hello! Greetings to you!)","role":"assistant",...}}],
 "usage":{"completion_tokens":27,"prompt_tokens":20,"total_tokens":47,...}}
```

One note from the after run: the first model alias ("haiku – tāhua tier") now loads and routes correctly, but a chat completion against it fails later in chat_completion with a separate latin-1 header encoding error that exists on every OS and is unrelated to config loading. I kept it in the proof config because its macron is what triggers the startup crash in the before run, and used the latin-1-safe "haiku café tier" alias for the end-to-end call. Happy to file that second bug as its own issue

## Type

🐛 Bug Fix

## Changes

Adds encoding="utf-8" to the two config.yaml open() calls in ProxyConfig (_load_yaml_file and _get_config_from_file). Adds two regression tests in tests/test_litellm/proxy/proxy_server/test_proxy_config.py that simulate a non-UTF-8 locale by defaulting open() to ascii when no encoding is passed, so they fail on the old code on any platform, including UTF-8 Linux CI, and assert the exact non-ASCII values round-trip. open() is patched at the builtins level so the tests can reproduce a non-UTF-8 locale and fail on the unfixed code even on UTF-8 Linux CI; dependency-injecting an opener would mean widening the ProxyConfig read signature that this two-line fix intentionally leaves untouched

One deliberate non-change: the config write path (yaml.dump in save_config) is left alone because yaml.dump escapes non-ASCII by default, so its output is pure ASCII and writes safely under any locale. The CLI's get_model_list_from_yaml_file has the same read issue but lives in a different module; happy to fix it in a follow-up if wanted

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
