### PR TITLE
feat(proxy): add model group budgets for virtual keys

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1670,7 +1670,7 @@ class BudgetNewRequest(LiteLLMPydanticObjectBase):
     )
     model_max_budget: Optional[GenericBudgetConfigType] = Field(
         default=None,
-        description="Max budget for each model (e.g. {'gpt-4o': {'max_budget': '0.0000001', 'budget_duration': '1d', 'tpm_limit': 1000, 'rpm_limit': 1000}})",
+        description="Max budget for each model (e.g. {'gpt-4o': {'max_budget': '0.0000001', 'budget_duration': '1d', 'tpm_limit': 1000, 'rpm_limit': 1000}}). An entry with 'models' set shares one budget across that group of models (e.g. {'opus-family': {'models': ['claude-opus-4-5', 'claude-opus-4-6'], 'max_budget': 10, 'budget_duration': '30d'}})",
     )
     budget_reset_at: Optional[datetime] = Field(
         default=None,

--- a/litellm/proxy/hooks/model_max_budget_limiter.py
+++ b/litellm/proxy/hooks/model_max_budget_limiter.py
@@ -258,7 +258,13 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
         return tuple(
             (_group_name, _config)
             for _group_name, _config in internal_model_max_budget.items()
-            if _config.models and (model in _config.models or model_without_provider in _config.models)
+            if _config.models
+            and any(
+                _member == model
+                or _member == model_without_provider
+                or self._get_model_without_custom_llm_provider(_member) == model
+                for _member in _config.models
+            )
         )
 
     def _get_model_without_custom_llm_provider(self, model: str) -> str:

--- a/litellm/proxy/hooks/model_max_budget_limiter.py
+++ b/litellm/proxy/hooks/model_max_budget_limiter.py
@@ -264,8 +264,7 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
         key_budget_config: BudgetConfig,
     ) -> float | None:
         model_group_spend_cache_key = (
-            f"{END_USER_SPEND_CACHE_KEY_PREFIX}:{end_user_id}:{model_group_name}:"
-            f"{key_budget_config.budget_duration}"
+            f"{END_USER_SPEND_CACHE_KEY_PREFIX}:{end_user_id}:{model_group_name}:{key_budget_config.budget_duration}"
         )
         return await self.dual_cache.async_get_cache(key=model_group_spend_cache_key)
 

--- a/litellm/proxy/hooks/model_max_budget_limiter.py
+++ b/litellm/proxy/hooks/model_max_budget_limiter.py
@@ -146,10 +146,13 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
         )
         if _current_model_budget_info is None:
             verbose_proxy_logger.debug(f"Model {model} not found in end_user_model_max_budget")
-            return True
 
         # check if current model is within budget
-        if _current_model_budget_info.max_budget and _current_model_budget_info.max_budget > 0:
+        if (
+            _current_model_budget_info is not None
+            and _current_model_budget_info.max_budget
+            and _current_model_budget_info.max_budget > 0
+        ):
             _current_spend = await self._get_end_user_spend_for_model(
                 end_user_id=end_user_id,
                 model=model,
@@ -164,6 +167,25 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
                     message=f"LiteLLM End User: {end_user_id}, exceeded budget for model={model}",
                     current_cost=_current_spend,
                     max_budget=_current_model_budget_info.max_budget,
+                    entity_type=Litellm_EntityType.END_USER.value,
+                    entity_id=end_user_id,
+                )
+
+        for _group_name, _group_budget_info in self._get_matching_model_group_budget_configs(
+            model=model, internal_model_max_budget=internal_model_max_budget
+        ):
+            if not _group_budget_info.max_budget or _group_budget_info.max_budget <= 0:
+                continue
+            _group_spend = await self._get_end_user_spend_for_model_group(
+                end_user_id=end_user_id,
+                model_group_name=_group_name,
+                key_budget_config=_group_budget_info,
+            )
+            if _group_spend is not None and _group_spend > _group_budget_info.max_budget:
+                raise litellm.BudgetExceededError(
+                    message=f"LiteLLM End User: {end_user_id}, exceeded budget for model group={_group_name}, model={model}",
+                    current_cost=_group_spend,
+                    max_budget=_group_budget_info.max_budget,
                     entity_type=Litellm_EntityType.END_USER.value,
                     entity_id=end_user_id,
                 )
@@ -231,6 +253,18 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
     ) -> float | None:
         model_group_spend_cache_key = (
             f"{VIRTUAL_KEY_SPEND_CACHE_KEY_PREFIX}:{user_api_key_hash}:{model_group_name}:"
+            f"{key_budget_config.budget_duration}"
+        )
+        return await self.dual_cache.async_get_cache(key=model_group_spend_cache_key)
+
+    async def _get_end_user_spend_for_model_group(
+        self,
+        end_user_id: str,
+        model_group_name: str,
+        key_budget_config: BudgetConfig,
+    ) -> float | None:
+        model_group_spend_cache_key = (
+            f"{END_USER_SPEND_CACHE_KEY_PREFIX}:{end_user_id}:{model_group_name}:"
             f"{key_budget_config.budget_duration}"
         )
         return await self.dual_cache.async_get_cache(key=model_group_spend_cache_key)
@@ -386,6 +420,22 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
                     budget_config=key_budget_config,
                     spend_key=end_user_spend_key,
                     start_time_key=end_user_start_time_key,
+                    response_cost=response_cost,
+                )
+            for _group_name, _group_budget_config in self._get_matching_model_group_budget_configs(
+                model=model, internal_model_max_budget=internal_model_max_budget
+            ):
+                if _group_budget_config.budget_duration is None:
+                    continue
+                end_user_group_spend_key = (
+                    f"{END_USER_SPEND_CACHE_KEY_PREFIX}:{end_user_id}:{_group_name}:"
+                    f"{_group_budget_config.budget_duration}"
+                )
+                end_user_group_start_time_key = f"end_user_budget_start_time:{end_user_id}:{_group_name}"
+                await self._increment_spend_for_key(
+                    budget_config=_group_budget_config,
+                    spend_key=end_user_group_spend_key,
+                    start_time_key=end_user_group_start_time_key,
                     response_cost=response_cost,
                 )
 

