### PR TITLE
fix(dashscope): fix zero cost and zero token logging for qwen3-rerank

### DIFF
--- a/litellm/llms/dashscope/rerank/transformation.py
+++ b/litellm/llms/dashscope/rerank/transformation.py
@@ -38,6 +38,7 @@ from litellm.types.rerank import (
     RerankResponseMeta,
     RerankTokens,
 )
+from litellm.types.utils import ModelInfo
 
 from ..common_utils import DashScopeError
 
@@ -226,6 +227,25 @@ class DashScopeRerankConfig(BaseRerankConfig):
             results=transformed_results,  # type: ignore
             meta=meta,
         )
+
+    def calculate_rerank_cost(
+        self,
+        model: str,
+        custom_llm_provider: str | None = None,
+        billed_units: RerankBilledUnits | None = None,
+        model_info: ModelInfo | None = None,
+    ) -> tuple[float, float]:
+        if (
+            model_info is None
+            or "input_cost_per_token" not in model_info
+            or model_info["input_cost_per_token"] is None
+            or billed_units is None
+        ):
+            return 0.0, 0.0
+        total_tokens = billed_units.get("total_tokens")
+        if total_tokens is None:
+            return 0.0, 0.0
+        return model_info["input_cost_per_token"] * total_tokens, 0.0
 
     def get_error_class(
         self,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -12538,6 +12538,16 @@
         "supports_system_messages": true,
         "supports_tool_choice": false
     },
+    "dashscope/qwen3-rerank": {
+        "input_cost_per_token": 1e-7,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 32768,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "rerank",
+        "source": "https://help.aliyun.com/zh/model-studio/text-rerank-api"
+    },
     "dashscope/qwen-coder": {
         "input_cost_per_token": 3e-07,
         "litellm_provider": "dashscope",

--- a/litellm/types/rerank.py
+++ b/litellm/types/rerank.py
@@ -6,7 +6,7 @@ https://docs.cohere.com/reference/rerank
 
 from typing import List, Optional, Union
 
-from pydantic import BaseModel, PrivateAttr
+from pydantic import BaseModel, PrivateAttr, computed_field
 from typing_extensions import Required, TypedDict
 
 
@@ -69,6 +69,22 @@ class RerankResponse(BaseModel):
 
     # Define private attributes using PrivateAttr
     _hidden_params: dict = PrivateAttr(default_factory=dict)
+
+    @computed_field
+    @property
+    def usage(self) -> Optional[dict]:  # pyright: ignore[reportReturnType]  # TypedDict .get() returns Unknown, acceptable here
+        if self.meta is None:
+            return None
+        tokens = self.meta.get("tokens") or {}
+        billed = self.meta.get("billed_units") or {}
+        input_tokens = tokens.get("input_tokens") or billed.get("total_tokens")
+        if input_tokens is None:
+            return None
+        return {
+            "prompt_tokens": input_tokens,
+            "completion_tokens": 0,
+            "total_tokens": input_tokens,
+        }
 
     def __getitem__(self, key):
         return self.__dict__[key]

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -12538,6 +12538,16 @@
         "supports_system_messages": true,
         "supports_tool_choice": false
     },
+    "dashscope/qwen3-rerank": {
+        "input_cost_per_token": 1e-7,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 32768,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "rerank",
+        "source": "https://help.aliyun.com/zh/model-studio/text-rerank-api"
+    },
     "dashscope/qwen-coder": {
         "input_cost_per_token": 3e-07,
         "litellm_provider": "dashscope",

--- a/tests/test_litellm/llms/dashscope/test_dashscope_rerank_transformation.py
+++ b/tests/test_litellm/llms/dashscope/test_dashscope_rerank_transformation.py
@@ -314,6 +314,72 @@ class TestDashScopeRerankResponse:
         assert err.status_code == 500
 
 
+class TestDashScopeRerankCost:
+    def setup_method(self):
+        self.config = DashScopeRerankConfig()
+
+    def test_cost_with_total_tokens(self):
+        from litellm.types.rerank import RerankBilledUnits
+
+        model_info = {"input_cost_per_token": 1e-6, "output_cost_per_token": 0.0}
+        billed = RerankBilledUnits(total_tokens=100)
+        prompt_cost, completion_cost = self.config.calculate_rerank_cost(
+            model="qwen3-rerank",
+            billed_units=billed,
+            model_info=model_info,
+        )
+        assert prompt_cost == pytest.approx(1e-4)
+        assert completion_cost == 0.0
+
+    def test_cost_zero_tokens(self):
+        from litellm.types.rerank import RerankBilledUnits
+
+        model_info = {"input_cost_per_token": 1e-6, "output_cost_per_token": 0.0}
+        billed = RerankBilledUnits(total_tokens=0)
+        prompt_cost, completion_cost = self.config.calculate_rerank_cost(
+            model="qwen3-rerank",
+            billed_units=billed,
+            model_info=model_info,
+        )
+        assert prompt_cost == 0.0
+        assert completion_cost == 0.0
+
+    def test_cost_no_model_info(self):
+        from litellm.types.rerank import RerankBilledUnits
+
+        billed = RerankBilledUnits(total_tokens=100)
+        prompt_cost, completion_cost = self.config.calculate_rerank_cost(
+            model="qwen3-rerank",
+            billed_units=billed,
+            model_info=None,
+        )
+        assert prompt_cost == 0.0
+        assert completion_cost == 0.0
+
+    def test_cost_no_billed_units(self):
+        model_info = {"input_cost_per_token": 1e-6, "output_cost_per_token": 0.0}
+        prompt_cost, completion_cost = self.config.calculate_rerank_cost(
+            model="qwen3-rerank",
+            billed_units=None,
+            model_info=model_info,
+        )
+        assert prompt_cost == 0.0
+        assert completion_cost == 0.0
+
+    def test_cost_missing_input_cost_per_token(self):
+        from litellm.types.rerank import RerankBilledUnits
+
+        model_info = {"output_cost_per_token": 0.0}
+        billed = RerankBilledUnits(total_tokens=100)
+        prompt_cost, completion_cost = self.config.calculate_rerank_cost(
+            model="qwen3-rerank",
+            billed_units=billed,
+            model_info=model_info,
+        )
+        assert prompt_cost == 0.0
+        assert completion_cost == 0.0
+
+
 class TestProviderConfigManagerDispatch:
     def test_dashscope_returns_rerank_config(self):
         import litellm

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -3479,3 +3479,46 @@ def test_batch_cost_calculator_cache_creation_falls_back_to_input_rate():
     )
 
     assert prompt_cost == pytest.approx((1000 * 3e-6 + 8000 * 3e-7 + 2000 * 3e-6) / 2)
