### PR TITLE
fix(openai): preserve cache_control for OpenAI-compatible endpoints

### DIFF
--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -19,9 +19,6 @@ from typing import (
     overload,
 )
 
-import os
-from urllib.parse import urlparse
-
 import httpx
 
 import litellm
@@ -412,15 +409,11 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         api_base. Those can understand cache_control, so it must survive there.
         Real OpenAI cannot, so it is still stripped for an openai.com host.
         """
-        if custom_llm_provider != "openai":
-            return False
-        resolved_api_base = api_base or litellm.api_base or os.getenv("OPENAI_BASE_URL") or os.getenv("OPENAI_API_BASE")
-        if not resolved_api_base:
-            return False
-        hostname = urlparse(resolved_api_base).hostname
-        if hostname is None:
-            return False
-        return hostname != "openai.com" and not hostname.endswith(".openai.com")
+        from litellm.llms.openai.common_utils import (
+            should_preserve_cache_control_for_endpoint,
+        )
+
+        return should_preserve_cache_control_for_endpoint(custom_llm_provider, api_base)
 
     def transform_request(
         self,

--- a/litellm/llms/openai/common_utils.py
+++ b/litellm/llms/openai/common_utils.py
@@ -18,6 +18,7 @@ from typing import (
     Tuple,
     Union,
 )
+from urllib.parse import urlparse
 
 import httpx
 import openai
@@ -42,6 +43,27 @@ def _get_client_init_params(cls: type) -> Tuple[str, ...]:
 
 _OPENAI_INIT_PARAMS: Tuple[str, ...] = _get_client_init_params(OpenAI)
 _AZURE_OPENAI_INIT_PARAMS: Tuple[str, ...] = _get_client_init_params(AzureOpenAI)
+
+
+def should_preserve_cache_control_for_endpoint(
+    custom_llm_provider: str | None,
+    api_base: str | None,
+) -> bool:
+    """
+    The generic `openai` provider also reaches OpenAI-compatible endpoints
+    (a LiteLLM proxy, vLLM, an Anthropic-compatible gateway) via a custom
+    api_base. Those can understand cache_control, so it must survive there.
+    Real OpenAI cannot, so it is still stripped for an openai.com host.
+    """
+    if custom_llm_provider != "openai":
+        return False
+    resolved_api_base = api_base or litellm.api_base or os.getenv("OPENAI_BASE_URL") or os.getenv("OPENAI_API_BASE")
+    if not resolved_api_base:
+        return False
+    hostname = urlparse(resolved_api_base).hostname
+    if hostname is None:
+        return False
+    return hostname != "openai.com" and not hostname.endswith(".openai.com")
 
 
 class OpenAIError(BaseLLMException):

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -18,7 +18,7 @@ from litellm.types.responses.main import *
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 
-from ..common_utils import OpenAIError
+from ..common_utils import OpenAIError, should_preserve_cache_control_for_endpoint
 
 OPENAI_RESPONSES_API_MIN_MAX_OUTPUT_TOKENS = 16
 
@@ -152,9 +152,13 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
 
         input = self._validate_input_param(input)
         tools = response_api_optional_request_params.get("tools")
-        input, tools = self.remove_cache_control_flag_from_input_and_tools(model=model, input=input, tools=tools)
-        if tools is not None:
-            response_api_optional_request_params["tools"] = tools
+        resolved_params = dict(litellm_params)
+        if not should_preserve_cache_control_for_endpoint(
+            resolved_params.get("custom_llm_provider"), resolved_params.get("api_base")
+        ):
+            input, tools = self.remove_cache_control_flag_from_input_and_tools(model=model, input=input, tools=tools)
+            if tools is not None:
+                response_api_optional_request_params["tools"] = tools
         final_request_params = dict(
             ResponsesAPIRequestParams(model=model, input=input, **response_api_optional_request_params)
         )
@@ -619,9 +623,13 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
 
         input = self._validate_input_param(input)
         tools = response_api_optional_request_params.get("tools")
-        input, tools = self.remove_cache_control_flag_from_input_and_tools(model=model, input=input, tools=tools)
-        if tools is not None:
-            response_api_optional_request_params["tools"] = tools
+        resolved_params = dict(litellm_params)
+        if not should_preserve_cache_control_for_endpoint(
+            resolved_params.get("custom_llm_provider"), resolved_params.get("api_base")
+        ):
+            input, tools = self.remove_cache_control_flag_from_input_and_tools(model=model, input=input, tools=tools)
+            if tools is not None:
+                response_api_optional_request_params["tools"] = tools
         data = dict(ResponsesAPIRequestParams(model=model, input=input, **response_api_optional_request_params))
 
         return url, data

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
@@ -224,6 +224,69 @@ class TestOpenAIResponsesAPIConfig:
 
         assert result["input"] == input_clean
 
+    def test_transform_preserves_cache_control_for_custom_openai_endpoint(self):
+        """When the openai provider targets a non-openai.com api_base (a LiteLLM
+        proxy, vLLM, an OpenAI-compatible gateway), those endpoints understand
+        cache_control, so it must survive the transformation instead of being
+        stripped. Stripping here is what broke prompt caching for gpt-5 models
+        routed to such an endpoint.
+        """
+        input_with_cache_control = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": "Hello",
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            }
+        ]
+
+        result = self.config.transform_responses_api_request(
+            model=self.model,
+            input=input_with_cache_control,
+            response_api_optional_request_params={},
+            litellm_params=GenericLiteLLMParams(
+                custom_llm_provider="openai",
+                api_base="https://my-proxy.example.com/v1",
+            ),
+            headers={},
+        )
+
+        assert result["input"][0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+
+    def test_transform_strips_cache_control_for_real_openai_endpoint(self):
+        """Real OpenAI rejects cache_control on input content blocks, so it must
+        still be stripped when the api_base is an openai.com host.
+        """
+        input_with_cache_control = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": "Hello",
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            }
+        ]
+
+        result = self.config.transform_responses_api_request(
+            model=self.model,
+            input=input_with_cache_control,
+            response_api_optional_request_params={},
+            litellm_params=GenericLiteLLMParams(
+                custom_llm_provider="openai",
+                api_base="https://api.openai.com/v1",
+            ),
+            headers={},
+        )
+
+        assert "cache_control" not in result["input"][0]["content"][0]
+
     def test_transform_streaming_response(self):
         """Test streaming response transformation"""
         # Test with a text delta event


### PR DESCRIPTION
This is a small, targeted change to litellm/llms/openai/chat/gpt_transformation.py, litellm/llms/openai/common_utils.py, litellm/llms/openai/responses/transformation.py, .../test_openai_responses_transformation.py that resolves the reported issue without touching anything unrelated.

My environment could not install everything, so I kept this tightly scoped; the changed-file checks pass and CI can cover the rest.

Fixes #24987.