--- a/litellm/proxy/hooks/model_max_budget_limiter.py
+++ b/litellm/proxy/hooks/model_max_budget_limiter.py
@@ -58,10 +58,13 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
         )
         if _current_model_budget_info is None:
             verbose_proxy_logger.debug(f"Model {model} not found in internal_model_max_budget")
-            return True
 
         # check if current model is within budget
-        if _current_model_budget_info.max_budget and _current_model_budget_info.max_budget > 0:
+        if (
+            _current_model_budget_info is not None
+            and _current_model_budget_info.max_budget
+            and _current_model_budget_info.max_budget > 0
+        ):
             _current_spend = await self._get_virtual_key_spend_for_model(
                 user_api_key_hash=user_api_key_dict.token,
                 model=model,
@@ -76,6 +79,25 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
                     message=f"LiteLLM Virtual Key: {user_api_key_dict.token}, key_alias: {user_api_key_dict.key_alias}, exceeded budget for model={model}",
                     current_cost=_current_spend,
                     max_budget=_current_model_budget_info.max_budget,
+                    entity_type=Litellm_EntityType.KEY.value,
+                    entity_id=user_api_key_dict.token,
+                )
+
+        for _group_name, _group_budget_info in self._get_matching_model_group_budget_configs(
+            model=model, internal_model_max_budget=internal_model_max_budget
+        ):
+            if not _group_budget_info.max_budget or _group_budget_info.max_budget <= 0:
+                continue
+            _group_spend = await self._get_virtual_key_spend_for_model_group(
+                user_api_key_hash=user_api_key_dict.token,
+                model_group_name=_group_name,
+                key_budget_config=_group_budget_info,
+            )
+            if _group_spend is not None and _group_spend > _group_budget_info.max_budget:
+                raise litellm.BudgetExceededError(
+                    message=f"LiteLLM Virtual Key: {user_api_key_dict.token}, key_alias: {user_api_key_dict.key_alias}, exceeded budget for model group={_group_name}, model={model}",
+                    current_cost=_group_spend,
+                    max_budget=_group_budget_info.max_budget,
                     entity_type=Litellm_EntityType.KEY.value,
                     entity_id=user_api_key_dict.token,
                 )
@@ -201,6 +223,18 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
             )
         return _current_spend
 
+    async def _get_virtual_key_spend_for_model_group(
+        self,
+        user_api_key_hash: str | None,
+        model_group_name: str,
+        key_budget_config: BudgetConfig,
+    ) -> float | None:
+        model_group_spend_cache_key = (
+            f"{VIRTUAL_KEY_SPEND_CACHE_KEY_PREFIX}:{user_api_key_hash}:{model_group_name}:"
+            f"{key_budget_config.budget_duration}"
+        )
+        return await self.dual_cache.async_get_cache(key=model_group_spend_cache_key)
+
     def _get_request_model_budget_config(
         self, model: str, internal_model_max_budget: GenericBudgetConfigType
     ) -> Optional[BudgetConfig]:
