### PR TITLE
fix(proxy): disconnect the per-call PrismaClient in global_spend_refresh

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -2549,9 +2549,7 @@ async def global_spend_refresh():
                 try:
                     await new_client.disconnect()
                 except Exception:
-                    verbose_proxy_logger.exception(
-                        "Failed to disconnect MonthlyGlobalSpend refresh client"
-                    )
+                    verbose_proxy_logger.exception("Failed to disconnect MonthlyGlobalSpend refresh client")
 
 
 async def global_spend_for_internal_user(

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -2514,6 +2514,7 @@ async def global_spend_refresh():
         sql_query = """
         REFRESH MATERIALIZED VIEW "MonthlyGlobalSpend";    
         """
+        new_client = None
         try:
             from litellm.proxy._types import CommonProxyErrors
             from litellm.proxy.proxy_server import proxy_logging_obj
@@ -2543,6 +2544,14 @@ async def global_spend_refresh():
                 "message": "Failed to refresh materialized view",
                 "status": "failure",
             }
+        finally:
+            if new_client is not None:
+                try:
+                    await new_client.db.disconnect()
+                except Exception:
+                    verbose_proxy_logger.exception(
+                        "Failed to disconnect MonthlyGlobalSpend refresh client"
+                    )
 
 
 async def global_spend_for_internal_user(

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -2547,7 +2547,7 @@ async def global_spend_refresh():
         finally:
             if new_client is not None:
                 try:
-                    await new_client.db.disconnect()
+                    await new_client.disconnect()
                 except Exception:
                     verbose_proxy_logger.exception(
                         "Failed to disconnect MonthlyGlobalSpend refresh client"

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -3159,7 +3159,7 @@ async def global_spend_refresh():
         finally:
             if new_client is not None:
                 try:
-                    await new_client.db.disconnect()
+                    await new_client.disconnect()
                 except Exception:
                     verbose_proxy_logger.exception(
                         "Failed to disconnect MonthlyGlobalSpend refresh client"

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -3126,7 +3126,6 @@ async def global_spend_refresh():
         sql_query: Final = """
         REFRESH MATERIALIZED VIEW "MonthlyGlobalSpend";    
         """
-        new_client = None
         try:
             from litellm.proxy._types import CommonProxyErrors
             from litellm.proxy.proxy_server import proxy_logging_obj
@@ -3142,13 +3141,19 @@ async def global_spend_refresh():
                     "timeout": 6000,
                 },
             )
-            await new_client.db.connect()
-            await _query_raw(new_client, sql_query)
-            verbose_proxy_logger.info("MonthlyGlobalSpend view refreshed")
-            return {
-                "message": "MonthlyGlobalSpend view refreshed",
-                "status": "success",
-            }
+            try:
+                await new_client.db.connect()
+                await _query_raw(new_client, sql_query)
+                verbose_proxy_logger.info("MonthlyGlobalSpend view refreshed")
+                return {
+                    "message": "MonthlyGlobalSpend view refreshed",
+                    "status": "success",
+                }
+            finally:
+                try:
+                    await new_client.disconnect()
+                except Exception:
+                    verbose_proxy_logger.exception("Failed to disconnect MonthlyGlobalSpend refresh client")
 
         except Exception as e:
             verbose_proxy_logger.exception("Failed to refresh materialized view - %s", e)
@@ -3156,12 +3161,6 @@ async def global_spend_refresh():
                 "message": "Failed to refresh materialized view",
                 "status": "failure",
             }
