### PR TITLE
feat(router): add opt-in flag to honor Retry-After with multiple deployments

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -326,6 +326,7 @@ class Router:
         tag_filtering_match_any: bool = True,
         plugins: list[RoutingPlugin] | None = None,
         retry_after: int = 0,  # min time to wait before retrying a failed request
+        respect_retry_after_with_multiple_deployments: bool = False,  # honor an explicit Retry-After header even when there are healthy sibling deployments (they often share the same throttled upstream)
         retry_policy: Optional[Union[RetryPolicy, dict]] = None,  # set custom retries for different exceptions
         model_group_retry_policy: Dict[str, RetryPolicy] = {},  # set custom retry policies based on model group
         allowed_fails: Optional[int] = None,  # Number of times a deployment can failbefore being added to cooldown
@@ -579,6 +580,7 @@ class Router:
         self.stream_timeout = stream_timeout
 
         self.retry_after = retry_after
+        self.respect_retry_after_with_multiple_deployments = respect_retry_after_with_multiple_deployments
         self.routing_strategy = self._normalize_strategy(routing_strategy)
         self._routing_groups_input: Optional[List[Union[RoutingGroup, dict]]] = routing_groups
 
@@ -6790,19 +6792,36 @@ class Router:
         It should instantly retry only when:
             1. there are healthy deployments in the same model group
             2. there are fallbacks for the completion call
-        """
 
-        ## base case - single deployment
-        if all_deployments is not None and len(all_deployments) == 1:
-            pass
-        elif healthy_deployments is not None and isinstance(healthy_deployments, list) and len(healthy_deployments) > 0:
-            return 0
+        Exception: if respect_retry_after_with_multiple_deployments is enabled
+        and the exception carries an explicit Retry-After header, that is
+        honored even with healthy sibling deployments present -- siblings
+        often share the same throttled upstream, so an instant failover just
+        hammers it and silently discards the provider's requested wait.
+        """
 
         response_headers: Optional[httpx.Headers] = None
         if hasattr(e, "response") and hasattr(e.response, "headers"):  # type: ignore
             response_headers = e.response.headers  # type: ignore
         if hasattr(e, "litellm_response_headers"):
             response_headers = e.litellm_response_headers  # type: ignore
