### PR TITLE
fix(azure): update Azure Claude Opus 4.8 context window to 1M

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -2762,7 +2762,7 @@
         "input_cost_per_token": 5e-06,
         "output_cost_per_token": 2.5e-05,
         "litellm_provider": "azure_ai",
-        "max_input_tokens": 200000,
+        "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -2762,7 +2762,7 @@
         "input_cost_per_token": 5e-06,
         "output_cost_per_token": 2.5e-05,
         "litellm_provider": "azure_ai",
-        "max_input_tokens": 200000,
+        "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",

--- a/tests/test_litellm/test_claude_opus_4_8_config.py
+++ b/tests/test_litellm/test_claude_opus_4_8_config.py
@@ -60,10 +60,9 @@ def test_opus_4_8_model_pricing_and_capabilities():
             "provider": "vertex_ai-anthropic_models",
             "max_input_tokens": 1000000,
         },
-        # Microsoft Foundry / Azure caps Opus 4.8 at a 200k context window.
         "azure_ai/claude-opus-4-8": {
             "provider": "azure_ai",
-            "max_input_tokens": 200000,
+            "max_input_tokens": 1000000,
         },
     }
 


### PR DESCRIPTION
Fixes #34134

Azure AI Claude Opus 4.8 natively supports 1M token context windows. This PR removes the stale 200k limitation.

### Checklist
- [x] Verified Azure documentation regarding 1M token limit for Opus 4.8
- [x] Tested with local changes (`pytest tests/test_litellm/test_claude_opus_4_8_config.py`)

Note: As discussed internally, bumping this to 1M requires the proxy environment to accommodate potentially higher memory buffers for massive requests, but it should correctly reflect the model's capabilities without an artificial cap.