### PR TITLE
fix(proxy): preserve explicit customer update values

### DIFF
--- a/litellm/proxy/management_endpoints/customer_endpoints.py
+++ b/litellm/proxy/management_endpoints/customer_endpoints.py
@@ -53,6 +53,12 @@ def _to_customer_response(record: BaseModel) -> CustomerResponse:
     return CustomerResponse.model_validate(record.model_dump())
 
 
+def _customer_update_values(data: UpdateCustomerRequest) -> dict:
+    """Return the scalar values explicitly supplied by the caller."""
+    data_json: Final[dict] = data.json(exclude_unset=True)
+    return {key: value for key, value in data_json.items() if value not in ([], {})}
+
+
 @router.post(
     "/end_user/block",
     tags=["Customer Management"],
@@ -210,6 +216,11 @@ async def _handle_customer_object_permission_update(
         prisma_client: Prisma database client
     """
     if "object_permission" in non_default_values:
+        if non_default_values["object_permission"] is None:
+            non_default_values.pop("object_permission")
+            update_end_user_table_data["object_permission_id"] = None
+            return
+
         existing_object_permission_id: Final = (
             end_user_table_data_typed.object_permission_id if end_user_table_data_typed is not None else None
         )
@@ -533,20 +544,12 @@ async def update_end_user(
     from litellm.proxy.proxy_server import litellm_proxy_admin_name, prisma_client
 
     try:
-        data_json: Final[dict] = data.json()
         # get the row from db
         if prisma_client is None:
             raise Exception("Not connected to DB!")
 
-        # get non default values for key
-        non_default_values: Final = {}
-        for k, v in data_json.items():
-            if v is not None and v not in (
-                [],
-                {},
-                0,
-            ):  # models default to [], spend defaults to 0, we should not reset these values
-                non_default_values[k] = v
+        # Build the update from fields present in the request.
+        non_default_values: Final = _customer_update_values(data)
 
         ## Get end user table data ##
         end_user_table_data: Final = await EndUserRepository(prisma_client).table.find_first(
@@ -590,17 +593,18 @@ async def update_end_user(
         ## Check if we need to create a new budget (only if budget fields are provided, not just budget_id) ##
         if budget_table_data:
             if end_user_budget_table is None:
-                ## Create new budget ##
-                budget_table_data_record = await BudgetRepository(prisma_client).table.create(
-                    data={
-                        **budget_table_data,
-                        "created_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
-                        "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
-                    },
-                    include={"end_users": True},
-                )
+                if any(value is not None for value in budget_table_data.values()):
+                    ## Create new budget ##
+                    budget_table_data_record = await BudgetRepository(prisma_client).table.create(
+                        data={
+                            **budget_table_data,
+                            "created_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
+                            "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
+                        },
+                        include={"end_users": True},
+                    )
 
-                update_end_user_table_data["budget_id"] = budget_table_data_record.budget_id
+                    update_end_user_table_data["budget_id"] = budget_table_data_record.budget_id
             else:
                 ## Update existing budget ##
                 budget_table_data_record = await BudgetRepository(prisma_client).table.update(

--- a/tests/test_litellm/proxy/management_endpoints/test_customer_budget.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_customer_budget.py
@@ -344,6 +344,108 @@ async def test_update_customer_with_budget_id_and_creation_fields(
     assert update_data["budget_id"] == "new-budget-combo"  # From created budget
 
 
+@pytest.mark.asyncio
+@patch("litellm.proxy.proxy_server.prisma_client")
+@patch("litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin")
+async def test_update_customer_can_set_zero_budget(
+    mock_prisma_client, mock_user_api_key_dict, mock_existing_customer
+):
+    mock_existing_customer.model_dump.return_value = {
+        "user_id": "test-user",
+        "blocked": False,
+        "litellm_budget_table": {
+            "budget_id": "budget-1",
+            "max_budget": 10.0,
+        },
+    }
+
+    mock_prisma_client.db.litellm_endusertable.find_first = AsyncMock(
+        return_value=mock_existing_customer
+    )
+
+    mock_updated_budget = MagicMock()
+    mock_updated_budget.budget_id = "budget-1"
+    mock_prisma_client.db.litellm_budgettable.update = AsyncMock(
+        return_value=mock_updated_budget
+    )
+
+    mock_updated_user = MagicMock()
+    mock_updated_user.model_dump.return_value = {"user_id": "test-user", "blocked": False}
+    mock_prisma_client.db.litellm_endusertable.update = AsyncMock(
+        return_value=mock_updated_user
+    )
+
+    update_request = UpdateCustomerRequest(user_id="test-user", max_budget=0)
+
+    await update_end_user(update_request, mock_user_api_key_dict)
+
+    mock_prisma_client.db.litellm_budgettable.update.assert_called_once()
+    call_args = mock_prisma_client.db.litellm_budgettable.update.call_args
+    assert call_args.kwargs["where"] == {"budget_id": "budget-1"}
+    assert call_args.kwargs["data"]["max_budget"] == 0
+
+
+@pytest.mark.asyncio
+@patch("litellm.proxy.proxy_server.prisma_client")
+@patch("litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin")
+async def test_update_customer_can_clear_existing_budget_limit(
+    mock_prisma_client, mock_user_api_key_dict, mock_existing_customer
+):
+    mock_existing_customer.model_dump.return_value = {
+        "user_id": "test-user",
+        "blocked": False,
+        "litellm_budget_table": {
+            "budget_id": "budget-1",
+            "max_budget": 10.0,
+        },
+    }
+    mock_prisma_client.db.litellm_endusertable.find_first = AsyncMock(
+        return_value=mock_existing_customer
+    )
+    mock_prisma_client.db.litellm_budgettable.update = AsyncMock()
+    mock_updated_user = MagicMock()
+    mock_updated_user.model_dump.return_value = {"user_id": "test-user", "blocked": False}
+    mock_prisma_client.db.litellm_endusertable.update = AsyncMock(
+        return_value=mock_updated_user
+    )
+
+    await update_end_user(
+        UpdateCustomerRequest(user_id="test-user", max_budget=None),
+        mock_user_api_key_dict,
+    )
+
+    update_data = mock_prisma_client.db.litellm_budgettable.update.call_args.kwargs["data"]
+    assert update_data["max_budget"] is None
+
+
+@pytest.mark.asyncio
+@patch("litellm.proxy.proxy_server.prisma_client")
+@patch("litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin")
+async def test_null_budget_limit_does_not_create_empty_budget(
+    mock_prisma_client, mock_user_api_key_dict, mock_existing_customer
+):
+    mock_existing_customer.model_dump.return_value = {
+        "user_id": "test-user",
+        "blocked": False,
+        "litellm_budget_table": None,
+    }
+    mock_prisma_client.db.litellm_endusertable.find_first = AsyncMock(
+        return_value=mock_existing_customer
+    )
+    mock_updated_user = MagicMock()
+    mock_updated_user.model_dump.return_value = {"user_id": "test-user", "blocked": False}
+    mock_prisma_client.db.litellm_endusertable.update = AsyncMock(
+        return_value=mock_updated_user
+    )
+
+    await update_end_user(
+        UpdateCustomerRequest(user_id="test-user", max_budget=None),
+        mock_user_api_key_dict,
+    )
+
+    assert not mock_prisma_client.db.litellm_budgettable.create.called
+
+
 def test_new_budget_request_sets_budget_reset_at_when_duration_provided():
     """
     Test that new_budget_request auto-populates budget_reset_at when

--- a/tests/test_litellm/proxy/management_endpoints/test_customer_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_customer_endpoints.py
@@ -353,6 +353,64 @@ def test_update_customer_response_preserves_budget_id(mock_prisma_client, mock_u
     assert response.json()["budget_id"] == "budget-123"
 
 
+def test_update_customer_can_set_blocked_false(mock_prisma_client, mock_user_api_key_auth):
+    existing = LiteLLM_EndUserTable(user_id="cust-1", blocked=True)
+    updated = LiteLLM_EndUserTable(user_id="cust-1", blocked=False)
+    mock_prisma_client.db.litellm_endusertable.find_first = AsyncMock(return_value=existing)
+    mock_prisma_client.db.litellm_endusertable.update = AsyncMock(return_value=updated)
+
+    response = client.post(
+        "/customer/update",
+        json={"user_id": "cust-1", "blocked": False},
+        headers={"Authorization": "Bearer test-key"},
+    )
+
+    assert response.status_code == 200
+    update_data = mock_prisma_client.db.litellm_endusertable.update.call_args.kwargs["data"]
+    assert update_data["blocked"] is False
+    assert response.json()["blocked"] is False
+
+
+def test_update_customer_does_not_send_default_blocked_false(mock_prisma_client, mock_user_api_key_auth):
+    existing = LiteLLM_EndUserTable(user_id="cust-1", alias="old", blocked=True)
+    updated = LiteLLM_EndUserTable(user_id="cust-1", alias="new", blocked=True)
+    mock_prisma_client.db.litellm_endusertable.find_first = AsyncMock(return_value=existing)
+    mock_prisma_client.db.litellm_endusertable.update = AsyncMock(return_value=updated)
+
+    response = client.post(
+        "/customer/update",
+        json={"user_id": "cust-1", "alias": "new"},
+        headers={"Authorization": "Bearer test-key"},
+    )
+
+    assert response.status_code == 200
+    update_data = mock_prisma_client.db.litellm_endusertable.update.call_args.kwargs["data"]
+    assert "blocked" not in update_data
+
+
+def test_update_customer_can_clear_nullable_fields(mock_prisma_client, mock_user_api_key_auth):
+    existing = LiteLLM_EndUserTable(
+        user_id="cust-1",
+        alias="old alias",
+        blocked=False,
+        object_permission_id="permission-1",
+    )
+    updated = LiteLLM_EndUserTable(user_id="cust-1", blocked=False)
+    mock_prisma_client.db.litellm_endusertable.find_first = AsyncMock(return_value=existing)
+    mock_prisma_client.db.litellm_endusertable.update = AsyncMock(return_value=updated)
+
+    response = client.post(
+        "/customer/update",
+        json={"user_id": "cust-1", "alias": None, "object_permission": None},
+        headers={"Authorization": "Bearer test-key"},
+    )
+
+    assert response.status_code == 200
+    update_data = mock_prisma_client.db.litellm_endusertable.update.call_args.kwargs["data"]
+    assert update_data["alias"] is None
+    assert update_data["object_permission_id"] is None
+
+
 def test_update_customer_response_keeps_nested_budget_server_fields(mock_prisma_client, mock_user_api_key_auth):
     """
     Faithfulness regression: /customer/update embeds the full budget row. The


### PR DESCRIPTION
## What changed
- Build customer updates from fields that are present in the request.
- Preserve deliberate `false`, `0` and `null` values.
- Detach object permissions when `object_permission` is explicitly null.
- Avoid creating an empty budget when a customer without one sends `max_budget: null`.
- Add regressions for omitted defaults, unblocking, zero budgets and nullable fields.

Fixes #34379

## Why
The previous value filter treated valid falsey values as though the caller had omitted them. That made unblock and zero-budget requests report success without applying the requested change. Explicit nulls need the same distinction so nullable fields can be cleared.

## Testing
- `.venv/bin/python -m pytest tests/test_litellm/proxy/management_endpoints/test_customer_endpoints.py tests/test_litellm/proxy/management_endpoints/test_customer_budget.py -q` (40 passed)
- `.venv/bin/python -m ruff check litellm/proxy/management_endpoints/customer_endpoints.py tests/test_litellm/proxy/management_endpoints/test_customer_endpoints.py tests/test_litellm/proxy/management_endpoints/test_customer_budget.py`
- `.venv/bin/python scripts/type_discipline_gate.py --base origin/litellm_internal_staging`
- `git diff --check`