### PR TITLE
fix: handle item ids in response endpoint

### DIFF
--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -1111,6 +1111,11 @@ def responses(
 
         # Decode any litellm-encoded encrypted-content item IDs back to their original IDs
         input = ResponsesAPIRequestUtils._restore_encrypted_content_item_ids_in_input(input)
+        input = ResponsesAPIRequestUtils._normalize_function_call_ids_in_input(
+            request_input=input,
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+        )
 
         # Call the handler with _is_async flag instead of directly calling the async handler
         if custom_llm_provider is None:

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -480,6 +480,24 @@ class ResponsesAPIRequestUtils:
         return _remove_thought_signature_from_id(call_id, THOUGHT_SIGNATURE_SEPARATOR)
 
     @staticmethod
+    def _provider_uses_openai_function_call_item_ids(
+        custom_llm_provider: str | None,
+        model: str | None = None,
+    ) -> bool:
+        """True when the target Responses adapter expects OpenAI fc_ item ids."""
+        if custom_llm_provider is None:
+            return False
+
+        from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
+        from litellm.utils import ProviderConfigManager
+
+        config = ProviderConfigManager.get_provider_responses_api_config(
+            provider=custom_llm_provider,
+            model=model,
+        )
+        return isinstance(config, OpenAIResponsesAPIConfig)
+
+    @staticmethod
     def _normalize_function_call_item_id_for_provider(
         item_id: str,
         model: str | None,
@@ -492,7 +510,10 @@ class ResponsesAPIRequestUtils:
             custom_llm_provider=custom_llm_provider,
         )
 
-        if custom_llm_provider != "openai":
+        if not ResponsesAPIRequestUtils._provider_uses_openai_function_call_item_ids(
+            custom_llm_provider=custom_llm_provider,
+            model=model,
+        ):
             return item_id
 
         if item_id.startswith("call_"):

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -464,6 +464,93 @@ class ResponsesAPIRequestUtils:
         return request_input
 
     @staticmethod
+    def _normalize_call_id_for_provider(
+        call_id: str,
+        model: str | None,
+        custom_llm_provider: str | None,
+    ) -> str:
+        """Strip Gemini thought signatures from call_id when replaying to non-Gemini models."""
+        from litellm.litellm_core_utils.prompt_templates.factory import (
+            THOUGHT_SIGNATURE_SEPARATOR,
+        )
+        from litellm.utils import _is_gemini_model, _remove_thought_signature_from_id
+
+        if _is_gemini_model(model=model, custom_llm_provider=custom_llm_provider):
+            return call_id
+        return _remove_thought_signature_from_id(call_id, THOUGHT_SIGNATURE_SEPARATOR)
+
+    @staticmethod
+    def _normalize_function_call_item_id_for_provider(
+        item_id: str,
+        model: str | None,
+        custom_llm_provider: str | None,
+    ) -> str:
+        """Rewrite foreign provider function_call item ids to OpenAI fc_ format."""
+        item_id = ResponsesAPIRequestUtils._normalize_call_id_for_provider(
+            call_id=item_id,
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+        )
+
+        if custom_llm_provider != "openai":
+            return item_id
+
+        if item_id.startswith("call_"):
+            return f"fc_{item_id[len('call_') :]}"
+        if item_id.startswith("tooluse_"):
+            return f"fc_{item_id[len('tooluse_') :]}"
+        if item_id.startswith("toolu_vrtx_"):
+            return f"fc_{item_id[len('toolu_vrtx_') :]}"
+
+        return item_id
+
+    @staticmethod
+    def _normalize_function_call_ids_in_input(
+        request_input: Any,
+        model: str | None,
+        custom_llm_provider: str | None,
+    ) -> Any:
+        """Normalize function_call / function_call_output IDs before upstream replay.
+
+        - Strips Gemini thought signatures from call_id for non-Gemini targets.
+        - Rewrites foreign function_call item ids (call_, tooluse_) to fc_ for OpenAI-compatible targets.
+        """
+        if not isinstance(request_input, list):
+            return request_input
+
+        for item in request_input:
+            if not isinstance(item, dict):
+                continue
+
+            item_type = item.get("type")
+            if item_type == "function_call":
+                call_id = item.get("call_id")
+                if call_id and isinstance(call_id, str):
+                    item["call_id"] = ResponsesAPIRequestUtils._normalize_call_id_for_provider(
+                        call_id=call_id,
+                        model=model,
+                        custom_llm_provider=custom_llm_provider,
+                    )
+
+                item_id = item.get("id")
+                if item_id and isinstance(item_id, str):
+                    item["id"] = ResponsesAPIRequestUtils._normalize_function_call_item_id_for_provider(
+                        item_id=item_id,
+                        model=model,
+                        custom_llm_provider=custom_llm_provider,
+                    )
+            elif item_type == "function_call_output":
+                call_id = item.get("call_id")
+                if call_id and isinstance(call_id, str):
+                    item["call_id"] = ResponsesAPIRequestUtils._normalize_call_id_for_provider(
+                        call_id=call_id,
+                        model=model,
+                        custom_llm_provider=custom_llm_provider,
+                    )
+
+        return request_input
+
+    @staticmethod
     def _build_responses_api_response_id(
         custom_llm_provider: Optional[str],
         model_id: Optional[str],

--- a/tests/test_litellm/responses/test_responses_utils.py
+++ b/tests/test_litellm/responses/test_responses_utils.py
@@ -228,6 +228,87 @@ class TestResponsesAPIRequestUtils:
         assert decoded.get("custom_llm_provider") == "azure"
         assert decoded.get("response_id") == "cntr_x"
 
+    def test_normalize_call_id_strips_thought_signature_for_non_gemini(self):
+        from litellm.litellm_core_utils.prompt_templates.factory import (
+            THOUGHT_SIGNATURE_SEPARATOR,
+        )
+
+        call_id = f"call_abc123{THOUGHT_SIGNATURE_SEPARATOR}sig_xyz"
+        result = ResponsesAPIRequestUtils._normalize_call_id_for_provider(
+            call_id=call_id,
+            model="gpt-4o",
+            custom_llm_provider="openai",
+        )
+        assert result == "call_abc123"
+
+    def test_normalize_call_id_preserves_thought_signature_for_gemini(self):
+        from litellm.litellm_core_utils.prompt_templates.factory import (
+            THOUGHT_SIGNATURE_SEPARATOR,
+        )
+
+        call_id = f"call_abc123{THOUGHT_SIGNATURE_SEPARATOR}sig_xyz"
+        result = ResponsesAPIRequestUtils._normalize_call_id_for_provider(
+            call_id=call_id,
+            model="gemini-2.5-flash",
+            custom_llm_provider="gemini",
+        )
+        assert result == call_id
+
+    def test_normalize_function_call_item_id_rewrites_for_openai(self):
+        result = ResponsesAPIRequestUtils._normalize_function_call_item_id_for_provider(
+            item_id="call_abc123",
+            model="gpt-4o",
+            custom_llm_provider="openai",
+        )
+        assert result == "fc_abc123"
+
+        result_tooluse = (
+            ResponsesAPIRequestUtils._normalize_function_call_item_id_for_provider(
+                item_id="tooluse_abc123",
+                model="gpt-4o",
+                custom_llm_provider="openai",
+            )
+        )
+        assert result_tooluse == "fc_abc123"
+
+    def test_normalize_function_call_item_id_no_rewrite_for_anthropic(self):
+        result = ResponsesAPIRequestUtils._normalize_function_call_item_id_for_provider(
+            item_id="call_abc123",
+            model="claude-3-5-sonnet",
+            custom_llm_provider="anthropic",
+        )
+        assert result == "call_abc123"
+
+    def test_normalize_function_call_ids_in_input(self):
+        from litellm.litellm_core_utils.prompt_templates.factory import (
+            THOUGHT_SIGNATURE_SEPARATOR,
+        )
+
+        request_input = [
+            {
+                "type": "function_call",
+                "id": "tooluse_xyz",
+                "call_id": f"call_abc{THOUGHT_SIGNATURE_SEPARATOR}sig",
+                "name": "get_weather",
+                "arguments": "{}",
+            },
+            {
+                "type": "function_call_output",
+                "call_id": f"call_abc{THOUGHT_SIGNATURE_SEPARATOR}sig",
+                "output": "sunny",
+            },
+        ]
+
+        result = ResponsesAPIRequestUtils._normalize_function_call_ids_in_input(
+            request_input=request_input,
+            model="gpt-4o",
+            custom_llm_provider="openai",
+        )
+
+        assert result[0]["id"] == "fc_xyz"
+        assert result[0]["call_id"] == "call_abc"
+        assert result[1]["call_id"] == "call_abc"
+
 
 class TestResponseAPILoggingUtils:
     def test_is_response_api_usage_true(self):

--- a/tests/test_litellm/responses/test_responses_utils.py
+++ b/tests/test_litellm/responses/test_responses_utils.py
@@ -271,6 +271,57 @@ class TestResponsesAPIRequestUtils:
         )
         assert result_tooluse == "fc_abc123"
 
+        result_vertex = (
+            ResponsesAPIRequestUtils._normalize_function_call_item_id_for_provider(
+                item_id="toolu_vrtx_abc123",
+                model="gpt-4o",
+                custom_llm_provider="openai",
+            )
+        )
+        assert result_vertex == "fc_abc123"
+
+    def test_normalize_function_call_item_id_rewrites_for_azure(self):
+        result = ResponsesAPIRequestUtils._normalize_function_call_item_id_for_provider(
+            item_id="call_abc123",
+            model="gpt-4o",
+            custom_llm_provider="azure",
+        )
+        assert result == "fc_abc123"
+
+        result_tooluse = (
+            ResponsesAPIRequestUtils._normalize_function_call_item_id_for_provider(
+                item_id="tooluse_abc123",
+                model="gpt-4o",
+                custom_llm_provider="azure",
+            )
+        )
+        assert result_tooluse == "fc_abc123"
+
+    def test_normalize_function_call_item_id_rewrites_for_xai(self):
+        result = ResponsesAPIRequestUtils._normalize_function_call_item_id_for_provider(
+            item_id="call_abc123",
+            model="grok-4",
+            custom_llm_provider="xai",
+        )
+        assert result == "fc_abc123"
+
+        result_tooluse = (
+            ResponsesAPIRequestUtils._normalize_function_call_item_id_for_provider(
+                item_id="tooluse_abc123",
+                model="grok-4",
+                custom_llm_provider="xai",
+            )
+        )
+        assert result_tooluse == "fc_abc123"
+
+    def test_normalize_function_call_item_id_rewrites_for_hosted_vllm(self):
+        result = ResponsesAPIRequestUtils._normalize_function_call_item_id_for_provider(
+            item_id="toolu_vrtx_abc123",
+            model="gpt-4o",
+            custom_llm_provider="hosted_vllm",
+        )
+        assert result == "fc_abc123"
+
     def test_normalize_function_call_item_id_no_rewrite_for_anthropic(self):
         result = ResponsesAPIRequestUtils._normalize_function_call_item_id_for_provider(
             item_id="call_abc123",
@@ -278,6 +329,66 @@ class TestResponsesAPIRequestUtils:
             custom_llm_provider="anthropic",
         )
         assert result == "call_abc123"
+
+    def test_provider_uses_openai_function_call_item_ids(self):
+        assert (
+            ResponsesAPIRequestUtils._provider_uses_openai_function_call_item_ids(
+                custom_llm_provider="openai",
+                model="gpt-4o",
+            )
+            is True
+        )
+        assert (
+            ResponsesAPIRequestUtils._provider_uses_openai_function_call_item_ids(
+                custom_llm_provider="azure",
+                model="gpt-4o",
+            )
+            is True
+        )
+        assert (
+            ResponsesAPIRequestUtils._provider_uses_openai_function_call_item_ids(
+                custom_llm_provider="xai",
+                model="grok-4",
+            )
+            is True
+        )
+        assert (
+            ResponsesAPIRequestUtils._provider_uses_openai_function_call_item_ids(
+                custom_llm_provider="hosted_vllm",
+                model="gpt-4o",
+            )
+            is True
+        )
+        assert (
+            ResponsesAPIRequestUtils._provider_uses_openai_function_call_item_ids(
+                custom_llm_provider="anthropic",
+                model="claude-3-5-sonnet",
+            )
+            is False
+        )
+        assert (
+            ResponsesAPIRequestUtils._provider_uses_openai_function_call_item_ids(
+                custom_llm_provider=None,
+            )
+            is False
+        )
+
+    def test_normalize_function_call_item_id_leaves_unmatched_prefix(self):
+        result = ResponsesAPIRequestUtils._normalize_function_call_item_id_for_provider(
+            item_id="fc_already_normalized",
+            model="gpt-4o",
+            custom_llm_provider="openai",
+        )
+        assert result == "fc_already_normalized"
+
+        result_other = (
+            ResponsesAPIRequestUtils._normalize_function_call_item_id_for_provider(
+                item_id="random_id_123",
+                model="gpt-4o",
+                custom_llm_provider="openai",
+            )
+        )
+        assert result_other == "random_id_123"
 
     def test_normalize_function_call_ids_in_input(self):
         from litellm.litellm_core_utils.prompt_templates.factory import (
@@ -308,6 +419,76 @@ class TestResponsesAPIRequestUtils:
         assert result[0]["id"] == "fc_xyz"
         assert result[0]["call_id"] == "call_abc"
         assert result[1]["call_id"] == "call_abc"
+
+    def test_normalize_function_call_ids_in_input_for_azure(self):
+        from litellm.litellm_core_utils.prompt_templates.factory import (
+            THOUGHT_SIGNATURE_SEPARATOR,
+        )
+
+        request_input = [
+            {
+                "type": "function_call",
+                "id": "call_abc123",
+                "call_id": f"call_abc{THOUGHT_SIGNATURE_SEPARATOR}sig",
+                "name": "get_weather",
+                "arguments": "{}",
+            },
+            "skip-me",
+            {
+                "type": "message",
+                "role": "user",
+                "content": "hi",
+            },
+        ]
+
+        result = ResponsesAPIRequestUtils._normalize_function_call_ids_in_input(
+            request_input=request_input,
+            model="gpt-4o",
+            custom_llm_provider="azure",
+        )
+
+        assert result[0]["id"] == "fc_abc123"
+        assert result[0]["call_id"] == "call_abc"
+        assert result[1] == "skip-me"
+        assert result[2]["type"] == "message"
+
+    def test_normalize_function_call_ids_in_input_for_xai(self):
+        from litellm.litellm_core_utils.prompt_templates.factory import (
+            THOUGHT_SIGNATURE_SEPARATOR,
+        )
+
+        request_input = [
+            {
+                "type": "function_call",
+                "id": "tooluse_xyz",
+                "call_id": f"call_abc{THOUGHT_SIGNATURE_SEPARATOR}sig",
+                "name": "get_weather",
+                "arguments": "{}",
+            },
+            {
+                "type": "function_call_output",
+                "call_id": f"call_abc{THOUGHT_SIGNATURE_SEPARATOR}sig",
+                "output": "sunny",
+            },
+        ]
+
+        result = ResponsesAPIRequestUtils._normalize_function_call_ids_in_input(
+            request_input=request_input,
+            model="grok-4",
+            custom_llm_provider="xai",
+        )
+
+        assert result[0]["id"] == "fc_xyz"
+        assert result[0]["call_id"] == "call_abc"
+        assert result[1]["call_id"] == "call_abc"
+
+    def test_normalize_function_call_ids_in_input_non_list(self):
+        result = ResponsesAPIRequestUtils._normalize_function_call_ids_in_input(
+            request_input="just a string",
+            model="gpt-4o",
+            custom_llm_provider="openai",
+        )
+        assert result == "just a string"
 
 
 class TestResponseAPILoggingUtils:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cross-provider Responses replay rejects foreign function_call ids
- Gemini thought signatures on call_id break non-Gemini upstreams

How it solves it:

- Normalize function_call / function_call_output ids before upstream send
- Strip Gemini thought signatures unless the target is Gemini
- Rewrite call_ / tooluse_ item ids to fc_ for OpenAI targets

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Running this request before and the fix:
```
curl -sS https://litellm-dev.alphasights.io/v1/responses \                                                                                            
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-5.4",
    "input": [
      {"role": "user", "content": "What is the weather in SF?"},
      {
        "type": "function_call",
        "id": "call_abc__thought__sig",
        "call_id": "call_abc__thought__sig",
        "name": "get_weather",
        "arguments": "{\"city\":\"SF\"}"
      },
      {
        "type": "function_call_output",
        "call_id": "call_abc__thought__sig",
        "output": "sunny"
      }
    ],
    "tools": [
      {
        "type": "function",
        "name": "get_weather",
        "parameters": {
          "type": "object",
          "properties": {"city": {"type": "string"}},
          "required": ["city"]
        }
      }
    ]
  }'
```

Before the fix:
```
{
   "error":{
      "message":"litellm.BadRequestError: OpenAIException - {\n  \"error\": {\n    \"message\": \"Invalid 'input[1].id': 'call_abc__thought__sig'. Expected an ID that begins with 'fc'.\",\n    \"type\": \"invalid_request_error\",\n    \"param\": \"input[1].id\",\n    \"code\": \"invalid_value\"\n  }\n}. Received Model Group=gpt-5.4\nAvailable Model Group Fallbacks=None",
      "type":null,
      "param":null,
      "code":"400"
   }
}
```
- Errored as id does not begins with `fc`

After:
```
{
   "id":"resp_LtNIln86MyTLWTv4CGq_uo2bd0NFAzjpidyM1oGfjpFgFEjBdKSQc0G3G5Jbt_FC5pG70Tkm0xPukTWaIWnX53wzf9bHpn_E_9GUrSTLBB6_Kn0aRXk9LklzMNnY3YESmelH2ZNgevnkc18Tpo0RrK2BMsXpi0iPOn3n8KdJCNwTlA-TyTa-9hJ7nnS7i04DHOUI-bOMEKpEaV5oGxwureaREsmN7rxz53QywCSS8F9Oz9_DO064r0t98AJ5VSOtpaAXbEuKkdXlwrkkyLN5smPXtwVFeblWV2RDzoqK3WZDEczYeC0LvpdikKMviM83RUNiOxkwFfVMgQaiPcfrsw1djClZDtIoXX9SBbiprHIloKmXNJK7te8VPdhlTFRoD9qGdq-MiQGIpD_MVvDyx64QLWJlPDtjI3OeRdcau4jdEDQVjXTGWDW2UZwigXtmtufwH7OkUFD5chhNnHislXsxCSvJ7_9_tUlbfjw=",
   "created_at":1784806382,
   "error":null,
   "incomplete_details":null,
   "instructions":null,
   "metadata":{
      
   },
   "model":"gpt-5.4",
   "object":"response",
   "output":[
      {
         "id":"msg_09fae1905266ef93016a61fbefe8d0819a8695e354988c6791",
         "content":[
            {
               "annotations":[
                  
               ],
               "text":"It’s sunny in SF.",
               "type":"output_text",
               "logprobs":[
                  
               ]
            }
         ],
         "role":"assistant",
         "status":"completed",
         "type":"message",
         "phase":"final_answer"
      }
   ],
   "parallel_tool_calls":true,
   "temperature":1.0,
   "tool_choice":"auto",
   "tools":[
      {
         "name":"get_weather",
         "parameters":{
            "type":"object",
            "properties":{
               "city":{
                  "type":"string"
               }
            },
            "required":[
               "city"
            ],
            "additionalProperties":false
         },
         "strict":true,
         "type":"function",
         "allowed_callers":null,
         "defer_loading":null,
         "description":null,
         "output_schema":null
      }
   ],
   "top_p":0.98,
   "max_output_tokens":null,
   "previous_response_id":null,
   "reasoning":{
      "context":"current_turn",
      "effort":"none",
      "mode":"standard",
      "summary":null
   },
   "status":"completed",
   "text":{
      "format":{
         "type":"text"
      },
      "verbosity":"medium"
   },
   "truncation":"disabled",
   "usage":{
      "input_tokens":73,
      "input_tokens_details":{
         "audio_tokens":null,
         "cached_tokens":0,
         "text_tokens":null,
         "cache_write_tokens":0
      },
      "output_tokens":10,
      "output_tokens_details":{
         "reasoning_tokens":0,
         "text_tokens":null
      },
      "total_tokens":83,
      "cost":null
   },
   "user":null,
   "store":false,
   "background":false,
   "billing":{
      "payer":"developer"
   },
   "completed_at":1784806384,
   "frequency_penalty":0.0,
   "max_tool_calls":null,
   "moderation":null,
   "presence_penalty":0.0,
   "prompt_cache_key":null,
   "prompt_cache_retention":"in_memory",
   "safety_identifier":null,
   "service_tier":"default",
   "tool_usage":{
      "image_gen":{
         "input_tokens":0,
         "input_tokens_details":{
            "image_tokens":0,
            "text_tokens":0
         },
         "output_tokens":0,
         "output_tokens_details":{
            "image_tokens":0,
            "text_tokens":0
         },
         "total_tokens":0
      },
      "web_search":{
         "num_requests":0
      }
   },
   "top_logprobs":0
}
```

## Type

🐛 Bug Fix


## Changes

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