-        finally:
-            if new_client is not None:
-                try:
-                    await new_client.disconnect()
-                except Exception:
-                    verbose_proxy_logger.exception("Failed to disconnect MonthlyGlobalSpend refresh client")
 
 
 async def global_spend_for_internal_user(

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -3161,9 +3161,7 @@ async def global_spend_refresh():
                 try:
                     await new_client.disconnect()
                 except Exception:
-                    verbose_proxy_logger.exception(
-                        "Failed to disconnect MonthlyGlobalSpend refresh client"
-                    )
+                    verbose_proxy_logger.exception("Failed to disconnect MonthlyGlobalSpend refresh client")
 
 
 async def global_spend_for_internal_user(

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -3126,6 +3126,7 @@ async def global_spend_refresh():
         sql_query: Final = """
         REFRESH MATERIALIZED VIEW "MonthlyGlobalSpend";    
         """
+        new_client = None
         try:
             from litellm.proxy._types import CommonProxyErrors
             from litellm.proxy.proxy_server import proxy_logging_obj
@@ -3155,6 +3156,14 @@ async def global_spend_refresh():
                 "message": "Failed to refresh materialized view",
                 "status": "failure",
             }
+        finally:
+            if new_client is not None:
+                try:
+                    await new_client.db.disconnect()
+                except Exception:
+                    verbose_proxy_logger.exception(
+                        "Failed to disconnect MonthlyGlobalSpend refresh client"
+                    )
 
 
 async def global_spend_for_internal_user(

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -4391,3 +4391,57 @@ def test_ui_view_request_response_reads_from_cold_storage(client, monkeypatch):
         assert cold_logger.requested_object_keys == ["k/cold.json"]
     finally:
         app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_global_spend_refresh_disconnects_client_on_success(monkeypatch):
+    from litellm.proxy.spend_tracking.spend_management_endpoints import (
+        global_spend_refresh,
+    )
+
+    fake_singleton = MagicMock()
+    fake_singleton.db = MagicMock()
+    fake_singleton.db.query_raw = AsyncMock(
+        return_value=[{"relname": "MonthlyGlobalSpend", "relkind": "m"}]
+    )
+    monkeypatch.setattr(ps, "prisma_client", fake_singleton)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://localhost:5432/db")
+
+    fake_client = MagicMock()
+    fake_client.db = MagicMock()
+    fake_client.db.connect = AsyncMock()
+    fake_client.db.query_raw = AsyncMock(return_value=None)
+    fake_client.db.disconnect = AsyncMock()
+
+    with patch("litellm.proxy.utils.PrismaClient", return_value=fake_client):
+        result = await global_spend_refresh()
+
+    assert result["status"] == "success"
+    fake_client.db.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_global_spend_refresh_disconnects_client_on_failure(monkeypatch):
+    from litellm.proxy.spend_tracking.spend_management_endpoints import (
+        global_spend_refresh,
+    )
+
+    fake_singleton = MagicMock()
+    fake_singleton.db = MagicMock()
+    fake_singleton.db.query_raw = AsyncMock(
+        return_value=[{"relname": "MonthlyGlobalSpend", "relkind": "m"}]
+    )
+    monkeypatch.setattr(ps, "prisma_client", fake_singleton)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://localhost:5432/db")
+
+    fake_client = MagicMock()
+    fake_client.db = MagicMock()
+    fake_client.db.connect = AsyncMock()
+    fake_client.db.query_raw = AsyncMock(side_effect=Exception("refresh timed out"))
+    fake_client.db.disconnect = AsyncMock()
+
+    with patch("litellm.proxy.utils.PrismaClient", return_value=fake_client):
+        result = await global_spend_refresh()
+
+    assert result["status"] == "failure"
+    fake_client.db.disconnect.assert_awaited_once()

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -4411,13 +4411,13 @@ async def test_global_spend_refresh_disconnects_client_on_success(monkeypatch):
     fake_client.db = MagicMock()
     fake_client.db.connect = AsyncMock()
     fake_client.db.query_raw = AsyncMock(return_value=None)
-    fake_client.db.disconnect = AsyncMock()
+    fake_client.disconnect = AsyncMock()
 
     with patch("litellm.proxy.utils.PrismaClient", return_value=fake_client):
         result = await global_spend_refresh()
 
     assert result["status"] == "success"
-    fake_client.db.disconnect.assert_awaited_once()
+    fake_client.disconnect.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -4438,10 +4438,10 @@ async def test_global_spend_refresh_disconnects_client_on_failure(monkeypatch):
     fake_client.db = MagicMock()
     fake_client.db.connect = AsyncMock()
     fake_client.db.query_raw = AsyncMock(side_effect=Exception("refresh timed out"))
-    fake_client.db.disconnect = AsyncMock()
+    fake_client.disconnect = AsyncMock()
 
     with patch("litellm.proxy.utils.PrismaClient", return_value=fake_client):
         result = await global_spend_refresh()
 
     assert result["status"] == "failure"
-    fake_client.db.disconnect.assert_awaited_once()
+    fake_client.disconnect.assert_awaited_once()

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -4445,3 +4445,30 @@ async def test_global_spend_refresh_disconnects_client_on_failure(monkeypatch):
 
     assert result["status"] == "failure"
     fake_client.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_global_spend_refresh_swallows_disconnect_error(monkeypatch):
+    from litellm.proxy.spend_tracking.spend_management_endpoints import (
+        global_spend_refresh,
+    )
+
+    fake_singleton = MagicMock()
+    fake_singleton.db = MagicMock()
+    fake_singleton.db.query_raw = AsyncMock(
+        return_value=[{"relname": "MonthlyGlobalSpend", "relkind": "m"}]
+    )
+    monkeypatch.setattr(ps, "prisma_client", fake_singleton)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://localhost:5432/db")
+
+    fake_client = MagicMock()
+    fake_client.db = MagicMock()
+    fake_client.db.connect = AsyncMock()
+    fake_client.db.query_raw = AsyncMock(return_value=None)
+    fake_client.disconnect = AsyncMock(side_effect=Exception("disconnect failed"))
+
+    with patch("litellm.proxy.utils.PrismaClient", return_value=fake_client):
+        result = await global_spend_refresh()
+
+    assert result["status"] == "success"
+    fake_client.disconnect.assert_awaited_once()

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -5317,13 +5317,13 @@ async def test_global_spend_refresh_disconnects_client_on_success(monkeypatch):
     fake_client.db = MagicMock()
     fake_client.db.connect = AsyncMock()
     fake_client.db.query_raw = AsyncMock(return_value=None)
-    fake_client.db.disconnect = AsyncMock()
+    fake_client.disconnect = AsyncMock()
 
     with patch("litellm.proxy.utils.PrismaClient", return_value=fake_client):
         result = await global_spend_refresh()
 
     assert result["status"] == "success"
-    fake_client.db.disconnect.assert_awaited_once()
+    fake_client.disconnect.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -5344,10 +5344,10 @@ async def test_global_spend_refresh_disconnects_client_on_failure(monkeypatch):
     fake_client.db = MagicMock()
     fake_client.db.connect = AsyncMock()
     fake_client.db.query_raw = AsyncMock(side_effect=Exception("refresh timed out"))
-    fake_client.db.disconnect = AsyncMock()
+    fake_client.disconnect = AsyncMock()
 
     with patch("litellm.proxy.utils.PrismaClient", return_value=fake_client):
         result = await global_spend_refresh()
 
     assert result["status"] == "failure"
-    fake_client.db.disconnect.assert_awaited_once()
+    fake_client.disconnect.assert_awaited_once()

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -5299,3 +5299,55 @@ def test_scoped_spend_report_range_at_max_allowed(client, monkeypatch):
         mock_prisma.db.query_raw.assert_awaited_once()
     finally:
         app.dependency_overrides.pop(ps.user_api_key_auth, None)
+@pytest.mark.asyncio
+async def test_global_spend_refresh_disconnects_client_on_success(monkeypatch):
+    from litellm.proxy.spend_tracking.spend_management_endpoints import (
+        global_spend_refresh,
+    )
+
+    fake_singleton = MagicMock()
+    fake_singleton.db = MagicMock()
+    fake_singleton.db.query_raw = AsyncMock(
+        return_value=[{"relname": "MonthlyGlobalSpend", "relkind": "m"}]
+    )
+    monkeypatch.setattr(ps, "prisma_client", fake_singleton)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://localhost:5432/db")
+
+    fake_client = MagicMock()
+    fake_client.db = MagicMock()
+    fake_client.db.connect = AsyncMock()
+    fake_client.db.query_raw = AsyncMock(return_value=None)
+    fake_client.db.disconnect = AsyncMock()
+
+    with patch("litellm.proxy.utils.PrismaClient", return_value=fake_client):
+        result = await global_spend_refresh()
+
+    assert result["status"] == "success"
+    fake_client.db.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_global_spend_refresh_disconnects_client_on_failure(monkeypatch):
+    from litellm.proxy.spend_tracking.spend_management_endpoints import (
+        global_spend_refresh,
+    )
+
+    fake_singleton = MagicMock()
+    fake_singleton.db = MagicMock()
+    fake_singleton.db.query_raw = AsyncMock(
+        return_value=[{"relname": "MonthlyGlobalSpend", "relkind": "m"}]
+    )
+    monkeypatch.setattr(ps, "prisma_client", fake_singleton)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://localhost:5432/db")
+
+    fake_client = MagicMock()
+    fake_client.db = MagicMock()
+    fake_client.db.connect = AsyncMock()
+    fake_client.db.query_raw = AsyncMock(side_effect=Exception("refresh timed out"))
+    fake_client.db.disconnect = AsyncMock()
+
+    with patch("litellm.proxy.utils.PrismaClient", return_value=fake_client):
+        result = await global_spend_refresh()
+
+    assert result["status"] == "failure"
+    fake_client.db.disconnect.assert_awaited_once()

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -5351,3 +5351,30 @@ async def test_global_spend_refresh_disconnects_client_on_failure(monkeypatch):
 
     assert result["status"] == "failure"
     fake_client.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_global_spend_refresh_swallows_disconnect_error(monkeypatch):
+    from litellm.proxy.spend_tracking.spend_management_endpoints import (
+        global_spend_refresh,
+    )
+
+    fake_singleton = MagicMock()
+    fake_singleton.db = MagicMock()
+    fake_singleton.db.query_raw = AsyncMock(
+        return_value=[{"relname": "MonthlyGlobalSpend", "relkind": "m"}]
+    )
+    monkeypatch.setattr(ps, "prisma_client", fake_singleton)
+    monkeypatch.setenv("DATABASE_URL", "postgresql://localhost:5432/db")
+
+    fake_client = MagicMock()
+    fake_client.db = MagicMock()
+    fake_client.db.connect = AsyncMock()
+    fake_client.db.query_raw = AsyncMock(return_value=None)
+    fake_client.disconnect = AsyncMock(side_effect=Exception("disconnect failed"))
+
+    with patch("litellm.proxy.utils.PrismaClient", return_value=fake_client):
+        result = await global_spend_refresh()
+
+    assert result["status"] == "success"
+    fake_client.disconnect.assert_awaited_once()


### PR DESCRIPTION
## TLDR

<!-- Problem this solves -->
- `global_spend_refresh()` leaks a DB connection on every `/global/spend/refresh` call
- Leak accumulates until Postgres `max_connections` is hit → proxy-wide auth failures

<!-- How it solves it -->
- The per-call dedicated `PrismaClient` is now always disconnected via `try/finally`
- Its long `timeout:6000` (needed for slow matview refreshes) is preserved unchanged

## Relevant issues

Fixes #34269

## Type

🐛 Bug Fix

## Changes

`global_spend_refresh()`'s REFRESH MATERIALIZED VIEW branch builds a dedicated `PrismaClient` (with `http_client={"timeout": 6000}`, because a `REFRESH MATERIALIZED VIEW` on a large `LiteLLM_SpendLogs` table can far exceed the default 30s client timeout), connects it, runs the refresh — but never disconnects it. Every call leaks a Prisma engine + DB connection until the pool is exhausted and the proxy fails with `FATAL: sorry, too many clients already`.

This wraps the refresh in `try/finally` and disconnects the dedicated client on **every** path (success, refresh-error, and the early `db_url is None` raise). The dedicated client and its long timeout are intentionally kept as-is, so refresh behavior is unchanged — the only difference is the connection is now released.

Note: reusing the module-global `prisma_client` instead was considered and rejected — it would silently drop the long timeout, and on read-replica deployments would route the `REFRESH` (a write) through `query_raw` to a read-only standby.

## Pre-Submission checklist

- [x] Meaningful tests added (3 mocked tests in `test_spend_management_endpoints.py`: disconnect asserted on the success path, the refresh-failure path, and when `disconnect()` itself raises)
- [x] CI / unit tests pass locally (ruff format clean)
- [x] Scope isolated to one problem (the connection leak only)
- [x] Greptile review passed (5/5)

## Screenshots / Proof of Fix

Validated on our dev LiteLLM proxy against a live RDS Postgres, exercising the exact mechanism the patched `global_spend_refresh` uses (dedicated `PrismaClient(http_client={"timeout": 6000})` → `.db.connect()` → query → cleanup) while watching `pg_stat_activity`:

```
=== global_spend_refresh connection-leak fix — validated on dev (live RDS) ===
baseline pg_stat_activity connections: 12

BEFORE (upstream: dedicated client, no disconnect):
  after 5 refresh calls: 17 connections  (+5, leaked)

AFTER (this PR: dedicated client + finally: disconnect()):
  after 20 refresh calls: 12 connections  (net +0 — every client released)
```

- **Before** (current upstream path — dedicated client, never disconnected): 5 calls leak 5 connections that never return.
- **After** (this PR — `finally: await new_client.disconnect()`): 20 calls, net **+0**; every dedicated client is released and the count returns to baseline.
- Causality confirmed: applying `disconnect()` to the leaked clients dropped the count straight back from 17 to 12 — the disconnect is what releases them, which the `finally` now guarantees on every path.

Screenshot of the live run
<img width="1087" height="758" alt="image" src="https://github.com/user-attachments/assets/bae89fb2-5de0-4b1f-a13c-c3c0f1b5491d" />


