### PR TITLE
feat(guardrails): generic apply_guardrail_to_model_groups scoping in CustomGuardrail base class

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -733,6 +733,12 @@ class CustomGuardrail(CustomLogger):
         """
         Returns True if the guardrail should be run on the event_type
         """
+        apply_guardrail_to_model_groups: frozenset[str] = getattr(self, "apply_guardrail_to_model_groups", frozenset())
+        if apply_guardrail_to_model_groups:
+            model_group = data.get("model") or self._resolve_metadata_model_group(data)
+            if str(model_group or "").strip().lower() not in apply_guardrail_to_model_groups:
+                return False
+
         requested_guardrails = self.get_guardrail_from_metadata(data)
         disable_global_guardrail = self.get_disable_global_guardrail(data)
         opted_out_global_guardrails = self.get_opted_out_global_guardrails_from_metadata(data)
@@ -792,6 +798,16 @@ class CustomGuardrail(CustomLogger):
             if result is not None:
                 return result
         return True
+
+    @staticmethod
+    def _resolve_metadata_model_group(data: dict[str, object]) -> str | None:
+        for dict_key in ("litellm_metadata", "metadata"):
+            container = data.get(dict_key) or {}
+            if isinstance(container, dict) and container:
+                value = container.get("model_group")
+                if value is not None:
+                    return str(value).strip()
+        return None
 
     def _event_hook_is_event_type(self, event_type: GuardrailEventHooks) -> bool:
         """

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -736,8 +736,10 @@ class CustomGuardrail(CustomLogger):
         apply_guardrail_to_model_groups: frozenset[str] = getattr(self, "apply_guardrail_to_model_groups", frozenset())
         if apply_guardrail_to_model_groups:
             model = str(data.get("model") or "").strip().lower()
-            model_group = str(self._resolve_metadata_model_group(data) or "").strip().lower()
-            if model not in apply_guardrail_to_model_groups and model_group not in apply_guardrail_to_model_groups:
+            model_groups = {g.lower() for g in self._resolve_metadata_model_groups(data)}
+            if model not in apply_guardrail_to_model_groups and apply_guardrail_to_model_groups.isdisjoint(
+                model_groups
+            ):
                 return False
 
         requested_guardrails = self.get_guardrail_from_metadata(data)
@@ -801,14 +803,27 @@ class CustomGuardrail(CustomLogger):
         return True
 
     @staticmethod
-    def _resolve_metadata_model_group(data: dict[str, object]) -> str | None:
+    def _resolve_metadata_model_groups(data: dict[str, object]) -> list[str]:
+        """Collect every candidate model_group from request metadata.
+
+        ``metadata`` and ``litellm_metadata`` are both client-addressable top-level
+        request fields (OpenAI's own `metadata` field and litellm's newer
+        `litellm_metadata`); only whichever one the router actually writes deployment
+        info into for this call type is authoritative, and which one that is depends
+        on call type. Rather than guessing a single "authoritative" container (which a
+        client can defeat by populating the container the router does *not* write for
+        their call type with an out-of-scope value), return every candidate so the
+        caller can match on any of them - a client can only ever widen the match, never
+        narrow it to force a scoped guardrail to be skipped.
+        """
+        candidates = []
         for dict_key in ("litellm_metadata", "metadata"):
             container = data.get(dict_key) or {}
             if isinstance(container, dict) and container:
                 value = container.get("model_group")
                 if value is not None:
-                    return str(value).strip()
-        return None
+                    candidates.append(str(value).strip())
+        return candidates
 
     def _event_hook_is_event_type(self, event_type: GuardrailEventHooks) -> bool:
         """

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -1200,6 +1200,16 @@ class CustomGuardrail(CustomLogger):
                 value = frozenset(str(v).strip().lower() for v in value if str(v).strip())
             setattr(self, key, value)
 
+        # Every guardrail initializer constructs the callback with event_hook=mode
+        # (guardrail_initializers.py); should_run_guardrail gates on event_hook, not
+        # mode, so a mode-only update without this would leave the callback enforcing
+        # its old event_hook (e.g. still pre_call after a PUT changes mode to
+        # post_call) until the proxy restarts. mode is a required LitellmParams field,
+        # so it's always present on a valid update.
+        mode = params.get("mode")
+        if mode is not None:
+            self.event_hook = mode
+
     def get_guardrails_messages_for_call_type(
         self, call_type: CallTypes, data: Optional[dict] = None
     ) -> Optional[List[AllMessageValues]]:

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -735,8 +735,9 @@ class CustomGuardrail(CustomLogger):
         """
         apply_guardrail_to_model_groups: frozenset[str] = getattr(self, "apply_guardrail_to_model_groups", frozenset())
         if apply_guardrail_to_model_groups:
-            model_group = data.get("model") or self._resolve_metadata_model_group(data)
-            if str(model_group or "").strip().lower() not in apply_guardrail_to_model_groups:
+            model = str(data.get("model") or "").strip().lower()
+            model_group = str(self._resolve_metadata_model_group(data) or "").strip().lower()
+            if model not in apply_guardrail_to_model_groups and model_group not in apply_guardrail_to_model_groups:
                 return False
 
         requested_guardrails = self.get_guardrail_from_metadata(data)
@@ -1165,6 +1166,8 @@ class CustomGuardrail(CustomLogger):
         Update the guardrails litellm params in memory
         """
         for key, value in vars(litellm_params).items():