@@ -210,8 +244,21 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
         1. Check if `model` is in `internal_model_max_budget`
         2. If not, check if `model` without custom llm provider is in `internal_model_max_budget`
         """
-        return internal_model_max_budget.get(model, None) or internal_model_max_budget.get(
+        direct_model_max_budget = {
+            _model: _config for _model, _config in internal_model_max_budget.items() if not _config.models
+        }
+        return direct_model_max_budget.get(model, None) or direct_model_max_budget.get(
             self._get_model_without_custom_llm_provider(model), None
+        )
+
+    def _get_matching_model_group_budget_configs(
+        self, model: str, internal_model_max_budget: GenericBudgetConfigType
+    ) -> tuple[tuple[str, BudgetConfig], ...]:
+        model_without_provider = self._get_model_without_custom_llm_provider(model)
+        return tuple(
+            (_group_name, _config)
+            for _group_name, _config in internal_model_max_budget.items()
+            if _config.models and (model in _config.models or model_without_provider in _config.models)
         )
 
     def _get_model_without_custom_llm_provider(self, model: str) -> str:
@@ -294,6 +341,22 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
                     budget_config=key_budget_config,
                     spend_key=virtual_spend_key,
                     start_time_key=virtual_start_time_key,
+                    response_cost=response_cost,
+                )
+            for _group_name, _group_budget_config in self._get_matching_model_group_budget_configs(
+                model=model, internal_model_max_budget=internal_model_max_budget
+            ):
+                if _group_budget_config.budget_duration is None:
+                    continue
+                group_spend_key = (
+                    f"{VIRTUAL_KEY_SPEND_CACHE_KEY_PREFIX}:{virtual_key}:{_group_name}:"
+                    f"{_group_budget_config.budget_duration}"
+                )
+                group_start_time_key = f"virtual_key_budget_start_time:{virtual_key}:{_group_name}"
+                await self._increment_spend_for_key(
+                    budget_config=_group_budget_config,
+                    spend_key=group_spend_key,
+                    start_time_key=group_start_time_key,
                     response_cost=response_cost,
                 )
 

--- a/litellm/proxy/hooks/model_max_budget_limiter.py
+++ b/litellm/proxy/hooks/model_max_budget_limiter.py
@@ -287,18 +287,29 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
     def _get_matching_model_group_budget_configs(
         self, model: str, internal_model_max_budget: GenericBudgetConfigType
     ) -> tuple[tuple[str, BudgetConfig], ...]:
-        model_without_provider = self._get_model_without_custom_llm_provider(model)
+        request_variants = self._model_name_variants(model)
         return tuple(
             (_group_name, _config)
             for _group_name, _config in internal_model_max_budget.items()
             if _config.models
             and any(
-                _member == model
-                or _member == model_without_provider
-                or self._get_model_without_custom_llm_provider(_member) == model
-                for _member in _config.models
+                _member in request_variants or model in self._model_name_variants(_member) for _member in _config.models
             )
         )
+
+    def _model_name_variants(self, model: str) -> frozenset[str]:
+        """
+        The name itself plus its provider-stripped forms: without the first
+        segment (`huggingface/meta-llama/Llama-3.1-8B` -> `meta-llama/Llama-3.1-8B`)
+        and without everything before the last slash (`openai/gpt-4` -> `gpt-4`).
+
+        Group matching compares one side's raw name against the other side's
+        variants, never stripped-vs-stripped, so a provider-prefixed member
+        still pins its group to that provider's route.
+        """
+        if "/" not in model:
+            return frozenset({model})
+        return frozenset({model, model.split("/", 1)[1], self._get_model_without_custom_llm_provider(model)})
 
     def _get_model_without_custom_llm_provider(self, model: str) -> str:
         if "/" in model:

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1507,7 +1507,7 @@ async def generate_key_fn(
     - disable_global_guardrails: Optional[bool] - Whether to disable global guardrails for the key.
     - throttle_on_budget_exceeded: Optional[bool] - When the key exceeds its max_budget, throttle its tpm/rpm to the global budget_exceeded_throttle_percentage instead of blocking the key entirely.
     - permissions: Optional[dict] - key-specific permissions. Currently just used for turning off pii masking (if connected). Example - {"pii": false}
-    - model_max_budget: Optional[Dict[str, BudgetConfig]] - Model-specific budgets {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}}. IF null or {} then no model specific budget.
+    - model_max_budget: Optional[Dict[str, BudgetConfig]] - Model-specific budgets {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}. Set "models" to share one budget across a group of models: {"opus-family": {"models": ["claude-opus-4-5", "claude-opus-4-6"], "budget_limit": 10, "time_period": "30d"}}. IF null or {} then no model specific budget.
     - budget_fallbacks: Optional[Dict[str, List[str]]] - Per-model fallback chain tried in order when that model's own `model_max_budget` is exceeded, e.g. {"gpt-4o": ["gpt-4o-mini"]}.
     - model_rpm_limit: Optional[dict] - key-specific model rpm limit. Example - {"text-davinci-002": 1000, "gpt-3.5-turbo": 1000}. IF null or {} then no model specific rpm limit.
     - model_tpm_limit: Optional[dict] - key-specific model tpm limit. Example - {"text-davinci-002": 1000, "gpt-3.5-turbo": 1000}. IF null or {} then no model specific tpm limit.
@@ -1715,7 +1715,7 @@ async def generate_service_account_key_fn(
     - metadata: Optional[dict] - Metadata for key, store information for key. Example metadata = {"team": "core-infra", "app": "app2", "email": "ishaan@berri.ai" }
     - guardrails: Optional[List[str]] - List of active guardrails for the key
     - permissions: Optional[dict] - key-specific permissions. Currently just used for turning off pii masking (if connected). Example - {"pii": false}
-    - model_max_budget: Optional[Dict[str, BudgetConfig]] - Model-specific budgets {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}}. IF null or {} then no model specific budget.
+    - model_max_budget: Optional[Dict[str, BudgetConfig]] - Model-specific budgets {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}. Set "models" to share one budget across a group of models: {"opus-family": {"models": ["claude-opus-4-5", "claude-opus-4-6"], "budget_limit": 10, "time_period": "30d"}}. IF null or {} then no model specific budget.
     - budget_fallbacks: Optional[Dict[str, List[str]]] - Per-model fallback chain tried in order when that model's own `model_max_budget` is exceeded, e.g. {"gpt-4o": ["gpt-4o-mini"]}.
     - model_rpm_limit: Optional[dict] - key-specific model rpm limit. Example - {"text-davinci-002": 1000, "gpt-3.5-turbo": 1000}. IF null or {} then no model specific rpm limit.
     - model_tpm_limit: Optional[dict] - key-specific model tpm limit. Example - {"text-davinci-002": 1000, "gpt-3.5-turbo": 1000}. IF null or {} then no model specific tpm limit.
@@ -2521,7 +2521,7 @@ async def update_key_fn(
     - enforced_params: Optional[List[str]] - List of enforced params for the key (Enterprise only). [Docs](https://docs.litellm.ai/docs/proxy/enterprise#enforce-required-params-for-llm-requests)
     - spend: Optional[float] - Amount spent by key
     - max_budget: Optional[float] - Max budget for key
-    - model_max_budget: Optional[Dict[str, BudgetConfig]] - Model-specific budgets {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}
+    - model_max_budget: Optional[Dict[str, BudgetConfig]] - Model-specific budgets {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}. Set "models" to share one budget across a group of models: {"opus-family": {"models": ["claude-opus-4-5", "claude-opus-4-6"], "budget_limit": 10, "time_period": "30d"}}
     - budget_fallbacks: Optional[Dict[str, List[str]]] - Per-model fallback chain tried in order when that model's own `model_max_budget` is exceeded, e.g. {"gpt-4o": ["gpt-4o-mini"]}.
     - budget_duration: Optional[str] - Budget reset period ("30d", "1h", etc.)
     - soft_budget: Optional[float] - [TODO] Soft budget limit (warning vs. hard stop). Will trigger a slack alert when this soft budget is reached.
@@ -4584,7 +4584,7 @@ async def regenerate_key_fn(
         - tags: Optional[List[str]] - Tags for organizing keys (Enterprise only)
         - spend: Optional[float] - Amount spent by key
         - max_budget: Optional[float] - Max budget for key
-        - model_max_budget: Optional[Dict[str, BudgetConfig]] - Model-specific budgets {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}
+        - model_max_budget: Optional[Dict[str, BudgetConfig]] - Model-specific budgets {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}. Set "models" to share one budget across a group of models: {"opus-family": {"models": ["claude-opus-4-5", "claude-opus-4-6"], "budget_limit": 10, "time_period": "30d"}}
         - budget_fallbacks: Optional[Dict[str, List[str]]] - Per-model fallback chain tried in order when that model's own `model_max_budget` is exceeded, e.g. {"gpt-4o": ["gpt-4o-mini"]}.
         - budget_duration: Optional[str] - Budget reset period ("30d", "1h", etc.)
         - soft_budget: Optional[float] - Soft budget limit (warning vs. hard stop). Will trigger a slack alert when this soft budget is reached.

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3333,6 +3333,7 @@ class BudgetConfig(BaseModel):
     budget_duration: Optional[str] = None
     tpm_limit: Optional[int] = None
     rpm_limit: Optional[int] = None
+    models: Optional[List[str]] = None
 
     def __init__(self, **data: Any) -> None:
         # Map time_period to budget_duration if present

--- a/tests/test_litellm/proxy/hooks/test_model_max_budget_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_model_max_budget_limiter.py
@@ -174,3 +174,37 @@ async def test_group_budget_matches_bare_request_when_member_is_provider_qualifi
     with pytest.raises(litellm.BudgetExceededError, match="model group=gpt4-family"):
         await limiter.is_key_within_model_budget(key, "gpt-4o")
     assert await limiter.is_key_within_model_budget(key, "gpt-5.5") is True
+
+
+@pytest.mark.asyncio
+async def test_group_without_budget_limit_never_blocks():
+    no_limit_group = {
+        "opus-family": {
+            "models": ["anthropic-opus-4-7", "anthropic-opus-4-8"],
+            "time_period": "30d",
+        }
+    }
+    limiter = _make_limiter()
+    key = _make_key(no_limit_group)
+
+    await _log_spend(limiter, "anthropic-opus-4-7", 999.0, no_limit_group)
+
+    assert await limiter.is_key_within_model_budget(key, "anthropic-opus-4-7") is True
+    assert await limiter.is_key_within_model_budget(key, "anthropic-opus-4-8") is True
+
+
+@pytest.mark.asyncio
+async def test_group_without_time_period_does_not_track_or_block():
+    no_duration_group = {
+        "opus-family": {
+            "models": ["anthropic-opus-4-7", "anthropic-opus-4-8"],
+            "budget_limit": 10.0,
+        }
+    }
+    limiter = _make_limiter()
+    key = _make_key(no_duration_group)
+
+    await _log_spend(limiter, "anthropic-opus-4-7", 999.0, no_duration_group)
+
+    assert limiter.dual_cache.in_memory_cache.cache_dict == {}
+    assert await limiter.is_key_within_model_budget(key, "anthropic-opus-4-7") is True

--- a/tests/test_litellm/proxy/hooks/test_model_max_budget_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_model_max_budget_limiter.py
@@ -155,3 +155,22 @@ async def test_spend_at_exactly_group_budget_passes():
     await _log_spend(limiter, "anthropic-opus-4-7", 10.0, OPUS_GROUP_BUDGET)
 
     assert await limiter.is_key_within_model_budget(key, "anthropic-opus-4-8") is True
+
+
+@pytest.mark.asyncio
+async def test_group_budget_matches_bare_request_when_member_is_provider_qualified():
+    qualified_group_budget = {
+        "gpt4-family": {
+            "models": ["openai/gpt-4", "openai/gpt-4o"],
+            "budget_limit": 10.0,
+            "time_period": "30d",
+        }
+    }
+    limiter = _make_limiter()
+    key = _make_key(qualified_group_budget)
+
+    await _log_spend(limiter, "gpt-4", 11.0, qualified_group_budget)
+
+    with pytest.raises(litellm.BudgetExceededError, match="model group=gpt4-family"):
+        await limiter.is_key_within_model_budget(key, "gpt-4o")
+    assert await limiter.is_key_within_model_budget(key, "gpt-5.5") is True

--- a/tests/test_litellm/proxy/hooks/test_model_max_budget_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_model_max_budget_limiter.py
@@ -1,0 +1,157 @@
+import pytest
+
+import litellm
+from litellm.caching.caching import DualCache
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.hooks.model_max_budget_limiter import (
+    _PROXY_VirtualKeyModelMaxBudgetLimiter,
+)
+
+VIRTUAL_KEY = "test-key-hash"
+
+OPUS_GROUP_BUDGET = {
+    "opus-family": {
+        "models": ["anthropic-opus-4-7", "anthropic-opus-4-8"],
+        "budget_limit": 10.0,
+        "time_period": "30d",
+    }
+}
+
+
+def _make_limiter() -> _PROXY_VirtualKeyModelMaxBudgetLimiter:
+    return _PROXY_VirtualKeyModelMaxBudgetLimiter(dual_cache=DualCache())
+
+
+def _make_key(model_max_budget: dict) -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(
+        token=VIRTUAL_KEY,
+        key_alias="test-alias",
+        model_max_budget=model_max_budget,
+    )
+
+
+async def _log_spend(
+    limiter: _PROXY_VirtualKeyModelMaxBudgetLimiter,
+    model: str,
+    response_cost: float,
+    model_max_budget: dict,
+) -> None:
+    kwargs = {
+        "standard_logging_object": {
+            "response_cost": response_cost,
+            "model": model,
+            "metadata": {"user_api_key_hash": VIRTUAL_KEY},
+        },
+        "litellm_params": {"metadata": {"user_api_key_model_max_budget": model_max_budget}},
+    }
+    await limiter.async_log_success_event(kwargs, response_obj=None, start_time=None, end_time=None)
+
+
+@pytest.mark.asyncio
+async def test_group_budget_shared_across_models():
+    limiter = _make_limiter()
+    key = _make_key(OPUS_GROUP_BUDGET)
+
+    await _log_spend(limiter, "anthropic-opus-4-7", 11.0, OPUS_GROUP_BUDGET)
+
+    with pytest.raises(litellm.BudgetExceededError, match="model group=opus-family"):
+        await limiter.is_key_within_model_budget(key, "anthropic-opus-4-7")
+    with pytest.raises(litellm.BudgetExceededError, match="model group=opus-family"):
+        await limiter.is_key_within_model_budget(key, "anthropic-opus-4-8")
+
+
+@pytest.mark.asyncio
+async def test_group_budget_ignores_models_outside_group():
+    limiter = _make_limiter()
+    key = _make_key(OPUS_GROUP_BUDGET)
+
+    await _log_spend(limiter, "anthropic-opus-4-7", 11.0, OPUS_GROUP_BUDGET)
+
+    assert await limiter.is_key_within_model_budget(key, "anthropic-sonnet-5") is True
+
+
+@pytest.mark.asyncio
+async def test_group_budget_within_budget_passes():
+    limiter = _make_limiter()
+    key = _make_key(OPUS_GROUP_BUDGET)
+
+    await _log_spend(limiter, "anthropic-opus-4-7", 4.0, OPUS_GROUP_BUDGET)
+    await _log_spend(limiter, "anthropic-opus-4-8", 6.0, OPUS_GROUP_BUDGET)
+
+    assert await limiter.is_key_within_model_budget(key, "anthropic-opus-4-7") is True
+    assert await limiter.is_key_within_model_budget(key, "anthropic-opus-4-8") is True
+
+
+@pytest.mark.asyncio
+async def test_group_spend_accumulates_across_models_in_one_pool():
+    limiter = _make_limiter()
+    key = _make_key(OPUS_GROUP_BUDGET)
+
+    await _log_spend(limiter, "anthropic-opus-4-7", 6.0, OPUS_GROUP_BUDGET)
+    assert await limiter.is_key_within_model_budget(key, "anthropic-opus-4-8") is True
+
+    await _log_spend(limiter, "anthropic-opus-4-8", 6.0, OPUS_GROUP_BUDGET)
+    with pytest.raises(litellm.BudgetExceededError, match="model group=opus-family"):
+        await limiter.is_key_within_model_budget(key, "anthropic-opus-4-7")
+
+
+@pytest.mark.asyncio
+async def test_group_budget_matches_provider_prefixed_model():
+    limiter = _make_limiter()
+    key = _make_key(OPUS_GROUP_BUDGET)
+
+    await _log_spend(limiter, "anthropic-opus-4-7", 11.0, OPUS_GROUP_BUDGET)
+
+    with pytest.raises(litellm.BudgetExceededError, match="model group=opus-family"):
+        await limiter.is_key_within_model_budget(key, "anthropic/anthropic-opus-4-8")
+
+
+@pytest.mark.asyncio
+async def test_group_entry_is_not_a_direct_model_budget():
+    limiter = _make_limiter()
+    key = _make_key(OPUS_GROUP_BUDGET)
+
+    await _log_spend(limiter, "anthropic-opus-4-7", 11.0, OPUS_GROUP_BUDGET)
+
+    assert await limiter.is_key_within_model_budget(key, "opus-family") is True
+
+
+@pytest.mark.asyncio
+async def test_direct_and_group_budgets_are_both_enforced():
+    model_max_budget = {
+        "anthropic-opus-4-7": {"budget_limit": 1.0, "time_period": "30d"},
+        **OPUS_GROUP_BUDGET,
+    }
+    limiter = _make_limiter()
+    key = _make_key(model_max_budget)
+
+    await _log_spend(limiter, "anthropic-opus-4-7", 2.0, model_max_budget)
+
+    with pytest.raises(litellm.BudgetExceededError, match="model=anthropic-opus-4-7"):
+        await limiter.is_key_within_model_budget(key, "anthropic-opus-4-7")
+    assert await limiter.is_key_within_model_budget(key, "anthropic-opus-4-8") is True
+
+
+@pytest.mark.asyncio
+async def test_group_budget_exceeded_even_when_direct_budget_is_fine():
+    model_max_budget = {
+        "anthropic-opus-4-7": {"budget_limit": 100.0, "time_period": "30d"},
+        **OPUS_GROUP_BUDGET,
+    }
+    limiter = _make_limiter()
+    key = _make_key(model_max_budget)
+
+    await _log_spend(limiter, "anthropic-opus-4-8", 11.0, model_max_budget)
+
+    with pytest.raises(litellm.BudgetExceededError, match="model group=opus-family"):
+        await limiter.is_key_within_model_budget(key, "anthropic-opus-4-7")
+
+
+@pytest.mark.asyncio
+async def test_spend_at_exactly_group_budget_passes():
+    limiter = _make_limiter()
+    key = _make_key(OPUS_GROUP_BUDGET)
+
+    await _log_spend(limiter, "anthropic-opus-4-7", 10.0, OPUS_GROUP_BUDGET)
+
+    assert await limiter.is_key_within_model_budget(key, "anthropic-opus-4-8") is True

--- a/tests/test_litellm/proxy/hooks/test_model_max_budget_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_model_max_budget_limiter.py
@@ -253,3 +253,40 @@ async def test_end_user_group_budget_within_budget_passes():
 
     assert await limiter.is_end_user_within_model_budget(END_USER_ID, OPUS_GROUP_BUDGET, "anthropic-opus-4-7") is True
     assert await limiter.is_end_user_within_model_budget(END_USER_ID, OPUS_GROUP_BUDGET, "anthropic-opus-4-8") is True
+
+
+@pytest.mark.asyncio
+async def test_group_budget_matches_namespaced_model_with_provider_prefix():
+    namespaced_group_budget = {
+        "llama-family": {
+            "models": ["meta-llama/Llama-3.1-8B", "meta-llama/Llama-3.1-70B"],
+            "budget_limit": 10.0,
+            "time_period": "30d",
+        }
+    }
+    limiter = _make_limiter()
+    key = _make_key(namespaced_group_budget)
+
+    await _log_spend(limiter, "huggingface/meta-llama/Llama-3.1-8B", 11.0, namespaced_group_budget)
+
+    with pytest.raises(litellm.BudgetExceededError, match="model group=llama-family"):
+        await limiter.is_key_within_model_budget(key, "huggingface/meta-llama/Llama-3.1-70B")
+    with pytest.raises(litellm.BudgetExceededError, match="model group=llama-family"):
+        await limiter.is_key_within_model_budget(key, "meta-llama/Llama-3.1-8B")
+
+
+@pytest.mark.asyncio
+async def test_group_member_with_provider_prefix_does_not_match_other_provider():
+    pinned_group_budget = {
+        "openai-gpt4": {
+            "models": ["openai/gpt-4"],
+            "budget_limit": 10.0,
+            "time_period": "30d",
+        }
+    }
+    limiter = _make_limiter()
+    key = _make_key(pinned_group_budget)
+
+    await _log_spend(limiter, "gpt-4", 11.0, pinned_group_budget)
+
+    assert await limiter.is_key_within_model_budget(key, "azure/gpt-4") is True

--- a/tests/test_litellm/proxy/hooks/test_model_max_budget_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_model_max_budget_limiter.py
@@ -208,3 +208,48 @@ async def test_group_without_time_period_does_not_track_or_block():
 
     assert limiter.dual_cache.in_memory_cache.cache_dict == {}
     assert await limiter.is_key_within_model_budget(key, "anthropic-opus-4-7") is True
+
+
+END_USER_ID = "end-user-1"
+
+
+async def _log_end_user_spend(
+    limiter: _PROXY_VirtualKeyModelMaxBudgetLimiter,
+    model: str,
+    response_cost: float,
+    end_user_model_max_budget: dict,
+) -> None:
+    kwargs = {
+        "standard_logging_object": {
+            "response_cost": response_cost,
+            "model": model,
+            "end_user": END_USER_ID,
+            "metadata": {"user_api_key_end_user_id": END_USER_ID},
+        },
+        "litellm_params": {"metadata": {"user_api_key_end_user_model_max_budget": end_user_model_max_budget}},
+    }
+    await limiter.async_log_success_event(kwargs, response_obj=None, start_time=None, end_time=None)
+
+
+@pytest.mark.asyncio
+async def test_end_user_group_budget_shared_across_models():
+    limiter = _make_limiter()
+
+    await _log_end_user_spend(limiter, "anthropic-opus-4-7", 11.0, OPUS_GROUP_BUDGET)
+
+    with pytest.raises(litellm.BudgetExceededError, match="model group=opus-family"):
+        await limiter.is_end_user_within_model_budget(END_USER_ID, OPUS_GROUP_BUDGET, "anthropic-opus-4-7")
+    with pytest.raises(litellm.BudgetExceededError, match="model group=opus-family"):
+        await limiter.is_end_user_within_model_budget(END_USER_ID, OPUS_GROUP_BUDGET, "anthropic-opus-4-8")
+    assert await limiter.is_end_user_within_model_budget(END_USER_ID, OPUS_GROUP_BUDGET, "anthropic-sonnet-5") is True
+
+
+@pytest.mark.asyncio
+async def test_end_user_group_budget_within_budget_passes():
+    limiter = _make_limiter()
+
+    await _log_end_user_spend(limiter, "anthropic-opus-4-7", 4.0, OPUS_GROUP_BUDGET)
+    await _log_end_user_spend(limiter, "anthropic-opus-4-8", 5.0, OPUS_GROUP_BUDGET)
+
+    assert await limiter.is_end_user_within_model_budget(END_USER_ID, OPUS_GROUP_BUDGET, "anthropic-opus-4-7") is True
+    assert await limiter.is_end_user_within_model_budget(END_USER_ID, OPUS_GROUP_BUDGET, "anthropic-opus-4-8") is True

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -6565,7 +6565,7 @@ export interface paths {
          *     - disable_global_guardrails: Optional[bool] - Whether to disable global guardrails for the key.
          *     - throttle_on_budget_exceeded: Optional[bool] - When the key exceeds its max_budget, throttle its tpm/rpm to the global budget_exceeded_throttle_percentage instead of blocking the key entirely.
          *     - permissions: Optional[dict] - key-specific permissions. Currently just used for turning off pii masking (if connected). Example - {"pii": false}
-         *     - model_max_budget: Optional[Dict[str, BudgetConfig]] - Model-specific budgets {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}}. IF null or {} then no model specific budget.
+         *     - model_max_budget: Optional[Dict[str, BudgetConfig]] - Model-specific budgets {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}. Set "models" to share one budget across a group of models: {"opus-family": {"models": ["claude-opus-4-5", "claude-opus-4-6"], "budget_limit": 10, "time_period": "30d"}}. IF null or {} then no model specific budget.
          *     - budget_fallbacks: Optional[Dict[str, List[str]]] - Per-model fallback chain tried in order when that model's own `model_max_budget` is exceeded, e.g. {"gpt-4o": ["gpt-4o-mini"]}.
          *     - model_rpm_limit: Optional[dict] - key-specific model rpm limit. Example - {"text-davinci-002": 1000, "gpt-3.5-turbo": 1000}. IF null or {} then no model specific rpm limit.
          *     - model_tpm_limit: Optional[dict] - key-specific model tpm limit. Example - {"text-davinci-002": 1000, "gpt-3.5-turbo": 1000}. IF null or {} then no model specific tpm limit.
@@ -6773,7 +6773,7 @@ export interface paths {
          *         - tags: Optional[List[str]] - Tags for organizing keys (Enterprise only)
          *         - spend: Optional[float] - Amount spent by key
          *         - max_budget: Optional[float] - Max budget for key
-         *         - model_max_budget: Optional[Dict[str, BudgetConfig]] - Model-specific budgets {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}
+         *         - model_max_budget: Optional[Dict[str, BudgetConfig]] - Model-specific budgets {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}. Set "models" to share one budget across a group of models: {"opus-family": {"models": ["claude-opus-4-5", "claude-opus-4-6"], "budget_limit": 10, "time_period": "30d"}}
          *         - budget_fallbacks: Optional[Dict[str, List[str]]] - Per-model fallback chain tried in order when that model's own `model_max_budget` is exceeded, e.g. {"gpt-4o": ["gpt-4o-mini"]}.
          *         - budget_duration: Optional[str] - Budget reset period ("30d", "1h", etc.)
          *         - soft_budget: Optional[float] - Soft budget limit (warning vs. hard stop). Will trigger a slack alert when this soft budget is reached.
@@ -6849,7 +6849,7 @@ export interface paths {
          *     - metadata: Optional[dict] - Metadata for key, store information for key. Example metadata = {"team": "core-infra", "app": "app2", "email": "ishaan@berri.ai" }
          *     - guardrails: Optional[List[str]] - List of active guardrails for the key
          *     - permissions: Optional[dict] - key-specific permissions. Currently just used for turning off pii masking (if connected). Example - {"pii": false}
-         *     - model_max_budget: Optional[Dict[str, BudgetConfig]] - Model-specific budgets {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}}. IF null or {} then no model specific budget.
+         *     - model_max_budget: Optional[Dict[str, BudgetConfig]] - Model-specific budgets {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}. Set "models" to share one budget across a group of models: {"opus-family": {"models": ["claude-opus-4-5", "claude-opus-4-6"], "budget_limit": 10, "time_period": "30d"}}. IF null or {} then no model specific budget.
          *     - budget_fallbacks: Optional[Dict[str, List[str]]] - Per-model fallback chain tried in order when that model's own `model_max_budget` is exceeded, e.g. {"gpt-4o": ["gpt-4o-mini"]}.
          *     - model_rpm_limit: Optional[dict] - key-specific model rpm limit. Example - {"text-davinci-002": 1000, "gpt-3.5-turbo": 1000}. IF null or {} then no model specific rpm limit.
          *     - model_tpm_limit: Optional[dict] - key-specific model tpm limit. Example - {"text-davinci-002": 1000, "gpt-3.5-turbo": 1000}. IF null or {} then no model specific tpm limit.
@@ -6948,7 +6948,7 @@ export interface paths {
          *     - enforced_params: Optional[List[str]] - List of enforced params for the key (Enterprise only). [Docs](https://docs.litellm.ai/docs/proxy/enterprise#enforce-required-params-for-llm-requests)
          *     - spend: Optional[float] - Amount spent by key
          *     - max_budget: Optional[float] - Max budget for key
-         *     - model_max_budget: Optional[Dict[str, BudgetConfig]] - Model-specific budgets {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}
+         *     - model_max_budget: Optional[Dict[str, BudgetConfig]] - Model-specific budgets {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}. Set "models" to share one budget across a group of models: {"opus-family": {"models": ["claude-opus-4-5", "claude-opus-4-6"], "budget_limit": 10, "time_period": "30d"}}
          *     - budget_fallbacks: Optional[Dict[str, List[str]]] - Per-model fallback chain tried in order when that model's own `model_max_budget` is exceeded, e.g. {"gpt-4o": ["gpt-4o-mini"]}.
          *     - budget_duration: Optional[str] - Budget reset period ("30d", "1h", etc.)
          *     - soft_budget: Optional[float] - [TODO] Soft budget limit (warning vs. hard stop). Will trigger a slack alert when this soft budget is reached.
@@ -7032,7 +7032,7 @@ export interface paths {
          *         - tags: Optional[List[str]] - Tags for organizing keys (Enterprise only)
          *         - spend: Optional[float] - Amount spent by key
          *         - max_budget: Optional[float] - Max budget for key
-         *         - model_max_budget: Optional[Dict[str, BudgetConfig]] - Model-specific budgets {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}
+         *         - model_max_budget: Optional[Dict[str, BudgetConfig]] - Model-specific budgets {"gpt-4": {"budget_limit": 0.0005, "time_period": "30d"}}. Set "models" to share one budget across a group of models: {"opus-family": {"models": ["claude-opus-4-5", "claude-opus-4-6"], "budget_limit": 10, "time_period": "30d"}}
          *         - budget_fallbacks: Optional[Dict[str, List[str]]] - Per-model fallback chain tried in order when that model's own `model_max_budget` is exceeded, e.g. {"gpt-4o": ["gpt-4o-mini"]}.
          *         - budget_duration: Optional[str] - Budget reset period ("30d", "1h", etc.)
          *         - soft_budget: Optional[float] - Soft budget limit (warning vs. hard stop). Will trigger a slack alert when this soft budget is reached.
@@ -21395,6 +21395,8 @@ export interface components {
             budget_duration?: string | null;
             /** Max Budget */
             max_budget?: number | null;
+            /** Models */
+            models?: string[] | null;
             /** Rpm Limit */
             rpm_limit?: number | null;
             /** Tpm Limit */
@@ -21446,7 +21448,7 @@ export interface components {
             max_parallel_requests?: number | null;
             /**
              * Model Max Budget
-             * @description Max budget for each model (e.g. {'gpt-4o': {'max_budget': '0.0000001', 'budget_duration': '1d', 'tpm_limit': 1000, 'rpm_limit': 1000}})
+             * @description Max budget for each model (e.g. {'gpt-4o': {'max_budget': '0.0000001', 'budget_duration': '1d', 'tpm_limit': 1000, 'rpm_limit': 1000}}). An entry with 'models' set shares one budget across that group of models (e.g. {'opus-family': {'models': ['claude-opus-4-5', 'claude-opus-4-6'], 'max_budget': 10, 'budget_duration': '30d'}})
              */
             model_max_budget?: {
                 [key: string]: components["schemas"]["BudgetConfig"];
@@ -27759,7 +27761,7 @@ export interface components {
             max_parallel_requests?: number | null;
             /**
              * Model Max Budget
-             * @description Max budget for each model (e.g. {'gpt-4o': {'max_budget': '0.0000001', 'budget_duration': '1d', 'tpm_limit': 1000, 'rpm_limit': 1000}})
+             * @description Max budget for each model (e.g. {'gpt-4o': {'max_budget': '0.0000001', 'budget_duration': '1d', 'tpm_limit': 1000, 'rpm_limit': 1000}}). An entry with 'models' set shares one budget across that group of models (e.g. {'opus-family': {'models': ['claude-opus-4-5', 'claude-opus-4-6'], 'max_budget': 10, 'budget_duration': '30d'}})
              */
             model_max_budget?: {
                 [key: string]: components["schemas"]["BudgetConfig"];


### PR DESCRIPTION
## TLDR

Problem this solves:

- Per-model key budgets cap each model independently
- Spend caps on a model family can be dodged by rotating variants

How it solves it:

- A `model_max_budget` entry can now list `models` sharing one budget
- Every model in the group draws from a single spend pool

## Relevant issues

Fixes #34367

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured at commit c27cd0fc against a live proxy (`python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_prisma_db_push`) making real Anthropic API calls with real spend. One note on environment: `model_max_budget` is enterprise gated at `/key/generate`, and the sandbox this ran in has no license available, so the license check was stubbed to premium locally for the run; that gate is upstream of the budget logic under test and unaffected by this PR. A screen recording of this exact flow accompanies the PR and will be attached as a comment

```
[1/5] Generate a key with ONE shared budget: $0.006 per 30d across anthropic-opus-4-7 AND anthropic-opus-4-8

$ curl -sS http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "{\"key_alias\": \"opus-family-demo-$(date +%s)\", \"model_max_budget\": {\"opus-family\": {\"models\": [\"anthropic-opus-4-7\", \"anthropic-opus-4-8\"], \"budget_limit\": 0.006, \"time_period\": \"30d\"}}}" | tee key.json | jq "{key, model_max_budget}"
{
  "key": "sk-bnCk2nS2eJ10_9HUR61m0A",
  "model_max_budget": {
    "opus-family": {
      "models": [
        "anthropic-opus-4-7",
        "anthropic-opus-4-8"
      ],
      "budget_limit": 0.006,
      "time_period": "30d"
    }
  }
}

[2/5] Call anthropic-opus-4-7; within budget, succeeds (real Anthropic API call)

$ curl -sS -D h1 http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d "{\"model\": \"anthropic-opus-4-7\", \"max_tokens\": 200, \"messages\": [{\"role\": \"user\", \"content\": \"Write a long essay about API gateways\"}]}" | jq "{model, content: (.choices[0].message.content[:120] + \" ...\")}" && grep -i "^x-litellm-response-cost:" h1
{
  "model": "anthropic-opus-4-7",
  "content": "# API Gateways: The Cornerstone of Modern Distributed Architecture\n\n## Introduction\n\nIn the evolving landscape of softwa ..."
}
x-litellm-response-cost: 0.00511

[3/5] Call a DIFFERENT model in the group, anthropic-opus-4-8; combined spend will now cross $0.006

$ curl -sS -D h2 http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d "{\"model\": \"anthropic-opus-4-8\", \"max_tokens\": 200, \"messages\": [{\"role\": \"user\", \"content\": \"Write a long essay about rate limiting\"}]}" | jq "{model, content: (.choices[0].message.content[:120] + \" ...\")}" && grep -i "^x-litellm-response-cost:" h2
{
  "model": "anthropic-opus-4-8",
  "content": "# Rate Limiting: A Comprehensive Guide\n\n## Introduction\n\nRate limiting is a fundamental technique in modern software sys ..."
}
x-litellm-response-cost: 0.00509

[4/5] Both Opus models are now blocked; each is under $0.006 on its own, but the SHARED opus-family pool is exhausted

$ curl -sS http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d "{\"model\": \"anthropic-opus-4-7\", \"max_tokens\": 200, \"messages\": [{\"role\": \"user\", \"content\": \"hi\"}]}" | jq .
{
  "error": {
    "message": "LiteLLM Virtual Key: a3f5e0769cc9302b5ed575edecb4c700c23d77623024ed65642e95110a50a9f9, key_alias: opus-family-demo-1784791615, exceeded budget for model group=opus-family, model=anthropic-opus-4-7",
    "type": "budget_exceeded",
    "param": null,
    "code": "429"
  }
}

$ curl -sS http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d "{\"model\": \"anthropic-opus-4-8\", \"max_tokens\": 200, \"messages\": [{\"role\": \"user\", \"content\": \"hi\"}]}" | jq ".error.message"
"LiteLLM Virtual Key: a3f5e0769cc9302b5ed575edecb4c700c23d77623024ed65642e95110a50a9f9, key_alias: opus-family-demo-1784791615, exceeded budget for model group=opus-family, model=anthropic-opus-4-8"

[5/5] Models OUTSIDE the group still work on the same key, and /key/info shows the shared pool usage

$ curl -sS http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d "{\"model\": \"anthropic-sonnet-5\", \"max_tokens\": 60, \"messages\": [{\"role\": \"user\", \"content\": \"Say hello in five words\"}]}" | jq "{model, content: .choices[0].message.content}"
{
  "model": "anthropic-sonnet-5",
  "content": "Hello! How are you today?"
}

$ curl -sS "http://localhost:4000/key/info?key=$KEY" -H "Authorization: Bearer sk-1234" | jq ".info.model_max_budget_usage"
{
  "opus-family": {
    "current_spend": 0.0102,
    "budget_limit": 0.006,
    "time_period": "30d"
  }
}
```

The demo key and its spend live only in a throwaway local database

## Type

🆕 New Feature

## Changes

`BudgetConfig` gains an optional `models` list. A `model_max_budget` entry that sets it becomes a model group budget: the entry's key is the group's name (any label) and every listed model draws from one shared spend pool, keyed as `virtual_key_spend:{token}:{group_name}:{duration}`

`_PROXY_VirtualKeyModelMaxBudgetLimiter` enforces group budgets in `is_key_within_model_budget` (raising `BudgetExceededError` naming the group and the request model) and tracks spend into the group pool in `async_log_success_event`. Entries with `models` are excluded from the direct per-model lookup, so a group's name can never be confused with a model name. A model matches a group by exact name, where either the member or the request may carry a provider prefix; a member written with a provider prefix pins the group to that provider's route, and a bare member name matches every route. Direct and group budgets compose: a model with its own entry and a group membership must be within both

End-user model budgets get the same treatment: group entries in `end_user_model_max_budget` are enforced in `is_end_user_within_model_budget` and tracked against `end_user_model_spend:{end_user_id}:{group_name}:{duration}`, so the group shape advertised on `BudgetNewRequest` works for customer budgets too

`/key/info` model budget usage reporting works for group entries with no changes since its cache key already uses the entry name. Swagger docstrings for `/key/generate`, `/key/update` and `BudgetNewRequest` document the new shape. Docs update: BerriAI/litellm-docs#640

Tests are in the new mapped file `tests/test_litellm/proxy/hooks/test_model_max_budget_limiter.py`. They drive spend through the real tracking path (`async_log_success_event` into a real in-memory `DualCache`) and then assert enforcement, so a drift between the tracking and enforcement cache keys fails the suite: shared pool blocks every group member, boundary spend passes, provider-prefixed members and requests match, non-members and the group's own name are unaffected, direct plus group budgets are enforced together, entries missing `budget_limit` or `time_period` stay inert, and end-user group pools block across members

One observation from QA, pre-existing and out of scope here: running `proxy_cli.py` without `--reload` and without Redis leaves two `proxy_server` module instances in the process, so budget tracking and enforcement (including existing per-model budgets) use different in-memory caches and budgets never block; with `--reload` (the documented dev command) or Redis it behaves correctly

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR