### PR TITLE
feat(proxy): add overwrite_user_with_key_hash to stamp outgoing user param with key hash

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -211,6 +211,9 @@ filter_invalid_headers: Optional[bool] = False
 add_user_information_to_llm_headers: Optional[bool] = (
     None  # adds user_id, team_id, token hash (params from StandardLoggingMetadata) to request headers
 )
+overwrite_user_with_key_hash: bool = (
+    False  # force the outgoing `user` param to the hashed api key, so providers see a stable, tamper-proof id
+)
 store_audit_logs = False  # Enterprise feature, allow users to see audit logs
 skip_system_message_in_guardrail: bool = False
 skip_tool_message_in_guardrail: bool = False

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2616,6 +2616,16 @@ class UserAPIKeyAuth(LiteLLM_VerificationTokenView):  # the expected response ob
     # key off. Server-only and stripped from validated input for the same reason as the marker
     # above: a forged entry would let a caller pick which team's rpm bucket it is charged against.
     mcp_source_team_rpm_limits: dict[str, dict[str, int]] | None = Field(default=None, exclude=True)
+    via_virtual_key: bool = Field(
+        default=False,
+        exclude=True,
+        description=(
+            "Server-only marker set exclusively by the DB virtual-key auth path via post-construction "
+            "assignment. Stripped from validated input so custom auth handlers, JWT claims, or key "
+            "metadata cannot forge it. Gates overwrite_user_with_key_hash stamping: only a credential "
+            "the proxy itself validated as a virtual key may be forwarded as the provider-facing user id."
+        ),
+    )
     budget_reservation: Optional[Dict[str, Any]] = Field(default=None, exclude=True)
     budget_throttle_pct: Optional[float] = Field(default=None, exclude=True)
     user: Optional[Any] = None  # Expanded user object when expand=user is used
@@ -2641,6 +2651,7 @@ class UserAPIKeyAuth(LiteLLM_VerificationTokenView):  # the expected response ob
         # kwargs, model_validate, a JWT/key claim splat) so it can never be forged from caller data.
         values.pop("mcp_admitted_user_subject", None)
         values.pop("mcp_source_team_rpm_limits", None)