+            if key == "apply_guardrail_to_model_groups" and isinstance(value, list):
+                value = frozenset(str(v).strip().lower() for v in value if str(v).strip())
             setattr(self, key, value)
 
     def get_guardrails_messages_for_call_type(

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -1183,9 +1183,20 @@ class CustomGuardrail(CustomLogger):
         ``litellm_params`` may arrive as a ``LitellmParams`` instance (config-driven
         updates) or as the raw DB dict (the PUT /guardrails immediate-sync path reads
         a Prisma JSON column and never converts it), so handle both shapes.
+
+        ``LitellmParams`` merges every guardrail subclass's config fields into one
+        flat model, so a partial update (a PUT payload that only intends to change
+        one field) still serializes every *other* field as ``None`` - either because
+        it's irrelevant to this guardrail type, or because the admin simply didn't
+        set it. Skip ``None`` values here rather than overwriting existing config with
+        them, so a partial update can't silently null out a field it never mentioned;
+        clearing a field to empty requires an explicit empty value (``[]``/``{}``/``""``),
+        not omission.
         """
         params = litellm_params if isinstance(litellm_params, dict) else vars(litellm_params)
         for key, value in params.items():
+            if value is None:
+                continue
             if key == "apply_guardrail_to_model_groups" and isinstance(value, list):
                 value = frozenset(str(v).strip().lower() for v in value if str(v).strip())
             setattr(self, key, value)

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -1184,19 +1184,18 @@ class CustomGuardrail(CustomLogger):
         updates) or as the raw DB dict (the PUT /guardrails immediate-sync path reads
         a Prisma JSON column and never converts it), so handle both shapes.
 
-        ``LitellmParams`` merges every guardrail subclass's config fields into one
-        flat model, so a partial update (a PUT payload that only intends to change
-        one field) still serializes every *other* field as ``None`` - either because
-        it's irrelevant to this guardrail type, or because the admin simply didn't
-        set it. Skip ``None`` values here rather than overwriting existing config with
-        them, so a partial update can't silently null out a field it never mentioned;
-        clearing a field to empty requires an explicit empty value (``[]``/``{}``/``""``),
-        not omission.
+        PUT /guardrails replaces the guardrail's whole config rather than merging a
+        partial patch (the endpoint fetches the existing DB row only to check it
+        exists, then overwrites it with exactly what the caller sent), so an explicit
+        ``None`` for a field is the caller's real signal to clear it, not evidence the
+        field was merely omitted - apply it. A subclass whose field must never be
+        ``None`` at rest (e.g. a list a downstream method iterates unconditionally)
+        should coalesce it to a safe default in its own override, the way ``__init__``
+        already does for that field, rather than this loop guessing at every subclass's
+        invariants.
         """
         params = litellm_params if isinstance(litellm_params, dict) else vars(litellm_params)
         for key, value in params.items():
-            if value is None:
-                continue
             if key == "apply_guardrail_to_model_groups" and isinstance(value, list):
                 value = frozenset(str(v).strip().lower() for v in value if str(v).strip())
             setattr(self, key, value)

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -1161,11 +1161,16 @@ class CustomGuardrail(CustomLogger):
         # Mask the content
         return content_string[:start_index] + mask_string + content_string[end_index:]
 
-    def update_in_memory_litellm_params(self, litellm_params: LitellmParams) -> None:
+    def update_in_memory_litellm_params(self, litellm_params: Union[LitellmParams, dict]) -> None:
         """
         Update the guardrails litellm params in memory
+
+        ``litellm_params`` may arrive as a ``LitellmParams`` instance (config-driven
+        updates) or as the raw DB dict (the PUT /guardrails immediate-sync path reads
+        a Prisma JSON column and never converts it), so handle both shapes.
         """
-        for key, value in vars(litellm_params).items():
+        params = litellm_params if isinstance(litellm_params, dict) else vars(litellm_params)
+        for key, value in params.items():
             if key == "apply_guardrail_to_model_groups" and isinstance(value, list):
                 value = frozenset(str(v).strip().lower() for v in value if str(v).strip())
             setattr(self, key, value)

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1360,14 +1360,20 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         inputs["texts"] = new_texts
         return inputs
 
-    def update_in_memory_litellm_params(self, litellm_params: LitellmParams) -> None:
+    def update_in_memory_litellm_params(self, litellm_params: Union[LitellmParams, dict]) -> None:
         """
         Update the guardrails litellm params in memory
+
+        ``litellm_params`` may arrive as a ``LitellmParams`` instance or as the raw DB
+        dict (the PUT /guardrails immediate-sync path reads a Prisma JSON column and
+        never converts it); the base implementation now setattrs either shape, so read
+        these Presidio-specific fields the same way here.
         """
         super().update_in_memory_litellm_params(litellm_params)
-        if litellm_params.pii_entities_config:
-            self.pii_entities_config = litellm_params.pii_entities_config
-        if litellm_params.presidio_score_thresholds:
-            self.presidio_score_thresholds = litellm_params.presidio_score_thresholds
-        if litellm_params.presidio_entities_deny_list:
-            self.presidio_entities_deny_list = litellm_params.presidio_entities_deny_list
+        params = litellm_params if isinstance(litellm_params, dict) else vars(litellm_params)
+        if params.get("pii_entities_config"):
+            self.pii_entities_config = params["pii_entities_config"]
+        if params.get("presidio_score_thresholds"):
+            self.presidio_score_thresholds = params["presidio_score_thresholds"]
+        if params.get("presidio_entities_deny_list"):
+            self.presidio_entities_deny_list = params["presidio_entities_deny_list"]

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1366,14 +1366,16 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
 
         ``litellm_params`` may arrive as a ``LitellmParams`` instance or as the raw DB
         dict (the PUT /guardrails immediate-sync path reads a Prisma JSON column and
-        never converts it); the base implementation now setattrs either shape, so read
-        these Presidio-specific fields the same way here.
+        never converts it); the base implementation now setattrs either shape.
+
+        PUT /guardrails replaces the whole config, so the base class's setattr applies
+        these fields verbatim, including an explicit ``None`` (the caller's real signal
+        to clear a field). Re-coalesce them to the same empty defaults ``__init__``
+        uses, so a cleared or omitted field lands as ``{}``/``[]`` rather than ``None`` -
+        filter_analyze_results_by_score and friends iterate these unconditionally.
         """
         super().update_in_memory_litellm_params(litellm_params)
         params = litellm_params if isinstance(litellm_params, dict) else vars(litellm_params)
-        if params.get("pii_entities_config"):
-            self.pii_entities_config = params["pii_entities_config"]
-        if params.get("presidio_score_thresholds"):
-            self.presidio_score_thresholds = params["presidio_score_thresholds"]
-        if params.get("presidio_entities_deny_list"):
-            self.presidio_entities_deny_list = params["presidio_entities_deny_list"]
+        self.pii_entities_config = params.get("pii_entities_config") or {}
+        self.presidio_score_thresholds = params.get("presidio_score_thresholds") or {}
+        self.presidio_entities_deny_list = params.get("presidio_entities_deny_list") or []

--- a/litellm/proxy/guardrails/guardrail_hooks/tool_permission.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/tool_permission.py
@@ -130,17 +130,13 @@ class ToolPermissionGuardrail(CustomGuardrail):
         immediate in-memory sync take effect, mirroring the PresidioGuardrail
         override of this method.
         """
-        # ``litellm_params`` may arrive as the raw DB dict (the proxy ``cast()``s
-        # it to ``LitellmParams`` without converting), so handle both shapes. The
-        # base ``setattr`` loop is model-only, so apply the dict case here.
+        # ``litellm_params`` may arrive as a ``LitellmParams`` instance or as the
+        # raw DB dict (the PUT /guardrails immediate-sync path reads a Prisma JSON
+        # column and never converts it); the base implementation now setattrs
+        # either shape, so mirror that here for the ``.get()`` calls below.
         previous_rules = self.rules
-        if isinstance(litellm_params, dict):
-            params = litellm_params
-            for key, value in params.items():
-                setattr(self, key, value)
-        else:
-            super().update_in_memory_litellm_params(litellm_params)
-            params = vars(litellm_params)
+        super().update_in_memory_litellm_params(litellm_params)
+        params = litellm_params if isinstance(litellm_params, dict) else vars(litellm_params)
 
         # The generic update above sets ``self.rules`` from the incoming value
         # (None on a partial update that omits rules), but never rebuilds the

--- a/litellm/proxy/guardrails/guardrail_hooks/tool_permission.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/tool_permission.py
@@ -138,24 +138,20 @@ class ToolPermissionGuardrail(CustomGuardrail):
         super().update_in_memory_litellm_params(litellm_params)
         params = litellm_params if isinstance(litellm_params, dict) else vars(litellm_params)
 
-        # The generic update above sets ``self.rules`` from the incoming value
-        # (None on a partial update that omits rules), but never rebuilds the
-        # compiled maps. Rebuild them when rules are provided; otherwise restore
-        # the previous ruleset so a partial update doesn't silently wipe it. An
-        # explicit empty list still clears the rules.
+        # The generic update above sets ``self.rules`` from the incoming value but
+        # never rebuilds the compiled maps. PUT /guardrails replaces the whole
+        # config rather than merging a partial patch, so an explicit ``None`` is
+        # the caller's real signal to clear the rules (``_load_rules`` already
+        # treats ``None`` the same as ``[]``), not evidence the update omitted them.
         rules = params.get("rules")
-        if rules is not None:
-            try:
-                self._load_rules(rules)
-            except Exception:
-                # The generic update above may have overwritten self.rules with
-                # the raw payload; restore the prior consistent ruleset so a
-                # rejected update can't leave the live guardrail enforcing a
-                # broken policy.
-                self.rules = previous_rules
-                raise
-        else:
+        try:
+            self._load_rules(rules)
+        except Exception:
+            # The generic update above may have overwritten self.rules with the
+            # raw payload; restore the prior consistent ruleset so a rejected
+            # update can't leave the live guardrail enforcing a broken policy.
             self.rules = previous_rules
+            raise
         default_action = params.get("default_action")
         if isinstance(default_action, str):
             self.default_action = default_action.lower()

--- a/litellm/proxy/guardrails/guardrail_registry.py
+++ b/litellm/proxy/guardrails/guardrail_registry.py
@@ -588,7 +588,10 @@ class InMemoryGuardrailHandler:
 
         custom_guardrail_callback = self.guardrail_id_to_custom_guardrail.get(guardrail_id)
         if custom_guardrail_callback:
-            updated_litellm_params = cast(LitellmParams, guardrail.get("litellm_params", {}))
+            # ``guardrail`` may come from a DB read (a Prisma JSON column, deserialized
+            # to a plain dict) rather than a constructed ``LitellmParams`` instance;
+            # update_in_memory_litellm_params accepts either shape.
+            updated_litellm_params = guardrail.get("litellm_params", {})
             custom_guardrail_callback.update_in_memory_litellm_params(litellm_params=updated_litellm_params)
 
     def delete_in_memory_guardrail(self, guardrail_id: str) -> None:

--- a/litellm/proxy/guardrails/guardrail_registry.py
+++ b/litellm/proxy/guardrails/guardrail_registry.py
@@ -54,6 +54,13 @@ from .guardrail_initializers import (
     initialize_tool_permission,
 )
 
+
+def _normalize_model_group_allowlist(values: list[str] | None) -> frozenset[str]:
+    if not values:
+        return frozenset()
+    return frozenset(str(v).strip().lower() for v in values if str(v).strip())
+
+
 guardrail_initializer_registry = {
     SupportedGuardrailIntegrations.BEDROCK.value: initialize_bedrock,
     SupportedGuardrailIntegrations.LAKERA.value: initialize_lakera,
@@ -492,6 +499,11 @@ class InMemoryGuardrailHandler:
             configured_run_in_parallel = getattr(litellm_params, "run_in_parallel", None)
             if configured_run_in_parallel is not None:
                 custom_guardrail_callback.run_in_parallel = bool(configured_run_in_parallel)
+            setattr(
+                custom_guardrail_callback,
+                "apply_guardrail_to_model_groups",
+                _normalize_model_group_allowlist(getattr(litellm_params, "apply_guardrail_to_model_groups", None)),
+            )
 
         parsed_guardrail = Guardrail(
             guardrail_id=guardrail.get("guardrail_id"),

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -757,6 +757,16 @@ class BaseLitellmParams(ContentFilterConfigModel):  # works for new and patch up
         ),
     )
 
+    apply_guardrail_to_model_groups: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "If set, run this guardrail only for requests whose requested model group "
+            "is in this list (matched case-insensitively against the request's model / "
+            "model_group). Empty/None = all model groups. Enforced generically by "
+            "CustomGuardrail.should_run_guardrail for every guardrail type."
+        ),
+    )
+
     # Lakera specific params
     category_thresholds: Optional[LakeraCategoryThresholds] = Field(
         default=None,

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -2222,6 +2222,19 @@ class TestShouldRunGuardrailModelGroupGate:
             data={"model": "ai-gateway-other"}, event_type=GuardrailEventHooks.pre_call
         ) is False
 
+    def test_update_in_memory_does_not_null_out_omitted_fields(self):
+        """LitellmParams merges every guardrail subclass's fields into one flat model,
+        so a partial update that only intends to change one field still serializes
+        every other field as None. A None value must not overwrite an existing
+        attribute the update never mentioned - e.g. clearing a previously-set
+        run_in_parallel just because a later update omits it."""
+        g = self._guardrail(run_in_parallel=True)
+        assert g.run_in_parallel is True
+
+        g.update_in_memory_litellm_params({"guardrail": "test-guardrail", "mode": "pre_call", "run_in_parallel": None})
+
+        assert g.run_in_parallel is True
+
 
 class TestResolveMetadataModelGroups:
     def test_returns_both_containers_values(self):

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -2049,3 +2049,106 @@ class TestRecordsOwnGuardrailInformation:
         )
 
         assert _guardrail_entries(request_data) == []
+
+
+class TestShouldRunGuardrailModelGroupGate:
+    def _guardrail(self, **kwargs) -> CustomGuardrail:
+        return CustomGuardrail(guardrail_name="test-guardrail", default_on=True, **kwargs)
+
+    def _with_allowlist(self, g: CustomGuardrail, groups: frozenset[str]) -> CustomGuardrail:
+        setattr(g, "apply_guardrail_to_model_groups", groups)
+        return g
+
+    def test_no_attribute_does_not_restrict(self):
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        g = self._guardrail()
+        assert not hasattr(g, "apply_guardrail_to_model_groups")
+        assert g.should_run_guardrail(data={"model": "anything"}, event_type=GuardrailEventHooks.pre_call) is True
+
+    def test_empty_allowlist_does_not_restrict(self):
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        g = self._with_allowlist(self._guardrail(), frozenset())
+        assert g.should_run_guardrail(data={"model": "anything"}, event_type=GuardrailEventHooks.pre_call) is True
+
+    def test_model_in_allowlist_passes_gate(self):
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        g = self._with_allowlist(self._guardrail(), frozenset({"ai-gateway-low-intelligence-general"}))
+        result = g.should_run_guardrail(
+            data={"model": "ai-gateway-low-intelligence-general"},
+            event_type=GuardrailEventHooks.pre_call,
+        )
+        assert result is True
+
+    def test_model_not_in_allowlist_blocked(self):
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        g = self._with_allowlist(self._guardrail(), frozenset({"ai-gateway-low-intelligence-general"}))
+        result = g.should_run_guardrail(
+            data={"model": "ai-gateway-high-intelligence-general"},
+            event_type=GuardrailEventHooks.pre_call,
+        )
+        assert result is False
+
+    def test_model_match_is_case_insensitive(self):
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        g = self._with_allowlist(self._guardrail(), frozenset({"ai-gateway-low-intelligence-general"}))
+        result = g.should_run_guardrail(
+            data={"model": "AI-GATEWAY-LOW-INTELLIGENCE-GENERAL"},
+            event_type=GuardrailEventHooks.pre_call,
+        )
+        assert result is True
+
+    def test_metadata_model_group_used_as_fallback(self):
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        g = self._with_allowlist(self._guardrail(), frozenset({"scoped-group"}))
+        result = g.should_run_guardrail(
+            data={"metadata": {"model_group": "scoped-group"}},
+            event_type=GuardrailEventHooks.pre_call,
+        )
+        assert result is True
+
+    def test_litellm_metadata_model_group_used_as_fallback(self):
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        g = self._with_allowlist(self._guardrail(), frozenset({"scoped-group"}))
+        result = g.should_run_guardrail(
+            data={"litellm_metadata": {"model_group": "scoped-group"}},
+            event_type=GuardrailEventHooks.pre_call,
+        )
+        assert result is True
+
+    def test_no_model_or_metadata_is_blocked(self):
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        g = self._with_allowlist(self._guardrail(), frozenset({"scoped-group"}))
+        result = g.should_run_guardrail(data={}, event_type=GuardrailEventHooks.pre_call)
+        assert result is False
+
+
+class TestResolveMetadataModelGroup:
+    def test_litellm_metadata_takes_priority(self):
+        data = {
+            "litellm_metadata": {"model_group": "from-litellm"},
+            "metadata": {"model_group": "from-metadata"},
+        }
+        assert CustomGuardrail._resolve_metadata_model_group(data) == "from-litellm"
+
+    def test_metadata_fallback_when_litellm_metadata_absent(self):
+        data = {"metadata": {"model_group": "from-metadata"}}
+        assert CustomGuardrail._resolve_metadata_model_group(data) == "from-metadata"
+
+    def test_returns_none_when_neither_container_present(self):
+        assert CustomGuardrail._resolve_metadata_model_group({}) is None
+
+    def test_returns_none_when_model_group_key_absent(self):
+        data = {"litellm_metadata": {"something_else": "value"}}
+        assert CustomGuardrail._resolve_metadata_model_group(data) is None
+
+    def test_strips_whitespace(self):
+        data = {"metadata": {"model_group": "  scoped-group  "}}
+        assert CustomGuardrail._resolve_metadata_model_group(data) == "scoped-group"

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -2222,18 +2222,31 @@ class TestShouldRunGuardrailModelGroupGate:
             data={"model": "ai-gateway-other"}, event_type=GuardrailEventHooks.pre_call
         ) is False
 
-    def test_update_in_memory_does_not_null_out_omitted_fields(self):
-        """LitellmParams merges every guardrail subclass's fields into one flat model,
-        so a partial update that only intends to change one field still serializes
-        every other field as None. A None value must not overwrite an existing
-        attribute the update never mentioned - e.g. clearing a previously-set
-        run_in_parallel just because a later update omits it."""
+    def test_update_in_memory_applies_explicit_none(self):
+        """PUT /guardrails replaces the whole config rather than merging a partial
+        patch (it never reads the existing DB row's fields back into the update), so
+        an explicit None for a field is the caller's real signal to clear it, not
+        evidence it was merely omitted - update_in_memory_litellm_params must apply
+        it rather than silently keeping the old value."""
         g = self._guardrail(run_in_parallel=True)
         assert g.run_in_parallel is True
 
         g.update_in_memory_litellm_params({"guardrail": "test-guardrail", "mode": "pre_call", "run_in_parallel": None})
 
-        assert g.run_in_parallel is True
+        assert g.run_in_parallel is None
+
+    def test_update_in_memory_clears_model_group_scope_on_explicit_none(self):
+        """apply_guardrail_to_model_groups=None must clear a previously-set scope
+        restriction, not leave should_run_guardrail still gating on the old allowlist."""
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        g = self._with_allowlist(self._guardrail(), frozenset({"group-a"}))
+
+        g.update_in_memory_litellm_params(
+            {"guardrail": "test-guardrail", "mode": "pre_call", "apply_guardrail_to_model_groups": None}
+        )
+
+        assert g.should_run_guardrail(data={"model": "group-b"}, event_type=GuardrailEventHooks.pre_call) is True
 
 
 class TestResolveMetadataModelGroups:

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -2177,6 +2177,32 @@ class TestShouldRunGuardrailModelGroupGate:
             data={"model": "ai-gateway-other"}, event_type=GuardrailEventHooks.pre_call
         ) is False
 
+    def test_update_in_memory_normalizes_model_groups_from_raw_db_dict(self):
+        """The PUT /guardrails immediate-sync path reads litellm_params back from a
+        Prisma JSON column as a plain dict, not a LitellmParams instance (the proxy
+        only `cast()`s it, which is a no-op at runtime). update_in_memory_litellm_params
+        must handle that shape instead of calling vars() on a dict and raising TypeError."""
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        g = self._guardrail()
+        g.update_in_memory_litellm_params(
+            {
+                "guardrail": "test-guardrail",
+                "mode": "pre_call",
+                "default_on": True,
+                "apply_guardrail_to_model_groups": ["  AI-Gateway-Low  ", "AI-GATEWAY-HIGH"],
+            }
+        )
+        stored = getattr(g, "apply_guardrail_to_model_groups")
+        assert isinstance(stored, frozenset)
+        assert stored == frozenset({"ai-gateway-low", "ai-gateway-high"})
+        assert g.should_run_guardrail(
+            data={"model": "ai-gateway-low"}, event_type=GuardrailEventHooks.pre_call
+        ) is True
+        assert g.should_run_guardrail(
+            data={"model": "ai-gateway-other"}, event_type=GuardrailEventHooks.pre_call
+        ) is False
+
 
 class TestResolveMetadataModelGroup:
     def test_litellm_metadata_takes_priority(self):

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -2155,6 +2155,25 @@ class TestShouldRunGuardrailModelGroupGate:
         )
         assert result is False
 
+    def test_client_supplied_litellm_metadata_cannot_shadow_authoritative_metadata_group(self):
+        """For a regular /chat/completions call, the router writes the authoritative
+        routed group into metadata.model_group and never touches litellm_metadata; a
+        client can still set litellm_metadata.model_group directly in their request
+        body. A client should not be able to use that to make an in-scope request look
+        out-of-scope and skip its own guardrail."""
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        g = self._with_allowlist(self._guardrail(), frozenset({"ai-gateway-low-intelligence-general"}))
+        result = g.should_run_guardrail(
+            data={
+                "model": "bedrock/anthropic.claude-haiku-3",
+                "metadata": {"model_group": "ai-gateway-low-intelligence-general"},
+                "litellm_metadata": {"model_group": "attacker-supplied-out-of-scope-group"},
+            },
+            event_type=GuardrailEventHooks.post_call,
+        )
+        assert result is True
+
     def test_update_in_memory_normalizes_model_groups(self):
         from litellm.types.guardrails import GuardrailEventHooks, LitellmParams
 
@@ -2204,25 +2223,25 @@ class TestShouldRunGuardrailModelGroupGate:
         ) is False
 
 
-class TestResolveMetadataModelGroup:
-    def test_litellm_metadata_takes_priority(self):
+class TestResolveMetadataModelGroups:
+    def test_returns_both_containers_values(self):
         data = {
             "litellm_metadata": {"model_group": "from-litellm"},
             "metadata": {"model_group": "from-metadata"},
         }
-        assert CustomGuardrail._resolve_metadata_model_group(data) == "from-litellm"
+        assert CustomGuardrail._resolve_metadata_model_groups(data) == ["from-litellm", "from-metadata"]
 
-    def test_metadata_fallback_when_litellm_metadata_absent(self):
+    def test_metadata_used_when_litellm_metadata_absent(self):
         data = {"metadata": {"model_group": "from-metadata"}}
-        assert CustomGuardrail._resolve_metadata_model_group(data) == "from-metadata"
+        assert CustomGuardrail._resolve_metadata_model_groups(data) == ["from-metadata"]
 
-    def test_returns_none_when_neither_container_present(self):
-        assert CustomGuardrail._resolve_metadata_model_group({}) is None
+    def test_returns_empty_list_when_neither_container_present(self):
+        assert CustomGuardrail._resolve_metadata_model_groups({}) == []
 
-    def test_returns_none_when_model_group_key_absent(self):
+    def test_returns_empty_list_when_model_group_key_absent(self):
         data = {"litellm_metadata": {"something_else": "value"}}
-        assert CustomGuardrail._resolve_metadata_model_group(data) is None
+        assert CustomGuardrail._resolve_metadata_model_groups(data) == []
 
     def test_strips_whitespace(self):
         data = {"metadata": {"model_group": "  scoped-group  "}}
-        assert CustomGuardrail._resolve_metadata_model_group(data) == "scoped-group"
+        assert CustomGuardrail._resolve_metadata_model_groups(data) == ["scoped-group"]

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -2248,6 +2248,21 @@ class TestShouldRunGuardrailModelGroupGate:
 
         assert g.should_run_guardrail(data={"model": "group-b"}, event_type=GuardrailEventHooks.pre_call) is True
 
+    def test_update_in_memory_syncs_event_hook_with_mode_change(self):
+        """Every guardrail initializer constructs the callback with event_hook=mode,
+        but should_run_guardrail gates on event_hook, not mode. A PUT that changes
+        mode must update event_hook too, or the callback keeps enforcing its old
+        hook (e.g. still pre_call after mode is changed to post_call) until restart."""
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        g = self._guardrail(event_hook="pre_call")
+        assert g.should_run_guardrail(data={}, event_type=GuardrailEventHooks.post_call) is False
+
+        g.update_in_memory_litellm_params({"guardrail": "test-guardrail", "mode": "post_call"})
+
+        assert g.should_run_guardrail(data={}, event_type=GuardrailEventHooks.post_call) is True
+        assert g.should_run_guardrail(data={}, event_type=GuardrailEventHooks.pre_call) is False
+
 
 class TestResolveMetadataModelGroups:
     def test_returns_both_containers_values(self):

--- a/tests/test_litellm/integrations/test_custom_guardrail.py
+++ b/tests/test_litellm/integrations/test_custom_guardrail.py
@@ -2129,6 +2129,54 @@ class TestShouldRunGuardrailModelGroupGate:
         result = g.should_run_guardrail(data={}, event_type=GuardrailEventHooks.pre_call)
         assert result is False
 
+    def test_routed_request_uses_metadata_model_group(self):
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        g = self._with_allowlist(self._guardrail(), frozenset({"ai-gateway-low-intelligence-general"}))
+        result = g.should_run_guardrail(
+            data={
+                "model": "bedrock/anthropic.claude-haiku-3",
+                "litellm_metadata": {"model_group": "ai-gateway-low-intelligence-general"},
+            },
+            event_type=GuardrailEventHooks.pre_call,
+        )
+        assert result is True
+
+    def test_routed_request_scoped_out_model_group_blocked(self):
+        from litellm.types.guardrails import GuardrailEventHooks
+
+        g = self._with_allowlist(self._guardrail(), frozenset({"ai-gateway-low-intelligence-general"}))
+        result = g.should_run_guardrail(
+            data={
+                "model": "bedrock/anthropic.claude-sonnet-3-7",
+                "litellm_metadata": {"model_group": "ai-gateway-high-intelligence-general"},
+            },
+            event_type=GuardrailEventHooks.pre_call,
+        )
+        assert result is False
+
+    def test_update_in_memory_normalizes_model_groups(self):
+        from litellm.types.guardrails import GuardrailEventHooks, LitellmParams
+
+        g = self._guardrail()
+        g.update_in_memory_litellm_params(
+            LitellmParams(
+                guardrail="test-guardrail",
+                mode="pre_call",
+                default_on=True,
+                apply_guardrail_to_model_groups=["  AI-Gateway-Low  ", "AI-GATEWAY-HIGH"],
+            )
+        )
+        stored = getattr(g, "apply_guardrail_to_model_groups")
+        assert isinstance(stored, frozenset)
+        assert stored == frozenset({"ai-gateway-low", "ai-gateway-high"})
+        assert g.should_run_guardrail(
+            data={"model": "ai-gateway-low"}, event_type=GuardrailEventHooks.pre_call
+        ) is True
+        assert g.should_run_guardrail(
+            data={"model": "ai-gateway-other"}, event_type=GuardrailEventHooks.pre_call
+        ) is False
+
 
 class TestResolveMetadataModelGroup:
     def test_litellm_metadata_takes_priority(self):

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -1366,6 +1366,27 @@ def test_update_in_memory_applies_score_thresholds():
     assert guardrail.presidio_score_thresholds == {PiiEntityType.CREDIT_CARD: 0.85}
 
 
+def test_update_in_memory_accepts_raw_db_dict():
+    """The PUT /guardrails immediate-sync path reads litellm_params back from a
+    Prisma JSON column as a plain dict, not a LitellmParams instance. Presidio's
+    override must handle that shape instead of accessing dict fields as attributes."""
+    guardrail = _OPTIONAL_PresidioPIIMasking(mock_testing=True)
+
+    guardrail.update_in_memory_litellm_params(
+        {
+            "guardrail": "presidio",
+            "mode": "pre_call",
+            "pii_entities_config": {PiiEntityType.CREDIT_CARD: "MASK"},
+            "presidio_score_thresholds": {PiiEntityType.CREDIT_CARD: 0.85},
+            "presidio_entities_deny_list": [PiiEntityType.CREDIT_CARD],
+        }
+    )
+
+    assert guardrail.pii_entities_config == {PiiEntityType.CREDIT_CARD: "MASK"}
+    assert guardrail.presidio_score_thresholds == {PiiEntityType.CREDIT_CARD: 0.85}
+    assert guardrail.presidio_entities_deny_list == [PiiEntityType.CREDIT_CARD]
+
+
 @pytest.mark.asyncio
 async def test_get_session_iterator_thread_safety(presidio_guardrail):
     """

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -1387,6 +1387,29 @@ def test_update_in_memory_accepts_raw_db_dict():
     assert guardrail.presidio_entities_deny_list == [PiiEntityType.CREDIT_CARD]
 
 
+def test_update_in_memory_preserves_deny_list_when_update_omits_it():
+    """A PUT update that only changes presidio_score_thresholds still serializes
+    presidio_entities_deny_list as None (LitellmParams merges every guardrail
+    subclass's fields into one flat model). That None must not wipe out an
+    already-configured deny list - filter_analyze_results_by_score iterates it
+    unconditionally whenever presidio_score_thresholds is non-empty, so a None
+    deny list would raise TypeError on the next request."""
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True, presidio_entities_deny_list=[PiiEntityType.CREDIT_CARD]
+    )
+
+    guardrail.update_in_memory_litellm_params(
+        {
+            "guardrail": "presidio",
+            "mode": "pre_call",
+            "presidio_score_thresholds": {PiiEntityType.CREDIT_CARD: 0.9},
+            "presidio_entities_deny_list": None,
+        }
+    )
+
+    assert guardrail.presidio_entities_deny_list == [PiiEntityType.CREDIT_CARD]
+
+
 @pytest.mark.asyncio
 async def test_get_session_iterator_thread_safety(presidio_guardrail):
     """

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -1387,13 +1387,14 @@ def test_update_in_memory_accepts_raw_db_dict():
     assert guardrail.presidio_entities_deny_list == [PiiEntityType.CREDIT_CARD]
 
 
-def test_update_in_memory_preserves_deny_list_when_update_omits_it():
-    """A PUT update that only changes presidio_score_thresholds still serializes
-    presidio_entities_deny_list as None (LitellmParams merges every guardrail
-    subclass's fields into one flat model). That None must not wipe out an
-    already-configured deny list - filter_analyze_results_by_score iterates it
-    unconditionally whenever presidio_score_thresholds is non-empty, so a None
-    deny list would raise TypeError on the next request."""
+def test_update_in_memory_coalesces_cleared_deny_list_to_empty_list():
+    """PUT /guardrails replaces the whole config rather than merging a partial patch,
+    so presidio_entities_deny_list=None is the caller's real signal to clear it, not
+    evidence it was merely omitted. update_in_memory_litellm_params must apply that
+    (matching __init__'s own `presidio_entities_deny_list or []` default) rather than
+    leaving it as None - filter_analyze_results_by_score iterates it unconditionally
+    whenever presidio_score_thresholds is non-empty, so a None deny list would raise
+    TypeError on the next request."""
     guardrail = _OPTIONAL_PresidioPIIMasking(
         mock_testing=True, presidio_entities_deny_list=[PiiEntityType.CREDIT_CARD]
     )
@@ -1407,7 +1408,7 @@ def test_update_in_memory_preserves_deny_list_when_update_omits_it():
         }
     )
 
-    assert guardrail.presidio_entities_deny_list == [PiiEntityType.CREDIT_CARD]
+    assert guardrail.presidio_entities_deny_list == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_tool_permission.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_tool_permission.py
@@ -974,7 +974,12 @@ class TestToolPermissionGuardrailInMemoryUpdate:
         assert "deny-bash" in guardrail._compiled_rule_targets
         assert guardrail._get_permission_for_tool_call(self._bash("echo x"))[0] is False
 
-    def test_update_in_memory_preserves_rules_when_rules_absent(self):
+    def test_update_in_memory_clears_rules_when_rules_absent(self):
+        """PUT /guardrails replaces the whole config rather than merging a partial
+        patch, so a LitellmParams update that doesn't carry `rules` (None) is the
+        caller's real signal to clear them, not evidence they were merely omitted -
+        matching how every other optional field behaves under this same PUT
+        contract (see CustomGuardrail.update_in_memory_litellm_params)."""
         guardrail = ToolPermissionGuardrail(
             guardrail_name="tp",
             rules=[
@@ -990,8 +995,6 @@ class TestToolPermissionGuardrailInMemoryUpdate:
         )
         assert "command" in guardrail._compiled_rule_patterns.get("native-bash", {})
 
-        # A partial update that does not carry `rules` must NOT wipe the existing
-        # ruleset / compiled maps.
         guardrail.update_in_memory_litellm_params(
             LitellmParams(
                 guardrail="tool_permission",
@@ -1001,12 +1004,30 @@ class TestToolPermissionGuardrailInMemoryUpdate:
             )
         )
 
-        assert len(guardrail.rules) == 1
-        assert "command" in guardrail._compiled_rule_patterns.get("native-bash", {})
+        assert guardrail.rules == []
+        assert guardrail._compiled_rule_patterns == {}
+        # No rules left to match, so the call falls through to default_action="deny".
         assert (
             guardrail._get_permission_for_tool_call(self._bash("echo blockme"))[0]
             is False
         )
+
+    def test_update_in_memory_clears_rules_on_explicit_null(self):
+        """A PUT replacing the guardrail with rules: null (the raw DB dict shape)
+        must clear the live ruleset, not restore the previous one - PUT /guardrails
+        replaces the whole config, so explicit null is a real clear signal."""
+        guardrail = ToolPermissionGuardrail(
+            guardrail_name="tp",
+            rules=[{"id": "native-bash", "tool_name": r"^Bash$", "decision": "deny"}],
+            default_action="allow",
+        )
+
+        guardrail.update_in_memory_litellm_params(
+            {"guardrail": "tool_permission", "mode": "post_call", "rules": None}
+        )
+
+        assert guardrail.rules == []
+        assert guardrail._compiled_rule_targets == {}
 
     def test_update_in_memory_rejects_invalid_regex_and_keeps_previous_rules(self):
         """Regression: a live update whose rules contain an invalid regex must be

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_registry.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_registry.py
@@ -95,7 +95,32 @@ def test_update_in_memory_guardrail():
         )
         is True
     )
-    assert handler.guardrail_id_to_custom_guardrail["123"].event_hook is GuardrailEventHooks.pre_call
+    assert handler.guardrail_id_to_custom_guardrail["123"].event_hook == GuardrailEventHooks.pre_call
+
+
+def test_update_in_memory_guardrail_syncs_event_hook_on_mode_change():
+    """Every guardrail initializer constructs the callback with event_hook=mode, but
+    should_run_guardrail gates on event_hook, not mode. A PUT that changes mode from
+    pre_call to post_call must update event_hook too, or the live callback keeps
+    enforcing pre_call until the proxy restarts."""
+    handler = InMemoryGuardrailHandler()
+    handler.guardrail_id_to_custom_guardrail["123"] = CustomGuardrail(
+        guardrail_name="test-guardrail",
+        default_on=True,
+        event_hook=GuardrailEventHooks.pre_call,
+    )
+
+    handler.update_in_memory_guardrail(
+        "123",
+        Guardrail(
+            guardrail_name="test-guardrail",
+            litellm_params=LitellmParams(guardrail="test-guardrail", mode="post_call", default_on=True),
+        ),
+    )
+
+    guardrail = handler.guardrail_id_to_custom_guardrail["123"]
+    assert guardrail.should_run_guardrail(data={}, event_type=GuardrailEventHooks.post_call) is True
+    assert guardrail.should_run_guardrail(data={}, event_type=GuardrailEventHooks.pre_call) is False
 
 
 def _make_guardrail(guardrail_id: str, name: str = "g") -> Guardrail:

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_registry.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_registry.py
@@ -2,6 +2,7 @@ import pytest
 
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.proxy.guardrails.guardrail_registry import (
+    _normalize_model_group_allowlist,
     get_guardrail_initializer_from_hooks,
     InMemoryGuardrailHandler,
 )
@@ -469,3 +470,54 @@ def test_reinitialized_judge_guardrail_uses_lazy_router_provider():
     finally:
         for cb_list, snapshot in zip(lists, snapshots):
             cb_list[:] = snapshot
+
+
+class TestNormalizeModelGroupAllowlist:
+    def test_none_returns_empty_frozenset(self):
+        assert _normalize_model_group_allowlist(None) == frozenset()
+
+    def test_empty_list_returns_empty_frozenset(self):
+        assert _normalize_model_group_allowlist([]) == frozenset()
+
+    def test_normalizes_to_lowercase_and_strips_whitespace(self):
+        result = _normalize_model_group_allowlist(["  AI-Gateway-Low  ", "AI-Gateway-High"])
+        assert result == frozenset({"ai-gateway-low", "ai-gateway-high"})
+
+    def test_deduplicates_entries(self):
+        result = _normalize_model_group_allowlist(["group-a", "GROUP-A", "  group-a  "])
+        assert result == frozenset({"group-a"})
+
+    def test_drops_blank_entries(self):
+        result = _normalize_model_group_allowlist(["valid-group", "  ", ""])
+        assert result == frozenset({"valid-group"})
+
+    def test_returns_frozenset(self):
+        result = _normalize_model_group_allowlist(["group-a"])
+        assert isinstance(result, frozenset)
+
+
+def test_initialize_guardrail_sets_apply_guardrail_to_model_groups_on_callback():
+    handler = InMemoryGuardrailHandler()
+
+    callback = CustomGuardrail(
+        guardrail_name="test-guardrail",
+        default_on=True,
+        event_hook=GuardrailEventHooks.pre_call,
+    )
+    litellm_params = LitellmParams(
+        guardrail="test-guardrail",
+        mode="pre_call",
+        default_on=True,
+        apply_guardrail_to_model_groups=["Group-A", "  GROUP-B  "],
+    )
+    setattr(callback, "skip_system_message_in_guardrail", None)
+    setattr(callback, "skip_tool_message_in_guardrail", None)
+    setattr(
+        callback,
+        "apply_guardrail_to_model_groups",
+        _normalize_model_group_allowlist(
+            getattr(litellm_params, "apply_guardrail_to_model_groups", None)
+        ),
+    )
+
+    assert getattr(callback, "apply_guardrail_to_model_groups") == frozenset({"group-a", "group-b"})

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -23501,7 +23501,7 @@ export interface components {
              * @description Default role assigned to new users created
              * @default internal_user_viewer
              */
-            user_role: ("internal_user" | "internal_user_viewer" | "proxy_admin" | "proxy_admin_viewer") | null;
+            user_role: ("proxy_admin" | "proxy_admin_viewer" | "internal_user" | "internal_user_viewer") | null;
         };
         /**
          * DefaultTeamSSOParams
@@ -26032,7 +26032,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: number | string | null;
+            stream_timeout?: string | number | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */
@@ -34104,7 +34104,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: number | string | null;
+            stream_timeout?: string | number | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */


### PR DESCRIPTION
## TLDR

Problem this solves:

- No config-level way to restrict a guardrail to specific model groups; a guardrail with default_on: true runs for every model behind the proxy with no scoping knob
- Operationally, this means a during_call guardrail pays latency and API cost for every model tier even when only low-intelligence/high-risk tiers need it

How it solves it:

- Adds apply_guardrail_to_model_groups to BaseLitellmParams; any guardrail type picks this up from config with zero subclass changes
- GuardrailRegistry.initialize_guardrail normalizes the list to a frozenset and sets it via setattr, following the same pattern as skip_system_message_in_guardrail
- CustomGuardrail.should_run_guardrail gates on the frozenset before any other check; matching is case-insensitive; checks the normalized data["model"] and the resolved metadata.model_group / litellm_metadata.model_group independently and passes if either matches, so a routed request where the router has rewritten data["model"] to the physical deployment still matches on the requested model group
- update_in_memory_litellm_params normalizes apply_guardrail_to_model_groups the same way on the PUT/update path, so an admin update with mixed-case or padded model groups matches consistently with the init path instead of silently skipping the guardrail

## Relevant issues

Fixes #34397

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

This change adds a config gate in should_run_guardrail. The gate is a no-op (frozenset is empty) when apply_guardrail_to_model_groups is unset, so no proxy round-trip is needed to prove the no-regression case. The behavioural change (gate blocks or passes) is a pure Python conditional tested by the unit tests below; a live proxy run would require Lakera/Bedrock credentials just to hit the same code path.

All 23 unit tests pass at commit af8b10d67f (20 from the initial commit plus 3 added while addressing review feedback: routed-request coverage for both directions of the model/model_group check, and update-path normalization):

```
tests/test_litellm/proxy/guardrails/test_guardrail_registry.py::TestNormalizeModelGroupAllowlist::test_deduplicates_entries PASSED
tests/test_litellm/proxy/guardrails/test_guardrail_registry.py::TestNormalizeModelGroupAllowlist::test_drops_blank_entries PASSED
tests/test_litellm/integrations/test_custom_guardrail.py::TestShouldRunGuardrailModelGroupGate::test_empty_allowlist_does_not_restrict PASSED
tests/test_litellm/proxy/guardrails/test_guardrail_registry.py::TestNormalizeModelGroupAllowlist::test_empty_list_returns_empty_frozenset PASSED
tests/test_litellm/proxy/guardrails/test_guardrail_registry.py::test_initialize_guardrail_sets_apply_guardrail_to_model_groups_on_callback PASSED
tests/test_litellm/integrations/test_custom_guardrail.py::TestShouldRunGuardrailModelGroupGate::test_litellm_metadata_model_group_used_as_fallback PASSED
tests/test_litellm/integrations/test_custom_guardrail.py::TestResolveMetadataModelGroup::test_litellm_metadata_takes_priority PASSED
tests/test_litellm/integrations/test_custom_guardrail.py::TestResolveMetadataModelGroup::test_metadata_fallback_when_litellm_metadata_absent PASSED
tests/test_litellm/integrations/test_custom_guardrail.py::TestShouldRunGuardrailModelGroupGate::test_metadata_model_group_used_as_fallback PASSED
tests/test_litellm/integrations/test_custom_guardrail.py::TestShouldRunGuardrailModelGroupGate::test_model_in_allowlist_passes_gate PASSED
tests/test_litellm/integrations/test_custom_guardrail.py::TestShouldRunGuardrailModelGroupGate::test_model_match_is_case_insensitive PASSED
tests/test_litellm/integrations/test_custom_guardrail.py::TestShouldRunGuardrailModelGroupGate::test_model_not_in_allowlist_blocked PASSED
tests/test_litellm/integrations/test_custom_guardrail.py::TestShouldRunGuardrailModelGroupGate::test_no_attribute_does_not_restrict PASSED
tests/test_litellm/integrations/test_custom_guardrail.py::TestShouldRunGuardrailModelGroupGate::test_no_model_or_metadata_is_blocked PASSED
tests/test_litellm/proxy/guardrails/test_guardrail_registry.py::TestNormalizeModelGroupAllowlist::test_none_returns_empty_frozenset PASSED
tests/test_litellm/proxy/guardrails/test_guardrail_registry.py::TestNormalizeModelGroupAllowlist::test_normalizes_to_lowercase_and_strips_whitespace PASSED
tests/test_litellm/proxy/guardrails/test_guardrail_registry.py::TestNormalizeModelGroupAllowlist::test_returns_frozenset PASSED
tests/test_litellm/integrations/test_custom_guardrail.py::TestResolveMetadataModelGroup::test_returns_none_when_model_group_key_absent PASSED
tests/test_litellm/integrations/test_custom_guardrail.py::TestResolveMetadataModelGroup::test_returns_none_when_neither_container_present PASSED
tests/test_litellm/integrations/test_custom_guardrail.py::TestShouldRunGuardrailModelGroupGate::test_routed_request_scoped_out_model_group_blocked PASSED
tests/test_litellm/integrations/test_custom_guardrail.py::TestShouldRunGuardrailModelGroupGate::test_routed_request_uses_metadata_model_group PASSED
tests/test_litellm/integrations/test_custom_guardrail.py::TestResolveMetadataModelGroup::test_strips_whitespace PASSED
tests/test_litellm/integrations/test_custom_guardrail.py::TestShouldRunGuardrailModelGroupGate::test_update_in_memory_normalizes_model_groups PASSED
23 passed in 50.06s
```

## Type

🆕 New Feature

## Changes

Adds a single config field, apply_guardrail_to_model_groups, to BaseLitellmParams. When set, only requests whose model (or metadata.model_group / litellm_metadata.model_group as a fallback) matches one of the listed values will trigger the guardrail; all other requests skip it silently. Matching is case-insensitive. When the field is unset or empty the gate is a no-op: existing behaviour is byte-for-byte unchanged.

The implementation follows the same generic-field-plus-base-class-gate shape already established by skip_system_message_in_guardrail and skip_tool_message_in_guardrail. GuardrailRegistry.initialize_guardrail normalizes the list to a frozenset and attaches it via setattr, so every guardrail type (Lakera, Bedrock, Akto, generic_guardrail_api, custom module paths) gets this capability for free with no per-class code.

Following review feedback, the gate now checks the normalized model and the resolved model_group independently (either can match the allowlist) instead of preferring one over the other, so a request routed to a physical deployment still matches on its requested model group. update_in_memory_litellm_params also normalizes apply_guardrail_to_model_groups on the PUT/update path so it stays consistent with the init path.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
