### PR TITLE
refactor(e2e): drop require_env, read os.environ where a cred is used

### DIFF
--- a/tests/e2e/batches/test_batches_e2e.py
+++ b/tests/e2e/batches/test_batches_e2e.py
@@ -23,7 +23,7 @@ from typing import Callable
 
 import pytest
 
-from e2e_config import require_env, unique_marker
+from e2e_config import unique_marker
 
 from batch_client import (
     UPLOAD_FILENAME,
@@ -702,14 +702,7 @@ class TestBedrockBatchAssumeRole:
     def test_unified_batch_create_with_assume_role(
         self, client: BatchClient, resources: ResourceManager
     ) -> None:
-        (role_arn,) = require_env("AWS_ROLE_NAME")
-        require_env(
-            "AWS_ACCESS_KEY_ID",
-            "AWS_SECRET_ACCESS_KEY",
-            "AWS_REGION",
-            "AWS_BATCH_S3_BUCKET",
-            "AWS_BATCH_ROLE_ARN",
-        )
+        role_arn = os.environ["AWS_ROLE_NAME"]
         session_name = f"e2e-batch-sts-{unique_marker()}"[:64]
         model_name = batch_model_name("bedrock-sts-batch")
 
@@ -819,7 +812,7 @@ class TestHostedVllmBatch:
     def test_unified_file_and_batch_create(
         self, client: BatchClient, resources: ResourceManager
     ) -> None:
-        (api_base,) = require_env("HOSTED_VLLM_API_BASE")
+        api_base = os.environ["HOSTED_VLLM_API_BASE"]
         api_key = (os.environ.get("HOSTED_VLLM_API_KEY") or "").strip() or None
         model_id = (
             os.environ.get("HOSTED_VLLM_MODEL") or "meta-llama/Llama-3.2-3B-Instruct"

--- a/tests/e2e/e2e_config.py
+++ b/tests/e2e/e2e_config.py
@@ -99,22 +99,6 @@ ANOMALY_SPEND_SETTLE_SECONDS = float(
 )
 
 
-def require_env(*names: str) -> tuple[str, ...]:
-    """Return the non-empty values for each env name, or hard-fail naming which are missing.
-
-    Live e2e never skips for missing credentials: a missing key is a red run so
-    ops knows the suite cannot prove the product path.
-    """
-    missing = tuple(name for name in names if not (os.environ.get(name) or "").strip())
-    if missing:
-        joined = ", ".join(missing)
-        raise AssertionError(
-            f"missing required env for e2e: {joined}. "
-            "Add them to tests/e2e/.env locally and to litellm ops for stage/CI."
-        )
-    return tuple((os.environ.get(name) or "").strip() for name in names)
-
-
 def datadog_mcp_url(*, toolsets: str = "core") -> str:
     """Regional Datadog remote MCP endpoint for this process's DD_SITE.
 

--- a/tests/e2e/guardrails/test_bedrock_guardrail_e2e.py
+++ b/tests/e2e/guardrails/test_bedrock_guardrail_e2e.py
@@ -8,9 +8,11 @@ a 200 means the guardrail never ran.
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
-from e2e_config import require_env, unique_marker
+from e2e_config import unique_marker
 from e2e_http import UnknownApiError
 from guardrails_client import GuardrailsClient
 from lifecycle import ResourceManager
@@ -33,11 +35,8 @@ class TestBedrockGuardrail:
     def test_bedrock_pre_call_blocks_harmful_prompt(
         self, client: GuardrailsClient, resources: ResourceManager, scoped_key: str
     ) -> None:
-        (identifier, version) = require_env(
-            "BEDROCK_GUARDRAIL_IDENTIFIER",
-            "BEDROCK_GUARDRAIL_VERSION",
-        )
-        require_env("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION")
+        identifier = os.environ["BEDROCK_GUARDRAIL_IDENTIFIER"]
+        version = os.environ["BEDROCK_GUARDRAIL_VERSION"]
 
         name = f"e2e-bedrock-guard-{unique_marker()}"
         guardrail_id = client.create_bedrock_guardrail(

--- a/tests/e2e/guardrails/test_block_code_execution_guardrail_e2e.py
+++ b/tests/e2e/guardrails/test_block_code_execution_guardrail_e2e.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import pytest
 
-from e2e_config import require_env, unique_marker
+from e2e_config import unique_marker
 from e2e_http import unwrap
 from guardrails_client import BlockCodeExecutionParamsBody, GuardrailsClient
 from lifecycle import ResourceManager
@@ -46,7 +46,6 @@ class TestBlockCodeExecutionGuardrail:
     def test_blocks_execution_request_but_allows_explanation(
         self, client: GuardrailsClient, resources: ResourceManager, scoped_key: str
     ) -> None:
-        require_env("GEMINI_API_KEY")
         model = client.create_backend_model(resources, prefix="e2e-blockcode-backend")
 
         name = f"e2e-block-code-{unique_marker()}"

--- a/tests/e2e/guardrails/test_openai_moderation_guardrail_e2e.py
+++ b/tests/e2e/guardrails/test_openai_moderation_guardrail_e2e.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import pytest
 
-from e2e_config import require_env, unique_marker
+from e2e_config import unique_marker
 from e2e_http import UnknownApiError, unwrap
 from guardrails_client import GuardrailsClient, OpenAIModerationParamsBody
 from lifecycle import ResourceManager
@@ -34,7 +34,6 @@ class TestOpenAIModerationGuardrail:
     def test_moderation_blocks_flagged_input(
         self, client: GuardrailsClient, resources: ResourceManager, scoped_key: str
     ) -> None:
-        require_env("OPENAI_API_KEY", "GEMINI_API_KEY")
         model = client.create_backend_model(resources, prefix="e2e-moderation-backend")
 
         name = f"e2e-openai-moderation-{unique_marker()}"

--- a/tests/e2e/guardrails/test_presidio_guardrail_e2e.py
+++ b/tests/e2e/guardrails/test_presidio_guardrail_e2e.py
@@ -25,11 +25,12 @@ The chat backend is a gemini deployment created for the test.
 
 from __future__ import annotations
 
+import os
 import time
 
 import pytest
 
-from e2e_config import POLL_INTERVAL, POLL_TIMEOUT, require_env, unique_marker
+from e2e_config import POLL_INTERVAL, POLL_TIMEOUT, unique_marker
 from e2e_http import NoBody, require_successful_call, unwrap
 from guardrails_client import GuardrailMode, GuardrailsClient, PresidioParamsBody
 from lifecycle import ResourceManager
@@ -88,9 +89,8 @@ def _poll_logged_prompt(reader: OtelReader, *, call_id: str, genai_span: str) ->
 def _presidio_params(
     mode: GuardrailMode, *, apply_to_output: bool = False, logging_only: bool = False
 ) -> PresidioParamsBody:
-    analyzer, anonymizer = require_env(
-        "PRESIDIO_ANALYZER_API_BASE", "PRESIDIO_ANONYMIZER_API_BASE"
-    )
+    analyzer = os.environ["PRESIDIO_ANALYZER_API_BASE"]
+    anonymizer = os.environ["PRESIDIO_ANONYMIZER_API_BASE"]
     return PresidioParamsBody(
         mode=mode,
         default_on=False,
@@ -124,7 +124,6 @@ class TestPresidioGuardrail:
     def test_pre_call_masks_pii_before_the_model_sees_it(
         self, client: GuardrailsClient, resources: ResourceManager, scoped_key: str
     ) -> None:
-        require_env("GEMINI_API_KEY")
         model = client.create_backend_model(resources, prefix="e2e-presidio-pre")
         name = f"e2e-presidio-pre-{unique_marker()}"
         guardrail_id = client.register(name, _presidio_params("pre_call"))
@@ -149,7 +148,6 @@ class TestPresidioGuardrail:
     def test_post_call_masks_pii_in_model_output(
         self, client: GuardrailsClient, resources: ResourceManager, scoped_key: str
     ) -> None:
-        require_env("GEMINI_API_KEY")
         model = client.create_backend_model(resources, prefix="e2e-presidio-post")
         name = f"e2e-presidio-post-{unique_marker()}"
         guardrail_id = client.register(name, _presidio_params("post_call", apply_to_output=True))
@@ -173,7 +171,6 @@ class TestPresidioGuardrail:
     def test_logging_only_masks_the_logged_prompt(
         self, client: GuardrailsClient, resources: ResourceManager, scoped_key: str
     ) -> None:
-        require_env("GEMINI_API_KEY")
         _require_otel_v2_active(client)
         reader = build_otel_reader()
 

--- a/tests/e2e/llm_translation/test_chat_completions_regression_e2e.py
+++ b/tests/e2e/llm_translation/test_chat_completions_regression_e2e.py
@@ -21,7 +21,7 @@ import os
 import pytest
 from pydantic import BaseModel
 
-from e2e_config import require_env, unique_marker
+from e2e_config import unique_marker
 from e2e_http import StreamingResponse, unwrap
 from lifecycle import ResourceManager
 from models import (
@@ -250,7 +250,7 @@ class TestCohereChat:
     def test_cohere_chat_returns_content(
         self, client: PassthroughClient, resources: ResourceManager
     ) -> None:
-        (cohere_key,) = require_env("COHERE_API_KEY")
+        cohere_key = os.environ["COHERE_API_KEY"]
         model = f"e2e-cohere-chat-{unique_marker()}"
         model_id = client.proxy.create_model(
             model,
@@ -343,7 +343,7 @@ class TestHostedVllmChat:
     def test_hosted_vllm_chat_returns_content(
         self, client: PassthroughClient, resources: ResourceManager
     ) -> None:
-        (api_base,) = require_env("HOSTED_VLLM_API_BASE")
+        api_base = os.environ["HOSTED_VLLM_API_BASE"]
         api_key = (os.environ.get("HOSTED_VLLM_API_KEY") or "").strip() or None
         backend = (
             os.environ.get("HOSTED_VLLM_MODEL") or "meta-llama/Llama-3.2-3B-Instruct"
@@ -395,7 +395,6 @@ class TestOpenAIChatCompletions:
     def test_openai_chat_streams_real_content(
         self, client: PassthroughClient, resources: ResourceManager
     ) -> None:
-        require_env("OPENAI_API_KEY")
         model = f"e2e-openai-chat-{unique_marker()}"
         model_id = client.proxy.create_model(
             model, LiteLLMParamsBody(model=OPENAI_BACKEND, api_key="os.environ/OPENAI_API_KEY")
@@ -423,7 +422,6 @@ class TestOpenAIChatCompletions:
     def test_openai_chat_logs_cost(
         self, client: PassthroughClient, resources: ResourceManager
     ) -> None:
-        require_env("OPENAI_API_KEY")
         model = f"e2e-openai-cost-{unique_marker()}"
         model_id = client.proxy.create_model(
             model, LiteLLMParamsBody(model=OPENAI_BACKEND, api_key="os.environ/OPENAI_API_KEY")
@@ -457,7 +455,6 @@ class TestOpenAIChatCompletions:
     def test_openai_chat_returns_tool_call(
         self, client: PassthroughClient, resources: ResourceManager
     ) -> None:
-        require_env("OPENAI_API_KEY")
         model = f"e2e-openai-tool-{unique_marker()}"
         model_id = client.proxy.create_model(
             model, LiteLLMParamsBody(model=OPENAI_BACKEND, api_key="os.environ/OPENAI_API_KEY")
@@ -488,7 +485,6 @@ class TestOpenAIChatCompletions:
     def test_openai_chat_structured_output_conforms_to_schema(
         self, client: PassthroughClient, resources: ResourceManager
     ) -> None:
-        require_env("OPENAI_API_KEY")
         model = f"e2e-openai-schema-{unique_marker()}"
         model_id = client.proxy.create_model(
             model, LiteLLMParamsBody(model=OPENAI_BACKEND, api_key="os.environ/OPENAI_API_KEY")
@@ -522,7 +518,6 @@ class TestOpenAIChatCompletions:
     def test_openai_chat_reasoning_reports_reasoning_tokens(
         self, client: PassthroughClient, resources: ResourceManager
     ) -> None:
-        require_env("OPENAI_API_KEY")
         model = f"e2e-openai-reasoning-{unique_marker()}"
         model_id = client.proxy.create_model(
             model, LiteLLMParamsBody(model=OPENAI_BACKEND, api_key="os.environ/OPENAI_API_KEY")
@@ -561,7 +556,6 @@ class TestOpenAIChatCompletions:
     def test_openai_chat_vision_describes_image(
         self, client: PassthroughClient, resources: ResourceManager
     ) -> None:
-        require_env("OPENAI_API_KEY")
         model = f"e2e-openai-vision-{unique_marker()}"
         model_id = client.proxy.create_model(
             model, LiteLLMParamsBody(model=OPENAI_VISION_BACKEND, api_key="os.environ/OPENAI_API_KEY")
@@ -579,7 +573,6 @@ class TestOpenAIChatCompletions:
     def test_openai_chat_prompt_cache_hits_on_repeat(
         self, client: PassthroughClient, resources: ResourceManager
     ) -> None:
-        require_env("OPENAI_API_KEY")
         model = f"e2e-openai-cache-{unique_marker()}"
         model_id = client.proxy.create_model(
             model, LiteLLMParamsBody(model=OPENAI_BACKEND, api_key="os.environ/OPENAI_API_KEY")
@@ -610,7 +603,6 @@ class TestOpenAIChatCompletions:
     def test_openai_chat_streams_tool_call(
         self, client: PassthroughClient, resources: ResourceManager
     ) -> None:
-        require_env("OPENAI_API_KEY")
         model = f"e2e-openai-tool-stream-{unique_marker()}"
         model_id = client.proxy.create_model(
             model, LiteLLMParamsBody(model=OPENAI_BACKEND, api_key="os.environ/OPENAI_API_KEY")
@@ -645,7 +637,6 @@ class TestBedrockConverseChatCompletions:
     """
 
     def _register(self, client: PassthroughClient, resources: ResourceManager, prefix: str) -> str:
-        require_env("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION")
         model = f"{prefix}-{unique_marker()}"
         model_id = client.proxy.create_model(model, _bedrock_params())
         resources.defer(lambda: client.proxy.delete_model(model_id))

--- a/tests/e2e/llm_translation/test_image_generation_e2e.py
+++ b/tests/e2e/llm_translation/test_image_generation_e2e.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pytest
 
-from e2e_config import require_env, unique_marker
+from e2e_config import unique_marker
 from e2e_http import require_successful_call
 from endpoints_client import EndpointsClient, ImagesResult
 from lifecycle import ResourceManager
@@ -50,7 +50,6 @@ class TestImageGeneration:
     def test_bedrock_image_generation_returns_image(
         self, endpoints_client: EndpointsClient, resources: ResourceManager
     ) -> None:
-        require_env("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION")
         model = f"e2e-bedrock-image-{unique_marker()}"
         model_id = endpoints_client.create_model(
             model,

--- a/tests/e2e/llm_translation/test_messages_e2e.py
+++ b/tests/e2e/llm_translation/test_messages_e2e.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import pytest
 
-from e2e_config import require_env, unique_marker
+from e2e_config import unique_marker
 from e2e_http import require_successful_call, unwrap
 from endpoints_client import EndpointsClient, MessagesResult
 from lifecycle import ResourceManager
@@ -73,7 +73,6 @@ class TestAnthropicMessages:
     def test_messages_logs_cost_matching_the_response_header(
         self, endpoints_client: EndpointsClient, resources: ResourceManager
     ) -> None:
-        require_env("ANTHROPIC_API_KEY")
         model = f"e2e-messages-cost-{unique_marker()}"
         model_id = endpoints_client.create_model(
             model,

--- a/tests/e2e/llm_translation/test_rerank_e2e.py
+++ b/tests/e2e/llm_translation/test_rerank_e2e.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pytest
 
-from e2e_config import require_env, unique_marker
+from e2e_config import unique_marker
 from e2e_http import require_successful_call
 from endpoints_client import EndpointsClient, RerankResult
 from lifecycle import ResourceManager
@@ -56,7 +56,6 @@ class TestRerank:
     def test_bedrock_rerank_scores_top_n(
         self, endpoints_client: EndpointsClient, resources: ResourceManager
     ) -> None:
-        require_env("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION")
         model = f"e2e-bedrock-rerank-{unique_marker()}"
         model_id = endpoints_client.create_model(
             model,

--- a/tests/e2e/llm_translation/test_responses_e2e.py
+++ b/tests/e2e/llm_translation/test_responses_e2e.py
@@ -13,7 +13,7 @@ from typing import cast
 import pytest
 from pydantic import BaseModel, ValidationError
 
-from e2e_config import require_env, unique_marker
+from e2e_config import unique_marker
 from e2e_http import require_successful_call
 from endpoints_client import (
     EndpointsClient,
@@ -255,7 +255,6 @@ class TestResponses:
     def test_responses_bedrock_returns_completion(
         self, endpoints_client: EndpointsClient, resources: ResourceManager
     ) -> None:
-        require_env("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION")
         model = f"e2e-responses-{unique_marker()}"
         model_id = endpoints_client.create_model(model, _bedrock_params())
         resources.defer(lambda: endpoints_client.delete_model(model_id))
@@ -270,7 +269,6 @@ class TestResponses:
     def test_responses_bedrock_returns_function_call(
         self, endpoints_client: EndpointsClient, resources: ResourceManager
     ) -> None:
-        require_env("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION")
         model = f"e2e-responses-{unique_marker()}"
         model_id = endpoints_client.create_model(model, _bedrock_params())
         resources.defer(lambda: endpoints_client.delete_model(model_id))

--- a/tests/e2e/llm_translation/test_responses_metadata_e2e.py
+++ b/tests/e2e/llm_translation/test_responses_metadata_e2e.py
@@ -14,7 +14,7 @@ import time
 import pytest
 from pydantic import BaseModel, ConfigDict
 
-from e2e_config import require_env, unique_marker
+from e2e_config import unique_marker
 from e2e_http import require_successful_call
 from endpoints_client import EndpointsClient, ResponsesResult
 from lifecycle import ResourceManager
@@ -42,7 +42,7 @@ class RedisKeyInfo(BaseModel):
 def _redis_scan(marker: str) -> tuple[RedisKeyInfo, ...]:
     import redis
 
-    (host,) = require_env("REDIS_HOST")
+    host = os.environ["REDIS_HOST"]
     port = int((os.environ.get("REDIS_PORT") or "6379").strip() or "6379")
     try:
         with socket.create_connection((host, port), timeout=3):

--- a/tests/e2e/quota_management/ratelimit/test_redis_backed_ratelimit_e2e.py
+++ b/tests/e2e/quota_management/ratelimit/test_redis_backed_ratelimit_e2e.py
@@ -11,7 +11,7 @@ import socket
 
 import pytest
 
-from e2e_config import require_env, unique_marker
+from e2e_config import unique_marker
 from e2e_http import require_successful_call
 from lifecycle import ResourceManager
 from models import KeyGenerateBody, LiteLLMParamsBody
@@ -23,7 +23,7 @@ BACKEND = "anthropic/claude-haiku-4-5-20251001"
 
 
 def _require_redis_reachable() -> None:
-    (host,) = require_env("REDIS_HOST")
+    host = os.environ["REDIS_HOST"]
     port = int((os.environ.get("REDIS_PORT") or "6379").strip() or "6379")
     try:
         with socket.create_connection((host, port), timeout=3):

--- a/tests/e2e/quota_management/ratelimit/test_redis_circuit_breaker_e2e.py
+++ b/tests/e2e/quota_management/ratelimit/test_redis_circuit_breaker_e2e.py
@@ -13,7 +13,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import pytest
 
-from e2e_config import require_env, unique_marker
+from e2e_config import unique_marker
 from e2e_http import require_successful_call
 from lifecycle import ResourceManager
 from models import KeyGenerateBody, LiteLLMParamsBody
@@ -28,7 +28,7 @@ RECOVERY_TIMEOUT = float(
 
 
 def _require_redis() -> None:
-    (host,) = require_env("REDIS_HOST")
+    host = os.environ["REDIS_HOST"]
     port = int((os.environ.get("REDIS_PORT") or "6379").strip() or "6379")
     try:
         with socket.create_connection((host, port), timeout=3):


### PR DESCRIPTION
## TLDR

Problem this solves:

- `require_env` hard-failed a test whenever an optional cred was absent
- it pushed teams to cram every provider cred into one shared ops secret
- several call sites gated on the runner's env for keys only the gateway uses

How it solves it:

- read `os.environ` directly where a test actually uses the value
- delete the presence-only gates so those cases run against the proxy
- remove the `require_env` helper from `e2e_config`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This is a test-harness refactor with no product-behavior change, so there is no live-proxy or LLM output to capture; the relevant gates are the e2e type check and lint. Captured at 45779d3ddf:

```
$ make lint-e2e-basedpyright
0 errors, 0 warnings, 0 notes

$ uv run ruff check tests/e2e
All checks passed!

$ grep -rn "require_env" tests/ litellm/ docs/
(no matches)
```

Tests that read a value they use (`REDIS_HOST`, `COHERE_API_KEY`, `HOSTED_VLLM_API_BASE`, `AWS_ROLE_NAME`, the presidio bases, the bedrock guardrail id/version) behave the same as before when the cred is present. The tests that only had a presence gate now run against the proxy instead of pre-failing on the runner's own environment

## Type

🧹 Refactoring
✅ Test

## Changes

Every `require_env(...)` call fell into one of two buckets. Where the test reads a value it then uses (a provider key it puts on a `/model/new` body, a role ARN, a backend URL, the Redis host), it now reads that var from `os.environ` directly. Where the call only asserted a key was present and threw the result away, it was checking the runner process's env for a credential the gateway is the one that consumes; those gates are deleted so the test exercises the real product path and fails only if the proxy cannot actually serve the request

The `require_env` helper is removed from `tests/e2e/e2e_config.py`, and no references remain anywhere in the repo

## QA runbook

This PR does not change what any e2e test asserts; it only changes how the harness obtains credentials, so the existing per-test behavior is unchanged. To confirm against a live proxy with the provider creds present, run one representative touched test from each bucket and expect the same pass as before:

- tests/e2e/llm_translation/test_chat_completions_regression_e2e.py::... (value read: cohere path builds a model from `COHERE_API_KEY`)
  - [ ] With `COHERE_API_KEY` exported, run the cohere case and expect it to pass
- tests/e2e/llm_translation/test_rerank_e2e.py::... (deleted presence gate: bedrock rerank)
  - [ ] With the gateway holding AWS creds, run the bedrock rerank case and expect it to pass; the runner no longer needs AWS creds of its own
  - [ ] Sanity check: the test still asserts real rerank behavior, not a hand-wavey presence of output

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