+        values.pop("via_virtual_key", None)
         if values.get("api_key") is not None:
             values.update({"token": cls._safe_hash_litellm_api_key(values.get("api_key"))})
             if isinstance(values.get("api_key"), str):

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2620,10 +2620,11 @@ class UserAPIKeyAuth(LiteLLM_VerificationTokenView):  # the expected response ob
         default=False,
         exclude=True,
         description=(
-            "Server-only marker set exclusively by the DB virtual-key auth path via post-construction "
-            "assignment. Stripped from validated input so custom auth handlers, JWT claims, or key "
-            "metadata cannot forge it. Gates overwrite_user_with_key_hash stamping: only a credential "
-            "the proxy itself validated as a virtual key may be forwarded as the provider-facing user id."
+            "Server-only marker set exclusively by the DB virtual-key and master-key auth paths via "
+            "post-construction assignment. Stripped from validated input so custom auth handlers, JWT "
+            "claims, or key metadata cannot forge it. Gates overwrite_user_with_key_hash stamping: only "
+            "a credential the proxy itself validated as a key may be forwarded as the provider-facing "
+            "user id."
         ),
     )
     budget_reservation: Optional[Dict[str, Any]] = Field(default=None, exclude=True)

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -2021,7 +2021,7 @@ async def _user_api_key_auth_builder(
             # No token was found when looking up in the DB
             raise Exception("Invalid proxy server token passed")
         if valid_token_dict is not None:
-            return await _return_user_api_key_auth_obj(
+            virtual_key_auth_obj = await _return_user_api_key_auth_obj(
                 user_obj=user_obj,
                 api_key=api_key,
                 parent_otel_span=parent_otel_span,
@@ -2029,6 +2029,8 @@ async def _user_api_key_auth_builder(
                 route=route,
                 start_time=start_time,
             )
+            virtual_key_auth_obj.via_virtual_key = True
+            return virtual_key_auth_obj
     except Exception as e:
         return await UserAPIKeyAuthExceptionHandler._handle_authentication_error(
             e=e,

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1614,6 +1614,7 @@ async def _user_api_key_auth_builder(
             _user_api_key_obj = update_valid_token_with_end_user_params(
                 valid_token=_user_api_key_obj, end_user_params=end_user_params
             )
+            _user_api_key_obj.via_virtual_key = True
 
             return _user_api_key_obj
 

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1497,6 +1497,13 @@ async def _user_api_key_auth_builder(
                             check_cache_only=True,
                         ).resolve(hashed_token=hash_token(api_key))
                     )
+                # Key-cache entries are written only after the proxy validated a
+                # virtual key or the master key, but via_virtual_key is exclude=True
+                # so serialization drops it; restore it at this trusted boundary.
+                # The UI-login JWT fallback below constructs its token from a
+                # decrypted blob, not this cache, and stays unmarked.
+                if isinstance(valid_token, UserAPIKeyAuth):
+                    valid_token.via_virtual_key = True
             except Exception:
                 verbose_logger.debug("api key not found in cache.")
                 valid_token = None

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -31,6 +31,7 @@ from litellm.proxy._types import (
     SpecialHeaders,
     TeamCallbackMetadata,
     UserAPIKeyAuth,
+    hash_token,
 )
 from litellm.proxy.common_utils.callback_utils import (
     decrypt_callback_vars,
@@ -48,6 +49,18 @@ _EXPLICIT_SESSION_HEADERS = frozenset({"x-litellm-trace-id", "x-litellm-session-
 # Session-id values must be non-empty strings of alphanumerics, hyphens, or underscores
 # (covers UUIDs and most common session-id formats).
 _SESSION_ID_VALUE_RE = re.compile(r"^[a-zA-Z0-9_\-]{8,}$")
+
+_SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _non_reversible_key_hash(api_key: str) -> str:
+    """UserAPIKeyAuth only hashes sk- keys and JWTs; custom-auth credentials arrive
+    raw, and raw auth material must never be forwarded to the provider."""
+    if _SHA256_HEX_RE.fullmatch(api_key) or api_key.startswith("hashed-jwt-"):
+        return api_key
+    return hash_token(api_key)
+
+
 _ANTHROPIC_SESSION_ID_VALUE_RE = re.compile(r"^[a-zA-Z0-9_\-]+$")
 
 
@@ -1448,7 +1461,7 @@ async def add_litellm_data_to_request(
             data["user"] = user
 
     if litellm.overwrite_user_with_key_hash is True and user_api_key_dict.api_key is not None:
-        data["user"] = user_api_key_dict.api_key
+        data["user"] = _non_reversible_key_hash(user_api_key_dict.api_key)
 
     data["secret_fields"] = SecretFields(raw_headers=_raw_headers)
 

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1447,6 +1447,9 @@ async def add_litellm_data_to_request(
         if "user" not in data:
             data["user"] = user
 
+    if litellm.overwrite_user_with_key_hash is True and user_api_key_dict.api_key is not None:
+        data["user"] = user_api_key_dict.api_key
+
     data["secret_fields"] = SecretFields(raw_headers=_raw_headers)
 
     ## Dynamic api version (Azure OpenAI endpoints) ##

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -52,11 +52,13 @@ _SESSION_ID_VALUE_RE = re.compile(r"^[a-zA-Z0-9_\-]{8,}$")
 _SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
-def _stampable_key_hash(api_key: str | None) -> str | None:
-    """Only standard virtual keys are stamped: UserAPIKeyAuth stores them as a sha256
-    hex digest. Custom-auth credentials arrive raw (never forward auth material) and
-    hashed JWTs rotate on re-issue (useless as a stable ban id), so both are skipped."""
-    if api_key is not None and _SHA256_HEX_RE.fullmatch(api_key):
+def _stampable_key_hash(user_api_key_dict: UserAPIKeyAuth) -> str | None:
+    """Only DB-validated virtual keys are stamped, proven by the unforgeable
+    via_virtual_key marker AND the sha256-hex shape UserAPIKeyAuth stores them in.
+    Custom-auth credentials arrive raw (never forward auth material) and hashed
+    JWTs rotate on re-issue (useless as a stable ban id), so both are skipped."""
+    api_key = user_api_key_dict.api_key
+    if user_api_key_dict.via_virtual_key and api_key is not None and _SHA256_HEX_RE.fullmatch(api_key):
         return api_key
     return None
 
@@ -1461,7 +1463,7 @@ async def add_litellm_data_to_request(
             data["user"] = user
 
     if litellm.overwrite_user_with_key_hash is True:
-        stampable_hash = _stampable_key_hash(user_api_key_dict.api_key)
+        stampable_hash = _stampable_key_hash(user_api_key_dict)
         if stampable_hash is not None:
             data["user"] = stampable_hash
 

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -13,7 +13,7 @@ from starlette.datastructures import Headers
 import litellm
 from litellm._logging import verbose_logger, verbose_proxy_logger
 from litellm._service_logger import ServiceLogging
-from litellm.constants import PRE_CALL_EXECUTED_GUARDRAILS_KEY
+from litellm.constants import LITELLM_PROXY_MASTER_KEY_ALIAS, PRE_CALL_EXECUTED_GUARDRAILS_KEY
 from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.litellm_core_utils.initialize_dynamic_callback_params import (
     iter_client_callback_metadata_dicts,
@@ -53,12 +53,15 @@ _SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
 def _stampable_key_hash(user_api_key_dict: UserAPIKeyAuth) -> str | None:
-    """Only DB-validated virtual keys are stamped, proven by the unforgeable
-    via_virtual_key marker AND the sha256-hex shape UserAPIKeyAuth stores them in.
+    """Only proxy-validated keys are stamped, proven by the unforgeable
+    via_virtual_key marker AND a known non-secret shape: the sha256 hex digest
+    UserAPIKeyAuth stores virtual keys in, or the master key's stable alias.
     Custom-auth credentials arrive raw (never forward auth material) and hashed
     JWTs rotate on re-issue (useless as a stable ban id), so both are skipped."""
     api_key = user_api_key_dict.api_key
-    if user_api_key_dict.via_virtual_key and api_key is not None and _SHA256_HEX_RE.fullmatch(api_key):
+    if not user_api_key_dict.via_virtual_key or api_key is None:
+        return None
+    if api_key == LITELLM_PROXY_MASTER_KEY_ALIAS or _SHA256_HEX_RE.fullmatch(api_key):
         return api_key
     return None
 

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -31,7 +31,6 @@ from litellm.proxy._types import (
     SpecialHeaders,
     TeamCallbackMetadata,
     UserAPIKeyAuth,
-    hash_token,
 )
 from litellm.proxy.common_utils.callback_utils import (
     decrypt_callback_vars,
@@ -53,12 +52,13 @@ _SESSION_ID_VALUE_RE = re.compile(r"^[a-zA-Z0-9_\-]{8,}$")
 _SHA256_HEX_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
-def _non_reversible_key_hash(api_key: str) -> str:
-    """UserAPIKeyAuth only hashes sk- keys and JWTs; custom-auth credentials arrive
-    raw, and raw auth material must never be forwarded to the provider."""
-    if _SHA256_HEX_RE.fullmatch(api_key) or api_key.startswith("hashed-jwt-"):
+def _stampable_key_hash(api_key: str | None) -> str | None:
+    """Only standard virtual keys are stamped: UserAPIKeyAuth stores them as a sha256
+    hex digest. Custom-auth credentials arrive raw (never forward auth material) and
+    hashed JWTs rotate on re-issue (useless as a stable ban id), so both are skipped."""
+    if api_key is not None and _SHA256_HEX_RE.fullmatch(api_key):
         return api_key
-    return hash_token(api_key)
+    return None
 
 
 _ANTHROPIC_SESSION_ID_VALUE_RE = re.compile(r"^[a-zA-Z0-9_\-]+$")
@@ -1460,8 +1460,10 @@ async def add_litellm_data_to_request(
         if "user" not in data:
             data["user"] = user
 
-    if litellm.overwrite_user_with_key_hash is True and user_api_key_dict.api_key is not None:
-        data["user"] = _non_reversible_key_hash(user_api_key_dict.api_key)
+    if litellm.overwrite_user_with_key_hash is True:
+        stampable_hash = _stampable_key_hash(user_api_key_dict.api_key)
+        if stampable_hash is not None:
+            data["user"] = stampable_hash
 
     data["secret_fields"] = SecretFields(raw_headers=_raw_headers)
 

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -1291,6 +1291,75 @@ async def test_scim_deactivated_user_key_is_rejected():
 
 
 @pytest.mark.asyncio
+async def test_master_key_auth_sets_via_virtual_key_marker():
+    """Master-key requests must also be stamped by overwrite_user_with_key_hash;
+    the auth path substitutes the stable alias for api_key and must mark the
+    result as proxy-validated."""
+    from fastapi import Request
+    from starlette.datastructures import URL
+
+    from litellm.constants import LITELLM_PROXY_MASTER_KEY_ALIAS
+    from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
+
+    master_key = "sk-master-key"
+
+    mock_cache = AsyncMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=None)
+    mock_cache.delete_cache = MagicMock()
+
+    mock_proxy_logging_obj = MagicMock()
+    mock_proxy_logging_obj.internal_usage_cache = MagicMock()
+    mock_proxy_logging_obj.internal_usage_cache.dual_cache = AsyncMock()
+    mock_proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache = (
+        AsyncMock()
+    )
+    mock_proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
+
+    import litellm.proxy.proxy_server as _proxy_server_mod
+
+    _attrs_to_set = {
+        "prisma_client": MagicMock(),
+        "user_api_key_cache": mock_cache,
+        "proxy_logging_obj": mock_proxy_logging_obj,
+        "master_key": master_key,
+        "general_settings": {},
+        "llm_model_list": [],
+        "llm_router": None,
+        "open_telemetry_logger": None,
+        "model_max_budget_limiter": MagicMock(),
+        "user_custom_auth": None,
+        "jwt_handler": None,
+        "litellm_proxy_admin_name": "admin",
+    }
+    _original_values = {
+        attr: getattr(_proxy_server_mod, attr, None) for attr in _attrs_to_set
+    }
+    try:
+        for attr, val in _attrs_to_set.items():
+            setattr(_proxy_server_mod, attr, val)
+
+        request = Request(scope={"type": "http"})
+        request._url = URL(url="/chat/completions")
+
+        result = await _user_api_key_auth_builder(
+            request=request,
+            api_key=f"Bearer {master_key}",
+            azure_api_key_header="",
+            anthropic_api_key_header=None,
+            google_ai_studio_api_key_header=None,
+            azure_apim_header=None,
+            request_data={},
+        )
+
+        assert isinstance(result, UserAPIKeyAuth)
+        assert result.via_virtual_key is True
+        assert result.api_key == LITELLM_PROXY_MASTER_KEY_ALIAS
+    finally:
+        for attr, val in _original_values.items():
+            setattr(_proxy_server_mod, attr, val)
+
+
+@pytest.mark.asyncio
 async def test_db_virtual_key_auth_sets_via_virtual_key_marker():
     """via_virtual_key gates overwrite_user_with_key_hash stamping and is
     forge-stripped from validated input, so the DB auth path setting it by

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -1291,6 +1291,96 @@ async def test_scim_deactivated_user_key_is_rejected():
 
 
 @pytest.mark.asyncio
+async def test_db_virtual_key_auth_sets_via_virtual_key_marker():
+    """via_virtual_key gates overwrite_user_with_key_hash stamping and is
+    forge-stripped from validated input, so the DB auth path setting it by
+    post-construction assignment is the only thing that turns stamping on."""
+    from fastapi import Request
+    from starlette.datastructures import URL
+
+    from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
+    from litellm.proxy.proxy_server import hash_token
+
+    api_key = "sk-via-virtual-key-marker-test"
+    hashed_key = hash_token(api_key)
+
+    valid_token = UserAPIKeyAuth(
+        api_key=api_key,
+        token=hashed_key,
+        user_id="marker-test-user",
+    )
+
+    mock_cache = AsyncMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=None)
+    mock_cache.delete_cache = MagicMock()
+
+    mock_proxy_logging_obj = MagicMock()
+    mock_proxy_logging_obj.internal_usage_cache = MagicMock()
+    mock_proxy_logging_obj.internal_usage_cache.dual_cache = AsyncMock()
+    mock_proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache = (
+        AsyncMock()
+    )
+    mock_proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
+
+    mock_prisma_client = MagicMock()
+
+    import litellm.proxy.proxy_server as _proxy_server_mod
+
+    _attrs_to_set = {
+        "prisma_client": mock_prisma_client,
+        "user_api_key_cache": mock_cache,
+        "proxy_logging_obj": mock_proxy_logging_obj,
+        "master_key": "sk-master-key",
+        "general_settings": {},
+        "llm_model_list": [],
+        "llm_router": None,
+        "open_telemetry_logger": None,
+        "model_max_budget_limiter": MagicMock(),
+        "user_custom_auth": None,
+        "jwt_handler": None,
+        "litellm_proxy_admin_name": "admin",
+    }
+    _original_values = {
+        attr: getattr(_proxy_server_mod, attr, None) for attr in _attrs_to_set
+    }
+    try:
+        for attr, val in _attrs_to_set.items():
+            setattr(_proxy_server_mod, attr, val)
+
+        request = Request(scope={"type": "http"})
+        request._url = URL(url="/chat/completions")
+
+        with (
+            patch(
+                "litellm.proxy.auth.resolvers.store.IdentityStore._resolve_key",
+                new_callable=AsyncMock,
+                return_value=valid_token,
+            ),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.get_user_object",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            result = await _user_api_key_auth_builder(
+                request=request,
+                api_key=f"Bearer {api_key}",
+                azure_api_key_header="",
+                anthropic_api_key_header=None,
+                google_ai_studio_api_key_header=None,
+                azure_apim_header=None,
+                request_data={},
+            )
+
+        assert isinstance(result, UserAPIKeyAuth)
+        assert result.via_virtual_key is True
+        assert result.api_key == hashed_key
+    finally:
+        for attr, val in _original_values.items():
+            setattr(_proxy_server_mod, attr, val)
+
+
+@pytest.mark.asyncio
 async def test_return_user_api_key_auth_obj_user_spend_and_budget():
     """
     Test that _return_user_api_key_auth_obj correctly sets user_spend and user_max_budget

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -1291,6 +1291,91 @@ async def test_scim_deactivated_user_key_is_rejected():
 
 
 @pytest.mark.asyncio
+async def test_cached_proxy_admin_key_sets_via_virtual_key_marker():
+    """Cached PROXY_ADMIN auth objects early-return before the marked DB and
+    master-key returns, and cache serialization drops the exclude=True marker;
+    the cache-hit boundary must restore it or cached admin traffic silently
+    bypasses overwrite_user_with_key_hash stamping."""
+    from fastapi import Request
+    from starlette.datastructures import URL
+
+    from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
+    from litellm.proxy.proxy_server import hash_token
+
+    api_key = "sk-cached-admin-marker-test"
+    hashed_key = hash_token(api_key)
+
+    cached_token = UserAPIKeyAuth(
+        api_key=api_key,
+        token=hashed_key,
+        user_id="cached-admin-user",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+    assert cached_token.via_virtual_key is False
+
+    mock_cache = AsyncMock()
+    mock_cache.async_get_cache = AsyncMock(return_value=None)
+    mock_cache.delete_cache = MagicMock()
+
+    mock_proxy_logging_obj = MagicMock()
+    mock_proxy_logging_obj.internal_usage_cache = MagicMock()
+    mock_proxy_logging_obj.internal_usage_cache.dual_cache = AsyncMock()
+    mock_proxy_logging_obj.internal_usage_cache.dual_cache.async_delete_cache = (
+        AsyncMock()
+    )
+    mock_proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
+
+    import litellm.proxy.proxy_server as _proxy_server_mod
+
+    _attrs_to_set = {
+        "prisma_client": MagicMock(),
+        "user_api_key_cache": mock_cache,
+        "proxy_logging_obj": mock_proxy_logging_obj,
+        "master_key": "sk-master-key",
+        "general_settings": {},
+        "llm_model_list": [],
+        "llm_router": None,
+        "open_telemetry_logger": None,
+        "model_max_budget_limiter": MagicMock(),
+        "user_custom_auth": None,
+        "jwt_handler": None,
+        "litellm_proxy_admin_name": "admin",
+    }
+    _original_values = {
+        attr: getattr(_proxy_server_mod, attr, None) for attr in _attrs_to_set
+    }
+    try:
+        for attr, val in _attrs_to_set.items():
+            setattr(_proxy_server_mod, attr, val)
+
+        request = Request(scope={"type": "http"})
+        request._url = URL(url="/chat/completions")
+
+        with patch(
+            "litellm.proxy.auth.resolvers.store.IdentityStore._resolve_key",
+            new_callable=AsyncMock,
+            return_value=cached_token,
+        ):
+            result = await _user_api_key_auth_builder(
+                request=request,
+                api_key=f"Bearer {api_key}",
+                azure_api_key_header="",
+                anthropic_api_key_header=None,
+                google_ai_studio_api_key_header=None,
+                azure_apim_header=None,
+                request_data={},
+            )
+
+        assert isinstance(result, UserAPIKeyAuth)
+        assert result.user_role == LitellmUserRoles.PROXY_ADMIN
+        assert result.via_virtual_key is True
+        assert result.api_key == hashed_key
+    finally:
+        for attr, val in _original_values.items():
+            setattr(_proxy_server_mod, attr, val)
+
+
+@pytest.mark.asyncio
 async def test_master_key_auth_sets_via_virtual_key_marker():
     """Master-key requests must also be stamped by overwrite_user_with_key_hash;
     the auth path substitutes the stable alias for api_key and must mark the

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -5226,3 +5226,74 @@ async def test_add_litellm_data_to_request_unions_metadata_tags_with_header_tags
     tags = updated["litellm_metadata"]["tags"]
     assert "header-tag" in tags
     assert "body-tag" in tags
+
+
+def _make_chat_request_mock() -> MagicMock:
+    return _make_request_mock("/v1/chat/completions", {"Content-Type": "application/json"})
+
+
+@pytest.mark.asyncio
+async def test_overwrite_user_with_key_hash_clobbers_caller_supplied_user(monkeypatch):
+    """The flag exists so providers can ban by a tamper-proof id; a caller-chosen
+    `user` must never survive, and the raw sk- key must never be forwarded."""
+    from litellm.proxy._types import hash_token
+
+    monkeypatch.setattr(litellm, "overwrite_user_with_key_hash", True)
+
+    raw_key = "sk-overwrite-user-test-1234"
+    user_api_key_dict = UserAPIKeyAuth(api_key=raw_key)
+    data = {"model": "gpt-4o", "user": "attacker-chosen-id"}
+
+    updated_data = await add_litellm_data_to_request(
+        data=data,
+        request=_make_chat_request_mock(),
+        user_api_key_dict=user_api_key_dict,
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    assert updated_data["user"] == hash_token(raw_key)
+    assert updated_data["user"] != "attacker-chosen-id"
+    assert raw_key not in updated_data["user"]
+
+
+@pytest.mark.asyncio
+async def test_overwrite_user_with_key_hash_sets_user_when_absent(monkeypatch):
+    from litellm.proxy._types import hash_token
+
+    monkeypatch.setattr(litellm, "overwrite_user_with_key_hash", True)
+
+    raw_key = "sk-overwrite-user-test-5678"
+    user_api_key_dict = UserAPIKeyAuth(api_key=raw_key)
+    data = {"model": "gpt-4o"}
+
+    updated_data = await add_litellm_data_to_request(
+        data=data,
+        request=_make_chat_request_mock(),
+        user_api_key_dict=user_api_key_dict,
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    assert updated_data["user"] == hash_token(raw_key)
+
+
+@pytest.mark.asyncio
+async def test_overwrite_user_with_key_hash_disabled_preserves_caller_user():
+    assert litellm.overwrite_user_with_key_hash is False
+
+    user_api_key_dict = UserAPIKeyAuth(api_key="sk-overwrite-user-test-9999")
+    data = {"model": "gpt-4o", "user": "caller-chosen-id"}
+
+    updated_data = await add_litellm_data_to_request(
+        data=data,
+        request=_make_chat_request_mock(),
+        user_api_key_dict=user_api_key_dict,
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    assert updated_data["user"] == "caller-chosen-id"

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -5242,6 +5242,7 @@ async def test_overwrite_user_with_key_hash_clobbers_caller_supplied_user(monkey
 
     raw_key = "sk-overwrite-user-test-1234"
     user_api_key_dict = UserAPIKeyAuth(api_key=raw_key)
+    user_api_key_dict.via_virtual_key = True
     data = {"model": "gpt-4o", "user": "attacker-chosen-id"}
 
     updated_data = await add_litellm_data_to_request(
@@ -5266,6 +5267,7 @@ async def test_overwrite_user_with_key_hash_sets_user_when_absent(monkeypatch):
 
     raw_key = "sk-overwrite-user-test-5678"
     user_api_key_dict = UserAPIKeyAuth(api_key=raw_key)
+    user_api_key_dict.via_virtual_key = True
     data = {"model": "gpt-4o"}
 
     updated_data = await add_litellm_data_to_request(
@@ -5285,6 +5287,7 @@ async def test_overwrite_user_with_key_hash_disabled_preserves_caller_user():
     assert litellm.overwrite_user_with_key_hash is False
 
     user_api_key_dict = UserAPIKeyAuth(api_key="sk-overwrite-user-test-9999")
+    user_api_key_dict.via_virtual_key = True
     data = {"model": "gpt-4o", "user": "caller-chosen-id"}
 
     updated_data = await add_litellm_data_to_request(
@@ -5342,3 +5345,35 @@ async def test_overwrite_user_with_key_hash_skips_jwt_auth(monkeypatch):
     )
 
     assert updated_data["user"] == "caller-chosen-id"
+
+
+@pytest.mark.asyncio
+async def test_overwrite_user_with_key_hash_skips_hex_shaped_custom_credential(monkeypatch):
+    """A custom-auth credential that happens to be 64 hex chars is indistinguishable
+    from a key hash by shape alone; only the server-set via_virtual_key marker may
+    authorize stamping, so this raw credential must never be forwarded."""
+    monkeypatch.setattr(litellm, "overwrite_user_with_key_hash", True)
+
+    hex_shaped_credential = "a" * 64
+    user_api_key_dict = UserAPIKeyAuth(api_key=hex_shaped_credential)
+    assert user_api_key_dict.api_key == hex_shaped_credential
+    assert user_api_key_dict.via_virtual_key is False
+
+    updated_data = await add_litellm_data_to_request(
+        data={"model": "gpt-4o", "user": "caller-chosen-id"},
+        request=_make_chat_request_mock(),
+        user_api_key_dict=user_api_key_dict,
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    assert updated_data["user"] == "caller-chosen-id"
+
+
+def test_via_virtual_key_cannot_be_forged_from_validated_input():
+    from_kwargs = UserAPIKeyAuth(api_key="b" * 64, via_virtual_key=True)
+    assert from_kwargs.via_virtual_key is False
+
+    from_dict = UserAPIKeyAuth.model_validate({"api_key": "b" * 64, "via_virtual_key": True})
+    assert from_dict.via_virtual_key is False

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -5297,3 +5297,49 @@ async def test_overwrite_user_with_key_hash_disabled_preserves_caller_user():
     )
 
     assert updated_data["user"] == "caller-chosen-id"
+
+
+@pytest.mark.asyncio
+async def test_overwrite_user_with_key_hash_never_forwards_raw_custom_credential(monkeypatch):
+    """Custom-auth credentials are not sk-prefixed or JWTs, so UserAPIKeyAuth
+    stores them raw; forwarding them upstream would leak auth material."""
+    from litellm.proxy._types import hash_token
+
+    monkeypatch.setattr(litellm, "overwrite_user_with_key_hash", True)
+
+    raw_credential = "my-custom-auth-credential-abc123"
+    user_api_key_dict = UserAPIKeyAuth(api_key=raw_credential)
+    assert user_api_key_dict.api_key == raw_credential
+
+    updated_data = await add_litellm_data_to_request(
+        data={"model": "gpt-4o"},
+        request=_make_chat_request_mock(),
+        user_api_key_dict=user_api_key_dict,
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    assert updated_data["user"] == hash_token(raw_credential)
+    assert updated_data["user"] != raw_credential
+
+
+@pytest.mark.asyncio
+async def test_overwrite_user_with_key_hash_preserves_hashed_jwt_identifier(monkeypatch):
+    from litellm.proxy._types import hash_token
+
+    monkeypatch.setattr(litellm, "overwrite_user_with_key_hash", True)
+
+    hashed_jwt = f"hashed-jwt-{hash_token('some-jwt-token')}"
+    user_api_key_dict = UserAPIKeyAuth(api_key=hashed_jwt)
+
+    updated_data = await add_litellm_data_to_request(
+        data={"model": "gpt-4o"},
+        request=_make_chat_request_mock(),
+        user_api_key_dict=user_api_key_dict,
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    assert updated_data["user"] == hashed_jwt

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -5300,11 +5300,9 @@ async def test_overwrite_user_with_key_hash_disabled_preserves_caller_user():
 
 
 @pytest.mark.asyncio
-async def test_overwrite_user_with_key_hash_never_forwards_raw_custom_credential(monkeypatch):
-    """Custom-auth credentials are not sk-prefixed or JWTs, so UserAPIKeyAuth
-    stores them raw; forwarding them upstream would leak auth material."""
-    from litellm.proxy._types import hash_token
-
+async def test_overwrite_user_with_key_hash_skips_custom_auth_credential(monkeypatch):
+    """Custom-auth credentials are not sk-prefixed or JWTs, so UserAPIKeyAuth stores
+    them raw; the stamp must skip them entirely so auth material never leaks."""
     monkeypatch.setattr(litellm, "overwrite_user_with_key_hash", True)
 
     raw_credential = "my-custom-auth-credential-abc123"
@@ -5312,7 +5310,7 @@ async def test_overwrite_user_with_key_hash_never_forwards_raw_custom_credential
     assert user_api_key_dict.api_key == raw_credential
 
     updated_data = await add_litellm_data_to_request(
-        data={"model": "gpt-4o"},
+        data={"model": "gpt-4o", "user": "caller-chosen-id"},
         request=_make_chat_request_mock(),
         user_api_key_dict=user_api_key_dict,
         proxy_config=MagicMock(),
@@ -5320,12 +5318,13 @@ async def test_overwrite_user_with_key_hash_never_forwards_raw_custom_credential
         version="test-version",
     )
 
-    assert updated_data["user"] == hash_token(raw_credential)
-    assert updated_data["user"] != raw_credential
+    assert updated_data["user"] == "caller-chosen-id"
 
 
 @pytest.mark.asyncio
-async def test_overwrite_user_with_key_hash_preserves_hashed_jwt_identifier(monkeypatch):
+async def test_overwrite_user_with_key_hash_skips_jwt_auth(monkeypatch):
+    """A hashed JWT rotates on every token re-issue, so it is useless as a stable
+    ban id; JWT-authenticated requests are not stamped."""
     from litellm.proxy._types import hash_token
 
     monkeypatch.setattr(litellm, "overwrite_user_with_key_hash", True)
@@ -5334,7 +5333,7 @@ async def test_overwrite_user_with_key_hash_preserves_hashed_jwt_identifier(monk
     user_api_key_dict = UserAPIKeyAuth(api_key=hashed_jwt)
 
     updated_data = await add_litellm_data_to_request(
-        data={"model": "gpt-4o"},
+        data={"model": "gpt-4o", "user": "caller-chosen-id"},
         request=_make_chat_request_mock(),
         user_api_key_dict=user_api_key_dict,
         proxy_config=MagicMock(),
@@ -5342,4 +5341,4 @@ async def test_overwrite_user_with_key_hash_preserves_hashed_jwt_identifier(monk
         version="test-version",
     )
 
-    assert updated_data["user"] == hashed_jwt
+    assert updated_data["user"] == "caller-chosen-id"

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -5377,3 +5377,47 @@ def test_via_virtual_key_cannot_be_forged_from_validated_input():
 
     from_dict = UserAPIKeyAuth.model_validate({"api_key": "b" * 64, "via_virtual_key": True})
     assert from_dict.via_virtual_key is False
+
+
+@pytest.mark.asyncio
+async def test_overwrite_user_with_key_hash_stamps_master_key_alias(monkeypatch):
+    """Master-key requests carry the stable alias instead of a hash (so the master
+    key never propagates anywhere); the alias is the stampable id for them."""
+    from litellm.constants import LITELLM_PROXY_MASTER_KEY_ALIAS
+
+    monkeypatch.setattr(litellm, "overwrite_user_with_key_hash", True)
+
+    user_api_key_dict = UserAPIKeyAuth(api_key=LITELLM_PROXY_MASTER_KEY_ALIAS)
+    user_api_key_dict.via_virtual_key = True
+
+    updated_data = await add_litellm_data_to_request(
+        data={"model": "gpt-4o", "user": "attacker-chosen-id"},
+        request=_make_chat_request_mock(),
+        user_api_key_dict=user_api_key_dict,
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    assert updated_data["user"] == LITELLM_PROXY_MASTER_KEY_ALIAS
+
+
+@pytest.mark.asyncio
+async def test_overwrite_user_with_key_hash_rejects_alias_without_marker(monkeypatch):
+    from litellm.constants import LITELLM_PROXY_MASTER_KEY_ALIAS
+
+    monkeypatch.setattr(litellm, "overwrite_user_with_key_hash", True)
+
+    user_api_key_dict = UserAPIKeyAuth(api_key=LITELLM_PROXY_MASTER_KEY_ALIAS)
+    assert user_api_key_dict.via_virtual_key is False
+
+    updated_data = await add_litellm_data_to_request(
+        data={"model": "gpt-4o", "user": "caller-chosen-id"},
+        request=_make_chat_request_mock(),
+        user_api_key_dict=user_api_key_dict,
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    assert updated_data["user"] == "caller-chosen-id"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Providers ban/rate-limit by the `user` param, but callers control it
- A customer needs a tamper-proof id so provider bans map back to a key

How it solves it:

- New `litellm_settings.overwrite_user_with_key_hash` flag, off by default
- When on, outgoing `user` is force-set to the key's sha256 token hash
- Caller-supplied `user` is always clobbered, so it cannot be spoofed
- The stamped value equals `user_api_key_hash` in spend logs, so mapping hash -> key -> owner needs no new plumbing

## Relevant issues

## Linear ticket

Resolves LIT-5026

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured at 9183869138 and re-verified at a4f21dd1f6 (the run below re-ran end to end with the provenance gate in place: the marker set by the real DB-key auth path survives to the stamp) against a live proxy (real Groq call, real spend). Config:

```yaml
litellm_settings:
  overwrite_user_with_key_hash: true
```

Generate a key and note its expected hash:

```
$ curl -s http://localhost:4123/key/generate -H 'Authorization: Bearer sk-1234' \
    -H 'Content-Type: application/json' -d '{"key_alias":"qa-overwrite-user-demo-1"}'
raw key: sk-wwXfECYZv...
expected hash: 2a9ffaf8bbe581c06ba73193767946f223e8cdbf28deb94d1d461ac4098e981b
```

Call chat completions with that key and an attacker-chosen `user`:

```
$ curl -s http://localhost:4123/v1/chat/completions -H "Authorization: Bearer $RAW_KEY" \
    -H 'Content-Type: application/json' \
    -d '{"model":"groq-gpt-oss-120b","messages":[{"role":"user","content":"say pong"}],"user":"attacker-chosen-id"}'
{"id": "chatcmpl-40df16bb-b563-4f97-a0ed-8a1169c6b108", "model": "groq-gpt-oss-120b", "content": "pong"}
```

Proxy `--detailed_debug` log shows the incoming body carried the attacker value and the request data was stamped with the key hash before dispatch:

```
{"model": "groq-gpt-oss-120b", "messages": [...], "user": "attacker-chosen-id", "metadata": {}}
litellm_pre_call_utils.py:1775 - [PROXY] returned data from litellm_pre_call_utils:
{'model': 'groq-gpt-oss-120b', ...,
 'user': '2a9ffaf8bbe581c06ba73193767946f223e8cdbf28deb94d1d461ac4098e981b',
 'metadata': {..., 'user_api_key_hash': '2a9ffaf8bbe581c06ba73193767946f223e8cdbf28deb94d1d461ac4098e981b', ...}}
```

The stamped value matches the expected sha256 of the raw key and `user_api_key_hash` exactly

Note: whether the provider transformation forwards `user` on the wire is existing per-provider behavior this PR does not change. OpenAI sends it verbatim and Anthropic maps it to `metadata.user_id`; Groq (used above because it is the only provider key in this environment) drops it because `user` is only marked supported for known OpenAI models (`gpt_transformation.py` `get_supported_openai_params`)

### Independent before/after QA (virtual keys, teams, master key)

Re-verified end to end across the ownership scenarios raised in review: master key, a plain virtual key with no user and no team, a virtual key with a user, a virtual key under a team with no user, and a virtual key under a team with a user. Two proxies ran against one Postgres, one on the base branch `litellm_internal_staging` with the feature absent and one on this branch with `overwrite_user_with_key_hash: true`. Both pointed at a local echo upstream configured as `openai/gpt-4o`, so the outgoing `user` is forwarded verbatim on the wire (the OpenAI behavior noted just above), which lets the exact value the provider receives be read back directly instead of inferred. Every request sent a spoofed `"user": "attacker-chosen-id"`

On the base branch the spoofed value reaches the provider unchanged in all five scenarios. With the flag on, the outgoing `user` is always clobbered: to the key's sha256 hash for virtual keys (identical whether or not the key has a user and/or sits under a team) and to the `litellm_proxy_master_key` alias for the master key, so neither the raw master key nor its hash ever leaves the proxy. The stamped hash equals the key's `user_api_key_hash` in spend logs, matching the mapping this PR relies on. The no-incoming-user, streaming, and flag-off backward-compat cases were checked separately and behave as expected

![before/after across master key, plain key, key+user, team key, team key+user](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvNTljMmEyODAtNTk2Ny00YmEzLTliYTgtOWIwNGFhZmM2NjBiIiwiaWF0IjoxNzg0ODQ0MDU2LCJleHAiOjE3ODU0NDg4NTYsImZpbGVuYW1lIjoicHIzNDQxNy1iZWZvcmUtYWZ0ZXIud2VicCJ9.uvHEoGBRdcPUaVEjjsBDTjOtATz1FHJdAbJYY9OJWNI)

## Type

🆕 New Feature

## Changes

- `litellm/__init__.py`: declare `overwrite_user_with_key_hash: bool = False` so it is settable via `litellm_settings`
- `litellm/proxy/litellm_pre_call_utils.py`: in `add_litellm_data_to_request`, set `data["user"]` to the key's hash when the flag is on; placed after the header-derived user injection so the stamp always wins
- The stamp applies only to proxy-validated keys, gated by `_stampable_key_hash` on two conditions: the new `via_virtual_key` provenance marker, and a known non-secret value shape (the sha256 hex digest `UserAPIKeyAuth` stores virtual keys in, or the master key's stable `LITELLM_PROXY_MASTER_KEY_ALIAS`). Shape alone cannot distinguish a key hash from a raw custom-auth credential that happens to be 64 hex chars, so provenance is the authoritative signal and shape is defense in depth
- `via_virtual_key` follows the existing `mcp_admitted_user_subject` server-only marker pattern on `UserAPIKeyAuth` (`litellm/proxy/_types.py`): `Field(exclude=True)`, stripped from all validated input in `check_api_key` so custom auth handlers, JWT claims, and key metadata cannot forge it, and set by post-construction assignment at exactly three places in `_user_api_key_auth_builder` (`litellm/proxy/auth/user_api_key_auth.py`): the DB virtual-key return, the master-key return, and the key-cache hit boundary (cache entries are written only after the proxy validated a key, but serialization drops the excluded marker, and cached PROXY_ADMIN objects early-return before the other two sites; the UI-login JWT fallback is not this cache and stays unmarked)
- Master-key requests are stamped with the alias rather than a hash: the auth path deliberately substitutes the alias so neither the master key nor its hash propagates into logs or metrics, and the alias is exactly what spend logs record for these requests, so the mapping stays consistent without ever deriving anything from the secret
- Custom-auth credentials arrive raw on `api_key` (forwarding them would leak auth material) and hashed JWTs rotate on every token re-issue (useless as a stable ban id), so both auth methods are explicitly skipped; supporting them means stamping a different identifier (e.g. resolved user id), which is the planned configurable follow-up
- `tests/test_litellm/proxy/test_litellm_pre_call_utils.py`: regression tests proving the caller-supplied `user` is clobbered, the raw `sk-` key never leaks (only its hash), the param is set even when absent, the flag off by default preserves caller values, JWT plus custom-auth requests are left unstamped, a 64-hex-shaped custom credential is not stamped, and `via_virtual_key` cannot be forged through the constructor or `model_validate`
- `tests/test_litellm/proxy/auth/test_user_api_key_auth.py`: exercises the real `_user_api_key_auth_builder` DB, master-key, and cached-PROXY_ADMIN paths with mocked infrastructure and asserts the returned auth objects carry `via_virtual_key` (and the alias for the master key); deleting any marker assignment fails these tests (DB and cache sites verified by mutation)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


Link to Devin session: https://app.devin.ai/sessions/e5b8c2fb45ef43448416364a7de5a3e8