### PR TITLE
fix(schema): arm max_inlined_bytes budget for Bedrock/Vertex tool schema unpacking

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5064,7 +5064,10 @@ def _bedrock_tools_pt(tools: List, model: Optional[str] = None) -> List[BedrockT
         bedrock_converse_supports_strict_tools,
         normalize_json_schema_custom_types_to_object,
     )
-    from litellm.litellm_core_utils.prompt_templates.common_utils import unpack_defs
+    from litellm.litellm_core_utils.prompt_templates.common_utils import (
+        _LEGACY_DEFS_MAX_INLINED_BYTES,
+        unpack_defs,
+    )
 
     _valid_json_schema_root_types = frozenset(("array", "boolean", "integer", "null", "number", "object", "string"))
     # Only Claude on Bedrock honours strict tool schemas; other families
@@ -5114,7 +5117,11 @@ def _bedrock_tools_pt(tools: List, model: Optional[str] = None) -> List[BedrockT
         # Note: We don't pre-flatten defs as that causes exponential memory growth
         # with circular references (see issue #19098). unpack_defs handles nested
         # refs recursively and correctly detects/skips circular references.
-        unpack_defs(parameters, defs_copy)
+        unpack_defs(
+            parameters,
+            defs_copy,
+            max_inlined_bytes=_LEGACY_DEFS_MAX_INLINED_BYTES,
+        )
         normalize_json_schema_custom_types_to_object(parameters)
         if parameters.get("type") not in _valid_json_schema_root_types:
             parameters["type"] = "object"

--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -8,7 +8,10 @@ import httpx
 import litellm
 from litellm._logging import verbose_logger
 from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
-from litellm.litellm_core_utils.prompt_templates.common_utils import unpack_defs
+from litellm.litellm_core_utils.prompt_templates.common_utils import (
+    _LEGACY_DEFS_MAX_INLINED_BYTES,
+    unpack_defs,
+)
 from litellm.llms.base_llm.base_utils import BaseLLMModelInfo, BaseTokenCounter
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.types.llms.openai import AllMessageValues
@@ -598,7 +601,11 @@ def _build_vertex_schema(parameters: dict, add_property_ordering: bool = False):
     # Note: We don't pre-flatten defs as that causes exponential memory growth
     # with circular references (see issue #19098). unpack_defs handles nested
     # refs recursively and correctly detects/skips circular references.
-    unpack_defs(parameters, defs)
+    unpack_defs(
+        parameters,
+        defs,
+        max_inlined_bytes=_LEGACY_DEFS_MAX_INLINED_BYTES,
+    )
 
     # 5. Nullable fields:
     #     * https://github.com/pydantic/pydantic/issues/1270

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_common_utils.py
@@ -548,6 +548,101 @@ class TestExtractFileDataBareStr:
         assert extracted.get("content") == b"raw bytes content"
 
 
+class TestUnpackDefsCallerBudgets:
+    """
+    Regression tests for: https://github.com/BerriAI/litellm/issues/34328
+
+    unpack_defs() (the $defs-style sibling of unpack_legacy_defs) already had
+    a max_inlined_bytes budget guard, but neither the Bedrock nor Vertex/Gemini
+    caller passed it, so it defaulted to None (unbounded). The existing
+    ref_chain cycle guard only catches path cycles, not diamond fan-out --
+    the same def reused across sibling branches, which recursive high-fan-in
+    Pydantic-style schemas produce. Each caller must arm the budget so this
+    fails fast instead of hanging until gateway timeout.
+    """
+
+    def test_unpack_defs_rejects_diamond_fan_out_bomb(self):
+        """Recursive, high-fan-in $defs schema (fan-out 3, depth 14) --
+        mirrors what Pydantic emits for recursive models. Must trip the
+        byte budget instead of expanding unboundedly."""
+        import copy
+
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            unpack_defs,
+        )
+
+        defs = {
+            f"N{i}": {
+                "type": "object",
+                "properties": {
+                    f"c{j}": {"$ref": f"#/$defs/N{i + 1}"} for j in range(3)
+                },
+            }
+            for i in range(14)
+        }
+        defs["N14"] = {"type": "object"}
+        schema = {"type": "object", "properties": {"root": {"$ref": "#/$defs/N0"}}}
+
+        with pytest.raises(ValueError, match="byte budget"):
+            unpack_defs(schema, copy.deepcopy(defs), max_inlined_bytes=100_000)
+
+    def test_bedrock_tools_pt_arms_max_inlined_bytes_budget(self):
+        """_bedrock_tools_pt must pass a real max_inlined_bytes to unpack_defs,
+        not rely on the (unbounded) default, for a recursive high-fan-in tool
+        schema."""
+        from litellm.litellm_core_utils.prompt_templates.factory import (
+            _bedrock_tools_pt,
+        )
+
+        depth, fanout = 12, 3
+        defs = {
+            f"N{i}": {
+                "type": "object",
+                "properties": {
+                    f"c{j}": {"$ref": f"#/$defs/N{i + 1}"} for j in range(fanout)
+                },
+            }
+            for i in range(depth)
+        }
+        defs["N{}".format(depth)] = {"type": "object"}
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "recursive_tool",
+                    "description": "test",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"root": {"$ref": "#/$defs/N0"}},
+                        "$defs": defs,
+                    },
+                },
+            }
+        ]
+
+        with pytest.raises(ValueError, match="byte budget"):
+            _bedrock_tools_pt(tools, model="anthropic.claude-3-5-sonnet-20241022-v2:0")
+
+    def test_unpack_defs_allows_legitimate_moderate_schema(self):
+        """A normal, non-recursive tool schema with several $defs must still
+        inline cleanly under the armed budget -- the fix must not regress
+        ordinary tool calls."""
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            unpack_defs,
+        )
+
+        defs = {f"T{i}": {"type": "string"} for i in range(20)}
+        schema = {
+            "type": "object",
+            "properties": {f"f{i}": {"$ref": f"#/$defs/T{i}"} for i in range(20)},
+        }
+
+        unpack_defs(schema, defs, max_inlined_bytes=1_000_000)
+        for i in range(20):
+            assert schema["properties"][f"f{i}"] == {"type": "string"}
+
+
 class TestUnpackLegacyDefs:
     """Cover the public ``unpack_legacy_defs`` helper directly so the no-op
     branches (non-dict input, schema with no legacy/OpenAPI defs) are exercised


### PR DESCRIPTION
Fixes #34328

## Problem
`unpack_defs()` already has a `max_inlined_bytes` budget guard, but neither the Bedrock Converse (`_bedrock_tools_pt`) nor Vertex/Gemini (`_build_vertex_schema`) caller passed it, so it defaulted to `None` (unbounded). The existing `ref_chain` guard only catches path cycles, not diamond fan-out — the same def reused across sibling branches, which recursive high-fan-in schemas (the shape Pydantic emits for recursive models) produce. Each reuse got its own deepcopy and was re-queued for full expansion, causing O(fanout^depth) growth: a ~23KB tool schema could expand past 510MB within 30s without converging, hanging the request until the fronting gateway/LB timed out (~80s → 502).

## Fix
Armed both call sites with the existing `_LEGACY_DEFS_MAX_INLINED_BYTES` constant (already used by the legacy `definitions`-style path), so oversized recursive schemas now fail fast with a clear `ValueError` instead of hanging.

## Tests
Added a new `TestUnpackDefsCallerBudgets` class:
- The diamond fan-out bomb from the issue's own repro now fails fast (verified locally: fails in 0.7s vs. hanging unboundedly before the fix)
- `_bedrock_tools_pt` correctly arms the budget end-to-end
- A legitimate moderate schema still inlines cleanly — no regression for ordinary tool calls

Full existing test file (52 tests) still passes.