### PR TITLE
fix(proxy): drop tool_choice and parallel_tool_use config when no tools

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -1576,7 +1576,7 @@ class AmazonConverseConfig(BaseConfig):
                 additional_request_params, parallel_tool_use_config
             )
 
-        tool_choice_values: Optional[ToolChoiceValuesBlock] = inference_params.pop("tool_choice", None)
+        tool_choice_values: ToolChoiceValuesBlock = inference_params.pop("tool_choice", None)
         bedrock_tool_config: Optional[ToolConfigBlock] = None
         if len(bedrock_tools) > 0:
             bedrock_tool_config = ToolConfigBlock(

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -1288,13 +1288,6 @@ class AmazonConverseConfig(BaseConfig):
         additional_request_params = {k: v for k, v in inference_params.items() if k not in total_supported_params}
         inference_params = {k: v for k, v in inference_params.items() if k in total_supported_params}
 
-        # Handle parallel_tool_calls configuration
-        parallel_tool_use_config = additional_request_params.pop("_parallel_tool_use_config", None)
-        if parallel_tool_use_config is not None and bedrock_converse_supports_parallel_tool_use_config(model):
-            additional_request_params = self._merge_parallel_tool_use_config(
-                additional_request_params, parallel_tool_use_config
-            )
-
         additional_request_params.pop("parallel_tool_calls", None)
 
         # Only set the topK value in for models that support it
@@ -1573,9 +1566,19 @@ class AmazonConverseConfig(BaseConfig):
                     bedrock_tools.append(ToolBlock(cachePoint=cache_point))
                     break
 
+        parallel_tool_use_config = additional_request_params.pop("_parallel_tool_use_config", None)
+        if (
+            parallel_tool_use_config is not None
+            and len(bedrock_tools) > 0
+            and bedrock_converse_supports_parallel_tool_use_config(model)
+        ):
+            additional_request_params = self._merge_parallel_tool_use_config(
+                additional_request_params, parallel_tool_use_config
+            )
+
+        tool_choice_values: Optional[ToolChoiceValuesBlock] = inference_params.pop("tool_choice", None)
         bedrock_tool_config: Optional[ToolConfigBlock] = None
         if len(bedrock_tools) > 0:
-            tool_choice_values: ToolChoiceValuesBlock = inference_params.pop("tool_choice", None)
             bedrock_tool_config = ToolConfigBlock(
                 tools=bedrock_tools,
             )

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -624,6 +624,15 @@ def test_parallel_tool_calls_config_kept_for_sonnet_5():
             optional_params={},
             drop_params=False,
         )
+        optional_params["tools"] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
 
         data = config._transform_request_helper(
             model="anthropic.claude-sonnet-5",
@@ -642,6 +651,53 @@ def test_parallel_tool_calls_config_kept_for_sonnet_5():
             os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
         else:
             os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = old_env
+
+
+def test_parallel_tool_use_config_dropped_when_no_tools():
+    old_env = os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP")
+    old_cost = litellm.model_cost
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    try:
+        config = AmazonConverseConfig()
+        optional_params = config.map_openai_params(
+            model="anthropic.claude-sonnet-5",
+            non_default_params={"parallel_tool_calls": False},
+            optional_params={},
+            drop_params=False,
+        )
+
+        data = config._transform_request_helper(
+            model="anthropic.claude-sonnet-5",
+            system_content_blocks=[],
+            optional_params=optional_params,
+            messages=None,
+        )
+
+        assert "tool_choice" not in data.get("additionalModelRequestFields", {})
+        assert "tool_choice" not in data["inferenceConfig"]
+        assert "toolConfig" not in data
+    finally:
+        litellm.model_cost = old_cost
+        if old_env is None:
+            os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
+        else:
+            os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = old_env
+
+
+def test_tool_choice_dropped_when_no_tools():
+    config = AmazonConverseConfig()
+    optional_params = {"tool_choice": {"auto": {}}}
+
+    data = config._transform_request_helper(
+        model="anthropic.claude-sonnet-5",
+        system_content_blocks=[],
+        optional_params=optional_params,
+        messages=None,
+    )
+
+    assert "toolConfig" not in data
+    assert "tool_choice" not in data["inferenceConfig"]
 
 
 def test_parallel_tool_calls_config_dropped_for_ttl_only_model(

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -685,6 +685,39 @@ def test_parallel_tool_use_config_dropped_when_no_tools():
             os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = old_env
 
 
+def test_parallel_tool_use_config_dropped_when_tools_filtered_to_empty():
+    old_env = os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP")
+    old_cost = litellm.model_cost
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    try:
+        config = AmazonConverseConfig()
+        optional_params = config.map_openai_params(
+            model="anthropic.claude-sonnet-5",
+            non_default_params={"parallel_tool_calls": False},
+            optional_params={},
+            drop_params=False,
+        )
+        optional_params["tools"] = [{"type": "tool_search_tool_regex_20251119"}]
+
+        data = config._transform_request_helper(
+            model="anthropic.claude-sonnet-5",
+            system_content_blocks=[],
+            optional_params=optional_params,
+            messages=None,
+        )
+
+        assert "tool_choice" not in data.get("additionalModelRequestFields", {})
+        assert "tool_choice" not in data["inferenceConfig"]
+        assert "toolConfig" not in data
+    finally:
+        litellm.model_cost = old_cost
+        if old_env is None:
+            os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
+        else:
+            os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = old_env
+
+
 def test_tool_choice_dropped_when_no_tools():
     config = AmazonConverseConfig()
     optional_params = {"tool_choice": {"auto": {}}}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock Converse 400s on toolless requests that set `parallel_tool_calls`
- Breaks n8n / agent frameworks that send `parallel_tool_calls=false` every turn

How it solves it:

- Pop `tool_choice` unconditionally; forward to `toolConfig` only when tools exist
- Gate the parallel-tool-use merge on post-filter `len(bedrock_tools) > 0`

## Relevant issues

Fixes #34420

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Bedrock Converse leaked two tool-config artifacts on toolless requests, each producing a 400 from Bedrock.

**Reproduction (before the fix)** — with the source at base but the new regression tests present, the toolless assertions fail because `tool_choice` leaks into the request:

```
$ pytest tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py \
    -k "dropped_when_no_tools or tool_choice_dropped or filtered_to_empty"

FAILED test_parallel_tool_use_config_dropped_when_no_tools
  AssertionError: assert 'tool_choice' not in {'tool_choice': {'type': 'auto', 'disable_parallel_tool_use': True}}
FAILED test_tool_choice_dropped_when_no_tools
  AssertionError: assert 'tool_choice' not in {'tool_choice': {'auto': {}}}
FAILED test_parallel_tool_use_config_dropped_when_tools_filtered_to_empty
  AssertionError: assert 'tool_choice' not in {'tool_choice': {'type': 'auto', 'disable_parallel_tool_use': True}}
```
(captured with the source file reverted to base `1b2a7ce518`)

**After the fix** — full transformation suite green, including the toolless cases, the post-filter (tool_search-only → zero tools) case, and the tools-present backward-compat case:

```
$ pytest tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
168 passed
```
(captured at `460edcfbd4`)

**Live end-to-end proof (real Bedrock call):** _to be added — reproduction of the 400 before the fix and a successful toolless completion after, against a live Bedrock Claude model, with the commit hash for each run._

<img width="1212" height="1049" alt="image" src="https://github.com/user-attachments/assets/3d778f54-f21f-4ca4-9004-f8bda1d81f77" />

## Type

## Type

🐛 Bug Fix

## Changes

Two independent leaks in `litellm/llms/bedrock/chat/converse_transformation.py` caused a toolless request that sets `parallel_tool_calls` (or `tool_choice`) to 400 on Bedrock Converse:

1. **`tool_choice` leaked into `inferenceConfig`.** `tool_choice` was popped from `inference_params` only inside `if len(bedrock_tools) > 0`, so a toolless request left it in `inference_params`, where it flowed into `_transform_inference_params(...)` → `InferenceConfig(**inference_params)`. It is now popped unconditionally in `_transform_request_helper` and only attached to `toolConfig` when tools are present.

2. **`parallel_tool_use` config injected without tools.** The `parallel_tool_calls`-derived `disable_parallel_tool_use` block was merged into `additionalModelRequestFields` in `_prepare_request_params`, gated only on model capability. A toolless request therefore emitted a `tool_choice` block with no accompanying `toolConfig`. The merge now runs in `_transform_request_helper` after tool processing, guarded by `len(bedrock_tools) > 0` — the post-filter tool count, so requests whose tools are all filtered out during transformation (leaving zero Bedrock tools) are handled as toolless too.

Notes for review:

- The `_parallel_tool_use_config` marker set in `map_openai_params` is now intentionally carried through `_prepare_request_params` and consumed later in `_transform_request_helper`. It passes untouched through `filter_internal_params` (which only strips the MCP-handler keys) and the non-serializable-object filter.
- Backward compatibility is preserved: a request **with** tools and `parallel_tool_calls=false` still injects the `disable_parallel_tool_use` config, and the `"type"` field on that block is untouched.
- `test_parallel_tool_calls_config_kept_for_sonnet_5` was updated to include a tool. Its previous assertion encoded the buggy toolless emission (leak #2); adding a tool asserts the intended tools-present backward-compat behavior.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