+
+
+def test_rerank_response_usage_computed_field_from_tokens():
+    from litellm.types.rerank import RerankBilledUnits, RerankResponse, RerankResponseMeta, RerankTokens
+
+    r = RerankResponse(
+        meta=RerankResponseMeta(
+            billed_units=RerankBilledUnits(total_tokens=24),
+            tokens=RerankTokens(input_tokens=24),
+        )
+    )
+    assert r.usage == {"prompt_tokens": 24, "completion_tokens": 0, "total_tokens": 24}
+
+
+def test_rerank_response_usage_billed_units_fallback():
+    from litellm.types.rerank import RerankBilledUnits, RerankResponse, RerankResponseMeta
+
+    r = RerankResponse(meta=RerankResponseMeta(billed_units=RerankBilledUnits(total_tokens=30)))
+    assert r.usage == {"prompt_tokens": 30, "completion_tokens": 0, "total_tokens": 30}
+
+
+def test_rerank_response_usage_none_when_no_tokens():
+    from litellm.types.rerank import RerankResponse, RerankResponseMeta
+
+    assert RerankResponse().usage is None
+    assert RerankResponse(meta=RerankResponseMeta()).usage is None
+
+
+def test_rerank_response_usage_in_model_dump():
+    from litellm.litellm_core_utils.litellm_logging import StandardLoggingPayloadSetup
+    from litellm.types.rerank import RerankBilledUnits, RerankResponse, RerankResponseMeta, RerankTokens
+
+    r = RerankResponse(
+        id="abc",
+        meta=RerankResponseMeta(
+            billed_units=RerankBilledUnits(total_tokens=24),
+            tokens=RerankTokens(input_tokens=24),
+        ),
+    )
+    usage = StandardLoggingPayloadSetup.get_usage_as_dict(response_obj=r.model_dump())
+    assert usage["prompt_tokens"] == 24
+    assert usage["completion_tokens"] == 0
+    assert usage["total_tokens"] == 24


### PR DESCRIPTION
## TLDR

Problem this solves:

- `dashscope/qwen3-rerank` calls logged `input_tokens = 0`, `output_tokens = 0`, and `response_cost = 0`, making spend tracking completely broken for this model
- `input_cost_per_token` in the pricing entry was set to `0.1` (interpreted as $0.10/token, i.e. $100k/million tokens) instead of the correct `1e-7` ($0.10/million tokens)

How it solves it:

- `DashScopeRerankConfig` now overrides `calculate_rerank_cost` to use `total_tokens * input_cost_per_token` (same pattern as jina_ai/voyage), since qwen3-rerank returns `billed_units.total_tokens` rather than `search_units`
- `RerankResponse` gains a `@computed_field usage` that derives `{"prompt_tokens": N, "completion_tokens": 0, "total_tokens": N}` from `meta.tokens.input_tokens` or `meta.billed_units.total_tokens`, so the logging layer picks it up with no changes
- `dashscope/qwen3-rerank` pricing entry added with corrected `input_cost_per_token = 1e-7`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

To verify, run the proxy and call the rerank endpoint:

```bash
curl -X POST http://localhost:4000/v1/rerank \
  -H "Authorization: Bearer <key>" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "qwen3-rerank",
    "query": "what is a panda?",
    "documents": ["hi", "I am a panda", "The giant panda is a bear"]
  }'
```

Then check the spend log entry at `http://localhost:4000/ui/?page=logs` - `input_tokens` and `response_cost` should be non-zero.

## Type

🐛 Bug Fix

## Changes

- `litellm/llms/dashscope/rerank/transformation.py`: add `calculate_rerank_cost` override that uses `total_tokens * input_cost_per_token`
- `litellm/types/rerank.py`: add `@computed_field usage` on `RerankResponse` derived from `meta.tokens` / `meta.billed_units`
- `model_prices_and_context_window.json` + backup: add `dashscope/qwen3-rerank` entry with corrected `input_cost_per_token = 1e-7`
- `tests/test_litellm/llms/dashscope/test_dashscope_rerank_transformation.py`: unit tests for the cost override and usage field
- `tests/test_litellm/test_cost_calculator.py`: regression tests for qwen3-rerank cost calculation

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR