### PR TITLE
fix(advisor): gate orchestration on the deployment provider, not the alias

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -306,14 +306,15 @@ async def anthropic_messages(
     # Named params on `anthropic_messages` are bound to locals, not `**kwargs`,
     # so forward them explicitly — otherwise interceptor sub-calls drop them.
     for interceptor in get_messages_interceptors():
-        if interceptor.can_handle(tools, custom_llm_provider):
+        gate_provider = interceptor.resolve_gate_provider(model, custom_llm_provider, tools)
+        if interceptor.can_handle(tools, gate_provider):
             return await interceptor.handle(
                 model=model,
                 messages=messages,
                 tools=tools,
                 stream=original_stream,
                 max_tokens=max_tokens,
-                custom_llm_provider=custom_llm_provider,
+                custom_llm_provider=gate_provider,
                 api_key=api_key,
                 api_base=api_base,
                 metadata=metadata,

--- a/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
@@ -51,6 +51,30 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
         is_non_native = custom_llm_provider not in ADVISOR_NATIVE_PROVIDERS
         return has_advisor and is_non_native
 
+    def resolve_gate_provider(
+        self,
+        model: str,
+        custom_llm_provider: Optional[str],
+        tools: Optional[List[Dict]],
+    ) -> Optional[str]:
+        """Gate on the deployment provider, not the alias's name-inferred one.
+
+        A proxy alias using Anthropic naming may route to a non-Anthropic
+        deployment; gating on the name-inferred ``anthropic`` would skip
+        orchestration and leak the advisor tool_use. Re-resolve via the router
+        when an advisor tool is present and the provider is unset/name-inferred
+        Anthropic; otherwise leave it unchanged.
+        """
+        if custom_llm_provider not in (None, "", "anthropic"):
+            return custom_llm_provider
+        if not tools or not any(isinstance(t, dict) and t.get("type") == ANTHROPIC_ADVISOR_TOOL_TYPE for t in tools):
+            return custom_llm_provider
+        try:
+            _, resolved_provider, _ = _resolve_call_target(model, custom_llm_provider)
+            return resolved_provider or custom_llm_provider
+        except Exception:
+            return custom_llm_provider
+
     async def handle(
         self,
         *,
@@ -97,21 +121,23 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
         metadata_base: Dict = dict(kwargs.pop("metadata", None) or {})
         iteration = 0
 
+        executor_model, executor_provider, executor_extra = _resolve_call_target(model, custom_llm_provider)
+
         while True:
             # --- Executor call (always non-streaming) ---
             executor_response: AnthropicMessagesResponse = await _call_messages_handler(
-                model=model,
+                model=executor_model,
                 messages=current_messages,
                 tools=executor_tools,
                 stream=False,
                 max_tokens=max_tokens,
-                custom_llm_provider=custom_llm_provider,
+                custom_llm_provider=executor_provider,
                 metadata={
                     **metadata_base,
                     "advisor_sub_call": False,
                     "parent_request_id": parent_request_id,
                 },
-                **kwargs,
+                **{**executor_extra, **kwargs},
             )
 
             advisor_use_block = _find_advisor_tool_use(executor_response)
@@ -133,13 +159,14 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
             advisor_messages = _build_advisor_context(current_messages, executor_response, advisor_use_block)
 
             # --- Advisor sub-call (always non-streaming, no tools) ---
+            adv_model, adv_provider, adv_extra = _resolve_call_target(advisor_model, None)
             advisor_response: AnthropicMessagesResponse = await _call_messages_handler(
-                model=advisor_model,
+                model=adv_model,
                 messages=advisor_messages,
                 tools=None,
                 stream=False,
                 max_tokens=max_tokens,
-                custom_llm_provider=None,  # let litellm resolve from model name
+                custom_llm_provider=adv_provider,
                 metadata={
                     **metadata_base,
                     "advisor_sub_call": True,
@@ -147,6 +174,7 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
                 },
                 api_key=advisor_api_key,
                 api_base=advisor_api_base,
+                **adv_extra,
             )
 
             advisor_text = _extract_response_text(advisor_response)
@@ -163,6 +191,74 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+# Backend routing/credential keys forwarded onto the router-bypassing sub-call.
+# Allowlist (not blocklist) so request-shaping params that are also explicit
+# named args (max_tokens, tools, …) can't collide with them.
+_FORWARDED_DEPLOYMENT_PARAMS = frozenset(
+    {
+        # AWS Bedrock / SageMaker
+        "aws_region_name",
+        "aws_access_key_id",
+        "aws_secret_access_key",
+        "aws_session_token",
+        "aws_session_name",
+        "aws_role_name",
+        "aws_web_identity_token",
+        "aws_bedrock_runtime_endpoint",
+        "aws_profile_name",
+        # GCP Vertex
+        "vertex_project",
+        "vertex_location",
+        "vertex_credentials",
+        # Azure / misc backends
+        "api_version",
+        "watsonx_region_name",
+    }
+)
+
+
+def _resolve_model_via_router(alias: str):
+    """Resolve a proxy ``model_list`` alias to ``(deployment_model, litellm_params)``
+    via the router. Falls back to ``(alias, {})`` when no router is configured or the
+    alias is unknown (SDK / native use).
+    """
+    try:
+        from litellm.proxy.proxy_server import llm_router
+    except Exception:
+        return alias, {}
+    if llm_router is None:
+        return alias, {}
+    try:
+        deployment = llm_router.get_available_deployment(model=alias)
+    except Exception:
+        return alias, {}
+    if not deployment:
+        return alias, {}
+    litellm_params = dict(deployment.get("litellm_params") or {})
+    resolved_model = litellm_params.pop("model", None) or alias
+    return resolved_model, litellm_params
+
+
+def _resolve_call_target(alias: str, custom_llm_provider: Optional[str]):
+    """Resolve an alias to ``(model, custom_llm_provider, extra_routing_kwargs)``
+    for a router-bypassing sub-call, preferring the deployment's explicit provider
+    over name inference. Falls back to the alias unchanged when no router is set.
+    """
+    resolved_model, params = _resolve_model_via_router(alias)
+    explicit_provider = params.get("custom_llm_provider")
+    if explicit_provider:
+        provider = explicit_provider
+    elif resolved_model != alias:
+        try:
+            _, provider, _, _ = litellm.get_llm_provider(model=resolved_model)
+        except Exception:
+            provider = custom_llm_provider
+    else:
+        provider = custom_llm_provider
+    extra = {k: v for k, v in params.items() if k in _FORWARDED_DEPLOYMENT_PARAMS and v is not None}
+    return resolved_model, provider, extra
 
 
 def _allow_client_side_advisor_credentials() -> bool:

--- a/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/base.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/base.py
@@ -26,6 +26,19 @@ class MessagesInterceptor(ABC):
     ) -> bool:
         """Return True if this interceptor should handle the request."""
 
+    def resolve_gate_provider(
+        self,
+        model: str,
+        custom_llm_provider: Optional[str],
+        tools: Optional[List[Dict]],
+    ) -> Optional[str]:
+        """Return the provider ``can_handle`` should be gated on (default: unchanged).
+
+        An interceptor may override this when ``custom_llm_provider`` was
+        name-inferred from a proxy alias and does not reflect the routed deployment.
+        """
+        return custom_llm_provider
+
     @abstractmethod
     async def handle(
         self,

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_advisor_integration.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_advisor_integration.py
@@ -39,9 +39,7 @@ def _text_resp(text: str, model: str = "gpt-4o-mini") -> Dict:
     }
 
 
-def _advisor_call_resp(
-    question: str = "How do I approach this?", tool_id: str = "tid_01"
-) -> Dict:
+def _advisor_call_resp(question: str = "How do I approach this?", tool_id: str = "tid_01") -> Dict:
     return {
         "id": "msg_int_test",
         "type": "message",
@@ -106,14 +104,10 @@ async def test_full_dispatch_interceptor_fires_and_loop_completes():
     assert isinstance(result, dict)
     content = result.get("content", [])
     text_blocks = [b for b in content if b.get("type") == "text"]
-    advisor_uses = [
-        b for b in content if b.get("type") == "tool_use" and b.get("name") == "advisor"
-    ]
+    advisor_uses = [b for b in content if b.get("type") == "tool_use" and b.get("name") == "advisor"]
 
     assert len(text_blocks) >= 1, "Final response must have text"
-    assert (
-        len(advisor_uses) == 0
-    ), "No advisor tool_use blocks must appear in final output"
+    assert len(advisor_uses) == 0, "No advisor tool_use blocks must appear in final output"
 
 
 # ---------------------------------------------------------------------------
@@ -221,9 +215,7 @@ async def test_named_params_forwarded_into_advisor_executor_subcall():
 
     captured_executor_kwargs: Dict = {}
 
-    async def mock_handler(
-        model, messages, tools, stream, max_tokens, custom_llm_provider, **kwargs
-    ):
+    async def mock_handler(model, messages, tools, stream, max_tokens, custom_llm_provider, **kwargs):
         # First call is the executor sub-call (returns advisor tool_use).
         # Capture its kwargs so we can assert the forwarded params.
         if not captured_executor_kwargs:
@@ -267,8 +259,7 @@ async def test_named_params_forwarded_into_advisor_executor_subcall():
         )
 
     assert captured_executor_kwargs["thinking"] == {"type": "adaptive"}, (
-        "thinking must be forwarded into executor sub-call — see "
-        "anthropic_messages.handler interceptor invocation."
+        "thinking must be forwarded into executor sub-call — see anthropic_messages.handler interceptor invocation."
     )
     # The advisor enriches metadata with `advisor_sub_call` / `parent_request_id`,
     # but the original caller fields must survive into the executor sub-call.
@@ -304,9 +295,7 @@ async def test_pre_request_hook_override_does_not_collide_with_explicit_kwargs()
 
     captured: Dict = {}
 
-    async def mock_handler(
-        model, messages, tools, stream, max_tokens, custom_llm_provider, **kwargs
-    ):
+    async def mock_handler(model, messages, tools, stream, max_tokens, custom_llm_provider, **kwargs):
         if not captured:
             captured.update(
                 {
@@ -320,9 +309,7 @@ async def test_pre_request_hook_override_does_not_collide_with_explicit_kwargs()
             return _text_resp("Some advice.", model="claude-opus-4-6")
         return _text_resp("Final answer.")
 
-    async def fake_pre_request_hooks(
-        model, messages, tools, stream, custom_llm_provider, **hook_kwargs
-    ):
+    async def fake_pre_request_hooks(model, messages, tools, stream, custom_llm_provider, **hook_kwargs):
         # Simulate a CustomLogger.async_pre_request_hook that overrides several
         # named params on its way through. Without the request_kwargs.pop()
         # extraction in handler.py, these would collide with the explicit
@@ -364,3 +351,214 @@ async def test_pre_request_hook_override_does_not_collide_with_explicit_kwargs()
     assert captured["thinking"] == {"type": "enabled", "budget_tokens": 2048}
     assert captured["system"] == "Hook overrode the system prompt."
     assert captured["temperature"] == 0.1
+
+
+# ---------------------------------------------------------------------------
+# 6. Gate + sub-call routing on the deployment provider, not the alias's
+#    name-inferred one. A proxy alias using Anthropic naming
+#    ("claude-sonnet-4-6") may route to a non-Anthropic deployment; the advisor
+#    interceptor must engage and the router-bypassing sub-calls must land on the
+#    deployment backend (incl. deployments configured WITHOUT a provider prefix).
+# ---------------------------------------------------------------------------
+
+
+class _FakeRouter:
+    """Minimal stand-in for the proxy llm_router with one alias → deployment."""
+
+    def __init__(self, alias: str, litellm_params: Dict):
+        self._alias = alias
+        self._params = litellm_params
+
+    def get_available_deployment(self, model: str):
+        if model == self._alias:
+            return {"litellm_params": dict(self._params)}
+        return None
+
+
+@pytest.mark.asyncio
+async def test_gate_resolves_bedrock_mapped_alias_and_engages():
+    """A ``claude-*`` alias mapped to a bedrock deployment must engage the
+    advisor interceptor (gate on the deployment provider, not the alias name)."""
+    from litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor import (
+        AdvisorOrchestrationHandler,
+    )
+
+    router = _FakeRouter(
+        "claude-sonnet-4-6",
+        {"model": "bedrock/us.anthropic.claude-sonnet-4-6", "aws_region_name": "us-east-1"},
+    )
+    with patch("litellm.proxy.proxy_server.llm_router", router):
+        provider = AdvisorOrchestrationHandler().resolve_gate_provider(
+            model="claude-sonnet-4-6",
+            custom_llm_provider="anthropic",  # name-inferred from the alias
+            tools=[ADVISOR_TOOL],
+        )
+    assert provider == "bedrock", (
+        "gate must resolve the alias to its deployment provider (bedrock), not keep the name-inferred 'anthropic'"
+    )
+
+
+@pytest.mark.asyncio
+async def test_gate_leaves_native_anthropic_and_non_advisor_untouched():
+    from litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor import (
+        AdvisorOrchestrationHandler,
+    )
+
+    handler = AdvisorOrchestrationHandler()
+    # No advisor tool → unchanged (do not touch the router / non-advisor traffic).
+    assert handler.resolve_gate_provider("claude-3-5-sonnet", "anthropic", tools=None) == "anthropic"
+    # Provider already explicitly set to something other than name-inferred
+    # anthropic → unchanged (already router-resolved upstream).
+    assert handler.resolve_gate_provider("bedrock/whatever", "bedrock", tools=[ADVISOR_TOOL]) == "bedrock"
+
+
+@pytest.mark.asyncio
+async def test_executor_subcall_routes_prefixless_bedrock_deployment():
+    """The executor sub-call bypasses the router, so it must forward the
+    deployment's explicit ``custom_llm_provider``. A deployment configured
+    WITHOUT a provider prefix (``model: us.anthropic...`` + a separate
+    ``custom_llm_provider: bedrock``) must still reach Bedrock, not name-infer
+    to Anthropic."""
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        anthropic_messages,
+    )
+
+    router = _FakeRouter(
+        "claude-sonnet-4-6",
+        {
+            "model": "us.anthropic.claude-sonnet-4-6",  # NO bedrock/ prefix
+            "custom_llm_provider": "bedrock",
+            "aws_region_name": "us-west-2",
+        },
+    )
+
+    captured: Dict = {}
+
+    async def mock_handler(model, messages, tools, stream, max_tokens, custom_llm_provider, **kwargs):
+        if not captured:
+            captured.update(
+                {
+                    "model": model,
+                    "custom_llm_provider": custom_llm_provider,
+                    "aws_region_name": kwargs.get("aws_region_name"),
+                }
+            )
+        return _text_resp("Final answer.")
+
+    with (
+        patch("litellm.proxy.proxy_server.llm_router", router),
+        patch(
+            "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._call_messages_handler",
+            side_effect=mock_handler,
+        ),
+    ):
+        await anthropic_messages(
+            model="claude-sonnet-4-6",
+            messages=MESSAGES,
+            tools=[ADVISOR_TOOL],
+            stream=False,
+            max_tokens=512,
+            custom_llm_provider="anthropic",  # name-inferred from the alias
+        )
+
+    # Executor sub-call must carry the deployment's provider + routing params,
+    # NOT the name-inferred anthropic that would send it to Anthropic-direct.
+    assert captured["custom_llm_provider"] == "bedrock"
+    assert captured["model"] == "us.anthropic.claude-sonnet-4-6"
+    assert captured["aws_region_name"] == "us-west-2"
+
+
+@pytest.mark.asyncio
+async def test_gate_resolves_non_name_inferable_deployment_via_explicit_provider():
+    """A deployment whose model id does NOT name-infer to its real provider
+    (e.g. an inference-profile ARN or a friendly id) but declares an explicit
+    ``custom_llm_provider`` must still gate correctly — the advisor interceptor
+    must engage, not read it as native anthropic and skip."""
+    from litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor import (
+        AdvisorOrchestrationHandler,
+    )
+
+    router = _FakeRouter(
+        "my-internal-claude",
+        {"model": "my-internal-claude-prod", "custom_llm_provider": "bedrock"},
+    )
+    with patch("litellm.proxy.proxy_server.llm_router", router):
+        provider = AdvisorOrchestrationHandler().resolve_gate_provider(
+            model="my-internal-claude",
+            custom_llm_provider="anthropic",  # name-inferred from the alias
+            tools=[ADVISOR_TOOL],
+        )
+    assert provider == "bedrock", (
+        "gate must prefer the deployment's explicit custom_llm_provider, not "
+        "name-infer the (non-inferable) model id back to anthropic"
+    )
+
+
+@pytest.mark.asyncio
+async def test_executor_subcall_ignores_deployment_request_shaping_params():
+    """Deployment litellm_params may carry request-shaping defaults (max_tokens,
+    tools, temperature, …) that are ALSO explicit named args of the sub-call.
+    Those must NOT be forwarded as **kwargs (would raise 'got multiple values for
+    keyword argument'); only routing/credential params (aws_region_name, …) are."""
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        anthropic_messages,
+    )
+
+    router = _FakeRouter(
+        "claude-sonnet-4-6",
+        {
+            "model": "bedrock/us.anthropic.claude-sonnet-4-6",
+            "aws_region_name": "eu-central-1",
+            # request-shaping defaults that collide with explicit sub-call args:
+            "max_tokens": 4096,
+            "temperature": 0.2,
+            "tools": [{"name": "leftover"}],
+            "metadata": {"deployment_default": True},
+        },
+    )
+
+    captured: Dict = {}
+
+    async def mock_handler(model, messages, tools, stream, max_tokens, custom_llm_provider, **kwargs):
+        if not captured:
+            captured.update(
+                {
+                    "aws_region_name": kwargs.get("aws_region_name"),
+                    "max_tokens": max_tokens,
+                    "custom_llm_provider": custom_llm_provider,
+                    # temperature is a named arg the handler forwards from the
+                    # ORIGINAL request (None here); the deployment default (0.2)
+                    # must NOT override it.
+                    "temperature": kwargs.get("temperature"),
+                    # deployment's own `tools`/`metadata` defaults must not leak in.
+                    "deployment_tools_leaked": any(
+                        isinstance(t, dict) and t.get("name") == "leftover" for t in (tools or [])
+                    ),
+                    "deployment_metadata_leaked": (kwargs.get("metadata") or {}).get("deployment_default"),
+                }
+            )
+        return _text_resp("Final answer.")
+
+    with (
+        patch("litellm.proxy.proxy_server.llm_router", router),
+        patch(
+            "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._call_messages_handler",
+            side_effect=mock_handler,
+        ),
+    ):
+        # Must NOT raise TypeError.
+        await anthropic_messages(
+            model="claude-sonnet-4-6",
+            messages=MESSAGES,
+            tools=[ADVISOR_TOOL],
+            stream=False,
+            max_tokens=512,
+            custom_llm_provider="anthropic",
+        )
+
+    assert captured["custom_llm_provider"] == "bedrock"
+    assert captured["aws_region_name"] == "eu-central-1"  # routing param forwarded
+    assert captured["max_tokens"] == 512  # explicit arg wins; deployment default not forwarded
+    assert captured["temperature"] is None  # deployment's 0.2 not forwarded over the request's value
+    assert captured["deployment_tools_leaked"] is False  # deployment `tools` default dropped
+    assert captured["deployment_metadata_leaked"] is None  # deployment `metadata` default dropped


### PR DESCRIPTION
## TLDR

Problem this solves:

- Advisor orchestration silently skipped for proxy aliases mapped to Bedrock
- Advisor `tool_use` leaks to client → "No such tool available"

How it solves it:

- Gate the interceptor on the deployment's provider, not the alias name
- Router-bypassing advisor sub-calls now resolve the real deployment too

## Relevant issues

Fixes #34383

## Linear ticket

<!-- external contributor — no Linear ticket -->

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Validated end-to-end on our dev LiteLLM proxy (real Bedrock calls), commit `e980ce4e9a`

**Setup:** a proxy alias `claude-fable-5` (Anthropic naming) mapped to `bedrock/us.anthropic.claude-fable-5`, request carries an `advisor_20260301` tool.

**Before (mechanism):** `get_llm_provider("claude-fable-5")` name-infers `anthropic`, so `can_handle()` treats it as advisor-native and skips orchestration → the advisor `tool_use` is returned to the client unresolved ("No such tool available").

**After (this PR) — live `/v1/messages` run:**
HTTP 200
content block types: ['thinking', 'text']
advisor tool_use LEAKED to client: False   (orchestration engaged, handled the advisor call)
text: "Yes, 97 is prime because it is not divisible by any prime up to its square root (2, 3, 5, or 7)."
The gate now resolves `claude-fable-5` → deployment provider `bedrock`, so orchestration engages and the client gets a clean answer with no leaked `tool_use`.

<img width="1192" height="1082" alt="image" src="https://github.com/user-attachments/assets/b042763d-376e-4611-90a8-38c82c4ece3c" />


## Type

🐛 Bug Fix

## Changes

- `MessagesInterceptor.resolve_gate_provider()` — new optional hook (default returns the provider unchanged) so an interceptor can re-resolve the provider its gate keys on.
- `anthropic_messages` handler gates `can_handle()` on `resolve_gate_provider(...)` instead of the raw request provider.
- `AdvisorOrchestrationHandler.resolve_gate_provider()` resolves a proxy alias to its deployment provider via the router (prefers the deployment's explicit `custom_llm_provider`, falls back to name-inference of the resolved model).
- The executor/advisor sub-calls (which bypass the router) resolve the deployment model + provider the same way, forwarding only allowlisted backend routing/credential params so request-shaping args can't collide.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