+
+        has_explicit_retry_after = (
+            self.respect_retry_after_with_multiple_deployments
+            and response_headers is not None
+            and ("retry-after" in response_headers or "Retry-After" in response_headers)
+        )
+
+        ## base case - single deployment
+        if all_deployments is not None and len(all_deployments) == 1:
+            pass
+        elif (
+            not has_explicit_retry_after
+            and healthy_deployments is not None
+            and isinstance(healthy_deployments, list)
+            and len(healthy_deployments) > 0
+        ):
+            return 0
 
         if response_headers is not None:
             timeout = litellm._calculate_retry_after(

--- a/tests/litellm/test_router_retry_backoff_headers.py
+++ b/tests/litellm/test_router_retry_backoff_headers.py
@@ -86,3 +86,138 @@ async def test_retry_backoff_uses_current_exception_headers():
     assert captured_backoff_errors[0] is first_error
     assert captured_backoff_errors[1] is second_error
     assert captured_backoff_errors[2] is third_error
+
+
+def test_time_to_sleep_before_retry_default_ignores_retry_after_with_multiple_deployments():
+    """
+    Default behavior (respect_retry_after_with_multiple_deployments=False,
+    the default) is unchanged: instant retry (timeout == 0) when there are
+    healthy sibling deployments, even with an explicit Retry-After header.
+    """
+    router = Router(
+        model_list=[
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {"model": "gpt-3.5-turbo", "api_key": "sk-a"},
+            },
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {"model": "gpt-3.5-turbo", "api_key": "sk-b"},
+            },
+        ],
+        num_retries=3,
+    )
+
+    error = litellm.RateLimitError(
+        message="Rate limited",
+        model="gpt-3.5-turbo",
+        llm_provider="openai",
+    )
+    error.litellm_response_headers = httpx.Headers({"retry-after": "15"})
+
+    healthy_deployments = [
+        {"model_info": {"id": "dep-a"}},
+        {"model_info": {"id": "dep-b"}},
+    ]
+
+    timeout = router._time_to_sleep_before_retry(
+        e=error,
+        remaining_retries=2,
+        num_retries=3,
+        healthy_deployments=healthy_deployments,
+        all_deployments=healthy_deployments,
+    )
+
+    assert timeout == 0
+
+
+def test_time_to_sleep_before_retry_opt_in_honors_retry_after_with_multiple_deployments():
+    """
+    Regression test for: https://github.com/BerriAI/litellm/issues/34399
+
+    With respect_retry_after_with_multiple_deployments=True, an explicit
+    Retry-After header must be honored even when there are multiple healthy
+    deployments in the model group -- sibling deployments frequently share
+    the same throttled upstream, so instant failover just hammers it.
+    """
+    router = Router(
+        model_list=[
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {"model": "gpt-3.5-turbo", "api_key": "sk-a"},
+            },
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {"model": "gpt-3.5-turbo", "api_key": "sk-b"},
+            },
+        ],
+        num_retries=3,
+        respect_retry_after_with_multiple_deployments=True,
+    )
+
+    error = litellm.RateLimitError(
+        message="Rate limited",
+        model="gpt-3.5-turbo",
+        llm_provider="openai",
+    )
+    error.litellm_response_headers = httpx.Headers({"retry-after": "15"})
+
+    healthy_deployments = [
+        {"model_info": {"id": "dep-a"}},
+        {"model_info": {"id": "dep-b"}},
+    ]
+
+    timeout = router._time_to_sleep_before_retry(
+        e=error,
+        remaining_retries=2,
+        num_retries=3,
+        healthy_deployments=healthy_deployments,
+        all_deployments=healthy_deployments,
+    )
+
+    assert timeout != 0
+    assert timeout > 0
+
+
+def test_time_to_sleep_before_retry_opt_in_still_instant_without_retry_after():
+    """
+    Sanity check: even with respect_retry_after_with_multiple_deployments=True,
+    multi-deployment groups still get instant failover (timeout == 0) when
+    there is no explicit Retry-After header -- the opt-in only changes
+    behavior when the provider actually sent one.
+    """
+    router = Router(
+        model_list=[
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {"model": "gpt-3.5-turbo", "api_key": "sk-a"},
+            },
+            {
+                "model_name": "gpt-3.5-turbo",
+                "litellm_params": {"model": "gpt-3.5-turbo", "api_key": "sk-b"},
+            },
+        ],
+        num_retries=3,
+        respect_retry_after_with_multiple_deployments=True,
+    )
+
+    error = litellm.RateLimitError(
+        message="Rate limited, no retry-after header",
+        model="gpt-3.5-turbo",
+        llm_provider="openai",
+    )
+
+    healthy_deployments = [
+        {"model_info": {"id": "dep-a"}},
+        {"model_info": {"id": "dep-b"}},
+    ]
+
+    timeout = router._time_to_sleep_before_retry(
+        e=error,
+        remaining_retries=2,
+        num_retries=3,
+        healthy_deployments=healthy_deployments,
+        all_deployments=healthy_deployments,
+    )
+
+    assert timeout == 0


### PR DESCRIPTION
Fixes #34399

## Problem
`_time_to_sleep_before_retry` unconditionally returns 0 (instant retry) whenever a model group has more than one healthy deployment, discarding any `Retry-After` header the upstream provider sent. Sibling deployments frequently share the same throttled upstream (e.g. two deployments with different `api_key`s pointing at the same backend), so instant retries hammer the throttled endpoint and burn through `num_retries` well within the provider's advertised backoff window.

## Why opt-in, not a default change
The existing instant-retry-on-healthy-deployments behavior is deliberate and locked in by an existing test (`test_timeout_for_rate_limit_error_with_healthy_deployments`), which explicitly asserts `timeout == 0` in this scenario. Rather than changing default behavior, this adds an opt-in `respect_retry_after_with_multiple_deployments` flag (default `False`) to `Router.__init__`. Default behavior is completely unchanged and verified unchanged by a new test.

## Fix
When `respect_retry_after_with_multiple_deployments=True`, an explicit `Retry-After` header is honored even with healthy sibling deployments present.

## Tests
- Default behavior unchanged (instant retry, even with `Retry-After` present)
- Opt-in honors `Retry-After` with multiple deployments
- Opt-in still allows instant retry when no `Retry-After` header is present

All existing router retry tests pass except one pre-existing, unrelated environmental failure (missing `ANTHROPIC_API_KEY` locally), confirmed identical with and without this change via `git stash`.